### PR TITLE
Fix flaky Benefit-payments-and-debt E2E-spec

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
@@ -52,8 +52,7 @@ describe('The My VA Dashboard - Payments and Debt', () => {
       }).should('not.exist');
 
       // make the a11y check
-      cy.injectAxe();
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
   });
   describe('when the feature is not hidden', () => {
@@ -95,8 +94,7 @@ describe('The My VA Dashboard - Payments and Debt', () => {
       }).should('exist');
 
       // make the a11y check
-      cy.injectAxe();
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
     it('and they have no payments in the last 30 days - C13195', () => {
       cy.intercept('/v0/profile/payment_history', paymentsSuccess());
@@ -116,8 +114,7 @@ describe('The My VA Dashboard - Payments and Debt', () => {
       }).should('not.exist');
 
       // make the a11y check
-      cy.injectAxe();
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
   });
 });

--- a/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
@@ -80,41 +80,52 @@ describe('The My VA Dashboard - Payments and Debt', () => {
       );
       cy.intercept('/v1/facilities/va?ids=*', MOCK_FACILITIES);
     });
-    it('and they have payments in the last 30 days - C13194', () => {
-      cy.intercept('/v0/profile/payment_history', paymentsSuccess(true));
-      cy.intercept('/v0/debts', debtsSuccess);
-      cy.visit('my-va/');
-      // make sure that the Payment and Debt section is shown
-      cy.findByTestId('dashboard-section-payment-and-debts').should('exist');
-      cy.findByRole('link', { name: /manage your direct deposit/i }).should(
-        'exist',
-      );
-      cy.findByRole('heading', {
-        name: /We deposited.*in your account/i,
-      }).should('exist');
 
-      // make the a11y check
-      cy.injectAxeThenAxeCheck();
+    context('and user has payments', () => {
+      beforeEach(() => {
+        cy.intercept('/v0/profile/payment_history', paymentsSuccess(true));
+        cy.intercept('/v0/debts', debtsSuccess);
+        cy.visit('my-va/');
+        cy.wait(['@pmtsSuccess1', '@debtsSuccess1']);
+      });
+      it('and they have payments in the last 30 days - C13194', () => {
+        // make sure that the Payment and Debt section is shown
+        cy.findByTestId('dashboard-section-payment-and-debts').should('exist');
+        cy.findByRole('link', { name: /manage your direct deposit/i }).should(
+          'exist',
+        );
+        cy.findByRole('heading', {
+          name: /We deposited.*in your account/i,
+        }).should('exist');
+
+        // make the a11y check
+        cy.injectAxeThenAxeCheck();
+      });
     });
-    it('and they have no payments in the last 30 days - C13195', () => {
-      cy.intercept('/v0/profile/payment_history', paymentsSuccess());
-      cy.intercept('/v0/debts', debtsSuccess);
-      cy.visit('my-va/');
-      // make sure that the Payment and Debt section is shown
-      cy.findByTestId('dashboard-section-payment-and-debts').should('exist');
-      cy.findByRole('link', { name: /manage your direct deposit/i }).should(
-        'exist',
-      );
-      cy.findByRole('link', { name: /view your payment history/i }).should(
-        'exist',
-      );
-      cy.findByText(/you*.*payments in the past 30 days/i).should('exist');
-      cy.findByRole('heading', {
-        name: /We deposited.*in your account/i,
-      }).should('not.exist');
 
-      // make the a11y check
-      cy.injectAxeThenAxeCheck();
+    context('and user has no payments', () => {
+      beforeEach(() => {
+        cy.intercept('/v0/profile/payment_history', paymentsSuccess());
+        cy.intercept('/v0/debts', debtsSuccess);
+        cy.visit('my-va/');
+      });
+      it('and they have no payments in the last 30 days - C13195', () => {
+        // make sure that the Payment and Debt section is shown
+        cy.findByTestId('dashboard-section-payment-and-debts').should('exist');
+        cy.findByRole('link', { name: /manage your direct deposit/i }).should(
+          'exist',
+        );
+        cy.findByRole('link', { name: /view your payment history/i }).should(
+          'exist',
+        );
+        cy.findByText(/you*.*payments in the past 30 days/i).should('exist');
+        cy.findByRole('heading', {
+          name: /We deposited.*in your account/i,
+        }).should('not.exist');
+
+        // make the a11y check
+        cy.injectAxeThenAxeCheck();
+      });
     });
   });
 });

--- a/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
@@ -86,7 +86,6 @@ describe('The My VA Dashboard - Payments and Debt', () => {
         cy.intercept('/v0/profile/payment_history', paymentsSuccess(true));
         cy.intercept('/v0/debts', debtsSuccess);
         cy.visit('my-va/');
-        cy.wait(['@pmtsSuccess1', '@debtsSuccess1']);
       });
       it('and they have payments in the last 30 days - C13194', () => {
         // make sure that the Payment and Debt section is shown

--- a/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefit-payments-and-debt.cypress.spec.js
@@ -28,7 +28,6 @@ describe('The My VA Dashboard - Payments and Debt', () => {
       });
       mockLocalStorage();
       cy.login(mockUser);
-      cy.visit('my-va/');
       cy.intercept('/v0/profile/service_history', serviceHistory);
       cy.intercept('/v0/profile/full_name', fullName);
       cy.intercept('/v0/evss_claims_async', claimsSuccess());
@@ -38,6 +37,7 @@ describe('The My VA Dashboard - Payments and Debt', () => {
         disabilityRating,
       );
       cy.intercept('/v1/facilities/va?ids=*', MOCK_FACILITIES);
+      cy.visit('my-va/');
     });
     it('the payment and debt section does not show up - C13193', () => {
       // make sure that the Payment and Debt section is not shown
@@ -71,7 +71,6 @@ describe('The My VA Dashboard - Payments and Debt', () => {
       });
       mockLocalStorage();
       cy.login(mockUser);
-      cy.visit('my-va/');
       cy.intercept('/v0/profile/service_history', serviceHistory);
       cy.intercept('/v0/profile/full_name', fullName);
       cy.intercept('/v0/evss_claims_async', claimsSuccess());
@@ -85,6 +84,7 @@ describe('The My VA Dashboard - Payments and Debt', () => {
     it('and they have payments in the last 30 days - C13194', () => {
       cy.intercept('/v0/profile/payment_history', paymentsSuccess(true));
       cy.intercept('/v0/debts', debtsSuccess);
+      cy.visit('my-va/');
       // make sure that the Payment and Debt section is shown
       cy.findByTestId('dashboard-section-payment-and-debts').should('exist');
       cy.findByRole('link', { name: /manage your direct deposit/i }).should(
@@ -101,6 +101,7 @@ describe('The My VA Dashboard - Payments and Debt', () => {
     it('and they have no payments in the last 30 days - C13195', () => {
       cy.intercept('/v0/profile/payment_history', paymentsSuccess());
       cy.intercept('/v0/debts', debtsSuccess);
+      cy.visit('my-va/');
       // make sure that the Payment and Debt section is shown
       cy.findByTestId('dashboard-section-payment-and-debts').should('exist');
       cy.findByRole('link', { name: /manage your direct deposit/i }).should(


### PR DESCRIPTION
## Description
Fix flaky Benefit-payments-and-debt Cypress E2E-spec:
- Move `cy.visit()`s to after all `cy.intercept()`s for visited page.
- Isolate common-endpoint `cy.intercept()`s that return different mock-responses, using `cy.context()`s.
- [misc] Use combined `cy.injectAxeThenAxeCheck()` calls.


## Original issue(s)
[n/a]

## Testing done
- Ran fixed spec locally [12 times for consecutive all-Passed results](https://dsvavsp.testrail.io/index.php?/runs/overview/4) (under **Tuesday, January 25, 2022** section).  [Screenshot also provided below.]
- [CI test-run also Passed](https://github.com/department-of-veterans-affairs/vets-website/runs/4944051634?check_suite_focus=true#step:9:131) for pushed branch.

## Screenshot
![2022-01-25_15-48-15](https://user-images.githubusercontent.com/587583/151073032-297648f9-285f-458f-944d-2b8f5c982201.png)


## Acceptance criteria
- [ ] Code reviewer(s) approved changes.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
