### PR TITLE
changing link to point to requested appts when a patient is over the …

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/RequestEligibilityMessage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/RequestEligibilityMessage.jsx
@@ -72,8 +72,8 @@ export default function RequestEligibilityMessage({
             </p>
             <ul>
               <li>
-                Go to <Link to="/">your appointment list</Link> and cancel open
-                requests, or
+                Go to <Link to="/requested">your appointment list </Link>
+                and cancel open requests, or
               </li>
               {facilityDetails && (
                 <li>

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
@@ -94,7 +94,7 @@ export default function getEligibilityMessage({
         <p>
           Call this facility to schedule or cancel an open appointment request.
           You can also cancel a request from{' '}
-          <Link to="/">your appointment list</Link>.
+          <Link to="/requested">your appointment list</Link>.
         </p>
         {facilityDetails &&
           includeFacilityContactInfo && (

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
@@ -548,7 +548,8 @@ describe('VAOS <VAFacilityPage> eligibility check', () => {
         .exist;
     });
 
-    it('should show request limit message when not eligible for direct, requests are supported, over request limit', async () => {
+    it('should show request limit message and link to the requested appointments, when current appt is over the request limit', async () => {
+      // Given the user is requesting an appointment
       mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
       mockDirectBookingEligibilityCriteria(parentSiteIds, directFacilities);
       mockRequestEligibilityCriteria(parentSiteIds, requestFacilities);
@@ -564,15 +565,26 @@ describe('VAOS <VAFacilityPage> eligibility check', () => {
       const store = createTestStore(initialState);
       await setTypeOfCare(store, /primary care/i);
 
+      // And the facitility page is presented
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
       });
 
+      // When the user selects the facility
       fireEvent.click(await screen.findByLabelText(/Fake facility name 1/i));
       fireEvent.click(screen.getByText(/Continue/));
+
+      // Then they are presented with the message that they are over the request limit
       await screen.findByText(
         /You’ve reached the limit for appointment requests/i,
       );
+
+      // And the link in the over the limit message takes the user to the requested appt page
+      expect(
+        screen.getByRole('link', {
+          name: /your appointment list/i,
+        }),
+      ).to.have.attribute('href', '/requested');
     });
 
     it('should show past visits message when not eligible for direct, requests are supported, no past visit', async () => {


### PR DESCRIPTION
…request limit

## Description
This PR is to address when the client has reached the request limit for a clinic. When the client clicks the link to view appointments they are sent to their requested appointments.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30510


## Testing done
Manual

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/148402428-ca7f3943-cada-4b17-88c8-a433a7c71574.png)
![image](https://user-images.githubusercontent.com/3951775/148450141-1f730a0a-6852-4702-b80a-3b1bc9963770.png)

-After clicking links

![image](https://user-images.githubusercontent.com/3951775/148403045-9b0215df-236b-4d87-ba7a-6985fe081d92.png)


## Acceptance criteria
- [ ] Given user has reached the request limit
When user clicks "your appointment request" in the request limit alert modal
Then load the appointment request list (/health-care/schedule-view-va-appointments/appointments/requested)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
