### PR TITLE
remove moment dependencies

### DIFF
--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import getSeconds from 'date-fns/getSeconds';
+import differenceInSeconds from 'date-fns/differenceInSeconds';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
@@ -40,14 +40,9 @@ class SessionTimeoutModal extends React.Component {
     }
 
     const expirationDate = localStorage.getItem('sessionExpiration');
-    if (!expirationDate) return;
+    if (!expirationDate || isNaN(new Date(expirationDate).getTime())) return;
 
-    const expirationTime = new Date(expirationDate).getTime();
-    if (isNaN(expirationTime)) return;
-
-    const countdown = Math.floor(
-      getSeconds(expirationDate) - getSeconds(new Date()),
-    );
+    const countdown = differenceInSeconds(new Date(expirationDate), Date.now());
     if (countdown < 0) this.expireSession();
     else if (countdown <= MODAL_DURATION) this.setState({ countdown });
   };

--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import getSeconds from 'date-fns/getSeconds';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
@@ -44,7 +45,9 @@ class SessionTimeoutModal extends React.Component {
     const expirationTime = new Date(expirationDate).getTime();
     if (isNaN(expirationTime)) return;
 
-    const countdown = Math.floor((expirationTime - Date.now()) / 1000);
+    const countdown = Math.floor(
+      getSeconds(expirationDate) - getSeconds(new Date()),
+    );
     if (countdown < 0) this.expireSession();
     else if (countdown <= MODAL_DURATION) this.setState({ countdown });
   };

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -1,4 +1,3 @@
-// import moment from 'moment';
 import addSeconds from 'date-fns/addSeconds';
 import differenceInSeconds from 'date-fns/differenceInSeconds';
 import environment from 'platform/utilities/environment';
@@ -116,7 +115,7 @@ export function checkAndUpdateSSOeSession() {
     const sessionExpiration = localStorage.getItem('sessionExpirationSSO');
 
     const remainingSessionTime = differenceInSeconds(
-      sessionExpiration,
+      new Date(sessionExpiration),
       new Date(),
     );
     if (remainingSessionTime <= keepAliveThreshold) {

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -1,4 +1,6 @@
-import moment from 'moment';
+// import moment from 'moment';
+import addSeconds from 'date-fns/addSeconds';
+import differenceInSeconds from 'date-fns/differenceInSeconds';
 import environment from 'platform/utilities/environment';
 import localStorage from '../storage/localStorage';
 import { hasSessionSSO } from '../../user/profile/utilities';
@@ -29,7 +31,7 @@ export async function ssoKeepAliveSession() {
   if (ttl > 0) {
     // ttl is positive, user has an active session
     // ttl is in seconds, add from now
-    const expirationTime = moment().add(ttl, 's');
+    const expirationTime = addSeconds(new Date(), ttl);
     localStorage.setItem('sessionExpirationSSO', expirationTime);
     localStorage.setItem('hasSessionSSO', true);
   } else if (ttl === 0) {
@@ -113,7 +115,10 @@ export function checkAndUpdateSSOeSession() {
   if (hasSessionSSO()) {
     const sessionExpiration = localStorage.getItem('sessionExpirationSSO');
 
-    const remainingSessionTime = moment(sessionExpiration).diff(moment());
+    const remainingSessionTime = differenceInSeconds(
+      sessionExpiration,
+      new Date(),
+    );
     if (remainingSessionTime <= keepAliveThreshold) {
       ssoKeepAliveSession();
     }


### PR DESCRIPTION
## Description
This PR removes the `moment` dependency for modifying JS dates in favor of `date-fns` due to it's lightweight characteristics.  Additionally, it unifies the SessionTimeoutModal to use `date-fns` instead of vanilla JS dates.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#30007


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] The `sessionExpiration` still is parsed as a Date object
- [x] SessionTimeoutModal works as expected
- [x] Moment dependency is removed from sso files

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
