### PR TITLE
remove 'a' in pronouns field description

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInformationView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationView.jsx
@@ -14,8 +14,15 @@ import {
 
 const ProfileInformationView = props => {
   const { data, fieldName, title } = props;
+
+  const titleLower = title.toLowerCase();
+
+  // decide whether to use 'a', or nothing
+  const titleFormatted =
+    titleLower !== 'pronouns' ? `a ${titleLower}` : titleLower;
+
   if (!data) {
-    return <span>Edit your profile to add a {title.toLowerCase()}.</span>;
+    return <span>Edit your profile to add {titleFormatted}.</span>;
   }
 
   if (fieldName === FIELD_NAMES.EMAIL) {


### PR DESCRIPTION
## Description
Minor spelling correction so that the pronouns field description does not include 'a'

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31685


## Testing done
Ran e2e tests and tested locally.


## Screenshots

Fixed view:
![Screen Shot 2021-12-14 at 8 28 57 AM](https://user-images.githubusercontent.com/8332986/146028139-01a8185c-109f-4e36-aa66-c6718ef46bad.png)


## Acceptance criteria
- [x] Pronouns description doesn't include 'a'
