### PR TITLE
letters update to va-loading-indicator

### DIFF
--- a/src/applications/letters/containers/Main.jsx
+++ b/src/applications/letters/containers/Main.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { systemDownMessage } from 'platform/static-data/error-messages';
 import { selectVAPContactInfo } from 'platform/user/selectors';
 import { AVAILABILITY_STATUSES } from '../utils/constants';
@@ -47,7 +46,7 @@ export class Main extends React.Component {
         appContent = this.props.children;
         break;
       case awaitingResponse:
-        appContent = <LoadingIndicator message="Loading your letters..." />;
+        appContent = <va-loading-indicator message="Loading your letters..." />;
         break;
       case backendAuthenticationError:
         appContent = recordsNotFound;

--- a/src/applications/letters/tests/containers/Main.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/Main.unit.spec.jsx
@@ -47,7 +47,7 @@ describe('<Main>', () => {
 
   it('shows a loading spinner when awaiting response', () => {
     const tree = SkinDeep.shallowRender(<Main {...defaultProps} />);
-    expect(tree.subTree('LoadingIndicator')).to.not.be.false;
+    expect(tree.subTree('va-loading-indicator')).to.not.be.false;
   });
 
   it('renders its children when letters are available', () => {


### PR DESCRIPTION
## Description
All instances of `LoadingIndicator` need to be replaced with `<va-loading-indicator>` web component.

## Original issue(s)
closes department-of-veterans-affairs/va.gov-team#34701


## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Replaced loadingIndicator
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
