### PR TITLE
CST: Fix some linting issues

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -54,7 +54,6 @@ export const DONE_UPLOADING = 'DONE_UPLOADING';
 export const SET_PROGRESS = 'SET_PROGRESS';
 export const SET_UPLOAD_ERROR = 'SET_UPLOAD_ERROR';
 export const UPDATE_FIELD = 'UPDATE_FIELD';
-export const SHOW_MAIL_MESSAGE = 'SHOW_MAIL_MESSAGE';
 export const CANCEL_UPLOAD = 'CANCEL_UPLOAD';
 export const SET_FIELDS_DIRTY = 'SET_FIELD_DIRTY';
 export const SHOW_CONSOLIDATED_MODAL = 'SHOW_CONSOLIDATED_MODAL';
@@ -569,13 +568,6 @@ export function updateField(path, field) {
     type: UPDATE_FIELD,
     path,
     field,
-  };
-}
-
-export function showMailMessageModal(visible) {
-  return {
-    type: SHOW_MAIL_MESSAGE,
-    visible,
   };
 }
 

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -11,7 +11,6 @@ import TextInput from '@department-of-veterans-affairs/component-library/TextInp
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
-import recordEvent from 'platform/monitoring/record-event';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   readAndCheckFile,
@@ -21,7 +20,7 @@ import {
 } from 'platform/forms-system/src/js/utilities/file';
 
 import UploadStatus from './UploadStatus';
-import MailMessage from './MailMessage';
+import mailMessage from './MailMessage';
 import { displayFileSize, DOC_TYPES, getTopPosition } from '../utils/helpers';
 import { getScrollOptions } from 'platform/utilities/ui';
 import {
@@ -163,19 +162,9 @@ class AddFilesForm extends React.Component {
       <div>
         <div>
           <p>
-            <a
-              href="#"
-              onClick={evt => {
-                evt.preventDefault();
-                recordEvent({
-                  event: 'claims-mailfax-modal',
-                });
-                this.props.onShowMailMessage(true);
-              }}
-            >
-              Need to mail your files
-            </a>
-            ?
+            <va-additional-info trigger="Need to mail your files?">
+              {mailMessage}
+            </va-additional-info>
           </p>
         </div>
         <Element name="filesList" />
@@ -322,16 +311,6 @@ class AddFilesForm extends React.Component {
             />
           }
         />
-        <Modal
-          onClose={() => true}
-          visible={this.props.showMailMessage}
-          hideCloseButton
-          focusSelector="button"
-          cssClass=""
-          contents={
-            <MailMessage onClose={() => this.props.onShowMailMessage(false)} />
-          }
-        />
       </div>
     );
   }
@@ -341,7 +320,6 @@ AddFilesForm.propTypes = {
   files: PropTypes.array.isRequired,
   field: PropTypes.object.isRequired,
   uploading: PropTypes.bool,
-  showMailMessage: PropTypes.bool,
   backUrl: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   onAddFile: PropTypes.func.isRequired,

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -180,18 +180,16 @@ export default class ClaimPhase extends React.Component {
 
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-      <li
-        onClick={e => {
-          e.preventDefault();
-          this.expandCollapse();
-        }}
-        className={`${getClasses(phase, current)}`}
-      >
+      <li className={`${getClasses(phase, current)}`}>
         {expandCollapseIcon}
         <h3 className="section-header vads-u-font-size--h4">
           <button
             className="section-header-button"
             aria-expanded={this.state.open}
+            onClick={e => {
+              e.preventDefault();
+              this.expandCollapse();
+            }}
           >
             {getUserPhaseDescription(phase)}
           </button>

--- a/src/applications/claims-status/components/MailMessage.jsx
+++ b/src/applications/claims-status/components/MailMessage.jsx
@@ -1,41 +1,27 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function MailMessage({ onClose }) {
-  return (
-    <div>
-      <h3 className="claims-status-upload-header">Mail Instructions</h3>
-      <button
-        className="va-modal-close"
-        type="button"
-        aria-label="Close this modal"
-        onClick={onClose}
-      >
-        <i className="fas fa-times-circle" />
-      </button>
-      <p>
-        Please upload your documents online here to help us process your claim
-        quickly.
-      </p>
-      <p>If you can’t upload documents:</p>
-      <ol>
-        <li>Make copies of the documents.</li>
-        <li>Make sure you write your name and claim number on every page.</li>
-        <li>
-          Mail them to the{' '}
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="http://www.benefits.va.gov/COMPENSATION/mailingaddresses.asp"
-          >
-            VA Claims Intake Center.
-          </a>
-        </li>
-      </ol>
-    </div>
-  );
-}
+const mailMessage = (
+  <>
+    <p>
+      Please upload your documents online here to help us process your claim
+      quickly.
+    </p>
+    <p>If you can’t upload documents:</p>
+    <ol className="vads-u-padding-bottom--1">
+      <li>Make copies of the documents.</li>
+      <li>Make sure you write your name and claim number on every page.</li>
+      <li>
+        Mail them to the{' '}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="http://www.benefits.va.gov/COMPENSATION/mailingaddresses.asp"
+        >
+          VA Claims Intake Center.
+        </a>
+      </li>
+    </ol>
+  </>
+);
 
-MailMessage.propTypes = {
-  onClose: PropTypes.func.isRequired,
-};
+export default mailMessage;

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -15,7 +15,6 @@ import {
   removeFile,
   submitFiles,
   updateField,
-  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,
@@ -94,7 +93,6 @@ class AdditionalEvidencePage extends React.Component {
             progress={this.props.progress}
             uploading={this.props.uploading}
             files={this.props.files}
-            showMailMessage={this.props.showMailMessage}
             backUrl={this.props.lastPage || filesPath}
             onSubmit={() =>
               this.props.submitFiles(
@@ -106,7 +104,6 @@ class AdditionalEvidencePage extends React.Component {
             onAddFile={this.props.addFile}
             onRemoveFile={this.props.removeFile}
             onFieldChange={this.props.updateField}
-            onShowMailMessage={this.props.showMailMessageModal}
             onCancel={this.props.cancelUpload}
             onDirtyFields={this.props.setFieldsDirty}
           />
@@ -134,7 +131,6 @@ function mapStateToProps(state) {
     uploadError: claimsState.uploads.uploadError,
     uploadComplete: claimsState.uploads.uploadComplete,
     uploadField: claimsState.uploads.uploadField,
-    showMailMessage: claimsState.uploads.showMailMessage,
     lastPage: claimsState.routing.lastPage,
     message: claimsState.notifications.additionalEvidenceMessage,
   };
@@ -145,7 +141,6 @@ const mapDispatchToProps = {
   removeFile,
   submitFiles,
   updateField,
-  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -17,7 +17,6 @@ import {
   submitFiles,
   resetUploads,
   updateField,
-  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,
@@ -116,7 +115,6 @@ class DocumentRequestPage extends React.Component {
             progress={this.props.progress}
             uploading={this.props.uploading}
             files={this.props.files}
-            showMailMessage={this.props.showMailMessage}
             backUrl={this.props.lastPage || filesPath}
             onSubmit={() =>
               this.props.submitFiles(
@@ -128,13 +126,24 @@ class DocumentRequestPage extends React.Component {
             onAddFile={this.props.addFile}
             onRemoveFile={this.props.removeFile}
             onFieldChange={this.props.updateField}
-            onShowMailMessage={this.props.showMailMessageModal}
             onCancel={this.props.cancelUpload}
             onDirtyFields={this.props.setFieldsDirty}
           />
         </>
       );
     }
+
+    const docRequest = this.props.loading ? (
+      <span>Document request</span>
+    ) : (
+      <Link
+        to={`your-claims/${this.props.params.id}/document-request/${
+          trackedItem.id
+        }`}
+      >
+        Document request
+      </Link>
+    );
 
     return (
       <div>
@@ -144,17 +153,7 @@ class DocumentRequestPage extends React.Component {
             <div className="vads-l-col--12">
               <ClaimsBreadcrumbs>
                 <Link to={filesPath}>Status details</Link>
-                <Link
-                  to={
-                    !this.props.loading
-                      ? `your-claims/${this.props.params.id}/document-request/${
-                          trackedItem.id
-                        }`
-                      : ''
-                  }
-                >
-                  Document request
-                </Link>
+                {docRequest}
               </ClaimsBreadcrumbs>
             </div>
           </div>
@@ -191,7 +190,6 @@ function mapStateToProps(state, ownProps) {
     uploadError: claimsState.uploads.uploadError,
     uploadComplete: claimsState.uploads.uploadComplete,
     uploadField: claimsState.uploads.uploadField,
-    showMailMessage: claimsState.uploads.showMailMessage,
     lastPage: claimsState.routing.lastPage,
     message: claimsState.notifications.message,
   };
@@ -202,7 +200,6 @@ const mapDispatchToProps = {
   removeFile,
   submitFiles,
   updateField,
-  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,

--- a/src/applications/claims-status/reducers/uploads.js
+++ b/src/applications/claims-status/reducers/uploads.js
@@ -8,7 +8,6 @@ import {
   DONE_UPLOADING,
   SET_UPLOAD_ERROR,
   UPDATE_FIELD,
-  SHOW_MAIL_MESSAGE,
   CANCEL_UPLOAD,
   SET_FIELDS_DIRTY,
   SET_UPLOADER,
@@ -23,7 +22,6 @@ const initialState = {
   uploadComplete: false,
   uploadError: false,
   uploadField: makeField(''),
-  showMailMessage: false,
   uploader: null,
 };
 
@@ -85,9 +83,6 @@ export default function claimDetailReducer(state = initialState, action) {
     }
     case UPDATE_FIELD: {
       return set(action.path, action.field, state);
-    }
-    case SHOW_MAIL_MESSAGE: {
-      return set('showMailMessage', action.visible, state);
     }
     case CANCEL_UPLOAD: {
       return {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -549,6 +549,9 @@ h1:focus {
   padding-top: 0;
 
   .section-header-button {
+    width: 100%;
+    position: relative;
+    top: -1rem;
     background: inherit;
     border: inherit;
     color: inherit;
@@ -562,7 +565,7 @@ h1:focus {
     padding: inherit;
     z-index: inherit;
     text-align: left;
-    padding-top: 0;
+    padding: 1rem;
   }
 
   .section-header-button:focus {
@@ -592,10 +595,10 @@ h1:focus {
     }
   }
 
-  > .section-current,
-  > .section-complete {
-    cursor: pointer;
-  }
+  // > .section-current,
+  // > .section-complete {
+  //   cursor: pointer;
+  // }
 }
 
 .usa-alert {

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -44,9 +44,7 @@ import {
   setAdditionalEvidenceNotification,
   setUnavailable,
   SHOW_CONSOLIDATED_MODAL,
-  SHOW_MAIL_MESSAGE,
   showConsolidatedMessage,
-  showMailMessageModal,
   SUBMIT_DECISION_REQUEST,
   submitRequest,
   UPDATE_FIELD,
@@ -163,16 +161,6 @@ describe('Actions', () => {
         type: UPDATE_FIELD,
         path: 'path',
         field: 'field',
-      });
-    });
-  });
-  describe('showMailMessageModal', () => {
-    it('should return the correct action object', () => {
-      const action = showMailMessageModal(true);
-
-      expect(action).to.eql({
-        type: SHOW_MAIL_MESSAGE,
-        visible: true,
       });
     });
   });

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -70,7 +70,7 @@ describe('<AddFilesForm>', () => {
     expect(tree.everySubTree('Modal')[0].props.visible).to.be.true;
   });
 
-  it('should show mail modal', () => {
+  it('should show mail info', () => {
     const files = [];
     const field = { value: '', dirty: false };
     const onSubmit = sinon.spy();
@@ -82,7 +82,6 @@ describe('<AddFilesForm>', () => {
 
     const tree = SkinDeep.shallowRender(
       <AddFilesForm
-        showMailMessage
         files={files}
         field={field}
         onSubmit={onSubmit}
@@ -93,7 +92,7 @@ describe('<AddFilesForm>', () => {
         onDirtyFields={onDirtyFields}
       />,
     );
-    expect(tree.everySubTree('Modal')[1].props.visible).to.be.true;
+    expect(tree.everySubTree('va-additional-info')[1].props.visible).to.be.true;
   });
 
   it('should not submit if files empty', () => {

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -41,7 +41,6 @@ describe('<AddFilesForm>', () => {
     );
     expect(tree.everySubTree('FileInput')).not.to.be.empty;
     expect(tree.everySubTree('Modal')[0].props.visible).to.be.false;
-    expect(tree.everySubTree('Modal')[1].props.visible).to.be.false;
   });
 
   it('should show uploading modal', () => {
@@ -70,7 +69,7 @@ describe('<AddFilesForm>', () => {
     expect(tree.everySubTree('Modal')[0].props.visible).to.be.true;
   });
 
-  it('should show mail info', () => {
+  it('should include mail info additional info', () => {
     const files = [];
     const field = { value: '', dirty: false };
     const onSubmit = sinon.spy();
@@ -92,7 +91,7 @@ describe('<AddFilesForm>', () => {
         onDirtyFields={onDirtyFields}
       />,
     );
-    expect(tree.everySubTree('va-additional-info')[1].props.visible).to.be.true;
+    expect(tree.everySubTree('va-additional-info')[0]).to.exist;
   });
 
   it('should not submit if files empty', () => {

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -165,7 +165,7 @@ class TrackClaimsPage {
   }
 
   verifyClosedClaim() {
-    cy.get('li.list-one')
+    cy.get('li.list-one .section-header-button')
       .click()
       .then(() => {
         cy.get('li.list-one .claims-evidence', {

--- a/src/applications/claims-status/tests/reducers/uploads.unit.spec.jsx
+++ b/src/applications/claims-status/tests/reducers/uploads.unit.spec.jsx
@@ -11,7 +11,6 @@ import {
   DONE_UPLOADING,
   SET_UPLOAD_ERROR,
   UPDATE_FIELD,
-  SHOW_MAIL_MESSAGE,
   CANCEL_UPLOAD,
   SET_FIELDS_DIRTY,
 } from '../../actions';
@@ -165,18 +164,6 @@ describe('Uploads reducer', () => {
     );
 
     expect(state.uploadField.value).to.equal('test');
-  });
-
-  it('toggle mail modal', () => {
-    const state = uploads(
-      {},
-      {
-        type: SHOW_MAIL_MESSAGE,
-        visible: true,
-      },
-    );
-
-    expect(state.showMailMessage).to.be.true;
   });
 
   it('cancel upload', () => {


### PR DESCRIPTION
## Description

Accessibility linting rules have been enabled to show as warnings. This PR fixes 2/11 problems:

- [x] `src/applications/claims-status/components/AddFilesForm.jsx`
  166:13  error  Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid

In `AddFilesForm`, a link was set up to open a modal, but since changing the link to a button didn't fit the design, I opted to move the modal content into a `va-additional-info` component. All associated action and props have been removed

- [x] `src/applications/claims-status/components/ClaimPhase.jsx`
  183:7  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events

In `ClaimPhase`, the `<li>` was clickable. When clicked it toggled content within the list item. A clickable button already contained within the `<li>` was made to extend the width.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36054

## Testing done

Manual

## Screenshots

<details><summary>AddFilesForm additional info</summary>
<img width="555" alt="Screen Shot 2022-01-28 at 8 29 16 AM" src="https://user-images.githubusercontent.com/136959/151597087-fd276cdc-8960-4840-b9ed-89cdbbd312c2.png"></details>

<details><summary>ClaimPhase toggle</summary>
Before
<img width="515" alt="Screen Shot 2022-01-28 at 9 14 16 AM" src="https://user-images.githubusercontent.com/136959/151597081-83902987-218d-49ba-b837-57e51c240909.png">
<p>After</p>
<img width="503" alt="Screen Shot 2022-01-28 at 9 08 40 AM" src="https://user-images.githubusercontent.com/136959/151597085-a959dcf7-4b87-433d-b927-8dcf290ba136.png">

Note: It would be possible to expand the button clickable area to cover both the icon on the left and the right, but it may not work the same in all browsers.</details>

## Acceptance criteria
- [x] Mail info modal content moved to additional info
- [x] Remove clickable `<li>` code & expand button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
