### PR TITLE
Added a ARIA status role to the loading text in the validate button.

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
@@ -60,7 +60,11 @@ const AppointmentAction = props => {
           disabled={isCheckingIn}
           aria-label="Check in now for your appointment"
         >
-          {isCheckingIn ? <>Loading...</> : <>Check in now</>}
+          {isCheckingIn ? (
+            <span role="status">Loading...</span>
+          ) : (
+            <>Check in now</>
+          )}
         </button>
       );
     } else if (

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentAction.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentAction.unit.spec.jsx
@@ -58,6 +58,21 @@ describe('check-in', () => {
         'Check in now',
       );
     });
+    it('should have a role for the loading state of the button', () => {
+      const action = render(
+        <Provider store={store}>
+          <AppointmentAction
+            appointment={{
+              eligibility: ELIGIBILITY.ELIGIBLE,
+            }}
+          />
+        </Provider>,
+      );
+
+      expect(action.getByTestId('check-in-button')).to.exist;
+      action.getByTestId('check-in-button').click();
+      expect(action.getByRole('status')).to.have.text('Loading...');
+    });
     it('should render the bad status message for appointments with INELIGIBLE_BAD_STATUS status', () => {
       const action = render(
         <Provider store={store}>

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -49,7 +49,7 @@ export default function ValidateDisplay({
         aria-label="Check in now for your appointment"
       >
         {' '}
-        {isLoading ? <>Loading...</> : <>Continue</>}
+        {isLoading ? <span role="status">Loading...</span> : <>Continue</>}
       </button>
       {Footer && <Footer isPreCheckIn={isPreCheckIn} />}
     </div>

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
@@ -38,12 +38,12 @@ describe('check-in experience', () => {
 
         expect(getByText('foo')).to.exist;
       });
-      it('renders loading message if isLoading is true', () => {
-        const { getByText } = render(<ValidateDisplay isLoading />);
+      it('renders loading message with status role if isLoading is true', () => {
+        const { getByRole } = render(<ValidateDisplay isLoading />);
 
-        expect(getByText('Loading...')).to.exist;
+        expect(getByRole('status')).to.have.text('Loading...');
       });
-      it('renders loading message if isLoading is true', () => {
+      it('renders continue button if isLoading false', () => {
         const { getByText } = render(<ValidateDisplay isLoading={false} />);
 
         expect(getByText('Continue')).to.exist;


### PR DESCRIPTION
## Description
Added an ARIA status role to the loading text in the validate button and confirmed that Mac Safari voice over reads it as soon as the text is shown. Also tested other loading transitions and they all seem to read fine. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35471


## Testing done
Updated unit tests to look for status role.

Manually tested with Mac voice over. Also used the accessibility inspector with xcode simulator on an iPhone. These tests were not great 1 to 1 tests of an actual device though. 

