### PR TITLE
Changed to functional component and added saveInProgreeIntro

### DIFF
--- a/src/applications/personalization/search-representative/config/form.js
+++ b/src/applications/personalization/search-representative/config/form.js
@@ -14,6 +14,9 @@ import {
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
+  customText: {
+    appType: 'search',
+  },
   urlPrefix: '/',
   submitUrl: '/v0/api',
   trackingPrefix: 'search-representative-',

--- a/src/applications/personalization/search-representative/containers/IntroductionPage.jsx
+++ b/src/applications/personalization/search-representative/containers/IntroductionPage.jsx
@@ -1,46 +1,42 @@
 import React from 'react';
-import manifest from '../manifest.json';
-import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import formConfig from '../config/form';
 import FormFooter from 'platform/forms/components/FormFooter';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
-
-  render() {
-    return (
-      <div className="schemaform-intro">
-        <FormTitle title="Find an accredited representative" />
-        <p className="vads-u-font-family--serif vads-u-font-size--h3 vads-u-font-weight--normal vads-u-padding-bottom--1">
-          An accredited attorney, claims agent, or Veterans Service Officer
-          (VSO) can help you file VA claims and appeals.
-        </p>
-        <h2>Search for a representative</h2>
-        <p>
-          Click the link below and follow the steps to find a representative
-          near you.
-        </p>
-        <a
-          className="vads-c-action-link--green"
-          href={`${manifest.rootUrl}/representative-type`}
-        >
-          Search for a representative
-        </a>
-
-        <h3>Learn more about accredited representatives</h3>
-        <p>
-          If you're not ready to look for an accredited representative, you can
-          find out more about how a representative can help with your VA claims
-          and appeals
-        </p>
-        <a href="#">Get help filing your claim or appeal</a>
-        <FormFooter formConfig={formConfig} />
-      </div>
-    );
-  }
-}
+const IntroductionPage = props => {
+  return (
+    <div className="schemaform-intro">
+      <FormTitle title="Find an accredited representative" />
+      <p className="vads-u-font-family--serif vads-u-font-size--h3 vads-u-font-weight--normal vads-u-padding-bottom--1">
+        An accredited attorney, claims agent, or Veterans Service Officer (VSO)
+        can help you file VA claims and appeals.
+      </p>
+      <h2>Search for a representative</h2>
+      <p>
+        Click the link below and follow the steps to find a representative near
+        you.
+      </p>
+      <SaveInProgressIntro
+        buttonOnly
+        testActionLink
+        unauthStartText="Sign in and search for a representative"
+        prefillEnabled={formConfig.prefillEnabled}
+        messages={formConfig.savedFormMessages}
+        formConfig={formConfig}
+        pageList={props.route.pageList}
+        downtime={formConfig.downtime}
+      />
+      <h3>Learn more about accredited representatives</h3>
+      <p>
+        If you’re not ready to look for an accredited representative, you can
+        find out more about how a representative can help with your VA claims
+        and appeals
+      </p>
+      <a href="#">Get help filing your claim or appeal</a>
+      <FormFooter formConfig={formConfig} />
+    </div>
+  );
+};
 
 export default IntroductionPage;


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/33437)

When putting the search representative on staging we realized that when entering the form you get redirected back to the introduction page.  Upon investigation it was determined that we needed to change the static link we were using to enter the form into the `saveInProgressIntro` component instead.

## Acceptance criteria
- [x] The search representative form does not redirect

