### PR TITLE
Page description changed to match new requirements

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
@@ -32,13 +32,15 @@ const uiSchema = {
   'ui:description': (
     <>
       <p>
-        This is the information we’ll use to contact you about your appointment.
-        You can update your contact information here, but the updates will only
-        apply to this tool.
+        We’ll use this information to contact you about your appointment. Any
+        updates you make here will only apply to VA online appointment
+        scheduling.
       </p>
       <p className="vads-u-margin-y--2">
-        To update your contact information for all your VA accounts, please{' '}
-        <NewTabAnchor href="/profile">go to your profile page</NewTabAnchor>.
+        Want to update your contact information for more VA benefits and
+        services?
+        <br />
+        <NewTabAnchor href="/profile">Go to your VA profile</NewTabAnchor>.
       </p>
     </>
   ),

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -110,13 +110,15 @@ export default function ContactInfoPage() {
     'ui:description': (
       <>
         <p>
-          This is the information we’ll use to contact you about your
-          appointment. You can update your contact information here, but the
-          updates will only apply to this tool.
+          We’ll use this information to contact you about your appointment. Any
+          updates you make here will only apply to VA online appointment
+          scheduling.
         </p>
         <p className="vads-u-margin-y--2">
-          To update your contact information for all your VA accounts, please{' '}
-          <NewTabAnchor href="/profile">go to your profile page</NewTabAnchor>.
+          Want to update your contact information for more VA benefits and
+          services?
+          <br />
+          <NewTabAnchor href="/profile">Go to your VA profile</NewTabAnchor>.
         </p>
       </>
     ),

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactInfoPage.unit.spec.jsx
@@ -20,8 +20,20 @@ describe('VAOS <ContactInfoPage>', () => {
     input = screen.getByLabelText(/^Your email address/);
     userEvent.type(input, 'joe.blow@gmail.com');
 
-    // it should display page heading
+    // it should display page heading and description
     expect(screen.getByText('Confirm your contact information')).to.be.ok;
+    expect(
+      screen.getByText(
+        /We’ll use this information to contact you about your appointment\. Any updates you make here will only apply to VA online appointment scheduling/i,
+      ),
+    ).to.be.ok;
+
+    expect(
+      screen.getByText(
+        /Want to update your contact information for more VA benefits and services\?/,
+      ),
+    ).to.be.ok;
+
     const button = await screen.findByText(/^Continue/);
 
     userEvent.click(button);

--- a/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
@@ -32,8 +32,19 @@ describe('VAOS <ContactInfoPage>', () => {
     input = screen.getByLabelText(/^Your email address/);
     userEvent.type(input, 'joe.blow@gmail.com');
 
-    // it should display page heading
+    // it should display page heading and description
     expect(screen.getByText('Confirm your contact information')).to.be.ok;
+    expect(
+      screen.getByText(
+        /We’ll use this information to contact you about your appointment\. Any updates you make here will only apply to VA online appointment scheduling/i,
+      ),
+    ).to.be.ok;
+
+    expect(
+      screen.getByText(
+        /Want to update your contact information for more VA benefits and services\?/,
+      ),
+    ).to.be.ok;
     const button = await screen.findByText(/^Continue/);
 
     userEvent.click(button);


### PR DESCRIPTION
## Description
This PR changes the covid vaccine contact information page description to match the new requirements in the copy doc

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32194


## Testing done
Manual and Unit


## Screenshots
<img width="934" alt="32194" src="https://user-images.githubusercontent.com/3951775/144460099-008cdebd-3502-478e-be22-48b0fefb0197.PNG">

- New Appointment Flow
![image](https://user-images.githubusercontent.com/3951775/145068123-325af5f2-224b-47ed-a285-341ff1aeae65.png)

## Acceptance criteria
- [ ] Given the COVID-19 new appointment workflow,
When the user enters the Confirm your contact information page,
Then the page description matches the copy doc

- [ ] Given the new appointment workflow,
When the user enters the Confirm your contact information page,
Then the page description matches the copy doc

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
