### PR TITLE
SiP: Remove period from link content

### DIFF
--- a/src/platform/forms-system/src/js/constants.js
+++ b/src/platform/forms-system/src/js/constants.js
@@ -2,8 +2,7 @@ export const START_NEW_APP_DEFAULT_MESSAGE = 'Start a new application';
 export const CONTINUE_APP_DEFAULT_MESSAGE = 'Continue your application';
 export const APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE =
   'Your application has been saved.';
-export const FINISH_APP_LATER_DEFAULT_MESSAGE =
-  'Finish this application later.';
+export const FINISH_APP_LATER_DEFAULT_MESSAGE = 'Finish this application later';
 export const UNAUTH_SIGN_IN_DEFAULT_MESSAGE =
   'Sign in to start your application';
 export const APP_TYPE_DEFAULT = 'application';

--- a/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
+++ b/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
@@ -119,7 +119,7 @@ describe('Review PreSubmitSection component', () => {
       </Provider>,
     );
 
-    expect(tree.getByText('Finish this application later.')).to.exist;
+    expect(tree.getByText('Finish this application later')).to.exist;
 
     tree.unmount();
   });


### PR DESCRIPTION
## Description

In a recent staging review, the "Finish this application later" link, above the back button, should not include a period. This was found to be a globally set default value for the save-in-progress component. Form specific custom text was not changed in this PR.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34810

## Testing done

Updated unit test

## Screenshots

![Finish this application later link without a period at the end](https://user-images.githubusercontent.com/136959/148836775-2d0a6032-6922-42c4-99ec-7a25d3c6e93e.png)

## Acceptance criteria
- [x] Period removed from save-in-progress link
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
