### PR TITLE
Ensure startsAt and endsAt uses timezone

### DIFF
--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -65,10 +65,10 @@ export const Results = ({
             const timezone = mostRecentDate?.timezone;
 
             // Derive starts at and ends at.
-            const formattedStartsAt = moment(startsAtUnix * 1000).format(
+            const formattedStartsAt = moment.tz(startsAtUnix * 1000, timezone).format(
               'ddd MMM D, YYYY, h:mm a',
             );
-            const formattedEndsAt = moment(endsAtUnix * 1000).format('h:mm a');
+            const formattedEndsAt = moment.tz(endsAtUnix * 1000, timezone).format('h:mm a');
             const endsAtTimezone = moment
               .tz(endsAtUnix * 1000, timezone)
               .format('z');

--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -65,10 +65,12 @@ export const Results = ({
             const timezone = mostRecentDate?.timezone;
 
             // Derive starts at and ends at.
-            const formattedStartsAt = moment.tz(startsAtUnix * 1000, timezone).format(
-              'ddd MMM D, YYYY, h:mm a',
-            );
-            const formattedEndsAt = moment.tz(endsAtUnix * 1000, timezone).format('h:mm a');
+            const formattedStartsAt = moment
+              .tz(startsAtUnix * 1000, timezone)
+              .format('ddd MMM D, YYYY, h:mm a');
+            const formattedEndsAt = moment
+              .tz(endsAtUnix * 1000, timezone)
+              .format('h:mm a');
             const endsAtTimezone = moment
               .tz(endsAtUnix * 1000, timezone)
               .format('z');


### PR DESCRIPTION
## Description

This PR standardizes the timestamp shown for events v2 across event listing pages + event detail pages.

## Screenshots

### Before where all timestamps were showing different values

![image](https://user-images.githubusercontent.com/12773166/147858218-31779699-2d99-4074-9afe-2ef4f0b05426.png)
![image](https://user-images.githubusercontent.com/12773166/147858222-ce983abb-1b8a-4d03-b829-f1924bd4abc1.png)
![image](https://user-images.githubusercontent.com/12773166/147858228-cdba4cc2-6441-434c-9311-1e8ef8efc74e.png)

### Now all values are `Wednesday, Jan 5, 2022, 1:00 p.m. – 2:00 p.m. EST` for this example

## Acceptance criteria
- [x] Standardize event timestamps

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
