### PR TITLE
NOD: show loading indicator

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -21,6 +21,7 @@ import { showWorkInProgress } from '../content/WorkInProgressMessage';
 import { getContestableIssues as getContestableIssuesAction } from '../actions';
 
 export const FormApp = ({
+  isLoading,
   loggedIn,
   showNod,
   location,
@@ -95,15 +96,26 @@ export const FormApp = ({
     ],
   );
 
+  let content = isLoading ? (
+    <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+      <va-loading-indicator
+        set-focus
+        message="Loading your previous decisions..."
+      />
+    </h1>
+  ) : (
+    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      {children}
+    </RoutedSavableApp>
+  );
+
+  if (showNod === false) {
+    content = showWorkInProgress(formConfig);
+  }
+
   return (
     <article id="form-10182" data-location={`${location?.pathname?.slice(1)}`}>
-      {showNod ? (
-        <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-          {children}
-        </RoutedSavableApp>
-      ) : (
-        showWorkInProgress(formConfig)
-      )}
+      {content}
     </article>
   );
 };
@@ -112,9 +124,10 @@ const mapStateToProps = state => {
   const profile = selectProfile(state);
   const formData = state.form?.data || {};
   const showNod = noticeOfDisagreementFeature(state);
+  const isLoading = state.featureToggles?.loading;
   const loggedIn = isLoggedIn(state);
   const { contestableIssues } = state;
-  return { profile, formData, showNod, contestableIssues, loggedIn };
+  return { profile, formData, showNod, contestableIssues, isLoading, loggedIn };
 };
 
 const mapDispatchToProps = {

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -35,10 +35,12 @@ const profile = {
 
 const getData = ({
   showNod = true,
+  isLoading = false,
   loggedIn = true,
   mockProfile = profile,
 } = {}) => ({
   props: {
+    isLoading,
     loggedIn,
     showNod,
     location: { pathname: '/introduction', search: '' },
@@ -86,6 +88,13 @@ describe('FormApp', () => {
 
     expect(tree.find('Connect(RoutedSavableApp)')).to.exist;
 
+    tree.unmount();
+  });
+  it('should render loading indicator', () => {
+    const { props } = getData({ isLoading: true });
+    const tree = shallow(<FormApp {...props} />);
+    const loading = tree.find('va-loading-indicator');
+    expect(loading).to.exist;
     tree.unmount();
   });
   it('should render WIP alert', () => {


### PR DESCRIPTION
## Description

Show loading indicator while the feature flags are still loading. This prevents the work-in-progress alert from flashing on the screen momentarily.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36068

## Testing done

Added unit test

## Screenshots

N/A

## Acceptance criteria
- [x] Loading indicator shows while feature flags are loading
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
