### PR TITLE
Remove homepage refresh flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -113,7 +113,6 @@ export default Object.freeze({
   vaOnlineSchedulingCheetah: 'va_online_scheduling_cheetah',
   vaOnlineSchedulingCommunityCare: 'va_online_scheduling_community_care',
   vaOnlineSchedulingDirect: 'va_online_scheduling_direct',
-  vaOnlineSchedulingHomepageRefresh: 'va_online_scheduling_homepage_refresh',
   vaOnlineSchedulingProviderSelection:
     'va_online_scheduling_provider_selection',
   vaOnlineSchedulingRequests: 'va_online_scheduling_requests',


### PR DESCRIPTION
## Description
Now that homepage refresh is launched and is the default design flow of VAOS, we will delete all FE `va_online_scheduling_homepage_refresh` toggle

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35524


## Testing done
n/a

## Screenshots
n/a

## Acceptance criteria
- [ ] remove `va_online_scheduling_homepage_refresh` toggle flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
