### PR TITLE
32768 authd personal info edit state

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
@@ -315,6 +315,7 @@ export class ProfileInformationEditView extends Component {
 
                   {!isLoading && (
                     <button
+                      data-testid="cancel-edit-button"
                       type="button"
                       className="usa-button-secondary small-screen:vads-u-margin-top--0"
                       onClick={onCancel}

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -89,7 +89,7 @@ const PersonalInformationSection = ({ gender, dob }) => (
         },
         { title: 'Sex assigned at birth', value: renderGender(gender) },
         {
-          title: 'Gender Identity',
+          title: 'Gender identity',
           id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
           value: (
             <ProfileInformationFieldController
@@ -98,7 +98,7 @@ const PersonalInformationSection = ({ gender, dob }) => (
           ),
         },
         {
-          title: 'Sexual Orientation',
+          title: 'Sexual orientation',
           id: FIELD_IDS[FIELD_NAMES.SEXUAL_ORIENTATION],
           value: (
             <ProfileInformationFieldController

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -80,4 +80,4 @@ export const militaryInformationLoadError = state => {
 };
 
 export const showProfileLGBTQEnhancements = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.profileEnhancements];
+  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileEnhancements] || false;

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
@@ -45,12 +45,12 @@ describe('Content on the personal information page', () => {
     cy.findByText('Sex assigned at birth').should('exist');
     cy.findByText('Male').should('exist');
 
-    cy.findByText('Gender Identity').should('exist');
+    cy.findByText('Gender identity').should('exist');
     cy.findByText('Edit your profile to add a gender identity.').should(
       'exist',
     );
 
-    cy.findByText('Sexual Orientation').should('exist');
+    cy.findByText('Sexual orientation').should('exist');
     cy.findByText('Edit your profile to add a sexual orientation.').should(
       'exist',
     );

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -1,0 +1,143 @@
+import { PROFILE_PATHS_LGBTQ_ENHANCEMENT } from '@@profile/constants';
+
+import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import mockPersonalInformationEnhanced from '@@profile/tests/fixtures/personal-information-success-enhanced.json';
+import mockServiceHistory from '@@profile/tests/fixtures/service-history-success.json';
+import mockFullName from '@@profile/tests/fixtures/full-name-success.json';
+import mockProfileEnhancementsToggles from '@@profile/tests/fixtures/personal-information-feature-toggles.json';
+import { mockGETEndpoints } from '@@profile/tests/e2e/helpers';
+
+const setup = () => {
+  cy.login(mockUser);
+  cy.intercept(
+    'v0/profile/personal_information',
+    mockPersonalInformationEnhanced,
+  );
+  cy.intercept('v0/profile/service_history', mockServiceHistory);
+  cy.intercept('v0/profile/full_name', mockFullName);
+  cy.intercept('v0/feature_toggles*', mockProfileEnhancementsToggles);
+  mockGETEndpoints(['v0/mhv_account', 'v0/ppiu/payment_information']);
+  cy.visit(PROFILE_PATHS_LGBTQ_ENHANCEMENT.PERSONAL_INFORMATION);
+  cy.injectAxe();
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByText(/loading your information/i).should('not.exist');
+  cy.findByRole('progressbar').should('not.exist');
+};
+
+describe('Content in EDIT state on the personal information page', () => {
+  it('should render each edit field with update/cancel buttons, and remove field on cancel', () => {
+    setup();
+
+    // preferred name field
+    const nameEditButtonLabel = 'Edit Preferred name';
+    const nameEditInputLabel =
+      'Provide your preferred name (100 characters maximum)';
+    const nameEditInputField = 'input[name="root_preferredName"]';
+
+    cy.findByLabelText(nameEditButtonLabel)
+      .should('exist')
+      .click();
+
+    cy.findByText(nameEditInputLabel).should('exist');
+
+    cy.get(nameEditInputField).should('exist');
+
+    cy.findAllByTestId('cancel-edit-button')
+      .should('exist')
+      .click();
+
+    cy.findByText(nameEditInputLabel).should('not.exist');
+
+    cy.get(nameEditInputField).should('not.exist');
+
+    // pronoun fields
+    const pronounsEditButtonLabel = 'Edit Pronouns';
+    const pronounsEditInputLabel = 'Select all of your pronouns';
+    const pronounsEditInputField = 'input[name="root_pronounsNotListedText"]';
+
+    cy.findByLabelText(pronounsEditButtonLabel)
+      .should('exist')
+      .click();
+
+    cy.findByText(pronounsEditInputLabel).should('exist');
+
+    cy.get(pronounsEditInputField).should('exist');
+    cy.findByText('He/him/his').should('exist');
+    cy.findByText('She/her/hers').should('exist');
+    cy.findByText('They/them/theirs').should('exist');
+    cy.findByText('Ze/zir/zirs').should('exist');
+    cy.findByText('Use my preferred name').should('exist');
+    cy.findByText('Prefer not to answer').should('exist');
+    cy.findByText('Pronouns not listed here').should('exist');
+    cy.findByText(
+      'If not listed, please provide your preferred pronouns (255 characters maximum)',
+    ).should('exist');
+
+    cy.findAllByTestId('cancel-edit-button')
+      .should('exist')
+      .click();
+
+    cy.findByText(pronounsEditInputLabel).should('not.exist');
+
+    cy.get(pronounsEditInputField).should('not.exist');
+
+    // gender fields
+    const genderEditButtonLabel = 'Edit Gender identity';
+    const genderEditInputLabel = 'Select your gender identity';
+
+    cy.findByLabelText(genderEditButtonLabel)
+      .should('exist')
+      .click();
+
+    cy.findByText(genderEditInputLabel).should('exist');
+
+    cy.findByText('Woman').should('exist');
+    cy.findByText('Man').should('exist');
+    cy.findByText('Transgender woman').should('exist');
+    cy.findByText('Transgender man').should('exist');
+    cy.findByText('Non-binary').should('exist');
+    cy.findByText('Prefer not to answer').should('exist');
+    cy.findByText('A gender not listed here').should('exist');
+
+    cy.findAllByTestId('cancel-edit-button')
+      .should('exist')
+      .click();
+
+    cy.findByText(genderEditInputLabel).should('not.exist');
+
+    // sexual orientation fields
+    const sexualOrientationEditButtonLabel = 'Edit Sexual orientation';
+    const sexualOrientationEditInputLabel = 'Select your sexual orientation';
+    const sexualOrientationEditInputField =
+      'input[name="root_sexualOrientationNotListedText"]';
+
+    cy.findByLabelText(sexualOrientationEditButtonLabel)
+      .should('exist')
+      .click();
+
+    cy.get(sexualOrientationEditInputField).should('exist');
+    cy.findByText(sexualOrientationEditInputLabel).should('exist');
+    cy.findByText('Lesbian, gay, or homosexual').should('exist');
+    cy.findByText('Straight or heterosexual').should('exist');
+    cy.findByText('Bisexual').should('exist');
+    cy.findByText('Queer').should('exist');
+    cy.findByText('Don’t know').should('exist');
+    cy.findByText('Prefer not to answer').should('exist');
+    cy.findByText('A sexual orientation not listed here').should('exist');
+
+    cy.findAllByTestId('cancel-edit-button')
+      .should('exist')
+      .click();
+
+    cy.findByText(sexualOrientationEditInputLabel).should('not.exist');
+
+    cy.get(sexualOrientationEditInputField).should('not.exist');
+
+    cy.axeCheck();
+  });
+});

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -70,9 +70,13 @@ export const personalInformationFormSchemas = {
         type: 'string',
         enum: genderOptions,
       },
+      genderIdentityNotListed: {
+        type: 'string',
+      },
     },
     required: [],
   },
+
   sexualOrientation: {
     type: 'object',
     properties: {
@@ -89,7 +93,7 @@ export const personalInformationUiSchemas = {
   preferredName: {
     preferredName: {
       'ui:widget': TextWidget,
-      'ui:title': `Provide your preferred name (25 characters maximum)`,
+      'ui:title': `Provide your preferred name (100 characters maximum)`,
       'ui:errorMessages': {
         pattern: 'Preferred name required',
       },
@@ -106,6 +110,10 @@ export const personalInformationUiSchemas = {
     preferNotToAnswer: { 'ui:title': 'Prefer not to answer' },
     pronounsNotListed: {
       'ui:title': 'Pronouns not listed here',
+    },
+    pronounsNotListedText: {
+      'ui:title':
+        'If not listed, please provide your preferred pronouns (255 characters maximum)',
     },
   },
   genderIdentity: {
@@ -124,6 +132,10 @@ export const personalInformationUiSchemas = {
       'ui:options': {
         labels: sexualOrientationLabels,
       },
+    },
+    sexualOrientationNotListedText: {
+      'ui:title':
+        'If not listed, please provide your sexual orientation (255 characters maximum)',
     },
   },
 };

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -84,10 +84,11 @@ export const personalInformationFormSchemas = {
         type: 'string',
         enum: sexualOrientationOptions,
       },
+      sexualOrientationNotListedText: {
+        type: 'string',
+      },
     },
-    sexualOrientationNotListedText: {
-      type: 'string',
-    },
+
     required: [],
   },
 };

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -60,6 +60,9 @@ export const personalInformationFormSchemas = {
       useMyPreferredName: { type: 'boolean' },
       preferNotToAnswer: { type: 'boolean' },
       pronounsNotListed: { type: 'boolean' },
+      pronounsNotListedText: {
+        type: 'string',
+      },
     },
     required: [],
   },
@@ -69,9 +72,6 @@ export const personalInformationFormSchemas = {
       genderIdentity: {
         type: 'string',
         enum: genderOptions,
-      },
-      genderIdentityNotListed: {
-        type: 'string',
       },
     },
     required: [],
@@ -84,6 +84,9 @@ export const personalInformationFormSchemas = {
         type: 'string',
         enum: sexualOrientationOptions,
       },
+    },
+    sexualOrientationNotListedText: {
+      type: 'string',
     },
     required: [],
   },


### PR DESCRIPTION
## Description
Adds fields for editing the personal information at `/profile/personal-information`

Editing each field 'locks' the other fields so the editing must be completed or cancelled in order to edit a different field. Note: the actual saving or POST request is not wired up to api yet, so this is just the UI creation for editing. (live on staging only as well behind a feature toggle)

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32768


## Testing done
E2E test has been added to verify functionality

## Acceptance criteria
- [x] Preferred Name has text edit field
- [x] Pronouns has checkboxes and text field for pronouns not listed
- [x] Gender identity has radio buttons
- [x] Sexual orientation has radio buttons and text fields for sexual orientation not listed
- [x] Fields cannot be edited simultaneously and only one at a time.
