### PR TITLE
36078 authd change preferred name char limit

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Content in EDIT state on the personal information page', () => {
     // preferred name field
     const nameEditButtonLabel = 'Edit Preferred name';
     const nameEditInputLabel =
-      'Provide your preferred name (100 characters maximum)';
+      'Provide your preferred name (25 characters maximum)';
     const nameEditInputField = 'input[name="root_preferredName"]';
 
     cy.findByLabelText(nameEditButtonLabel)

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -109,7 +109,7 @@ export const personalInformationUiSchemas = {
   preferredName: {
     preferredName: {
       'ui:widget': TextWidget,
-      'ui:title': `Provide your preferred name (100 characters maximum)`,
+      'ui:title': `Provide your preferred name (25 characters maximum)`,
       'ui:errorMessages': {
         pattern: 'Preferred name required',
       },


### PR DESCRIPTION
## Description
Tiny change to update the label of preferred name to have a 25 character (to be in line with what the api will be limited to accepting). The form config was actually already set to this limit, but the label just needed to be updated to reflect the limit.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36078


## Testing done
updated e2e test to check this

## Acceptance criteria
- [ ] Label is updated to 25 character limit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
