### PR TITLE
Add va-select web component to GA tracking

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -36,6 +36,7 @@ const analyticsEvents = {
   TextInput: [{ action: 'blur', event: 'int-text-input-blur' }],
   'va-checkbox': [{ action: 'change', event: 'int-checkbox-option-click' }],
   'va-text-input': [{ action: 'blur', event: 'int-text-input-blur' }],
+  'va-select': [{ action: 'change', event: 'int-select-box-option-click' }],
 };
 
 export function subscribeComponentAnalyticsEvents(


### PR DESCRIPTION
## Description
Web component `va-select` needs to be added to the component GA lookup object in https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/component-library-analytics-setup.js


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34351


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
