### PR TITLE
Remove Distance in Miles

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelect.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelect.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import recordEvent from 'platform/monitoring/record-event';
 import { selectProviderSelectionInfo } from '../../redux/selectors';
-import { FACILITY_SORT_METHODS, GA_PREFIX } from '../../../utils/constants';
+import { GA_PREFIX } from '../../../utils/constants';
 import RemoveProviderModal from './RemoveProviderModal';
 
 export default function SelectedProvider({
@@ -14,21 +14,8 @@ export default function SelectedProvider({
   setProvidersListLength,
   setShowProvidersList,
 }) {
-  const { address, sortMethod } = useSelector(
-    selectProviderSelectionInfo,
-    shallowEqual,
-  );
+  const { address } = useSelector(selectProviderSelectionInfo, shallowEqual);
   const [showRemoveProviderModal, setShowRemoveProviderModal] = useState(false);
-
-  const srSortMethod = () => {
-    if (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation) {
-      return 'from your current location';
-    } else if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
-      return 'from your home address';
-    } else {
-      return 'from closest VA facility';
-    }
-  };
 
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
@@ -55,7 +42,7 @@ export default function SelectedProvider({
             id="providerPostSelectionHeader"
             className="vads-u-font-size--h3 vads-u-margin-top--0"
           >
-            Selected Provider
+            Selected provider
           </h2>
           <span className="vads-u-display--block">{formData.name}</span>
           <span className="vads-u-display--block">
@@ -64,10 +51,6 @@ export default function SelectedProvider({
           <span className="vads-u-display--block">
             {formData.address?.city}, {formData.address?.state}{' '}
             {formData.address?.postalCode}
-          </span>
-          <span className="vads-u-display--block vads-u-font-size--sm">
-            {formData[sortMethod]} miles{' '}
-            <span className="sr-only">{srSortMethod()}</span>
           </span>
           <div className="vads-u-display--flex vads-u-margin-top--1">
             <button
@@ -97,7 +80,6 @@ export default function SelectedProvider({
         <RemoveProviderModal
           provider={formData}
           address={address}
-          distanceInMiles={formData[sortMethod]}
           onClose={response => {
             setShowRemoveProviderModal(false);
             if (response === true) {

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
-export default function RemoveProviderModal({
-  onClose,
-  provider,
-  distanceInMiles = null,
-}) {
+export default function RemoveProviderModal({ onClose, provider }) {
   const title = 'Are you sure you want to remove this provider?';
   const content = (
     <>
@@ -13,15 +9,10 @@ export default function RemoveProviderModal({
         {provider.name}
       </span>
       <span className="vads-u-display--block">{provider.address?.line}</span>
-      <span className="vads-u-display--block">
+      <span className="vads-u-display--block vads-u-margin-bottom--1">
         {provider.address?.city}, {provider.address?.state}{' '}
         {provider.address?.postalCode}
       </span>
-      {distanceInMiles && (
-        <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-bottom--2">
-          {distanceInMiles} miles
-        </span>
-      )}
       <button type="button" onClick={() => onClose(true)}>
         Yes, remove provider
       </button>

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -156,7 +156,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
       ),
     );
     expect(await screen.baseElement).to.contain.text(
-      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400397.3 miles',
+      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400',
     );
 
     userEvent.click(screen.getByText(/Continue/i));
@@ -230,11 +230,10 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     userEvent.click(
       await screen.getByRole('button', { name: /choose provider/i }),
     );
-    expect(screen.baseElement).to.contain.text('Selected Provider');
+    expect(screen.baseElement).to.contain.text('Selected provider');
     expect(screen.baseElement).to.contain.text(
       'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-6599',
     );
-    expect(screen.baseElement).to.contain.text('408.5 miles');
 
     // Change Provider
     userEvent.click(
@@ -246,7 +245,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     );
 
     expect(screen.baseElement).to.contain.text(
-      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400397.3 miles',
+      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400',
     );
 
     // Cancel Selection (not clearing of a selected provider)
@@ -257,7 +256,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
       .exist;
     userEvent.click(await screen.findByRole('button', { name: /cancel/i }));
     expect(screen.baseElement).to.contain.text(
-      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400397.3 miles',
+      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400',
     );
   });
 
@@ -283,7 +282,6 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     expect(screen.baseElement).to.contain.text(
       'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-6599',
     );
-    expect(screen.baseElement).to.contain.text('408.5 miles');
 
     // Remove Provider
     userEvent.click(await screen.findByRole('button', { name: /remove/i }));
@@ -802,7 +800,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     );
 
     expect(screen.baseElement).to.contain.text(
-      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-24007019.4 miles',
+      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-2400',
     );
   });
 


### PR DESCRIPTION


## Description
This change removes the distance in miles from the selected provider and remove provider pages. This also fixes the sentence casing on the card header for selected provider page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33553


## Testing done
Manual and Unit

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/147128595-a4866cfb-fc9c-48d6-9b0b-7597b8e1279c.png)
![image](https://user-images.githubusercontent.com/3951775/147129253-d1e1ee11-de57-4af3-9046-83a6b4a2edbc.png)


## Acceptance criteria
- [ ] AC1 - Preference selected
Given any user on the CC provider preference page
When user makes a provider preference selection
Then show selected provider's name and address
And page design matches the design spec
And card heading is sentence case (see copy doc)

- [ ] AC2 - Remove preference modal
Given any user on the CC provider preference page with a selected provider
When user selects remove
Then show removal confirmation message
And show selected provider's name and address
And design matches the spec



## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
