### PR TITLE
[MCP]: Only show latest copay on overview page and sort PDFs by date

### DIFF
--- a/src/applications/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/medical-copays/components/BalanceCard.jsx
@@ -21,25 +21,18 @@ const BalanceCard = ({ id, amount, facility, city, date }) => (
     >
       Copay balance for {facility} - {city}
     </p>
-    {!!amount && (
-      <div className="card-content">
-        <i
-          aria-hidden="true"
-          role="img"
-          className="fa fa-exclamation-triangle"
-        />
-        <p>
-          Pay your full balance or request financial help before
-          <strong
-            className="vads-u-margin-x--0p5"
-            data-testid={`due-date-${id}`}
-          >
-            {calcDueDate(date, 30)}
-          </strong>
-          to avoid late charges, interest, or collection actions.
-        </p>
-      </div>
-    )}
+
+    <div className="card-content">
+      <i aria-hidden="true" role="img" className="fa fa-exclamation-triangle" />
+      <p>
+        Pay your full balance or request financial help before
+        <strong className="vads-u-margin-x--0p5" data-testid={`due-date-${id}`}>
+          {calcDueDate(date, 30)}
+        </strong>
+        to avoid late charges, interest, or collection actions.
+      </p>
+    </div>
+
     <Link
       className="vads-u-font-size--sm"
       to={`/balance-details/${id}`}

--- a/src/applications/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/medical-copays/components/BalanceCard.jsx
@@ -22,16 +22,25 @@ const BalanceCard = ({ id, amount, facility, city, date }) => (
       Copay balance for {facility} - {city}
     </p>
 
-    <div className="card-content">
-      <i aria-hidden="true" role="img" className="fa fa-exclamation-triangle" />
-      <p>
-        Pay your full balance or request financial help before
-        <strong className="vads-u-margin-x--0p5" data-testid={`due-date-${id}`}>
-          {calcDueDate(date, 30)}
-        </strong>
-        to avoid late charges, interest, or collection actions.
-      </p>
-    </div>
+    {!!amount && (
+      <div className="card-content">
+        <i
+          aria-hidden="true"
+          role="img"
+          className="fa fa-exclamation-triangle"
+        />
+        <p>
+          Pay your full balance or request financial help before
+          <strong
+            className="vads-u-margin-x--0p5"
+            data-testid={`due-date-${id}`}
+          >
+            {calcDueDate(date, 30)}
+          </strong>
+          to avoid late charges, interest, or collection actions.
+        </p>
+      </div>
+    )}
 
     <Link
       className="vads-u-font-size--sm"

--- a/src/applications/medical-copays/components/PDFStatementList.jsx
+++ b/src/applications/medical-copays/components/PDFStatementList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+import { sortStatementsByDate } from '../utils/helpers';
 
 import DownloadStatements from './DownloadStatement';
 
@@ -18,6 +19,9 @@ const PDFStatementList = () => {
   const facilityCopays = statements?.filter(
     ({ pSFacilityNum }) => pSFacilityNum === facilityNumber,
   );
+
+  const sortedFacilityCopays = sortStatementsByDate(facilityCopays);
+
   const fullName = userFullName.middle
     ? `${userFullName.first} ${userFullName.middle} ${userFullName.last}`
     : `${userFullName.first} ${userFullName.last}`;
@@ -30,7 +34,7 @@ const PDFStatementList = () => {
         months.
       </p>
 
-      {facilityCopays.map(statement => (
+      {sortedFacilityCopays.map(statement => (
         <DownloadStatements
           key={statement.id}
           statementId={statement.id}

--- a/src/applications/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/medical-copays/containers/OverviewPage.jsx
@@ -1,14 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { uniqBy } from 'lodash';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 import FacilityContacts from '../components/FacilityContacts';
 import Balances from '../components/Balances';
 import BalanceQuestions from '../components/BalanceQuestions';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import Alert from '../components/Alerts';
+import { sortStatementsByDate } from '../utils/helpers';
 
 const OverviewPage = () => {
   const statementData = useSelector(({ mcp }) => mcp.statements);
+  const statementsByDate = sortStatementsByDate(statementData);
+  const statementsByUniqueFacility = uniqBy(statementsByDate, 'pSFacilityNum');
   const error = useSelector(({ mcp }) => mcp.error);
   const [alertType, setAlertType] = useState(null);
 
@@ -52,7 +56,7 @@ const OverviewPage = () => {
             Check your VA health care and prescription charges from each of your
             facilities. Find out how to make payments or request financial help.
           </p>
-          <Balances statementData={statementData} />
+          <Balances statementData={statementsByUniqueFacility} />
           <BalanceQuestions />
           <FacilityContacts facilities={facilities} />
         </>

--- a/src/applications/medical-copays/utils/helpers.js
+++ b/src/applications/medical-copays/utils/helpers.js
@@ -41,6 +41,23 @@ export const titleCase = str => {
     .join(' ');
 };
 
+export const sortStatementsByDate = statements => {
+  return statements.sort((a, b) => {
+    const aDate = formatDate(a.pSProcessDateOutput);
+    const bDate = formatDate(b.pSProcessDateOutput);
+
+    if (aDate > bDate) {
+      return 1;
+    }
+
+    if (aDate < bDate) {
+      return -1;
+    }
+
+    return 0;
+  });
+};
+
 export const transform = data => {
   return data.map(statement => {
     const { station } = statement;


### PR DESCRIPTION
## Description
- Sort statements by date
- deDuplicate statements by facility
- Sort PDF from newest to oldest

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33709
department-of-veterans-affairs/va.gov-team#33707


## Testing done
Manual testing

## Screenshots
N/A

## Acceptance criteria
- [x] Facilities are not repeated on overview page
- [x] Only the latest copay shows on overview page 
- [x] PDFs are sorted from newest to oldest.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
