### PR TITLE
#29367 fix: update caution flags layout when none are present

### DIFF
--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -373,7 +373,9 @@ const CompareLayout = ({
                 <div className="vads-u-display--flex">                  
                   {hasFlags && (
                     <div className="caution-flag-icon vads-u-flex--1">
-                      <i aria-hidden="true" className={`fa fa-exclamation-triangle`} />
+                      <i 
+                        aria-hidden="true" 
+                        className={`fa fa-exclamation-triangle`} />
                     </div>
                   )}
                   <div className="vads-u-flex--4">

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -370,24 +370,27 @@ const CompareLayout = ({
             mapper: institution => {
               const hasFlags = institution.cautionFlags.length > 0;
               return (
-                <div className="vads-u-display--flex">
-                  <div className="caution-flag-icon vads-u-flex--1">
-                    {!hasFlags && <i className={`fa fa-check`} />}
-                    {hasFlags && <i className={`fa fa-exclamation-triangle`} />}
-                  </div>
+                <div className="vads-u-display--flex">                  
+                  {hasFlags && (
+                    <div className="caution-flag-icon vads-u-flex--1">
+                      <i className={`fa fa-exclamation-triangle`} />
+                    </div>
+                  )}
                   <div className="vads-u-flex--4">
-                    <div className="caution-header">
-                      {!hasFlags && (
+                    {!hasFlags && (
+                      <div>
                         <span>This school doesn’t have any caution flags</span>
-                      )}
-                      {hasFlags && (
+                      </div>
+                    )}
+                    {hasFlags && (
+                      <div className="caution-header">
                         <span>
                           This school has {institution.cautionFlags.length}{' '}
                           cautionary warning
                           {institution.cautionFlags.length > 1 && 's'}
                         </span>
-                      )}
-                    </div>
+                      </div>
+                    )}
                     {hasFlags && (
                       <div>
                         <ul>

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -373,7 +373,7 @@ const CompareLayout = ({
                 <div className="vads-u-display--flex">                  
                   {hasFlags && (
                     <div className="caution-flag-icon vads-u-flex--1">
-                      <i className={`fa fa-exclamation-triangle`} />
+                      <i aria-hidden="true" className={`fa fa-exclamation-triangle`} />
                     </div>
                   )}
                   <div className="vads-u-flex--4">

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -370,12 +370,13 @@ const CompareLayout = ({
             mapper: institution => {
               const hasFlags = institution.cautionFlags.length > 0;
               return (
-                <div className="vads-u-display--flex">                  
+                <div className="vads-u-display--flex">
                   {hasFlags && (
                     <div className="caution-flag-icon vads-u-flex--1">
-                      <i 
-                        aria-hidden="true" 
-                        className={`fa fa-exclamation-triangle`} />
+                      <i
+                        aria-hidden="true"
+                        className={`fa fa-exclamation-triangle`}
+                      />
                     </div>
                   )}
                   <div className="vads-u-flex--4">


### PR DESCRIPTION
## Description

- A change to the comparison tool layout was required to comply with design standards when a school does not have any cautionary warnings

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29367

## Testing done

- Verified locally

## Screenshots

![Screen Shot 2021-12-14 at 11 07 08 AM](https://user-images.githubusercontent.com/3201/146046792-e129cb99-3d1e-435c-b79a-890a3146f927.png)

## Acceptance criteria
- [ ] the display matches the ticket

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
