### PR TITLE
Pre-check-in confirmation page updates

### DIFF
--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -22,13 +22,14 @@ const Confirmation = () => {
       data-testid="confirmation-wrapper"
     >
       <h1 tabIndex="-1" className="vads-u-margin-top--2">
-        You’ve completed pre check-in
+        You’ve completed pre-check-in
       </h1>
       <AppointmentBlock appointments={appointments} />
       {hasUpdates ? (
         <va-alert
           background-only
           status="info"
+          show-icon
           data-testid="confirmation-update-alert"
         >
           {/** TODO INFO ICON */}

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
@@ -4,13 +4,13 @@ class Confirmation {
   validatePageLoaded() {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
-      .and('have.text', 'You’ve completed pre check-in');
+      .and('have.text', 'You’ve completed pre-check-in');
   }
 
   validatePageContent() {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
-      .and('have.text', 'You’ve completed pre check-in');
+      .and('have.text', 'You’ve completed pre-check-in');
     cy.get("[data-testid='confirmation-wrapper']");
     cy.get("p[data-testid='appointment-day-location']");
     cy.get("[data-testid='appointment-list']");


### PR DESCRIPTION
## Description
Update pre-check-in subtitle on confirmation page and add icon to info alert box.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34210


## Testing done
Updated e2e test

## Screenshot
<img width="848" alt="Screen Shot 2021-12-17 at 9 53 56 AM" src="https://user-images.githubusercontent.com/4554388/146564316-e768df98-021e-425a-87f2-baee6bc7b190.png">
enshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
