### PR TITLE
Temporarily assume control of manifest files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 
 # VSP
 *       @department-of-veterans-affairs/frontend-review-group
+*/manifest.json @department-of-veterans-affairs/qa-standards
 src/platform/forms        @department-of-veterans-affairs/vsp-design-system-fe
 src/platform/forms-system @department-of-veterans-affairs/vsp-design-system-fe
 script/component-migration @department-of-veterans-affairs/vsp-design-system-fe


### PR DESCRIPTION
## Description
This PR temporarily grants the QA Standards team codeowner privileges for the manifest files in vets-website. We will be adding a product ID to each manifest for our QA Dashboard efforts and did not want to try and request many teams approval for one-line inconsequential changes.

The work for this should be completed by noon EST on February 4, 2022 at which time a new request will be opened to remove these privileges.