### PR TITLE
update eslint rules for label

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -1,10 +1,10 @@
 module.exports = {
   extends: './.eslintrc.js',
   rules: {
-    'jsx-a11y/control-has-associated-label': 2,
+    'jsx-a11y/control-has-associated-label': 1,
     'jsx-a11y/click-events-have-key-events': 2,
     'jsx-a11y/anchor-is-valid': 2,
-    'jsx-a11y/label-has-associated-control': 2,
+    'jsx-a11y/label-has-associated-control': 1,
     'jsx-a11y/no-static-element-interactions': 2,
   },
 };


### PR DESCRIPTION
## Description
It has been determined that the following eslint rules are throwing errors during the pre-commit check and blocking commits therefore the decision was made to update the vals to return a warning.

```
'jsx-a11y/control-has-associated-label': 1,
'jsx-a11y/label-has-associated-control': 1,
```

Related slack convo: https://dsva.slack.com/archives/CBU0KDSB1/p1643816017918069

![craigwheeler@MacBook-Pro~codegovernmentcioVAvets-website 2022-02-02 11-07-42](https://user-images.githubusercontent.com/7518899/152237125-9de8be47-7f02-4881-9295-e8c9ba9fcb2b.png)


## Acceptance criteria
- [x] should return a warning instead of an error during pre-commit

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
