### PR TITLE
[Assistive tech and device support] Page functionality isn't keyboard accessible. (11.05.1)#33877

### DIFF
--- a/src/applications/gi-sandbox/components/Modal.jsx
+++ b/src/applications/gi-sandbox/components/Modal.jsx
@@ -204,7 +204,6 @@ class Modal extends React.Component {
             this.element = el;
           }}
         >
-          {closeButton}
           <div className={bodyClass}>
             <div role="document">
               {title && (
@@ -216,6 +215,7 @@ class Modal extends React.Component {
             </div>
             {this.renderAlertActions()}
           </div>
+          {closeButton}
         </div>
       </div>
     );
@@ -288,7 +288,7 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   clickToClose: false,
-  focusSelector: 'button, input, select, a',
+  focusSelector: 'h3, button, input, select, a',
 };
 
 export default Modal;


### PR DESCRIPTION
## Description
### Platform Issue
Page functionality isn't keyboard accessible.

### Issue Details
Sidebar "Learn more" modal content is not accessible by keyboard/screenreader technology. Focus is brought to the close button and if there is no link present in the modal content then the user is unable to navigate the content of the modal with the keyboard and therefore cannot read the modal content with a screenreader.

### Link, screenshot or steps to recreate
Navigate to GI Bill Search tool results. Use keyboard to tab to a "Learn More" button in sidebar. Open modal with keyboard. Try and use arrow keys or tabbing to reach the mooal content

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#33877
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/33877)

## Testing done
local Environment

## Screenshots
<img width="713" alt="Screen Shot 2021-12-16 at 3 49 26 PM" src="https://user-images.githubusercontent.com/18352271/146454202-e0427fcf-d28a-4e6b-8158-f0490d0b8bb5.png">
<img width="757" alt="Screen Shot 2021-12-16 at 3 49 33 PM" src="https://user-images.githubusercontent.com/18352271/146454223-251e34b0-7058-4efe-93a0-e5b1d5e78849.png">
<img width="750" alt="Screen Shot 2021-12-16 at 3 49 40 PM" src="https://user-images.githubusercontent.com/18352271/146454232-484c3483-79fd-47d9-96bc-4fdf3f1c970d.png">


## Acceptance criteria
- [ ] On open modal focus header.
- [ ] Modal is navigable by keyboard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
