### PR TITLE
Clear out GHA warnings

### DIFF
--- a/.github/workflows/configure-bigquery/action.yml
+++ b/.github/workflows/configure-bigquery/action.yml
@@ -11,7 +11,7 @@ runs:
         env_variable_name: BIGQUERY_SERVICE_CREDENTIALS
 
     - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: vsp-analytics-and-insights
         service_account_key: ${{ env.BIGQUERY_SERVICE_CREDENTIALS }}

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -117,7 +117,7 @@ jobs:
         working-directory: testing-tools-team-dashboard-data
 
       - name: Setup Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: vsp-analytics-and-insights
           service_account_key: ${{ env.BIGQUERY_SERVICE_CREDENTIALS }}


### PR DESCRIPTION
## Description
GHA was giving warning for these two instances, so I'm just updating them to the recommended strings

## Message

Testing Reports Prep
google-github-actions/setup-gcloud is pinned at HEAD. We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.