### PR TITLE
33843: [MCP] detail page content updates

### DIFF
--- a/src/applications/medical-copays/components/HowToPay.jsx
+++ b/src/applications/medical-copays/components/HowToPay.jsx
@@ -71,7 +71,7 @@ export const HowToPay = ({ acctNum, facility }) => (
         <p>
           <strong>Note: </strong> You’ll find these stubs at the bottom of each
           statement. If you don’t have your most recent statement, you can
-          download and print it below or include a note listing the facility
+          download and print it above or include a note listing the facility
           you’d like to pay.
         </p>
         <p>

--- a/src/applications/medical-copays/components/Modals.jsx
+++ b/src/applications/medical-copays/components/Modals.jsx
@@ -72,7 +72,7 @@ Modals.Rights = () => (
       </li>
       <li>
         By Mail: Make check or money order payable to "VA" and include account
-        number and payment stub Submit to: Department of Veterans Affairs, P.O.
+        number and payment stub. Submit to: Department of Veterans Affairs, P.O.
         Box 3978, Portland, OR 97208-3978
       </li>
     </ul>
@@ -278,15 +278,15 @@ Modals.Rights = () => (
     <p>
       When you provide a check as payment, you authorize VA to either use
       information from your check to make a one-time electronic fund transfer
-      from your account or to process the payment asa check transaction. When VA
-      uses information from your check to make an electronic transfer, funds may
-      be withdrawn from your account as soon as the day we process your payment,
-      and you will not receive your check back from the financial institution. A
-      Privacy Act Statement required by 5 U.S.C & 552a(e)(3) stating our
-      authority for soliciting and collecting the information from your check,
-      and explaining the purposes and routine uses which will be made of your
-      check information, VA Notice of Privacy Practices, IB 10-163 is available
-      online at
+      from your account or to process the payment as a check transaction. When
+      VA uses information from your check to make an electronic transfer, funds
+      may be withdrawn from your account as soon as the day we process your
+      payment, and you will not receive your check back from the financial
+      institution. A Privacy Act Statement required by 5 U.S.C & 552a(e)(3)
+      stating our authority for soliciting and collecting the information from
+      your check, and explaining the purposes and routine uses which will be
+      made of your check information, VA Notice of Privacy Practices, IB 10-163
+      is available online at
       <a
         className="vads-u-margin--0p5"
         href="http://www.va.gov/vhapublications"


### PR DESCRIPTION
## Description
corrected a few content and styling anomalies found on the detail page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33843

## Screenshots
![Medical Copays  Veterans Affairs 2022-01-05 13-15-18(1)](https://user-images.githubusercontent.com/7518899/148268173-59d68935-59c9-4d9f-933f-2536eeae6e7f.png)

## Acceptance criteria
- [x] (1) **How do I pay...** section > **Note** re. paystubs should say "**...print it above**".  [Download section has been moved up.]
- [x] (2) **Notice of rights...** modal > **Pay your bill** section > **By Mail** item, "**...payment stub**" should have a period at end of sentence &mdash; "**payment stub."
- [x] (3) Same modal > **Notice to customers...** section, "...payment asa check transaction..." should have a space between "as" and "a" &mdash; "**...payment as a check transaction...**".

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
