### PR TITLE
35975 auth profile remove fax

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/phone-numbers/PhoneNumbersTable.jsx
+++ b/src/applications/personalization/profile/components/contact-information/phone-numbers/PhoneNumbersTable.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 
 import ProfileInfoTable from '../../ProfileInfoTable';
 
-const PhoneNumbersTable = ({ className }) => (
-  <ProfileInfoTable
-    title="Phone numbers"
-    level={2}
-    namedAnchor="phone-numbers"
-    data={[
+import { profileShowFaxNumber } from '@@profile/selectors';
+
+const PhoneNumbersTable = ({ className, shouldProfileShowFaxNumber }) => {
+  const tableFields = [
+    ...[
       {
         title: 'Home',
         id: FIELD_IDS[FIELD_NAMES.HOME_PHONE],
@@ -39,22 +39,41 @@ const PhoneNumbersTable = ({ className }) => (
           />
         ),
       },
-      {
-        title: 'Fax',
-        id: FIELD_IDS[FIELD_NAMES.FAX_NUMBER],
-        value: (
-          <ProfileInformationFieldController
-            fieldName={FIELD_NAMES.FAX_NUMBER}
-          />
-        ),
-      },
-    ]}
-    className={className}
-  />
-);
+    ],
+    ...(shouldProfileShowFaxNumber
+      ? [
+          {
+            title: 'Fax',
+            id: FIELD_IDS[FIELD_NAMES.FAX_NUMBER],
+            value: (
+              <ProfileInformationFieldController
+                fieldName={FIELD_NAMES.FAX_NUMBER}
+              />
+            ),
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <ProfileInfoTable
+      title="Phone numbers"
+      level={2}
+      namedAnchor="phone-numbers"
+      data={tableFields}
+      className={className}
+    />
+  );
+};
 
 PhoneNumbersTable.propTypes = {
   className: PropTypes.string,
 };
 
-export default PhoneNumbersTable;
+export const mapStateToProps = state => {
+  return {
+    shouldProfileShowFaxNumber: profileShowFaxNumber(state),
+  };
+};
+
+export default connect(mapStateToProps)(PhoneNumbersTable);

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -86,6 +86,9 @@ export const profileShowAddressChangeModal = state =>
   toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowAddressChangeModal] ||
   false;
 
+export const profileShowFaxNumber = state =>
+  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowFaxNumber];
+
 export function selectVAProfilePersonalInformation(state, fieldName) {
   const fieldValue = state?.vaProfile?.personalInformation?.[fieldName];
 

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -16,6 +16,13 @@ import {
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
+// the list of number fields that we need to test
+const numbers = [
+  FIELD_NAMES.HOME_PHONE,
+  FIELD_NAMES.MOBILE_PHONE,
+  FIELD_NAMES.WORK_PHONE,
+];
+
 const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 const newAreaCode = '415';
 const newPhoneNumber = '555-0055';
@@ -80,8 +87,12 @@ async function testQuickSuccess(numberName) {
   ).to.exist;
   // and the new number should exist in the DOM
   // TODO: make better assertions for this?
-  expect(view.getAllByText(newAreaCode, { exact: false }).length).to.eql(4);
-  expect(view.getAllByText(newPhoneNumber, { exact: false }).length).to.eql(4);
+  expect(view.getAllByText(newAreaCode, { exact: false }).length).to.eql(
+    numbers.length,
+  );
+  expect(view.getAllByText(newPhoneNumber, { exact: false }).length).to.eql(
+    numbers.length,
+  );
   // and the 'add' button should be gone
   expect(
     view.queryByText(new RegExp(`new.*${numberName}`, 'i'), {
@@ -118,8 +129,12 @@ async function testSlowSuccess(numberName) {
   ).to.exist;
   // and the updated phone numbers should be in the DOM
   // TODO: make better assertions for this?
-  expect(view.getAllByText(newAreaCode, { exact: false }).length).to.eql(4);
-  expect(view.getAllByText(newPhoneNumber, { exact: false }).length).to.eql(4);
+  expect(view.getAllByText(newAreaCode, { exact: false }).length).to.eql(
+    numbers.length,
+  );
+  expect(view.getAllByText(newPhoneNumber, { exact: false }).length).to.eql(
+    numbers.length,
+  );
   // and the 'add' button should be gone
   expect(
     view.queryByText(new RegExp(`new.*${numberName}`, 'i'), {
@@ -216,14 +231,6 @@ describe('Editing', () => {
   after(() => {
     server.close();
   });
-
-  // the list of number fields that we need to test
-  const numbers = [
-    FIELD_NAMES.HOME_PHONE,
-    FIELD_NAMES.MOBILE_PHONE,
-    FIELD_NAMES.WORK_PHONE,
-    FIELD_NAMES.FAX_NUMBER,
-  ];
 
   numbers.forEach(number => {
     const numberName = FIELD_TITLES[number];

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -82,7 +82,6 @@ describe('PersonalInformation', () => {
     expect(view.getByText('804-205-5544, ext. 17747')).to.exist;
     expect(view.getByText('214-718-2112', { exact: false })).to.exist;
 
-    expect(view.getByText(/to add a fax number/i)).to.exist;
     expect(view.getByText(/alongusername/)).to.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/focus-management.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/focus-management.cypress.spec.js
@@ -76,17 +76,6 @@ describe('Contact info fields', () => {
       'be.focused',
     );
 
-    cy.findByRole('button', { name: /edit fax.*number/i }).click();
-    cy.findByLabelText(/fax.*number/i).should('be.focused');
-    cy.axeCheck();
-    cy.findByRole('button', { name: /cancel/i }).click();
-    // We have to click the cancel button twice because the fax number input is
-    // empty. Since that field is given focus and it is a required field, once
-    // you blur the input, form validation is triggered and results in a
-    // validation error.
-    cy.findByRole('button', { name: /cancel/i }).click();
-    cy.findByRole('button', { name: /edit fax.*number/i }).should('be.focused');
-
     cy.findByRole('button', { name: /edit contact email/i }).click();
     cy.findByLabelText(/email address/i).should('be.focused');
     cy.axeCheck();

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -68,6 +68,7 @@ export default Object.freeze({
   profileNotificationSettings: 'profile_notification_settings',
   profileEnhancements: 'profile_enhancements',
   profileShowAddressChangeModal: 'profile_show_address_change_modal',
+  profileShowFaxNumber: 'profile_show_fax_number',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',
   searchTypeaheadEnabled: 'search_typeahead_enabled',


### PR DESCRIPTION
## Description
Removes the fax number section of the Profile page depending on a feature flag.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35975

## Testing done
E2E and Unit tests updated for removal of the field


## Acceptance criteria
- [x] Fax field is not displayed on the user profile

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
