### PR TITLE
[eBenefits] replace external manifest imports

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -2,31 +2,9 @@ import React from 'react';
 import * as Sentry from '@sentry/browser';
 import { isPlainObject } from 'lodash';
 
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-
-import { VA_FORM_IDS } from 'platform/forms/constants.js';
+import { VA_FORM_IDS } from 'platform/forms/constants';
 import recordEvent from 'platform/monitoring/record-event';
-
-import hcaManifest from 'applications/hca/manifest.json';
-import dependentStatusManifest from 'applications/disability-benefits/686c-674/manifest.json';
-import feedbackManifest from 'applications/edu-benefits/feedback-tool/manifest.json';
-import burialsManifest from 'applications/burials/manifest.json';
-import edu1990Manifest from 'applications/edu-benefits/1990/manifest.json';
-import edu1995Manifest from 'applications/edu-benefits/1995/manifest.json';
-import edu1990eManifest from 'applications/edu-benefits/1990e/manifest.json';
-import edu1990nManifest from 'applications/edu-benefits/1990n/manifest.json';
-import edu5490Manifest from 'applications/edu-benefits/5490/manifest.json';
-import edu5495Manifest from 'applications/edu-benefits/5495/manifest.json';
-import edu0993Manifest from 'applications/edu-benefits/0993/manifest.json';
-import edu0994Manifest from 'applications/edu-benefits/0994/manifest.json';
-import edu10203Manifest from 'applications/edu-benefits/10203/manifest.json';
-import preneedManifest from 'applications/pre-need/manifest.json';
-import pensionManifest from 'applications/pensions/manifest.json';
-import disability526Manifest from 'applications/disability-benefits/all-claims/manifest.json';
-import hlrManifest from 'applications/disability-benefits/996/manifest.json';
-import mdotManifest from 'applications/disability-benefits/2346/manifest.json';
-import fsrManifest from 'applications/financial-status-report/manifest.json';
-import mebManifest from 'applications/my-education-benefits/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 
 export const formBenefits = {
   [VA_FORM_IDS.FORM_21_526EZ]: 'disability compensation',
@@ -88,26 +66,26 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
 );
 
 export const formLinks = {
-  [VA_FORM_IDS.FORM_21_526EZ]: `${disability526Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_21P_527EZ]: `${pensionManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_21P_530]: `${burialsManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_10_10EZ]: `${hcaManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_0993]: `${edu0993Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_0994]: `${edu0994Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_1990]: `${edu1990Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_1990E]: `${edu1990eManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_1990EZ]: `${mebManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_1990N]: `${edu1990nManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_1995]: `${edu1995Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_5490]: `${edu5490Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_5495]: `${edu5495Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_22_10203]: `${edu10203Manifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_40_10007]: `${preneedManifest.rootUrl}/`,
-  [VA_FORM_IDS.FEEDBACK_TOOL]: `${feedbackManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_21_686C]: `${dependentStatusManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_20_0996]: `${hlrManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_VA_2346A]: `${mdotManifest.rootUrl}/`,
-  [VA_FORM_IDS.FORM_5655]: `${fsrManifest.rootUrl}/`,
+  [VA_FORM_IDS.FEEDBACK_TOOL]: `${getAppUrl('feedback-tool')}/`,
+  [VA_FORM_IDS.FORM_10_10EZ]: `${getAppUrl('hca')}/`,
+  [VA_FORM_IDS.FORM_20_0996]: `${getAppUrl('0996-higher-level-review')}/`,
+  [VA_FORM_IDS.FORM_21_526EZ]: `${getAppUrl('526EZ-all-claims')}/`,
+  [VA_FORM_IDS.FORM_21_686C]: `${getAppUrl('686C-674')}/`,
+  [VA_FORM_IDS.FORM_21P_527EZ]: `${getAppUrl('pensions')}/`,
+  [VA_FORM_IDS.FORM_21P_530]: `${getAppUrl('burials')}/`,
+  [VA_FORM_IDS.FORM_22_0993]: `${getAppUrl('0993-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_0994]: `${getAppUrl('0994-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_1990]: `${getAppUrl('1990-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_1990E]: `${getAppUrl('1990e-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_1990EZ]: `${getAppUrl('1990ez-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_1990N]: `${getAppUrl('1990n-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_1995]: `${getAppUrl('1995-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_5490]: `${getAppUrl('5490-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_5495]: `${getAppUrl('5495-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_22_10203]: `${getAppUrl('10203-edu-benefits')}/`,
+  [VA_FORM_IDS.FORM_40_10007]: `${getAppUrl('pre-need')}/`,
+  [VA_FORM_IDS.FORM_5655]: `${getAppUrl('request-debt-help-form-5655')}/`,
+  [VA_FORM_IDS.FORM_VA_2346A]: `${getAppUrl('order-form-2346')}/`,
 };
 
 export const trackingPrefixes = {
@@ -246,7 +224,7 @@ export const renderWidgetDowntimeNotification = (appName, sectionTitle) => (
     return (
       <div>
         <h2>{sectionTitle}</h2>
-        <AlertBox
+        <va-alert
           content={
             <div>
               <h4 className="usa-alert-heading">

--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityView.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityView.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import RatedDisabilityList from './RatedDisabilityList';
-import TotalRatedDisabilities from '../components/TotalRatedDisabilities';
-import facilityLocator from 'applications/facility-locator/manifest.json';
+
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
+
+import { getAppUrl } from 'platform/utilities/registry-helpers';
+
+import TotalRatedDisabilities from '../components/TotalRatedDisabilities';
 import { OnThisPageLink } from './OnThisPageLink';
+import RatedDisabilityList from './RatedDisabilityList';
+
+const facilityLocatorUrl = getAppUrl('facilities');
 
 class RatedDisabilityView extends React.Component {
   static propTypes = {
@@ -40,10 +45,7 @@ class RatedDisabilityView extends React.Component {
             help.
           </p>
           <p>
-            <a
-              className="vads-u-font-size--base"
-              href={facilityLocator.rootUrl}
-            >
+            <a className="vads-u-font-size--base" href={facilityLocatorUrl}>
               Find your nearest VA medical center
             </a>
           </p>

--- a/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+
 import recordEvent from 'platform/monitoring/record-event';
-import manifest from 'applications/disability-benefits/686c-674/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 
 import { errorFragment } from '../../layouts/helpers';
 
-const { rootUrl: form686RootUrl } = manifest;
+const form686Url = getAppUrl('686C-674');
 
 const CALLSTATUS = {
   pending: 'pending',
@@ -83,7 +84,7 @@ function ViewDependentsHeader(props) {
         </p>
         {props.dependentsToggle && (
           <a
-            href={form686RootUrl}
+            href={form686Url}
             className="usa-button-primary va-button-primary"
             onClick={handleClick}
           >

--- a/src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js
+++ b/src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js
@@ -1,8 +1,8 @@
 import { getAppUrl } from 'platform/utilities/registry-helpers';
-import mockDependents from 'applications/personalization/view-dependents/tests/e2e/fixtures/mock-dependents.json';
-import mockDiaries from './fixtures/diaries.json';
 
 import { RETRIEVE_DIARIES } from '../utils';
+import mockDependents from './fixtures/mock-dependents.json';
+import mockDiaries from './fixtures/diaries.json';
 
 const DEPENDENTS_ENDPOINT = 'v0/dependents_applications/show';
 const viewDependentsUrl = getAppUrl('dependents-view-dependents');

--- a/src/applications/static-pages/dependency-verification/tests/fixtures/mock-dependents.json
+++ b/src/applications/static-pages/dependency-verification/tests/fixtures/mock-dependents.json
@@ -1,0 +1,42 @@
+{
+    "data": {
+      "id": "",
+      "attributes": {
+        "persons": [
+          {
+            "firstName": "Billy",
+            "lastName": "Blank",
+            "relationship": "Spouse",
+            "ssn": "312-243-5634",
+            "awardIndicator": "Y",
+            "dateOfBirth": "05-05-1983"
+          },
+          {
+            "firstName": "Billy",
+            "lastName": "Blank",
+            "relationship": "Child",
+            "ssn": "312-243-5634",
+            "awardIndicator": "Y",
+            "dateOfBirth": "05-05-1983"
+          },
+          {
+            "firstName": "Billy",
+            "lastName": "Blank",
+            "relationship": "Spouse",
+            "ssn": "312-243-5634",
+            "awardIndicator": "N",
+            "dateOfBirth": "05-05-1983"
+          },
+          {
+            "firstName": "Billy",
+            "lastName": "Blank",
+            "relationship": "Spouse",
+            "ssn": "312-243-5634",
+            "awardIndicator": "N",
+            "dateOfBirth": "05-05-1983"
+          }
+        ]
+      }
+    }
+  }
+  

--- a/src/applications/static-pages/dependency-verification/tests/fixtures/mock-dependents.json
+++ b/src/applications/static-pages/dependency-verification/tests/fixtures/mock-dependents.json
@@ -1,42 +1,41 @@
 {
-    "data": {
-      "id": "",
-      "attributes": {
-        "persons": [
-          {
-            "firstName": "Billy",
-            "lastName": "Blank",
-            "relationship": "Spouse",
-            "ssn": "312-243-5634",
-            "awardIndicator": "Y",
-            "dateOfBirth": "05-05-1983"
-          },
-          {
-            "firstName": "Billy",
-            "lastName": "Blank",
-            "relationship": "Child",
-            "ssn": "312-243-5634",
-            "awardIndicator": "Y",
-            "dateOfBirth": "05-05-1983"
-          },
-          {
-            "firstName": "Billy",
-            "lastName": "Blank",
-            "relationship": "Spouse",
-            "ssn": "312-243-5634",
-            "awardIndicator": "N",
-            "dateOfBirth": "05-05-1983"
-          },
-          {
-            "firstName": "Billy",
-            "lastName": "Blank",
-            "relationship": "Spouse",
-            "ssn": "312-243-5634",
-            "awardIndicator": "N",
-            "dateOfBirth": "05-05-1983"
-          }
-        ]
-      }
+  "data": {
+    "id": "",
+    "attributes": {
+      "persons": [
+        {
+          "firstName": "Billy",
+          "lastName": "Blank",
+          "relationship": "Spouse",
+          "ssn": "312-243-5634",
+          "awardIndicator": "Y",
+          "dateOfBirth": "05-05-1983"
+        },
+        {
+          "firstName": "Billy",
+          "lastName": "Blank",
+          "relationship": "Child",
+          "ssn": "312-243-5634",
+          "awardIndicator": "Y",
+          "dateOfBirth": "05-05-1983"
+        },
+        {
+          "firstName": "Billy",
+          "lastName": "Blank",
+          "relationship": "Spouse",
+          "ssn": "312-243-5634",
+          "awardIndicator": "N",
+          "dateOfBirth": "05-05-1983"
+        },
+        {
+          "firstName": "Billy",
+          "lastName": "Blank",
+          "relationship": "Spouse",
+          "ssn": "312-243-5634",
+          "awardIndicator": "N",
+          "dateOfBirth": "05-05-1983"
+        }
+      ]
     }
   }
-  
+}


### PR DESCRIPTION
## Description
Replaces imports to external `manifest.json` files with calls to `getAppUrl` from `platform/utilities`. This is to get ready for single app builds. Also replaces an instance of `AlertBox` with `va-alert` and adds a copy of `mock-dependents.json` to `static-pages/dependency-verification`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34660

## Acceptance criteria
- [x] All imports to external `manifest.json` files are replaced with calls to `getAppUrl` for eBenefits applications

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
