### PR TITLE
Removed contact info from va booked appt requests

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -168,17 +168,5 @@ export function transformFormToVAOSAppointment(state) {
     },
     locationId: data.vaFacility,
     comment: getUserMessage(data),
-    contact: {
-      telecom: [
-        {
-          type: 'phone',
-          value: data.phoneNumber,
-        },
-        {
-          type: 'email',
-          value: data.email,
-        },
-      ],
-    },
   };
 }

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -397,18 +397,6 @@ describe('VAOS <ReviewPage> direct scheduling with v2 api', () => {
       extension: {
         desiredDate: '2021-05-06T00:00:00+00:00',
       },
-      contact: {
-        telecom: [
-          {
-            type: 'phone',
-            value: '2234567890',
-          },
-          {
-            type: 'email',
-            value: 'joeblow@gmail.com',
-          },
-        ],
-      },
       slot: store.getState().newAppointment.availableSlots[0],
     });
   });

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
@@ -114,12 +114,6 @@ describe('VAOS V2 data transformation', () => {
         extension: { desiredDate: '2019-12-02T00:00:00+00:00' },
         locationId: '983',
         comment: 'Follow-up/Routine: asdfasdf',
-        contact: {
-          telecom: [
-            { type: 'phone', value: '5035551234' },
-            { type: 'email', value: 'test@va.gov' },
-          ],
-        },
       });
     });
   });


### PR DESCRIPTION
## Description
VA booked appointments is failing with contact info should be null error. Removed contact info from VA booked appointment request body.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36285


## Testing done
Updated unit tests to reflect change.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
