### PR TITLE
HLR: prevent duplicate API calls

### DIFF
--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -39,13 +39,17 @@ export const Form0996App = ({
 }) => {
   const { email = {}, mobilePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
+  // Make sure we're only loading issues once - see
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
+  const [isLoadingIssues, setIsLoadingIssues] = useState(false);
 
   useEffect(
     () => {
       if (loggedIn && getHlrWizardStatus() === WIZARD_STATUS_COMPLETE) {
         const { veteran = {} } = formData || {};
         const areaOfDisagreement = getSelected(formData);
-        if (!contestableIssues?.status) {
+        if (!isLoadingIssues && (contestableIssues?.status || '') === '') {
+          setIsLoadingIssues(true);
           const benefitType =
             sessionStorage.getItem(SAVED_CLAIM_TYPE) || formData.benefitType;
           getContestableIssues({ benefitType, hlrV2 });
@@ -105,6 +109,7 @@ export const Form0996App = ({
       setFormData,
       hlrV2,
       contestableIssues,
+      isLoadingIssues,
       getContestableIssues,
     ],
   );

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -17,10 +17,7 @@ import { selectVAPContactInfoField } from '@@vap-svc/selectors';
 import { FIELD_NAMES } from '@@vap-svc/constants';
 import { WIZARD_STATUS_NOT_STARTED } from 'platform/site-wide/wizard';
 
-import {
-  getContestableIssues as getContestableIssuesAction,
-  FETCH_CONTESTABLE_ISSUES_INIT,
-} from '../actions';
+import { FETCH_CONTESTABLE_ISSUES_INIT } from '../actions';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 
@@ -246,7 +243,6 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   toggleLoginModal,
-  getContestableIssues: getContestableIssuesAction,
 };
 
 export default connect(

--- a/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
@@ -141,7 +141,7 @@ describe('Form0996App', () => {
 
     tree.setProps();
     expect(tree.find('h1').text()).to.contain('Loading your previous decision');
-    expect(getIssues.called).to.be.true;
+    expect(getIssues.calledOnce).to.be.true;
     tree.unmount();
   });
   it('should not call API if not logged in', () => {
@@ -187,7 +187,7 @@ describe('Form0996App', () => {
     );
 
     tree.setProps();
-    expect(getIssues.called).to.be.true;
+    expect(getIssues.calledOnce).to.be.true;
 
     tree.unmount();
   });


### PR DESCRIPTION
## Description

The Higher-Level Review contestable issues endpoint has had a significane increase in API calls since October 2021. This PR adds a state check to ensure the API is only called once per page load. This may fix the problem, so we will follow up on the API call rate once this change is in place.

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
- Analytics: https://vpc-dvp-prod-kong-logs-lxxvek5z56mgfqmvkwzjeqiadi.us-gov-west-1.es.amazonaws.com/_plugin/kibana/app/visualize#/edit/052d79e0-3e34-11eb-b8d1-a1cd19a6562c?_g=h@9dba178&_a=h@8523f02

## Testing done

Added a check

## Screenshots

<details><summary>Increase API calls</summary>

<!-- leave a blank line above -->
![Screen Shot 2022-01-03 at 1 47 47 PM](https://user-images.githubusercontent.com/136959/147974386-da6e90d3-62c1-4420-b281-ae198aefb366.png)</details>

## Acceptance criteria
- [x] Add method to prevent duplicate API calls
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
