### PR TITLE
the desired data for V2 appointments has been corrected

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -155,7 +155,7 @@ export function transformFormToVAOSAppointment(state) {
     clinic: getClinicId(clinic),
     slot,
     extension: {
-      desiredDate: data.preferredDate,
+      desiredDate: `${data.preferredDate}T00:00:00+00:00`,
     },
     locationId: data.vaFacility,
     serviceType: typeOfCare.idV2,

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -396,7 +396,7 @@ describe('VAOS <ReviewPage> direct scheduling with v2 api', () => {
       serviceType: 'primaryCare',
       comment: 'Follow-up/Routine: I need an appt',
       extension: {
-        desiredDate: '2021-05-06',
+        desiredDate: '2021-05-06T00:00:00+00:00',
       },
       contact: {
         telecom: [


### PR DESCRIPTION
## Description
This fix is to correctly format the desiredDate for appointment requests.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#34348


## Testing done


## Screenshots


## Acceptance criteria
- [ ] The appointment request desired date field is iso8601 formatted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
