### PR TITLE
remove all gender display from profile

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/phone-numbers/PhoneNumbersTable.jsx
+++ b/src/applications/personalization/profile/components/contact-information/phone-numbers/PhoneNumbersTable.jsx
@@ -5,9 +5,9 @@ import { connect } from 'react-redux';
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 
-import ProfileInfoTable from '../../ProfileInfoTable';
-
 import { profileShowFaxNumber } from '@@profile/selectors';
+
+import ProfileInfoTable from '../../ProfileInfoTable';
 
 const PhoneNumbersTable = ({ className, shouldProfileShowFaxNumber }) => {
   const tableFields = [

--- a/src/applications/personalization/profile/components/personal-information/LegacyGenderAndDOBSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/LegacyGenderAndDOBSection.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { connect } from 'react-redux';
-
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { profileShowGender } from '../../selectors';
+import {
+  renderGender,
+  renderDOB,
+} from '../../util/personal-information/personalInformationUtils';
 
 import ProfileInfoTable from '../ProfileInfoTable';
 
-const notSetText = 'This information is not available right now.';
-
-const renderDOB = dob => (dob ? moment(dob).format('LL') : notSetText);
-
-const LegacyGenderAndDOBSection = ({ dob, className }) => (
+const LegacyGenderAndDOBSection = ({
+  gender,
+  dob,
+  className,
+  shouldProfileShowGender,
+}) => (
   <div className={className}>
     <div className="vads-u-margin-bottom--2">
       <AdditionalInfo triggerText="How do I update my personal information?">
@@ -39,7 +43,12 @@ const LegacyGenderAndDOBSection = ({ dob, className }) => (
     </div>
     <ProfileInfoTable
       title="Personal information"
-      data={[{ title: 'Date of birth', value: renderDOB(dob) }]}
+      data={[
+        { title: 'Date of birth', value: renderDOB(dob) },
+        ...(shouldProfileShowGender
+          ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
+          : []),
+      ]}
       className="vads-u-margin-bottom--3"
       level={2}
     />
@@ -47,12 +56,16 @@ const LegacyGenderAndDOBSection = ({ dob, className }) => (
 );
 
 LegacyGenderAndDOBSection.propTypes = {
-  className: PropTypes.string,
   dob: PropTypes.string.isRequired,
+  shouldProfileShowGender: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+  gender: PropTypes.string,
 };
 
 const mapStateToProps = state => ({
   dob: state.vaProfile?.personalInformation?.birthDate,
+  gender: state.vaProfile?.personalInformation?.gender,
+  shouldProfileShowGender: profileShowGender(state),
 });
 
 export default connect(mapStateToProps)(LegacyGenderAndDOBSection);

--- a/src/applications/personalization/profile/components/personal-information/LegacyGenderAndDOBSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/LegacyGenderAndDOBSection.jsx
@@ -9,16 +9,9 @@ import ProfileInfoTable from '../ProfileInfoTable';
 
 const notSetText = 'This information is not available right now.';
 
-const renderGender = gender => {
-  let content = notSetText;
-  if (gender === 'M') content = 'Male';
-  else if (gender === 'F') content = 'Female';
-  return content;
-};
-
 const renderDOB = dob => (dob ? moment(dob).format('LL') : notSetText);
 
-const LegacyGenderAndDOBSection = ({ gender, dob, className }) => (
+const LegacyGenderAndDOBSection = ({ dob, className }) => (
   <div className={className}>
     <div className="vads-u-margin-bottom--2">
       <AdditionalInfo triggerText="How do I update my personal information?">
@@ -46,10 +39,7 @@ const LegacyGenderAndDOBSection = ({ gender, dob, className }) => (
     </div>
     <ProfileInfoTable
       title="Personal information"
-      data={[
-        { title: 'Date of birth', value: renderDOB(dob) },
-        { title: 'Gender', value: renderGender(gender) },
-      ]}
+      data={[{ title: 'Date of birth', value: renderDOB(dob) }]}
       className="vads-u-margin-bottom--3"
       level={2}
     />
@@ -58,12 +48,10 @@ const LegacyGenderAndDOBSection = ({ gender, dob, className }) => (
 
 LegacyGenderAndDOBSection.propTypes = {
   className: PropTypes.string,
-  gender: PropTypes.string.isRequired,
   dob: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => ({
-  gender: state.vaProfile?.personalInformation?.gender,
   dob: state.vaProfile?.personalInformation?.birthDate,
 });
 

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -1,115 +1,127 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
+import { profileShowGender } from '@@profile/selectors';
+
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
+import {
+  renderGender,
+  renderDOB,
+} from '@@profile/util/personal-information/personalInformationUtils';
 import ProfileInfoTable from '../ProfileInfoTable';
 
-const notSetText = 'This information is not available right now.';
+const PersonalInformationSection = ({
+  gender,
+  dob,
+  shouldProfileShowGender,
+}) => {
+  const tableFields = [
+    { title: 'Date of birth', value: renderDOB(dob) },
+    {
+      title: 'Preferred name',
+      id: FIELD_IDS[FIELD_NAMES.PREFERRED_NAME],
+      value: (
+        <ProfileInformationFieldController
+          fieldName={FIELD_NAMES.PREFERRED_NAME}
+          isDeleteDisabled
+        />
+      ),
+    },
+    {
+      title: 'Pronouns',
+      id: FIELD_IDS[FIELD_NAMES.PRONOUNS],
+      value: (
+        <ProfileInformationFieldController
+          fieldName={FIELD_NAMES.PRONOUNS}
+          isDeleteDisabled
+        />
+      ),
+    },
+    ...(shouldProfileShowGender
+      ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
+      : []),
+    {
+      title: 'Gender identity',
+      id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
+      value: (
+        <ProfileInformationFieldController
+          fieldName={FIELD_NAMES.GENDER_IDENTITY}
+          isDeleteDisabled
+        />
+      ),
+    },
+    {
+      title: 'Sexual orientation',
+      id: FIELD_IDS[FIELD_NAMES.SEXUAL_ORIENTATION],
+      value: (
+        <ProfileInformationFieldController
+          fieldName={FIELD_NAMES.SEXUAL_ORIENTATION}
+          isDeleteDisabled
+        />
+      ),
+    },
+  ];
 
-const renderDOB = dob => (dob ? moment(dob).format('LL') : notSetText);
-
-const PersonalInformationSection = ({ dob }) => (
-  <div className="vads-u-margin-bottom--6">
-    <div className="vads-u-margin-bottom--3">
-      <AdditionalInfo triggerText="Why do we ask for this?">
-        <p className="vads-u-margin-y--1">
-          Some of the information in this section tells us how you want to be
-          addressed as a person. For example, our staff will know your pronouns
-          and the name you’d like us to use when you call or come in to VA.
-        </p>
-        <p className="vads-u-margin-y--1">
-          If you get health care through VA, information in this section helps
-          your care team better assess your health needs and risks. For example,
-          gender identity and sexual orientation are some of the factors that
-          can affect a person’s health, well-being, and quality of life. We call
-          these factors “social determinants of health.”
-        </p>
-        <p className="vads-u-margin-y--1">
-          We also collect this information to better understand our Veteran
-          community. This helps us make sure that we’re serving the needs of all
-          Veterans.
-        </p>
-      </AdditionalInfo>
+  return (
+    <div className="vads-u-margin-bottom--6">
+      <div className="vads-u-margin-bottom--3">
+        <AdditionalInfo triggerText="Why do we ask for this?">
+          <p className="vads-u-margin-y--1">
+            Some of the information in this section tells us how you want to be
+            addressed as a person. For example, our staff will know your
+            pronouns and the name you’d like us to use when you call or come in
+            to VA.
+          </p>
+          <p className="vads-u-margin-y--1">
+            If you get health care through VA, information in this section helps
+            your care team better assess your health needs and risks. For
+            example, gender identity and sexual orientation are some of the
+            factors that can affect a person’s health, well-being, and quality
+            of life. We call these factors “social determinants of health.”
+          </p>
+          <p className="vads-u-margin-y--1">
+            We also collect this information to better understand our Veteran
+            community. This helps us make sure that we’re serving the needs of
+            all Veterans.
+          </p>
+        </AdditionalInfo>
+      </div>
+      <div className="vads-u-margin-bottom--3">
+        <AdditionalInfo triggerText="How do I update my name or date of birth?">
+          <h2 className="vads-u-font-size--h5 vads-u-margin-top--3">
+            If you’re enrolled in the VA health care program
+          </h2>
+          <p className="vads-u-margin-y--1">
+            Please contact your nearest VA medical center to update your
+            personal information.
+          </p>
+          <a href="/find-locations/?facilityType=health">
+            Find your nearest VA medical center{' '}
+          </a>
+          <h2 className="vads-u-font-size--h5 vads-u-margin-top--3 vads-u-margin-bottom--1">
+            If you receive VA benefits, but aren’t enrolled in VA health care
+          </h2>
+          <p className="vads-u-margin-y--1">
+            Please contact your nearest VA regional office to update your
+            personal information
+          </p>
+          <a href="/find-locations/?facilityType=benefits">
+            Find your nearest VA regional office
+          </a>
+        </AdditionalInfo>
+      </div>
+      <ProfileInfoTable data={tableFields} level={2} />
     </div>
-    <div className="vads-u-margin-bottom--3">
-      <AdditionalInfo triggerText="How do I update my name or date of birth?">
-        <h2 className="vads-u-font-size--h5 vads-u-margin-top--3">
-          If you’re enrolled in the VA health care program
-        </h2>
-        <p className="vads-u-margin-y--1">
-          Please contact your nearest VA medical center to update your personal
-          information.
-        </p>
-        <a href="/find-locations/?facilityType=health">
-          Find your nearest VA medical center{' '}
-        </a>
-        <h2 className="vads-u-font-size--h5 vads-u-margin-top--3 vads-u-margin-bottom--1">
-          If you receive VA benefits, but aren’t enrolled in VA health care
-        </h2>
-        <p className="vads-u-margin-y--1">
-          Please contact your nearest VA regional office to update your personal
-          information
-        </p>
-        <a href="/find-locations/?facilityType=benefits">
-          Find your nearest VA regional office
-        </a>
-      </AdditionalInfo>
-    </div>
-    <ProfileInfoTable
-      data={[
-        { title: 'Date of birth', value: renderDOB(dob) },
-        {
-          title: 'Preferred name',
-          id: FIELD_IDS[FIELD_NAMES.PREFERRED_NAME],
-          value: (
-            <ProfileInformationFieldController
-              fieldName={FIELD_NAMES.PREFERRED_NAME}
-              isDeleteDisabled
-            />
-          ),
-        },
-        {
-          title: 'Pronouns',
-          id: FIELD_IDS[FIELD_NAMES.PRONOUNS],
-          value: (
-            <ProfileInformationFieldController
-              fieldName={FIELD_NAMES.PRONOUNS}
-              isDeleteDisabled
-            />
-          ),
-        },
-        {
-          title: 'Gender identity',
-          id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
-          value: (
-            <ProfileInformationFieldController
-              fieldName={FIELD_NAMES.GENDER_IDENTITY}
-              isDeleteDisabled
-            />
-          ),
-        },
-        {
-          title: 'Sexual orientation',
-          id: FIELD_IDS[FIELD_NAMES.SEXUAL_ORIENTATION],
-          value: (
-            <ProfileInformationFieldController
-              fieldName={FIELD_NAMES.SEXUAL_ORIENTATION}
-              isDeleteDisabled
-            />
-          ),
-        },
-      ]}
-      level={2}
-    />
-  </div>
-);
+  );
+};
 
 PersonalInformationSection.propTypes = {
   dob: PropTypes.string.isRequired,
+  shouldProfileShowGender: PropTypes.bool.isRequired,
+  gender: PropTypes.string,
 };
 
 const mapStateToProps = state => ({
@@ -119,6 +131,7 @@ const mapStateToProps = state => ({
   pronouns: state.vaProfile?.personalInformation?.pronouns,
   genderIdentity: state.vaProfile?.personalInformation?.genderIdentity,
   sexualOrientation: state.vaProfile?.personalInformation?.sexualOrientation,
+  shouldProfileShowGender: profileShowGender(state),
 });
 
 export default connect(mapStateToProps)(PersonalInformationSection);

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -36,7 +36,7 @@ const PersonalInformationSection = ({ dob }) => (
       </AdditionalInfo>
     </div>
     <div className="vads-u-margin-bottom--3">
-      <AdditionalInfo triggerText="How do I update my name, date of birth, or sex assigned at birth?">
+      <AdditionalInfo triggerText="How do I update my name or date of birth?">
         <h2 className="vads-u-font-size--h5 vads-u-margin-top--3">
           If you’re enrolled in the VA health care program
         </h2>

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -10,16 +10,9 @@ import ProfileInfoTable from '../ProfileInfoTable';
 
 const notSetText = 'This information is not available right now.';
 
-const renderGender = gender => {
-  let content = notSetText;
-  if (gender === 'M') content = 'Male';
-  else if (gender === 'F') content = 'Female';
-  return content;
-};
-
 const renderDOB = dob => (dob ? moment(dob).format('LL') : notSetText);
 
-const PersonalInformationSection = ({ gender, dob }) => (
+const PersonalInformationSection = ({ dob }) => (
   <div className="vads-u-margin-bottom--6">
     <div className="vads-u-margin-bottom--3">
       <AdditionalInfo triggerText="Why do we ask for this?">
@@ -89,7 +82,6 @@ const PersonalInformationSection = ({ gender, dob }) => (
             />
           ),
         },
-        { title: 'Sex assigned at birth', value: renderGender(gender) },
         {
           title: 'Gender identity',
           id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
@@ -117,7 +109,6 @@ const PersonalInformationSection = ({ gender, dob }) => (
 );
 
 PersonalInformationSection.propTypes = {
-  gender: PropTypes.string.isRequired,
   dob: PropTypes.string.isRequired,
 };
 

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -54,3 +54,5 @@ export const ACCOUNT_TYPES_OPTIONS = {
 // 637: Asheville
 // 983: test-only facility ID, used by user 36 among others
 export const RX_TRACKING_SUPPORTING_FACILITIES = new Set(['554', '637', '983']);
+
+export const NOT_SET_TEXT = 'This information is not available right now.';

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -89,6 +89,9 @@ export const profileShowAddressChangeModal = state =>
 export const profileShowFaxNumber = state =>
   toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowFaxNumber];
 
+export const profileShowGender = state =>
+  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowGender];
+
 export function selectVAProfilePersonalInformation(state, fieldName) {
   const fieldValue = state?.vaProfile?.personalInformation?.[fieldName];
 

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -39,7 +39,6 @@ describe('PersonalInformation', () => {
     });
 
     expect(view.getByText(/^May 6, 1986$/)).to.exist;
-    expect(view.getByText(/^Male$/)).to.exist;
   });
 
   it('should render the correct contact based on what exists in the Redux state', () => {

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/fields-check.cypress.spec.js
@@ -40,9 +40,6 @@ describe('Content on the personal information section in the profile', () => {
     // Check date of birth
     cy.findByText(/May 6, 1986/i).should('exist');
 
-    // Check gender
-    cy.findByText(/Male/i).should('exist');
-
     // Check mailing address
     cy.get('div[data-field-name="mailingAddress"]')
       .contains(/1493 Martin Luther King Rd, Apt 1/i)

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/vap-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/vap-error.cypress.spec.js
@@ -43,9 +43,6 @@ describe('When there is a known issue connecting to VA Profile', () => {
     // Check date of birth
     cy.findByText(/May 6, 1986/i).should('exist');
 
-    // Check gender
-    cy.findByText(/Male/i).should('exist');
-
     // Contact info sections should not be shown
     cy.findByText(/^Mailing address$/i).should('not.exist');
     cy.findByText(/^Residential address$/i).should('not.exist');

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
@@ -42,9 +42,6 @@ describe('Content on the personal information page', () => {
     cy.findByText('Pronouns').should('exist');
     cy.findByText('Edit your profile to add pronouns.').should('exist');
 
-    cy.findByText('Sex assigned at birth').should('exist');
-    cy.findByText('Male').should('exist');
-
     cy.findByText('Gender identity').should('exist');
     cy.findByText('Edit your profile to add a gender identity.').should(
       'exist',

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -1,6 +1,10 @@
+import moment from 'moment';
+
 import TextWidget from 'platform/forms-system/src/js/widgets/TextWidget';
 import RadioWidget from 'platform/forms-system/src/js/widgets/RadioWidget';
 import OtherTextField from '@@profile/components/personal-information/OtherTextField';
+
+import { NOT_SET_TEXT } from '@@profile/constants';
 
 const genderOptions = [
   'woman',
@@ -203,3 +207,12 @@ export const formatSexualOrientation = (
   }
   return sexualOrientationNotListedText;
 };
+
+export const renderGender = gender => {
+  let content = NOT_SET_TEXT;
+  if (gender === 'M') content = 'Male';
+  else if (gender === 'F') content = 'Female';
+  return content;
+};
+
+export const renderDOB = dob => (dob ? moment(dob).format('LL') : NOT_SET_TEXT);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -69,6 +69,7 @@ export default Object.freeze({
   profileEnhancements: 'profile_enhancements',
   profileShowAddressChangeModal: 'profile_show_address_change_modal',
   profileShowFaxNumber: 'profile_show_fax_number',
+  profileShowGender: 'profile_show_gender',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',
   searchTypeaheadEnabled: 'search_typeahead_enabled',


### PR DESCRIPTION
## Description
Removes the Gender and 'Gender assigned at birth' from the UI of the profile based on a feature toggle. This was done because it is not an editable field and was expressed as a potentially triggering piece of data for certain individuals.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36009

## Testing done
e2e tests have been updated for this


## Acceptance criteria
- [ ] Gender information not visible on profile UI

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
