### PR TITLE
replace old link with new one

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/common.jsx
+++ b/src/applications/disability-benefits/all-claims/content/common.jsx
@@ -28,7 +28,7 @@ export const ContactCrisis = () => (
       </li>
       <li>
         Visit{' '}
-        <a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">
+        <a href="https://www.veteranscrisisline.net/get-help-now/chat/">
           Veterans Crisis Line
         </a>{' '}
         to start a confidential chat online, <strong>or</strong>

--- a/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
+++ b/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
@@ -57,7 +57,7 @@ export default function CrisisPanel() {
               />
               <a
                 className="no-external-icon"
-                href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat"
+                href="https://www.veteranscrisisline.net/get-help-now/chat/"
               >
                 Start a confidential chat
               </a>


### PR DESCRIPTION
## Description
Update the old link from 
https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/
to
https://www.veteranscrisisline.net/get-help-now/chat/

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35612


## Testing done
Manual testing

## Screenshots

