### PR TITLE
hlr update to va-loading-indicator

### DIFF
--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { selectProfile, isLoggedIn } from 'platform/user/selectors';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
@@ -124,7 +122,7 @@ export const Form0996App = ({
     router.push('/start');
     content = (
       <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-        <LoadingIndicator message="Please wait while we restart the application for you." />
+        <va-loading-indicator message="Please wait while we restart the application for you." />
       </h1>
     );
   } else if (
@@ -134,8 +132,8 @@ export const Form0996App = ({
   ) {
     content = (
       <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          set-focus
           message="Loading your previous decisions..."
         />
       </h1>

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -58,8 +57,8 @@ export class IntroductionPage extends React.Component {
         contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT)
     ) {
       return (
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          set-focus
           message="Loading your previous decisions..."
         />
       );

--- a/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
@@ -97,7 +97,7 @@ describe('Form0996App', () => {
     expect(article.props()['data-location']).to.eq('introduction');
     expect(tree.find('h1').text()).to.eq('Intro');
     expect(tree.find('Connect(RoutedSavableApp)')).to.exist;
-    expect(tree.find('LoadingIndicator')).to.have.lengthOf(0);
+    expect(tree.find('va-loading-indicator')).to.have.lengthOf(0);
 
     tree.unmount();
   });
@@ -113,7 +113,7 @@ describe('Form0996App', () => {
     );
 
     expect(tree.find('h1').text()).to.contain('restart');
-    expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
+    expect(tree.find('va-loading-indicator')).to.have.lengthOf(1);
     expect(routerPushSpy.called).to.be.true;
     expect(routerPushSpy.args[0][0]).to.eq('/start');
 

--- a/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
@@ -112,7 +112,7 @@ describe('Form0996App', () => {
       </Provider>,
     );
 
-    expect(tree.find('h1').text()).to.contain('restart');
+    expect(tree.find('va-loading-indicator').html()).to.contain('restart');
     expect(tree.find('va-loading-indicator')).to.have.lengthOf(1);
     expect(routerPushSpy.called).to.be.true;
     expect(routerPushSpy.args[0][0]).to.eq('/start');
@@ -140,7 +140,9 @@ describe('Form0996App', () => {
     );
 
     tree.setProps();
-    expect(tree.find('h1').text()).to.contain('Loading your previous decision');
+    expect(tree.find('va-loading-indicator').html()).to.contain(
+      'Loading your previous decision',
+    );
     expect(getIssues.calledOnce).to.be.true;
     tree.unmount();
   });

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -186,7 +186,7 @@ describe('IntroductionPage', () => {
     };
 
     const tree = shallow(<IntroductionPage {...props} />);
-    const loading = tree.find('LoadingIndicator').first();
+    const loading = tree.find('va-loading-indicator').first();
     expect(loading.props().message).to.contain(
       'Loading your previous decisions',
     );


### PR DESCRIPTION
## Description
All instances of `LoadingIndicator` need to be replaced with `<va-loading-indicator>` web component.

## Original issue(s)
closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/34698


## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Replaced loadingIndicator
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
