### PR TITLE
Add type of care to the details page of the appointment

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -12,6 +12,7 @@ import PrintLink from './PrintLink';
 import VAInstructions from './VAInstructions';
 import NoOnlineCancelAlert from './NoOnlineCancelAlert';
 import PhoneInstructions from './PhoneInstructions';
+import { getTypeOfCareById } from '../../../utils/appointment';
 
 function formatHeader(appointment) {
   if (appointment.vaos.isCOVIDVaccine) {
@@ -23,29 +24,41 @@ function formatHeader(appointment) {
   }
 }
 
-export default function DetailsVA({ appointment, facilityData }) {
+export default function DetailsVA({
+  appointment,
+  facilityData,
+  useV2 = false,
+}) {
   const locationId = getVAAppointmentLocationId(appointment);
 
   const facility = facilityData?.[locationId];
   const isCovid = appointment.vaos.isCOVIDVaccine;
   const header = formatHeader(appointment);
   const isPhone = appointment.vaos.isPhoneAppointment;
+  const serviceType = useV2
+    ? appointment.vaos.apiData.serviceType
+    : appointment.vaos.apiData.vdsAppointments[0]?.clinic?.stopCode;
+  const typeOfCare = getTypeOfCareById(serviceType)?.name;
 
   return (
     <>
       <Breadcrumbs>
         <Link to={`/va/${appointment.id}`}>Appointment detail</Link>
       </Breadcrumbs>
-
       <h1>
         <AppointmentDateTime appointment={appointment} />
       </h1>
-
       <StatusAlert appointment={appointment} facility={facility} />
-
+      {typeOfCare && (
+        <>
+          <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
+            Type of care:
+          </h2>
+          <div className="vads-u-display--inline"> {typeOfCare}</div>
+        </>
+      )}
       <TypeHeader>{header}</TypeHeader>
       <PhoneInstructions appointment={appointment} />
-
       <VAFacilityLocation
         facility={facility}
         facilityName={facility?.name}
@@ -54,9 +67,7 @@ export default function DetailsVA({ appointment, facilityData }) {
         showCovidPhone={isCovid}
         isPhone={isPhone}
       />
-
       <VAInstructions appointment={appointment} />
-
       <CalendarLink appointment={appointment} facility={facility} />
       <PrintLink appointment={appointment} />
       {!isCovid && <CancelLink appointment={appointment} />}

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -26,6 +26,7 @@ export default function ConfirmedAppointmentDetailsPage() {
     appointmentDetailsStatus,
     cancelInfo,
     facilityData,
+    useV2,
   } = useSelector(
     state => getConfirmedAppointmentDetailsInfo(state, id),
     shallowEqual,
@@ -103,7 +104,11 @@ export default function ConfirmedAppointmentDetailsPage() {
         <DetailsVideo appointment={appointment} facilityData={facilityData} />
       )}
       {isVA && (
-        <DetailsVA appointment={appointment} facilityData={facilityData} />
+        <DetailsVA
+          appointment={appointment}
+          facilityData={facilityData}
+          useV2={useV2}
+        />
       )}
       <CancelAppointmentModal
         {...cancelInfo}

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -22,6 +22,7 @@ import {
   selectFeatureRequests,
   selectIsCernerOnlyPatient,
   selectFeatureCancel,
+  selectFeatureVAOSServiceVAAppointments,
 } from '../../redux/selectors';
 import { TYPE_OF_CARE_ID as VACCINE_TYPE_OF_CARE_ID } from '../../covid-19-vaccine/utils';
 
@@ -253,7 +254,9 @@ export function getUpcomingAppointmentListInfo(state) {
 
 export function getConfirmedAppointmentDetailsInfo(state, id) {
   const { appointmentDetailsStatus, facilityData } = state.appointments;
-
+  const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
+    state,
+  );
   return {
     appointment: selectAppointmentById(state, id, [
       APPOINTMENT_TYPES.vaAppointment,
@@ -262,6 +265,7 @@ export function getConfirmedAppointmentDetailsInfo(state, id) {
     cancelInfo: getCancelInfo(state),
     facilityData,
     showCancelButton: selectFeatureCancel(state),
+    useV2: featureVAOSServiceVAAppointments,
   };
 }
 

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
@@ -14,6 +14,7 @@ import {
   getTimezoneByFacilityId,
 } from '../../../utils/timezone';
 import { GA_PREFIX, PURPOSE_TEXT } from '../../../utils/constants';
+import { getTypeOfCareById } from '../../../utils/appointment';
 
 export default function ConfirmationDirectScheduleInfoV2({
   data,
@@ -26,7 +27,7 @@ export default function ConfirmationDirectScheduleInfoV2({
     ? moment(slot.start).tz(timezone, true)
     : moment(slot.start);
   const appointmentLength = moment(slot.end).diff(slot.start, 'minutes');
-
+  const typeOfCare = getTypeOfCareById(data.typeOfCareId)?.name;
   return (
     <>
       <h1 className="vads-u-font-size--h2">
@@ -52,6 +53,14 @@ export default function ConfirmationDirectScheduleInfoV2({
           <Link to="/new-appointment">Schedule a new appointment</Link>
         </div>
       </InfoAlert>
+      {typeOfCare && (
+        <>
+          <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
+            Type of care:
+          </h2>
+          <div className="vads-u-display--inline"> {typeOfCare}</div>
+        </>
+      )}
       <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
         <div className="vads-u-flex--1 vads-u-margin-top--2 vads-u-margin-right--1 vaos-u-word-break--break-word">
           <h2

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -9,10 +9,6 @@ import {
   PURPOSE_TEXT,
   EXPRESS_CARE,
   TYPE_OF_VISIT,
-  TYPES_OF_EYE_CARE,
-  TYPES_OF_SLEEP_CARE,
-  AUDIOLOGY_TYPES_OF_CARE,
-  TYPES_OF_CARE,
   CANCELLATION_REASONS,
 } from '../../utils/constants';
 import { getTimezoneByFacilityId } from '../../utils/timezone';
@@ -26,6 +22,8 @@ import {
   FUTURE_APPOINTMENTS_HIDE_STATUS_SET,
   PAST_APPOINTMENTS_HIDE_STATUS_SET,
 } from './index';
+
+import { getTypeOfCareById } from '../../utils/appointment';
 
 /**
  * Determines what type of appointment a VAR appointment object is depending on
@@ -472,19 +470,6 @@ function getTypeOfVisit(appt) {
  */
 export function transformConfirmedAppointments(appointments) {
   return appointments.map(appt => transformConfirmedAppointment(appt));
-}
-
-function getTypeOfCareById(id) {
-  const allTypesOfCare = [
-    ...TYPES_OF_EYE_CARE,
-    ...TYPES_OF_SLEEP_CARE,
-    ...AUDIOLOGY_TYPES_OF_CARE,
-    ...TYPES_OF_CARE,
-  ];
-
-  return allTypesOfCare.find(
-    care => care.idV2 === id || care.ccId === id || care.id === id,
-  );
 }
 
 /**

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -1,17 +1,14 @@
 import moment from 'moment';
 import { getPatientInstruction } from '../appointment';
 import {
-  TYPES_OF_CARE,
   APPOINTMENT_TYPES,
   PURPOSE_TEXT,
   TYPE_OF_VISIT,
-  TYPES_OF_EYE_CARE,
-  TYPES_OF_SLEEP_CARE,
-  AUDIOLOGY_TYPES_OF_CARE,
   COVID_VACCINE_ID,
 } from '../../utils/constants';
 import { getTimezoneByFacilityId } from '../../utils/timezone';
 import { transformFacilityV2 } from '../location/transformers.v2';
+import { getTypeOfCareById } from '../../utils/appointment';
 
 function getAppointmentType(appt) {
   if (appt.kind === 'cc' && appt.start) {
@@ -23,19 +20,6 @@ function getAppointmentType(appt) {
   }
 
   return APPOINTMENT_TYPES.vaAppointment;
-}
-
-function getTypeOfCareById(id) {
-  const allTypesOfCare = [
-    ...TYPES_OF_EYE_CARE,
-    ...TYPES_OF_SLEEP_CARE,
-    ...AUDIOLOGY_TYPES_OF_CARE,
-    ...TYPES_OF_CARE,
-  ];
-
-  return allTypesOfCare.find(
-    care => care.idV2 === id || care.ccId === id || care.id === id,
-  );
 }
 
 /**

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -289,8 +289,8 @@ const responses = {
 
     if (
       isDirect &&
-      (req.query.facility_id.startsWith('984') &&
-        req.query.clinical_service_id !== 'primaryCare')
+      req.query.facility_id.startsWith('984') &&
+      req.query.clinical_service_id !== 'primaryCare'
     ) {
       ineligibilityReasons.push({
         coding: [

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -18,7 +18,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -45,7 +46,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -270,7 +272,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "123"
             },
             "type": "REGULAR",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -298,7 +301,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -325,7 +329,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -352,7 +357,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "ORGAN DONORS",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -379,7 +385,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "NO ACTION TAKEN/TODAY"
@@ -406,7 +413,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -433,7 +441,8 @@
             "clinic": {
               "name": "CHY VISUAL FIELD",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -460,7 +469,8 @@
             "clinic": {
               "name": "CHY PC CASSIDY",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -487,7 +497,8 @@
             "clinic": {
               "name": "CHY VISUAL FIELD",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "SERVICE CONNECTED",
             "currentStatus": "CANCELLED BY CLINIC"
@@ -514,7 +525,8 @@
             "clinic": {
               "name": "CHY VISUAL FIELD",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "SERVICE CONNECTED",
             "currentStatus": "FUTURE"
@@ -541,7 +553,8 @@
             "clinic": {
               "name": "DAY AUDIOLOGY FELLOW 1",
               "askForCheckIn": false,
-              "facilityCode": "984"
+              "facilityCode": "984",
+              "stopCode": "203"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -568,7 +581,8 @@
             "clinic": {
               "name": "WHT AUDIO VAR2",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "203"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -595,7 +609,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -622,7 +637,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "407"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -649,7 +665,8 @@
             "clinic": {
               "name": "CHY VISUAL FIELD",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "407"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -676,7 +693,8 @@
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -703,7 +721,8 @@
             "clinic": {
               "name": "CHY VISUAL FIELD",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "REGULAR",
             "currentStatus": "FUTURE"
@@ -730,7 +749,8 @@
             "clinic": {
               "name": "ZZFTC C&P AUDIO BEV",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "COMPENSATION & PENSION",
             "currentStatus": "FUTURE"
@@ -976,7 +996,8 @@
             "clinic": {
               "name": "MARCYTESTSLOTS",
               "askForCheckIn": false,
-              "facilityCode": "983"
+              "facilityCode": "983",
+              "stopCode": "323"
             },
             "type": "SERVICE CONNECTED",
             "currentStatus": "FUTURE"

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -41,6 +41,7 @@ const initialState = {
     vaOnlineSchedulingPast: true,
     // eslint-disable-next-line camelcase
     show_new_schedule_view_appointments_page: true,
+    vaOnlineSchedulingVAOSServiceVAAppointments: false,
   },
 };
 
@@ -66,6 +67,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       status: 'booked',
       clinicFriendlyName: "Jennie's Lab",
       comment: 'New issue: ASAP',
+      stopCode: '123',
     };
     const appointment = createMockAppointmentByVersion({
       version: 0,
@@ -143,6 +145,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         ),
       }),
     ).to.be.ok;
+    expect(screen.getByText(/Nutrition and food/i)).to.be.ok;
     expect(screen.getByText(/Print/)).to.be.ok;
     expect(screen.getByText(/Cancel appointment/)).to.be.ok;
 
@@ -236,6 +239,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       locationId: '983GC',
       clinicFriendlyName: "Jennie's Lab",
       comment: 'New issue: ASAP',
+      stopCode: '323',
     };
     const appointment = createMockAppointmentByVersion({
       version: 0,
@@ -306,6 +310,8 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         name: 'You shared these details about your concern',
       }),
     ).to.be.ok;
+
+    expect(screen.getByText(/Primary care/i)).to.be.ok;
     expect(screen.getByText(/New issue: ASAP/)).to.be.ok;
     expect(screen.baseElement).not.to.contain.text(
       new RegExp(
@@ -1115,6 +1121,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       }),
     ).to.be.ok;
 
+    expect(screen.getByText('Primary care')).to.be.ok;
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
     expect(await screen.findByText(/Cheyenne VA Medical Center/)).to.be.ok;
     expect(await screen.findByText(/Some fancy clinic name/)).to.be.ok;
@@ -1335,6 +1342,8 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
         ),
       }),
     ).to.be.ok;
+
+    expect(screen.getByText('Primary care')).to.be.ok;
 
     // Then it should display who canceled the appointment
     expect(await screen.findByText(/You canceled this appointment./i)).to.exist;

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -106,6 +106,7 @@ export function createMockAppointmentByVersion({
           name: clinicName,
           askForCheckIn: false,
           facilityCode: fields.locationId?.substr(0, 3) || null,
+          stopCode: fields.stopCode,
         },
         type: 'REGULAR',
         currentStatus: vistaStatus,

--- a/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.unit.spec.jsx
@@ -97,6 +97,7 @@ describe('VAOS <ConfirmationDirectScheduleInfoV2>', () => {
         new RegExp(start.format('MMMM D, YYYY [at] h:mm a'), 'i'),
       ),
     ).to.be.ok;
+    expect(screen.getByText('Primary care')).to.be.ok;
     expect(screen.getByText(/Cheyenne VA Medical Center/i)).to.be.ok;
     expect(screen.getByText(/2360 East Pershing Boulevard/i)).to.be.ok;
     expect(screen.baseElement).to.contain.text(

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -5,7 +5,12 @@
  */
 
 import environment from 'platform/utilities/environment';
-
+import {
+  TYPES_OF_EYE_CARE,
+  TYPES_OF_SLEEP_CARE,
+  AUDIOLOGY_TYPES_OF_CARE,
+  TYPES_OF_CARE,
+} from '../utils/constants';
 /**
  * Replaces a mock facility id with a real facility id in non production environments
  *
@@ -19,4 +24,18 @@ export function getRealFacilityId(facilityId) {
   }
 
   return facilityId;
+}
+
+export function getTypeOfCareById(inputId) {
+  const allTypesOfCare = [
+    ...TYPES_OF_EYE_CARE,
+    ...TYPES_OF_SLEEP_CARE,
+    ...AUDIOLOGY_TYPES_OF_CARE,
+    ...TYPES_OF_CARE,
+  ];
+
+  return allTypesOfCare.find(
+    ({ idV2 = '', ccId = '', id = '' }) =>
+      idV2 === inputId || ccId === inputId || id === inputId,
+  );
 }


### PR DESCRIPTION
## Description
This code change adds Type of care to the appointment details page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34392


## Testing done
Unit and manual

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/149231428-f551e976-48c5-4c8d-b27c-c563879dfdaa.png)
![image](https://user-images.githubusercontent.com/3951775/149231703-84b3ba45-146d-4464-82c2-7129699a3f4e.png)
![image](https://user-images.githubusercontent.com/3951775/149233107-ab767b9a-3fe7-441e-add2-cce04da080ac.png)


## Acceptance criteria
- [ ] Given the user is in the new appointment workflow,
When the user books the appointment,
Then user will be able to see the type of care on the confirmation details page,
And page content matches the copy doc
And page design matches the design spec desktop, mobile, and tablet

- [ ] Given the user is in the VAOS homepage,
When the user views their booked VA appointment,
Then user will be able to see the type of care on the appointment details page,
And page content matches the copy doc
And page design matches the design spec desktop, mobile, and tablet

- [ ] Given the user is in the VAOS homepage,
When the user views their canceled VA appointment,
Then user will be able to see the type of care on the appointment details page,
And page content matches the copy doc
And page design matches the design spec desktop, mobile, and tablet

- [ ] Given the user is in the VAOS homepage,
When the user views their past VA appointment,
Then user will be able to see the type of care on the appointment details page,
And page content matches the copy doc
And page design matches the design spec desktop, mobile, and tablet

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
