### PR TITLE
Remove external manifest import from pre-need

### DIFF
--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -6,8 +6,7 @@ import BurialModalContent from 'platform/forms/components/OMBInfoModalContent/Bu
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import environment from 'platform/utilities/environment';
-
-import facilityLocator from '../../facility-locator/manifest.json';
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -47,7 +46,7 @@ class IntroductionPage extends React.Component {
                   The name of the VA national cemetery where you’d prefer to be
                   buried.
                   <br />
-                  <a href={facilityLocator.rootUrl}>
+                  <a href={getAppUrl('facilities')}>
                     Find a VA national cemetery
                   </a>
                   .


### PR DESCRIPTION
## Description
Now that we have the `getAppUrl` registry helper function, we can use that for getting the app URLs of other apps.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
