### PR TITLE
HLR v2: Fix wizard invalid ID in `aria-describedby`

### DIFF
--- a/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
@@ -46,6 +46,12 @@ const ClaimType = ({ setPageState, state = {}, hlrV2 }) => {
     }
   };
 
+  // aria-describedby fix for #34873
+  const ariaDescribedby = [
+    hlrV2 ? pageNames.legacyNo : pageNames.legacyChoice,
+    pageNames.other,
+  ];
+
   return (
     <RadioButtons
       name={name}
@@ -54,7 +60,7 @@ const ClaimType = ({ setPageState, state = {}, hlrV2 }) => {
       options={options}
       onValueChange={setState}
       value={{ value: state.selected }}
-      ariaDescribedby={[pageNames.legacyChoice, pageNames.other]}
+      ariaDescribedby={ariaDescribedby}
     />
   );
 };


### PR DESCRIPTION
## Description

The Higher-Level Review wizard was improperly setting the ID for the radio button selection for v2 choices. This PR ensures the proper ID is applied.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34873

## Testing done

N/A - no specific test for this ID check

## Screenshots

N/A

## Acceptance criteria
- [x] The correct `aria-desribedby` ID is applied for HLR v2
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
