### PR TITLE
Enable Cypress viewport ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -264,6 +264,7 @@ module.exports = {
       files: ['**/*.cypress.spec.js'],
       rules: {
         'va/axe-check-required': 1,
+        'va/cypress-viewport-deprecated': 1,
       },
     },
   ],

--- a/script/eslint-plugin-va/index.js
+++ b/script/eslint-plugin-va/index.js
@@ -6,6 +6,7 @@ module.exports = {
     'resolved-path-on-required': require('./rules/resolved-path-on-required.js'),
     'axe-check-required': require('./rules/axe-e2e-tests.js'),
     'correct-apostrophe': require('./rules/correct-apostrophe'),
+    'cypress-viewport-deprecated': require('./rules/cypress-viewport-deprecated'),
   },
   rulesConfig: {
     'proptypes-camel-cased': 2,


### PR DESCRIPTION
## Description
PR to enable the `cypress-viewport-deprecated` ESLint rule.

## Acceptance criteria
- [ ] Rule works locally.
- [ ] CI passes.