### PR TITLE
Fix parseISODate for partial strings

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -151,7 +151,7 @@ export function formatReviewDate(dateString, monthYear = false) {
 }
 export function parseISODate(dateString) {
   if (typeof dateString === 'string') {
-    const [year, month, day] = dateString.split('-', 3);
+    const [year = 'XXXX', month = 'XX', day = 'XX'] = dateString.split('-', 3);
 
     return {
       month: month === 'XX' ? '' : Number(month).toString(),

--- a/src/platform/forms-system/test/js/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/helpers.unit.spec.js
@@ -35,6 +35,21 @@ describe('Schemaform helpers:', () => {
         day: '3',
         year: '2003',
       });
+      expect(parseISODate('2003-02-XX')).to.eql({
+        month: '2',
+        day: '',
+        year: '2003',
+      });
+      expect(parseISODate('2003-02')).to.eql({
+        month: '2',
+        day: '',
+        year: '2003',
+      });
+      expect(parseISODate('2003')).to.eql({
+        month: '',
+        day: '',
+        year: '2003',
+      });
     });
   });
   describe('formatISOPartialDate', () => {


### PR DESCRIPTION
## Description

When a partial date string is passed to the `parseISODate` function, it works when "XX" is included for the missing part, but returns "NaN" when the date string does not include the "XX", e.g. "2022-01" or "2022". With "2022-01" the `day` value will return `NaN`, and "2022" will return both `day` and `month` values as `NaN`.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34827

## Testing done

Added unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Partial dates include a default value that is not undefined
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
