### PR TITLE
UI fixes for button and header alignment on Calendar Widget

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarNavigation.jsx
+++ b/src/applications/vaos/components/calendar/CalendarNavigation.jsx
@@ -28,7 +28,7 @@ const CalendarNavigation = ({
       {momentMonth.format('MMMM YYYY')}
     </h2>
     <button
-      className="vaos-calendar__nav-links-button vads-u-display--flex vads-u-justify-content--flex-end vads-u-align-items--center vads-u-font-weight--normal vads-u-padding--0 vads-u-margin-bottom--0 vads-u-margin-top--0p5  vads-u-color--primary"
+      className="vaos-calendar__nav-links-button vads-u-display--flex vads-u-justify-content--flex-end vads-u-align-items--center vads-u-font-weight--normal vads-u-padding--0 vads-u-margin-bottom--0 vads-u-margin-top--0p5  vads-u-color--primary vads-u-margin-right--0"
       onClick={nextOnClick}
       disabled={nextDisabled}
       type="button"

--- a/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
@@ -19,7 +19,7 @@ export default function CalendarWeekdayHeader({ showFullWeek = false }) {
   return (
     <div role="rowgroup">
       <div
-        className="vaos-calendar__weekday-container vads-u-display--flex vads-u-justify-content--space-between"
+        className="vaos-calendar__weekday-container vads-u-display--flex vads-u-justify-content--space-around"
         role="row"
       >
         {daysToRender.map((day, index) => (


### PR DESCRIPTION
## Description
This PR is for the alignment fixes requested on the Calendar widget

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33389


## Testing done
Manual

## Screenshots
Desktop
<img width="947" alt="33389-Desktop" src="https://user-images.githubusercontent.com/3951775/145054902-fc3fecf0-36b2-4af9-9d1c-e4e26557ef91.PNG">

Tablet
<img width="596" alt="33389-Tablet" src="https://user-images.githubusercontent.com/3951775/145055041-aa3f9b5c-4bd4-4281-8980-72035a39bbbe.PNG">

Mobile
<img width="526" alt="33389-Mobile" src="https://user-images.githubusercontent.com/3951775/145055121-87e120f5-1b2a-4c3d-b0e2-e8ebddfae6d3.PNG">



## Acceptance criteria
- [ ] Day of week text should be aligned with the day numbers
- [ ] Next button margin should be right aligned with the underline (like Previous is aligned to the left)
- [ ] Should match the specs:
https://www.sketch.com/s/ccd66412-dd7c-41ba-9528-88892a33af63/p/E68B491D-ED59-4EF0-A4D2-73A161AE0632

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
