### PR TITLE
33470: Adds unit test to validate login buttons passing proper arguments

### DIFF
--- a/src/platform/user/authentication/components/NewDesignButtons.jsx
+++ b/src/platform/user/authentication/components/NewDesignButtons.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import {
-  login,
-  loginGovSignupUrl,
-  idmeSignupUrl,
-} from 'platform/user/authentication/utilities';
+import * as authUtilities from 'platform/user/authentication/utilities';
 import LoginGovSVG from 'platform/user/authentication/components/LoginGovSVG';
 import IDMeSVG from 'platform/user/authentication/components/IDMeSVG';
+import { CSP_IDS } from '../constants';
 
 function loginHandler(loginType) {
   recordEvent({ event: `login-attempted-${loginType}` });
-  login({
+  authUtilities.login({
     policy: loginType,
   });
 }
@@ -52,7 +49,8 @@ export default function NewDesignButtons({
           type="button"
           aria-label="Sign in with Login.gov"
           className="usa-button logingov-button vads-u-margin-y--1p5 vads-u-padding-y--2"
-          onClick={() => loginHandler('logingov')}
+          data-csp={CSP_IDS.LOGIN_GOV}
+          onClick={() => loginHandler(CSP_IDS.LOGIN_GOV)}
         >
           <LoginGovSVG />
         </button>
@@ -62,7 +60,8 @@ export default function NewDesignButtons({
         type="button"
         aria-label="Sign in with ID.me"
         className="usa-button idme-button vads-u-margin-y--1p5 vads-u-padding-y--2"
-        onClick={() => loginHandler('idme')}
+        data-csp={CSP_IDS.ID_ME}
+        onClick={() => loginHandler(CSP_IDS.ID_ME)}
       >
         <IDMeSVG />
       </button>
@@ -71,7 +70,8 @@ export default function NewDesignButtons({
         type="button"
         aria-label="Sign in with DS Logon"
         className="usa-button dslogon-button vads-u-margin-y--1p5 vads-u-padding-y--2"
-        onClick={() => loginHandler('dslogon')}
+        data-csp={CSP_IDS.DS_LOGON}
+        onClick={() => loginHandler(CSP_IDS.DS_LOGON)}
       >
         DS Logon
       </button>
@@ -80,7 +80,8 @@ export default function NewDesignButtons({
         type="button"
         aria-label="Sign in with My HealtheVet"
         className="usa-button mhv-button vads-u-margin-y--1p5 vads-u-padding-y--2"
-        onClick={() => loginHandler('mhv')}
+        data-csp={CSP_IDS.MHV}
+        onClick={() => loginHandler(CSP_IDS.MHV)}
       >
         My HealtheVet
       </button>
@@ -90,7 +91,7 @@ export default function NewDesignButtons({
           {showLoginGov() &&
             loginGovCreateAccountEnabled && (
               <a
-                href={loginGovSignupUrl()}
+                href={authUtilities.loginGovSignupUrl()}
                 className="vads-c-action-link--blue logingov"
                 disabled={isDisabled}
                 onClick={() => signupHandler('logingov')}
@@ -99,7 +100,7 @@ export default function NewDesignButtons({
               </a>
             )}
           <a
-            href={idmeSignupUrl()}
+            href={authUtilities.idmeSignupUrl()}
             className="vads-c-action-link--blue"
             disabled={isDisabled}
             onClick={() => signupHandler('idme')}

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -7,3 +7,10 @@ export const AUTH_EVENTS = {
   LOGOUT: 'logout-link-clicked',
   REGISTER: 'register-link-clicked',
 };
+
+export const CSP_IDS = {
+  MHV: 'mhv',
+  ID_ME: 'idme',
+  DS_LOGON: 'dslogon',
+  LOGIN_GOV: 'logingov',
+};

--- a/src/platform/user/tests/authentication/components/loginButtons.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/loginButtons.unit.spec.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import * as authUtilities from '../../../authentication/utilities';
+import NewDesignButtons from '../../../authentication/components/NewDesignButtons';
+import { CSP_IDS } from '../../../authentication/constants';
+
+describe('login DOM ', () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(function() {
+    sandbox.spy(authUtilities, 'login');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('login buttons should properly call login method', () => {
+    const loginButtons = mount(<NewDesignButtons />);
+
+    const testButton = button => {
+      const loginCSP = button.prop('data-csp');
+
+      const expectedArgs = {
+        idme: { policy: CSP_IDS.ID_ME },
+        logingov: { policy: CSP_IDS.LOGIN_GOV },
+        dslogon: { policy: CSP_IDS.DS_LOGON },
+        mhv: { policy: CSP_IDS.MHV },
+      };
+
+      button.simulate('click');
+
+      expect(authUtilities.login.calledOnce).to.be.true;
+      expect(authUtilities.login.getCall(0).args[0]).to.deep.equal(
+        expectedArgs[loginCSP],
+      );
+
+      sandbox.reset();
+    };
+
+    loginButtons.find('button').forEach(testButton);
+    loginButtons.unmount();
+  });
+});

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -1,14 +1,10 @@
-import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
-import sinon from 'sinon';
 
 import {
   getLoginAttempted,
   removeLoginAttempted,
 } from 'platform/utilities/sso/loginAttempted';
 import * as authUtilities from '../../authentication/utilities';
-import NewDesignButtons from '../../authentication/components/NewDesignButtons';
 import { CSP_IDS } from '../../authentication/constants';
 
 const setup = () => {
@@ -201,40 +197,5 @@ describe('loginAppUrlRE', () => {
   it('should not resolve to a login app url', () => {
     expect(authUtilities.loginAppUrlRE.test('/sign-in-faq')).to.be.false;
     expect(authUtilities.loginAppUrlRE.test('/sign-in-faq/')).to.be.false;
-  });
-});
-
-describe('login DOM ', () => {
-  const sandbox = sinon.createSandbox();
-
-  beforeEach(function() {
-    sandbox.spy(authUtilities, 'login');
-  });
-
-  it('login buttons should properly call login method', () => {
-    const loginButtons = mount(<NewDesignButtons />);
-
-    const testButton = button => {
-      const loginCSP = button.prop('data-csp');
-
-      const expectedArgs = {
-        idme: { policy: CSP_IDS.ID_ME },
-        logingov: { policy: CSP_IDS.LOGIN_GOV },
-        dslogon: { policy: CSP_IDS.DS_LOGON },
-        mhv: { policy: CSP_IDS.MHV },
-      };
-
-      button.simulate('click');
-
-      expect(authUtilities.login.calledOnce).to.be.true;
-      expect(authUtilities.login.getCall(0).args[0]).to.deep.equal(
-        expectedArgs[loginCSP],
-      );
-
-      sandbox.reset();
-    };
-
-    loginButtons.find('button').forEach(testButton);
-    loginButtons.unmount();
   });
 });

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -1,20 +1,15 @@
+import React from 'react';
 import { expect } from 'chai';
-
-import {
-  login,
-  loginAppUrlRE,
-  mfa,
-  verify,
-  logout,
-  signup,
-  standaloneRedirect,
-  externalRedirects,
-} from '../../authentication/utilities';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
 
 import {
   getLoginAttempted,
   removeLoginAttempted,
 } from 'platform/utilities/sso/loginAttempted';
+import * as authUtilities from '../../authentication/utilities';
+import NewDesignButtons from '../../authentication/components/NewDesignButtons';
+import { CSP_IDS } from '../../authentication/constants';
 
 const setup = () => {
   global.window.location = {
@@ -32,56 +27,59 @@ describe('authentication URL helpers', () => {
   beforeEach(setup);
 
   it('should redirect for signup v1', () => {
-    signup();
+    authUtilities.signup();
     expect(global.window.location).to.include(
       '/v1/sessions/idme_signup/new?op=signup',
     );
-    signup({ version: 'v1', csp: 'idme' });
+    authUtilities.signup({ version: 'v1', csp: CSP_IDS.ID_ME });
     expect(global.window.location).to.include(
       '/v1/sessions/idme_signup/new?op=signup',
     );
-    signup({ version: 'v1', csp: 'logingov' });
+    authUtilities.signup({ version: 'v1', csp: CSP_IDS.LOGIN_GOV });
     expect(global.window.location).to.include(
       '/v1/sessions/logingov_signup/new',
     );
   });
 
   it('should redirect for login v1', () => {
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 
   it('should redirect for login with custom event', () => {
-    login({ policy: 'idme', clickedEvent: 'custom-event' });
+    authUtilities.login({
+      policy: CSP_IDS.ID_ME,
+      clickedEvent: 'custom-event',
+    });
     expect(global.window.location).to.include('/v1/sessions/idme/new');
     expect(global.window.dataLayer[0].event).to.eq('custom-event');
   });
 
   it('should redirect for logout v1', () => {
-    logout('v1');
+    authUtilities.logout('v1');
     expect(global.window.location).to.include('/v1/sessions/slo/new');
   });
 
   it('should redirect for logout with custom event', () => {
-    logout('v1', 'custom-event');
+    authUtilities.logout('v1', 'custom-event');
     expect(global.window.location).to.include('/v1/sessions/slo/new');
     expect(global.window.dataLayer[0].event).to.eq('custom-event');
   });
 
   it('should redirect for MFA v1', () => {
-    mfa('v1');
+    authUtilities.mfa('v1');
     expect(global.window.location).to.include('/v1/sessions/mfa/new');
   });
 
   it('should redirect for verify v1', () => {
-    verify('v1');
+    authUtilities.verify('v1');
     expect(global.window.location).to.include('/v1/sessions/verify/new');
   });
 
   it('should not append unneeded query parameters on unified sign-in page on a signup', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=mhv';
-    signup();
+    authUtilities.signup();
     expect(global.window.location).to.include(
       `/v1/sessions/idme_signup/new?op=signup`,
     );
@@ -90,10 +88,10 @@ describe('authentication URL helpers', () => {
   it('should redirect to the proper unified sign-in page redirect for mhv', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=mhv';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(global.window.location).to.include(
       `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${
-        externalRedirects.mhv
+        authUtilities.externalRedirects.mhv
       }&postLogin=true`,
     );
   });
@@ -102,10 +100,10 @@ describe('authentication URL helpers', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=mhv&to=secure_messaging';
 
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(global.window.location).to.include(
       `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${
-        externalRedirects.mhv
+        authUtilities.externalRedirects.mhv
       }?deeplinking=secure_messaging&postLogin=true`,
     );
   });
@@ -113,20 +111,20 @@ describe('authentication URL helpers', () => {
   it('should redirect to the proper unified sign-in page redirect for cerner', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=myvahealth';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 
   it('should mimic modal behavior when sign-in page lacks appliction param', () => {
     global.window.location.pathname = '/sign-in/';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 
   it('should mimic modal behavior when sign-in page has invalid application param', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=foobar';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 });
@@ -135,14 +133,14 @@ describe('setLoginAttempted', () => {
   beforeEach(setup);
 
   it('should setLoginAttempted true when logging in from modal', () => {
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(getLoginAttempted()).to.equal('true');
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 
   it('should setLoginAttempted true when logging in from /sign-in with no external redirect', () => {
     global.window.location.pathname = '/sign-in/';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(getLoginAttempted()).to.equal('true');
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
@@ -150,7 +148,7 @@ describe('setLoginAttempted', () => {
   it('should setLoginAttempted true when logging in from /sign-in with invalid external redirect', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=foobar';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(getLoginAttempted()).to.equal('true');
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
@@ -158,7 +156,7 @@ describe('setLoginAttempted', () => {
   it('should not setLoginAttempted when logging in from /sign-in with valid external redirect', () => {
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=mhv';
-    login({ policy: 'idme' });
+    authUtilities.login({ policy: CSP_IDS.ID_ME });
     expect(getLoginAttempted()).to.be.null;
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
@@ -169,37 +167,74 @@ describe('standaloneRedirect', () => {
 
   it('should return null when an application param is not provided', () => {
     global.window.location.search = '';
-    expect(standaloneRedirect()).to.be.null;
+    expect(authUtilities.standaloneRedirect()).to.be.null;
   });
 
   it('should return null when an application redirect is not found', () => {
     global.window.location.search = '?application=unmappedapplication';
-    expect(standaloneRedirect()).to.be.null;
+    expect(authUtilities.standaloneRedirect()).to.be.null;
   });
 
   it.skip('should return a plain url when no `to` search query is provided', () => {
     global.window.location.search = '?application=myvahealth';
-    expect(standaloneRedirect()).to.equal(externalRedirects.myvahealth);
+    expect(authUtilities.standaloneRedirect()).to.equal(
+      authUtilities.externalRedirects.myvahealth,
+    );
   });
 
   it('should strip any CRLF characters from the "to" parameter', () => {
     global.window.location.search =
       '?application=myvahealth&to=/some/sub/route\r\n';
-    expect(standaloneRedirect()).to.equal(
-      `${externalRedirects.myvahealth}/some/sub/route`,
+    expect(authUtilities.standaloneRedirect()).to.equal(
+      `${authUtilities.externalRedirects.myvahealth}/some/sub/route`,
     );
   });
 });
 
 describe('loginAppUrlRE', () => {
   it('should resolve to a login app url', () => {
-    expect(loginAppUrlRE.test('/sign-in')).to.be.true;
-    expect(loginAppUrlRE.test('/sign-in/')).to.be.true;
-    expect(loginAppUrlRE.test('/sign-in/verify')).to.be.true;
-    expect(loginAppUrlRE.test('/sign-in/verify/')).to.be.true;
+    expect(authUtilities.loginAppUrlRE.test('/sign-in')).to.be.true;
+    expect(authUtilities.loginAppUrlRE.test('/sign-in/')).to.be.true;
+    expect(authUtilities.loginAppUrlRE.test('/sign-in/verify')).to.be.true;
+    expect(authUtilities.loginAppUrlRE.test('/sign-in/verify/')).to.be.true;
   });
   it('should not resolve to a login app url', () => {
-    expect(loginAppUrlRE.test('/sign-in-faq')).to.be.false;
-    expect(loginAppUrlRE.test('/sign-in-faq/')).to.be.false;
+    expect(authUtilities.loginAppUrlRE.test('/sign-in-faq')).to.be.false;
+    expect(authUtilities.loginAppUrlRE.test('/sign-in-faq/')).to.be.false;
+  });
+});
+
+describe('login DOM ', () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(function() {
+    sandbox.spy(authUtilities, 'login');
+  });
+
+  it('login buttons should properly call login method', () => {
+    const loginButtons = mount(<NewDesignButtons />);
+
+    const testButton = button => {
+      const loginCSP = button.prop('data-csp');
+
+      const expectedArgs = {
+        idme: { policy: CSP_IDS.ID_ME },
+        logingov: { policy: CSP_IDS.LOGIN_GOV },
+        dslogon: { policy: CSP_IDS.DS_LOGON },
+        mhv: { policy: CSP_IDS.MHV },
+      };
+
+      button.simulate('click');
+
+      expect(authUtilities.login.calledOnce).to.be.true;
+      expect(authUtilities.login.getCall(0).args[0]).to.deep.equal(
+        expectedArgs[loginCSP],
+      );
+
+      sandbox.reset();
+    };
+
+    loginButtons.find('button').forEach(testButton);
+    loginButtons.unmount();
   });
 });


### PR DESCRIPTION
## Description
We had a close call on 11/16 where a `login` refactor left the UI in a state where the buttons passed invalid arguments. This led to the buttons not working.

This update aims to add a unit test that will test current/and newly added login buttons without overhead.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33470


## Testing done
- Unit tests

## Screenshots


## Acceptance criteria
- [ ] Unit test that renders and simulates clicks on login buttons to validate the arguments being passed to `login` method
- [ ] Unit test should account for newly added/removed buttons without any/much effort.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
