### PR TITLE
31442 adjust button aria labels for remove profile info

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/post-delete-mobile-phone-alert.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-delete-mobile-phone-alert.cypress.spec.js
@@ -45,7 +45,7 @@ describe('Contact info update success alert', () => {
 
     // confirm the deletion action. This button is _not_ the same as the one
     // that was just clicked in the previous step
-    cy.findByRole('button', { name: /remove mobile phone/i }).click();
+    cy.findByRole('button', { name: 'Yes, remove my information' }).click();
 
     cy.injectAxeThenAxeCheck();
 

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmRemoveModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmRemoveModal.jsx
@@ -68,7 +68,7 @@ const ConfirmRemoveModal = ({
         <LoadingButton
           isLoading={isLoading}
           onClick={deleteAction}
-          aria-label={`Remove ${title}`}
+          aria-label="Yes, remove my information"
           loadingText="Removing your information"
         >
           Yes, remove my information


### PR DESCRIPTION
## Description
Was requested that the `aria-label` for the remove button on profile information modal matched the button text for a11y. This PR updates that and updates the matching e2e test that uses that aria-label.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31442


## Testing done
tested locally & e2e test updated


## Acceptance criteria
- [x] aria-label updated to match button text in remove information modal on profile

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
