### PR TITLE
Fix Redirect Logic; Don't Expect HTTP Response Code

### DIFF
--- a/src/applications/my-education-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/my-education-benefits/containers/IntroductionPage.jsx
@@ -28,7 +28,7 @@ export const IntroductionPage = ({ user, route }) => {
   );
 
   const handleRedirect = async response => {
-    if (response.status >= 204 || !response?.data?.attributes?.claimant) {
+    if (!response?.data?.attributes?.claimant) {
       window.location.href =
         '/education/apply-for-education-benefits/application/1990/';
     }


### PR DESCRIPTION
## Description
Don't expect a response code in the logic to redirect when a claimant isn't found.