### PR TITLE
Fix CSS for TTY details in crisis line modal

### DIFF
--- a/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
+++ b/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
@@ -67,10 +67,12 @@ export default function CrisisPanel() {
                 className="fa fa-deaf va-crisis-panel-icon"
                 aria-hidden="true"
               />
-              Call TTY if you have hearing loss
-              <strong className="vads-u-margin-left--0p5">
-                <Telephone contact={CONTACTS.SUICIDE_PREVENTION_LIFELINE} />
-              </strong>
+              <p>
+                Call TTY if you have hearing loss
+                <strong className="vads-u-margin-left--0p5">
+                  <Telephone contact={CONTACTS.SUICIDE_PREVENTION_LIFELINE} />
+                </strong>
+              </p>
             </li>
           </ul>
           Get more resources at{' '}


### PR DESCRIPTION
## Description
This PR fixes the TTY phone number section of the crisis line modal so that it appears vertically centered.

## Screenshots

Before:

<img width="760" alt="Screen Shot 2022-01-31 at 2 01 10 PM" src="https://user-images.githubusercontent.com/3535749/151864160-18a8070e-9edb-4421-b887-0fc9129446e0.png">

After:

<img width="758" alt="Screen Shot 2022-01-31 at 1 57 39 PM" src="https://user-images.githubusercontent.com/3535749/151864181-6268e0c3-05eb-4f16-b706-fbe7e67ef621.png">

## Acceptance criteria
- [ ] CI passes.

## Testing done
Manual testing.