### PR TITLE
add keypress handler

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -247,6 +247,11 @@ const SearchResult = ({
           rel="noreferrer noopener"
           href={showPDFInfoVersionOne && !doesCookieExist ? null : url}
           tabIndex="0"
+          onKeyDown={event => {
+            if ((event.which || event.keycode) === 13) {
+              pdfDownloadHandler();
+            }
+          }}
           onClick={() => pdfDownloadHandler()}
           {...linkProps}
         >


### PR DESCRIPTION
## Description
This PR adds a keypress handler for keyboard nav of the find form results page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33342


## Testing done
manual testing

