### PR TITLE
36223: [Debt Letters] eslint (react/prop-types)

### DIFF
--- a/src/applications/debt-letters/actions/index.js
+++ b/src/applications/debt-letters/actions/index.js
@@ -1,8 +1,7 @@
+import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
 import recordEvent from '~/platform/monitoring/record-event';
 import { apiRequest } from '~/platform/utilities/api';
 import environment from '~/platform/utilities/environment';
-import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
-
 import { debtMockResponse, debtMockResponseVBMS } from '../utils/mockResponses';
 import { deductionCodes } from '../const/deduction-codes';
 

--- a/src/applications/debt-letters/components/Alerts.jsx
+++ b/src/applications/debt-letters/components/Alerts.jsx
@@ -17,10 +17,10 @@ export const DownloadLettersAlert = () => (
       We’re sorry. The length of time listed for repayment plans in these
       letters is too short. Use the letters you get in the mail to find the
       correct repayment plan terms. If you have any questions, call us at
-      <Telephone contact={'800-827-0648'} className="vads-u-margin-x--0p5" />
+      <Telephone contact="800-827-0648" className="vads-u-margin-x--0p5" />
       (or
       <Telephone
-        contact={'1-612-713-6415'}
+        contact="1-612-713-6415"
         pattern={PATTERNS.OUTSIDE_US}
         className="vads-u-margin-x--0p5"
       />

--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import DebtLetterCard from './DebtLetterCard';
-import { ErrorMessage, DowntimeMessage } from './Alerts';
 import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
+import DebtLetterCard from './DebtLetterCard';
+import { ErrorMessage, DowntimeMessage } from './Alerts';
 
 const DebtCardsList = ({ debts, errors }) => {
   const error = errors.length ? errors[0] : [];
@@ -78,13 +78,10 @@ const DebtCardsList = ({ debts, errors }) => {
         <p className="vads-u-font-family--sans">
           If you received a letter about a VA benefit debt that isn’t listed
           here, call us at
-          <Telephone
-            contact={'800-827-0648'}
-            className="vads-u-margin-x--0p5"
-          />
+          <Telephone contact="800-827-0648" className="vads-u-margin-x--0p5" />
           (or
           <Telephone
-            contact={'1-612-713-6415'}
+            contact="1-612-713-6415"
             pattern={PATTERNS.OUTSIDE_US}
             className="vads-u-margin-x--0p5"
           />
@@ -128,12 +125,12 @@ DebtCardsList.propTypes = {
       fileNumber: PropTypes.string,
     }),
   ),
-  errors: PropTypes.array.isRequired,
+  errors: PropTypes.array,
 };
 
 DebtCardsList.defaultProps = {
-  debts: [],
   errors: [],
+  debts: [],
 };
 
 const mapStateToProps = ({ debtLetters }) => ({

--- a/src/applications/debt-letters/components/DebtDetails.jsx
+++ b/src/applications/debt-letters/components/DebtDetails.jsx
@@ -10,11 +10,11 @@ import Breadcrumbs from '@department-of-veterans-affairs/component-library/Bread
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
 import NeedHelp from './NeedHelp';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { setPageFocus, getCurrentDebt, currency } from '../utils/page';
-import { OnThisPageLinks } from './OnThisPageLinks';
+import OnThisPageLinks from './OnThisPageLinks';
 import { renderAdditionalInfo } from '../const/diary-codes';
 import HistoryTable from './HistoryTable';
 import {
@@ -179,6 +179,7 @@ DebtDetails.defaultProps = {
 };
 
 DebtDetails.propTypes = {
+  debts: PropTypes.array,
   selectedDebt: PropTypes.shape({
     currentAr: PropTypes.number,
     debtHistory: PropTypes.arrayOf(
@@ -188,7 +189,7 @@ DebtDetails.propTypes = {
     ),
     deductionCode: PropTypes.string,
     originalAr: PropTypes.number,
-  }).isRequired,
+  }),
 };
 
 export default connect(mapStateToProps)(DebtDetails);

--- a/src/applications/debt-letters/components/DebtLetterCard.jsx
+++ b/src/applications/debt-letters/components/DebtLetterCard.jsx
@@ -89,7 +89,11 @@ DebtLetterCard.propTypes = {
     ),
     deductionCode: PropTypes.string,
     originalAr: PropTypes.number,
+    benefitType: PropTypes.string,
+    diaryCode: PropTypes.string,
+    fileNumber: PropTypes.string,
   }),
+  setActiveDebt: PropTypes.func,
 };
 
 DebtLetterCard.defaultProps = {

--- a/src/applications/debt-letters/components/DebtLettersDownload.jsx
+++ b/src/applications/debt-letters/components/DebtLettersDownload.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-import { setPageFocus } from '../utils/page';
-import DebtLettersTable from './DebtLettersTable';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { DownloadLettersAlert } from './Alerts';
 import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
+import { setPageFocus } from '../utils/page';
+import DebtLettersTable from './DebtLettersTable';
+import { DownloadLettersAlert } from './Alerts';
 
 const DebtLettersDownload = ({
   debtLinks,
@@ -61,12 +61,12 @@ const DebtLettersDownload = ({
             If you’ve received a letter about a VA debt that isn’t listed here,
             call us at
             <Telephone
-              contact={'800-827-0648'}
+              contact="800-827-0648"
               className="vads-u-margin-x--0p5"
             />
             (or
             <Telephone
-              contact={'1-612-713-6415'}
+              contact="1-612-713-6415"
               pattern={PATTERNS.OUTSIDE_US}
               className="vads-u-margin-x--0p5"
             />
@@ -106,9 +106,6 @@ const mapStateToProps = ({ debtLetters }) => ({
 });
 
 DebtLettersDownload.propTypes = {
-  hasDependentDebts: PropTypes.bool.isRequired,
-  isVBMSError: PropTypes.bool.isRequired,
-  isError: PropTypes.bool.isRequired,
   debtLinks: PropTypes.arrayOf(
     PropTypes.shape({
       documentId: PropTypes.string,
@@ -116,6 +113,9 @@ DebtLettersDownload.propTypes = {
       typeDescription: PropTypes.string,
     }),
   ),
+  hasDependentDebts: PropTypes.bool,
+  isError: PropTypes.bool,
+  isVBMSError: PropTypes.bool,
 };
 
 DebtLettersDownload.defaultProps = {

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -7,7 +7,7 @@ import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
 import NeedHelp from './NeedHelp';
 import DebtCardsList from './DebtCardsList';
-import { OnThisPageLinks } from './OnThisPageLinks';
+import OnThisPageLinks from './OnThisPageLinks';
 
 const ErrorAlert = () => (
   <section
@@ -114,8 +114,6 @@ const mapStateToProps = state => ({
 });
 
 DebtLettersSummary.propTypes = {
-  isVBMSError: PropTypes.bool.isRequired,
-  isError: PropTypes.bool.isRequired,
   debtLinks: PropTypes.arrayOf(
     PropTypes.shape({
       documentId: PropTypes.string,
@@ -128,6 +126,8 @@ DebtLettersSummary.propTypes = {
       fileNumber: PropTypes.string,
     }),
   ),
+  isError: PropTypes.bool,
+  isVBMSError: PropTypes.bool,
 };
 
 DebtLettersSummary.defaultProps = {

--- a/src/applications/debt-letters/components/DebtLettersTable.jsx
+++ b/src/applications/debt-letters/components/DebtLettersTable.jsx
@@ -3,6 +3,7 @@ import Table from '@department-of-veterans-affairs/component-library/Table';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
+import PropTypes from 'prop-types';
 import { ErrorAlert, DependentDebt, NoDebtLinks } from './Alerts';
 
 const DebtLettersTable = ({ debtLinks, hasDependentDebts, isError }) => {
@@ -82,6 +83,18 @@ const DebtLettersTable = ({ debtLinks, hasDependentDebts, isError }) => {
   return (
     <Table data={tableData} currentSort={tableSort} fields={tableFields} />
   );
+};
+
+DebtLettersTable.propTypes = {
+  debtLinks: PropTypes.arrayOf(
+    PropTypes.shape({
+      documentId: PropTypes.string,
+      receivedAt: PropTypes.string,
+      typeDescription: PropTypes.string,
+    }),
+  ),
+  hasDependentDebts: PropTypes.bool,
+  isError: PropTypes.bool,
 };
 
 export default DebtLettersTable;

--- a/src/applications/debt-letters/components/DebtLettersWrapper.jsx
+++ b/src/applications/debt-letters/components/DebtLettersWrapper.jsx
@@ -70,8 +70,12 @@ const mapDispatchToProps = dispatch => ({
 });
 
 DebtLettersWrapper.propTypes = {
-  isPending: PropTypes.bool.isRequired,
-  isPendingVBMS: PropTypes.bool.isRequired,
+  children: PropTypes.array,
+  getDebtLetters: PropTypes.func,
+  isLoggedIn: PropTypes.bool,
+  isPending: PropTypes.bool,
+  isPendingVBMS: PropTypes.bool,
+  isProfileUpdating: PropTypes.bool,
   showDebtLetters: PropTypes.bool,
 };
 

--- a/src/applications/debt-letters/components/OnThisPageLinks.jsx
+++ b/src/applications/debt-letters/components/OnThisPageLinks.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
+const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
   <div>
     <h2>On this page</h2>
     <div className="vads-u-font-family--sans vads-u-display--flex vads-u-flex-direction--column">
@@ -61,3 +62,10 @@ export const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
     </div>
   </div>
 );
+
+OnThisPageLinks.propTypes = {
+  hasHistory: PropTypes.bool,
+  isDetailsPage: PropTypes.bool,
+};
+
+export default OnThisPageLinks;

--- a/src/applications/debt-letters/const/diary-codes/index.js
+++ b/src/applications/debt-letters/const/diary-codes/index.js
@@ -5,16 +5,14 @@ import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
-const ContactDMC = ({ className }) => (
-  <span className={className}>
-    {<Telephone contact={CONTACTS.DMC || '800-827-0648'} />} (or
-    {
-      <Telephone
-        className="vads-u-margin-x--0p5"
-        contact={CONTACTS.DMC_OVERSEAS || '1-612-713-6415'}
-        pattern={PATTERNS.OUTSIDE_US}
-      />
-    }
+const ContactDMC = () => (
+  <span className="vads-u-margin-x--0p5">
+    <Telephone contact={CONTACTS.DMC || '800-827-0648'} /> (or
+    <Telephone
+      className="vads-u-margin-x--0p5"
+      contact={CONTACTS.DMC_OVERSEAS || '1-612-713-6415'}
+      pattern={PATTERNS.OUTSIDE_US}
+    />
     from overseas)
   </span>
 );
@@ -40,9 +38,8 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
             >
               contact us online through Ask VA
             </a>
-            or call us at <ContactDMC className="vads-u-margin-x--0p5" /> to
-            verify your military status. We’re here Monday through Friday, 7:30
-            a.m. to 7:00 p.m. ET.
+            or call us at <ContactDMC /> to verify your military status. We’re
+            here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
           </p>
         ),
       };

--- a/src/applications/debt-letters/reducers/index.js
+++ b/src/applications/debt-letters/reducers/index.js
@@ -1,3 +1,5 @@
+import { FETCH_TOGGLE_VALUES_STARTED } from 'platform/site-wide/feature-toggles/actionTypes';
+import { UPDATE_LOGGEDIN_STATUS } from 'platform/user/authentication/actions';
 import {
   DEBTS_FETCH_INITIATED,
   DEBTS_FETCH_SUCCESS,
@@ -7,9 +9,6 @@ import {
   DEBT_LETTERS_FETCH_FAILURE,
   DEBT_LETTERS_FETCH_INITIATED,
 } from '../actions';
-
-import { FETCH_TOGGLE_VALUES_STARTED } from 'platform/site-wide/feature-toggles/actionTypes';
-import { UPDATE_LOGGEDIN_STATUS } from 'platform/user/authentication/actions';
 
 const initialState = {
   isProfileUpdating: true,

--- a/src/applications/debt-letters/routes.js
+++ b/src/applications/debt-letters/routes.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-
 import DebtLettersSummary from './components/DebtLettersSummary';
 import DebtLettersWrapper from './components/DebtLettersWrapper';
 import DebtDetails from './components/DebtDetails';

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -9,7 +9,6 @@ describe.skip('Debt Letters', () => {
     cy.intercept('GET', '/v0/debts', mockDebts);
     cy.visit('/manage-va-debt/your-debt/');
     cy.injectAxe();
-    cy.axeCheck();
   });
 
   it('C1033 displays the current debts section and navigates to debt details', () => {
@@ -19,6 +18,7 @@ describe.skip('Debt Letters', () => {
       .first()
       .click();
     cy.get('#debtLetterHistory').contains('Debt letter history');
+    cy.axeCheck();
   });
 
   it('C1034 displays download debt letters', () => {
@@ -27,20 +27,24 @@ describe.skip('Debt Letters', () => {
       selector: 'a',
     }).click();
     cy.get('#downloadDebtLetters').contains('Download debt letters');
+    cy.axeCheck();
   });
 
   it('C1035 displays how do I pay my VA debt?', () => {
     cy.findByText(/How do I pay my VA debt/i, { selector: 'a' }).click();
     cy.get('#howDoIPay').contains('How do I pay my VA debt?');
+    cy.axeCheck();
   });
 
   it('C1036 displays how do I get financial help?', () => {
     cy.findByText(/How do I get financial help/i, { selector: 'a' }).click();
     cy.get('#howDoIGetHelp').contains('How do I get financial help?');
+    cy.axeCheck();
   });
 
   it('C1037 displays how do I dispute a debt?', () => {
     cy.findByText(/How do I dispute a debt?/i, { selector: 'a' }).click();
     cy.get('#howDoIDispute').contains('How do I dispute a debt?');
+    cy.axeCheck();
   });
 });

--- a/src/applications/debt-letters/tests/e2e/diary-codes-content.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/diary-codes-content.cypress.spec.js
@@ -9,29 +9,28 @@ describe('Diary Codes', () => {
     cy.intercept('GET', '/v0/debts', mockDebts);
     cy.visit('/manage-va-debt/your-debt/');
     cy.injectAxe();
-    cy.axeCheck();
   });
 
   it('renders expected content for diary code: 080, 850, 852, 860, 855', () => {
     cy.get('[data-testid="diary-codes-status"]').contains(
       'Status: We referred this debt to the U.S. Department of the Treasury.',
     );
-
     cy.get('[data-testid="diary-code-080-next-step"]').should(
       'have.text',
       'Next step: Call the U.S. Department of the Treasury’s Debt Management Center at888-826-3127, 8:30 a.m. to 6:30 p.m. ET. Don’t send us payment directly. This will delay posting of payment to your account. And the Treasury Department may continue adding fees and interest.',
     );
+    cy.axeCheck();
   });
 
   it('renders expected content for diary code: 100, 102, 130, 140', () => {
     cy.get('[data-testid="diary-codes-status"]').contains(
       'Status: Your payment is due now.',
     );
-
     cy.get('[data-testid="diary-code-100-next-step"]').should(
       'have.text',
       'Next step: Please pay now or contact us to start making payments again to avoid collection actions. You cancontact us online through Ask VAor call us at 800-827-0648 (or+1-612-713-6415from overseas). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.Review payment options',
     );
+    cy.axeCheck();
   });
 
   it('renders expected content for diary code: 101, 602, 607, 608, 610, 611, 614, 615, 617', () => {
@@ -42,6 +41,7 @@ describe('Diary Codes', () => {
       'have.text',
       'Next step: We’ll keep offsetting your benefits each month until your debt is paid in full. If you’d like to pay in full now, please call us first to make sure you don’t overpay. If you stop receiving VA benefits, call us to set up a new payment plan. We’re here at800-827-0648 (or+1-612-713-6415from overseas), Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.',
     );
+    cy.axeCheck();
   });
 
   it('renders expected content for diary code: 117', () => {
@@ -52,6 +52,7 @@ describe('Diary Codes', () => {
       'have.text',
       'Next step: Please pay now or contact us about payment options byMay 31st, 2017,to avoid additional collection action. These include having your debt reported to credit reporting agencies or referred to the U.S. Department of the Treasury.You cancontact us online through Ask VAor call us at 800-827-0648 (or+1-612-713-6415from overseas). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.Review payment options',
     );
+    cy.axeCheck();
   });
 
   it('renders expected content for diary code: 123', () => {
@@ -62,5 +63,6 @@ describe('Diary Codes', () => {
       'have.text',
       'Next step: Please pay now or contact us about payment options byOctober 7th, 2018,to avoid collection actions. If you don’t pay or make other arrangements with us by this date, we’re required by law to refer your debt to the U.S. Department of the Treasury.You cancontact us online through Ask VAor call us at 800-827-0648 (or+1-612-713-6415from overseas). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.Review payment options',
     );
+    cy.axeCheck();
   });
 });

--- a/src/applications/debt-letters/tests/e2e/diary-codes-next-step.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/diary-codes-next-step.cypress.spec.js
@@ -9,7 +9,6 @@ describe.skip('Diary Codes - Next Steps', () => {
     cy.intercept('GET', '/v0/debts', mockDebts);
     cy.visit('/manage-va-debt/your-debt/');
     cy.injectAxe();
-    cy.axeCheck();
   });
 
   it('renders a debt card with next step', () => {
@@ -18,6 +17,7 @@ describe.skip('Diary Codes - Next Steps', () => {
       .first()
       .findByText(/Next step:/i)
       .should('exist');
+    cy.axeCheck();
   });
 
   it('renders debt details with next step', () => {
@@ -26,5 +26,6 @@ describe.skip('Diary Codes - Next Steps', () => {
       .first()
       .click();
     cy.get('[data-testid="diary-code-100-next-step"]');
+    cy.axeCheck();
   });
 });


### PR DESCRIPTION
## Description
Platform enabled linting rules recently which surfaced some warnings in debt letters. This PR updates missing `prop-types` and a few other lint warnings to ensure we adhere to best practices in our code.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36223

## Acceptance criteria
- [x] all eslint warnings for missing prop types should be clear

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
