### PR TITLE
526: Replace `LoadingIndicator` with web component

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import * as Sentry from '@sentry/browser';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
@@ -96,9 +95,10 @@ export const Form526Entry = ({
     const message = restarting
       ? 'Please wait while we restart the application for you.'
       : 'Please wait while we load the application for you.';
+    const label = restarting ? 'restarting' : 'loading';
     return (
       <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-        <LoadingIndicator message={message} />
+        <va-loading-indicator message={message} label={label} />
       </h1>
     );
   };

--- a/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { MissingServices } from './MissingServices';
 
 import {
@@ -15,12 +14,13 @@ import {
 
 const message =
   'We’re doing some additional work to enable you to file a claim...';
+const label = 'We’re doing some additional work';
 
 const loading = title => (
   <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
     <div className="usa-content">
       <h1>{title}</h1>
-      <LoadingIndicator message={message} />
+      <va-loading-indicator message={message} label={label} />
     </div>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-
 import ITFBanner from '../components/ITFBanner';
 import { isActiveITF } from '../utils';
 import { requestStates } from 'platform/utilities/constants';
@@ -69,11 +67,11 @@ export class ITFWrapper extends React.Component {
     );
   }
 
-  showLoading = (title, message) => (
+  showLoading = (title, message, label) => (
     <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
       <div className="usa-content">
         <h1>{title}</h1>
-        <LoadingIndicator message={message} />
+        <va-loading-indicator message={message} label={label} />
       </div>
     </div>
   );
@@ -89,6 +87,7 @@ export class ITFWrapper extends React.Component {
       return this.showLoading(
         title,
         'Please wait while we check to see if you have an existing Intent to File.',
+        'looking for an intent to file',
       );
     } else if (itf.fetchCallState === requestStates.failed) {
       // We'll get here after the fetchITF promise is fulfilled
@@ -128,7 +127,11 @@ export class ITFWrapper extends React.Component {
     } else if (fetchWaitingStates.includes(itf.creationCallState)) {
       // componentWillRecieveProps called createITF if there was no active ITF
       // found; While we're waiting (again), show the loading indicator...again
-      return this.showLoading(title, 'Submitting a new Intent to File...');
+      return this.showLoading(
+        title,
+        'Submitting a new Intent to File...',
+        'submitting a new intent to file',
+      );
     }
 
     // We'll get here after the createITF promise is fulfilled and we have no

--- a/src/applications/disability-benefits/all-claims/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-poll.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 export const successMessage = claimId => (
   <div className="vads-u-font-size--base">
@@ -16,5 +15,8 @@ export const pendingMessage = longWait => {
   const message = !longWait
     ? 'Please wait while we submit your application and give you a confirmation number.'
     : 'We’re sorry. It’s taking us longer than expected to submit your application. Thank you for your patience.';
-  return <LoadingIndicator message={message} />;
+  const label = longWait
+    ? 'we’re still trying to submit your application'
+    : 'submitting your application';
+  return <va-loading-indicator message={message} label={label} />;
 };

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -129,8 +129,8 @@ describe('ConfirmationPoll', () => {
     );
     setTimeout(() => {
       expect(global.fetch.callCount).to.equal(4);
-      const alert = form.find('LoadingIndicator');
-      expect(alert.text()).to.contain('longer than expected');
+      const alert = form.find('va-loading-indicator');
+      expect(alert.html()).to.contain('longer than expected');
       form.unmount();
       done();
     }, 50);

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -231,8 +231,10 @@ describe('Form 526EZ Entry Page', () => {
 
     expect(tree.find('h1').text()).to.contain('File for disability');
     expect(tree.find('main')).to.have.lengthOf(0);
-    expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
-    expect(tree.find('LoadingIndicator').text()).to.contain('additional work');
+    expect(tree.find('va-loading-indicator')).to.have.lengthOf(1);
+    expect(tree.find('va-loading-indicator').html()).to.contain(
+      'additional work',
+    );
     tree.unmount();
   });
 
@@ -293,7 +295,9 @@ describe('Form 526EZ Entry Page', () => {
       currentlyLoggedIn: true,
       router,
     });
-    expect(tree.find('h1').text()).to.contain('restart the app');
+    expect(tree.find('va-loading-indicator').html()).to.contain(
+      'restart the app',
+    );
     expect(router[0]).to.equal('/start');
     tree.unmount();
   });
@@ -353,7 +357,7 @@ describe('Form 526EZ Entry Page', () => {
         </Form526Entry>
       </Provider>,
     );
-    expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
+    expect(tree.find('va-loading-indicator')).to.have.lengthOf(1);
     expect(tree.find('WizardContainer')).to.have.lengthOf(0);
     tree.unmount();
   });

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -99,13 +99,13 @@ describe('526 ITFWrapper', () => {
         <p>Shouldn’t see me yet...</p>
       </ITFWrapper>,
     );
-    expect(tree.find('LoadingIndicator').length).to.equal(1);
+    expect(tree.find('va-loading-indicator').length).to.equal(1);
     tree.setProps(
       merge({}, defaultProps, {
         itf: { fetchCallState: requestStates.pending },
       }),
     );
-    expect(tree.find('LoadingIndicator').length).to.equal(1);
+    expect(tree.find('va-loading-indicator').length).to.equal(1);
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description

Switch from using `LoadingIndicator` React component to the `va-loading-indicator` web component within Form 526.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34699

## Testing done

Updated unit tests

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] `LoadingIndicator` components replaced
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
