### PR TITLE
removed default sorting

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
@@ -78,10 +78,6 @@ class Payments extends Component {
           <Table
             ariaLabelledBy={tableAriaLabelldBy}
             className="va-table"
-            currentSort={{
-              value: 'String',
-              order: 'ASC',
-            }}
             fields={this.props.fields}
             data={this.state.currentlyShowingData}
             maxRows={10}


### PR DESCRIPTION
## Description
[Orignal Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/33460)

We needed to remove the default sorting on the table in the view payments app so that the data is sorting according to how it comes back from the API, this PR removes that sorting.

## Testing done
Tested Locally

## Acceptance criteria
- [x] The list shown for a Veteran is defaulted to latest, most recent payments are at the top.
