### PR TITLE
removed serviceType from va booked appt posts

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
@@ -1,4 +1,3 @@
-import { COVID_VACCINE_ID } from '../../../utils/constants';
 import {
   getChosenClinicInfo,
   getChosenSlot,
@@ -20,7 +19,6 @@ export function transformFormToVAOSAppointment(state) {
       desiredDate: slot.start,
     },
     locationId: data.vaFacility,
-    serviceType: COVID_VACCINE_ID,
     comment: '',
     contact: {
       telecom: [

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -146,7 +146,6 @@ function getUserMessage(data) {
 export function transformFormToVAOSAppointment(state) {
   const data = getFormData(state);
   const clinic = getChosenClinicInfo(state);
-  const typeOfCare = getTypeOfCare(data);
   const slot = getChosenSlot(state);
 
   return {
@@ -158,7 +157,6 @@ export function transformFormToVAOSAppointment(state) {
       desiredDate: `${data.preferredDate}T00:00:00+00:00`,
     },
     locationId: data.vaFacility,
-    serviceType: typeOfCare.idV2,
     comment: getUserMessage(data),
     contact: {
       telecom: [

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -311,7 +311,6 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
       status: 'booked',
       locationId: '983',
       clinic: '455',
-      serviceType: 'covid',
       comment: '',
       extension: {
         desiredDate: store.getState().covid19Vaccine.newBooking

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -393,7 +393,6 @@ describe('VAOS <ReviewPage> direct scheduling with v2 api', () => {
       status: 'booked',
       locationId: '983',
       clinic: '455',
-      serviceType: 'primaryCare',
       comment: 'Follow-up/Routine: I need an appt',
       extension: {
         desiredDate: '2021-05-06T00:00:00+00:00',


### PR DESCRIPTION
## Description
The serviceType field was removed from booked va appointment posts because it's not allowed in the requestBody for those types of requests in VAOS Service.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35412


## Testing done
Tests have been updated to reflect this change.

## Screenshots


## Acceptance criteria
- [x] The serviceType is not present in any booked VA appointment requestBodies

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
