### PR TITLE
added tabIndex and role to "skip to estimated benefits"  a tag

### DIFF
--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -1002,6 +1002,8 @@ function CalculateYourBenefitsForm({
           aria-label="Skip to your estimated benefits"
           href="#estimated-benefits"
           id="skip-to-eyb"
+          tabIndex="0"
+          role="button"
         >
           Skip to your estimated benefits
         </a>


### PR DESCRIPTION
## Description
### Platform Issue
Page functionality isn't keyboard accessible.

### Issue Details
"Skip to your estimated benefits" link on single page is not functional

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#338800](https://github.com/department-of-veterans-affairs/va.gov-team/issues/33880)


## Testing done
local environment

## Screenshots
<img width="1052" alt="Screen Shot 2021-12-13 at 10 26 59 AM" src="https://user-images.githubusercontent.com/18352271/145851503-a5c24687-59be-428f-986c-801877c30599.png">


## Acceptance criteria
- [ ] skip to estimated benefits link is navigable by keyboard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
