### PR TITLE
add relative file paths from manifest to app list

### DIFF
--- a/.github/workflows/init-data-repo/action.yml
+++ b/.github/workflows/init-data-repo/action.yml
@@ -10,6 +10,7 @@ runs:
         repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
         path: testing-tools-team-dashboard-data
+        ref: qas-add-app-file-paths
 
     - name: Get Node version
       id: get-node-version

--- a/.github/workflows/init-data-repo/action.yml
+++ b/.github/workflows/init-data-repo/action.yml
@@ -10,7 +10,6 @@ runs:
         repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
         path: testing-tools-team-dashboard-data
-        ref: qas-add-app-file-paths
 
     - name: Get Node version
       id: get-node-version

--- a/script/github-actions/generate-app-list.js
+++ b/script/github-actions/generate-app-list.js
@@ -4,7 +4,11 @@ const { getAppManifests } = require('../../config/manifest-helpers');
 
 function exportAppList() {
   const applicationList = getAppManifests().map(app => {
-    return [app.appName, app.entryName];
+    return [
+      app.appName,
+      app.entryName,
+      app.filePath.substring(app.filePath.indexOf('src')),
+    ];
   });
   core.exportVariable('APPLICATION_LIST', applicationList);
 }


### PR DESCRIPTION
## Description
This PR adds the file paths to the app list that's generated off our manifests. This will allow us to link the manifests to the appropriate test results by the path of the spec and allow us to proceed with our dashboarding efforts.


## Testing done
App list generates and has appropriate properties in CI.



## Acceptance criteria
- [x] App list generates and has appropriate filepath added to each application.


