### PR TITLE
HLR: Accessibility fixes

### DIFF
--- a/src/applications/disability-benefits/996/components/EligibleIssuesWidget.jsx
+++ b/src/applications/disability-benefits/996/components/EligibleIssuesWidget.jsx
@@ -9,7 +9,7 @@ import { someSelected, isEmptyObject } from '../utils/helpers';
 import { ContestedIssuesAlert } from '../content/contestedIssues';
 
 /**
- * EligibleIssuesWidget
+ * EligibleIssuesWidget (HLR v1)
  * Form system parameters passed into this widget
  * @typedef {Object}
  * @property {Boolean} autofocus - should auto focus
@@ -69,7 +69,6 @@ const EligibleIssuesWidget = props => {
     );
   }
 
-  // HLR v1 only
   const showError = required && formContext.submitted && !hasSelected;
   const wrapperClass = showError ? 'usa-input-error vads-u-margin-top--0' : '';
 

--- a/src/applications/disability-benefits/996/content/areaOfDisagreement.jsx
+++ b/src/applications/disability-benefits/996/content/areaOfDisagreement.jsx
@@ -50,6 +50,11 @@ export const issueName = ({ formData, formContext } = {}) => {
 // "hidden" class uses an !important flag, so we're using "hide" here
 export const issusDescription = ({ formContext }) => {
   const { pagePerItemIndex, submitted } = formContext;
+
+  // submitted may be an array (until this bug is fixed)
+  // see https://dsva.slack.com/archives/CBU0KDSB1/p1639684843152000
+  const hasSubmitted = Array.isArray(submitted) || submitted;
+
   // adding data-submitted attribute; updating the class name outside of React
   // breaks the areaOfDisagreementWorkAround
   return (
@@ -57,7 +62,7 @@ export const issusDescription = ({ formContext }) => {
       key={pagePerItemIndex}
       id={`area-of-disagreement-label-${pagePerItemIndex}`}
       className="area-of-disagreement-label vads-u-font-size--base vads-u-font-weight--normal"
-      data-submitted={submitted}
+      data-submitted={hasSubmitted}
     >
       Tell us what you disagree with. You can choose more than one.
       <span className="vads-u-font-weight--normal schemaform-required-span">

--- a/src/applications/disability-benefits/996/pages/issueSummary.js
+++ b/src/applications/disability-benefits/996/pages/issueSummary.js
@@ -3,6 +3,9 @@ import { SummaryTitle } from '../content/issueSummary';
 export default {
   uiSchema: {
     'ui:title': SummaryTitle,
+    'ui:options': {
+      forceDivWrapper: true,
+    },
   },
 
   schema: {

--- a/src/applications/disability-benefits/996/utils/ui.js
+++ b/src/applications/disability-benefits/996/utils/ui.js
@@ -36,10 +36,12 @@ export const areaOfDisagreementWorkAround = (hasSelection, index) => {
   const label = $(`#area-of-disagreement-label-${index}`);
   if (label) {
     const showError = label.dataset.submitted === 'true' && !hasSelection;
+    const wrapper = label?.nextElementSibling;
     label.classList.toggle('usa-input-error', showError);
-    label.parentElement.nextElementSibling.classList.toggle(
-      'usa-input-error',
-      showError,
-    );
+    if (wrapper) {
+      wrapper.classList.toggle('usa-input-error', showError);
+      // remove 3rem top margin added by usa-input-error
+      wrapper.classList.add('vads-u-margin-top--0');
+    }
   }
 };


### PR DESCRIPTION
## Description

While accessibility testing the Higher-Level Review version 2 updates, some minor issues were discovered:

- Issue summary page included a `<fieldset>` without an accompanying `<legend>`. Since this page doesn't include any form elements. The `<fieldset>` was replaced with a `<div>`
- The area of disagreement page was not properly showing error messages when trying to continue without selecting any checkboxes. This was determined to be a problem with a recent form system change (see [Slack](https://dsva.slack.com/archives/CBU0KDSB1/p1639684843152000)), but a work-around was implemented

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34266

## Testing done

- Manual axe scans on all pages
- Manual WAVE scans on all pages
- Color checks on all pages
- Content zoomed in on all pages
- Keyboard navigation testing concurrently with screen reader testing
- e2e tests already include axe testing

## Screenshots

<details><summary>Issue summary page view</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-12-16 at 4 07 45 PM](https://user-images.githubusercontent.com/136959/146457279-2d5ca85d-c637-4955-87dc-1001449624fc.png)</details>

<details><summary>Area of disagreement errors</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-12-16 at 4 07 27 PM](https://user-images.githubusercontent.com/136959/146457280-887c4b85-00bf-4873-9de4-910322291421.png)</details>

## Acceptance criteria
- [x] Prep for full a11y testing complete - a11y problems addressed
- [x] All tests passing (unit & e2e)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
