### PR TITLE
adding a null check to reasonCode.coding before trying to access the …

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -138,7 +138,7 @@ export function transformVAOSAppointment(appt) {
       requestedPeriod: appt.requestedPeriods,
       created: null,
       reason: PURPOSE_TEXT.find(
-        purpose => purpose.serviceName === appt.reasonCode?.coding[0].code,
+        purpose => purpose.serviceName === appt.reasonCode?.coding?.[0].code,
       )?.short,
       preferredTimesForPhoneCall: appt.preferredTimesForPhoneCall,
       requestVisitType: getTypeOfVisit(appt.kind),


### PR DESCRIPTION
…array position zero

## Description
Adding a null check to reasonCode.coding.  Prior to this the front-end logic assumed that the `coding` field would always be present in the response body, but that is not the case is there are not codes.  This was causing an error in the front-end when attempting to read the list of appointment requests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
