### PR TITLE
Removes skip_dupe param from authn

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -67,7 +67,7 @@ export default async function keepAlive() {
         mhv: CSP_AUTHN.MHV,
         LOGINGOV: resp.headers.get(AUTHN_HEADERS.AUTHN_CONTEXT),
         idme: resp.headers.get(AUTHN_HEADERS.AUTHN_CONTEXT),
-      }[resp.headers.get(AUTHN_HEADERS.CSP)],
+      }[resp.headers.get(AUTHN_HEADERS.CSP)].replace('?skip_dupe=mhv'),
     };
   } catch (err) {
     logToSentry(err);


### PR DESCRIPTION
## Description
The `?skip_dupe=mhv` query parameter is used on the Unified Sign In page to allow a passthrough for MHV sign in flow (MHV -> VA.gov -> MHV) to let vets-api know to not fail auth if the user has multiple MHV IDs.

This PR removes the appended `?skip_dupe=mhv` query parameter that is passed in the `authncontextclassref` headers when the `/keepalive` endpoint is called (for AutoSSO).

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#35647


## Testing done
Visual

## Screenshots
n/a

## Acceptance criteria
- [x] Removes the `?skip_dupe=mhv` from the `authn` context that is passed to vets-api during AutoSSO

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
