### PR TITLE
Add # of results for CCP & pharmacies

### DIFF
--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -94,12 +94,9 @@ export const SearchResultsHeader = ({
         className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
         tabIndex="-1"
       >
-        {[
-          LocationType.URGENT_CARE,
-          LocationType.EMERGENCY_CARE,
-          LocationType.URGENT_CARE_PHARMACIES,
-          LocationType.CC_PROVIDER,
-        ].includes(facilityType)
+        {[LocationType.URGENT_CARE, LocationType.EMERGENCY_CARE].includes(
+          facilityType,
+        )
           ? messagePrefix
           : handleNumberOfResults()}{' '}
         for &quot;

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -207,11 +207,12 @@ describe('SearchResultsHeader', () => {
         serviceType="foo"
         context="new york"
         specialtyMap={{ foo: 'test' }}
+        pagination={{ totalEntries: 5 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+      /Showing 1 - 5 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -199,7 +199,73 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
-  it('should render header with LocationType.CC_PROVIDER', () => {
+  it('should render header with LocationType.URGENT_CARE_PHARMACIES, totalEntries = 1', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.URGENT_CARE_PHARMACIES}
+        context="new york"
+        pagination={{ totalEntries: 1 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 result for "Community pharmacies \(in VA’s network\)"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.URGENT_CARE_PHARMACIES, totalEntries = 5', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.URGENT_CARE_PHARMACIES}
+        context="new york"
+        pagination={{ totalEntries: 5 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 - 5 results for "Community pharmacies \(in VA’s network\)"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.URGENT_CARE_PHARMACIES, totalEntries = 15, currentPage = 2, totalPages = 2', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.URGENT_CARE_PHARMACIES}
+        context="new york"
+        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 11 - 15 of 15 results for "Community pharmacies \(in VA’s network\)"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.CC_PROVIDER, totalEntries = 1', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CC_PROVIDER}
+        serviceType="foo"
+        context="new york"
+        specialtyMap={{ foo: 'test' }}
+        pagination={{ totalEntries: 1 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 result for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.CC_PROVIDER, totalEntries = 5', () => {
     const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
@@ -213,6 +279,24 @@ describe('SearchResultsHeader', () => {
 
     expect(wrapper.find('h2').text()).to.match(
       /Showing 1 - 5 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.CC_PROVIDER, totalEntries = 15, currentPage = 2, totalPages = 2', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CC_PROVIDER}
+        serviceType="foo"
+        context="new york"
+        specialtyMap={{ foo: 'test' }}
+        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 11 - 15 of 15 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -173,9 +173,10 @@ describe('Facility VA search', () => {
 
   it('shows search result header even when no results are found', () => {
     cy.visit('/find-locations');
-    cy.intercept('GET', '/facilities_api/v1/ccp/provider?**', { data: [] }).as(
-      'searchFacilities',
-    );
+    cy.intercept('GET', '/facilities_api/v1/ccp/provider?**', {
+      data: [],
+      meta: { pagination: { totalEntries: 0 } },
+    }).as('searchFacilities');
 
     cy.get('#street-city-state-zip').type('27606');
     cy.get('#facility-type-dropdown').select(CC_PROVIDER);


### PR DESCRIPTION
## Description
Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/32811

This PR shows number of results for community care providers and pharmacy searches.

For example:
<details>
<summary>If we get back 1 result, should read as:</summary>


<img width="1037" alt="Screen Shot 2021-11-09 at 11 01 21 PM" src="https://user-images.githubusercontent.com/84030819/141202020-044c6b13-bd26-41bf-98b7-faaf957453ad.png">

</details>


<details>
<summary>If we get back less than or equal to 10 results, should read as:</summary>


![Screen Shot 2021-11-10 at 5 13 43 PM](https://user-images.githubusercontent.com/84030819/141202338-e4b15fa9-e4f2-46c7-b567-b7b254628ff6.png)
</details>

<details>
<summary>If we get back more than 10 results, should read as:</summary>

![Screen Shot 2021-11-10 at 5 12 14 PM](https://user-images.githubusercontent.com/84030819/141202156-da5e3f36-aa87-4262-85db-e66723d660ef.png)

</details>

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
