### PR TITLE
Do not lazy load in header v2 for faster rendering time

### DIFF
--- a/src/applications/static-pages/events/index.js
+++ b/src/applications/static-pages/events/index.js
@@ -2,25 +2,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+// Related imports.
+import App from './components/App';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+
   if (root) {
-    import(/* webpackChunkName: "ask-va" */
-    './components/App').then(module => {
-      const App = module.default;
+    // Derive the props to pass to the widget.
+    const pastEvents = window?.pastEvents?.entities || [];
+    const allEventTeasers = window?.allEventTeasers?.entities || [];
+    const rawEvents = [...pastEvents, ...allEventTeasers];
 
-      // Derive the props to pass to the widget.
-      const pastEvents = window?.pastEvents?.entities || [];
-      const allEventTeasers = window?.allEventTeasers?.entities || [];
-      const rawEvents = [...pastEvents, ...allEventTeasers];
-
-      ReactDOM.render(
-        <Provider store={store}>
-          <App rawEvents={rawEvents} />
-        </Provider>,
-        root,
-      );
-    });
+    ReactDOM.render(
+      <Provider store={store}>
+        <App rawEvents={rawEvents} />
+      </Provider>,
+      root,
+    );
   }
 };


### PR DESCRIPTION
## Description

This PR attempts to make it so that header v2 renders faster instead of there being a 0.5-3 second lag.

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Remove lazy loading of header v2

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
