### PR TITLE
HLR v2: Require day & month in decision date

### DIFF
--- a/src/applications/disability-benefits/996/validations/issues.js
+++ b/src/applications/disability-benefits/996/validations/issues.js
@@ -1,10 +1,7 @@
 import moment from 'moment';
 
 import { parseISODate } from 'platform/forms-system/src/js/helpers';
-import {
-  isValidYear,
-  isValidPartialDate,
-} from 'platform/forms-system/src/js/utilities/validations';
+import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
 
 import { $, areaOfDisagreementWorkAround } from '../utils/ui';
 import { getSelected, hasSomeSelected, hasDuplicates } from '../utils/helpers';
@@ -17,7 +14,11 @@ import {
   missingAreaOfDisagreementErrorMessage,
   missingAreaOfDisagreementOtherErrorMessage,
 } from '../content/areaOfDisagreement';
-import { MAX_SELECTIONS, MAX_ISSUE_NAME_LENGTH } from '../constants';
+import {
+  FORMAT_YMD,
+  MAX_SELECTIONS,
+  MAX_ISSUE_NAME_LENGTH,
+} from '../constants';
 
 /**
  *
@@ -61,16 +62,15 @@ const maxDate = moment().endOf('day');
 
 export const validateDate = (errors, dateString) => {
   const { day, month, year } = parseISODate(dateString);
-  const date = moment(dateString);
-
+  const date = moment(dateString, FORMAT_YMD);
   if (dateString === 'XXXX-XX-XX' || dateString === '') {
     errors.addError(issueErrorMessages.missingDecisionDate);
+  } else if (!day || !month) {
+    errors.addError(issueErrorMessages.invalidDate);
   } else if (year?.length >= 4 && !isValidYear(year)) {
     errors.addError(
       issueErrorMessages.invalidDateRange(minDate.year(), maxDate.year()),
     );
-  } else if (!isValidPartialDate(day, month, year)) {
-    errors.addError(issueErrorMessages.invalidDate);
   } else if (date.isAfter(maxDate)) {
     errors.addError(issueErrorMessages.pastDate);
   } else if (date.isBefore(minDate)) {


### PR DESCRIPTION
## Description

Entering only a year into the Higher-Level Review v2 add issue page still allows the Veteran to add an issue. This change prevents the issue from being added if the month and day are missing.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34827

## Testing done

Added unit tests

## Screenshots

![Screen Shot 2022-01-06 at 3 00 43 PM](https://user-images.githubusercontent.com/136959/148454509-afafbf42-31c1-4a11-8f0e-8357860a961f.png)

## Acceptance criteria
- [x] Fix decision date validation by requiring month & day
- [x] Update unit tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
