### PR TITLE
Remove manifest imports from resources-and-support

### DIFF
--- a/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
+++ b/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
 import URLSearchParams from 'url-search-params';
 import { focusElement } from 'platform/utilities/ui';
-import searchSettings from 'applications/search/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 // Relative imports.
 import SearchBar from './SearchBar';
 import SearchResultList from './SearchResultList';
@@ -86,9 +86,7 @@ const ResourcesAndSupportSearchApp = () => {
         We didn’t find any resources and support articles for "
         <strong>{query}</strong>
         ." Try using different words or{' '}
-        <a
-          href={`${searchSettings.rootUrl}/?query=${encodeURIComponent(query)}`}
-        >
+        <a href={`${getAppUrl('search')}/?query=${encodeURIComponent(query)}`}>
           search all of VA.gov
         </a>
         .

--- a/src/applications/resources-and-support/components/SearchBar.jsx
+++ b/src/applications/resources-and-support/components/SearchBar.jsx
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 // Relative imports.
 import recordEvent from 'platform/monitoring/record-event';
 import resourcesSettings from '../manifest.json';
-import searchSettings from 'applications/search/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
+
+const searchUrl = getAppUrl('search');
 
 export default function SearchBar({
   onInputChange,
@@ -75,9 +77,7 @@ export default function SearchBar({
         {/* Search form */}
         <form
           action={
-            isGlobalSearch
-              ? `${searchSettings.rootUrl}/`
-              : `${resourcesSettings.rootUrl}/`
+            isGlobalSearch ? `${searchUrl}/` : `${resourcesSettings.rootUrl}/`
           }
           className={`${
             expanded ? 'va-border-bottom-radius--5px ' : 'vads-u-display--none '


### PR DESCRIPTION
## Description
Now that we have the `getAppUrl` registry helper function, we can use that for getting the app URLs of other apps.

## Testing done


## Screenshots


## Acceptance criteria
- [x] `resources-and-support` doesn't import manifest files from apps

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
