### PR TITLE
HLR v2: Focus & scroll to alert when visible

### DIFF
--- a/src/applications/disability-benefits/996/content/contestableIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssues.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { scrollAndFocus } from 'platform/utilities/ui';
 
 import {
   BOARD_APPEALS_URL,
@@ -141,17 +141,28 @@ export const noneSelected = 'Please select at least one issue';
  * Shows the alert box only if the form has been submitted
  */
 export const NoneSelectedAlert = ({ count }) => {
-  setTimeout(() => scrollToTop(), 300);
+  const wrapAlert = useRef(null);
+
+  useEffect(
+    () => {
+      if (wrapAlert?.current) {
+        scrollAndFocus(wrapAlert.current);
+      }
+    },
+    [wrapAlert],
+  );
   return (
-    <va-alert status="error">
-      <h3
-        slot="headline"
-        className="eligible-issues-error vads-u-margin-x--2 vads-u-margin-y--1 vads-u-padding-x--3 vads-u-padding-y--2"
-      >
-        {`Please ${
-          count === 0 ? 'add, and select,' : 'select'
-        } at least one issue, so we can process your request`}
-      </h3>
-    </va-alert>
+    <div ref={wrapAlert}>
+      <va-alert status="error">
+        <h3
+          slot="headline"
+          className="eligible-issues-error vads-u-margin-x--2 vads-u-margin-y--1 vads-u-padding-x--3 vads-u-padding-y--2"
+        >
+          {`Please ${
+            count === 0 ? 'add, and select,' : 'select'
+          } at least one issue, so we can process your request`}
+        </h3>
+      </va-alert>
+    </div>
   );
 };


### PR DESCRIPTION
## Description

The alert that appears when attempting to continue past the Higher-Level Review v2 eligible issues page will now focus and scroll into view.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34871

## Testing done

N/A

## Screenshots

<details><summary>Scroll and focus alert when visible</summary>

<!-- leave a blank line above -->
![alert focused when it appears](https://user-images.githubusercontent.com/136959/148584255-3044fdc8-68c8-4498-ab1c-92140ede9014.gif)</details>

## Acceptance criteria
- [x] Focus & scroll to alert when visible
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
