### PR TITLE
33881  - Multiple HTML fixes for accessibility html issues

### DIFF
--- a/src/applications/gi-sandbox/components/Checkbox.jsx
+++ b/src/applications/gi-sandbox/components/Checkbox.jsx
@@ -18,6 +18,7 @@ const Checkbox = ({
   labelAriaLabel,
   inputAriaLabelledBy,
   inputAriaLabel,
+  screenReaderOnly,
 }) => {
   const inputId = _.uniqueId('errorable-checkbox-');
   const hasErrors = !!errorMessage;
@@ -55,6 +56,11 @@ const Checkbox = ({
       >
         {label}
         {required && <span className="form-required-span">*</span>}
+        {screenReaderOnly && (
+          <span className="vads-u-visibility--screen-reader">
+            {screenReaderOnly}
+          </span>
+        )}
       </label>
       {hasErrors && (
         <span className="usa-input-error-message" role="alert" id={errorSpanId}>

--- a/src/applications/gi-sandbox/components/CompareCheckbox.jsx
+++ b/src/applications/gi-sandbox/components/CompareCheckbox.jsx
@@ -5,16 +5,17 @@ export default function CompareCheckbox({
   institution,
   compareChecked,
   handleCompareUpdate,
+  facilityCode,
 }) {
-  const name = `Compare ${institution}`;
+  const name = `Compare ${institution} ${facilityCode}`;
   return (
     <div className="vads-u-padding--0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5">
       <Checkbox
         label="Compare"
         checked={compareChecked}
         onChange={handleCompareUpdate}
-        inputAriaLabel={name}
         name={name}
+        screenReaderOnly={name}
       />
     </div>
   );

--- a/src/applications/gi-sandbox/components/SchoolClassification.jsx
+++ b/src/applications/gi-sandbox/components/SchoolClassification.jsx
@@ -47,7 +47,7 @@ export default function SchoolClassification({
     <>
       <div
         className={schoolClassificationClasses}
-        id={`${facilityCode}-classification`}
+        id={`classification-${facilityCode}`}
       >
         <p className={schoolClassificationPTagClasses}>
           <strong>

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -114,14 +114,9 @@ export function ResultCard({
   const nameCityStateHeader = (
     <>
       <div>
-        <h3
-          className={nameClasses}
-          aria-label={`${institution.name}, `}
-          id={`${institution.facilityCode}-label`}
-        >
+        <h3 className={nameClasses} id={`label-${institution.facilityCode}`}>
           <Link
             to={profileLink}
-            aria-labelledby={`${facilityCode}-label ${facilityCode}-classification`}
             onClick={() =>
               recordEvent({
                 event: 'gibct-view-profile',
@@ -131,6 +126,9 @@ export function ResultCard({
             }
           >
             {name}
+            <span className="vads-u-visibility--screen-reader">
+              {`${institution.name}`}
+            </span>
           </Link>
         </h3>
       </div>
@@ -324,6 +322,7 @@ export function ResultCard({
             <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0">
               <CompareCheckbox
                 institution={name}
+                facilityCode={institution.facilityCode}
                 compareChecked={compareChecked}
                 handleCompareUpdate={handleCompareUpdate}
               />


### PR DESCRIPTION
## Multiple HTML fixes for accessibility html issues


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/33881

## Description

As per issue details and suggestions made additionally by @noahgelman:

> The HTML of card markup uses incorrect HTML. The id of the classification header begins with a number. Ids cannot start with numbers. The a tag does not need the aria-labelledby property to point to it's own content. The h3 inside the a tag does not need the aria-label. The aria-label value is the same as it's own value. All of this was done to add the classification to the end of the card link. Just add the classification to the end of the link as screenreader only text. Same thing for the Compare checkbox. Remove all the aria-labels. Put whatever labelling that is necessary inside the label element. If it needs to be screen reader only then put it in screenreader only text. The name and id attributes on the Compare checkbox and label are not unique. Some card titles are the same, but in different locations. Doing a search for UNIVERSITY OF HEALTH SCIENCES AND PHARMACY IN ST LOUIS has 2 UNIVERSITY OF HEALTH SCIENCES AND PHARMACY IN ST LOUIS results and therefore their id and name attributes are the same.

### Detailed individual issue resolution

**The id of the classification header begins with a number. Ids cannot start with numbers.**
*Reverse classification header facility code to end of property*

**The a tag does not need the aria-labelledby property to point to it's own content.**
*Remove aria-labelledby*

**The h3 inside the a tag does not need the aria-label. The aria-label value is the same as it's own value. All of this was done to add the classification to the end of the card link. Just add the classification to the end of the link as screenreader only text.**
*Remove aria-label and add screen reader only tag*

**Same thing for the Compare checkbox. Remove all the aria-labels. Put whatever labelling that is necessary inside the label element. If it needs to be screen reader only then put it in screenreader only text.**
*Remove aria-label and add screen reader only tag*

**The name and id attributes on the Compare checkbox and label are not unique. Some card titles are the same, but in different locations.**
*Add facilitycode to tags for screen reader unique identifier tags*


**Doing a search for UNIVERSITY OF HEALTH SCIENCES AND PHARMACY IN ST LOUIS has 2 UNIVERSITY OF HEALTH SCIENCES AND PHARMACY IN ST LOUIS results and therefore their id and name attributes are the same.**
*Add facilitycode to tags for screen reader unique identifier tags*

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
