### PR TITLE
Add medical copays to allowlist

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -1,6 +1,6 @@
 {
   "allow": {
-    "entryNames": ["vaos"],
+    "entryNames": ["vaos", "medical-copays"],
     "rootAppFolders": ["check-in"]
   }
 }


### PR DESCRIPTION
## Description
Add the medical copays app to the allowlist.

## Testing done
Verified the header test passes by running:
```
yarn cy:run --spec src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js --env app_url=/health-care/pay-copay-bill/your-current-balances
```

Verified medical copays is isolated by running:
```
yarn check-app-imports --app-folder medical-copays
```

## Acceptance criteria
- [x] The medical copays app should be on the allowlist.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
