### PR TITLE
add application date to COEAvailable component in form app

### DIFF
--- a/src/applications/lgy/coe/form/containers/introduction-content/COEIntroPageBox.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/COEIntroPageBox.jsx
@@ -11,7 +11,12 @@ const COEIntroPageBox = ({ coe, downloadURL }) => {
   if (coe.status) {
     switch (coe.status) {
       case COE_ELIGIBILITY_STATUS.available:
-        return <COEAvailable downloadURL={downloadURL} />;
+        return (
+          <COEAvailable
+            downloadURL={downloadURL}
+            applicationCreateDate={coe.applicationCreateDate}
+          />
+        );
       case COE_ELIGIBILITY_STATUS.denied:
         return <COEDenied />;
       case COE_ELIGIBILITY_STATUS.eligible:

--- a/src/applications/lgy/coe/form/containers/introduction-content/COEStatuses/COEAvailable.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/COEStatuses/COEAvailable.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import moment from 'moment';
 
-const COEAvailable = ({ downloadURL }) => (
+const COEAvailable = ({ downloadURL, applicationCreateDate }) => (
   <>
     <va-alert status="info">
       <h2 slot="headline">You already have a COE</h2>
       <div>
-        <p>You requested a COE on: June 30, 2020</p>
+        <p>
+          You requested a COE on:{' '}
+          {moment(applicationCreateDate).format('MMMM DD, YYYY')}
+        </p>
         <p>
           You have a COE available so you don’t need to fill out a request. You
           can review the details about your COE status or download your COE now.


### PR DESCRIPTION
## Description
We forgot to add the COE Eligibility Application date to the form app; this does that.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35989

## Screenshots
### Before
![Screen Shot 2022-01-26 at 10 03 32 AM](https://user-images.githubusercontent.com/1021154/151199809-9bd89566-9427-4b27-bef5-e94adb541ce0.png)

### After
<img width="725" alt="Screen Shot 2022-01-26 at 10 31 11 AM" src="https://user-images.githubusercontent.com/1021154/151204982-2ab6f029-ce03-45e6-a8d3-49dc6a625bfa.png">


## Acceptance criteria
- [x] The mocked (June 30th) date does not show, but instead of the dynamic date coming from the backend.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
