### PR TITLE
Remove Error Causing Import in Mock

### DIFF
--- a/src/applications/burials/tests/e2e/fixtures/mocks/mockUser.js
+++ b/src/applications/burials/tests/e2e/fixtures/mocks/mockUser.js
@@ -1,5 +1,4 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
-
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 /* eslint-disable camelcase */

--- a/src/applications/edu-benefits/1995/tests/e2e/fixtures/mocks/mockUser.js
+++ b/src/applications/edu-benefits/1995/tests/e2e/fixtures/mocks/mockUser.js
@@ -1,5 +1,4 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
-
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 /* eslint-disable camelcase */

--- a/src/applications/hca/tests/fixtures/mocks/mockUser.js
+++ b/src/applications/hca/tests/fixtures/mocks/mockUser.js
@@ -1,6 +1,5 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
-
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 
 /* eslint-disable camelcase */
 const mockUser = {

--- a/src/applications/health-care-questionnaire/shared/api/local-mock-api/feature-flip-error.js
+++ b/src/applications/health-care-questionnaire/shared/api/local-mock-api/feature-flip-error.js
@@ -1,4 +1,4 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 
 /* eslint-disable camelcase */
 const commonResponses = require('../../../../../platform/testing/local-dev-mock-api/common');

--- a/src/applications/health-care-questionnaire/shared/api/local-mock-api/index.js
+++ b/src/applications/health-care-questionnaire/shared/api/local-mock-api/index.js
@@ -1,4 +1,4 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 
 /* eslint-disable camelcase */
 const commonResponses = require('../../../../../platform/testing/local-dev-mock-api/common');

--- a/src/applications/pensions/tests/fixtures/mocks/mockUser.js
+++ b/src/applications/pensions/tests/fixtures/mocks/mockUser.js
@@ -1,5 +1,4 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
-
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 /* eslint-disable camelcase */

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -1,3 +1,5 @@
+const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
+
 /* eslint-disable camelcase */
 const responses = {
   'GET /v0/user': {
@@ -5,7 +7,7 @@ const responses = {
       attributes: {
         profile: {
           sign_in: {
-            service_name: 'idme',
+            service_name: CSP_IDS.ID_ME,
           },
           email: 'fake@fake.com',
           loa: { current: 3 },

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -1,5 +1,3 @@
-import { CSP_IDS } from 'platform/user/authentication/constants';
-
 /* eslint-disable camelcase */
 const responses = {
   'GET /v0/user': {
@@ -7,7 +5,7 @@ const responses = {
       attributes: {
         profile: {
           sign_in: {
-            service_name: CSP_IDS.ID_ME,
+            service_name: 'idme',
           },
           email: 'fake@fake.com',
           loa: { current: 3 },


### PR DESCRIPTION
## Description
Change imports to requires for CSP_IDS constants in necessary mock files

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Project builds locally

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
