### PR TITLE
Update `eslint-plugin-va` to handle VAOS custom aXe check

### DIFF
--- a/script/eslint-plugin-va/package.json
+++ b/script/eslint-plugin-va/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-va",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "index.js",
   "engines": {
     "node": ">= 12"

--- a/script/eslint-plugin-va/rules/axe-e2e-tests.js
+++ b/script/eslint-plugin-va/rules/axe-e2e-tests.js
@@ -29,7 +29,8 @@ module.exports = {
           node.callee.object.name === 'cy' &&
           node.callee.property.type === 'Identifier' &&
           (node.callee.property.name === 'axeCheck' ||
-            node.callee.property.name === 'injectAxeThenAxeCheck')
+            node.callee.property.name === 'injectAxeThenAxeCheck' || 
+            node.callee.property.name === 'axeCheckBestPractice')
         ) {
           // Found: cy.axeCheck() or cy.injectAxeThenAxeCheck()
           hasSeenAxeCheckCall = true;

--- a/script/eslint-plugin-va/tests/lib/rules/axe-e2e-tests.js
+++ b/script/eslint-plugin-va/tests/lib/rules/axe-e2e-tests.js
@@ -10,6 +10,7 @@ ruleTester.run('axe-e2e-tests', rule, {
     "it('does something', function() { cy.axeCheck(); });",
     "it('does something', function() { cy.injectAxeThenAxeCheck(); });",
     "it('does something', function() { if(foo) { cy.axeCheck(); } });",
+    "it('does something', function() { cy.axeCheckBestPractice() })",
     "notIt('does something', function() {});",
   ],
   invalid: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7989,7 +7989,7 @@ eslint-plugin-unicorn@^35.0.0:
     semver "^7.3.5"
 
 "eslint-plugin-va@file:./script/eslint-plugin-va":
-  version "1.0.4"
+  version "1.0.5"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
## Description
This PR modifies the aXe check rule in `eslint-plugin-va` to check for VAOS's custom aXe check in Cypress tests.

## Testing done
Local testing.

## Acceptance criteria
- [ ] CI passes.