### PR TITLE
Remove 'compare institutions' from breadcrumbs

### DIFF
--- a/src/applications/gi-sandbox/components/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi-sandbox/components/GiBillBreadcrumbs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-import { useRouteMatch, Link, useHistory } from 'react-router-dom';
+import { useRouteMatch, Link } from 'react-router-dom';
 import { useQueryParams } from '../utils/helpers';
 
 const GiBillBreadcrumbs = () => {
@@ -8,7 +8,6 @@ const GiBillBreadcrumbs = () => {
   const compareMatch = useRouteMatch('/compare');
   const queryParams = useQueryParams();
   const version = queryParams.get('version');
-  const history = useHistory();
 
   const root = version
     ? {
@@ -27,12 +26,6 @@ const GiBillBreadcrumbs = () => {
       GI Bill® Comparison Tool
     </Link>,
   ];
-
-  if (history.location?.state?.prevPath) {
-    crumbs.push(
-      <Link onClick={() => history.goBack()}>Compare institutions</Link>,
-    );
-  }
 
   if (profileMatch) {
     crumbs.push(


### PR DESCRIPTION
## Description
Removes compare instituions from the breadcrumbs.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33885


## Testing done

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/90346049/146051911-06749085-d9a9-4f37-8752-424bfda4f409.png)
After:
![image](https://user-images.githubusercontent.com/90346049/146051974-cea45046-a434-4e5b-a7b1-d63cbb048a00.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
