### PR TITLE
32922: Adds ?next=loginModal functionality to open page with login modal opened by default

### DIFF
--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -46,7 +46,9 @@ export class VerifyApp extends React.Component {
     if (this.props.profile.verified) {
       const nextParams = new URLSearchParams(window.location.search);
       const nextPath = nextParams.get('next');
-      window.location.replace(nextPath || '/');
+      if (nextPath && nextPath !== 'loginModal') {
+        window.location.replace(nextPath || '/');
+      }
     }
   }
 

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -71,16 +71,31 @@ export class Main extends Component {
   }
 
   getNextParameter() {
-    const nextParam = new URLSearchParams(window.location.search).get('next');
-    if (nextParam) {
+    return new URLSearchParams(window.location.search).get('next');
+  }
+
+  formatNextParameter() {
+    const nextParam = this.getNextParameter();
+    if (nextParam && nextParam !== 'loginModal') {
       return nextParam.startsWith('/') ? nextParam : `/${nextParam}`;
     }
 
     return null;
   }
 
+  appendNextParameter(url = 'loginModal', pageTitle = '') {
+    if (url === 'loginModal' && this.getNextParameter()) {
+      return null;
+    }
+
+    const nextQuery = { next: url };
+    const nextPath = appendQuery(window.location.toString(), nextQuery);
+    history.pushState({}, pageTitle, nextPath);
+    return nextQuery;
+  }
+
   executeRedirect() {
-    const redirectUrl = this.getNextParameter();
+    const redirectUrl = this.formatNextParameter();
     const shouldRedirect =
       redirectUrl && !window.location.pathname.includes('verify');
 
@@ -119,9 +134,9 @@ export class Main extends Component {
       el.addEventListener('click', e => {
         if (!this.props.currentlyLoggedIn) {
           e.preventDefault();
-          const nextQuery = { next: el.getAttribute('href') };
-          const nextPath = appendQuery('/', nextQuery);
-          history.pushState({}, el.textContent, nextPath);
+          const linkHref = el.getAttribute('href');
+          const pageTitle = el.textContent;
+          this.appendNextParameter(linkHref, pageTitle);
           this.openLoginModal();
         }
       });
@@ -149,6 +164,7 @@ export class Main extends Component {
 
   openLoginModal = () => {
     this.props.toggleLoginModal(true);
+    this.appendNextParameter();
   };
 
   signInSignUp = () => {
@@ -160,6 +176,7 @@ export class Main extends Component {
       // requests when the sign-in modal renders.
       this.props.getBackendStatuses();
       this.props.toggleLoginModal(true, 'header');
+      this.appendNextParameter();
     }
   };
 


### PR DESCRIPTION
## Description
Adds `?next=loginModal` functionality to open page with login modal opened by default. Historically, the `?next` param is a URL that designates a redirect after authentication and also already opened the login modal when it exists on a page url.

Rather than creating a new param, I added functionality to skip the redirect if the value of `next = loginModal`. This allows us to not double up logic. Also, provides a way for us to force the login modal opened on page load without the need for a redirect being designated.

Rules of this logic:
1. Anything that calls `toggleLoginModal(true)` will apply `?next=loginModal`
2. Rule 1 will not happen if there is already a ?next=<route>` applied. This prevents us from overriding needed redirects
3. Landing on a page with a `?next` value will open the modal on page load 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32922


## Testing done
- Unit tests

## Screenshots

https://user-images.githubusercontent.com/13320944/150386277-0604b5ff-f32e-405b-b84c-201708bd48c9.mov



## Acceptance criteria
- [x] landing on page with `?next=...` opens the page with the login modal opened
- [x] If the url does not contain `?next=...` clicking the sign up button appends `?next=loginModal`
- [x] If the url already contains a `?next=...`, clicking the sign up button does not overwrite it
- [x] Original `?next=...` logic works as before, and will redirect to the value after authentication
- [x] After authentication, if `?next=loginModal` it will not redirect to `/loginModal`

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
