### PR TITLE
Update where field to not be mocked value

### DIFF
--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -3,9 +3,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
 import moment from 'moment-timezone';
-import { sample } from 'lodash';
 // Relative imports.
 import {
+  deriveEventLocations,
   deriveMostRecentDate,
   deriveResultsEndNumber,
   deriveResultsStartNumber,
@@ -75,6 +75,9 @@ export const Results = ({
               .tz(endsAtUnix * 1000, timezone)
               .format('z');
 
+            // Derive the event locations.
+            const locations = deriveEventLocations(event);
+
             return (
               <div
                 className="vads-u-display--flex vads-u-flex-direction--column vads-u-border-top--1px vads-u-border-color--gray-light vads-u-padding-y--4"
@@ -115,18 +118,21 @@ export const Results = ({
                 </div>
 
                 {/* Where */}
-                <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
-                  <p className="vads-u-margin--0 vads-u-margin-right--0p5">
-                    <strong>Where:</strong>
-                  </p>
-                  <p className="vads-u-margin--0">
-                    {sample([
-                      'West Bend, Wisconsin',
-                      'Austin, Texas',
-                      'This is an online event.',
-                    ])}
-                  </p>
-                </div>
+                {locations?.length > 0 && (
+                  <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
+                    <p className="vads-u-margin--0 vads-u-margin-right--0p5">
+                      <strong>Where:</strong>
+                    </p>
+
+                    <div className="vads-u-display--flex vads-u-flex-direction--column">
+                      {locations?.map(location => (
+                        <p className="vads-u-margin--0" key={location}>
+                          {location}
+                        </p>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/src/applications/static-pages/events/helpers/index.js
+++ b/src/applications/static-pages/events/helpers/index.js
@@ -300,6 +300,40 @@ export const deriveEndsAtUnix = (startsAtUnix, endDateMonth, endDateDay) => {
   return endsAt.unix();
 };
 
+export const deriveEventLocations = event => {
+  const locations = [];
+
+  // Escape early if there is no event.
+  if (!event) {
+    return locations;
+  }
+
+  if (event?.fieldLocationHumanreadable) {
+    locations.push(event?.fieldLocationHumanreadable);
+  }
+
+  if (event?.fieldAddress?.addressLine1) {
+    locations.push(event?.fieldAddress?.addressLine1);
+  }
+
+  if (event?.fieldAddress?.addressLine2) {
+    locations.push(event?.fieldAddress?.addressLine2);
+  }
+
+  if (
+    event?.fieldAddress?.locality &&
+    event?.fieldAddress?.administrativeArea
+  ) {
+    locations.push(
+      `${event?.fieldAddress?.locality}, ${
+        event?.fieldAddress?.administrativeArea
+      }`,
+    );
+  }
+
+  return locations;
+};
+
 export const hideLegacyEvents = () => {
   // Derive the legacy events page.
   const legacyEvents = document.querySelector('div[id="events-v1"]');

--- a/src/applications/static-pages/events/helpers/index.unit.spec.js
+++ b/src/applications/static-pages/events/helpers/index.unit.spec.js
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import {
   dayOptions,
   deriveEndsAtUnix,
+  deriveEventLocations,
   deriveMostRecentDate,
   deriveStartsAtUnix,
   filterByOptions,
@@ -283,6 +284,38 @@ describe('filterEvents', () => {
         now.clone(),
       ),
     ).to.deep.equal([nextWeekEvent]);
+  });
+});
+
+describe('deriveEventLocations', () => {
+  it('returns an array with no arguments passed to it', () => {
+    expect(deriveEventLocations()).to.deep.equal([]);
+  });
+
+  it('handles when fieldLocationHumanreadable is truthy', () => {
+    expect(
+      deriveEventLocations({ fieldLocationHumanreadable: 'foo' }),
+    ).to.deep.equal(['foo']);
+  });
+
+  it('handles when fieldAddress?.addressLine1 is truthy', () => {
+    expect(
+      deriveEventLocations({ fieldAddress: { addressLine1: 'foo' } }),
+    ).to.deep.equal(['foo']);
+  });
+
+  it('handles when fieldAddress?.addressLine2 is truthy', () => {
+    expect(
+      deriveEventLocations({ fieldAddress: { addressLine2: 'foo' } }),
+    ).to.deep.equal(['foo']);
+  });
+
+  it('handles when fieldAddress?.locality is truthy', () => {
+    expect(
+      deriveEventLocations({
+        fieldAddress: { locality: 'foo', administrativeArea: 'bar' },
+      }),
+    ).to.deep.equal(['foo, bar']);
   });
 });
 


### PR DESCRIPTION
## Description

This PR updates the `Where:` field for events v2 listing pages to not be a mocked value.

## Screenshots


## Acceptance criteria
- [x] updates the `Where:` field for events v2 listing pages to not be a mocked value.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
