### PR TITLE
Add font weight bold to error messaging

### DIFF
--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -141,7 +141,7 @@ export const Search = ({ onSearch }) => {
             </label>
             {startDateMonthError && (
               <p
-                className="vads-u-color--secondary vads-u-margin--0"
+                className="vads-u-color--secondary vads-u-margin--0 vads-u-font-size--bold"
                 role="alert"
               >
                 <span className="sr-only">Error</span> Missing month
@@ -174,7 +174,7 @@ export const Search = ({ onSearch }) => {
             </label>
             {startDateDayError && (
               <p
-                className="vads-u-color--secondary vads-u-margin--0"
+                className="vads-u-color--secondary vads-u-margin--0 vads-u-font-size--bold"
                 role="alert"
               >
                 <span className="sr-only">Error</span> Missing day
@@ -223,7 +223,7 @@ export const Search = ({ onSearch }) => {
               </label>
               {startDateMonthError && (
                 <p
-                  className="vads-u-color--secondary vads-u-margin--0"
+                  className="vads-u-color--secondary vads-u-margin--0 vads-u-font-size--bold"
                   role="alert"
                 >
                   <span className="sr-only">Error</span> Missing month
@@ -256,7 +256,7 @@ export const Search = ({ onSearch }) => {
               </label>
               {startDateDayError && (
                 <p
-                  className="vads-u-color--secondary vads-u-margin--0"
+                  className="vads-u-color--secondary vads-u-margin--0 vads-u-font-size--bold"
                   role="alert"
                 >
                   <span className="sr-only">Error</span> Missing day
@@ -293,7 +293,7 @@ export const Search = ({ onSearch }) => {
               </label>
               {endDateMonthError && (
                 <p
-                  className="vads-u-color--secondary vads-u-margin--0"
+                  className="vads-u-color--secondary vads-u-margin--0 vads-u-font-size--bold"
                   role="alert"
                 >
                   <span className="sr-only">Error</span> Missing month
@@ -326,7 +326,7 @@ export const Search = ({ onSearch }) => {
               </label>
               {endDateDayError && (
                 <p
-                  className="vads-u-color--secondary vads-u-margin--0"
+                  className="vads-u-color--secondary vads-u-margin--0 vads-u-font-size--bold"
                   role="alert"
                 >
                   <span className="sr-only">Error</span> Missing day


### PR DESCRIPTION
## Description

This PR updates the font weight of error messaging to bold.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/148829996-379c4ec8-1d3a-4b3b-91ba-a4b3aa6b26dc.png)
![image](https://user-images.githubusercontent.com/12773166/148830022-a2415ea7-ad51-4905-b621-8a711e46d4ec.png)


## Acceptance criteria
- [x] Update error messaging to use bold

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
