### PR TITLE
526: Prevent `ratedDisabilities` override in non-production

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -7,6 +7,7 @@ import get from 'platform/utilities/data/get';
 import set from 'platform/utilities/data/set';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { autoSaveForm } from 'platform/forms/save-in-progress/actions';
+import environment from 'platform/utilities/environment';
 
 import { disabilityActionTypes } from '../constants';
 
@@ -80,11 +81,17 @@ class SelectArrayItemsWidget extends React.Component {
       required,
       formContext,
       formData,
+      testUpdatedRatedDisabilities,
     } = this.props;
 
     const updatedDisabilities = formData[this.updatedKeyValue];
     // rated disabilities updated on the backend
-    if (Array.isArray(updatedDisabilities) && updatedDisabilities.length) {
+    if (
+      // allows for save-in-progress testing
+      (environment.isProduction() || testUpdatedRatedDisabilities) &&
+      Array.isArray(updatedDisabilities) &&
+      updatedDisabilities.length
+    ) {
       this.processRatedDisabilityUpdates(updatedDisabilities);
     }
 
@@ -260,6 +267,7 @@ SelectArrayItemsWidget.propTypes = {
   }),
   setData: PropTypes.func,
   autoSaveForm: PropTypes.func,
+  testUpdatedRatedDisabilities: PropTypes.bool,
 };
 
 SelectArrayItemsWidget.defaultProps = {

--- a/src/applications/disability-benefits/all-claims/tests/components/SelectArrayItemsWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/SelectArrayItemsWidget.unit.spec.jsx
@@ -149,6 +149,7 @@ describe('<SelectArrayItemsWidget>', () => {
           ratingPercentage: 20,
         },
       ],
+      testUpdatedRatedDisabilities: true,
       formData: {
         updatedRatedDisabilities: [{}],
       },
@@ -212,6 +213,7 @@ describe('<SelectArrayItemsWidget>', () => {
           'view:selected': true,
         },
       ],
+      testUpdatedRatedDisabilities: true,
       formData: {
         updatedRatedDisabilities: [
           {
@@ -294,6 +296,7 @@ describe('<SelectArrayItemsWidget>', () => {
     const setDataSpy = sinon.spy();
     const initialProps = {
       value: [],
+      testUpdatedRatedDisabilities: true,
       formData: {
         updatedRatedDisabilities: [
           {


### PR DESCRIPTION
## Description

Prevent the list of rated disabilities added via the save-in-progress menu from being overridden by the rated disabilities associated with the logged in user. This will enable testing of mock

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/35335

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Mock data added via the save-in-progress menu remains intact
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
