### PR TITLE
(feature) Have useFormsRouting use router instead of `currentPage`

### DIFF
--- a/src/applications/check-in/actions/navigation/index.js
+++ b/src/applications/check-in/actions/navigation/index.js
@@ -1,11 +1,10 @@
 export const INIT_FORM = 'INIT_FORM';
 
-export const createInitFormAction = ({ pages, firstPage }) => {
+export const createInitFormAction = ({ pages }) => {
   return {
     type: INIT_FORM,
     payload: {
       pages,
-      currentPage: firstPage,
     },
   };
 };

--- a/src/applications/check-in/actions/navigation/index.js
+++ b/src/applications/check-in/actions/navigation/index.js
@@ -8,12 +8,3 @@ export const createInitFormAction = ({ pages }) => {
     },
   };
 };
-
-export const GO_TO_NEXT_PAGE = 'GO_TO_NEXT_PAGE';
-
-export const createGoToNextPageAction = ({ nextPage }) => {
-  return {
-    type: GO_TO_NEXT_PAGE,
-    payload: { nextPage },
-  };
-};

--- a/src/applications/check-in/actions/navigation/navigation.actions.unit.spec.js
+++ b/src/applications/check-in/actions/navigation/navigation.actions.unit.spec.js
@@ -1,11 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  INIT_FORM,
-  createInitFormAction,
-  GO_TO_NEXT_PAGE,
-  createGoToNextPageAction,
-} from './index';
+import { INIT_FORM, createInitFormAction } from './index';
 
 describe('check-in', () => {
   describe('actions', () => {
@@ -24,18 +19,6 @@ describe('check-in', () => {
           'first-page',
           'second-page',
         ]);
-      });
-    });
-    describe('createGoToNextPageAction', () => {
-      it('should return correct action', () => {
-        const action = createGoToNextPageAction({});
-        expect(action.type).to.equal(GO_TO_NEXT_PAGE);
-      });
-      it('should return correct structure', () => {
-        const action = createGoToNextPageAction({
-          nextPage: 'next-page',
-        });
-        expect(action.payload.nextPage).equal('next-page');
       });
     });
   });

--- a/src/applications/check-in/actions/navigation/navigation.actions.unit.spec.js
+++ b/src/applications/check-in/actions/navigation/navigation.actions.unit.spec.js
@@ -24,7 +24,6 @@ describe('check-in', () => {
           'first-page',
           'second-page',
         ]);
-        expect(action.payload.currentPage).to.equal('first-page');
       });
     });
     describe('createGoToNextPageAction', () => {

--- a/src/applications/check-in/day-of/components/AppointmentDisplay/tests/AppointmentAction.unit.spec.jsx
+++ b/src/applications/check-in/day-of/components/AppointmentDisplay/tests/AppointmentAction.unit.spec.jsx
@@ -23,7 +23,6 @@ describe('check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };

--- a/src/applications/check-in/day-of/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
+++ b/src/applications/check-in/day-of/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
@@ -20,7 +20,6 @@ describe('check-in', () => {
           context: {},
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };

--- a/src/applications/check-in/day-of/containers/tests/withToken.unit.spec.jsx
+++ b/src/applications/check-in/day-of/containers/tests/withToken.unit.spec.jsx
@@ -27,7 +27,6 @@ describe('check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };
@@ -50,7 +49,6 @@ describe('check-in', () => {
           context: {},
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };
@@ -90,7 +88,6 @@ describe('check-in', () => {
           context: {},
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };

--- a/src/applications/check-in/day-of/pages/CheckIn/tests/CheckIn.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/tests/CheckIn.test.unit.spec.jsx
@@ -22,7 +22,6 @@ describe('check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
           appointments: [
             {

--- a/src/applications/check-in/day-of/pages/CheckIn/tests/DisplayMultipleAppointments.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/tests/DisplayMultipleAppointments.unit.spec.jsx
@@ -21,7 +21,6 @@ describe('check-in', () => {
         checkInData: {
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };

--- a/src/applications/check-in/day-of/pages/tests/Demographics.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/Demographics.unit.spec.jsx
@@ -9,6 +9,8 @@ import { axeCheck } from 'platform/forms-system/test/config/helpers';
 
 import Demographics from '../Demographics';
 
+import { createMockRouter } from '../../../tests/unit/mocks/router';
+
 describe('check in', () => {
   describe('Demographics', () => {
     let store;
@@ -19,7 +21,6 @@ describe('check in', () => {
         },
         form: {
           pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-          currentPage: 'first-page',
         },
         demographics: {
           mailingAddress: {
@@ -103,10 +104,7 @@ describe('check in', () => {
 
     it('goes to the error page when the demographics data is unavailable', () => {
       const push = sinon.spy();
-      const mockRouter = {
-        push,
-        params: {},
-      };
+
       const updatedStore = {
         checkInData: {
           context: {
@@ -118,9 +116,15 @@ describe('check in', () => {
           },
         },
       };
+
       render(
         <Provider store={mockStore(updatedStore)}>
-          <Demographics router={mockRouter} />
+          <Demographics
+            router={createMockRouter({
+              push,
+              params: {},
+            })}
+          />
         </Provider>,
       );
 
@@ -129,12 +133,12 @@ describe('check in', () => {
 
     it('has a clickable no button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -149,12 +153,12 @@ describe('check in', () => {
 
     it('has a clickable yes button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -169,12 +173,12 @@ describe('check in', () => {
 
     it('has a clickable yes button with update page enabled', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -188,12 +192,12 @@ describe('check in', () => {
     });
     it('has a clickable yes button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>

--- a/src/applications/check-in/day-of/pages/tests/EmergencyContact.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/EmergencyContact.unit.spec.jsx
@@ -9,6 +9,8 @@ import { axeCheck } from 'platform/forms-system/test/config/helpers';
 
 import EmergencyContact from '../EmergencyContact';
 
+import { createMockRouter } from '../../../tests/unit/mocks/router';
+
 describe('check in', () => {
   describe('EmergencyContact', () => {
     let store;
@@ -19,7 +21,6 @@ describe('check in', () => {
         },
         form: {
           pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-          currentPage: 'first-page',
         },
         emergencyContact: {
           address: {
@@ -93,10 +94,10 @@ describe('check in', () => {
 
     it('goes to the error page when the data is unavailable', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {},
-      };
+      });
       const updatedStore = {
         checkInData: {
           context: {
@@ -138,12 +139,12 @@ describe('check in', () => {
 
     it('has a clickable yes button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>

--- a/src/applications/check-in/day-of/pages/tests/Error.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/Error.test.unit.spec.jsx
@@ -24,7 +24,6 @@ describe('check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };

--- a/src/applications/check-in/day-of/pages/tests/Insurance.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/Insurance.test.unit.spec.jsx
@@ -9,6 +9,8 @@ import { axeCheck } from 'platform/forms-system/test/config/helpers';
 
 import UpdateInformationQuestion from '../UpdateInformationQuestion';
 
+import { createMockRouter } from '../../../tests/unit/mocks/router';
+
 describe('check in', () => {
   describe('UpdateInformationQuestion', () => {
     let store;
@@ -25,7 +27,6 @@ describe('check in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };
@@ -52,12 +53,12 @@ describe('check in', () => {
     });
     it('has a clickable yes button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -71,12 +72,12 @@ describe('check in', () => {
     });
     it('has a clickable no button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>

--- a/src/applications/check-in/day-of/pages/tests/NextOfKin.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/NextOfKin.unit.spec.jsx
@@ -9,6 +9,8 @@ import { axeCheck } from 'platform/forms-system/test/config/helpers';
 
 import NextOfKin from '../NextOfKin';
 
+import { createMockRouter } from '../../../tests/unit/mocks/router';
+
 describe('check in', () => {
   describe('Next of Kin', () => {
     let store;
@@ -19,7 +21,6 @@ describe('check in', () => {
         },
         form: {
           pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-          currentPage: 'first-page',
         },
         nextOfKin: {
           address: {
@@ -101,10 +102,10 @@ describe('check in', () => {
 
     it('goes to the error page when the next of kin data is unavailable', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {},
-      };
+      });
       const updatedStore = {
         checkInData: {
           context: {
@@ -127,12 +128,12 @@ describe('check in', () => {
 
     it('has a clickable no button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -148,12 +149,12 @@ describe('check in', () => {
 
     it('has a clickable yes button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -169,12 +170,12 @@ describe('check in', () => {
 
     it('has a clickable yes button with update page enabled', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>
@@ -189,12 +190,12 @@ describe('check in', () => {
     });
     it('has a clickable yes button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
         params: {
           token: 'token-123',
         },
-      };
+      });
 
       const component = render(
         <Provider store={store}>

--- a/src/applications/check-in/day-of/pages/tests/SeeStaff-unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/SeeStaff-unit.spec.jsx
@@ -20,7 +20,6 @@ describe('check in', () => {
         },
         form: {
           pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-          currentPage: 'first-page',
         },
       };
       store = mockStore(initState);

--- a/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
@@ -14,16 +14,10 @@ class SeeStaff {
       .should('be.visible')
       .and('have.text', message);
   }
-  validateBackButton(
-    previousTitle = 'Is this your current contact information?',
-  ) {
+  validateBackButton() {
     cy.get('[data-testid=back-button]')
       .should('be.visible')
       .and('have.text', 'Back to last screen');
-    cy.get('[data-testid=back-button]').click();
-    cy.get('h1', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('have.text', previousTitle);
   }
   validateBTSSSLink() {
     cy.get('a[data-testid="btsss-link"]').should(
@@ -33,6 +27,9 @@ class SeeStaff {
     cy.get('a[data-testid="btsss-link"]')
       .invoke('attr', 'href')
       .should('contain', '/health-care/get-reimbursed-for-travel-pay/');
+  }
+  selectBackButton() {
+    cy.get('[data-testid="back-button"]').click();
   }
 }
 

--- a/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.routing.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.routing.cypress.spec.js
@@ -34,44 +34,34 @@ describe('Check In Experience', () => {
         window.sessionStorage.clear();
       });
     });
-    it('see staff display with demographics message', () => {
-      Demographics.attemptToGoToNextPage('no');
-      SeeStaff.validatePageLoaded();
-      SeeStaff.validateMessage();
+
+    it('Navigation routing hitting no on every page', () => {
       cy.injectAxeThenAxeCheck();
-    });
-    it('see staff page has BTSSS link', () => {
       Demographics.attemptToGoToNextPage('no');
+
       SeeStaff.validatePageLoaded();
-      SeeStaff.validateBTSSSLink();
-      cy.injectAxeThenAxeCheck();
-    });
-    it('back link goes back to previous page', () => {
-      Demographics.attemptToGoToNextPage('no');
-      SeeStaff.validatePageLoaded();
-      SeeStaff.validateBackButton();
       SeeStaff.selectBackButton();
+
       Demographics.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
-    });
-    it('see staff display with next of kin message', () => {
       Demographics.attemptToGoToNextPage();
-      EmergencyContact.attemptToGoToNextPage();
-      NextOfKin.attemptToGoToNextPage('no');
-      SeeStaff.validatePageLoaded();
-      SeeStaff.validateMessage(
-        'Our staff can help you update your next of kin information.',
-      );
-      cy.injectAxeThenAxeCheck();
-    });
-    it('see staff display with emergency contact message', () => {
-      Demographics.attemptToGoToNextPage();
+
+      EmergencyContact.validatePageLoaded();
       EmergencyContact.attemptToGoToNextPage('no');
+
       SeeStaff.validatePageLoaded();
-      SeeStaff.validateMessage(
-        'Our staff can help you update your emergency contact information.',
-      );
-      cy.injectAxeThenAxeCheck();
+      SeeStaff.selectBackButton();
+
+      EmergencyContact.validatePageLoaded();
+      EmergencyContact.attemptToGoToNextPage();
+
+      NextOfKin.validatePage.dayOf();
+      NextOfKin.attemptToGoToNextPage('no');
+
+      SeeStaff.validatePageLoaded();
+      SeeStaff.selectBackButton();
+
+      NextOfKin.validatePage.dayOf();
+      NextOfKin.attemptToGoToNextPage();
     });
   });
 });

--- a/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
@@ -14,13 +14,14 @@ export default function TestComponent({ router }) {
     VERIFY: 'verify',
   });
   const {
-    currentPage,
+    getCurrentPageFromRouter,
     goToPreviousPage,
     goToNextPage,
     goToErrorPage,
     jumpToPage,
     pages,
   } = useFormRouting(router, URLS);
+  const currentPage = getCurrentPageFromRouter();
   return (
     <div>
       <h1>Test component for the useFormRouting hook</h1>

--- a/src/applications/check-in/hooks/tests/useFormRouting/useFormRouting.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/useFormRouting.unit.spec.jsx
@@ -7,7 +7,8 @@ import sinon from 'sinon';
 import { render, fireEvent } from '@testing-library/react';
 
 import TestComponent from './TestComponent';
-import { GO_TO_NEXT_PAGE } from '../../../actions/navigation';
+
+import { createMockRouter } from '../../../tests/unit/mocks/router';
 
 const URLS = Object.freeze({
   CONFIRMATION: 'complete',
@@ -32,17 +33,21 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'first-page',
             },
           },
         };
         store = mockStore(initState);
       });
 
-      it('should get the current pages from redux', () => {
+      it('should get the current pages from router', () => {
         const component = render(
           <Provider store={store}>
-            <TestComponent router={{ push: () => {} }} />
+            <TestComponent
+              router={createMockRouter({
+                push: () => {},
+                currentPage: 'first-page',
+              })}
+            />
           </Provider>,
         );
 
@@ -63,7 +68,6 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'first-page',
             },
           },
         };
@@ -74,9 +78,10 @@ describe('check-in', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'first-page',
+              })}
             />
           </Provider>,
         );
@@ -85,10 +90,6 @@ describe('check-in', () => {
         fireEvent.click(button);
 
         expect(push.calledWith('second-page')).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal('second-page');
       });
     });
     describe('goToNextPage', () => {
@@ -101,7 +102,6 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'fourth-page',
             },
           },
         };
@@ -112,9 +112,10 @@ describe('check-in', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'fourth-page',
+              })}
             />
           </Provider>,
         );
@@ -123,10 +124,6 @@ describe('check-in', () => {
         fireEvent.click(button);
 
         expect(push.calledWith(URLS.ERROR)).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal(URLS.ERROR);
       });
     });
     describe('goToPreviousPage', () => {
@@ -138,7 +135,6 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'third-page',
             },
           },
         };
@@ -149,9 +145,10 @@ describe('check-in', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'third-page',
+              })}
             />
           </Provider>,
         );
@@ -159,10 +156,6 @@ describe('check-in', () => {
         const button = component.getByTestId('prev-button');
         fireEvent.click(button);
         expect(push.calledWith('second-page')).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal('second-page');
       });
     });
     describe('goToPreviousPage', () => {
@@ -174,7 +167,6 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'first-page',
             },
           },
         };
@@ -185,9 +177,10 @@ describe('check-in', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'first-page',
+              })}
             />
           </Provider>,
         );
@@ -195,10 +188,6 @@ describe('check-in', () => {
         const button = component.getByTestId('prev-button');
         fireEvent.click(button);
         expect(push.calledWith(URLS.ERROR)).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal(URLS.ERROR);
       });
     });
     describe('goToErrorPage', () => {
@@ -210,7 +199,6 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'first-page',
             },
           },
         };
@@ -221,9 +209,10 @@ describe('check-in', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'first-page',
+              })}
             />
           </Provider>,
         );
@@ -231,10 +220,6 @@ describe('check-in', () => {
         const button = component.getByTestId('error-button');
         fireEvent.click(button);
         expect(push.calledWith(URLS.ERROR)).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal(URLS.ERROR);
       });
     });
     describe('jumpToPage', () => {
@@ -246,7 +231,6 @@ describe('check-in', () => {
           checkInData: {
             form: {
               pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-              currentPage: 'first-page',
             },
           },
         };
@@ -257,9 +241,10 @@ describe('check-in', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'first-page',
+              })}
             />
           </Provider>,
         );
@@ -267,19 +252,16 @@ describe('check-in', () => {
         const button = component.getByTestId('jump-button');
         fireEvent.click(button);
         expect(push.calledWith({ pathname: URLS.INTRODUCTION })).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal(URLS.INTRODUCTION);
       });
       it('accept urls params', () => {
         const push = sinon.spy();
         const component = render(
           <Provider store={store}>
             <TestComponent
-              router={{
+              router={createMockRouter({
                 push,
-              }}
+                currentPage: 'first-page',
+              })}
             />
           </Provider>,
         );
@@ -292,10 +274,6 @@ describe('check-in', () => {
             search: '?id=1234&query=some-query',
           }),
         ).to.be.true;
-        const routingAction = store
-          .getActions()
-          .find(action => action.type === GO_TO_NEXT_PAGE);
-        expect(routingAction.payload.nextPage).to.equal(URLS.INTRODUCTION);
       });
     });
   });

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -1,37 +1,25 @@
 import { useCallback, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import URLSearchParams from 'url-search-params';
 
 import { makeSelectForm } from '../selectors';
-import { createGoToNextPageAction } from '../actions/navigation';
 
 const useFormRouting = (router = {}, URLS) => {
   const selectForm = useMemo(makeSelectForm, []);
   const { pages } = useSelector(selectForm);
 
-  const dispatch = useDispatch();
-
-  const dispatchGoToNextPage = useCallback(
-    nextPage => {
-      dispatch(createGoToNextPageAction({ nextPage }));
-    },
-    [dispatch],
-  );
-
   const goToErrorPage = useCallback(
     () => {
-      dispatchGoToNextPage(URLS.ERROR);
       router.push(URLS.ERROR);
     },
-    [URLS.ERROR, dispatchGoToNextPage, router],
+    [URLS.ERROR, router],
   );
 
   const jumpToPage = useCallback(
     (page, options = {}) => {
       if (Object.values(URLS).includes(page)) {
         const nextPage = page;
-        dispatchGoToNextPage(nextPage);
         // check for params
         const query = {
           pathname: nextPage,
@@ -50,7 +38,7 @@ const useFormRouting = (router = {}, URLS) => {
         goToErrorPage();
       }
     },
-    [URLS, dispatchGoToNextPage, goToErrorPage, router],
+    [URLS, goToErrorPage, router],
   );
 
   const getCurrentPageFromRouter = useCallback(
@@ -66,20 +54,18 @@ const useFormRouting = (router = {}, URLS) => {
       const here = getCurrentPageFromRouter();
       const currentPageIndex = pages.findIndex(page => page === here);
       const nextPage = pages[currentPageIndex + 1] ?? URLS.ERROR;
-      dispatchGoToNextPage(nextPage);
       router.push(nextPage);
     },
-    [getCurrentPageFromRouter, pages, URLS.ERROR, dispatchGoToNextPage, router],
+    [getCurrentPageFromRouter, pages, URLS.ERROR, router],
   );
   const goToPreviousPage = useCallback(
     () => {
       const here = getCurrentPageFromRouter();
       const currentPageIndex = pages.findIndex(page => page === here);
       const nextPage = pages[currentPageIndex - 1] ?? URLS.ERROR;
-      dispatchGoToNextPage(nextPage);
       router.push(nextPage);
     },
-    [getCurrentPageFromRouter, pages, URLS.ERROR, dispatchGoToNextPage, router],
+    [getCurrentPageFromRouter, pages, URLS.ERROR, router],
   );
 
   return {

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
 import URLSearchParams from 'url-search-params';
 
 import { makeSelectForm } from '../selectors';
@@ -7,9 +8,10 @@ import { createGoToNextPageAction } from '../actions/navigation';
 
 const useFormRouting = (router = {}, URLS) => {
   const selectForm = useMemo(makeSelectForm, []);
-  const { pages, currentPage } = useSelector(selectForm);
+  const { pages } = useSelector(selectForm);
 
   const dispatch = useDispatch();
+
   const dispatchGoToNextPage = useCallback(
     nextPage => {
       dispatch(createGoToNextPageAction({ nextPage }));
@@ -51,27 +53,37 @@ const useFormRouting = (router = {}, URLS) => {
     [URLS, dispatchGoToNextPage, goToErrorPage, router],
   );
 
+  const getCurrentPageFromRouter = useCallback(
+    () => {
+      // substring to remove the leading /
+      return router.location.pathname.substring(1);
+    },
+    [router],
+  );
+
   const goToNextPage = useCallback(
     () => {
-      const currentPageIndex = pages.findIndex(page => page === currentPage);
+      const here = getCurrentPageFromRouter();
+      const currentPageIndex = pages.findIndex(page => page === here);
       const nextPage = pages[currentPageIndex + 1] ?? URLS.ERROR;
       dispatchGoToNextPage(nextPage);
       router.push(nextPage);
     },
-    [pages, URLS.ERROR, dispatchGoToNextPage, router, currentPage],
+    [getCurrentPageFromRouter, pages, URLS.ERROR, dispatchGoToNextPage, router],
   );
   const goToPreviousPage = useCallback(
     () => {
-      const currentPageIndex = pages.findIndex(page => page === currentPage);
+      const here = getCurrentPageFromRouter();
+      const currentPageIndex = pages.findIndex(page => page === here);
       const nextPage = pages[currentPageIndex - 1] ?? URLS.ERROR;
       dispatchGoToNextPage(nextPage);
       router.push(nextPage);
     },
-    [pages, URLS.ERROR, dispatchGoToNextPage, router, currentPage],
+    [getCurrentPageFromRouter, pages, URLS.ERROR, dispatchGoToNextPage, router],
   );
 
   return {
-    currentPage,
+    getCurrentPageFromRouter,
     goToErrorPage,
     jumpToPage,
     goToPreviousPage,

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
@@ -31,7 +31,6 @@ describe('pre-check-in', () => {
             veteranData: { demographics: {} },
             form: {
               pages: [],
-              currentPage: 'complete',
               data: {
                 demographicsUpToDate: 'yes',
                 nextOfKinUpToDate: 'yes',
@@ -101,7 +100,6 @@ describe('pre-check-in', () => {
             veteranData: { demographics: {} },
             form: {
               pages: [],
-              currentPage: 'complete',
               data: {
                 demographicsUpToDate: 'yes',
                 nextOfKinUpToDate: 'yes',

--- a/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
@@ -16,10 +16,12 @@ import { makeSelectVeteranData } from '../../../selectors';
 const Demographics = props => {
   const dispatch = useDispatch();
   const { router } = props;
-  const { goToNextPage, goToPreviousPage, currentPage } = useFormRouting(
-    router,
-    URLS,
-  );
+  const {
+    goToNextPage,
+    goToPreviousPage,
+    getCurrentPageFromRouter,
+  } = useFormRouting(router, URLS);
+  const currentPage = getCurrentPageFromRouter();
   useEffect(() => {
     focusElement('h1');
   }, []);

--- a/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
@@ -4,6 +4,8 @@ import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import Demographics from '../index';
 
+import { createMockRouter } from '../../../../tests/unit/mocks/router';
+
 describe('pre-check-in', () => {
   describe('Demographics page', () => {
     let store;
@@ -95,7 +97,6 @@ describe('pre-check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };
@@ -104,7 +105,7 @@ describe('pre-check-in', () => {
     it('page passes axeCheck', () => {
       axeCheck(
         <Provider store={store}>
-          <Demographics router={{ push: () => {} }} />
+          <Demographics router={createMockRouter()} />
         </Provider>,
       );
     });

--- a/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
@@ -28,12 +28,11 @@ const EmergencyContact = props => {
   const dispatch = useDispatch();
 
   const {
-    currentPage,
-
+    getCurrentPageFromRouter,
     goToNextPage,
     goToPreviousPage,
   } = useFormRouting(router, URLS);
-
+  const currentPage = getCurrentPageFromRouter();
   useEffect(() => {
     focusElement('h1');
   }, []);

--- a/src/applications/check-in/pre-check-in/pages/EmergencyContact/tests/EmergencyContact.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/EmergencyContact/tests/EmergencyContact.unit.spec.jsx
@@ -4,6 +4,8 @@ import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import EmergencyContact from '../index';
 
+import { createMockRouter } from '../../../../tests/unit/mocks/router';
+
 describe('pre-check-in', () => {
   describe('Emergency Contact page', () => {
     let store;
@@ -35,7 +37,6 @@ describe('pre-check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'third-page',
             data: { demographicsUpToDate: 'yes', nextOfKinUpToDate: 'no' },
           },
           context: {
@@ -48,7 +49,7 @@ describe('pre-check-in', () => {
     it('page passes axeCheck', () => {
       axeCheck(
         <Provider store={store}>
-          <EmergencyContact router={{ push: () => {} }} />
+          <EmergencyContact router={createMockRouter()} />
         </Provider>,
       );
     });

--- a/src/applications/check-in/pre-check-in/pages/Introduction/tests/IntroductionDisplay.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/tests/IntroductionDisplay.unit.spec.jsx
@@ -97,7 +97,6 @@ describe('pre-check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'first-page',
           },
         },
       };

--- a/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
@@ -42,12 +42,12 @@ const NextOfKin = props => {
   const dispatch = useDispatch();
 
   const {
-    currentPage,
+    getCurrentPageFromRouter,
     goToErrorPage,
     goToNextPage,
     goToPreviousPage,
   } = useFormRouting(router, URLS);
-
+  const currentPage = getCurrentPageFromRouter();
   useEffect(() => {
     focusElement('h1');
   }, []);

--- a/src/applications/check-in/pre-check-in/pages/NextOfKin/tests/NextOfKin.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/NextOfKin/tests/NextOfKin.unit.spec.jsx
@@ -4,6 +4,8 @@ import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import NextOfKin from '../';
 
+import { createMockRouter } from '../../../../tests/unit/mocks/router';
+
 describe('pre-check-in', () => {
   describe('Next of kin page', () => {
     let store;
@@ -35,7 +37,6 @@ describe('pre-check-in', () => {
           },
           form: {
             pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            currentPage: 'third-page',
             data: { demographicsUpToDate: 'yes' },
           },
           context: {
@@ -48,7 +49,7 @@ describe('pre-check-in', () => {
     it('page passes axeCheck', () => {
       axeCheck(
         <Provider store={store}>
-          <NextOfKin router={{ push: () => {} }} />
+          <NextOfKin router={createMockRouter()} />
         </Provider>,
       );
     });

--- a/src/applications/check-in/pre-check-in/tests/e2e/routing/browser.back.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/routing/browser.back.button.cypress.spec.js
@@ -4,9 +4,9 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
+import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 import Demographics from '../../../../tests/e2e/pages/Demographics';
 import Confirmation from '../pages/Confirmation';
-import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Pre-Check In Experience ', () => {
   let apiData = {};
@@ -32,19 +32,19 @@ describe('Pre-Check In Experience ', () => {
       window.sessionStorage.clear();
     });
   });
-  it('Happy Path w/Emergency Contact', () => {
+  it('Browser back button still works with routing', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
     ValidateVeteran.validatePageLoaded();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
-
     ValidateVeteran.attemptToGoToNextPage();
 
     // page: Introduction
     Introduction.validatePageLoaded();
     Introduction.countAppointmentList(apiData.payload.appointments.length);
     cy.injectAxeThenAxeCheck();
+
     Introduction.attemptToGoToNextPage();
 
     // page: Demographics
@@ -60,10 +60,15 @@ describe('Pre-Check In Experience ', () => {
     // page: Next of Kin
     NextOfKin.validatePageLoaded();
     cy.injectAxeThenAxeCheck();
-    NextOfKin.attemptToGoToNextPage();
 
-    // page: Confirmation
+    cy.go('back');
+    cy.go('back');
+    Demographics.validatePageLoaded();
+    Demographics.attemptToGoToNextPage();
+    EmergencyContact.validatePageLoaded();
+    EmergencyContact.attemptToGoToNextPage();
+    NextOfKin.validatePageLoaded();
+    NextOfKin.attemptToGoToNextPage();
     Confirmation.validatePageLoaded();
-    cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/check-in/reducers/day-of/day-of.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/day-of/day-of.reducers.unit.spec.js
@@ -487,7 +487,6 @@ describe('check in', () => {
           const state = appReducer.checkInData(undefined, action);
           expect(state).haveOwnProperty('form');
           expect(state.form).haveOwnProperty('pages');
-          expect(state.form).haveOwnProperty('currentPage');
           expect(state.form.pages).to.deep.equal([
             'verify',
             'loading-appointments',

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -6,7 +6,6 @@ const initialState = {
   context: {},
   form: {
     pages: [],
-    currentPage: '',
     data: {},
   },
 };

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -50,18 +50,13 @@ import {
   seeStaffMessageUpdatedHandler,
 } from './day-of';
 
-import { GO_TO_NEXT_PAGE, INIT_FORM } from '../actions/navigation';
+import { INIT_FORM } from '../actions/navigation';
 
-import {
-  gotToNextPageHandler,
-  initFormHandler,
-  updateFormHandler,
-} from './navigation';
+import { initFormHandler, updateFormHandler } from './navigation';
 
 const handler = Object.freeze({
   [INIT_FORM]: initFormHandler,
   [SET_SESSION]: setSessionHandler,
-  [GO_TO_NEXT_PAGE]: gotToNextPageHandler,
   [RECORD_ANSWER]: recordAnswerHandler,
   [SET_VETERAN_DATA]: setVeteranDataHandler,
   [APPOINTMENT_WAS_CHECKED_INTO]: appointmentWasCheckedIntoHandler,

--- a/src/applications/check-in/reducers/navigation/index.js
+++ b/src/applications/check-in/reducers/navigation/index.js
@@ -4,15 +4,15 @@ const initFormHandler = (state, action) => {
     form: {
       ...state.form,
       pages: action.payload.pages,
-      currentPage: action.payload.currentPage,
     },
   };
 };
 
-const gotToNextPageHandler = (state, action) => {
+// no longer needed?
+const gotToNextPageHandler = state => {
   return {
     ...state,
-    form: { ...state.form, currentPage: action.payload.nextPage },
+    form: { ...state.form },
   };
 };
 

--- a/src/applications/check-in/reducers/navigation/index.js
+++ b/src/applications/check-in/reducers/navigation/index.js
@@ -8,14 +8,6 @@ const initFormHandler = (state, action) => {
   };
 };
 
-// TODO: no longer needed?
-const gotToNextPageHandler = state => {
-  return {
-    ...state,
-    form: { ...state.form },
-  };
-};
-
 const updateFormHandler = (state, action) => {
   return {
     ...state,
@@ -26,4 +18,4 @@ const updateFormHandler = (state, action) => {
   };
 };
 
-export { initFormHandler, gotToNextPageHandler, updateFormHandler };
+export { initFormHandler, updateFormHandler };

--- a/src/applications/check-in/reducers/navigation/index.js
+++ b/src/applications/check-in/reducers/navigation/index.js
@@ -8,7 +8,7 @@ const initFormHandler = (state, action) => {
   };
 };
 
-// no longer needed?
+// TODO: no longer needed?
 const gotToNextPageHandler = state => {
   return {
     ...state,

--- a/src/applications/check-in/reducers/navigation/navigation.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/navigation/navigation.reducers.unit.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { gotToNextPageHandler, initFormHandler } from './index';
+import { initFormHandler, updateFormHandler } from './index';
 import {
   createInitFormAction,
-  createGoToNextPageAction,
+  updateFormAction,
 } from '../../actions/navigation';
 
 import appReducer from '../index';
@@ -15,17 +15,14 @@ describe('check in', () => {
         it('should return the correct structure', () => {
           const action = createInitFormAction({
             pages: ['first-page', 'second-page', 'third-page'],
-            firstPage: 'first-page',
           });
           const state = initFormHandler({}, action);
           expect(state).haveOwnProperty('form');
           expect(state.form).haveOwnProperty('pages');
-          expect(state.form).haveOwnProperty('currentPage');
         });
         it('should set form data', () => {
           const action = createInitFormAction({
             pages: ['first-page', 'second-page', 'third-page'],
-            firstPage: 'first-page',
           });
           const state = initFormHandler({}, action);
           expect(state.form.pages).to.deep.equal([
@@ -33,14 +30,12 @@ describe('check in', () => {
             'second-page',
             'third-page',
           ]);
-          expect(state.form.currentPage).to.equal('first-page');
         });
       });
       describe('reducer is called; finds the correct handler', () => {
         it('should set form data', () => {
           const action = createInitFormAction({
             pages: ['first-page', 'second-page', 'third-page'],
-            firstPage: 'first-page',
           });
           const state = appReducer.checkInData(undefined, action);
           expect(state.form.data).to.deep.equal({});
@@ -49,34 +44,37 @@ describe('check in', () => {
             'second-page',
             'third-page',
           ]);
-          expect(state.form.currentPage).to.equal('first-page');
         });
       });
     });
-    describe('createGoToNextPageAction', () => {
-      describe('gotToNextPageHandler', () => {
+
+    describe('updateFormAction', () => {
+      describe('updateFormHandler', () => {
         it('should return the correct structure', () => {
-          const action = createGoToNextPageAction({
-            nextPage: 'second-page',
+          const action = updateFormAction({
+            patientDemographicsStatus: {},
           });
-          const state = gotToNextPageHandler({}, action);
-          expect(state.form).haveOwnProperty('currentPage');
-        });
-        it('should set the data', () => {
-          const action = createGoToNextPageAction({
-            nextPage: 'second-page',
-          });
-          const state = gotToNextPageHandler({}, action);
-          expect(state.form.currentPage).to.equal('second-page');
+          const state = updateFormHandler({}, action);
+          expect(state).haveOwnProperty('form');
+          expect(state.form).haveOwnProperty('pages');
         });
       });
-      describe('reducer is called;', () => {
+      describe('reducer is called; finds the correct handler', () => {
         it('should set form data', () => {
-          const action = createGoToNextPageAction({
-            nextPage: 'second-page',
+          const action = updateFormAction({
+            patientDemographicsStatus: {},
           });
           const state = appReducer.checkInData(undefined, action);
-          expect(state.form.currentPage).to.equal('second-page');
+          expect(state).haveOwnProperty('form');
+          expect(state.form).haveOwnProperty('pages');
+          expect(state.form.pages).to.deep.equal([
+            'verify',
+            'introduction',
+            'contact-information',
+            'emergency-contact',
+            'next-of-kin',
+            'complete',
+          ]);
         });
       });
     });

--- a/src/applications/check-in/reducers/navigation/navigation.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/navigation/navigation.reducers.unit.spec.js
@@ -1,10 +1,7 @@
 import { expect } from 'chai';
 
-import { initFormHandler, updateFormHandler } from './index';
-import {
-  createInitFormAction,
-  updateFormAction,
-} from '../../actions/navigation';
+import { initFormHandler } from './index';
+import { createInitFormAction } from '../../actions/navigation';
 
 import appReducer from '../index';
 
@@ -43,37 +40,6 @@ describe('check in', () => {
             'first-page',
             'second-page',
             'third-page',
-          ]);
-        });
-      });
-    });
-
-    describe('updateFormAction', () => {
-      describe('updateFormHandler', () => {
-        it('should return the correct structure', () => {
-          const action = updateFormAction({
-            patientDemographicsStatus: {},
-          });
-          const state = updateFormHandler({}, action);
-          expect(state).haveOwnProperty('form');
-          expect(state.form).haveOwnProperty('pages');
-        });
-      });
-      describe('reducer is called; finds the correct handler', () => {
-        it('should set form data', () => {
-          const action = updateFormAction({
-            patientDemographicsStatus: {},
-          });
-          const state = appReducer.checkInData(undefined, action);
-          expect(state).haveOwnProperty('form');
-          expect(state.form).haveOwnProperty('pages');
-          expect(state.form.pages).to.deep.equal([
-            'verify',
-            'introduction',
-            'contact-information',
-            'emergency-contact',
-            'next-of-kin',
-            'complete',
           ]);
         });
       });

--- a/src/applications/check-in/reducers/pre-check-in/pre-check-in.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/pre-check-in/pre-check-in.reducers.unit.spec.js
@@ -170,7 +170,6 @@ describe('check in', () => {
           const state = appReducer.checkInData(undefined, action);
           expect(state).haveOwnProperty('form');
           expect(state.form).haveOwnProperty('pages');
-          expect(state.form).haveOwnProperty('currentPage');
           expect(state.form.pages).to.deep.equal([
             'verify',
             'introduction',

--- a/src/applications/check-in/reducers/pre-check-in/pre-check-in.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/pre-check-in/pre-check-in.reducers.unit.spec.js
@@ -75,7 +75,6 @@ describe('check in', () => {
         beforeEach(() => {
           const action = createInitFormAction({
             pages: ['first-page', 'second-page', 'third-page'],
-            currentPage: 'first-page',
           });
           state = appReducer.checkInData(undefined, action);
         });

--- a/src/applications/check-in/reducers/reducer.unit.spec.js
+++ b/src/applications/check-in/reducers/reducer.unit.spec.js
@@ -15,7 +15,6 @@ describe('check in', () => {
           context: {},
           form: {
             pages: [],
-            currentPage: '',
             data: {},
           },
         });

--- a/src/applications/check-in/selectors/selector.unit.spec.js
+++ b/src/applications/check-in/selectors/selector.unit.spec.js
@@ -13,7 +13,6 @@ describe('check-in', () => {
         checkInData: {
           form: {
             pages: [],
-            currentPage: '',
           },
         },
       };
@@ -21,7 +20,6 @@ describe('check-in', () => {
         const selectFeatureToggles = makeSelectForm();
         expect(selectFeatureToggles(state)).to.eql({
           pages: [],
-          currentPage: '',
         });
       });
     });

--- a/src/applications/check-in/tests/e2e/pages/NextOfKin.js
+++ b/src/applications/check-in/tests/e2e/pages/NextOfKin.js
@@ -4,6 +4,16 @@ class NextOfKin {
   initializeApi() {
     // @TODO: fill in once we are actually using the API
   }
+
+  validatePage = {
+    dayOf: () => {
+      this.validatePageLoaded('Is this your current next of kin information?');
+    },
+    preCheckIn: () => {
+      this.validatePageLoaded('Is this your current next of kin?');
+    },
+  };
+
   validatePageLoaded(title = 'Is this your current next of kin?') {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')

--- a/src/applications/check-in/tests/unit/mocks/router/index.js
+++ b/src/applications/check-in/tests/unit/mocks/router/index.js
@@ -1,4 +1,8 @@
-const createMockRouter = ({ push = () => {}, currentPage = '' } = {}) => {
+const createMockRouter = ({
+  push = () => {},
+  currentPage = '',
+  params = {},
+} = {}) => {
   const pathname =
     currentPage && !currentPage.startsWith('/')
       ? `/${currentPage}`
@@ -8,6 +12,7 @@ const createMockRouter = ({ push = () => {}, currentPage = '' } = {}) => {
     location: {
       pathname,
     },
+    params,
   };
 };
 

--- a/src/applications/check-in/tests/unit/mocks/router/index.js
+++ b/src/applications/check-in/tests/unit/mocks/router/index.js
@@ -1,0 +1,14 @@
+const createMockRouter = ({ push = () => {}, currentPage = '' } = {}) => {
+  const pathname =
+    currentPage && !currentPage.startsWith('/')
+      ? `/${currentPage}`
+      : currentPage;
+  return {
+    push,
+    location: {
+      pathname,
+    },
+  };
+};
+
+export { createMockRouter };

--- a/src/applications/check-in/tests/unit/mocks/router/mock.router.unit.spec.js
+++ b/src/applications/check-in/tests/unit/mocks/router/mock.router.unit.spec.js
@@ -5,10 +5,11 @@ import { createMockRouter } from './index';
 describe('Pre check in', () => {
   describe('unit test utils', () => {
     describe('createMockRouter', () => {
-      it('returns an object with push as a function and location as an object', () => {
+      it('returns an object with push as a function, location and params as an object', () => {
         const result = createMockRouter();
         expect(result.push).to.be.a('function');
         expect(result.location).to.be.an('object');
+        expect(result.params).to.be.an('object');
       });
       it('should return custom push function that was passed in', () => {
         const push = () => {};

--- a/src/applications/check-in/tests/unit/mocks/router/mock.router.unit.spec.js
+++ b/src/applications/check-in/tests/unit/mocks/router/mock.router.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+
+import { createMockRouter } from './index';
+
+describe('Pre check in', () => {
+  describe('unit test utils', () => {
+    describe('createMockRouter', () => {
+      it('returns an object with push as a function and location as an object', () => {
+        const result = createMockRouter();
+        expect(result.push).to.be.a('function');
+        expect(result.location).to.be.an('object');
+      });
+      it('should return custom push function that was passed in', () => {
+        const push = () => {};
+        const result = createMockRouter({ push });
+        expect(result.push).to.equal(push);
+      });
+      it('returns location with a pathname that was passed at the currentPage', () => {
+        const currentPage = '/test';
+        const result = createMockRouter({ currentPage });
+        expect(result.location.pathname).to.equal(currentPage);
+      });
+      it('adds a leading / to currentPage', () => {
+        const currentPage = 'test';
+        const result = createMockRouter({ currentPage });
+        expect(result.location.pathname).to.equal(`/${currentPage}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
- fixes the bug from user hitting the back button
- Removed `currentPage` from redux in favor of getting the current page from router. By also looking at the router, we no longer have the risk of the `currentPage` getting out of sync and causing bugs/wackiness


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34965


## Testing done
- created e2e to simulate bug
- cleaned up unit tests