### PR TITLE
[COE] Get COE request status from backend

### DIFF
--- a/src/applications/lgy/coe/actions/index.js
+++ b/src/applications/lgy/coe/actions/index.js
@@ -1,27 +1,27 @@
+import { apiRequest } from 'platform/utilities/api';
+
 export const GENERATE_AUTOMATIC_COE_STARTED = 'GENERATE_AUTOMATIC_COE_STARTED';
 export const GENERATE_AUTOMATIC_COE_SUCCEEDED =
   'GENERATE_AUTOMATIC_COE_SUCCEEDED';
 export const GENERATE_AUTOMATIC_COE_FAILED = 'GENERATE_AUTOMATIC_COE_FAILED';
 export const SKIP_AUTOMATIC_COE_CHECK = 'SKIP_AUTOMATIC_COE_CHECK';
 
-const mockApiCall = () => {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve({ status: 'pending' });
-    }, 2000);
-  });
-  //   return new Promise(reject => {
-  //     setTimeout(() => {
-  //       reject({ errors: [{ status: '500' }] });
-  //     }, 2000);
-  //   });
+const COE_STATUS_URI = '/coe/status';
+
+export const getCoeStatus = async () => {
+  try {
+    const response = await apiRequest(COE_STATUS_URI);
+    return response.data.attributes;
+  } catch (error) {
+    return error;
+  }
 };
 
 export const generateCoe = (skip = '') => async dispatch => {
   const shouldSkip = !!skip;
   if (!shouldSkip) {
     dispatch({ type: GENERATE_AUTOMATIC_COE_STARTED });
-    const response = await mockApiCall();
+    const response = await getCoeStatus();
     if (response.errors) {
       dispatch({ type: GENERATE_AUTOMATIC_COE_FAILED, response });
     } else {


### PR DESCRIPTION
## Description
We have been mocking the API call to get the COE status. The backend code is almost in place for this endpoint, so we can start calling the API instead of mocking the call / response.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33840

## Acceptance criteria
- [ ] Frontend calls backend API to get COE status

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
