### PR TITLE
removed slot.start and slot.end

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -150,6 +150,10 @@ export function transformFormToVAOSAppointment(state) {
   const clinic = getChosenClinicInfo(state);
   const slot = getChosenSlot(state);
 
+  // slot start and end times are not allowed on a booked va appointment.
+  delete slot.start;
+  delete slot.end;
+
   return {
     kind: 'clinic',
     status: 'booked',

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
@@ -1,0 +1,121 @@
+import { expect } from 'chai';
+
+import { transformFormToVAOSAppointment } from '../../../../new-appointment/redux/helpers/formSubmitTransformers.v2';
+import { VHA_FHIR_ID } from '../../../../utils/constants';
+
+describe('VAOS V2 data transformation', () => {
+  it('remove slot.start and slot.end from new appointment object', () => {
+    const state = {
+      user: {
+        profile: {
+          vapContactInfo: {},
+        },
+      },
+      newAppointment: {
+        data: {
+          phoneNumber: '5035551234',
+          bestTimeToCall: {
+            morning: true,
+          },
+          email: 'test@va.gov',
+          reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: 'asdfasdf',
+          selectedDates: ['2019-11-22T09:30:00'],
+          preferredDate: '2019-12-02',
+          clinicId: '983_308',
+          vaParent: '983',
+          vaFacility: '983',
+          facilityType: 'vamc',
+          typeOfCareId: '323',
+        },
+        availableSlots: [
+          {
+            start: '2019-12-22T09:30:00',
+            end: '2019-12-22T10:00:00',
+          },
+          {
+            start: '2019-11-22T09:30:00',
+            end: '2019-11-22T10:00:00',
+          },
+        ],
+        parentFacilities: [
+          {
+            id: '983',
+            identifier: [
+              {
+                system: VHA_FHIR_ID,
+                value: '983',
+              },
+            ],
+            address: {
+              city: 'Cheyenne',
+              state: 'WY',
+            },
+          },
+        ],
+        facilities: {
+          '323': [
+            {
+              id: '983',
+              identifier: [
+                {
+                  system: VHA_FHIR_ID,
+                  value: '983',
+                },
+              ],
+              name: 'Cheyenne VA Medical Center',
+              address: {
+                city: 'Cheyenne',
+                state: 'WY',
+              },
+              legacyVAR: {
+                institutionTimezone: 'America/Denver',
+              },
+            },
+          ],
+        },
+        clinics: {
+          '983_323': [
+            {
+              id: '983_308',
+              serviceName: 'Green Team Clinic1',
+              stationId: '983',
+              stationName: 'CHYSHR-Cheyenne VA Medical Center',
+            },
+          ],
+        },
+      },
+      featureToggles: {},
+    };
+
+    const stateWithSlotId = {
+      ...state,
+      newAppointment: {
+        ...state.newAppointment,
+        availableSlots: [
+          { ...state.newAppointment.availableSlots[0], id: 'test' },
+          { ...state.newAppointment.availableSlots[1], id: 'test2' },
+        ],
+      },
+    };
+
+    const data = transformFormToVAOSAppointment(stateWithSlotId);
+    expect(data).to.deep.equal({
+      kind: 'clinic',
+      status: 'booked',
+      clinic: '308',
+      slot: {
+        id: 'test2',
+      },
+      extension: { desiredDate: '2019-12-02T00:00:00+00:00' },
+      locationId: '983',
+      comment: 'Follow-up/Routine: asdfasdf',
+      contact: {
+        telecom: [
+          { type: 'phone', value: '5035551234' },
+          { type: 'email', value: 'test@va.gov' },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description
When submitting a va booked appointment the following fields are not allowed:
slot.start
slot.end

These fields were removed from the request body


## Original issue(s)
department-of-veterans-affairs/va.gov-team#36103


## Testing done
A unit test was added to reflect this change

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
