### PR TITLE
NOD: switch to va-additional-info WC

### DIFF
--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
@@ -52,7 +51,7 @@ class IntroductionPage extends React.Component {
         <h2 id="main-content" className="vads-u-font-size--h3">
           Follow these steps to request a Board Appeal
         </h2>
-        <AdditionalInfo triggerText="Find out about opting in if you have an older claim">
+        <va-additional-info trigger="Find out about opting in if you have an older claim">
           <p>
             If you’re requesting a Board Appeal on an issue in a claim we
             decided before February 19, 2019, you’ll need to opt in to the new
@@ -64,7 +63,7 @@ class IntroductionPage extends React.Component {
             Our new decision review process is part of the Appeals Modernization
             Act. When you opt in, you’re likely to get a faster decision.
           </p>
-        </AdditionalInfo>
+        </va-additional-info>
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">
@@ -106,7 +105,7 @@ class IntroductionPage extends React.Component {
                 We’ll take you through each step of the process. It should take
                 about 30 minutes.
               </p>
-              <AdditionalInfo triggerText="What happens after you apply">
+              <va-additional-info trigger="What happens after you apply">
                 <p>
                   After you submit your request for a Board Appeal, you’ll get a
                   confirmation message. You can print this for your records.
@@ -119,7 +118,7 @@ class IntroductionPage extends React.Component {
                     Read about the 3 Board Appeal options
                   </a>
                 </p>
-              </AdditionalInfo>
+              </va-additional-info>
             </li>
           </ol>
         </div>

--- a/src/applications/appeals/10182/content/contestableIssues.jsx
+++ b/src/applications/appeals/10182/content/contestableIssues.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 // We shouldn't ever see the couldn't find contestable issues message since we
 // prevent the user from navigating past the intro page; but it's here just in
@@ -34,11 +33,11 @@ export const EligibleIssuesDescription = props => (
 );
 
 export const NotListedInfo = (
-  <AdditionalInfo triggerText="Why aren’t all my issues listed here?">
+  <va-additional-info trigger="Why aren’t all my issues listed here?">
     <p className="vads-u-margin-top--0">
       If you don’t see your issue or decision listed here, it may not be in our
       system yet. This can happen if it’s a more recent claim decision. We may
       still be processing it.
     </p>
-  </AdditionalInfo>
+  </va-additional-info>
 );

--- a/src/applications/appeals/10182/content/evidenceIntro.jsx
+++ b/src/applications/appeals/10182/content/evidenceIntro.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
 export const evidenceUploadIntroTitle = 'Additional evidence';
@@ -11,7 +10,7 @@ export const evidenceUploadIntroDescription = (
       receive this request.
     </p>
     <div className="vads-u-margin-y--2">
-      <AdditionalInfo triggerText="How do I submit evidence later?">
+      <va-additional-info trigger="How do I submit evidence later?">
         You can submit more evidence by mailing it to this address:
         <p>
           Board of Veterans’ Appeals
@@ -21,7 +20,7 @@ export const evidenceUploadIntroDescription = (
           Washington, D.C. 20038
         </p>
         You can also fax it to <Telephone notClickable contact="844-678-8979" />
-      </AdditionalInfo>
+      </va-additional-info>
     </div>
   </>
 );


### PR DESCRIPTION
## Description

Replaced all instances of `AdditionalInfo` with <va-additional-info> web component.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/34707

## Testing done

Unit tests

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] Replace `AdditionalInfo` with web component
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
