### PR TITLE
HLR: Update content to match design

### DIFF
--- a/src/applications/disability-benefits/996/content/addIssue.jsx
+++ b/src/applications/disability-benefits/996/content/addIssue.jsx
@@ -23,7 +23,8 @@ export const addIssueLabel = (
     <span className="vads-u-font-weight--normal vads-u-font-size--base vads-u-font-family--sans">
       Add an issue and our decision date on this issue. You can find the
       decision date on your decision notice (the letter you got in the mail from
-      us).
+      us). You can request a Higher-Level Review up to 1 year from the date on
+      your decision notice.
     </span>
     <p className="vads-u-font-weight--normal vads-u-font-size--base vads-u-font-family--sans">
       <strong>Note:</strong> You can only add an issue that you’ve already

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -281,6 +281,17 @@ article[data-location="contested-issues"] {
   }
 }
 
+/* Contestable issues - HLR v2 */
+article[data-location="contestable-issues"] {
+  /* fixes va.gov-team/issues/34714 */
+  fieldset > div {
+    clear: both;
+  }
+  fieldset legend {
+    float: left; /* moves legend inside fieldset */
+  }
+}
+
 /* Add issue loop page */
 article[data-location="add-issue"] {
   .usa-input-error {


### PR DESCRIPTION
## Description

In the Higher-Level Review eligible issues page, the legend content appears above the lead-in paragraph. And some content was missing from the add issue page. This PR addresses both content issues.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34714

## Testing done

N/A - content change only

## Screenshots

<details><summary>Eligible Issues page</summary>

<!-- leave a blank line above -->
![Screen Shot 2022-01-06 at 4 30 17 PM](https://user-images.githubusercontent.com/136959/148565726-e09cd453-ad28-4b88-9aef-9758750cf5cc.png)</details>

<details><summary>Add issue page</summary>

<!-- leave a blank line above -->
![Screen Shot 2022-01-07 at 9 27 18 AM](https://user-images.githubusercontent.com/136959/148566751-49fbee25-b68a-414b-adc1-c5a706641cba.png)</details>

## Acceptance criteria
- [x] Eligible issues content order matches design
- [x] Add issue content matches design

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
