### PR TITLE
Revert "Enable Dependabot for GitHub Actions"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/' # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
     schedule:
-      interval: 'daily'
-      time: '09:00'
-      timezone: 'America/New_York'
+      interval: "daily"
+      time: "09:00"
+      timezone: "America/New_York"
     # Allow up to 10 open pull requests for npm dependencies
     open-pull-requests-limit: 0
-
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      time: '09:00'
-      timezone: 'America/New_York'


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#19838

Dependabot PRs cannot load AWS credentials on GHA, so this configuration needs to be removed until these AWS issues are resolved. https://github.com/department-of-veterans-affairs/vets-website/pull/19843