### PR TITLE
HLR v2: Update content

### DIFF
--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -42,13 +42,8 @@ export class ConfirmationPage extends React.Component {
         <h2 className="confirmation-page-title vads-u-font-size--h3">
           Your request has been submitted
         </h2>
-        <p>
-          We may contact you for more information or documents.
-          <br className="screen-only" />
-          <em className="screen-only">
-            Please print this page for your records.
-          </em>
-        </p>
+        <p>We may contact you for more information or documents.</p>
+        <p className="screen-only">Please print this page for your records.</p>
         <div className="inset">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
             Request a Board Appeal{' '}

--- a/src/applications/disability-benefits/996/components/IssueCardV2.jsx
+++ b/src/applications/disability-benefits/996/components/IssueCardV2.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import { scrollAndFocus } from 'platform/utilities/ui';
 
 import { SELECTED, FORMAT_READABLE, LAST_HLR_ITEM } from '../constants';
+import { replaceDescriptionContent } from '../utils/replace';
 
 /** HLR v1 card */
 /**
@@ -31,7 +32,11 @@ export const IssueCardContent = ({
 
   return (
     <div className="widget-content-wrap">
-      {description && <p className="vads-u-margin-bottom--0">{description}</p>}
+      {description && (
+        <p className="vads-u-margin-bottom--0">
+          {replaceDescriptionContent(description)}
+        </p>
+      )}
       {showPercentNumber && (
         <p className="vads-u-margin-bottom--0">
           Current rating: <strong>{ratingIssuePercentNumber}%</strong>

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -47,13 +47,8 @@ export class ConfirmationPage extends React.Component {
         <h2 className="confirmation-page-title vads-u-font-size--h3">
           Your request has been submitted
         </h2>
-        <p>
-          We may contact you for more information or documents.
-          <br className="screen-only" />
-          <em className="screen-only">
-            Please print this page for your records.
-          </em>
-        </p>
+        <p>We may contact you for more information or documents.</p>
+        <p className="screen-only">Please print this page for your records.</p>
         <div className="inset">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
             Higher-Level Review{' '}

--- a/src/applications/disability-benefits/996/tests/utils/replace.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/replace.unit.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import { replaceDescriptionContent } from '../../utils/replace';
+
+describe('replaceDescriptionContent', () => {
+  it('should return an empty string', () => {
+    expect(replaceDescriptionContent()).to.eq('');
+    expect(replaceDescriptionContent(null)).to.eq('');
+    expect(replaceDescriptionContent('')).to.eq('');
+  });
+  it('should not alter an these strings', () => {
+    expect(replaceDescriptionContent('   ')).to.eq('   ');
+    expect(replaceDescriptionContent('abc 123')).to.eq('abc 123');
+  });
+  it('should replace percent with a % symbol', () => {
+    expect(replaceDescriptionContent('10 percent')).to.eq('10%');
+    expect(replaceDescriptionContent('10 percent.')).to.eq('10%.');
+    expect(replaceDescriptionContent('Percent effective')).to.eq('% effective');
+    expect(replaceDescriptionContent('Equal to 30 percent income')).to.eq(
+      'Equal to 30% income',
+    );
+  });
+  it('should not replace percent within words', () => {
+    expect(replaceDescriptionContent('Percentage due')).to.eq('Percentage due');
+    expect(replaceDescriptionContent('20 percentile')).to.eq('20 percentile');
+    expect(replaceDescriptionContent('percentpercent')).to.eq('percentpercent');
+  });
+});

--- a/src/applications/disability-benefits/996/utils/replace.js
+++ b/src/applications/disability-benefits/996/utils/replace.js
@@ -1,0 +1,23 @@
+/** Replace "percent" with "%" - see va.gov-team/issues/34810
+ * Include spacing in regexp so:
+ *  "10 percent " => "10% "
+ *  "20 percent." => "20%."
+ */
+const percentRegex = /(\s|\b)percent(\s|\b)/gi;
+const replacePercent = text => text.replace(percentRegex, '%$2');
+
+const transformers = [
+  // add more here
+  replacePercent,
+];
+
+/**
+ * Replace specific content within the issue description
+ * @param {String} text - text to modify
+ * @returns {String}
+ */
+export const replaceDescriptionContent = text =>
+  transformers.reduce(
+    (resultingText, transformer) => transformer(resultingText),
+    text || '',
+  );


### PR DESCRIPTION
## Description

In a staging review for Higher-Level Review v2, two issues were reported:
- Remove italics from confirmation page
- Replace "percent" with "%" symbol

This PR:
- Removes the italics from both the HLR form and the NOD form (quick fix)
- Since the contestable issue description containing the "percent" is coming from Caseflow, a simple string replacement is perform before displaying the description

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34810

## Testing done

Added unit test for the replacement function

## Screenshots

<details><summary>Confirmation page</summary>

<!-- leave a blank line above -->
![please print this page in plain text](https://user-images.githubusercontent.com/136959/148828841-1ec41c51-fca5-4f7c-a094-327177904c93.png)</details>

<details><summary>Contestable issue description before & after</summary>

<!-- leave a blank line above -->
Before

![contestable issue description with "percent" in the text](https://user-images.githubusercontent.com/48728214/148289494-27b669bc-4d8d-4246-9812-5f0e8fc06fa9.png)

After
![the word "percent" replaced with a symbol in the description](https://user-images.githubusercontent.com/136959/148828838-2f24d61b-0bb8-4ca3-aa75-3c4edcc362b3.png)</details>

## Acceptance criteria
- [x] Italicized text removed from form
- [x] Contestable issues descriptions have "percent" replaced with a symbol

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
