### PR TITLE
NOD/HLR v2: Add next step instructions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,7 +135,7 @@ module.exports = {
     'react/no-string-refs': 1,
     'react/button-has-type': 1,
     'react/jsx-props-no-spreading': 1,
-    'react/jsx-one-expression-per-line': 1,
+    'react/jsx-one-expression-per-line': 0,
     'react/destructuring-assignment': 1,
     'react/prop-types': 1,
     'react/jsx-sort-props': [0, { callbacksLast: true, shorthandFirst: true }],

--- a/src/applications/appeals/10182/content/contestableIssues.jsx
+++ b/src/applications/appeals/10182/content/contestableIssues.jsx
@@ -12,12 +12,18 @@ import { MAX_SELECTIONS } from '../constants';
 export const ContestableIssuesTitle = props => {
   if (props?.formData?.contestableIssues?.length === 0) {
     return (
-      <h2
-        className="vads-u-font-size--h4 vads-u-margin-top--0"
-        name="eligibleScrollElement"
-      >
-        Sorry, we couldn’t find any eligible issues
-      </h2>
+      <>
+        <h2
+          className="vads-u-font-size--h4 vads-u-margin-top--0"
+          name="eligibleScrollElement"
+        >
+          Sorry, we couldn’t find any eligible issues
+        </h2>
+        <p>
+          If you’d like to add an issue for review, please select "Add a new
+          issue" to get started.
+        </p>
+      </>
     );
   }
   return (

--- a/src/applications/disability-benefits/996/content/contestableIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssues.jsx
@@ -21,12 +21,18 @@ import DownloadLink from './DownloadLink';
 export const ContestableIssuesTitle = props => {
   if (props?.formData?.contestedIssues?.length === 0) {
     return (
-      <h2
-        className="vads-u-font-size--h4 vads-u-margin-top--0"
-        name="eligibleScrollElement"
-      >
-        Sorry, we couldn’t find any eligible issues
-      </h2>
+      <>
+        <h2
+          className="vads-u-font-size--h4 vads-u-margin-top--0"
+          name="eligibleScrollElement"
+        >
+          Sorry, we couldn’t find any eligible issues
+        </h2>
+        <p>
+          If you’d like to add an issue for review, please select "Add a new
+          issue" to get started.
+        </p>
+      </>
     );
   }
   return (
@@ -84,7 +90,7 @@ const disabilitiesList = (
       </li>
     </ul>
     <p>
-      <DownloadLink content={'Download VA Form 20-0996'} />
+      <DownloadLink content="Download VA Form 20-0996" />
     </p>
     <p className="vads-u-margin-top--2p5">
       To learn more about how COVID-19 may affect claims or appeals, please

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -23,9 +23,15 @@ import { apiVersion2 } from '../utils/helpers';
 export const ContestedIssuesTitle = props => {
   if (props?.formData?.contestedIssues?.length === 0) {
     return (
-      <h2 className="vads-u-font-size--h4" name="eligibleScrollElement">
-        Sorry, we couldn’t find any eligible issues
-      </h2>
+      <>
+        <h2 className="vads-u-font-size--h4" name="eligibleScrollElement">
+          Sorry, we couldn’t find any eligible issues
+        </h2>
+        <p>
+          If you’d like to add an issue for review, please select "Add a new
+          issue" to get started.
+        </p>
+      </>
     );
   }
   return apiVersion2(props.formData) ? (
@@ -133,7 +139,7 @@ const disabilitiesList = (
       </li>
     </ul>
     <p>
-      <DownloadLink content={'Download VA Form 20-0996'} />
+      <DownloadLink content="Download VA Form 20-0996" />
     </p>
     <p className="vads-u-margin-top--2p5">
       To learn more about how COVID-19 affect claims or appeals, please visit


### PR DESCRIPTION
## Description

Add next step instructions when a Veteran doesn't have any eligible issues load in from the API

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36229

## Testing done

N/A

## Screenshots

<details><summary>Before</summary>

![](https://user-images.githubusercontent.com/136959/151855520-a3ff6b23-dad8-4ca2-95b1-ed964b58d250.png)</details>

<details><summary>After</summary>

![Screen Shot 2022-01-31 at 2 54 12 PM](https://user-images.githubusercontent.com/136959/151880208-0936e797-2d10-4c73-9611-56b88fdab023.png)</details>

## Acceptance criteria
- [x] Add next step instructions
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
