### PR TITLE
Add analytic event on component did mount for header v2

### DIFF
--- a/src/platform/site-wide/header/components/App/index.js
+++ b/src/platform/site-wide/header/components/App/index.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
 import Header from '../Header';
 import { hideLegacyHeader, showLegacyHeader } from '../../helpers';
 
@@ -25,6 +26,12 @@ export const App = ({
     setIsDesktop(window.innerWidth >= MOBILE_BREAKPOINT_PX);
 
   useEffect(() => {
+    // Record analytic event.
+    recordEvent({
+      event: 'phased-roll-out-enabled',
+      'product-description': 'Header V2',
+    });
+
     // Set screen size listener.
     window.addEventListener('resize', deriveIsDesktop);
 


### PR DESCRIPTION
## Description

This PR adds the following event whenever header v2 renders:
```js
{
 event: 'phased-roll-out-enabled',
 'product-description': 'Header Menu variation',
}
```

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/33508

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/144467062-639dfeea-c549-4927-9466-a92dcff37757.png)

## Acceptance criteria
- [x] Add analytic event on component did mount for header v2

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
