### PR TITLE
remove row class from datewidget

### DIFF
--- a/src/platform/forms-system/src/js/widgets/DateWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/DateWidget.jsx
@@ -89,7 +89,7 @@ export default class DateWidget extends React.Component {
     }
 
     return (
-      <div className="usa-date-of-birth usa-datefields row">
+      <div className="usa-date-of-birth usa-datefields">
         <div className="form-datefield-month">
           <label className="input-date-label" htmlFor={`${id}Month`}>
             Month


### PR DESCRIPTION
## Description
I recently discovered that several forms (28-1900, 28-8832, 686c-674, 22-1990, 1990E, 22-0994) exhibited misaligned date fields. This was due to a `row` utility class adding negative margins to the parent div of the elements. This pull request removes this utility class on the widget itself. 

## Original issue(s)


## Testing done
- Local on Chrome, FireFox, and Safari with multiple viewport sizes

## Screenshots
<details><summary>Current Issue in staging</summary>

<img width="631" alt="Screen Shot 2022-01-07 at 9 10 23 AM" src="https://user-images.githubusercontent.com/15097156/148564602-112b98a9-7663-4d5f-b311-e498a379aa94.png">

</details>

<details><summary>Fix</summary>

<img width="696" alt="Screen Shot 2022-01-07 at 9 10 29 AM" src="https://user-images.githubusercontent.com/15097156/148564658-44bd09ed-94d5-4277-a193-de3fe1321ea7.png">


</details>

## Acceptance criteria
- [ ] Misalignment has been fixed

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
