### PR TITLE
Letters: Fix eslint issues

### DIFF
--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import recordEvent from 'platform/monitoring/record-event';
+import { formatDateShort } from 'platform/utilities/date';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
+
 import { updateBenefitSummaryRequestOption } from '../actions/letters';
 import {
   benefitOptionsMap,
@@ -10,9 +13,7 @@ import {
   optionsToAlwaysDisplay,
   getBenefitOptionText,
   stripOffTime,
-} from '../utils/helpers.jsx';
-import { formatDateShort } from 'platform/utilities/date';
-import CallVBACenter from 'platform/static-data/CallVBACenter';
+} from '../utils/helpers';
 
 export class VeteranBenefitSummaryLetter extends React.Component {
   constructor() {
@@ -54,10 +55,11 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       </tr>
     ));
 
-    const benefitInfo = this.props.benefitSummaryOptions.benefitInfo;
-    const requestOptions = this.props.requestOptions;
+    const { benefitInfo } = this.props.benefitSummaryOptions;
+    const { requestOptions } = this.props;
     const vaBenefitInfoRows = [];
 
+    /* eslint jsx-a11y/label-has-associated-control: [1, { assert: "either" }] */
     Object.keys(benefitInfo).forEach(key => {
       // Need to verify with EVSS and vets-api: values should be true, false, or
       // some value other than null or undefined, so this check should not be
@@ -91,7 +93,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
                 type="checkbox"
                 onChange={this.handleChange}
               />
-              <label />
+              <label htmlFor={key}> </label>
             </th>
             <td>
               <label id={`${key}Label`} htmlFor={key}>

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -16,6 +16,7 @@ import {
   stripOffTime,
 } from '../utils/helpers';
 
+/* eslint jsx-a11y/label-has-associated-control: 1 */
 export class VeteranBenefitSummaryLetter extends React.Component {
   constructor() {
     super();
@@ -65,8 +66,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
     ));
 
     const vaBenefitInfoRows = [];
-
-    /* eslint jsx-a11y/label-has-associated-control: [1, { assert: "either" }] */
     Object.keys(benefitInfo).forEach(key => {
       // Need to verify with EVSS and vets-api: values should be true, false, or
       // some value other than null or undefined, so this check should not be
@@ -99,12 +98,12 @@ export class VeteranBenefitSummaryLetter extends React.Component {
                 type="checkbox"
                 onChange={this.handleChange}
               />
-              <label htmlFor={key}> </label>
+              <label htmlFor={key}>
+                <div className="sr-only">{optionText}</div>
+              </label>
             </th>
             <td>
-              <label id={`${key}Label`} htmlFor={key}>
-                {optionText}
-              </label>
+              <div id={`${key}Label`}>{optionText}</div>
             </td>
           </tr>,
         );

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -1,12 +1,13 @@
 /* eslint-disable jsx-a11y/label-has-for */
 import React from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
 import { formatDateShort } from 'platform/utilities/date';
 import CallVBACenter from 'platform/static-data/CallVBACenter';
 
-import { updateBenefitSummaryRequestOption } from '../actions/letters';
+import { updateBenefitSummaryRequestOption as updateBenefitSummaryRequestOptionAction } from '../actions/letters';
 import {
   benefitOptionsMap,
   characterOfServiceContent,
@@ -22,6 +23,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
   }
 
   handleChange(domEvent) {
+    const { updateBenefitSummaryRequestOption } = this.props;
     recordEvent({
       // For Google Analytics
       event: 'letter-benefit-option-clicked',
@@ -30,15 +32,22 @@ export class VeteranBenefitSummaryLetter extends React.Component {
         ? 'checked'
         : 'unchecked',
     });
-    this.props.updateBenefitSummaryRequestOption(
+    updateBenefitSummaryRequestOption(
       benefitOptionsMap[domEvent.target.id],
       domEvent.target.checked,
     );
   }
 
   render() {
-    const serviceInfo = this.props.benefitSummaryOptions.serviceInfo || [];
-    const militaryServiceRows = serviceInfo.map((service, index) => (
+    const {
+      benefitSummaryOptions,
+      requestOptions,
+      isVeteran,
+      optionsAvailable,
+    } = this.props;
+    const { benefitInfo, serviceInfo } = benefitSummaryOptions;
+    const { militaryService } = requestOptions;
+    const militaryServiceRows = (serviceInfo || []).map((service, index) => (
       <tr key={`service${index}`}>
         <th scope="row" className="service-info">
           {(service.branch || '').toLowerCase()}
@@ -55,8 +64,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       </tr>
     ));
 
-    const { benefitInfo } = this.props.benefitSummaryOptions;
-    const { requestOptions } = this.props;
     const vaBenefitInfoRows = [];
 
     /* eslint jsx-a11y/label-has-associated-control: [1, { assert: "either" }] */
@@ -73,7 +80,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       const value = benefitInfo[key];
       const displayOption =
         optionsToAlwaysDisplay.includes(key) || value !== false;
-      const { isVeteran } = this.props;
       const optionText = getBenefitOptionText(
         key,
         value,
@@ -118,7 +124,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
     );
 
     let benefitSummaryContent;
-    if (this.props.optionsAvailable) {
+    if (optionsAvailable) {
       benefitSummaryContent = (
         <div>
           <h4>Choose the information you want to include.</h4>
@@ -130,7 +136,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
           <div className="form-checkbox">
             <input
               autoComplete="false"
-              checked={requestOptions.militaryService}
+              checked={militaryService}
               id="militaryService"
               name="militaryService"
               type="checkbox"
@@ -184,6 +190,19 @@ export class VeteranBenefitSummaryLetter extends React.Component {
   }
 }
 
+VeteranBenefitSummaryLetter.propTypes = {
+  benefitSummaryOptions: PropTypes.shape({
+    benefitInfo: PropTypes.array,
+    serviceInfo: PropTypes.array,
+  }),
+  isVeteran: PropTypes.bool,
+  optionsAvailable: PropTypes.shape({}),
+  requestOptions: PropTypes.shape({
+    militaryService: PropTypes.bool,
+  }),
+  updateBenefitSummaryRequestOption: PropTypes.func,
+};
+
 function mapStateToProps(state) {
   const letterState = state.letters;
 
@@ -201,7 +220,7 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  updateBenefitSummaryRequestOption,
+  updateBenefitSummaryRequestOption: updateBenefitSummaryRequestOptionAction,
 };
 
 export default connect(


### PR DESCRIPTION
## Description

Accessibility linting rules are being enabled, and two linting warning popped up within the letters app:

In `/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx`
- 94:15  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
- 137:13  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control

The first warning was  due to the checkbox being associated to two labels. This was fixed by adding screen-reader only content inside the empty first label (needed to render the styled checkbox) and changing the second label into a div.

The second warning never went away, it fulfills all the ["label is a sibling of the control" case](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-associated-control.md#case-the-label-is-a-sibling-of-the-control). I solved this by adding a eslint comment to the top of the page `/* eslint jsx-a11y/label-has-associated-control: 1 */` which is the same setting that the `.eslintrc.js` file has - maybe it's a `depth` thing?

Additional lint rules popped up within the VSCode editor, which were also fixed:
- Add `PropTypes` definitions
- Used destructuring of props

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36053

## Testing done

Unit & e2e tests checked

## Screenshots

Before
<img width="737" alt="Showing input with 2 labels, first label is empty" src="https://user-images.githubusercontent.com/136959/152248453-b4592fc8-7aee-4a46-b647-13d12ad1d4ba.png">

After
<img width="784" alt="Showing label adjacent to input with screenreader only content, second label now a div" src="https://user-images.githubusercontent.com/136959/152248847-fb069588-2117-423a-be4e-19e8a782dfe6.png">

## Acceptance criteria
- [x] a11y lint warning fixed
- [x] Other lint warnings (PropTypes & destructuring) fixed
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
