### PR TITLE
HLR: prevent JS error

### DIFF
--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -40,7 +40,8 @@ export const ContactInfoDescription = ({
 
   const list = readableList(missingInfo);
   const plural = missingInfo.length > 1;
-  const phoneNumber = `${mobilePhone?.areaCode}${mobilePhone?.phoneNumber}`;
+  const phoneNumber = `${mobilePhone?.areaCode ||
+    ''}${mobilePhone?.phoneNumber || ''}`;
   const phoneExt = mobilePhone?.extension;
 
   useEffect(

--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -35,13 +35,12 @@ export const ContactInfoDescription = ({
   const missingInfo = [
     email?.emailAddress ? '' : 'email',
     mobilePhone?.phoneNumber ? '' : 'phone',
-    mailingAddress.addressLine1 ? '' : requireAddress,
+    mailingAddress?.addressLine1 ? '' : requireAddress,
   ].filter(Boolean);
 
   const list = readableList(missingInfo);
   const plural = missingInfo.length > 1;
-
-  const phoneNumber = `${mobilePhone.areaCode}${mobilePhone?.phoneNumber}`;
+  const phoneNumber = `${mobilePhone?.areaCode}${mobilePhone?.phoneNumber}`;
   const phoneExt = mobilePhone?.extension;
 
   useEffect(

--- a/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
@@ -56,6 +56,22 @@ describe('Veteran information review content', () => {
     tree.unmount();
   });
 
+  it('should not throw JS error when contact info value is null', () => {
+    const data = getData();
+    data.profile.vapContactInfo = {
+      mobilePhone: null,
+      mailingAddress: null,
+      email: null,
+    };
+
+    const tree = shallow(<ContactInfoDescription {...data} />);
+
+    expect(tree.find('PhoneField')).to.exist;
+    expect(tree.find('EmailField')).to.exist;
+    expect(tree.find('MailingAddress')).to.exist;
+    tree.unmount();
+  });
+
   it('should render contact information main loop', () => {
     const data = getData({ loopPages: true });
     const tree = shallow(<ContactInfoDescription {...data} />);


### PR DESCRIPTION
## Description

Fix JS error that occurs in the Higher-Level Review contact information page when  either the mobile phone or mailing address isn't defined (`null`)

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34182

## Testing done

Added unit test

## Screenshots

N/A

## Acceptance criteria
- [x] Fix bug and prevent JS error
- [x] Add tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
