### PR TITLE
Add downtime notification to mcp and add VBS as service

### DIFF
--- a/src/applications/medical-copays/containers/MedicalCopaysApp.jsx
+++ b/src/applications/medical-copays/containers/MedicalCopaysApp.jsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { mcpFeatureToggle } from '../utils/helpers';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { isProfileLoading, isLoggedIn } from 'platform/user/selectors';
 import LoadingSpinner from '../components/LoadingSpinner';
+import { mcpFeatureToggle } from '../utils/helpers';
 import AlertView from '../components/AlertView';
 import { getStatements } from '../actions';
+import {
+  DowntimeNotification,
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 
 const MedicalCopaysApp = ({ children }) => {
   const showMCP = useSelector(state => mcpFeatureToggle(state));
@@ -58,15 +62,20 @@ const MedicalCopaysApp = ({ children }) => {
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0 vads-u-margin-bottom--5">
       <div className="vads-l-row vads-u-margin-x--neg2p5">
         <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--8">
-          {alertType ? (
-            <AlertView
-              pathname={pathname}
-              alertType={alertType}
-              error={error}
-            />
-          ) : (
-            children
-          )}
+          <DowntimeNotification
+            appTitle="Medical Copays Application"
+            dependencies={[externalServices.mvi, externalServices.vbs]}
+          >
+            {alertType ? (
+              <AlertView
+                pathname={pathname}
+                alertType={alertType}
+                error={error}
+              />
+            ) : (
+              children
+            )}
+          </DowntimeNotification>
         </div>
       </div>
     </div>

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -46,4 +46,6 @@ export default {
   vic: 'vic',
   // veteran readiness and employment
   vre: 'vre',
+  // veteran benefit services (used to source medical copay debt)
+  vbs: 'vbs',
 };


### PR DESCRIPTION
## Description
Medical copays uses a couple external services. Add those services to the global externalServices object if they are not already their and implement downtime notifications on Medical Copays application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27662


## Testing done
Manual testing

## Screenshots
TBA

## Acceptance criteria
- [x] Added VBS to `externalServices.js` object
- [x] Implement `<DowntimeNotificaitons/>` component in root of MCP

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
