### PR TITLE
removing extra margin

### DIFF
--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
@@ -62,7 +62,7 @@ export default function ConfirmationDirectScheduleInfoV2({
         </>
       )}
       <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
-        <div className="vads-u-flex--1 vads-u-margin-top--2 vads-u-margin-right--1 vaos-u-word-break--break-word">
+        <div className="vads-u-flex--1 vads-u-margin-right--1 vaos-u-word-break--break-word">
           <h2
             className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0"
             data-cy="va-appointment-details-header"
@@ -76,7 +76,7 @@ export default function ConfirmationDirectScheduleInfoV2({
             clinicFriendlyName={clinic.serviceName}
           />
         </div>
-        <div className="vads-u-flex--1 vads-u-margin-top--2 vaos-u-word-break--break-word">
+        <div className="vads-u-flex--1 vaos-u-word-break--break-word">
           <h3 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
             Your reason for your visit
           </h3>


### PR DESCRIPTION
## Description
This PR is to remove the extra margin in a direct flow confirmation when running v0 of the vaos service.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34392


## Testing done
Manual

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/151440462-1152acd4-615e-4fe0-9813-bb551d4e8375.png)


## Acceptance criteria
- [ ] Request from Leah to remove margin from header below the type of care line

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
