### PR TITLE
29363 map result oval

### DIFF
--- a/src/applications/gi-sandbox/sass/partials/_gi-search-location.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-location.scss
@@ -40,6 +40,7 @@ $ct-locator-shadow: rgba(0, 0, 0, 0.5);
     width: 28px;
     height: 24px;
     display: flex;
+    font-family: $font-sans;
     align-items: center;
     justify-content: center;
     background: $color-base;

--- a/src/applications/gi-sandbox/sass/partials/_gi-search-location.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-location.scss
@@ -39,7 +39,9 @@ $ct-locator-shadow: rgba(0, 0, 0, 0.5);
     border-radius: 50%;
     width: 28px;
     height: 24px;
-
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: $color-base;
     color: $color-gray-lightest;
     text-align: center;


### PR DESCRIPTION
## Description
Design components or patterns don't align with Design System guidelines.
On the map results, the number is inside an oval and the font family is incorrect

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29363


## Testing done
Local environment

## Screenshots
<img width="506" alt="Screen Shot 2021-12-03 at 11 35 29 AM" src="https://user-images.githubusercontent.com/18352271/144871328-77362bac-ffd0-4a17-a7bb-57b64c674b8c.png">

## Acceptance criteria
- [x] Font is Source Sans
- [x] The number is in the middle of the oval. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
