### PR TITLE
[3506] use city and state in screen reader text

### DIFF
--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -127,7 +127,8 @@ export function ResultCard({
           >
             {name}
             <span className="vads-u-visibility--screen-reader">
-              {`classification-${institution.facilityCode}`}
+              {city}
+              {state && `, ${state}`}
             </span>
           </Link>
         </h3>


### PR DESCRIPTION
## Description

Fixed screen reader text for result cards. Screen readers now first read Name, City, and then State for institutions.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#3506

## Testing done

- Tested locally

## Acceptance criteria
- [x] screen reader reads city and state for result card for institutions

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
