### PR TITLE
Removed environment flags so inclusive changes can be seen on prod

### DIFF
--- a/src/applications/gi/containers/FilterYourResults.jsx
+++ b/src/applications/gi/containers/FilterYourResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import SearchAccordion from '../components/SearchAccordion';
 import Checkbox from '../components/Checkbox';
@@ -6,7 +6,6 @@ import Dropdown from '../components/Dropdown';
 import LearnMoreLabel from '../components/LearnMoreLabel';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-import environment from 'platform/utilities/environment';
 
 import {
   getStateNameForCode,
@@ -52,9 +51,6 @@ export function FilterYourResults({
   const facets =
     search.tab === TABS.name ? search.name.facets : search.location.facets;
 
-  const [showAllSchoolTypes, setShowAllSchoolTypes] = useState(false);
-  const SEE_LESS_SIZE = 4;
-
   const recordCheckboxEvent = e => {
     recordEvent({
       event: 'gibct-form-change',
@@ -91,35 +87,23 @@ export function FilterYourResults({
     const checked = e.target.checked;
 
     if (!checked) {
-      if (environment.isProduction())
-        dispatchFilterChange({
-          ...filters,
-          schools: false,
-          excludedSchoolTypes: [],
-          excludeCautionFlags: false,
-          accredited: false,
-          studentVeteran: false,
-          yellowRibbonScholarship: false,
-          specialMission: 'ALL',
-        });
-      else
-        dispatchFilterChange({
-          ...filters,
-          schools: false,
-          excludedSchoolTypes: [
-            'PUBLIC',
-            'FOR PROFIT',
-            'PRIVATE',
-            'FOREIGN',
-            'FLIGHT',
-            'CORRESPONDENCE',
-          ],
-          excludeCautionFlags: false,
-          accredited: false,
-          studentVeteran: false,
-          yellowRibbonScholarship: false,
-          specialMission: 'ALL',
-        });
+      dispatchFilterChange({
+        ...filters,
+        schools: false,
+        excludedSchoolTypes: [
+          'PUBLIC',
+          'FOR PROFIT',
+          'PRIVATE',
+          'FOREIGN',
+          'FLIGHT',
+          'CORRESPONDENCE',
+        ],
+        excludeCautionFlags: false,
+        accredited: false,
+        studentVeteran: false,
+        yellowRibbonScholarship: false,
+        specialMission: 'ALL',
+      });
       recordCheckboxEvent(e);
     } else {
       onChangeCheckbox(e);
@@ -189,16 +173,8 @@ export function FilterYourResults({
     modalClose();
   };
 
-  const setFocusByName = name => {
-    const element = document.getElementsByName(name)[0];
-    if (element) element.focus();
-  };
-
   const excludedSchoolTypesGroup = () => {
-    const options = (showAllSchoolTypes || !environment.isProduction()
-      ? INSTITUTION_TYPES
-      : INSTITUTION_TYPES.slice(0, SEE_LESS_SIZE)
-    ).map(type => {
+    const options = INSTITUTION_TYPES.map(type => {
       return {
         name: type.toUpperCase(),
         checked: excludedSchoolTypes.includes(type.toUpperCase()),
@@ -206,35 +182,7 @@ export function FilterYourResults({
       };
     });
 
-    return environment.isProduction() ? (
-      <div className="vads-u-margin-bottom--5">
-        <CheckboxGroup
-          label={
-            <div className="vads-u-margin-left--neg0p25">
-              Exclude these school types:
-            </div>
-          }
-          onChange={handleIncludedSchoolTypesChange}
-          options={options}
-        />
-        {!showAllSchoolTypes && (
-          <button
-            className="va-button-link see-more-less"
-            onClick={() => setShowAllSchoolTypes(true)}
-          >
-            See more...
-          </button>
-        )}
-        {showAllSchoolTypes && (
-          <button
-            className="va-button-link see-more-less"
-            onClick={() => setShowAllSchoolTypes(false)}
-          >
-            See less...
-          </button>
-        )}
-      </div>
-    ) : (
+    return (
       <div className="vads-u-margin-bottom--5">
         <CheckboxGroup
           label={
@@ -248,21 +196,6 @@ export function FilterYourResults({
       </div>
     );
   };
-
-  useEffect(
-    () => {
-      if (showAllSchoolTypes) {
-        setFocusByName(
-          `${INSTITUTION_TYPES[SEE_LESS_SIZE].toUpperCase()}-label`,
-        );
-      } else {
-        setFocusByName(
-          `${INSTITUTION_TYPES[SEE_LESS_SIZE - 1].toUpperCase()}-label`,
-        );
-      }
-    },
-    [showAllSchoolTypes],
-  );
 
   const schoolAttributes = () => {
     const options = [

--- a/src/applications/gi/reducers/filters.js
+++ b/src/applications/gi/reducers/filters.js
@@ -4,7 +4,6 @@ import {
   SEARCH_STARTED,
 } from '../actions';
 import { FILTERS_EXCLUDED_FLIP } from '../selectors/filters';
-import environment from 'platform/utilities/environment';
 
 export const INITIAL_STATE = Object.freeze({
   expanded: false,
@@ -40,21 +39,16 @@ export default function(state = INITIAL_STATE, action) {
 
     case UPDATE_QUERY_PARAMS: {
       const queryParams = action.payload;
-      let environmentBasedLoadState;
-      if (environment.isProduction())
-        environmentBasedLoadState = { excludedSchoolTypes: [] };
-      else
-        environmentBasedLoadState = {
-          excludedSchoolTypes: [
-            'PUBLIC',
-            'FOR PROFIT',
-            'PRIVATE',
-            'FOREIGN',
-            'FLIGHT',
-            'CORRESPONDENCE',
-          ],
-        };
-      const onLoadState = environmentBasedLoadState;
+      const onLoadState = {
+        excludedSchoolTypes: [
+          'PUBLIC',
+          'FOR PROFIT',
+          'PRIVATE',
+          'FOREIGN',
+          'FLIGHT',
+          'CORRESPONDENCE',
+        ],
+      };
 
       Object.keys(INITIAL_STATE).forEach(key => {
         let value = queryParams[key];

--- a/src/applications/gi/selectors/filters.js
+++ b/src/applications/gi/selectors/filters.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import { INITIAL_STATE } from '../reducers/filters';
-import environment from 'platform/utilities/environment';
 
 // default state is checked so these will only be present if their corresponding boxes are unchecked
 export const FILTERS_EXCLUDED_FLIP = ['schools', 'employers', 'vettec'];
@@ -45,10 +44,9 @@ export const buildSearchFilters = filters => {
     },
   );
 
-  if (!environment.isProduction())
-    clonedFilters.excludedSchoolTypes = FILTERS_SCHOOL_TYPE_EXCLUDE_FLIP.filter(
-      exclusion => !clonedFilters.excludedSchoolTypes.includes(exclusion),
-    );
+  clonedFilters.excludedSchoolTypes = FILTERS_SCHOOL_TYPE_EXCLUDE_FLIP.filter(
+    exclusion => !clonedFilters.excludedSchoolTypes.includes(exclusion),
+  );
 
   if (clonedFilters.excludedSchoolTypes.length > 0) {
     searchFilters.excludedSchoolTypes = clonedFilters.excludedSchoolTypes;


### PR DESCRIPTION
Also removed some now unused code that enabled the show less/more functionality

## Description
Removed environment flags in the issue associated with this PR -> https://github.com/department-of-veterans-affairs/vets-website/pull/19781
Changed exclusion checkboxes on comparison tool search to be always be expanded, & and to include their school types instead of exclude.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29369)


## Testing done
Verified that search works as desired and no other functional changes have come to affect it.

## Screenshots
Results of search "yp" in search bar
<img width="1017" alt="Screen Shot 2022-01-06 at 10 47 58 AM" src="https://user-images.githubusercontent.com/86262790/148419023-768bc887-f763-4f5e-a765-b2ebf534b876.png">


## Acceptance criteria
- [x] No longer need to expand checkboxes
- [x] Checking boxes includes terms in search, not exclude
- [x] The boxes are checked by default to include all school types in searches

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs