### PR TITLE
style changes on insurance providers page

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/general.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/general.js
@@ -41,10 +41,10 @@ export default {
         },
         'view:policyOrGroupDesc': {
           'ui:description': (
-            <div className="vads-u-margin-top--6 vads-u-margin-bottom--2 schemaform-block-title schemaform-block-subtitle">
+            <div className="vads-u-margin-top--6 vads-u-margin-bottom--2 schemaform-block-title schemaform-block-subtitle vads-u-color--primary-darkest">
               {' '}
               Provide either your insurance policy number or group code.{' '}
-              <span className="schemaform-required-span vads-u-font-weight--normal">
+              <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
                 (*Required)
               </span>
             </div>
@@ -65,7 +65,7 @@ export default {
         },
         'view:or': {
           'ui:description': (
-            <div className="schemaform-block-title schemaform-block-subtitle vads-u-margin-bottom--neg2p5">
+            <div className="schemaform-block-title schemaform-block-subtitle vads-u-margin-bottom--neg2p5 vads-u-color--primary-darkest">
               or
             </div>
           ),


### PR DESCRIPTION
## Description
As a Veteran, I need to clearly and accurately answer the questions about my Insurance, in order to complete my application for VA Health Care.

Currently, the research shows that this question causes confusion, and people are having to guess what information to input. This can result in inaccurate information being submitted.

## Original issue(s)
[https://github.com/department-of-veterans-affairs/va.gov-team/issues/35347](https://github.com/department-of-veterans-affairs/va.gov-team/issues/35347)

## Testing done
verify axe accessibility test
verify unit tests
verify e2e tests

## Screenshots


<img width="231" alt="provider page" src="https://user-images.githubusercontent.com/32648173/150199161-e8245692-4e47-4626-b73f-ceee8f2595a1.PNG">

