### PR TITLE
Add OtherTextField component poc

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/OtherTextField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/OtherTextField.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const numberTypes = new Set(['number', 'integer']);
+
+export default function OtherTextField(props) {
+  let inputType = props.options.inputType;
+  if (!inputType) {
+    inputType = numberTypes.has(props.schema.type) ? 'number' : props.type;
+  }
+
+  const pageIndex = props.formContext?.pagePerItemIndex;
+  /**
+   * addIndex
+   * ui:options.ariaDescribedby id may be within an array, so the page index
+   * from formContext pagePerItemIndex will be appended
+   * @param {String|null} id - aria-describedby id of associated content
+   */
+  const addIndex = (id = '') =>
+    id && typeof pageIndex !== 'undefined' ? `${id}_${pageIndex}` : id;
+
+  const inputProps = {
+    ...(props.schema.minValue && { min: props.schema.minValue }),
+    ...(props.schema.maxValue && { max: props.schema.maxValue }),
+    autoComplete: props.options.autocomplete,
+    type: inputType,
+    id: props.id,
+    name: props.id,
+    disabled: props.disabled,
+    maxLength: props.schema.maxLength,
+    className: props.options.widgetClassNames,
+    value: typeof props.value === 'undefined' ? '' : props.value,
+    onBlur: () => props.onBlur(props.id),
+    onChange: event =>
+      props.onChange(event.target.value ? event.target.value : undefined),
+    onFocus: props.onFocus,
+    'aria-describedby': addIndex(props.options?.ariaDescribedby || null),
+  };
+
+  return (
+    <div className="vads-u-border-left--5px vads-u-padding-y--0p5 vads-u-padding-left--1 vads-u-border-color--primary-alt">
+      <label className="vads-u-margin--0" htmlFor={props.id}>
+        {props.options.title}
+      </label>
+      <input {...inputProps} />
+    </div>
+  );
+}
+OtherTextField.propTypes = {
+  /**
+   * ui:options from uiSchema
+   */
+  options: PropTypes.shape({
+    /*
+    * input's autocomplete attribute value
+    */
+    autocomplete: PropTypes.string,
+    /**
+     * input's aria-describedby attribute
+     */
+    ariaDescribedby: PropTypes.string,
+  }),
+};
+
+OtherTextField.defaultProps = {
+  options: {},
+  type: 'text',
+};

--- a/src/applications/personalization/profile/components/personal-information/OtherTextField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/OtherTextField.jsx
@@ -37,6 +37,8 @@ export default function OtherTextField(props) {
     'aria-describedby': addIndex(props.options?.ariaDescribedby || null),
   };
 
+  // this new component allows a text field to have a border and 'belong' to a field above it
+  // mostly used for checkbox and radio button groups with and other option
   return (
     <div className="vads-u-border-left--5px vads-u-padding-y--0p5 vads-u-padding-left--1 vads-u-border-color--primary-alt">
       <label className="vads-u-margin--0" htmlFor={props.id}>

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -1,5 +1,6 @@
 import TextWidget from 'platform/forms-system/src/js/widgets/TextWidget';
 import RadioWidget from 'platform/forms-system/src/js/widgets/RadioWidget';
+import OtherTextField from '@@profile/components/personal-information/OtherTextField';
 
 const genderOptions = [
   'woman',
@@ -127,8 +128,13 @@ export const personalInformationUiSchemas = {
       'ui:title': 'Pronouns not listed here',
     },
     pronounsNotListedText: {
-      'ui:title':
-        'If not listed, please provide your preferred pronouns (255 characters maximum)',
+      'ui:options': {
+        widgetClassNames: 'my-class-here',
+        hideLabelText: true,
+        widget: OtherTextField,
+        title:
+          'If not listed, please provide your preferred pronouns (255 characters maximum)',
+      },
     },
   },
   genderIdentity: {


### PR DESCRIPTION
## Description
Adds an experimental component in staging for the Personal Information section of the user profile, and only in the Pronouns section for now.

This new component is used to show that a text field is related to a radio or checkbox option. After this single usage of the `OtherTextField` is evaluated it will be modified further and implemented in the rest of the applicable sections of the profile.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34890


## Testing done
Tested locally

## Screenshots
![Screen Shot 2022-01-11 at 10 49 24 AM](https://user-images.githubusercontent.com/8332986/148995117-6a4bfe07-603d-44af-a5b7-259020447a89.png)


## Acceptance criteria
- [x] Displays component that matches design mockup

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
