### PR TITLE
18606/Direct-Deposit-Component-Aria-Label

### DIFF
--- a/src/platform/forms-system/src/js/components/ReviewCardField.jsx
+++ b/src/platform/forms-system/src/js/components/ReviewCardField.jsx
@@ -146,7 +146,9 @@ export default class ReviewCardField extends React.Component {
       this.props.uiSchema,
     );
 
-    const { volatileData, editTitle } = this.props.uiSchema['ui:options'];
+    const { volatileData, editTitle, ariaLabel } = this.props.uiSchema[
+      'ui:options'
+    ];
     const title = editTitle || this.getTitle();
     const subtitle = this.getSubtitle();
     const titleClasses = [
@@ -211,7 +213,11 @@ export default class ReviewCardField extends React.Component {
           <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--2p5">
             {!formContext.reviewMode && (
               <>
-                <button className={updateButtonClasses} onClick={this.update}>
+                <button
+                  className={updateButtonClasses}
+                  onClick={this.update}
+                  aria-label={`${ariaLabel || 'Save Changes'}`}
+                >
                   Save
                 </button>
                 {((volatileData && this.state.canCancel) || !volatileData) && (
@@ -219,6 +225,7 @@ export default class ReviewCardField extends React.Component {
                     className={cancelButtonClasses}
                     style={{ boxShadow: 'none' }}
                     onClick={this.cancelUpdate}
+                    aria-label={'Cancel Changes'}
                   >
                     Cancel
                   </button>

--- a/src/platform/forms-system/src/js/definitions/directDeposit.jsx
+++ b/src/platform/forms-system/src/js/definitions/directDeposit.jsx
@@ -56,6 +56,7 @@ const uiSchema = ({ affectedBenefits, unaffectedBenefits, optionalFields }) => {
         itemNameAction: 'Update',
         startInEdit: data => !data?.['view:hasPrefilledBank'],
         volatileData: true,
+        ariaLabel: 'Save direct deposit information',
       },
       'ui:order': [
         'view:paymentText',


### PR DESCRIPTION
## Description
Location of issue can be found on this form `/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s/apply` 
Save button of the direct deposit form was missing an `aria-label`

## Original issue(s)
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/18606

## Testing done / Screenshots
<img width="1394" alt="Screen Shot 2022-01-04 at 7 36 37 PM" src="https://user-images.githubusercontent.com/11822533/148142748-960689b2-8ab0-4a61-8893-e43eaa78998c.png">


## Acceptance criteria
- [X] Save button has either an aria-label or a more descriptive visual label
- [X] Label should say "Save direct deposit information" or something similar

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
