### PR TITLE
526: Replace `AdditionalInfo` with web component

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/FormSavedPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/FormSavedPage.jsx
@@ -1,6 +1,5 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 import FormSaved from 'platform/forms/save-in-progress/FormSaved';
 
@@ -16,12 +15,12 @@ const FormSavedPage = props => {
         <span className="expires">{itfExpirationDate}</span> so you can get back
         pay for any awarded benefits from your Intent to File date.
       </p>
-      <AdditionalInfo triggerText="What is an Intent to File?">
+      <va-additional-info trigger="What is an Intent to File?">
         An Intent to File lets VA know that you’re planning to file a claim and
         reserves a potential effective date for when you could start getting
         benefits. For you, this means you may get back pay starting from{' '}
         {itfExpirationDate}.
-      </AdditionalInfo>
+      </va-additional-info>
     </Fragment>
   );
 

--- a/src/applications/disability-benefits/all-claims/content/evidenceTypes.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypes.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 export const evidenceTypeHelp = (
-  <AdditionalInfo triggerText="Which evidence type should I choose?">
+  <va-additional-info trigger="Which evidence type should I choose?">
     <h3>Types of evidence</h3>
     <h4>VA medical records</h4>
     <p>
@@ -25,5 +24,5 @@ export const evidenceTypeHelp = (
       Posttraumatic Stress Disorder or military sexual trauma—could benefit from
       a lay or buddy statement.
     </p>
-  </AdditionalInfo>
+  </va-additional-info>
 );

--- a/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 export const hasEvidenceLabel =
   'Is there any evidence that you’d like us to review as part of your claim?';
@@ -19,7 +18,7 @@ export const evidenceTypeError =
   'Please select at least one type of supporting evidence';
 
 export const evidenceTypeHelp = (
-  <AdditionalInfo triggerText="Which evidence type should I choose?">
+  <va-additional-info trigger="Which evidence type should I choose?">
     <h4>Types of evidence</h4>
     <h5>Private medical records</h5>
     <p>
@@ -37,5 +36,5 @@ export const evidenceTypeHelp = (
       Posttraumatic Stress Disorder or military sexual trauma—could benefit from
       a lay or buddy statement.
     </p>
-  </AdditionalInfo>
+  </va-additional-info>
 );

--- a/src/applications/disability-benefits/all-claims/content/incidentDate.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentDate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import { recordEventOnce } from 'platform/monitoring/record-event';
 import {
   ANALYTICS_EVENTS,
@@ -24,8 +24,9 @@ export const PtsdDateDescription = ({ formType }) => {
         Please tell us when this event happened. If it happened over a period of
         time, please tell us when it started.
       </p>
-      <AdditionalInfo
-        triggerText="What if I can’t remember the date?"
+      <VaAdditionalInfo
+        trigger="What if I can’t remember the date?"
+        disableAnalytics
         onClick={() =>
           ptsdDateEvent &&
           recordEventOnce(ptsdDateEvent, HELP_TEXT_CLICKED_EVENT)
@@ -40,7 +41,7 @@ export const PtsdDateDescription = ({ formType }) => {
           the time of year or whether the event happened early or late in your
           military service.
         </p>
-      </AdditionalInfo>
+      </VaAdditionalInfo>
     </div>
   );
 };

--- a/src/applications/disability-benefits/all-claims/content/incomeDetails.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incomeDetails.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 
 import { recordEventOnce } from 'platform/monitoring/record-event';
 
@@ -19,8 +19,9 @@ export const incomeDescription = (
       year before taxes. If you can’t remember the exact dollar amount, you can
       give an estimated amount.
     </p>
-    <AdditionalInfo
-      triggerText={`What’s included in "gross income"?`}
+    <VaAdditionalInfo
+      trigger={`What’s included in "gross income"?`}
+      disableAnalytics
       onClick={helpClicked}
     >
       <p>
@@ -33,6 +34,6 @@ export const incomeDescription = (
         <li>Stock dividends</li>
         <li>Investment income.</li>
       </ul>
-    </AdditionalInfo>
+    </VaAdditionalInfo>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 
 import Telephone, {
   CONTACTS,
@@ -32,8 +32,9 @@ const recordITFHelpEvent = () =>
   });
 
 const expander = (
-  <AdditionalInfo
-    triggerText="What is an Intent to File?"
+  <VaAdditionalInfo
+    trigger="What is an Intent to File?"
+    disableAnalytics
     onClick={recordITFHelpEvent}
   >
     <p className="vads-u-font-size--base">
@@ -42,7 +43,7 @@ const expander = (
       could start getting benefits while you prepare your disability claim and
       gather supporting documents.
     </p>
-  </AdditionalInfo>
+  </VaAdditionalInfo>
 );
 
 export const claimsIntakeAddress = (

--- a/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
+++ b/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import { capitalizeEachWord } from '../utils';
 import { NULL_CONDITION_STRING } from '../constants';
 
@@ -12,7 +11,7 @@ export const disabilityNameTitle = ({ formData }) => (
 );
 
 export const ServiceConnectedDisabilityDescription = () => (
-  <AdditionalInfo triggerText="What does service-connected disability mean?">
+  <va-additional-info trigger="What does service-connected disability mean?">
     <p>
       To be eligible for service-connected disability benefits, you’ll need to
       show that your disability was caused by an event, injury, or disease
@@ -21,5 +20,5 @@ export const ServiceConnectedDisabilityDescription = () => (
       statements, with your claim. We may ask you to have a claim exam if you
       don’t submit evidence or if we need more information to decide your claim.
     </p>
-  </AdditionalInfo>
+  </va-additional-info>
 );

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 import { recordEventOnce } from 'platform/monitoring/record-event';
 
@@ -10,8 +10,9 @@ const {
 
 export const privateRecordsChoiceHelp = (
   <div className="private-records-choice-help">
-    <AdditionalInfo
-      triggerText="Which should I choose?"
+    <VaAdditionalInfo
+      trigger="Which should I choose?"
+      disableAnalytics
       onClick={() =>
         recordEventOnce(openedPrivateChoiceHelp, HELP_TEXT_CLICKED_EVENT)
       }
@@ -32,7 +33,7 @@ export const privateRecordsChoiceHelp = (
         your records may take us some time, and this could mean that it’ll take
         us longer to make a decision on your claim.
       </p>
-    </AdditionalInfo>
+    </VaAdditionalInfo>
   </div>
 );
 
@@ -42,8 +43,9 @@ export const patientAcknowledgmentTitle = (
 
 export const patientAcknowledgmentText = (
   <div className="patient-acknowldegment-help">
-    <AdditionalInfo
-      triggerText="Read the full text."
+    <VaAdditionalInfo
+      trigger="Read the full text."
+      disableAnalytics
       onClick={() =>
         recordEventOnce(
           openedPrivateRecordsAcknowledgment,
@@ -145,6 +147,6 @@ export const patientAcknowledgmentText = (
         </a>
         .
       </p>
-    </AdditionalInfo>
+    </VaAdditionalInfo>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecordsRelease.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecordsRelease.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import { recordEventOnce } from 'platform/monitoring/record-event';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
@@ -16,8 +16,9 @@ export const limitedConsentTextTitle = (
 
 const { openedLimitedConsentHelp } = ANALYTICS_EVENTS;
 export const limitedConsentDescription = (
-  <AdditionalInfo
-    triggerText="What does this mean?"
+  <VaAdditionalInfo
+    trigger="What does this mean?"
+    disableAnalytics
     onClick={() =>
       recordEventOnce(openedLimitedConsentHelp, HELP_TEXT_CLICKED_EVENT)
     }
@@ -27,7 +28,7 @@ export const limitedConsentDescription = (
       specify. Limiting consent could add to the time it takes to get your
       private medical records.
     </p>
-  </AdditionalInfo>
+  </VaAdditionalInfo>
 );
 
 export const recordReleaseDescription = () => (

--- a/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import { recordEventOnce } from 'platform/monitoring/record-event';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
@@ -26,8 +26,9 @@ export const nonCombatPtsdTypeLong = (
 );
 
 export const ptsdTypeHelp = (
-  <AdditionalInfo
-    triggerText="Which should I choose?"
+  <VaAdditionalInfo
+    trigger="Which should I choose?"
+    disableAnalytics
     onClick={() =>
       recordEventOnce(
         ANALYTICS_EVENTS.openedPtsdTypeHelp,
@@ -52,7 +53,7 @@ export const ptsdTypeHelp = (
     <h4 className="vads-u-font-size--h5">Personal assault</h4>
     <p>
       This means you were a victim of an assault, battery, robbery, mugging,
-      stalking, or harassment by a person who wasn't part of an enemy force.
+      stalking, or harassment by a person who wasn’t part of an enemy force.
     </p>
     <h4 className="vads-u-font-size--h5">
       Non-combat PTSD other than sexual trauma or personal assault
@@ -63,5 +64,5 @@ export const ptsdTypeHelp = (
       or to yourself, that was caused by something other than a hostile military
       or terrorist activity.
     </p>
-  </AdditionalInfo>
+  </VaAdditionalInfo>
 );

--- a/src/applications/disability-benefits/all-claims/content/ptsdWalkthroughChoice.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdWalkthroughChoice.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import { getPtsdClassification } from './ptsdClassification';
 import { recordEventOnce } from 'platform/monitoring/record-event';
 import {
@@ -20,8 +20,9 @@ export const PtsdUploadChoiceDescription = ({ formType }) => {
   }
 
   return (
-    <AdditionalInfo
-      triggerText="Which should I choose?"
+    <VaAdditionalInfo
+      trigger="Which should I choose?"
+      disableAnalytics
       onClick={() =>
         ptsdWalkthroughEvent &&
         recordEventOnce(ptsdWalkthroughEvent, HELP_TEXT_CLICKED_EVENT)
@@ -38,7 +39,7 @@ export const PtsdUploadChoiceDescription = ({ formType }) => {
         If you choose to upload a completed VA Form {`21-0${formType}`}, you’ll
         move to the next section of the disability application.
       </p>
-    </AdditionalInfo>
+    </VaAdditionalInfo>
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/content/recentEarnedIncome.jsx
+++ b/src/applications/disability-benefits/all-claims/content/recentEarnedIncome.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
-
 export const grossIncomeAdditionalInfo = () => (
-  <AdditionalInfo triggerText="What’s gross income?">
+  <va-additional-info trigger="What’s gross income?">
     <p>
       Gross income is money earned from employment before taxes. It includes
-      military pay. It doesn't include Social Security benefits, VA benefits,
+      military pay. It doesn’t include Social Security benefits, VA benefits,
       stock dividends, or investment income.
     </p>
-  </AdditionalInfo>
+  </va-additional-info>
 );

--- a/src/applications/disability-benefits/all-claims/content/recentJobApplications.jsx
+++ b/src/applications/disability-benefits/all-claims/content/recentJobApplications.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
-
 export const recentJobApplicationsDescription = () => (
   <div>
     <p>
@@ -15,7 +13,7 @@ export const recentJobApplicationsDescription = () => (
 );
 
 export const substantiallyGainfulEmployment = () => (
-  <AdditionalInfo triggerText="What’s substantially gainful employment?">
+  <va-additional-info trigger="What’s substantially gainful employment?">
     <p>Substantially gainful employment means:</p>
     <ul>
       <li>
@@ -27,5 +25,5 @@ export const substantiallyGainfulEmployment = () => (
         person.
       </li>
     </ul>
-  </AdditionalInfo>
+  </va-additional-info>
 );

--- a/src/applications/disability-benefits/all-claims/content/secondaryOtherSources.jsx
+++ b/src/applications/disability-benefits/all-claims/content/secondaryOtherSources.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import { recordEventOnce } from 'platform/monitoring/record-event';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
@@ -20,8 +20,9 @@ export const otherSourcesDescription = (
 );
 
 export const otherSourcesHelpText = (
-  <AdditionalInfo
-    triggerText="Which should I choose"
+  <VaAdditionalInfo
+    trigger="Which should I choose"
+    disableAnalytics
     onClick={() =>
       recordEventOnce(
         ANALYTICS_EVENTS.openedPtsd781aOtherSourcesHelp,
@@ -47,5 +48,5 @@ export const otherSourcesHelpText = (
       Choose "No" if you don’t need help getting this evidence for your claim
     </h4>
     <p>You’ll have a chance to upload them later in the application.</p>
-  </AdditionalInfo>
+  </VaAdditionalInfo>
 );

--- a/src/applications/disability-benefits/all-claims/content/separationLocation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/separationLocation.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 export const SeparationLocationTitle = 'Place of anticipated separation';
 
 export const SeparationLocationDescription = (
   <>
     <br />
-    <AdditionalInfo triggerText="What's this?">
+    <va-additional-info trigger="What's this?">
       <>
         <p>
           Your place of anticipated separation is where you expect to separate
@@ -18,10 +17,10 @@ export const SeparationLocationDescription = (
           your exact separation date, to help process your claim.
         </p>
         <b>
-          If you can't find your exact location from the list, please select
+          If you can’t find your exact location from the list, please select
           your nearest regional facility.
         </b>
       </>
-    </AdditionalInfo>
+    </va-additional-info>
   </>
 );

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 
 import { recordEventOnce } from 'platform/monitoring/record-event';
 
@@ -22,8 +22,9 @@ export const dateDescription = (
 
 export const dateFieldsDescription = (
   <div className="additional-info-title-help vads-u-margin-top--4">
-    <AdditionalInfo
-      triggerText="How are these dates different?"
+    <VaAdditionalInfo
+      trigger="How are these dates different?"
+      disableAnalytics
       onClick={helpClicked}
     >
       <h4 className="vads-u-font-size--h5">
@@ -45,6 +46,6 @@ export const dateFieldsDescription = (
         This is the date when started to reduce your work hours or to take time
         off from work due to your service-connected disability.
       </p>
-    </AdditionalInfo>
+    </VaAdditionalInfo>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { VaAdditionalInfo } from 'web-components/react-bindings';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -31,8 +31,9 @@ export const disabilitiesDescription = ({ formContext }) => {
         disabilities that prevent you from getting and keeping a steady job
         (substantially gainful employment).
       </p>
-      <AdditionalInfo
-        triggerText="What’s substantially gainful employment?"
+      <VaAdditionalInfo
+        trigger="What’s substantially gainful employment?"
+        disableAnalytics
         onClick={helpClicked}
       >
         <p>Substantially gainful employment means:</p>
@@ -47,7 +48,7 @@ export const disabilitiesDescription = ({ formContext }) => {
             person.
           </li>
         </ul>
-      </AdditionalInfo>
+      </VaAdditionalInfo>
     </div>
   );
 };

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -9,7 +9,6 @@ import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 
 import ReviewCardField from 'platform/forms-system/src/js/components/ReviewCardField';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 import {
   contactInfoDescription,
@@ -90,15 +89,12 @@ export const uiSchema = {
     'view:livesOnMilitaryBaseInfo': {
       'ui:description': () => (
         <div className="vads-u-padding-x--2p5">
-          <AdditionalInfo
-            status="info"
-            triggerText="Learn more about military base addresses"
-          >
+          <va-additional-info trigger="Learn more about military base addresses">
             <span>
               The United States is automatically chosen as your country if you
               live on a military base outside of the country.
             </span>
-          </AdditionalInfo>
+          </va-additional-info>
         </div>
       ),
     },

--- a/src/applications/disability-benefits/all-claims/pages/supplementalBenefits.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/supplementalBenefits.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 import {
   unemployabilityTitle,
@@ -13,7 +12,7 @@ const {
 } = fullSchema.properties.form8940.properties.unemployability.properties;
 
 const supplementalBenefitsHelp = (
-  <AdditionalInfo triggerText="How do these benefits affect my claim?">
+  <va-additional-info trigger="How do these benefits affect my claim?">
     <p>
       {' '}
       Your claim for unemployability won’t be affected if you get supplemental
@@ -24,7 +23,7 @@ const supplementalBenefitsHelp = (
       If you have a Social Security benefit letter, you may want to upload it to
       support your claim.
     </p>
-  </AdditionalInfo>
+  </va-additional-info>
 );
 
 export const uiSchema = {

--- a/src/applications/disability-benefits/all-claims/pages/terminallyIll.js
+++ b/src/applications/disability-benefits/all-claims/pages/terminallyIll.js
@@ -1,16 +1,15 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const { isTerminallyIll } = fullSchema.properties;
 
 const TerminallyIllInfo = (
-  <AdditionalInfo triggerText="Why does this matter?">
+  <va-additional-info trigger="Why does this matter?">
     We’ll help to get your claim processed faster if the evidence to support
     your claim shows that you’re terminally ill. Being terminally ill means
     you’re sick with an illness that can’t be cured and will likely result in
     death within a short period of time.
-  </AdditionalInfo>
+  </va-additional-info>
 );
 
 export const uiSchema = {


### PR DESCRIPTION
## Description

Switch from using the `AdditionalInfo` React component to the `va-additional-info` web component within Form 526

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34705

## Testing done

Unit tests all passing

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] AdditionalInfo components replaced
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
