### PR TITLE
Remove required es6 files with imports in mock modules

### DIFF
--- a/src/applications/burials/tests/e2e/fixtures/mocks/mockUser.js
+++ b/src/applications/burials/tests/e2e/fixtures/mocks/mockUser.js
@@ -1,4 +1,3 @@
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 /* eslint-disable camelcase */
@@ -7,7 +6,7 @@ const mockUser = {
     attributes: {
       profile: {
         sign_in: {
-          service_name: CSP_IDS.ID_ME,
+          service_name: 'idme',
         },
         email: 'fake@fake.com',
         loa: { current: 3 },

--- a/src/applications/edu-benefits/1995/tests/e2e/fixtures/mocks/mockUser.js
+++ b/src/applications/edu-benefits/1995/tests/e2e/fixtures/mocks/mockUser.js
@@ -1,4 +1,3 @@
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 /* eslint-disable camelcase */
@@ -7,7 +6,7 @@ const mockUser = {
     attributes: {
       profile: {
         sign_in: {
-          service_name: CSP_IDS.ID_ME,
+          service_name: 'idme',
         },
         email: 'fake@fake.com',
         loa: { current: 3 },

--- a/src/applications/hca/tests/fixtures/mocks/mockUser.js
+++ b/src/applications/hca/tests/fixtures/mocks/mockUser.js
@@ -1,5 +1,4 @@
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 
 /* eslint-disable camelcase */
 const mockUser = {
@@ -7,7 +6,7 @@ const mockUser = {
     attributes: {
       profile: {
         sign_in: {
-          service_name: CSP_IDS.ID_ME,
+          service_name: 'idme',
         },
         email: 'fake@fake.com',
         loa: { current: 3 },

--- a/src/applications/health-care-questionnaire/shared/api/local-mock-api/feature-flip-error.js
+++ b/src/applications/health-care-questionnaire/shared/api/local-mock-api/feature-flip-error.js
@@ -1,5 +1,3 @@
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
-
 /* eslint-disable camelcase */
 const commonResponses = require('../../../../../platform/testing/local-dev-mock-api/common');
 
@@ -18,7 +16,7 @@ const responses = {
       attributes: {
         profile: {
           sign_in: {
-            service_name: CSP_IDS.ID_ME,
+            service_name: 'idme',
           },
           email: 'fake@fake.com',
           loa: { current: 3 },

--- a/src/applications/health-care-questionnaire/shared/api/local-mock-api/index.js
+++ b/src/applications/health-care-questionnaire/shared/api/local-mock-api/index.js
@@ -1,5 +1,3 @@
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
-
 /* eslint-disable camelcase */
 const commonResponses = require('../../../../../platform/testing/local-dev-mock-api/common');
 
@@ -18,7 +16,7 @@ const responses = {
       attributes: {
         profile: {
           sign_in: {
-            service_name: CSP_IDS.ID_ME,
+            service_name: 'idme',
           },
           email: 'fake@fake.com',
           loa: { current: 3 },

--- a/src/applications/pensions/tests/fixtures/mocks/mockUser.js
+++ b/src/applications/pensions/tests/fixtures/mocks/mockUser.js
@@ -1,4 +1,3 @@
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 /* eslint-disable camelcase */
@@ -7,7 +6,7 @@ const mockUser = {
     attributes: {
       profile: {
         sign_in: {
-          service_name: CSP_IDS.ID_ME,
+          service_name: 'idme',
         },
         email: 'fake@fake.com',
         loa: { current: 3 },

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -1,5 +1,3 @@
-const CSP_IDS = require('platform/user/authentication/constants').CSP_IDS;
-
 /* eslint-disable camelcase */
 const responses = {
   'GET /v0/user': {
@@ -7,7 +5,7 @@ const responses = {
       attributes: {
         profile: {
           sign_in: {
-            service_name: CSP_IDS.ID_ME,
+            service_name: 'idme',
           },
           email: 'fake@fake.com',
           loa: { current: 3 },


### PR DESCRIPTION
## Description
Thought I could follow the existing pattern of importing a constant file similar to the `VA_FORM_IDS`. This is not the case since the Authentication Constants file uses imports where the `VA_FORMS_ID` file does not.

This resulted in a compatibility error with utilizing es6 imports in a module.

## Testing done
- yarn mock-api no longer fails

## Screenshots


## Acceptance criteria
- [ ] yarn mock-api no longer fails

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
