### PR TITLE
[35414] STEM (Form 22-10203): checkbox not checkable (in Step 5 of 6: Personal Information)

### DIFF
--- a/src/applications/edu-benefits/10203/pages/personalInformation.js
+++ b/src/applications/edu-benefits/10203/pages/personalInformation.js
@@ -54,6 +54,7 @@ export const uiSchema = {
   receiveTexts: {
     'ui:title':
       'I would like to receive text messages from VA about my GI Bill benefits.',
+    'ui:widget': 'checkbox',
   },
   'view:housingPaymentInfo': {
     'ui:description': receiveTextsAlert,


### PR DESCRIPTION
## Description

- fixes an issue with checkbox instantiation in step 5

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35414

## Testing done

- Local

## Screenshots

## Acceptance criteria
- [x] checkbox now allows itself to be checked

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
