### PR TITLE
lazy load remaining widgets and as many site wide components as possible

### DIFF
--- a/src/applications/static-pages/events/index.js
+++ b/src/applications/static-pages/events/index.js
@@ -2,10 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-// Related imports.
-import App from './components/App';
 
-export default (store, widgetType) => {
+export default async (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
 
   if (root) {
@@ -17,7 +15,9 @@ export default (store, widgetType) => {
         event1?.fieldDatetimeRangeTimezone?.value -
         event2?.fieldDatetimeRangeTimezone?.value,
     );
-
+    const {
+      App,
+    } = await import(/* webpackChunkName: "events" */ './components/App');
     ReactDOM.render(
       <Provider store={store}>
         <App rawEvents={rawEvents} />

--- a/src/applications/static-pages/facilities/createVetCentersHours.jsx
+++ b/src/applications/static-pages/facilities/createVetCentersHours.jsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 
 import widgetTypes from '../widgetTypes';
 import { standardizeDateTime } from './facilityUtilities';
-import VetCenterHours from './vetCentersHours';
 
 export default async function createVetCentersHours(store) {
   const vetCentersHoursWidget = document.querySelector(
@@ -12,8 +11,11 @@ export default async function createVetCentersHours(store) {
   );
 
   if (vetCentersHoursWidget) {
+    const {
+      default: VetCenterHours,
+    } = await import(/* webpackChunkName: "vet-center-hours-widget" */ './vetCentersHours');
     const vetCenterHoursArray = standardizeDateTime(window.vetCenterHours);
-    const isSatelliteLocation = window.isSatelliteLocation;
+    const { isSatelliteLocation } = window;
     ReactDOM.render(
       <Provider store={store}>
         <VetCenterHours

--- a/src/platform/site-wide/announcements/index.jsx
+++ b/src/platform/site-wide/announcements/index.jsx
@@ -12,7 +12,6 @@ import { Provider } from 'react-redux';
 import localStorage from 'platform/utilities/storage/localStorage';
 
 import startReactApp from '../../startup/react';
-import Announcement from './containers/Announcement';
 
 import { ANNOUNCEMENTS_LOCAL_STORAGE } from './actions';
 
@@ -21,12 +20,15 @@ import { ANNOUNCEMENTS_LOCAL_STORAGE } from './actions';
  *
  * @param {Redux.Store} store The common store used on the site
  */
-export default function startAnnouncement(store) {
+export default async function startAnnouncement(store) {
   const annoucementRoot = document.getElementById('announcement-root');
 
   const isDisabled = localStorage.getItem(ANNOUNCEMENTS_LOCAL_STORAGE) === '*';
   if (isDisabled) return;
 
+  const {
+    default: Announcement,
+  } = await import(/* webpackChunkName: "announcements-widget" */ './containers/Announcement');
   startReactApp(
     <Provider store={store}>
       <Announcement />

--- a/src/platform/site-wide/banners/index.js
+++ b/src/platform/site-wide/banners/index.js
@@ -1,16 +1,14 @@
 // Node modules.
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import Banner from '@department-of-veterans-affairs/component-library/Banner';
 // Relative imports.
-import MaintenanceBanner from './components/MaintenanceBanner';
 import startReactApp from '../../startup/react';
 import widgetTypes from '~/applications/static-pages/widgetTypes';
 import { deriveStorage } from './helpers';
 
 // Are you looking for where this is used?
 // Search for `data-widget-type="banner"` and `data-widget-type="maintenance-banner"` to find all the places this React widget is used.
-export default () => {
+export default async () => {
   // Derive the banner elements to place the App.
   const banners = document.querySelectorAll(
     `[data-widget-type="${widgetTypes.BANNER}"]`,
@@ -21,6 +19,10 @@ export default () => {
 
   // Create each banner component.
   if (banners) {
+    const {
+      default: Banner,
+    } = await import(/* webpackChunkName: "banner-widget" */ '@department-of-veterans-affairs/component-library/Banner');
+
     for (let index = 0; index < banners.length; index++) {
       const banner = banners[index];
 
@@ -42,6 +44,10 @@ export default () => {
 
   // Create the maintenance banner component.
   if (maintenanceBanner) {
+    const {
+      default: MaintenanceBanner,
+    } = await import(/* webpackChunkName: "maintenance-banner-widget" */ './components/MaintenanceBanner');
+
     startReactApp(
       <MaintenanceBanner {...maintenanceBanner.dataset} />,
       maintenanceBanner,

--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -52,12 +52,12 @@ export default function startSitewideComponents(commonStore) {
   startBanners();
   startPromoBanners();
   startMobileMenuButton(commonStore);
-  startVAFooter(window.VetsGov.headerFooter.footerData, commonStore);
-  startHeader(commonStore, window.VetsGov.headerFooter.megaMenuData);
-
-  // Start Veteran Crisis Line modal functionality.
-  document.addEventListener('DOMContentLoaded', () => {
+  // async IIFE so that modal initialized after widget loads
+  (async () => {
+    await startVAFooter(window.VetsGov.headerFooter.footerData, commonStore);
+    // Start Veteran Crisis Line modal functionality.
     addFocusBehaviorToCrisisLineModal();
     addOverlayTriggers();
-  });
+  })();
+  startHeader(commonStore, window.VetsGov.headerFooter.megaMenuData);
 }

--- a/src/platform/site-wide/promoBanners/index.js
+++ b/src/platform/site-wide/promoBanners/index.js
@@ -1,13 +1,12 @@
 // Node modules.
 import React from 'react';
 // Relative imports.
-import App from './components/App';
 import startReactApp from '../../startup/react';
 import { formatPromoBannerType } from './helpers';
 
 // Are you looking for where this is used?
 // Search for `data-widget-type="promo-banner"` to find all the places this React widget is used.
-export default () => {
+export default async () => {
   // Derive the promoBanner elements to place the App.
   const promoBanners = document.querySelectorAll(
     `[data-widget-type="promo-banner"]`,
@@ -15,6 +14,9 @@ export default () => {
 
   // Create each banner component.
   if (promoBanners) {
+    const {
+      default: App,
+    } = await import(/* webpackChunkName: "promo-banner-widget" */ './components/App');
     for (let index = 0; index < promoBanners.length; index++) {
       const promoBanner = promoBanners[index];
 

--- a/src/platform/site-wide/side-nav/index.js
+++ b/src/platform/site-wide/side-nav/index.js
@@ -2,14 +2,13 @@
 import React from 'react';
 // Relative
 import startReactApp from '../../startup/react';
-import SideNav from './components/SideNav';
 import { normalizeSideNavData } from './helpers';
 import widgetTypes from '~/applications/static-pages/widgetTypes';
 
 // Are you looking for where this is used?
 // Search for `<div data-widget-type="side-nav"></div>` to find all the places
 // this React widget is used.
-export default sideNavConfig => {
+export default async sideNavConfig => {
   // Derive the root element to place the SideNav.
   const root = document.querySelector(
     `[data-widget-type="${widgetTypes.SIDE_NAV}"]`,
@@ -19,6 +18,10 @@ export default sideNavConfig => {
   if (!root) {
     return;
   }
+
+  const {
+    default: SideNav,
+  } = await import(/* webpackChunkName: "side-nav-widget" */ './components/SideNav');
 
   const { rootPath, data } = sideNavConfig;
 

--- a/src/platform/site-wide/va-footer/index.js
+++ b/src/platform/site-wide/va-footer/index.js
@@ -9,7 +9,6 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import startReactApp from '../../startup/react';
-import Footer from './components/Footer';
 
 export const footerElemementId = 'footerNav';
 
@@ -18,7 +17,10 @@ export const footerElemementId = 'footerNav';
  *
  * @param {Redux.Store} store The common store used on the site
  */
-export default function startVAFooter(footerData, store, onFooterLoad) {
+export default async function startVAFooter(footerData, store, onFooterLoad) {
+  const {
+    default: Footer,
+  } = await import(/* webpackChunkName: "va-footer" */ './components/Footer');
   startReactApp(
     <Provider store={store}>
       <Footer footerData={footerData} onFooterLoad={onFooterLoad} />


### PR DESCRIPTION
## Description
This PR lazy loads widgets that were not lazy loading and implements lazy loading for a subset of site-wide components. 

Please note:  the crisis modal on team sites is not working. This issue may have been in production for some time. Please see [this message](https://dsva.slack.com/archives/C52CL1PKQ/p1643817139673009) for more information.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32791

## Testing done

local testing

## Screenshots


## Acceptance criteria
- [ ] the widgets load lazily and do not break any functionality.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
