### PR TITLE
Update Cypress test selection to run on master (Take 2)

### DIFF
--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -226,7 +226,7 @@ function run() {
   exportVariables(tests);
 }
 
-if (process.env.CHANGED_FILE_PATHS) {
+if (process.env.CHANGED_FILE_PATHS || IS_MASTER_BUILD) {
   run();
 }
 


### PR DESCRIPTION
## Description
This PR fixes a recent update to the `select-cypress-tests.js` that is preventing it from running on `master`. The logic for running the script only runs it when `process.env.CHANGED_FILE_PATHS` is `true`, but commits in `master` don't have `CHANGED_FILE_PATHS`, so we also need to check if `IS_MASTER_BUILD` is `true`.

Second take of https://github.com/department-of-veterans-affairs/vets-website/pull/19924
## Acceptance criteria
- [x] Cypress selection script should run in `master`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
