### PR TITLE
Fix tabbing issue

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -243,6 +243,7 @@ const SearchResult = ({
           data-testid={`pdf-link-${id}`}
           rel="noreferrer noopener"
           href={showPDFInfoVersionOne && !doesCookieExist ? null : url}
+          tabIndex="0"
           onClick={() => pdfDownloadHandler()}
           {...linkProps}
         >


### PR DESCRIPTION
## Description
This PR adds tab order 0 to add these clickable links without hrefs to the tab list. The tabIndex is set to 0 to ensure that no other tab order is disturbed, but without it, these items WILL NOT be tab-able.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33343


## Testing done
Manual Testing

