### PR TITLE
Remove search query from GIBCT locations search

### DIFF
--- a/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
@@ -401,7 +401,7 @@ function LocationSearchResults({
         recordEvent({
           event: 'view_search_results',
           'search-page-path': document.location.pathname,
-          'search-query': location,
+          'search-query': '[redacted]',
           'search-results-total-count': count,
           'search-results-total-pages': undefined,
           'search-selection': 'GIBCT',


### PR DESCRIPTION
## Description
Apologies for the last minute change @mrblanco, @dsrr47, and @af-manish, but I think the potential for PII in our search event is unfortunately too high to risk.  

([Google's guidance](https://support.google.com/analytics/answer/6366371?hl=en#zippy=%2Cin-this-article))

We can look into extracting acceptable geo parameters (like city + state) in the future, but for now I have to recommend we redact the search query.  The "Use My Location" feature definitely puts us over the edge.

Let me know if we can't sneak this out to staging for tomorrow and I'll try to redact via GTM for now.
