### PR TITLE
HLR: Replace `AdditionalInfo` with web component

### DIFF
--- a/src/applications/disability-benefits/996/content/contestableIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssues.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -105,16 +104,16 @@ const disabilitiesList = (
 export const disabilitiesExplanationAlert = (
   <>
     <p className="vads-u-margin-top--2p5" />
-    <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
+    <va-additional-info trigger="Why isn’t my issue eligible?">
       {disabilitiesList}
-    </AdditionalInfo>
+    </va-additional-info>
   </>
 );
 
 export const disabilitiesExplanation = (
-  <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
+  <va-additional-info trigger="Don’t see the issue you’re looking for?">
     {disabilitiesList}
-  </AdditionalInfo>
+  </va-additional-info>
 );
 
 export const maxSelectedErrorMessage =

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -154,16 +153,16 @@ const disabilitiesList = (
 export const disabilitiesExplanationAlert = (
   <>
     <p className="vads-u-margin-top--2p5" />
-    <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
+    <va-additional-info trigger="Why isn’t my issue eligible?">
       {disabilitiesList}
-    </AdditionalInfo>
+    </va-additional-info>
   </>
 );
 
 export const disabilitiesExplanation = (
-  <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
+  <va-additional-info trigger="Don’t see the issue you’re looking for?">
     {disabilitiesList}
-  </AdditionalInfo>
+  </va-additional-info>
 );
 
 /**


### PR DESCRIPTION
## Description

Switch from using the `AdditionalInfo` React component to the `va-additional-info` web component within the Higher-Level Review form

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34706

## Testing done

All unit tests continue to pass

## Screenshots

N/A

## Acceptance criteria
- [x] AdditionalInfo components replaced
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
