### PR TITLE
526: Remove empty facilities before submission

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js
@@ -52,6 +52,15 @@ describe('transformRelatedDisabilities', () => {
 });
 
 describe('stringifyRelatedDisabilities', () => {
+  it('should return an empty object if undefined', () => {
+    expect(stringifyRelatedDisabilities({})).to.be.empty;
+  });
+  it('should return an empty object with an empty array', () => {
+    const formData = {
+      vaTreatmentFacilities: [],
+    };
+    expect(stringifyRelatedDisabilities(formData)).to.be.empty;
+  });
   it('should return an array of strings', () => {
     const formData = {
       newDisabilities: [

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -250,7 +250,11 @@ export const stringifyRelatedDisabilities = formData => {
       facility,
     ),
   );
-  clonedData.vaTreatmentFacilities = newVAFacilities;
+  if (newVAFacilities.length) {
+    clonedData.vaTreatmentFacilities = newVAFacilities;
+  } else {
+    delete clonedData.vaTreatmentFacilities;
+  }
   return clonedData;
 };
 


### PR DESCRIPTION
## Description

The following error was shared:

```js
{
  "path": ["vaTreatmentFacilities"],
  "property": "instance.vaTreatmentFacilities",
  "message": "does not meet minimum length of 1",
  "schema": {
    "type": "array",
    "minItems": 1,
    "maxItems": 100,
    "items": []
  }
}
```

Which appears that the `vaTreatmentFacilities` array should not be passed on submission. This PR removes the entry if the array is empty.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34289

## Testing done

Added unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Remove empty `vaTreatmentFacilities` before submitting
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
