### PR TITLE
Add conditional link for contact based on flag

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
@@ -1,34 +1,46 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
+import { showProfileLGBTQEnhancements } from '@@profile/selectors';
 
-import { FIELD_NAMES } from '@@vap-svc/constants';
+import { FIELD_NAMES, MISSING_CONTACT_INFO } from '@@vap-svc/constants';
 
-export const MISSING_CONTACT_INFO = {
-  EMAIL: 'EMAIL',
-  MOBILE: 'MOBILE',
-};
-
-const linkMap = {
-  [MISSING_CONTACT_INFO.EMAIL]: {
-    linkText: 'Add your email address',
-    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true),
-  },
-  [MISSING_CONTACT_INFO.MOBILE]: {
-    linkText: 'Add your mobile phone number',
-    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true),
-  },
-};
-
-const AddContactInfoLink = ({ missingInfo }) => {
+const AddContactInfoLink = ({
+  missingInfo,
+  shouldShowProfileLGBTQEnhancements,
+}) => {
   const linkInfo = React.useMemo(
     () => {
+      const linkMap = {
+        [MISSING_CONTACT_INFO.EMAIL]: {
+          linkText: 'Add your email address',
+          linkTarget: getContactInfoDeepLinkURL(
+            FIELD_NAMES.EMAIL,
+            true,
+            shouldShowProfileLGBTQEnhancements,
+          ),
+        },
+        [MISSING_CONTACT_INFO.MOBILE]: {
+          linkText: 'Add your mobile phone number',
+          linkTarget: getContactInfoDeepLinkURL(
+            FIELD_NAMES.MOBILE_PHONE,
+            true,
+            shouldShowProfileLGBTQEnhancements,
+          ),
+        },
+      };
+
       return linkMap[missingInfo];
     },
-    [missingInfo],
+    [missingInfo, shouldShowProfileLGBTQEnhancements],
   );
   return <Link to={linkInfo.linkTarget}>{linkInfo.linkText}</Link>;
 };
 
-export default AddContactInfoLink;
+const mapStateToProps = state => ({
+  shouldShowProfileLGBTQEnhancements: showProfileLGBTQEnhancements(state),
+});
+
+export default connect(mapStateToProps)(AddContactInfoLink);

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
@@ -4,9 +4,9 @@ import AlertBox, {
   ALERT_TYPE,
 } from '@department-of-veterans-affairs/component-library/AlertBox';
 
-import AddContactInfoLink, {
-  MISSING_CONTACT_INFO,
-} from './MissingContactInfoAlertLink';
+import MissingContactInfoAlertLink from './MissingContactInfoAlertLink';
+
+import { MISSING_CONTACT_INFO } from '@@vap-svc/constants';
 
 const missingEmailAddressContent = (
   <>
@@ -15,7 +15,7 @@ const missingEmailAddressContent = (
       your profile.
     </p>
     <p>
-      <AddContactInfoLink missingInfo={MISSING_CONTACT_INFO.EMAIL} />
+      <MissingContactInfoAlertLink missingInfo={MISSING_CONTACT_INFO.EMAIL} />
     </p>
   </>
 );
@@ -26,7 +26,7 @@ const missingMobilePhoneContent = (
       phone number to your profile.
     </p>
     <p>
-      <AddContactInfoLink missingInfo={MISSING_CONTACT_INFO.MOBILE} />
+      <MissingContactInfoAlertLink missingInfo={MISSING_CONTACT_INFO.MOBILE} />
     </p>
   </>
 );

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 
+import { showProfileLGBTQEnhancements } from '@@profile/selectors';
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
 
 import { FIELD_NAMES } from '@@vap-svc/constants';
@@ -11,30 +13,44 @@ export const MISSING_CONTACT_INFO = {
   MOBILE: 'MOBILE',
 };
 
-const linkMap = {
-  [MISSING_CONTACT_INFO.ALL]: {
-    linkText: 'Update your contact information',
-    linkTarget: getContactInfoDeepLinkURL('phoneNumbers', false),
-  },
-  [MISSING_CONTACT_INFO.EMAIL]: {
-    linkText: 'Add an email address to your profile',
-    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true),
-  },
-  [MISSING_CONTACT_INFO.MOBILE]: {
-    linkText: 'Add a mobile phone number to your profile',
-    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true),
-  },
+// const getDeepLinkBasedOnFlag = flag => {
+//   if (flag) return;
+// };
+
+const makeLinkMap = (missingInfo, flag = false) => {
+  const linkMap = {
+    [MISSING_CONTACT_INFO.ALL]: {
+      linkText: 'Update your contact information',
+      linkTarget: getContactInfoDeepLinkURL('phoneNumbers', false, flag),
+    },
+    [MISSING_CONTACT_INFO.EMAIL]: {
+      linkText: 'Add an email address to your profile',
+      linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true, flag),
+    },
+    [MISSING_CONTACT_INFO.MOBILE]: {
+      linkText: 'Add a mobile phone number to your profile',
+      linkTarget: getContactInfoDeepLinkURL(
+        FIELD_NAMES.MOBILE_PHONE,
+        true,
+        flag,
+      ),
+    },
+  };
+  return linkMap[missingInfo];
 };
 
-const AddContactInfoLink = ({ missingInfo }) => {
+const AddContactInfoLink = ({
+  missingInfo,
+  shouldShowProfileLGBTQEnhancements,
+}) => {
   const linkInfo = React.useMemo(
     () => {
-      return linkMap[missingInfo];
+      return makeLinkMap(missingInfo, shouldShowProfileLGBTQEnhancements);
     },
-    [missingInfo],
+    [missingInfo, shouldShowProfileLGBTQEnhancements],
   );
   return (
-    <Link to={linkInfo.linkTarget}>
+    <Link to={linkInfo.linkTarget} data-testid="add-contact-info-link">
       <strong>{linkInfo.linkText}</strong>{' '}
       <i
         aria-hidden="true"
@@ -44,4 +60,8 @@ const AddContactInfoLink = ({ missingInfo }) => {
   );
 };
 
-export default AddContactInfoLink;
+const mapStateToProps = state => ({
+  shouldShowProfileLGBTQEnhancements: showProfileLGBTQEnhancements(state),
+});
+
+export default connect(mapStateToProps)(AddContactInfoLink);

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
@@ -13,10 +13,6 @@ export const MISSING_CONTACT_INFO = {
   MOBILE: 'MOBILE',
 };
 
-// const getDeepLinkBasedOnFlag = flag => {
-//   if (flag) return;
-// };
-
 const makeLinkMap = (missingInfo, flag = false) => {
   const linkMap = {
     [MISSING_CONTACT_INFO.ALL]: {

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
@@ -5,43 +5,41 @@ import { connect } from 'react-redux';
 import { showProfileLGBTQEnhancements } from '@@profile/selectors';
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
 
-import { FIELD_NAMES } from '@@vap-svc/constants';
+import { FIELD_NAMES, MISSING_CONTACT_INFO } from '@@vap-svc/constants';
 
-export const MISSING_CONTACT_INFO = {
-  ALL: 'ALL',
-  EMAIL: 'EMAIL',
-  MOBILE: 'MOBILE',
-};
-
-const makeLinkMap = (missingInfo, flag = false) => {
-  const linkMap = {
-    [MISSING_CONTACT_INFO.ALL]: {
-      linkText: 'Update your contact information',
-      linkTarget: getContactInfoDeepLinkURL('phoneNumbers', false, flag),
-    },
-    [MISSING_CONTACT_INFO.EMAIL]: {
-      linkText: 'Add an email address to your profile',
-      linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true, flag),
-    },
-    [MISSING_CONTACT_INFO.MOBILE]: {
-      linkText: 'Add a mobile phone number to your profile',
-      linkTarget: getContactInfoDeepLinkURL(
-        FIELD_NAMES.MOBILE_PHONE,
-        true,
-        flag,
-      ),
-    },
-  };
-  return linkMap[missingInfo];
-};
-
-const AddContactInfoLink = ({
+const MissingContactInfoAlertLink = ({
   missingInfo,
   shouldShowProfileLGBTQEnhancements,
 }) => {
   const linkInfo = React.useMemo(
     () => {
-      return makeLinkMap(missingInfo, shouldShowProfileLGBTQEnhancements);
+      const linkMap = {
+        [MISSING_CONTACT_INFO.ALL]: {
+          linkText: 'Update your contact information',
+          linkTarget: getContactInfoDeepLinkURL(
+            'phoneNumbers',
+            false,
+            shouldShowProfileLGBTQEnhancements,
+          ),
+        },
+        [MISSING_CONTACT_INFO.EMAIL]: {
+          linkText: 'Add an email address to your profile',
+          linkTarget: getContactInfoDeepLinkURL(
+            FIELD_NAMES.EMAIL,
+            true,
+            shouldShowProfileLGBTQEnhancements,
+          ),
+        },
+        [MISSING_CONTACT_INFO.MOBILE]: {
+          linkText: 'Add a mobile phone number to your profile',
+          linkTarget: getContactInfoDeepLinkURL(
+            FIELD_NAMES.MOBILE_PHONE,
+            true,
+            shouldShowProfileLGBTQEnhancements,
+          ),
+        },
+      };
+      return linkMap[missingInfo];
     },
     [missingInfo, shouldShowProfileLGBTQEnhancements],
   );
@@ -60,4 +58,4 @@ const mapStateToProps = state => ({
   shouldShowProfileLGBTQEnhancements: showProfileLGBTQEnhancements(state),
 });
 
-export default connect(mapStateToProps)(AddContactInfoLink);
+export default connect(mapStateToProps)(MissingContactInfoAlertLink);

--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannelUnavailable.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannelUnavailable.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import AddContactInfoLink, { MISSING_CONTACT_INFO } from './AddContactInfoLink';
+import AddContactInfoLink from './AddContactInfoLink';
+
+import { MISSING_CONTACT_INFO } from '@@vap-svc/constants';
 
 const NotificationChannelUnavailable = ({ channelType }) => {
   const missingInfo = React.useMemo(

--- a/src/applications/personalization/profile/helpers.js
+++ b/src/applications/personalization/profile/helpers.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import moment from 'moment';
-import { PROFILE_PATHS, USA_MILITARY_BRANCHES } from './constants';
+import {
+  PROFILE_PATHS,
+  PROFILE_PATHS_LGBTQ_ENHANCEMENT,
+  USA_MILITARY_BRANCHES,
+} from './constants';
 import { FIELD_IDS } from '@@vap-svc/constants';
 
 /**
@@ -60,8 +64,13 @@ export const transformServiceHistoryEntryIntoTableRow = entry => {
 export const getContactInfoDeepLinkURL = (
   fieldName,
   focusOnEditButton = false,
+  enhancementFlag = false,
 ) => {
   const targetId = FIELD_IDS[fieldName];
   const fragment = focusOnEditButton ? `edit-${targetId}` : targetId;
-  return `${PROFILE_PATHS.PERSONAL_INFORMATION}#${fragment}`;
+  return `${
+    enhancementFlag
+      ? PROFILE_PATHS_LGBTQ_ENHANCEMENT.CONTACT_INFORMATION
+      : PROFILE_PATHS.PERSONAL_INFORMATION
+  }#${fragment}`;
 };

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info-mobile.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info-mobile.cypress.spec.js
@@ -1,0 +1,115 @@
+import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
+import { makeMockUser } from '@@profile/tests/fixtures/users/user';
+import mockProfileEnhancementsToggles from '@@profile/tests/fixtures/personal-information-feature-toggles.json';
+import mockProfileEnhancementsTogglesOff from '@@profile/tests/fixtures/personal-information-feature-toggles-off.json';
+
+import {
+  PROFILE_PATHS,
+  PROFILE_PATHS_LGBTQ_ENHANCEMENT,
+} from '@@profile/constants';
+
+import {
+  mockNotificationSettingsAPIs,
+  registerCypressHelpers,
+} from '../helpers';
+
+registerCypressHelpers();
+
+describe('Notification Settings For Mobile Phone', () => {
+  let getCommPrefsStub;
+  beforeEach(() => {
+    getCommPrefsStub = cy.stub();
+    mockNotificationSettingsAPIs();
+    cy.intercept('/v0/profile/communication_preferences', req => {
+      getCommPrefsStub();
+      req.reply({
+        statusCode: 200,
+        body: mockCommunicationPreferences,
+      });
+    });
+    cy.injectAxe();
+  });
+  // TODO: Re-enable these tests when the COVID-19 alerts are a supported
+  // notification item. Or whenever a notification item supports email as a
+  // notification channel
+  context(
+    'mobile phone link correct when profileEnhancements feature flag is TRUE',
+    () => {
+      context('when user is missing mobile phone', () => {
+        it('should show the correct mobile phone link', () => {
+          cy.intercept('v0/feature_toggles*', mockProfileEnhancementsToggles);
+          const user = makeMockUser();
+          user.data.attributes.vet360ContactInformation.mobilePhone = null;
+          cy.login(user);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+          cy.loadingIndicatorWorks();
+          cy.findByRole('heading', {
+            name: 'Notification settings',
+            level: 1,
+          }).should('exist');
+
+          cy.findByTestId('missing-contact-info-alert')
+            .should('exist')
+            .and('contain.text', 'mobile phone')
+            .within(() => {
+              cy.findByRole('link', { name: /add.*mobile.*profile/i }).should(
+                'exist',
+              );
+            });
+
+          cy.findAllByTestId('add-contact-info-link')
+            .should('have.attr', 'href')
+            .and(
+              'include',
+              PROFILE_PATHS_LGBTQ_ENHANCEMENT.CONTACT_INFORMATION,
+            );
+
+          cy.findByRole('link', { name: /add your email/i }).should(
+            'not.exist',
+          );
+          cy.axeCheck();
+        });
+      });
+    },
+  );
+  context(
+    'mobile phone link correct when profileEnhancements feature flag is FALSE',
+    () => {
+      context('when user is missing mobile phone', () => {
+        it('should show the correct mobile phone link', () => {
+          cy.intercept(
+            'v0/feature_toggles*',
+            mockProfileEnhancementsTogglesOff,
+          );
+          const user = makeMockUser();
+          user.data.attributes.vet360ContactInformation.mobilePhone = null;
+          cy.login(user);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+          cy.loadingIndicatorWorks();
+          cy.findByRole('heading', {
+            name: 'Notification settings',
+            level: 1,
+          }).should('exist');
+
+          cy.findByTestId('missing-contact-info-alert')
+            .should('exist')
+            .and('contain.text', 'mobile phone')
+            .within(() => {
+              cy.findByRole('link', { name: /add.*mobile.*profile/i }).should(
+                'exist',
+              );
+            });
+
+          cy.findAllByTestId('add-contact-info-link')
+            .should('have.attr', 'href')
+            .and('include', PROFILE_PATHS.PERSONAL_INFORMATION);
+
+          cy.findByRole('link', { name: /add your email/i }).should(
+            'not.exist',
+          );
+          cy.axeCheck();
+        });
+      });
+    },
+  );
+});

--- a/src/applications/personalization/profile/tests/fixtures/personal-information-feature-toggles-off.json
+++ b/src/applications/personalization/profile/tests/fixtures/personal-information-feature-toggles-off.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "features": [
+      {
+        "name": "profileEnhancements",
+        "value": false
+      },
+      {
+        "name": "profile_enhancements",
+        "value": false
+      }
+    ]
+  }
+}

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -157,3 +157,9 @@ export const VAP_SERVICE_INITIALIZATION_STATUS = {
 export const ACTIVE_EDIT_VIEWS = {
   ADDRESS_VALIDATION: 'addressValidation',
 };
+
+export const MISSING_CONTACT_INFO = {
+  ALL: 'ALL',
+  EMAIL: 'EMAIL',
+  MOBILE: 'MOBILE',
+};


### PR DESCRIPTION
## Description
Uses the existing `profile_enhancements` feature flag to conditionally change the href of the `MissingContactInfoAlertLink`

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34241


## Testing done
E2E Tests added for new link href and regression test

## Acceptance criteria
- [x] When profile enhancement flag is true, the link to updating contact information goes to `/profile/contact-information` instead of `/profile/personal-information`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
