### PR TITLE
Remove Coverage report from logs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,7 +121,7 @@ jobs:
           APP_FOLDERS: ${{ steps.get-changed-apps.outputs.app_folders }}
 
       - name: Generate coverage report by app
-        run: node script/app-coverage-report.js && node script/app-coverage-report.js > test-results/coverage_report.txt
+        run: touch ./coverage/test-coverage-report.json && node script/app-coverage-report.js && node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Upload Coverage Report Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,7 +121,7 @@ jobs:
           APP_FOLDERS: ${{ steps.get-changed-apps.outputs.app_folders }}
 
       - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > test-results/coverage_report.txt
+        run: node script/app-coverage-report.js && node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Upload Coverage Report Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,7 +115,7 @@ jobs:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Run unit tests
-        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} --coverage
+        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"}
         env:
           MOCHA_FILE: test-results/unit-tests.xml
           APP_FOLDERS: ${{ steps.get-changed-apps.outputs.app_folders }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,7 +115,7 @@ jobs:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Run unit tests
-        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"}
+        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} -- --reporter spec
         env:
           MOCHA_FILE: test-results/unit-tests.xml
           APP_FOLDERS: ${{ steps.get-changed-apps.outputs.app_folders }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,15 +114,16 @@ jobs:
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Run unit tests
-        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} -- --reporter spec
         env:
           MOCHA_FILE: test-results/unit-tests.xml
           APP_FOLDERS: ${{ steps.get-changed-apps.outputs.app_folders }}
 
       - name: Generate coverage report by app
-        run: touch ./coverage/test-coverage-report.json && node script/app-coverage-report.js && node script/app-coverage-report.js > test-results/coverage_report.txt
+        run: node script/app-coverage-report.js && node script/app-coverage-report.js > test-results/coverage_report.txt
 
+      - name: Run unit tests
+        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} -- --reporter spec
+        
       - name: Upload Coverage Report Artifact
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
@@ -211,8 +212,8 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Create test results folder
-        run: mkdir -p test-results
+      - name: Create test result locations
+        run: mkdir -p test-results && touch coverage/test-coverage-report.json
 
       - name: Run contract tests
         run: yarn test:contract


### PR DESCRIPTION
## Description
Since we have the coverage report details by application readily available in two other places, we no longer need it to display at the end of our unit test logs. It would also be nice to have some information at the end of our unit test logs about the tests that have failed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29937
