### PR TITLE
Srsuddath find forms staging fixes

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -144,6 +144,7 @@ const SearchResult = ({
   formMetaInfo,
   showPDFInfoVersionOne,
   toggleModalState,
+  setPrevFocusedLink,
 }) => {
   // Escape early if we don't have the necessary form attributes.
   if (!form?.attributes) {
@@ -183,6 +184,7 @@ const SearchResult = ({
     recordGAEventHelper({ ...formMetaInfo, eventTitle, eventUrl, eventType });
 
   const pdfDownloadHandler = () => {
+    setPrevFocusedLink(`pdf-link-${id}`);
     if (showPDFInfoVersionOne) {
       if (!doesCookieExist) {
         recordEvent({
@@ -241,6 +243,7 @@ const SearchResult = ({
         <a
           className="find-forms-max-content vads-u-text-decoration--none"
           data-testid={`pdf-link-${id}`}
+          id={`pdf-link-${id}`}
           rel="noreferrer noopener"
           href={showPDFInfoVersionOne && !doesCookieExist ? null : url}
           tabIndex="0"

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -1,7 +1,6 @@
 // Dependencies.
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
 import { connect } from 'react-redux';
@@ -65,6 +64,8 @@ export const SearchResults = ({
     pdfLabel: '',
     doesCookieExist: false,
   });
+  const [prevFocusedLink, setPrevFocusedLink] = useState('');
+
   useEffect(() => {
     const justRefreshed = prevProps?.fetching && !fetching;
     if (justRefreshed) {
@@ -148,7 +149,9 @@ export const SearchResults = ({
 
   // Show loading indicator if we are fetching.
   if (fetching) {
-    return <LoadingIndicator setFocus message="Loading search results..." />;
+    return (
+      <va-loading-indicator setFocus message={'Loading search results...'} />
+    );
   }
 
   // Show the error alert box if there was an error.
@@ -229,6 +232,7 @@ export const SearchResults = ({
         formMetaInfo={{ ...formMetaInfo, currentPositionOnPage: index + 1 }}
         showPDFInfoVersionOne={showPDFInfoVersionOne}
         toggleModalState={toggleModalState}
+        setPrevFocusedLink={setPrevFocusedLink}
       />
     ));
 
@@ -276,8 +280,12 @@ export const SearchResults = ({
         }}
       >
         <Modal
-          onClose={() => toggleModalState(pdfSelected, pdfUrl, pdfLabel, true)}
+          onClose={() => {
+            toggleModalState(pdfSelected, pdfUrl, pdfLabel, true);
+            document.getElementById(prevFocusedLink).focus();
+          }}
           title="Download this PDF and open it in Acrobat Reader"
+          initialFocusSelector={'#va-modal-title'}
           visible={isOpen}
         >
           <>

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -291,7 +291,7 @@ export const SearchResults = ({
           initialFocusSelector={'#va-modal-title'}
           visible={isOpen}
         >
-          <>
+          <div className="vads-u-display--flex vads-u-flex-direction--column">
             <p>
               Download this PDF to your desktop computer or laptop. Then use
               Adobe Acrobat Reader to open and fill out the form. Don’t try to
@@ -306,9 +306,9 @@ export const SearchResults = ({
             </a>
             <a
               href={pdfUrl}
-              className="usa-button vads-u-margin-top--2"
+              className="vads-u-margin-top--2"
               rel="noreferrer noopener"
-              role="button"
+              target="_blank"
               onClick={() => {
                 recordEvent(
                   `Download VA form ${pdfSelected} ${pdfLabel}`,
@@ -317,9 +317,17 @@ export const SearchResults = ({
                 );
               }}
             >
-              Download VA Form {pdfSelected}
+              <i
+                aria-hidden="true"
+                className="fas fa-download fa-lg vads-u-margin-right--1"
+                role="presentation"
+              />
+
+              <span className="vads-u-text-decoration--underline">
+                Download VA Form {pdfSelected}
+              </span>
             </a>
-          </>
+          </div>
         </Modal>
       </div>
 

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -14,7 +14,11 @@ import {
   updateSortByPropertyNameThunk,
   updatePaginationAction,
 } from '../actions';
-import { doesCookieExist, setCookie } from '../helpers';
+import {
+  doesCookieExist,
+  setCookie,
+  deriveDefaultModalState,
+} from '../helpers';
 import { showPDFModal, getFindFormsAppState } from '../helpers/selectors';
 import { FAF_SORT_OPTIONS } from '../constants';
 import SearchResult from '../components/SearchResult';
@@ -57,13 +61,8 @@ export const SearchResults = ({
   const prevProps = usePreviousProps({
     fetching,
   });
-  const [modalState, setModalState] = useState({
-    isOpen: false,
-    pdfSelected: '',
-    pdfUrl: '',
-    pdfLabel: '',
-    doesCookieExist: false,
-  });
+  const [modalState, setModalState] = useState(deriveDefaultModalState());
+
   const [prevFocusedLink, setPrevFocusedLink] = useState('');
 
   useEffect(() => {
@@ -72,9 +71,13 @@ export const SearchResults = ({
       focusElement('[data-forms-focus]');
     }
   });
+
   useEffect(() => {
     if (doesCookieExist()) {
-      setModalState({ ...modalState, doesCookieExist: doesCookieExist() });
+      setModalState({
+        ...deriveDefaultModalState(),
+        doesCookieExist: doesCookieExist(),
+      });
     }
   }, []);
 

--- a/src/applications/find-forms/helpers/index.js
+++ b/src/applications/find-forms/helpers/index.js
@@ -95,3 +95,13 @@ export const setCookie = () => {
     document.cookie = `findForms=pdfModal; expires=${utcDateString};`;
   }
 };
+
+export const deriveDefaultModalState = () => {
+  return {
+    isOpen: false,
+    pdfSelected: '',
+    pdfUrl: '',
+    pdfLabel: '',
+    doesCookieExist: false,
+  };
+};

--- a/src/applications/find-forms/tests/containers/SearchResults.unit.spec.jsx
+++ b/src/applications/find-forms/tests/containers/SearchResults.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('Find VA Forms <SearchResults>', () => {
   it('renders a loading indicator', () => {
     const tree = shallow(<SearchResults fetching />);
 
-    const loadingIndicator = tree.find('LoadingIndicator');
+    const loadingIndicator = tree.find('va-loading-indicator');
     expect(loadingIndicator).to.have.lengthOf(1);
 
     tree.unmount();


### PR DESCRIPTION
## Description
This PR fixes two find forms modal defects from the staging review listed below.
As per Josh Kim, focusing the modal title when it opens rather than the close button will fix issue #33348
I also added functionality to track the link that was clicked to open the modal, so that focus can be re-set to it when the modal closes, which accomplishes #33348
I have removed the button styling and updated the download link functionality on the modal to match design standards, fixing #33346

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33348
department-of-veterans-affairs/va.gov-team#33346
department-of-veterans-affairs/va.gov-team#33342

