### PR TITLE
35700 lgy display application date

### DIFF
--- a/src/applications/lgy/coe/form/containers/introduction-content/COEIntroPageBox.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/COEIntroPageBox.jsx
@@ -21,7 +21,12 @@ const COEIntroPageBox = props => {
         return <COEIneligible />;
       case COE_ELIGIBILITY_STATUS.pending:
       case COE_ELIGIBILITY_STATUS.pendingUpload:
-        return <COEPending status={props.coe.status} />;
+        return (
+          <COEPending
+            status={props.coe.status}
+            applicationCreateDate={props.coe.applicationCreateDate}
+          />
+        );
       default:
         return <></>;
     }

--- a/src/applications/lgy/coe/form/containers/introduction-content/COEStatuses/COEPending.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/COEStatuses/COEPending.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+import moment from 'moment';
 
 const COEPending = props => {
   return (
@@ -10,7 +11,10 @@ const COEPending = props => {
             ? 'We need more information from you'
             : 'We’re reviewing your request'}
         </h2>
-        <p>You requested a COE on: June 30, 2020</p>
+        <p>
+          You requested a COE on:{' '}
+          {moment(props.applicationCreateDate).format('MMMM DD, YYYY')}
+        </p>
         <div>
           <p>
             {props.status === 'pending-upload'

--- a/src/applications/lgy/coe/status/components/CoePending.jsx
+++ b/src/applications/lgy/coe/status/components/CoePending.jsx
@@ -4,6 +4,7 @@ import Telephone from '@department-of-veterans-affairs/component-library/Telepho
 import { CoeDocumentUpload } from './CoeDocumentUpload';
 import { CoeDocumentList } from './CoeDocumentList';
 import { MoreQuestions } from './MoreQuestions';
+import moment from 'moment';
 
 export const CoePending = props => (
   <div className="row vads-u-margin-bottom--7">
@@ -12,7 +13,10 @@ export const CoePending = props => (
         <h2 slot="headline" className="vads-u-font-size--h3">
           We’re reviewing your request for a COE
         </h2>
-        <p>You requested a COE on: June 1, 2019</p>
+        <p>
+          You requested a COE on:{' '}
+          {moment(props.applicationCreateDate).format('MMMM DD, YYYY')}
+        </p>
         <p>
           If you qualify for a Certificate of Eligibility, we’ll notify you by
           email or mail to let you know how to get your COE.

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -66,10 +66,20 @@ const App = props => {
         content = <CoeDenied />;
         break;
       case COE_ELIGIBILITY_STATUS.pending:
-        content = <CoePending notOnUploadPage />;
+        content = (
+          <CoePending
+            notOnUploadPage
+            applicationCreateDate={coe.applicationCreateDate}
+          />
+        );
         break;
       case COE_ELIGIBILITY_STATUS.pendingUpload:
-        content = <CoePending uploadsNeeded />;
+        content = (
+          <CoePending
+            uploadsNeeded
+            applicationCreateDate={coe.applicationCreateDate}
+          />
+        );
         break;
       default:
         content = <CoeIneligible />;


### PR DESCRIPTION
## Description
This is the sibling PR to https://github.com/department-of-veterans-affairs/vets-api/pull/8916. We are adding the COE application date to the screen, and removing the static date (of June 30, 2020).

**NOTE: I am regularly a BE dev, but was full stack (Vue) in my previous life. This issue popped up today and I wanted to take care of both the BE and the FE for the stake holder without adding any work to @jerekshoe and @cohnjesse 's plates.**

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35700

## Screenshots

### Before
<img width="468" alt="Screen Shot 2022-01-20 at 11 07 46 PM" src="https://user-images.githubusercontent.com/1021154/150469468-61619116-b837-4090-94f8-333707c4a085.png">


### After
<img width="475" alt="Screen Shot 2022-01-20 at 11 06 30 PM" src="https://user-images.githubusercontent.com/1021154/150469400-5c5f546b-c24f-4523-b5a2-675bab70a413.png">



## Acceptance criteria
- [x] The static date of June 30, 2020 no longer displays, but in its place is the dynamic `applicationCreateDate`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
