### PR TITLE
Force formContext.submitted to be a bool

### DIFF
--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -90,7 +90,11 @@ class SchemaForm extends React.Component {
   }
 
   onError(hasSubmitted = true) {
-    const formContext = set('submitted', hasSubmitted, this.state.formContext);
+    const formContext = set(
+      'submitted',
+      !!hasSubmitted,
+      this.state.formContext,
+    );
     this.setState({ formContext });
     scrollToFirstError();
   }

--- a/src/platform/forms-system/test/js/components/SchemaForm.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/SchemaForm.unit.spec.jsx
@@ -125,7 +125,7 @@ describe('Schemaform <SchemaForm>', () => {
     it('non-boolean onError args', () => {
       tree.getMountedInstance().onError({ err: 'An error message' });
 
-      expect(tree.getMountedInstance().state.formContext.submitted).to.be.false;
+      expect(tree.getMountedInstance().state.formContext.submitted).to.be.true;
     });
 
     it('submit', () => {

--- a/src/platform/forms-system/test/js/components/SchemaForm.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/SchemaForm.unit.spec.jsx
@@ -122,6 +122,12 @@ describe('Schemaform <SchemaForm>', () => {
 
       expect(tree.getMountedInstance().state.formContext.submitted).to.be.false;
     });
+    it('non-boolean onError args', () => {
+      tree.getMountedInstance().onError({ err: 'An error message' });
+
+      expect(tree.getMountedInstance().state.formContext.submitted).to.be.false;
+    });
+
     it('submit', () => {
       tree.subTree('Form').props.onSubmit();
 


### PR DESCRIPTION
## Description

Solves a [support issue](https://dsva.slack.com/archives/CBU0KDSB1/p1639684843152000) that came up.

#19460 made a change to allow SchemaForm's `onError` function to accept an arg so that `formContext.submitted` could be false. This `onError` function also gets passed to a dependency which was already [calling the function with a non-boolean arg](https://github.com/department-of-veterans-affairs/react-jsonschema-form/blob/b10769a8c9ce1d69ac51febe8ad07af09cc12de2/src/components/Form.js#L101). This PR converts the arg into a boolean before setting `formContext.submitted`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done

Unit testing.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
