### PR TITLE
Check in/35472/screen reader reduce swiping

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -17,7 +17,7 @@ const AppointmentBlock = props => {
         className="vads-u-font-family--serif"
         data-testid="appointment-day-location"
       >
-        Your {appointmentString} on {appointmentsDay} at {appointmentFacility}.
+        {`Your ${appointmentString} on ${appointmentsDay} at ${appointmentFacility}.`}
       </p>
       <ol
         className="vads-u-border-top--1px vads-u-margin-bottom--4 pre-check-in--appointment-list"

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -31,6 +31,7 @@ const DisplayMultipleAppointments = props => {
   const { goToPreviousPage } = useFormRouting(router);
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
+  const today = format(new Date(), 'MMMM dd, yyyy');
   return (
     <div className="vads-l-grid-container vads-u-padding-bottom--5 vads-u-padding-top--2 appointment-check-in">
       <BackButton router={router} action={goToPreviousPage} />
@@ -38,8 +39,7 @@ const DisplayMultipleAppointments = props => {
         Your appointments
       </h1>
       <p data-testid="date-text">
-        {`Here are your appointments for today:${' '}
-        ${format(new Date(), 'MMMM dd, yyyy')}.`}
+        {`Here are your appointments for today: ${today}.`}
       </p>
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ol

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -63,12 +63,8 @@ const DisplayMultipleAppointments = props => {
       </p>
       <p data-testid="refresh-link">
         <button
-<<<<<<< HEAD
           className="usa-button-secondary"
           onClick={handleClick}
-=======
-          onClick={e => handleClick(e)}
->>>>>>> remvoed href attr from button.
           data-testid="refresh-appointments-button"
           type="button"
         >

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -38,8 +38,8 @@ const DisplayMultipleAppointments = props => {
         Your appointments
       </h1>
       <p data-testid="date-text">
-        Here are your appointments for today:{' '}
-        {format(new Date(), 'MMMM dd, yyyy')}.
+        {`Here are your appointments for today:${' '}
+        ${format(new Date(), 'MMMM dd, yyyy')}.`}
       </p>
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ol

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -63,8 +63,12 @@ const DisplayMultipleAppointments = props => {
       </p>
       <p data-testid="refresh-link">
         <button
+<<<<<<< HEAD
           className="usa-button-secondary"
           onClick={handleClick}
+=======
+          onClick={e => handleClick(e)}
+>>>>>>> remvoed href attr from button.
           data-testid="refresh-appointments-button"
           type="button"
         >


### PR DESCRIPTION
## Description
The screen reader was pausing on areas where sentences were rendered as multiple strings in the DOM. This was happening where we were mixing static strings with variables in JSX. I added template literal wrappers to get the DOM to render the sentences as a single string.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35472


## Testing done
tested with mac voice over.


