### PR TITLE
adding logic to handle passing provider to api call when the resident…

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -8,7 +8,7 @@ import {
   TYPE_OF_VISIT,
   LANGUAGES,
 } from '../../../utils/constants';
-import { selectHasVAPResidentialAddress } from '../../../redux/selectors';
+import { selectFeatureCCIterations } from '../../../redux/selectors';
 import {
   getTypeOfCare,
   getFormData,
@@ -116,12 +116,12 @@ export function transformFormToVARequest(state) {
 
 export function transformFormToCCRequest(state) {
   const data = getFormData(state);
-  const hasResidentialAddress = selectHasVAPResidentialAddress(state);
+  const featureCCIteration = selectFeatureCCIterations(state);
   const provider = data.communityCareProvider;
   let preferredProviders = [];
 
   if (
-    hasResidentialAddress &&
+    featureCCIteration &&
     !!data.communityCareProvider &&
     Object.keys(data.communityCareProvider).length
   ) {

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
@@ -67,6 +67,9 @@ describe('VAOS data transformation', () => {
         },
         flowType: FLOW_TYPES.REQUEST,
       },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: true,
+      },
     };
     const data = transformFormToVARequest(state);
     expect(data).to.deep.equal({
@@ -157,6 +160,9 @@ describe('VAOS data transformation', () => {
           ],
         },
         flowType: FLOW_TYPES.REQUEST,
+      },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: true,
       },
     };
     const data = transformFormToVARequest(state);
@@ -262,6 +268,9 @@ describe('VAOS data transformation', () => {
         facilityDetailsStatus: FETCH_STATUS.succeeded,
         pastAppointments: null,
         submitStatus: 'succeeded',
+      },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: false,
       },
     };
     const data = transformFormToCCRequest(state);
@@ -386,6 +395,9 @@ describe('VAOS data transformation', () => {
         facilityDetailsStatus: FETCH_STATUS.succeeded,
         pastAppointments: null,
         submitStatus: 'succeeded',
+      },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: false,
       },
     };
     const data = transformFormToCCRequest(state);
@@ -525,6 +537,9 @@ describe('VAOS data transformation', () => {
           ],
         },
       },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: true,
+      },
     };
     const data = transformFormToAppointment(state);
     expect(data).to.deep.equal({
@@ -608,6 +623,9 @@ describe('VAOS data transformation', () => {
           ],
         },
         flowType: FLOW_TYPES.REQUEST,
+      },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: true,
       },
     };
     const data = transformFormToVARequest(state);
@@ -719,6 +737,9 @@ describe('VAOS data transformation', () => {
         pastAppointments: null,
         submitStatus: 'succeeded',
       },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: true,
+      },
     };
     const data = transformFormToCCRequest(state);
     expect(data).to.deep.equal({
@@ -755,6 +776,126 @@ describe('VAOS data transformation', () => {
       optionTime3: 'No Time Selected',
       preferredCity: 'Cincinnati',
       preferredState: 'OH',
+      requestedPhoneCall: false,
+      email: 'test@va.gov',
+      officeHours: [],
+      reasonForVisit: '',
+      visitType: 'Office Visit',
+      distanceWillingToTravel: 40,
+      secondRequest: false,
+      secondRequestSubmitted: false,
+      inpatient: false,
+      status: 'Submitted',
+      providerId: '0',
+      providerOption: '',
+    });
+  });
+
+  it('should transform form using provider selection into CC request when residential address is missing', () => {
+    const state = {
+      user: {
+        profile: {
+          facilities: [{ facilityId: '983', isCerner: false }],
+          vapContactInfo: {
+            residentialAddress: null,
+          },
+        },
+      },
+      newAppointment: {
+        data: {
+          phoneNumber: '5035551234',
+          bestTimeToCall: {
+            afternoon: true,
+          },
+          email: 'test@va.gov',
+          reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: 'asdf',
+          communityCareSystemId: '983',
+          preferredLanguage: 'english',
+          communityCareProvider: {
+            name: 'Practice',
+            address: {
+              line: ['456 elm st', 'sfasdf'],
+              state: 'MA',
+              city: 'northampton',
+              postalCode: '01050',
+            },
+            firstName: 'test',
+            lastName: 'mctesty',
+          },
+          selectedDates: ['2019-11-20T12:00:00.000'],
+          facilityType: 'communityCare',
+          typeOfCareId: '323',
+        },
+        facilities: {},
+        facilityDetails: {},
+        clinics: {},
+        eligibility: {},
+        ccEnabledSystems: [
+          {
+            id: '983',
+            vistaId: '983',
+            name: 'CHYSHR-Cheyenne VA Medical Center',
+            address: {
+              city: 'Cheyenne',
+              state: 'WY',
+            },
+          },
+          {
+            id: '984',
+            vistaId: '984',
+            address: {
+              city: 'Dayton',
+              state: 'OH',
+            },
+          },
+        ],
+        pageChangeInProgress: false,
+        parentFacilitiesStatus: FETCH_STATUS.succeeded,
+        eligibilityStatus: FETCH_STATUS.succeeded,
+        facilityDetailsStatus: FETCH_STATUS.succeeded,
+        pastAppointments: null,
+        submitStatus: 'succeeded',
+      },
+      featureToggles: {
+        vaOnlineSchedulingCCIterations: true,
+      },
+    };
+    const data = transformFormToCCRequest(state);
+    expect(data).to.deep.equal({
+      typeOfCare: 'CCPRMYRTNE',
+      typeOfCareId: 'CCPRMYRTNE',
+      appointmentType: 'Primary care',
+      facility: {
+        name: 'CHYSHR-Cheyenne VA Medical Center',
+        facilityCode: '983',
+        parentSiteCode: '983',
+      },
+      purposeOfVisit: 'other',
+      phoneNumber: '5035551234',
+      verifyPhoneNumber: '5035551234',
+      bestTimetoCall: ['Afternoon'],
+      preferredProviders: [
+        {
+          address: {
+            street: '456 elm st, sfasdf',
+            city: 'northampton',
+            state: 'MA',
+            zipCode: '01050',
+          },
+          practiceName: 'Practice',
+        },
+      ],
+      newMessage: 'asdf',
+      preferredLanguage: 'English',
+      optionDate1: '11/20/2019',
+      optionDate2: 'No Date Selected',
+      optionDate3: 'No Date Selected',
+      optionTime1: 'PM',
+      optionTime2: 'No Time Selected',
+      optionTime3: 'No Time Selected',
+      preferredCity: 'Cheyenne',
+      preferredState: 'WY',
       requestedPhoneCall: false,
       email: 'test@va.gov',
       officeHours: [],


### PR DESCRIPTION
…ial address is null

## Description
This PR fixes the issue where the provider is missing when calling the api to schedule an appointment. This was occuring when the residential address was missing for a patient.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32687


## Testing done
Manual and Unit

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/145864475-b37b0d2f-0458-4708-b10f-06ae31eb1c34.png)


## Acceptance criteria
- [ ] Login to VAOS as a test user (grethel.g.petryniec@id.me)
Follow the steps to create a request for CC supported type of care (Eg:- Optometry, Food and Nutrition, Primary Care etc.)
Choose a provider from the list and click on continue
Fill in the required fields to enter a CC request
Expected Results: Previously selected provider information should display on the "Review your appointment detail" page and Request card details

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
