### PR TITLE
Update required label coloring

### DIFF
--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -136,7 +136,7 @@ export const Search = ({ onSearch }) => {
           {/* Month */}
           <div className="vads-u-display--flex vads-u-flex-direction--column">
             <label className="vads-u-margin--0" htmlFor="startDateMonth">
-              Month (Required)
+              Month <span className="vads-u-color--secondary">(*Required)</span>
             </label>
             {startDateMonthError && (
               <p
@@ -168,7 +168,7 @@ export const Search = ({ onSearch }) => {
           {/* Day */}
           <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-left--1">
             <label className="vads-u-margin--0" htmlFor="startDateDay">
-              Day (Required)
+              Day <span className="vads-u-color--secondary">(*Required)</span>
             </label>
             {startDateDayError && (
               <p
@@ -216,7 +216,8 @@ export const Search = ({ onSearch }) => {
             {/* Start date | Month */}
             <div className="vads-u-display--flex vads-u-flex-direction--column">
               <label className="vads-u-margin--0" htmlFor="startDateMonth">
-                Month (Required)
+                Month{' '}
+                <span className="vads-u-color--secondary">(*Required)</span>
               </label>
               {startDateMonthError && (
                 <p
@@ -248,7 +249,7 @@ export const Search = ({ onSearch }) => {
             {/* Start date | Day */}
             <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-left--1">
               <label className="vads-u-margin--0" htmlFor="startDateDay">
-                Day (Required)
+                Day <span className="vads-u-color--secondary">(*Required)</span>
               </label>
               {startDateDayError && (
                 <p
@@ -284,7 +285,8 @@ export const Search = ({ onSearch }) => {
             {/* End date | Month */}
             <div className="vads-u-display--flex vads-u-flex-direction--column">
               <label className="vads-u-margin--0" htmlFor="endDateMonth">
-                Month (Required)
+                Month{' '}
+                <span className="vads-u-color--secondary">(*Required)</span>
               </label>
               {endDateMonthError && (
                 <p
@@ -316,7 +318,7 @@ export const Search = ({ onSearch }) => {
             {/* End date | Day */}
             <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-left--1">
               <label className="vads-u-margin--0" htmlFor="endDateDay">
-                Day (Required)
+                Day <span className="vads-u-color--secondary">(*Required)</span>
               </label>
               {endDateDayError && (
                 <p


### PR DESCRIPTION
## Description

This PR updates the required labels from `(Required)` to `(*Required)` with error coloring for event listing v2 pages' search forms.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/149021817-111914bf-42c5-44e1-95bd-d5dfe2856f40.png)

## Acceptance criteria
- [x] updates the required labels from `(Required)` to `(*Required)` with error coloring for event listing v2 pages' search forms.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
