### PR TITLE
Fix web components in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^3.10.1",
+    "@department-of-veterans-affairs/component-library": "^3.11.1",
     "@department-of-veterans-affairs/formation": "6.17.3",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^3.11.1",
+    "@department-of-veterans-affairs/component-library": "^3.10.1",
     "@department-of-veterans-affairs/formation": "6.17.3",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/src/platform/site-wide/wc-loader.js
+++ b/src/platform/site-wide/wc-loader.js
@@ -3,7 +3,7 @@ import '@department-of-veterans-affairs/component-library/dist/main.css';
 import {
   applyPolyfills,
   defineCustomElements,
-} from '@department-of-veterans-affairs/component-library';
+} from '@department-of-veterans-affairs/web-components/loader';
 
 applyPolyfills().then(() => {
   defineCustomElements();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,13 +2130,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.10.1.tgz#3026de04a3561d94b366b898ed09f6c63e4b8722"
-  integrity sha512-sz/IqToMMb0VeTx7rscLes267jamwL6MO+k0DiVoZcTW7gVB2Hr2PGUfUwP29gcTodekz3yng8+M6HUdwYkK8w==
+"@department-of-veterans-affairs/component-library@^3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.11.1.tgz#ca25b141845c0067d36a29c77419ea5efa26545c"
+  integrity sha512-3DEgNlkEC733SO7vNtwq3eNDYChxspfLhyWR1JeShFneG8oLTr+tddpyUKUvd8yy7rYnPYcsujn4rELCJ2OsHQ==
   dependencies:
     "@department-of-veterans-affairs/react-components" "3.3.0"
-    "@department-of-veterans-affairs/web-components" "0.19.1"
+    "@department-of-veterans-affairs/web-components" "0.20.1"
     date-fns-tz "^1.1.1"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
@@ -2198,10 +2198,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@0.19.1":
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.19.1.tgz#7366350964c3cd8c98826dba36ad216619456fb2"
-  integrity sha512-uJX8/JQBjFaIZp2CNi9sjd+iIDVxW3najAeEQwvL5NeWzgM91msE8P0Q8b7Loegmj5MLYgIc30mE9cjSZv9GtA==
+"@department-of-veterans-affairs/web-components@0.20.1":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.20.1.tgz#69840f06697c716443949dc767fa89a95dacf79d"
+  integrity sha512-QYn81vfqjre2xQyzIVZxYpB63+yRBm9JCI12TAcJxbYe51PT8RI2P+zateK/vutiiJMNwcbqmtxsVuq3yM+7Uw==
   dependencies:
     "@stencil/core" "^2.10.0"
     "@stencil/postcss" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,13 +2130,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^3.11.1":
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.11.1.tgz#ca25b141845c0067d36a29c77419ea5efa26545c"
-  integrity sha512-3DEgNlkEC733SO7vNtwq3eNDYChxspfLhyWR1JeShFneG8oLTr+tddpyUKUvd8yy7rYnPYcsujn4rELCJ2OsHQ==
+"@department-of-veterans-affairs/component-library@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.10.1.tgz#3026de04a3561d94b366b898ed09f6c63e4b8722"
+  integrity sha512-sz/IqToMMb0VeTx7rscLes267jamwL6MO+k0DiVoZcTW7gVB2Hr2PGUfUwP29gcTodekz3yng8+M6HUdwYkK8w==
   dependencies:
     "@department-of-veterans-affairs/react-components" "3.3.0"
-    "@department-of-veterans-affairs/web-components" "0.20.1"
+    "@department-of-veterans-affairs/web-components" "0.19.1"
     date-fns-tz "^1.1.1"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
@@ -2198,10 +2198,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.20.1.tgz#69840f06697c716443949dc767fa89a95dacf79d"
-  integrity sha512-QYn81vfqjre2xQyzIVZxYpB63+yRBm9JCI12TAcJxbYe51PT8RI2P+zateK/vutiiJMNwcbqmtxsVuq3yM+7Uw==
+"@department-of-veterans-affairs/web-components@0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.19.1.tgz#7366350964c3cd8c98826dba36ad216619456fb2"
+  integrity sha512-uJX8/JQBjFaIZp2CNi9sjd+iIDVxW3najAeEQwvL5NeWzgM91msE8P0Q8b7Loegmj5MLYgIc30mE9cjSZv9GtA==
   dependencies:
     "@stencil/core" "^2.10.0"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

We noticed that web components aren't loading properly in IE11 due to a syntax issue with the build. This is a result of the "core" component-library build which isn't targeting ES5 for IE11 compatibility.

## Testing done

IE11 :eyes: 


## Screenshots

Web component working in IE11:

![image](https://user-images.githubusercontent.com/2008881/146978098-6e5f4d0b-628c-438a-b04c-791405361acd.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
