### PR TITLE
Abstract main Events component into separate folder/files

### DIFF
--- a/src/applications/static-pages/events/components/App/index.js
+++ b/src/applications/static-pages/events/components/App/index.js
@@ -1,143 +1,26 @@
 // Node modules.
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
-import Results from '../Results';
-import Search from '../Search';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import {
-  deriveDefaultSelectedOption,
-  deriveFilteredEvents,
-  deriveResults,
-  filterByOptions,
-  hideLegacyEvents,
-  showLegacyEvents,
-  updateQueryParams,
-} from '../../helpers';
-
-// Derive constants.
-const perPage = 10;
+import Events from '../Events';
+import { hideLegacyEvents, showLegacyEvents } from '../../helpers';
 
 export const App = ({ rawEvents, showEventsV2 }) => {
-  // Derive the query params on the URL.
-  const queryParams = new URLSearchParams(window.location.search);
-
-  // Derive our default state values.
-  const defaultSelectedOption = deriveDefaultSelectedOption();
-  const defaultEvents = deriveFilteredEvents({
-    endDateDay: queryParams.get('endDateDay') || undefined,
-    endDateMonth: queryParams.get('endDateMonth') || undefined,
-    rawEvents,
-    selectedOption: defaultSelectedOption,
-    startDateDay: queryParams.get('startDateDay') || undefined,
-    startDateMonth: queryParams.get('startDateMonth') || undefined,
-  });
-
-  // Derive our state.
-  const [events, setEvents] = useState(defaultEvents);
-  const [page, setPage] = useState(1);
-  const [results, setResults] = useState(deriveResults(events, page, perPage));
-  const [selectedOption, setSelectedOption] = useState(defaultSelectedOption);
-
   // If the feature toggle is disabled, do not render.
   if (!showEventsV2) {
+    // Ensure the legacy liquid page has display: flex.
     showLegacyEvents();
+
+    // Escape early and do not render.
     return null;
   }
 
-  const updateDisplayedResults = filteredEvents => {
-    // Reset pagination.
-    const newPage = 1;
-    setPage(newPage);
-
-    // Derive and set the new results.
-    setResults(deriveResults(filteredEvents, newPage, perPage));
-  };
-
-  // On search handler.
-  const onSearch = event => {
-    // Derive selected option.
-    const newSelectedOption = filterByOptions.find(
-      option => option?.value === event?.target?.filterBy?.value,
-    );
-
-    // Set selected option.
-    setSelectedOption(newSelectedOption);
-
-    // Derive startDateMonth, startDateDay, endDateMonth, and endDateDay values.
-    const startDateMonth = event?.target?.startDateMonth?.value;
-    const startDateDay = event?.target?.startDateDay?.value;
-    const endDateMonth = event?.target?.endDateMonth?.value;
-    const endDateDay = event?.target?.endDateDay?.value;
-
-    // Derive filteredEvents.
-    const filteredEvents = deriveFilteredEvents({
-      endDateDay,
-      endDateMonth,
-      rawEvents,
-      selectedOption: newSelectedOption,
-      startDateDay,
-      startDateMonth,
-    });
-
-    // Set events.
-    setEvents(filteredEvents);
-
-    // Update displayed results.
-    updateDisplayedResults(filteredEvents);
-
-    // Update query params.
-    updateQueryParams({
-      endDateDay,
-      endDateMonth,
-      selectedOption: newSelectedOption?.value,
-      startDateDay,
-      startDateMonth,
-    });
-  };
-
-  // On pagination change handler.
-  const onPageSelect = newPage => {
-    // Update the page.
-    setPage(newPage);
-
-    // Derive and set the new results.
-    setResults(deriveResults(events, newPage, perPage));
-
-    // Scroll to top.
-    scrollToTop();
-  };
-
+  // Ensure the legacy liquid page has display: none.
   hideLegacyEvents();
-  return (
-    <main className="usa-grid usa-grid-full">
-      <div className="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 vads-u-padding-bottom--2">
-        {/* Title */}
-        <h1 className="vads-u-margin--0 vads-">Outreach events</h1>
 
-        {/* Description */}
-        <p className="va-introtext">
-          VA benefits can help Veterans and their families buy homes, earn
-          degrees, start careers, stay healthy, and more. Join an event for
-          conversation and information.
-        </p>
-
-        {/* Search */}
-        <Search onSearch={onSearch} />
-
-        {/* Results */}
-        <Results
-          onPageSelect={onPageSelect}
-          page={page}
-          perPage={perPage}
-          query={selectedOption?.label}
-          results={results}
-          totalResults={events?.length || 0}
-        />
-      </div>
-    </main>
-  );
+  // Show the events listing page v2.
+  return <Events rawEvents={rawEvents} />;
 };
 
 App.propTypes = {

--- a/src/applications/static-pages/events/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/App/index.unit.spec.js
@@ -22,7 +22,7 @@ describe('Events <App>', () => {
     const wrapper = shallow(<App showEventsV2 />);
 
     // Assertions.
-    expect(wrapper.text()).includes('Outreach events');
+    expect(wrapper.find('Events')).to.have.length(1);
 
     // Clean up.
     wrapper.unmount();

--- a/src/applications/static-pages/events/components/Events/constants.js
+++ b/src/applications/static-pages/events/components/Events/constants.js
@@ -1,0 +1,1 @@
+export const perPage = 10;

--- a/src/applications/static-pages/events/components/Events/constants.unit.spec.js
+++ b/src/applications/static-pages/events/components/Events/constants.unit.spec.js
@@ -1,0 +1,11 @@
+// Node modules.
+import { expect } from 'chai';
+// Relative imports.
+import { perPage } from './constants';
+
+describe('Events constants.js', () => {
+  it('perPage', () => {
+    // Assertions.
+    expect(perPage).to.equal(10);
+  });
+});

--- a/src/applications/static-pages/events/components/Events/index.js
+++ b/src/applications/static-pages/events/components/Events/index.js
@@ -1,0 +1,149 @@
+// Node modules.
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+// Relative imports.
+import Results from '../Results';
+import Search from '../Search';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import {
+  deriveDefaultSelectedOption,
+  deriveFilteredEvents,
+  deriveResults,
+  filterByOptions,
+  updateQueryParams,
+} from '../../helpers';
+import { perPage } from './constants';
+
+export const Events = ({ rawEvents }) => {
+  // Derive the query params on the URL.
+  const queryParams = new URLSearchParams(window.location.search);
+
+  // Derive our default state values.
+  const defaultSelectedOption = deriveDefaultSelectedOption();
+  const defaultEvents = deriveFilteredEvents({
+    endDateDay: queryParams.get('endDateDay') || undefined,
+    endDateMonth: queryParams.get('endDateMonth') || undefined,
+    rawEvents,
+    selectedOption: defaultSelectedOption,
+    startDateDay: queryParams.get('startDateDay') || undefined,
+    startDateMonth: queryParams.get('startDateMonth') || undefined,
+  });
+
+  // Derive our state.
+  const [events, setEvents] = useState(defaultEvents);
+  const [page, setPage] = useState(1);
+  const [results, setResults] = useState(deriveResults(events, page, perPage));
+  const [selectedOption, setSelectedOption] = useState(defaultSelectedOption);
+
+  const updateDisplayedResults = filteredEvents => {
+    // Reset pagination.
+    const newPage = 1;
+    setPage(newPage);
+
+    // Derive and set the new results.
+    setResults(deriveResults(filteredEvents, newPage, perPage));
+  };
+
+  // On search handler.
+  const onSearch = event => {
+    // Derive selected option.
+    const newSelectedOption = filterByOptions.find(
+      option => option?.value === event?.target?.filterBy?.value,
+    );
+
+    // Set selected option.
+    setSelectedOption(newSelectedOption);
+
+    // Derive startDateMonth, startDateDay, endDateMonth, and endDateDay values.
+    const startDateMonth = event?.target?.startDateMonth?.value;
+    const startDateDay = event?.target?.startDateDay?.value;
+    const endDateMonth = event?.target?.endDateMonth?.value;
+    const endDateDay = event?.target?.endDateDay?.value;
+
+    // Derive filteredEvents.
+    const filteredEvents = deriveFilteredEvents({
+      endDateDay,
+      endDateMonth,
+      rawEvents,
+      selectedOption: newSelectedOption,
+      startDateDay,
+      startDateMonth,
+    });
+
+    // Set events.
+    setEvents(filteredEvents);
+
+    // Update displayed results.
+    updateDisplayedResults(filteredEvents);
+
+    // Update query params.
+    updateQueryParams({
+      endDateDay,
+      endDateMonth,
+      selectedOption: newSelectedOption?.value,
+      startDateDay,
+      startDateMonth,
+    });
+  };
+
+  // On pagination change handler.
+  const onPageSelect = newPage => {
+    // Update the page.
+    setPage(newPage);
+
+    // Derive and set the new results.
+    setResults(deriveResults(events, newPage, perPage));
+
+    // Scroll to top.
+    scrollToTop();
+  };
+
+  return (
+    <div className="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+      {/* Title */}
+      <h1 className="vads-u-margin--0 vads-">Outreach events</h1>
+
+      {/* Description */}
+      <p className="va-introtext">
+        VA benefits can help Veterans and their families buy homes, earn
+        degrees, start careers, stay healthy, and more. Join an event for
+        conversation and information.
+      </p>
+
+      {/* Search */}
+      <Search onSearch={onSearch} />
+
+      {/* Results */}
+      <Results
+        onPageSelect={onPageSelect}
+        page={page}
+        perPage={perPage}
+        query={selectedOption?.label}
+        results={results}
+        totalResults={events?.length || 0}
+      />
+    </div>
+  );
+};
+
+Events.propTypes = {
+  rawEvents: PropTypes.arrayOf(
+    PropTypes.shape({
+      entityUrl: PropTypes.shape({
+        path: PropTypes.string,
+      }),
+      fieldDatetimeRangeTimezone: PropTypes.shape({
+        value: PropTypes.number,
+        endValue: PropTypes.number,
+        timezone: PropTypes.string,
+      }),
+      fieldDescription: PropTypes.string,
+      fieldFacilityLocation: PropTypes.object,
+      fieldFeatured: PropTypes.bool,
+      fieldLocationHumanreadable: PropTypes.string,
+      title: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+export default Events;

--- a/src/applications/static-pages/events/components/Events/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/Events/index.unit.spec.js
@@ -1,0 +1,26 @@
+// Node modules.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import Results from '../Results';
+import Search from '../Search';
+import { Events } from '.';
+
+describe('Events <Events>', () => {
+  it('renders content', () => {
+    // Set up.
+    const wrapper = shallow(<Events />);
+
+    // Assertions.
+    expect(wrapper.text()).includes('Outreach events');
+    expect(wrapper.text()).includes(
+      'VA benefits can help Veterans and their families buy homes, earn degrees, start careers, stay healthy, and more. Join an event for conversation and information.',
+    );
+    expect(wrapper.find(Search)).to.have.length(1);
+    expect(wrapper.find(Results)).to.have.length(1);
+
+    // Clean up.
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -112,6 +112,7 @@ export const Search = ({ onSearch }) => {
           id="filterBy"
           name="filterBy"
           onChange={onFilterByChange}
+          style={{ maxWidth: 'unset' }}
           value={selectedOption?.value}
         >
           {filterByOptions?.map(option => (

--- a/src/applications/static-pages/events/components/Search/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/Search/index.unit.spec.js
@@ -12,6 +12,7 @@ describe('Events <Search>', () => {
 
     // Assertions.
     expect(wrapper.text()).includes('Filter by');
+    expect(wrapper.text()).includes('Filter events');
 
     // Clean up.
     wrapper.unmount();

--- a/src/applications/static-pages/events/helpers/index.js
+++ b/src/applications/static-pages/events/helpers/index.js
@@ -295,9 +295,7 @@ export const deriveEndsAtUnix = (startsAtUnix, endDateMonth, endDateDay) => {
 
 export const hideLegacyEvents = () => {
   // Derive the legacy events page.
-  const legacyEvents = document.querySelector(
-    'div[data-template="event_listing.drupal.liquid"]',
-  );
+  const legacyEvents = document.querySelector('div[id="events-v1"]');
 
   // Escape early if the legacy events page doesn't exist.
   if (!legacyEvents) {
@@ -312,9 +310,7 @@ export const hideLegacyEvents = () => {
 
 export const showLegacyEvents = () => {
   // Derive the legacy events page.
-  const legacyEvents = document.querySelector(
-    'div[data-template="event_listing.drupal.liquid"]',
-  );
+  const legacyEvents = document.querySelector('div[id="events-v1"]');
 
   // Escape early if the legacy events page doesn't exist.
   if (!legacyEvents) {


### PR DESCRIPTION
## Description

This PR tweaks the events v2 implementation to be located within the events v2 liquid template (where we won't have to render the sidebar conditionally on vamc events pages in react). It also abstracts the Events component into a separate file/folder for maintainability + adds a few tests.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32601


## Testing done
Updated a few tests

## Screenshots


## Acceptance criteria
- [x] tweaks the events v2 implementation to be located within the events v2 liquid template (where we won't have to render the sidebar conditionally on vamc events pages in react)
- [x] abstracts the Events component into a separate file/folder for maintainability + adds a few tests

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
