### PR TITLE
Force visual focus and tabability for Pagination component.

### DIFF
--- a/src/applications/gi-sandbox/containers/search/NameSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/NameSearchResults.jsx
@@ -36,6 +36,34 @@ export function NameSearchResults({
     [search.name.results],
   );
 
+  // We use the Pagination component from the VA Component Library. This doesn't seem to handle
+  // visual focus so after page load, let's grab the anchor tags for the 3 pagination elements
+  // and add href="#" to them (this is all that is needed to force visual focus and tabability)
+  useEffect(() => {
+    const paginationPrev = document.getElementsByClassName(
+      'va-pagination-prev',
+    );
+    const paginationInner = document.getElementsByClassName(
+      'va-pagination-inner',
+    );
+    const paginationNext = document.getElementsByClassName(
+      'va-pagination-next',
+    );
+
+    if (paginationInner.length > 0) {
+      const anchors = [
+        ...paginationPrev[0].getElementsByTagName('a'),
+        ...paginationInner[0].getElementsByTagName('a'),
+        ...paginationNext[0].getElementsByTagName('a'),
+      ];
+      if (anchors) {
+        for (const a of anchors) {
+          a.href = '#';
+        }
+      }
+    }
+  });
+
   useEffect(
     () => {
       focusElement('#name-search-results-count');


### PR DESCRIPTION
## Description
This modifies the Pagination component elements on page to have href="#" which will allow for tab focus and visual focus indicator.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33878


## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/90346049/145648483-50f830d3-8f35-4b98-a19d-7ed3d4bfbe35.png)
![image](https://user-images.githubusercontent.com/90346049/145648499-a5189283-63ab-4718-939a-16893c54d267.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
