### PR TITLE
526: Include non-active duty dates in treatment period checks

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -116,12 +116,15 @@ describe('526 All Claims validations', () => {
         serviceInformation: {
           servicePeriods: [
             { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
-            { dateRange: { from: '2000-01-14' }, serviceBranch: 'Army' },
+            {
+              dateRange: { from: '2000-01-14' },
+              serviceBranch: 'Army Reserve',
+            },
             { dateRange: { from: '2011-12-25' }, serviceBranch: 'Army' },
             // ignored
             {
               dateRange: { from: '1990-10-11' },
-              serviceBranch: 'Army Reserve',
+              serviceBranch: '', // missing branch name
             },
           ],
         },
@@ -138,12 +141,15 @@ describe('526 All Claims validations', () => {
         serviceInformation: {
           servicePeriods: [
             { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
-            { dateRange: { from: '2000-01-14' }, serviceBranch: 'Army' },
+            {
+              dateRange: { from: '2000-01-14' },
+              serviceBranch: 'Coast Guard Reserve',
+            },
             { dateRange: { from: '2011-12-25' }, serviceBranch: 'Coast Guard' },
             // ignored
             {
               dateRange: { from: '1990-10-11' },
-              serviceBranch: 'Coast Guard Reserve',
+              serviceBranch: '',
             },
           ],
         },
@@ -160,12 +166,15 @@ describe('526 All Claims validations', () => {
         serviceInformation: {
           servicePeriods: [
             { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
-            { dateRange: { from: '2000-01-14' }, serviceBranch: 'Army' },
+            {
+              dateRange: { from: '2000-01-14' },
+              serviceBranch: 'Army National Guard',
+            },
             { dateRange: { from: '2011-12-25' }, serviceBranch: 'Army' },
             // ignored
             {
               dateRange: { from: '1990-10-11' },
-              serviceBranch: 'Army National Guard',
+              serviceBranch: '',
             },
           ],
         },

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -19,7 +19,6 @@ import {
   MILITARY_STATE_VALUES,
   LOWERED_DISABILITY_DESCRIPTIONS,
   NULL_CONDITION_STRING,
-  RESERVE_GUARD_TYPES,
 } from './constants';
 
 export const hasMilitaryRetiredPay = data =>
@@ -224,18 +223,10 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
   if (!_.get('servicePeriods.length', formData.serviceInformation, false)) {
     return;
   }
-  const { nationalGuard, reserve } = RESERVE_GUARD_TYPES;
 
   // only check active duty periods
   const earliestServiceStartDate = formData.serviceInformation.servicePeriods
-    .filter(
-      ({ serviceBranch = '' } = {}) =>
-        serviceBranch &&
-        !(
-          serviceBranch.includes(nationalGuard) ||
-          serviceBranch.includes(reserve)
-        ),
-    )
+    .filter(({ serviceBranch } = {}) => (serviceBranch || '') !== '')
     .map(period => moment(period.dateRange.from, 'YYYY-MM-DD'))
     .reduce(
       (earliestDate, current) =>

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -224,7 +224,7 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
     return;
   }
 
-  // only check active duty periods
+  // find the earliest service period
   const earliestServiceStartDate = formData.serviceInformation.servicePeriods
     .filter(({ serviceBranch } = {}) => (serviceBranch || '') !== '')
     .map(period => moment(period.dateRange.from, 'YYYY-MM-DD'))
@@ -239,7 +239,7 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
   // the return value will be negative.
   if (treatmentStartDate.diff(earliestServiceStartDate, 'month') < 0) {
     err.addError(
-      'Your first treatment date needs to be after the start of your earliest active duty service period.',
+      'Your first treatment date needs to be after the start of your earliest service period.',
     );
   }
 }


### PR DESCRIPTION
## Description

In September 2021, we added a check to ensure that [treatment dates could not bet before a Veteran's earliest service period start date](https://github.com/department-of-veterans-affairs/vets-website/pull/18916). The EVSS validation rule was interpreted to not include non-active duty service periods. A submission issue ticket was opened specifically about a service member that was never active duty, and after verifying the validation rule with EVSS, it should include non-active-duty service periods. This PR removes the restriction.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34105

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Non-active duty service periods are included when determining the earliest service start date
- [x] Unit tests updated
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
