### PR TITLE
Visual focus on school title on result card

### DIFF
--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -114,25 +114,21 @@ export function ResultCard({
   const nameCityStateHeader = (
     <>
       <div>
-        <Link
-          to={profileLink}
-          aria-labelledby={`${facilityCode}-label ${facilityCode}-classification`}
-          onClick={() =>
-            recordEvent({
-              event: 'gibct-view-profile',
-              'school-name': name,
-              'has-warnings': cautionFlags.length > 0,
-            })
-          }
-        >
-          <h3
-            className={nameClasses}
-            aria-label={`${institution.name}, `}
-            id={`${institution.facilityCode}-label`}
+        <h3 className={nameClasses}>
+          <Link
+            to={profileLink}
+            aria-labelledby={`${facilityCode}-label ${facilityCode}-classification`}
+            onClick={() =>
+              recordEvent({
+                event: 'gibct-view-profile',
+                'school-name': name,
+                'has-warnings': cautionFlags.length > 0,
+              })
+            }
           >
             {name}
-          </h3>
-        </Link>
+          </Link>
+        </h3>
       </div>
       <p className="vads-u-padding--0">
         {city}

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -114,7 +114,11 @@ export function ResultCard({
   const nameCityStateHeader = (
     <>
       <div>
-        <h3 className={nameClasses}>
+        <h3
+          className={nameClasses}
+          aria-label={`${institution.name}, `}
+          id={`${institution.facilityCode}-label`}
+        >
           <Link
             to={profileLink}
             aria-labelledby={`${facilityCode}-label ${facilityCode}-classification`}


### PR DESCRIPTION
## Description
Visual focus was not indicated when tabbing through results for the title on the result card. This fixes that.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33875


## Testing done
See screenshots

## Screenshots
Focus is on school title, but obviously not visible on screen:
![image](https://user-images.githubusercontent.com/90346049/145632750-d2de150a-6f9f-427e-aa17-fc7db7621572.png)
After fix:
![image](https://user-images.githubusercontent.com/90346049/145632771-2bbaebe9-5caa-48a1-85aa-b6e620a04cc9.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
