### PR TITLE
Remove unused imports from static pages app

### DIFF
--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -13,9 +13,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "modules/m-drupal-sidebarnav";
 @import "modules/m-education-wizard";
 @import "../../../platform/forms/sass/m-applications";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-homepage-hero";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-linkslist";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-next-previous";
 
 //=============================
 // Additional information styles


### PR DESCRIPTION
## Description
Removing unused imports from static pages app Sass as part of the rearchitecture initiative 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32796

Searched build output for instances of class names (within static pages). Will also confirm on review instance