### PR TITLE
31446 fix profile navigation heading

### DIFF
--- a/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
@@ -83,9 +83,8 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
             <div className="menu-header vads-u-display--flex">
               <strong className="vads-u-flex--auto">
                 <h2 id="mobile-subnav-header" className={menuButtonClasses}>
-                  Profile
-                </h2>{' '}
-                menu
+                  Profile menu
+                </h2>
               </strong>
               <button
                 ref={closeMenuButton}

--- a/src/applications/personalization/profile/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNav.jsx
@@ -15,7 +15,7 @@ const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
     <nav className="va-subnav" aria-labelledby="subnav-header">
       <div>
         <h2 id="subnav-header" className="vads-u-font-size--h4">
-          Profile
+          Profile <span className="sr-only">menu</span>
         </h2>
         <ProfileSubNavItems routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
       </div>

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
@@ -18,7 +18,7 @@ import { makeUserObject } from '~/applications/personalization/common/helpers';
 import { CSP_IDS } from 'platform/user/authentication/constants';
 
 function confirmDDBlockedAlertIsNotShown() {
-  cy.findByRole('heading', { name: /^Profile$/ });
+  cy.findByRole('heading', { name: /^Profile menu$/ });
   cy.findByText(/You can’t update your financial information/i).should(
     'not.exist',
   );


### PR DESCRIPTION
## Description
Addresses some a11y concerns in regards to the Profile menu header and screen readers:

This PR addresses a previous comment by @joshkimux on the [original issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/31446#issuecomment-983767663):

> The heading profile on desktop doesn't provide that much context that this is a list of links to navigate to different parts of the user's profile. The heading profile on menu visibly provides more context with "menu" appended next to it, but that won't be available for screen reader users since it's outside of the h2.
> 
> We may want to consider:
> 
> Nesting "menu" within the h2 on mobile
> Nesting "menu" within a sr-only class on desktop
> That way regardless on desktop or mobile, screen reader users will know this heading is specific to a section based on navigation (similar to an on this page heading).



## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31446


## Testing done
E2E tests updated

## Acceptance criteria
- [x] 'menu' is nested within heading of desktop Profile heading and is classed with `sr-only`
- [x] 'menu' is moved to be nested inside the Profile heading on mobile 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
