### PR TITLE
Integrate Higher Lever Review contact-loop E2E spec with TestRail

### DIFF
--- a/src/applications/disability-benefits/996/tests/hlr-contact-loop.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-contact-loop.cypress.spec.js
@@ -1,3 +1,11 @@
+/**
+ * [TestRail-integrated] Spec for Higher Level Review - Wizard
+ * @testrailinfo projectId 5
+ * @testrailinfo suiteId 6
+ * @testrailinfo groupId 3256
+ * @testrailinfo runName HLR-e2e-ContactLoop
+ */
+
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 import { BASE_URL, WIZARD_STATUS, CONTESTABLE_ISSUES_API } from '../constants';
@@ -74,7 +82,7 @@ describe('HLR contact info loop', () => {
       .click();
   };
 
-  it('should edit info on a new page & cancel returns to contact info page', () => {
+  it('should edit info on a new page & cancel returns to contact info page - C12883', () => {
     getToContactPage();
 
     // Contact info
@@ -115,7 +123,7 @@ describe('HLR contact info loop', () => {
    * info page, but this isn't working... I think I'm missing an intermediate
    * step here?
 
-  it.skip('should edit info on a new page, update & return to contact info page', () => {
+  it.skip('should edit info on a new page, update & return to contact info page - C12884', () => {
     getToContactPage();
 
     // Contact info


### PR DESCRIPTION
## Description
Integrate Higher Lever Review contact-loop Cypress E2E spec with TestRail:
- Add comment-block to top of file
- Append case IDs to test-description strings.

## Original issue(s)
[n/a]


## Testing done
- Ran updated spec locally, and successfully [published results to TestRail](https://dsvavsp.testrail.io/index.php?/runs/view/2743&group_by=cases:section_id&group_order=asc).
    NOTE: 1 of the 2 tests in the spec is currently commented-out by the team.
     [See also screenshot below.]

## Screenshots
![2021-12-20_18-12-39](https://user-images.githubusercontent.com/587583/146854084-bca64084-608e-42ff-abde-aac4194ead7e.png)


## Acceptance criteria
- [ ] Code-reviewer(s) approved changes.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
