### PR TITLE
33881 - Additional accessibility changes for comparison tool search result card

### DIFF
--- a/src/applications/gi-sandbox/components/Checkbox.jsx
+++ b/src/applications/gi-sandbox/components/Checkbox.jsx
@@ -19,6 +19,7 @@ const Checkbox = ({
   inputAriaLabelledBy,
   inputAriaLabel,
   screenReaderOnly,
+  showArialLabelledBy,
 }) => {
   const inputId = _.uniqueId('errorable-checkbox-');
   const hasErrors = !!errorMessage;
@@ -27,6 +28,9 @@ const Checkbox = ({
   const ariaLabelledBy = [inputAriaLabelledBy, labelId].filter(
     ariaId => ariaId !== null && ariaId !== undefined,
   );
+  const ariaLabelledByContent = inputAriaLabel
+    ? null
+    : ariaLabelledBy.join(' ');
 
   return (
     <div
@@ -43,7 +47,7 @@ const Checkbox = ({
         onChange={onChange}
         onFocus={onFocus}
         aria-label={inputAriaLabel}
-        aria-labelledby={inputAriaLabel ? null : ariaLabelledBy.join(' ')}
+        aria-labelledby={showArialLabelledBy ? ariaLabelledByContent : null}
       />
       <label
         className={classNames('gi-checkbox-label', {

--- a/src/applications/gi-sandbox/components/CompareCheckbox.jsx
+++ b/src/applications/gi-sandbox/components/CompareCheckbox.jsx
@@ -15,6 +15,7 @@ export default function CompareCheckbox({
         checked={compareChecked}
         onChange={handleCompareUpdate}
         name={name}
+        showArialLabelledBy={false}
         screenReaderOnly={name}
       />
     </div>

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -127,7 +127,7 @@ export function ResultCard({
           >
             {name}
             <span className="vads-u-visibility--screen-reader">
-              {`${institution.name}`}
+              {`classification-${institution.facilityCode}`}
             </span>
           </Link>
         </h3>


### PR DESCRIPTION
…result card

## Additional accessibility changes for comparison tool search result card


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/33881

Updates requested by @noahgelman:
@noahgelman

- The card title h3 > a > span screen reader text is incorrect. It is supposed to be the classification, not the card title. It is announcing the card title twice now

- The compare checkbox still has aria attributes. It doesnt need it. Put the content in it's label. If any of the labelling needs to be hidden, put it in a screen reader only span

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
