### PR TITLE
HLR: Fix contact info header levels

### DIFF
--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -57,7 +57,7 @@ export const ContactInfoDescription = ({
   // loop to separate pages vs profile contact modals
   const contactSection = loopPages ? (
     <>
-      <h3>Mobile phone number</h3>
+      <h4 className="vads-u-font-size--h3">Mobile phone number</h4>
       <Telephone contact={phoneNumber} extension={phoneExt} notClickable />
       <p>
         <Link to="/edit-mobile-phone">
@@ -65,7 +65,7 @@ export const ContactInfoDescription = ({
           <span className="sr-only">mobile phone number</span>
         </Link>
       </p>
-      <h3>Email address</h3>
+      <h4 className="vads-u-font-size--h3">Email address</h4>
       <span>{email?.emailAddress || ''}</span>
       <p>
         <Link to="/edit-email-address">
@@ -73,7 +73,7 @@ export const ContactInfoDescription = ({
           <span className="sr-only">email address</span>
         </Link>
       </p>
-      <h3>Mailing address</h3>
+      <h4 className="vads-u-font-size--h3">Mailing address</h4>
       <AddressView data={mailingAddress} />
       <p>
         <Link to="/edit-mailing-address">


### PR DESCRIPTION
## Description

On the Higher-Level Review contact info page, the phone, email and mailing address blocks should have `h4` header levels.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34882

## Testing done

Visual, heading map extension check & manual axe check

## Screenshots

![Heading map showing Contact info header as an h3, and the phone, email and mailing headers as an h4](https://user-images.githubusercontent.com/136959/148600052-e94345c0-0b6f-41ea-ab61-6985c2f78771.png)

## Acceptance criteria
- [x] Header levels are nested properly & match recommendation
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
