### PR TITLE
Checkbox is no longer broken

### DIFF
--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -38,6 +38,7 @@ function CalculateYourBenefitsForm({
   showModal,
   updateEstimatedBenefits,
   focusHandler,
+  classesOutsideUSChecked,
 }) {
   const [invalidZip, setInvalidZip] = useState('');
   const [inputUpdated, setInputUpdated] = useState(false);
@@ -48,7 +49,7 @@ function CalculateYourBenefitsForm({
     scholarshipsAndOtherFunding: false,
   });
 
-  const displayExtensionBeneficiaryZipcode = !inputs.classesOutsideUS;
+  const displayExtensionBeneficiaryZipcode = !classesOutsideUSChecked;
 
   const getExtensions = () => {
     const facilityMap = profile.attributes.facilityMap;
@@ -842,7 +843,7 @@ function CalculateYourBenefitsForm({
             "I'll be taking classes outside of the U.S. and U.S. territories"
           }
           onChange={handleHasClassesOutsideUSChange}
-          checked={inputs.classesOutsideUS}
+          checked={classesOutsideUSChecked}
           name={'classesOutsideUS'}
         />
       );

--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -38,7 +38,6 @@ function CalculateYourBenefitsForm({
   showModal,
   updateEstimatedBenefits,
   focusHandler,
-  classesOutsideUSChecked,
 }) {
   const [invalidZip, setInvalidZip] = useState('');
   const [inputUpdated, setInputUpdated] = useState(false);
@@ -49,7 +48,7 @@ function CalculateYourBenefitsForm({
     scholarshipsAndOtherFunding: false,
   });
 
-  const displayExtensionBeneficiaryZipcode = !classesOutsideUSChecked;
+  const displayExtensionBeneficiaryZipcode = !inputs.classesoutsideus;
 
   const getExtensions = () => {
     const facilityMap = profile.attributes.facilityMap;
@@ -843,7 +842,7 @@ function CalculateYourBenefitsForm({
             "I'll be taking classes outside of the U.S. and U.S. territories"
           }
           onChange={handleHasClassesOutsideUSChange}
-          checked={classesOutsideUSChecked}
+          checked={inputs.classesoutsideus}
           name={'classesOutsideUS'}
         />
       );

--- a/src/applications/gi/selectors/calculator.js
+++ b/src/applications/gi/selectors/calculator.js
@@ -521,7 +521,7 @@ const getDerivedValues = createSelector(
     const hasClassesOutsideUS =
       (isCountryInternational(institutionCountry) &&
         !useBeneficiaryLocationRate) ||
-      inputs.classesOutsideUS;
+      inputs.classesoutsideus;
 
     // Calculate Housing Allowance for Term #1 - getHousingAllowTerm1
     if (


### PR DESCRIPTION
It can be checked and unchecked now.

## Description
Unable to select the checkbox "I'll be taking classes outside of the U.S. and U.S. territories" for the radio button "Other location" inside the accordion "Learning format and location"

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#33608](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/33608)

## Testing done
Confirmation that the checkbox checks & unchecks when clicked.

## Screenshots
Unchecked
<img width="436" alt="Unchecked" src="https://user-images.githubusercontent.com/86262790/146985215-d69ded4e-41ae-40fa-9104-c2f4a355de2d.png">

Checked
<img width="434" alt="Checked" src="https://user-images.githubusercontent.com/86262790/146985211-02ffcba8-31ee-4ff9-8350-430cb2a2849d.png">


## Acceptance criteria
- [x] The checkbox indicating foreign classes will be taken functions when clicked

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
