### PR TITLE
HLR: Edit contact link aria-labels

### DIFF
--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -60,25 +60,22 @@ export const ContactInfoDescription = ({
       <h4 className="vads-u-font-size--h3">Mobile phone number</h4>
       <Telephone contact={phoneNumber} extension={phoneExt} notClickable />
       <p>
-        <Link to="/edit-mobile-phone">
+        <Link to="/edit-mobile-phone" aria-label="Edit mobile phone number">
           Edit
-          <span className="sr-only">mobile phone number</span>
         </Link>
       </p>
       <h4 className="vads-u-font-size--h3">Email address</h4>
       <span>{email?.emailAddress || ''}</span>
       <p>
-        <Link to="/edit-email-address">
+        <Link to="/edit-email-address" aria-label="Edit email address">
           Edit
-          <span className="sr-only">email address</span>
         </Link>
       </p>
       <h4 className="vads-u-font-size--h3">Mailing address</h4>
       <AddressView data={mailingAddress} />
       <p>
-        <Link to="/edit-mailing-address">
+        <Link to="/edit-mailing-address" aria-label="Edit mailing address">
           Edit
-          <span className="sr-only">mailing address</span>
         </Link>
       </p>
     </>


### PR DESCRIPTION
## Description

Higher-Level Review contact page edit links previously included additional information for the screen-reader inside the link content. This was causing issues for Dragon-Natually Speaking users. This PR moves the extended link content into an `aria-label`.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34875

## Testing done

Manual screen-reader test

## Screenshots

N/A

## Acceptance criteria
- [x] Remove extra hidden content inside edit links
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
