### PR TITLE
claims status tool update to va-loading-indicator

### DIFF
--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import TabNav from '../components/TabNav';
 import ClaimSyncWarning from '../components/ClaimSyncWarning';
@@ -31,7 +30,10 @@ export default function ClaimDetailLayout(props) {
   let headingContent;
   if (loading) {
     bodyContent = (
-      <LoadingIndicator setFocus message="Loading your claim information..." />
+      <va-loading-indicator
+        set-focus
+        message="Loading your claim information..."
+      />
     );
   } else if (claim !== null) {
     headingContent = (

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -3,7 +3,6 @@ import Scroll from 'react-scroll';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import AddFilesForm from '../components/AddFilesForm';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Notification from '../components/Notification';
 import EvidenceWarning from '../components/EvidenceWarning';
 import { setPageFocus, setUpPage } from '../utils/page';
@@ -69,8 +68,8 @@ class AdditionalEvidencePage extends React.Component {
 
     if (this.props.loading) {
       content = (
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          set-focus
           message="Loading your claim information..."
         />
       );

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -6,7 +6,6 @@ import { Link } from 'react-router';
 import moment from 'moment';
 
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import AppealNotFound from '../components/appeals-v2/AppealNotFound';
 import { getAppealsV2 } from '../actions/index.jsx';
 import AppealHeader from '../components/appeals-v2/AppealHeader';
@@ -123,7 +122,7 @@ export class AppealInfo extends React.Component {
     if (appealsLoading) {
       appealContent = (
         <div className="vads-u-margin-bottom--2p5">
-          <LoadingIndicator message="Please wait while we load your appeal..." />
+          <va-loading-indicator message="Please wait while we load your appeal..." />
         </div>
       );
     } else if (appealsAvailability === AVAILABLE && appeal) {

--- a/src/applications/claims-status/containers/AppealStatusPage.jsx
+++ b/src/applications/claims-status/containers/AppealStatusPage.jsx
@@ -4,7 +4,6 @@ import { withRouter } from 'react-router';
 import moment from 'moment';
 import _ from 'lodash';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { getAppeals } from '../actions/index.jsx';
 import AppealEventItem from '../components/AppealEventItem';
 import AskVAQuestions from '../components/AskVAQuestions';
@@ -102,7 +101,10 @@ class AppealStatusPage extends React.Component {
 
     if (loading) {
       return (
-        <LoadingIndicator message="Loading your appeal status..." setFocus />
+        <va-loading-indicator
+          message="Loading your appeal status..."
+          setFocus
+        />
       );
     }
 

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import DueDate from '../components/DueDate';
 import AskVAQuestions from '../components/AskVAQuestions';
 import AddFilesForm from '../components/AddFilesForm';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Notification from '../components/Notification';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import { setPageFocus, setUpPage } from '../utils/page';
@@ -79,8 +78,8 @@ class DocumentRequestPage extends React.Component {
 
     if (this.props.loading) {
       content = (
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          set-focus
           message="Loading your claim information..."
         />
       );

--- a/src/applications/claims-status/containers/StemClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/StemClaimStatusPage.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { setUpPage } from '../utils/page';
 
 import { Link } from 'react-router';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import StemAskVAQuestions from '../components/StemAskVAQuestions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
@@ -27,8 +26,8 @@ class StemClaimStatusPage extends React.Component {
     let content;
     if (loading) {
       content = (
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          set-focus
           message="Loading your claim information..."
         />
       );

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -32,7 +32,6 @@ import ClaimsListItem from '../components/appeals-v2/ClaimsListItemV2';
 import AppealListItem from '../components/appeals-v2/AppealListItemV2';
 import NoClaims from '../components/NoClaims';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import ClosedClaimMessage from '../components/ClosedClaimMessage';
 import { setUpPage, setPageFocus } from '../utils/page';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
@@ -160,9 +159,9 @@ class YourClaimsPageV2 extends React.Component {
     const emptyList = !(list && list.length);
     if (allRequestsLoading || (atLeastOneRequestLoading && emptyList)) {
       content = (
-        <LoadingIndicator
+        <va-loading-indicator
           message="Loading your claims and appeals..."
-          setFocus
+          set-focus
         />
       );
     } else {
@@ -177,7 +176,7 @@ class YourClaimsPageV2 extends React.Component {
             )}
             <div className="claim-list">
               {atLeastOneRequestLoading && (
-                <LoadingIndicator message="Loading your claims and appeals..." />
+                <va-loading-indicator message="Loading your claims and appeals..." />
               )}
               {list.map(claim => this.renderListItem(claim))}
               <Pagination

--- a/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('<AdditionalEvidencePage>', () => {
     const tree = SkinDeep.shallowRender(
       <AdditionalEvidencePage params={params} loading />,
     );
-    expect(tree.everySubTree('LoadingIndicator')).not.to.be.empty;
+    expect(tree.everySubTree('va-loading-indicator')).not.to.be.empty;
   });
   it('should render upload error alert', () => {
     const claim = {

--- a/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('<ClaimDetailLayout>', () => {
   it('should render loading indicator', () => {
     const tree = SkinDeep.shallowRender(<ClaimDetailLayout loading />);
 
-    expect(tree.everySubTree('LoadingIndicator')).not.to.be.empty;
+    expect(tree.everySubTree('va-loading-indicator')).not.to.be.empty;
   });
   it('should render sync warning', () => {
     const claim = {

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('<DocumentRequestPage>', () => {
     const tree = SkinDeep.shallowRender(
       <DocumentRequestPage params={params} loading />,
     );
-    expect(tree.everySubTree('LoadingIndicator')).not.to.be.empty;
+    expect(tree.everySubTree('va-loading-indicator')).not.to.be.empty;
     expect(tree.everySubTree('.claim-container')).to.be.empty;
   });
   it('should render upload error alert', () => {

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -50,7 +50,7 @@ describe('<YourClaimsPageV2>', () => {
     props.claimsLoading = true;
     props.stemClaimsLoading = true;
     const wrapper = shallow(<YourClaimsPageV2 {...props} />);
-    expect(wrapper.find('LoadingIndicator').length).to.equal(1);
+    expect(wrapper.find('va-loading-indicator').length).to.equal(1);
     wrapper.unmount();
   });
 
@@ -59,7 +59,7 @@ describe('<YourClaimsPageV2>', () => {
     props.stemClaimsLoading = true;
     props.list = [];
     const wrapper = shallow(<YourClaimsPageV2 {...props} />);
-    expect(wrapper.find('LoadingIndicator').length).to.equal(1);
+    expect(wrapper.find('va-loading-indicator').length).to.equal(1);
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealInfo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealInfo.unit.spec.jsx
@@ -30,12 +30,12 @@ describe('<AppealInfo/>', () => {
     wrapper.unmount();
   });
 
-  it('should render LoadingIndicator when appeals loading', () => {
+  it('should render va-loading-indicator when appeals loading', () => {
     const props = { params: { id: appealIdParam }, appealsLoading: true };
     const wrapper = shallow(<AppealInfo {...props} />, {
       disableLifecycleMethods: true,
     });
-    const loadingIndicator = wrapper.find('LoadingIndicator');
+    const loadingIndicator = wrapper.find('va-loading-indicator');
     expect(loadingIndicator.length).to.equal(1);
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
All instances of `LoadingIndicator` need to be replaced with `<va-loading-indicator>` web component.

## Original issue(s)
closes department-of-veterans-affairs/va.gov-team#34703


## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Replaced loadingIndicator
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
