### PR TITLE
remove unneeded styling, add pointer cursor indicator

### DIFF
--- a/src/applications/personalization/profile/sass/notification-radio-buttons.scss
+++ b/src/applications/personalization/profile/sass/notification-radio-buttons.scss
@@ -9,11 +9,9 @@ $margin-left: units(1.5);
 $padding-left: calc(#{$margin-left} - #{$border-weight-left});
 $padding-left-negative: calc(-#{$margin-left} + #{$border-weight-left});
 
-input[type="radio"] {
-  height: 0;
-  width: 0;
-  margin: 0;
-  padding: 0;
+input[type="radio"],
+input[type="checkbox"] {
+  cursor: pointer;
 }
 
 [type="radio"]:disabled + label {


### PR DESCRIPTION
## Description
This is a small fix to undo some styling overrides on the Profile pages. 

Setting the radio button size to 0px actually made the radio unclickable on the Personal Information pages, and didn't change any noticeable layout on the other profile pages, so instead of changing that styling it was removed and a pointer cursor style was added to make sure it was shown as clickable as well.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35443

## Testing done
local testing done to verify


## Acceptance criteria
- [x] Radio button is clickable in Personal Information section of Profile

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
