### PR TITLE
Covice vaccine trials - create local mock for intake and update endpoints

### DIFF
--- a/src/applications/coronavirus-research/shared/api/local-mock-api/mocks/mock.js
+++ b/src/applications/coronavirus-research/shared/api/local-mock-api/mocks/mock.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 const commonResponses = require('../../../../../../platform/testing/local-dev-mock-api/common');
 
 const delay = require('mocker-api/lib/delay');

--- a/src/applications/coronavirus-research/shared/api/local-mock-api/mocks/mock.js
+++ b/src/applications/coronavirus-research/shared/api/local-mock-api/mocks/mock.js
@@ -1,0 +1,22 @@
+/* eslint-disable camelcase */
+const commonResponses = require('../../../../../../platform/testing/local-dev-mock-api/common');
+
+const delay = require('mocker-api/lib/delay');
+
+const responses = {
+  ...commonResponses,
+  'POST /covid-research/volunteer/create': (req, res) => {
+    return res.status(202).json({
+      status: 'accepted',
+      code: 202,
+    });
+  },
+  'POST /covid-research/volunteer/update': (req, res) => {
+    return res.status(202).json({
+      status: 'accepted',
+      code: 202,
+    });
+  },
+};
+
+module.exports = delay(responses, 2000);


### PR DESCRIPTION
## Description
This PR just adds a local mock file that mocks these endpoints:
* `POST /covid-research/volunteer/create`
* `POST /covid-research/volunteer/update`

launch mocks with: `yarn mock-api --responses src/applications/coronavirus-research/shared/api/local-mock-api/mocks/mock.js`

## Testing done
Manual testing

## Acceptance criteria
- [x] endpoints are mocked locally
- [x] HTTP response code 202 - `accepted` is returned for both endpoints

