### PR TITLE
change tag to button element

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -116,7 +116,8 @@ export default function FacilitiesRadioWidget({
               level="3"
             >
               <p>Make sure your browser’s location feature is turned on.</p>
-              <a
+              <button
+                className="va-button-link"
                 onClick={() =>
                   updateFacilitySortMethod(
                     FACILITY_SORT_METHODS.distanceFromCurrentLocation,
@@ -124,7 +125,7 @@ export default function FacilitiesRadioWidget({
                 }
               >
                 Retry searching based on current location
-              </a>
+              </button>
             </InfoAlert>
           </div>
         )}


### PR DESCRIPTION
## Description
change the <a> tag to button tag but keep the UI looking same where "Retry searching based on current location" looks like a regular href link

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35900


## Testing done
manual 

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/151043299-66da5cc1-3786-4cc8-ab54-101bce1aeedb.png)


## Acceptance criteria
- [ ] Keep the UI looking the same

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
