### PR TITLE
526: Add PTSD description when 781 bypassed

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/ptsdBypassContent.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdBypassContent.jsx
@@ -4,8 +4,11 @@ export const ptsdCombatTitle = (
   <h3 className="vads-u-font-size--h4">PTSD combat</h3>
 );
 
-export const ptsdNonCombatTitle =
-  'PTSD non-combat (other than sexual trauma or personal assault)';
+export const ptsdNonCombatTitle = (
+  <h3 className="vads-u-font-size--h4">
+    PTSD non-combat (other than sexual trauma or personal assault)
+  </h3>
+);
 
 export const ptsdBypassRadioLabel =
   'Is your PTSD related to a situation where you feared hostile military or terrorist activity during your military service?';
@@ -18,3 +21,6 @@ export const ptsdBypassAdditionalInfo = (
     supporting evidence section of the application.
   </va-additional-info>
 );
+
+export const ptsdBypassDescription =
+  'PTSD related to feared hostile military or terrorist activity';

--- a/src/applications/disability-benefits/all-claims/pages/ptsdBypassCombat.js
+++ b/src/applications/disability-benefits/all-claims/pages/ptsdBypassCombat.js
@@ -11,7 +11,7 @@ export const uiSchema = {
   'ui:options': {
     forceDivWrapper: true,
   },
-  'view:skip781ForCombatReason': {
+  skip781ForCombatReason: {
     'ui:title': ptsdBypassRadioLabel,
     'ui:required': showPtsdCombat,
     'ui:widget': 'yesNo',
@@ -25,7 +25,7 @@ export const uiSchema = {
 export const schema = {
   type: 'object',
   properties: {
-    'view:skip781ForCombatReason': {
+    skip781ForCombatReason: {
       type: 'boolean',
     },
     'view:ptsdCombatBypassAdditionalInfo': {

--- a/src/applications/disability-benefits/all-claims/pages/ptsdBypassNonCombat.js
+++ b/src/applications/disability-benefits/all-claims/pages/ptsdBypassNonCombat.js
@@ -11,7 +11,7 @@ export const uiSchema = {
   'ui:options': {
     forceDivWrapper: true,
   },
-  'view:skip781ForNonCombatReason': {
+  skip781ForNonCombatReason: {
     'ui:title': ptsdBypassRadioLabel,
     'ui:required': formData =>
       // shouldn't show if combat question already true
@@ -27,7 +27,7 @@ export const uiSchema = {
 export const schema = {
   type: 'object',
   properties: {
-    'view:skip781ForNonCombatReason': {
+    skip781ForNonCombatReason: {
       type: 'boolean',
     },
     'view:ptsdNonCombatBypassAdditionalInfo': {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/full-781-781a-8940-test.json
@@ -449,8 +449,8 @@
       "view:assaultPtsdType": true,
       "view:nonCombatPtsdType": true
     },
-    "view:skip781ForCombatReason": false,
-    "view:skip781ForNonCombatReason": false,
+    "skip781ForCombatReason": false,
+    "skip781ForNonCombatReason": false,
     "view:ptsdTypeHelp": {},
     "view:disabilitiesClarification": {},
     "isVaEmployee": false,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-skip-781.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-skip-781.json
@@ -6,9 +6,9 @@
     "view:terminallyIllInfo": {},
     "view:hasEvidence": false,
     "view:powStatus": false,
-    "view:skip781ForNonCombatReason": true,
+    "skip781ForCombatReason": false,
+    "skip781ForNonCombatReason": true,
     "view:ptsdNonCombatBypassAdditionalInfo": {},
-    "view:skip781ForCombatReason": false,
     "view:ptsdCombatBypassAdditionalInfo": {},
     "view:selectablePtsdTypes": {
       "view:combatPtsdType": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/minimal-skip-781.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/minimal-skip-781.json
@@ -35,7 +35,8 @@
     "privacyAgreementAccepted": true,
     "newPrimaryDisabilities": [{
       "condition": "PTSD",
-      "cause": "NEW"
+      "cause": "NEW",
+      "primaryDescription": "PTSD related to feared hostile military or terrorist activity"
     }]
   }
 }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/upload-781-781a-8940-test.json
@@ -47,8 +47,8 @@
       "view:assaultPtsdType": true,
       "view:nonCombatPtsdType": true
     },
-    "view:skip781ForCombatReason": false,
-    "view:skip781ForNonCombatReason": false,
+    "skip781ForCombatReason": false,
+    "skip781ForNonCombatReason": false,
     "view:ptsdTypeHelp": {},
     "newDisabilities": [
       {

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -505,13 +505,13 @@ describe('526 helpers', () => {
       expect(
         needsToEnter781({
           ...formData,
-          'view:skip781ForCombatReason': true,
+          skip781ForCombatReason: true,
         }),
       ).to.be.false;
       expect(
         needsToEnter781({
           ...formData,
-          'view:skip781ForNonCombatReason': true,
+          skip781ForNonCombatReason: true,
         }),
       ).to.be.false;
     });
@@ -1295,8 +1295,8 @@ describe('skip PTSD questions', () => {
       'view:combatPtsdType': combat,
       'view:nonCombatPtsdType': nonCombat,
     },
-    'view:skip781ForCombatReason': skipCombat,
-    'view:skip781ForNonCombatReason': skipNonCombat,
+    skip781ForCombatReason: skipCombat,
+    skip781ForNonCombatReason: skipNonCombat,
   });
 
   describe('showPtsdCombat', () => {

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -660,11 +660,11 @@ export const showPtsdNonCombat = formData =>
   hasNewPtsdDisability(formData) &&
   _.get('view:selectablePtsdTypes.view:nonCombatPtsdType', formData, false) &&
   // skip non-combat question if Veteran says yes to combat question
-  !_.get('view:skip781ForCombatReason', formData, false);
+  !_.get('skip781ForCombatReason', formData, false);
 
 export const skip781 = formData =>
-  _.get('view:skip781ForCombatReason', formData) === true ||
-  _.get('view:skip781ForNonCombatReason', formData) === true;
+  _.get('skip781ForCombatReason', formData) === true ||
+  _.get('skip781ForNonCombatReason', formData) === true;
 
 export const needsToEnter781 = formData =>
   (showPtsdCombat(formData) || showPtsdNonCombat(formData)) &&

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -14,6 +14,8 @@ import {
   sippableId,
 } from '../utils';
 
+import { ptsdBypassDescription } from '../content/ptsdBypassContent';
+
 /**
  * This is mostly copied from us-forms' own stringifyFormReplacer, but with
  * the incomplete / empty address check removed, since we don't need this
@@ -311,19 +313,29 @@ export const cleanUpMailingAddress = formData => {
 };
 
 // Add 'cause' of 'NEW' to new ptsd disabilities since form does not ask
-export const addPTSDCause = formData =>
-  formData.newDisabilities
+export const addPTSDCause = formData => {
+  const clonedData = formData.newDisabilities
     ? _.set(
         'newDisabilities',
-        formData.newDisabilities.map(
-          disability =>
-            isDisabilityPtsd(disability.condition)
-              ? _.set('cause', causeTypes.NEW, disability)
-              : disability,
-        ),
+        formData.newDisabilities.map(disability => {
+          if (isDisabilityPtsd(disability?.condition)) {
+            const updated = _.set('cause', causeTypes.NEW, disability);
+
+            // Adds PTSD description for Veterans bypassing form 781
+            return formData.skip781ForCombatReason ||
+              formData.skip781ForNonCombatReason
+              ? _.set('primaryDescription', ptsdBypassDescription, updated)
+              : updated;
+          }
+          return disability;
+        }),
         formData,
       )
     : formData;
+  delete clonedData.skip781ForCombatReason;
+  delete clonedData.skip781ForNonCombatReason;
+  return clonedData;
+};
 
 export const addForm4142 = formData => {
   if (!formData.providerFacility) {


### PR DESCRIPTION
## Description

When the Veteran answers that their PTSD is due to fear from hostile or terrorist activity, form 781 is skipped. This PR adds a "primaryDescription" to the PTSD entry upon submission:

```json
"newPrimaryDisabilities": [{
  "condition": "PTSD",
  "cause": "NEW",
  "primaryDescription": "PTSD related to feared hostile military or terrorist activity"
}]
```

This is done to notify the intake personnel that form 781 was skipped

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35437

## Testing done

Updated e2e testing data

## Screenshots

N/A

## Acceptance criteria
- [x] A description is added to submissions where form 781 is skipped
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
