### PR TITLE
Add downloadURL to COEEligible status header

### DIFF
--- a/src/applications/lgy/coe/form/containers/introduction-content/COEIntroPageBox.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/COEIntroPageBox.jsx
@@ -7,15 +7,15 @@ import COEEligible from './COEStatuses/COEEligible';
 import COEIneligible from './COEStatuses/COEIneligible';
 import COEPending from './COEStatuses/COEPending';
 
-const COEIntroPageBox = props => {
-  if (props.coe.status) {
-    switch (props.coe.status) {
+const COEIntroPageBox = ({ coe, downloadURL }) => {
+  if (coe.status) {
+    switch (coe.status) {
       case COE_ELIGIBILITY_STATUS.available:
-        return <COEAvailable downloadURL={props.downloadURL} />;
+        return <COEAvailable downloadURL={downloadURL} />;
       case COE_ELIGIBILITY_STATUS.denied:
         return <COEDenied />;
       case COE_ELIGIBILITY_STATUS.eligible:
-        return <COEEligible />;
+        return <COEEligible downloadURL={downloadURL} />;
       case COE_ELIGIBILITY_STATUS.ineligible:
       case COE_ELIGIBILITY_STATUS.unableToDetermine:
         return <COEIneligible />;
@@ -23,8 +23,8 @@ const COEIntroPageBox = props => {
       case COE_ELIGIBILITY_STATUS.pendingUpload:
         return (
           <COEPending
-            status={props.coe.status}
-            applicationCreateDate={props.coe.applicationCreateDate}
+            status={coe.status}
+            applicationCreateDate={coe.applicationCreateDate}
           />
         );
       default:

--- a/src/applications/lgy/coe/form/containers/introduction-content/COEStatuses/COEEligible.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/COEStatuses/COEEligible.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const COEEligible = () => (
+const COEEligible = ({ downloadURL }) => (
   <>
     <va-alert status="success">
       <h2 slot="headline">Congratulations on your automatic COE</h2>
@@ -22,7 +22,7 @@ const COEEligible = () => (
       </a>
     </div>
     <div className="vads-u-padding-top--4">
-      <a href="#">
+      <a href={downloadURL}>
         <i
           className="fas fa-download vads-u-padding-right--1"
           aria-hidden="true"


### PR DESCRIPTION
## Description
Adds the downloadURL prop to COEEligible status header so that the href for the 'Download your COE' section can be populated properly

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35595

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
