### PR TITLE
Remove manifest imports from vap-svc

### DIFF
--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import facilityLocator from '~/applications/facility-locator/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 
 import {
   DECEASED_ERROR_CODES,
@@ -36,7 +36,7 @@ export default function VAPServiceEditModalErrorMessage({
             deceased. If this isn’t true, please contact your nearest VA medical
             center.
           </p>
-          <a href={facilityLocator.rootUrl}>
+          <a href={getAppUrl('facilities')}>
             Find your nearest VA medical center
           </a>
         </div>

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionErrorBanner.jsx
@@ -4,7 +4,7 @@ import Telephone, {
   CONTACTS,
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
-import facilityLocator from '~/applications/facility-locator/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 
 import {
   hasGenericUpdateError,
@@ -90,7 +90,7 @@ export function MVILookupFailError(props) {
             Veteran records, so we can’t give you access to tools for managing
             your health and benefits.
           </p>
-          <a href={facilityLocator.rootUrl}>
+          <a href={getAppUrl('facilities')}>
             Find your nearest VA medical center
           </a>
         </div>


### PR DESCRIPTION
## Description
Now that we have the `getAppUrl` registry helper function, we can use that for getting the app URLs of other apps.


## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] `vap-svc` doesn't import manifest files from apps

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
