### PR TITLE
Fix migration script closing tags

### DIFF
--- a/script/component-migration/index.js
+++ b/script/component-migration/index.js
@@ -73,7 +73,7 @@ function replaceTags(fileContents, newTag) {
 
   return namedClosingTags
     .replace(new RegExp(`<${options.component}`, 'g'), `<${newTag}`)
-    .replace(`</${options.component}`, `</${newTag}`);
+    .replace(new RegExp(`</${options.component}`, 'g'), `</${newTag}`);
 }
 
 /**


### PR DESCRIPTION
## Description

This fix updates the replace function argument from a string to a regular expression. This ensures that all occurrences of a component's closing tags are correctly replaced when running the migration script.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33531


## Testing done
yarn migrate-component --dir script/component-migration/samples --component AdditionalInfo

## Screenshots
Sample file before running migration script
<img width="694" alt="Screen Shot 2021-12-02 at 16 31 14" src="https://user-images.githubusercontent.com/36863582/144506473-54a41c14-797b-4988-82d1-a7da3a09d25e.png">

Sample file after running migration script
<img width="615" alt="Screen Shot 2021-12-02 at 16 30 53" src="https://user-images.githubusercontent.com/36863582/144506529-f7a800b0-0f84-4cba-909b-f8b91be86d7a.png">

Result of `yarn migrate-component --dir script/component-migration/samples --component AdditionalInfo`
<img width="974" alt="Screen Shot 2021-12-02 at 16 31 41" src="https://user-images.githubusercontent.com/36863582/144506462-2d8f0eda-3b59-494b-81ce-c4cfc8338354.png">


## Acceptance criteria
- [ ] Migration script replaces all occurrences of React component with web component 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
