### PR TITLE
Add edge case so that custom date range can select today with results

### DIFF
--- a/src/applications/static-pages/events/helpers/index.js
+++ b/src/applications/static-pages/events/helpers/index.js
@@ -251,9 +251,12 @@ export const deriveStartsAtUnix = (startDateMonth, startDateDay) => {
   }
 
   // Derive the startsAt moment.
-  const startsAt = moment(`${startDateMonth}/${startDateDay}`, 'MM/DD').startOf(
-    'day',
-  );
+  let startsAt = moment(`${startDateMonth}/${startDateDay}`, 'MM/DD');
+
+  // If startsAt is today, then set it to now + 1 hour.
+  if (startsAt.isSame(moment(), 'day')) {
+    startsAt = moment().add(1, 'hour');
+  }
 
   // If the startsAt is in the past, we need to increase it by a year (since there are only month/day fields).
   if (startsAt.isBefore(moment())) {


### PR DESCRIPTION
## Description

This PR makes it so that when you choose the current day for startsAt in the custom date range field, it will show results (previously it was showing at the beginning of today + 1 year, which is why there were no results since the CMS team only shows recurring events up to 1 year from now.)

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34912


## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/12773166/148479323-2ac4311e-8bfe-44a0-a292-fc0ff481d9da.png)


## Acceptance criteria
- [x] Update custom date range startsAt when today is selected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
