### PR TITLE
[35036] Add city and state to the compare checkbox

### DIFF
--- a/src/applications/gi/components/CompareCheckbox.jsx
+++ b/src/applications/gi/components/CompareCheckbox.jsx
@@ -5,9 +5,9 @@ export default function CompareCheckbox({
   institution,
   compareChecked,
   handleCompareUpdate,
-  facilityCode,
+  cityState,
 }) {
-  const name = `Compare ${institution} ${facilityCode}`;
+  const name = `Compare ${institution} ${cityState}`;
   return (
     <div className="vads-u-padding--0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5">
       <Checkbox

--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -323,7 +323,7 @@ export function ResultCard({
             <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0">
               <CompareCheckbox
                 institution={name}
-                facilityCode={institution.facilityCode}
+                cityState={`${city}${state && `, ${state}`}`}
                 compareChecked={compareChecked}
                 handleCompareUpdate={handleCompareUpdate}
               />


### PR DESCRIPTION
## Description

- Fixes an issue with the screen reader for the result card checkbox

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35036


## Testing done

- local

## Acceptance criteria
- [ ] The screen reader properly reads the check box with Institution Name, City, and then State

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
