### PR TITLE
Replace the old va select component with the new VaSelect component

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import { VaSelect } from 'web-components/react-bindings';
 import { FACILITY_SORT_METHODS, FETCH_STATUS } from '../../../utils/constants';
 import { selectProviderSelectionInfo } from '../../redux/selectors';
 import {
@@ -58,13 +58,13 @@ export default function ProviderSortVariant({
     [selectedCCFacility, sortMethod],
   );
 
-  const handleValueChange = option => {
-    if (Object.values(FACILITY_SORT_METHODS).includes(option.value)) {
-      setSelectedSortMethod(option.value);
-      dispatch(updateCCProviderSortMethod(option.value));
+  const onValueChange = option => {
+    if (Object.values(FACILITY_SORT_METHODS).includes(option.detail.value)) {
+      setSelectedSortMethod(option.detail.value);
+      dispatch(updateCCProviderSortMethod(option.detail.value));
     } else {
       const selectedFacility = ccEnabledSystems.find(
-        facility => facility.id === option.value,
+        facility => facility.id === option.detail.value,
       );
       setSelectedSortMethod(selectedFacility.id);
       dispatch(
@@ -92,6 +92,15 @@ export default function ProviderSortVariant({
     });
   }
 
+  // format optons for new component
+  const options = sortOptions.map((s, i) => {
+    return (
+      <option key={i} value={s.value}>
+        {s.label}
+      </option>
+    );
+  });
+
   return (
     <div className="vads-u-margin-bottom--3">
       {notLoading &&
@@ -108,14 +117,15 @@ export default function ProviderSortVariant({
             {communityCareProviderList.length} providers
           </p>
         )}
-      <Select
+      <VaSelect
         label="Show providers closest to"
         name="sort"
-        onValueChange={handleValueChange}
-        options={hasUserAddress ? sortOptions : sortOptions.slice(1)}
-        value={{ dirty: false, value: selectedSortMethod }}
-        includeBlankOption={false}
-      />
+        onVaSelect={onValueChange}
+        value={selectedSortMethod}
+        data-testid="providersSelect"
+      >
+        {hasUserAddress ? options : options.slice(1)}
+      </VaSelect>
       {!hasUserAddress && (
         <p>
           Note: To show providers near your home, you need to add your home

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { getCernerURL } from 'platform/utilities/cerner';
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import { VaSelect } from 'web-components/react-bindings';
 import { selectFacilitiesRadioWidget } from '../../redux/selectors';
 import State from '../../../components/State';
 import InfoAlert from '../../../components/InfoAlert';
@@ -59,6 +59,16 @@ export default function FacilitiesRadioWidget({
     enumOptions.length > INITIAL_FACILITY_DISPLAY_COUNT
       ? enumOptions.length - INITIAL_FACILITY_DISPLAY_COUNT
       : 0;
+
+  // format optons for new component
+  const selectOptions = sortOptions.map((s, i) => {
+    return (
+      <option key={i} value={s.value}>
+        {s.label}
+      </option>
+    );
+  });
+
   useEffect(
     () => {
       if (displayedOptions.length > INITIAL_FACILITY_DISPLAY_COUNT) {
@@ -75,19 +85,20 @@ export default function FacilitiesRadioWidget({
       </div>
       <>
         <div className="vads-u-margin-bottom--3">
-          <Select
+          <VaSelect
             label="Sort facilities"
             name="sort"
-            onValueChange={type => {
+            onVaSelect={type => {
               recordEvent({
-                event: `${GA_PREFIX}-variant-method-${type.value}`,
+                event: `${GA_PREFIX}-variant-method-${type.detail.value}`,
               });
-              updateFacilitySortMethod(type.value);
+              updateFacilitySortMethod(type.detail.value);
             }}
-            options={hasUserAddress ? sortOptions : sortOptions.slice(1)}
-            value={{ dirty: false, value: sortMethod }}
-            includeBlankOption={false}
-          />
+            value={sortMethod}
+            data-testid="facilitiesSelect"
+          >
+            {hasUserAddress ? selectOptions : selectOptions.slice(1)}
+          </VaSelect>
         </div>
         {!hasUserAddress && (
           <p>

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/dom';
-import { fireEvent } from '@testing-library/react';
-
+import { within } from '@testing-library/react';
 import { mockFetch } from 'platform/testing/unit/helpers';
-
+import { waitFor } from '@testing-library/dom';
 import {
   createTestStore,
   renderWithStoreAndRouter,
@@ -134,7 +132,7 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
       }),
     );
     // Then providers should be displayed
-    expect(await screen.findByText(/Show providers closest to/i)).to.exist;
+    expect(await screen.findByTestId('providersSelect')).to.exist;
     expect(screen.baseElement).to.contain.text('Your home address');
 
     expect(await screen.findByText(/Displaying 1 to 5 of 16 providers/i)).to.be
@@ -175,11 +173,13 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
         selector: 'button',
       }),
     );
-    fireEvent.change(await screen.getByLabelText('Show providers closest to'), {
-      target: {
-        value: FACILITY_SORT_METHODS.distanceFromCurrentLocation,
-      },
+
+    const providersSelect = await screen.findByTestId('providersSelect');
+    // call VaSelect custom event for onChange handling
+    providersSelect.__events.vaSelect({
+      detail: { value: FACILITY_SORT_METHODS.distanceFromCurrentLocation },
     });
+
     // Then an error location alert should be displayed
     expect(
       await screen.findByRole('heading', {
@@ -237,11 +237,14 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
     // When the user selects to sort providers by distance from current location
     // Choose Provider based on current location
     await screen.findByText(/Displaying 1 to /i);
-    fireEvent.change(await screen.getByLabelText('Show providers closest to'), {
-      target: {
-        value: FACILITY_SORT_METHODS.distanceFromCurrentLocation,
-      },
+
+    const providersSelect = await screen.findByTestId('providersSelect');
+
+    // call VaSelect custom event for onChange handling
+    providersSelect.__events.vaSelect({
+      detail: { value: FACILITY_SORT_METHODS.distanceFromCurrentLocation },
     });
+
     userEvent.click(await screen.findByText(/more providers$/i));
     userEvent.click(await screen.findByText(/more providers$/i));
     userEvent.click(await screen.findByText(/more providers$/i));
@@ -296,11 +299,12 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
     await waitFor(() =>
       expect(screen.getAllByRole('radio').length).to.equal(5),
     );
-    fireEvent.change(await screen.getByLabelText('Show providers closest to'), {
-      target: {
-        value: FACILITY_SORT_METHODS.distanceFromCurrentLocation,
-      },
+    const providersSelect = await screen.findByTestId('providersSelect');
+    // call VaSelect custom event for onChange handling
+    providersSelect.__events.vaSelect({
+      detail: { value: FACILITY_SORT_METHODS.distanceFromCurrentLocation },
     });
+
     // And the error location alert is displayed
     expect(
       await screen.findByRole('heading', {
@@ -386,11 +390,12 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
     // When the user selects to sort providers by distance from a specific facility
     // Choose Provider based on facility address
     await screen.findByText(/Displaying 1 to /i);
-    fireEvent.change(await screen.getByLabelText('Show providers closest to'), {
-      target: {
-        value: '983',
-      },
+    const providersSelect = await screen.findByTestId('providersSelect');
+    // call VaSelect custom event for onChange handling
+    providersSelect.__events.vaSelect({
+      detail: { value: '983' },
     });
+
     userEvent.click(await screen.findByText(/more providers$/i));
     userEvent.click(await screen.findByText(/more providers$/i));
     userEvent.click(await screen.findByText(/more providers$/i));
@@ -472,19 +477,20 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
         selector: 'button',
       }),
     );
-    expect(await screen.findByText(/Show providers closest to/i)).to.exist;
+
+    expect(await screen.findByTestId('providersSelect')).to.exist;
 
     // Then the select options should default to sort by distance from the first CC enabled facility
     expect(screen.baseElement).not.to.contain.text('Your home address');
     expect(screen.baseElement).to.contain.text('Your current location');
-    const selectOptions = await screen.getByLabelText(
-      'Show providers closest to',
-    );
-    expect(selectOptions).to.be.ok;
+    const providerSelect = await screen.findByTestId('providersSelect');
+    expect(providerSelect).to.be.ok;
+
+    const options = within(providerSelect).getAllByRole('option');
     // first facility should not be selected
-    expect(selectOptions[0].selected).not.to.be.ok;
+    expect(options[0].value).not.to.equal(providerSelect.value);
     // current location should be selected
-    expect(selectOptions[1].selected).to.be.ok;
+    expect(options[1].value).to.equal(providerSelect.value);
   });
 
   it('should defalut to home address when user has a residential address', async () => {
@@ -558,7 +564,7 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
       }),
     );
 
-    expect(await screen.findByText(/Show providers closest to/i)).to.exist;
+    expect(await screen.findByTestId('providersSelect')).to.exist;
 
     // Then the select options should default to sort by distance from home address
     expect(screen.baseElement).to.contain.text('Your home address');

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -159,11 +159,12 @@ describe('VAOS <VAFacilityPage>', () => {
       });
 
       await screen.findAllByRole('radio');
-      fireEvent.change(screen.getByLabelText('Sort facilities'), {
-        target: {
-          value: 'distanceFromCurrentLocation',
-        },
+      const facilitiesSelect = await screen.findByTestId('facilitiesSelect');
+      // call VaSelect custom event for onChange handling
+      facilitiesSelect.__events.vaSelect({
+        detail: { value: 'distanceFromCurrentLocation' },
       });
+
       await waitFor(() => {
         expect(screen.baseElement).to.contain.text(
           'Your browser is blocked from finding your current location',
@@ -696,11 +697,12 @@ describe('VAOS <VAFacilityPage>', () => {
       expect(screen.queryByText(/Disabled facility near current location/i)).not
         .to.be.ok;
 
-      fireEvent.change(screen.getByLabelText('Sort facilities'), {
-        target: {
-          value: 'distanceFromCurrentLocation',
-        },
+      const facilitiesSelect = await screen.findByTestId('facilitiesSelect');
+      // call VaSelect custom event for onChange handling
+      facilitiesSelect.__events.vaSelect({
+        detail: { value: 'distanceFromCurrentLocation' },
       });
+
       expect(await screen.findByLabelText(/Facility that is enabled/i)).to.be
         .ok;
 
@@ -934,7 +936,8 @@ describe('VAOS <VAFacilityPage>', () => {
         'Select a VA facility where you’re registered that offers primary care appointments.',
       );
 
-      expect(screen.baseElement).to.contain.text('Sort facilities');
+      expect(await screen.findByTestId('facilitiesSelect')).to.be.ok;
+
       // Should contain radio buttons
       facilities.slice(0, 5).forEach(f => {
         expect(screen.baseElement).to.contain.text(f.attributes.name);
@@ -1075,11 +1078,12 @@ describe('VAOS <VAFacilityPage>', () => {
       });
       await screen.findAllByRole('radio');
 
-      fireEvent.change(screen.getByLabelText('Sort facilities'), {
-        target: {
-          value: 'distanceFromCurrentLocation',
-        },
+      const facilitiesSelect = await screen.findByTestId('facilitiesSelect');
+      // call VaSelect custom event for onChange handling
+      facilitiesSelect.__events.vaSelect({
+        detail: { value: 'distanceFromCurrentLocation' },
       });
+
       await screen.findAllByRole('radio');
       expect(screen.baseElement).to.contain.text('By your current location');
 
@@ -1150,13 +1154,14 @@ describe('VAOS <VAFacilityPage>', () => {
       let firstRadio = screen.container.querySelector('.form-radio-buttons');
       expect(firstRadio).to.contain.text('Closest facility');
 
-      fireEvent.change(screen.getByLabelText('Sort facilities'), {
-        target: {
-          value: 'alphabetical',
-        },
+      const facilitiesSelect = await screen.findByTestId('facilitiesSelect');
+      // call VaSelect custom event for onChange handling
+      facilitiesSelect.__events.vaSelect({
+        detail: { value: 'alphabetical' },
       });
+
       await screen.findAllByRole('radio');
-      expect(screen.baseElement).to.contain.text('Alphabetically');
+      expect(facilitiesSelect.value).to.equal('alphabetical');
 
       firstRadio = screen.container.querySelector('.form-radio-buttons');
       expect(firstRadio).to.contain.text('ABC facility');


### PR DESCRIPTION
## Description
This change is to replace the deprecated select component with the new VaSelect component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29418


## Testing done
Manual, unit and e2e

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/146953504-f1dfff13-8122-4f0e-9398-c28706ef4225.png)


## Acceptance criteria
- [ ] Replace Select React components with VaSelect web components
- [ ] selects work as intended

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
