### PR TITLE
Removed static pages Sass references

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -287,11 +287,22 @@ jobs:
             .cache/yarn
             node_modules
 
+      - name: Get files changed
+        id: get-files-changed
+        uses: trilom/file-changes-action@v1.2.4
+        continue-on-error: true
+        with:
+          output: 'json'
+
+      - name: Filter files
+        id: get-lint-files
+        run: node ./script/github-actions/filter-files-changed.js ${{ steps.get-files-changed.outputs.files }}
+
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
 
       - name: Run Stylelint
-        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
+        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json ${{ steps.get-lint-files.outputs.SCSSFILES }}
 
       - name: Annotate Stylelint results
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -286,12 +286,18 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+      - name: Get files changed
+        id: get-files-changed
+        uses: trilom/file-changes-action@v1.2.4
+        continue-on-error: true
+        with:
+          output: 'json'
 
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
 
       - name: Run Stylelint
-        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
+        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json ${{ steps.get-lint-files.outputs.SCSSFILES }}
 
       - name: Annotate Stylelint results
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -286,12 +286,17 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+
       - name: Get files changed
         id: get-files-changed
         uses: trilom/file-changes-action@v1.2.4
         continue-on-error: true
         with:
           output: 'json'
+
+      - name: Filter files
+        id: get-lint-files
+        run: node ./script/github-actions/filter-files-changed.js ${{ steps.get-files-changed.outputs.files }}
 
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -286,6 +286,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -286,23 +286,11 @@ jobs:
           path: |
             .cache/yarn
             node_modules
-
-      - name: Get files changed
-        id: get-files-changed
-        uses: trilom/file-changes-action@v1.2.4
-        continue-on-error: true
-        with:
-          output: 'json'
-
-      - name: Filter files
-        id: get-lint-files
-        run: node ./script/github-actions/filter-files-changed.js ${{ steps.get-files-changed.outputs.files }}
-
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
 
       - name: Run Stylelint
-        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json ${{ steps.get-lint-files.outputs.SCSSFILES }}
+        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
 
       - name: Annotate Stylelint results
         if: ${{ always() }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -239,23 +239,12 @@ jobs:
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
-      - name: Get files changed
-        id: get-files-changed
-        uses: trilom/file-changes-action@v1.2.4
-        continue-on-error: true
-        with:
-          output: 'json'
-
-      - name: Filter files
-        id: get-lint-files
-        run: node ./script/github-actions/filter-files-changed.js ${{ steps.get-files-changed.outputs.files }}
-
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --no-error-on-unmatched-pattern --format ./script/github-actions/eslint-annotation-format.js ${{ steps.get-lint-files.outputs.JSFILES }}
 
       - name: Run Stylelint
         if: ${{ steps.get-lint-files.outputs.SCSSFILES != '' }}
-        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json ${{ steps.get-lint-files.outputs.SCSSFILES }}
+        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
 
       - name: Annotate Stylelint results
         if: ${{ always() }}

--- a/script/github-actions/filter-files-changed.js
+++ b/script/github-actions/filter-files-changed.js
@@ -6,5 +6,12 @@ const filteredSCSSFiles = files
   .filter(file => /.+\.s?css$/.test(file))
   .join(' ');
 
+console.log('-----CHANGED SCSS FILES--------');
+console.log('-----CHANGED SCSS FILES--------');
+console.log('-----CHANGED SCSS FILES--------');
+console.log('-----CHANGED SCSS FILES--------');
+console.log('-----CHANGED SCSS FILES--------');
+console.log(filteredSCSSFiles);
+
 console.log(`::set-output name=JSFILES::${filteredJSFiles}`);
 console.log(`::set-output name=SCSSFILES::${filteredSCSSFiles}`);

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -1,1 +1,0 @@
-/* File to be removed in later PR */

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -3,7 +3,6 @@ import LazyLoad from 'vanilla-lazyload/dist/lazyload';
 import * as Sentry from '@sentry/browser';
 // Relative imports.
 import './analytics';
-import './sass/static-pages.scss';
 import 'platform/polyfills';
 import alertsBuildShow from './widget-creators/alerts-dismiss-view';
 import form686CTA from './view-modify-dependent/686-cta/form686CTA';


### PR DESCRIPTION
## Description
Removal of static-pages.css output as part of deprecation plan. This file reference needs to be removed from content-build first: https://github.com/department-of-veterans-affairs/content-build/pull/913

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32796
