### PR TITLE
526: Change schema to fix validation

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -3,7 +3,11 @@ import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/de
 import dateUI from 'platform/forms-system/src/js/definitions/monthYear';
 
 import { treatmentView } from '../content/vaMedicalRecords';
-import { queryForFacilities, makeSchemaForAllDisabilities } from '../utils';
+import {
+  queryForFacilities,
+  makeSchemaForAllDisabilities,
+  hasVAEvidence,
+} from '../utils';
 import {
   validateMilitaryTreatmentCity,
   validateMilitaryTreatmentState,
@@ -28,6 +32,10 @@ export const uiSchema = {
       itemAriaLabel: data => data.treatmentCenterName,
       viewField: treatmentView,
       showSave: true,
+      updateSchema: (formData, schema) => ({
+        ...schema,
+        minItems: hasVAEvidence(formData) ? 1 : 0,
+      }),
     },
     items: {
       'ui:order': [
@@ -103,6 +111,7 @@ export const schema = {
     },
     vaTreatmentFacilities: {
       ...vaTreatmentFacilities,
+      minItems: 0, // fixes validation issue
       items: {
         type: 'object',
         required: ['treatmentCenterName', 'treatedDisabilityNames'],

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -34,12 +34,46 @@ describe('VA Medical Records', () => {
         uiSchema={uiSchema}
         data={{
           ratedDisabilities,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasVaMedicalRecords': true,
+            },
+          },
         }}
       />,
     );
 
     expect(form.find('input').length).to.equal(6);
     expect(form.find('select').length).to.equal(3);
+    form.unmount();
+  });
+
+  // Ignore empty vaTreatmentFacilities when not selected, see
+  // va.gov-team/issues/34289
+  it('should allow submit if VA medical records not selected', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          ratedDisabilities,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasVaMedicalRecords': false,
+            },
+          },
+          vaTreatmentFacilities: [],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    // Required fields: Facility name and related disability
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 
@@ -52,6 +86,11 @@ describe('VA Medical Records', () => {
         uiSchema={uiSchema}
         data={{
           ratedDisabilities,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasVaMedicalRecords': true,
+            },
+          },
           vaTreatmentFacilities: [],
         }}
         onSubmit={onSubmit}


### PR DESCRIPTION
## Description

To fix a Veteran reported claim issue, we pulled their data and found that the `vaTreatmentFacilities` was an empty array which caused a validation error preventing them from submitting the form. This PR changes the schema so the validation error doesn't occur when the Veteran chooses not to supply their medical records from the VA.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34289

## Testing done

Added unit test

## Screenshots

N/A

## Acceptance criteria
- [x] An empty `vaTreatmentFacilities` array won't cause a validation error when VA records are not provided
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
