### PR TITLE
add poc health apt toggle flag

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -64,3 +64,6 @@ export const selectFeatureVariantTesting = state =>
 
 export const selectFeatureCCIterations = state =>
   toggleValues(state).vaOnlineSchedulingCCIterations;
+
+export const selectFeaturePocHealthApt = state =>
+  toggleValues(state).vaOnlineSchedulingPocHealthApt;

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -421,6 +421,7 @@ const responses = {
         { name: 'vaOnlineSchedulingVAOSServiceCCAppointments', value: true },
         { name: 'vaOnlineSchedulingVariantTesting', value: false },
         { name: 'vaOnlineSchedulingCCIterations', value: true },
+        { name: 'vaOnlineSchedulingPocHealthApt', value: true },
         { name: 'ssoe', value: true },
         { name: 'ssoe_inbound', value: false },
         { name: 'ssoe_ebenefits_links', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -126,6 +126,7 @@ export default Object.freeze({
     'va_online_scheduling_facilities_service_v2',
   vaOnlineSchedulingVariantTesting: 'va_online_scheduling_variant_testing',
   vaOnlineSchedulingCCIterations: 'va_online_scheduling_cc_iterations',
+  vaOnlineSchedulingPocHealthApt: 'va_online_scheduling_poc_health_apt',
   vaViewDependentsAccess: 'va_view_dependents_access',
   yellowRibbonEnhancements: 'yellow_ribbon_mvp_enhancement',
   showEduBenefits1990EZWizard: 'show_edu_benefits_1990EZ_Wizard',


### PR DESCRIPTION
## Description
create a feature toggle `va_online_scheduling_poc_health_apt` for health apartment POC work.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33387


## Testing done
n/a

## Screenshots
n/a

## Acceptance criteria
- [ ] Create frontend toggle and selector
- [ ] record name in [feature toggle documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/product/feature_toggles.md)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
