### PR TITLE
Adds new React app for Office Directory

### DIFF
--- a/src/applications/office-directory/app-entry.jsx
+++ b/src/applications/office-directory/app-entry.jsx
@@ -1,0 +1,14 @@
+import 'platform/polyfills';
+import './sass/office-directory.scss';
+
+import startApp from 'platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+});

--- a/src/applications/office-directory/containers/App.jsx
+++ b/src/applications/office-directory/containers/App.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function App({ children }) {
+  return (
+    <div className="vads-l-grid-container vads-u-padding-x--1p5 vads-u-padding-bottom--4">
+      <h1 className="vads-u-margin-bottom--0">All VA offices</h1>
+      {children}
+    </div>
+  );
+}

--- a/src/applications/office-directory/manifest.json
+++ b/src/applications/office-directory/manifest.json
@@ -1,0 +1,6 @@
+{
+  "appName": "All VA offices",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "office-directory",
+  "rootUrl": "/office-directory"
+}

--- a/src/applications/office-directory/reducers/index.js
+++ b/src/applications/office-directory/reducers/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/applications/office-directory/routes.jsx
+++ b/src/applications/office-directory/routes.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Route } from 'react-router';
+import App from './containers/App.jsx';
+
+const routes = <Route path="/" component={App} />;
+
+export default routes;

--- a/src/applications/office-directory/sass/office-directory.scss
+++ b/src/applications/office-directory/sass/office-directory.scss
@@ -1,0 +1,1 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/src/applications/office-directory/tests/office-directory.cypress.spec.js
+++ b/src/applications/office-directory/tests/office-directory.cypress.spec.js
@@ -1,0 +1,15 @@
+import manifest from '../manifest.json';
+
+describe(manifest.appName, () => {
+  // Skip tests in CI until the app is released.
+  // Remove this block when the app has a content page in production.
+  before(function() {
+    if (Cypress.env('CI')) this.skip();
+  });
+
+  it('is accessible', () => {
+    cy.visit(manifest.rootUrl)
+      .injectAxe()
+      .axeCheck();
+  });
+});


### PR DESCRIPTION
## Description
Adds new React app for Office Directory. Shows only initial page title, nothing more.  Most of the work is in this PR, but a small change in `content-build` goes with this.  See: https://github.com/department-of-veterans-affairs/content-build/pull/935

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7592

## Testing done
Local testing to confirm page title shows as in screenshot below.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/151053337-2c0b005d-1c34-445d-ad31-2bb830374597.png)


## Acceptance criteria
- [ ] Title displaying correctly at url `/office-directory`.
