### PR TITLE
HLR v2: Conditionally show legacy opt-in page

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -38,7 +38,12 @@ import informalConferenceTimes from '../pages/informalConferenceTimes';
 import informalConferenceTime from '../pages/informalConferenceTimeV2';
 
 import { errorMessages, WIZARD_STATUS } from '../constants';
-import { apiVersion1, apiVersion2, appStateSelector } from '../utils/helpers';
+import {
+  apiVersion1,
+  apiVersion2,
+  appStateSelector,
+  mayHaveLegacyAppeals,
+} from '../utils/helpers';
 import { getIssueTitle } from '../content/areaOfDisagreement';
 
 // import initialData from '../tests/schema/initialData';
@@ -198,7 +203,8 @@ const formConfig = {
           path: 'opt-in',
           uiSchema: optIn.uiSchema,
           schema: optIn.schema,
-          depends: apiVersion2,
+          depends: formData =>
+            apiVersion2(formData) && mayHaveLegacyAppeals(formData),
           initialData: {
             socOptIn: false,
           },

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -82,6 +82,8 @@ const supportedBenefitTypes = [
   // 'nca',
 ];
 
+export const LEGACY_TYPE = 'legacyAppeal';
+
 export const SUPPORTED_BENEFIT_TYPES = constants.benefitTypes.map(type => ({
   ...type,
   isSupported: supportedBenefitTypes.includes(type.value),

--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -34,6 +34,7 @@ export const Form0996App = ({
   hlrV2,
   getContestableIssues,
   contestableIssues = {},
+  legacyCount,
 }) => {
   const { email = {}, mobilePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
@@ -61,7 +62,8 @@ export const Form0996App = ({
           issuesNeedUpdating(
             contestableIssues?.issues,
             formData?.contestedIssues,
-          )
+          ) ||
+          contestableIssues.legacyCount !== formData.legacyCount
         ) {
           setFormData({
             ...formData,
@@ -77,6 +79,7 @@ export const Form0996App = ({
             contestedIssues: processContestableIssues(
               contestableIssues?.issues,
             ),
+            legacyCount: contestableIssues?.legacyCount || 0,
           });
         } else if (
           formData.hlrV2 && // easier to test formData.hlrV2 with SiP menu
@@ -109,6 +112,7 @@ export const Form0996App = ({
       contestableIssues,
       isLoadingIssues,
       getContestableIssues,
+      legacyCount,
     ],
   );
 
@@ -166,6 +170,7 @@ const mapStateToProps = state => ({
   savedForms: state.user?.profile?.savedForms || [],
   hlrV2: state.featureToggles?.hlrV2,
   contestableIssues: state.contestableIssues || {},
+  legacyCount: state.legacyCount || 0,
 });
 
 const mapDispatchToProps = {

--- a/src/applications/disability-benefits/996/reducers/contestableIssues.js
+++ b/src/applications/disability-benefits/996/reducers/contestableIssues.js
@@ -3,7 +3,10 @@ import {
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../actions';
-import { getEligibleContestableIssues } from '../utils/helpers';
+import {
+  getEligibleContestableIssues,
+  getLegacyAppealsLength,
+} from '../utils/helpers';
 
 const initialState = {
   issues: [],
@@ -23,6 +26,7 @@ export default function contestableIssues(state = initialState, action) {
       return {
         ...state,
         issues: getEligibleContestableIssues(action.response?.data),
+        legacyCount: getLegacyAppealsLength(action.response?.data),
         status: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
         error: '',
         benefitType: action.benefitType,
@@ -32,6 +36,7 @@ export default function contestableIssues(state = initialState, action) {
       return {
         ...state,
         issues: [],
+        legacyCount: 0,
         status: FETCH_CONTESTABLE_ISSUES_FAILED,
         error: action.errors,
         benefitType: action.benefitType,

--- a/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
@@ -1,11 +1,13 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
-import { SELECTED } from '../../constants';
+import { SELECTED, LEGACY_TYPE } from '../../constants';
 import { getDate } from '../../utils/dates';
 
 import {
   getEligibleContestableIssues,
+  getLegacyAppealsLength,
+  mayHaveLegacyAppeals,
   apiVersion1,
   apiVersion2,
   isVersion1Data,
@@ -76,6 +78,63 @@ describe('getEligibleContestableIssues', () => {
         ineligibleIssue,
       ]),
     ).to.deep.equal([eligibleIssue]);
+  });
+});
+
+describe('getLegacyAppealsLength', () => {
+  it('should return 0 with no issues', () => {
+    expect(getLegacyAppealsLength()).to.equal(0);
+  });
+  it('should return 0 with no legacy issues', () => {
+    expect(
+      getLegacyAppealsLength([{ type: 'one' }, { type: LEGACY_TYPE }]),
+    ).to.equal(0);
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: {} },
+      ]),
+    ).to.equal(0);
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: { issues: [] } },
+      ]),
+    ).to.equal(0);
+  });
+  it('should return a value > 0 with legacy issues', () => {
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: { issues: [{}, {}] } },
+      ]),
+    ).to.equal(2);
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: { issues: [{}, {}] } },
+        { type: LEGACY_TYPE, attributes: { issues: [] } },
+        { type: LEGACY_TYPE, attributes: { issues: [{}] } },
+      ]),
+    ).to.equal(3);
+  });
+});
+
+describe('mayHaveLegacyAppeals', () => {
+  it('should return false if there is no data', () => {
+    expect(mayHaveLegacyAppeals()).to.be.false;
+  });
+  it('should return false if there is no legacy & no additional issues', () => {
+    expect(mayHaveLegacyAppeals({ legacyCount: 0, additionalIssues: [] })).to.be
+      .false;
+  });
+  it('should return true if there are some legacy issues & no additional issues', () => {
+    expect(mayHaveLegacyAppeals({ legacyCount: 1, additionalIssues: [] })).to.be
+      .true;
+  });
+  it('should return true if there is no legacy & some additional issues', () => {
+    expect(mayHaveLegacyAppeals({ legacyCount: 0, additionalIssues: [{}] })).to
+      .be.true;
   });
 });
 


### PR DESCRIPTION
## Description

The opt-in legacy appeals page for Higher-Level Review v2 needs to be conditionally visible if the Veteran has _any_ legacy appeals, or if they add any additional issues with an unknown status.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/35366

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Legacy opt-in page is conditionally shown if the user has legacy or added issues
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
