### PR TITLE
Add chaining to mailingAddress checks

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -108,7 +108,7 @@ export const uiSchema = {
         updateSchema: (formData, schema, uiSchemaCountry) => {
           const uiSchemaDisabled = uiSchemaCountry;
 
-          if (formData.mailingAddress['view:livesOnMilitaryBase']) {
+          if (formData.mailingAddress?.['view:livesOnMilitaryBase']) {
             const formDataMailingAddress = formData.mailingAddress;
             formDataMailingAddress.country = USA;
 
@@ -150,7 +150,7 @@ export const uiSchema = {
       },
       'ui:options': {
         replaceSchema: formData => {
-          if (formData.mailingAddress['view:livesOnMilitaryBase'] === true) {
+          if (formData.mailingAddress?.['view:livesOnMilitaryBase'] === true) {
             return {
               type: 'string',
               title: 'APO/FPO/DPO',
@@ -177,11 +177,11 @@ export const uiSchema = {
       'ui:title': 'State',
       'ui:options': {
         hideIf: formData =>
-          !formData.mailingAddress['view:livesOnMilitaryBase'] &&
+          !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
           formData.mailingAddress.country !== USA,
         updateSchema: formData => {
           if (
-            formData.mailingAddress['view:livesOnMilitaryBase'] ||
+            formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
             MILITARY_CITIES.includes(formData.mailingAddress.city)
           ) {
             return {
@@ -196,7 +196,7 @@ export const uiSchema = {
         },
       },
       'ui:required': formData =>
-        formData.mailingAddress['view:livesOnMilitaryBase'] ||
+        formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
         formData.mailingAddress.country === USA,
       'ui:validations': [
         {
@@ -214,7 +214,7 @@ export const uiSchema = {
       'ui:title': 'Postal code',
       'ui:validations': [validateZIP],
       'ui:required': formData =>
-        formData.mailingAddress['view:livesOnMilitaryBase'] ||
+        formData.mailingAddress?.['view:livesOnMilitaryBase'] ||
         formData.mailingAddress.country === USA,
       'ui:errorMessages': {
         required: 'Please enter a postal code',
@@ -224,7 +224,7 @@ export const uiSchema = {
       'ui:options': {
         widgetClassNames: 'va-input-medium-large',
         hideIf: formData =>
-          !formData.mailingAddress['view:livesOnMilitaryBase'] &&
+          !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
           formData.mailingAddress.country !== USA,
       },
     },


### PR DESCRIPTION
## Description

Add optional chaining to `view:livesOnMilitaryBase` checks within the form 526 all-claims form.

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/34350
- http://sentry.vfs.va.gov/organizations/vsp/issues/59999

## Testing done

Unit tests still passing

## Screenshots

N/A

## Acceptance criteria
- [x] Add chaining to prevent `view:livesOnMilitaryBase` error
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
