### PR TITLE
Add rooturl to app list

### DIFF
--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 on:
-  ? workflow_dispatch
+  workflow_dispatch:
   schedule:
     - cron: '0 12 * * 1-5'
 

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 on:
-  workflow_dispatch:
+  ? workflow_dispatch
   schedule:
     - cron: '0 12 * * 1-5'
 
@@ -92,12 +92,16 @@ jobs:
       - name: Upload lighthouse report (HTML)
         run: aws s3 cp ${{ fromJSON(steps.lighthouse-checks.outputs.manifest)[0].htmlPath }} s3://vetsgov-website-builds-s3-upload/lighthouse${{ matrix.registry == '/' && '/homepage' || matrix.registry }}.html --acl public-read --region us-gov-west-1
 
+      - name: Generate new application list
+        run: yarn generate-app-list
+
       - name: Checkout Testing Tools Team Dashboard Data repo
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
+          ref: qas-coverage-app-names
 
       - name: Get Node version
         id: get-node-version
@@ -131,6 +135,8 @@ jobs:
       - name: Upload Lighthouse results to BigQuery
         run: yarn lighthouse-to-bigquery
         working-directory: testing-tools-team-dashboard-data
+        env:
+          APPLICATION_LIST: ${{ env.APPLICATION_LIST }}
 
   notify-slack:
     name: Notify Slack

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -43,6 +43,18 @@ jobs:
         registry: ${{ fromJson(needs.get-registries.outputs.registries) }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -1,10 +1,10 @@
 name: Lighthouse CI
 
 on:
-  ? workflow_dispatch
-  schedule:
-    - cron: '0 12 * * 1-5'
-
+  # ? workflow_dispatch
+  # schedule:
+  #   - cron: '0 12 * * 1-5'
+  push
 env:
   CHANNEL_ID: C02A8S3JPNZ
 

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -1,10 +1,10 @@
 name: Lighthouse CI
 
 on:
-  # ? workflow_dispatch
-  # schedule:
-  #   - cron: '0 12 * * 1-5'
-  push
+  ? workflow_dispatch
+  schedule:
+    - cron: '0 12 * * 1-5'
+
 env:
   CHANNEL_ID: C02A8S3JPNZ
 

--- a/script/github-actions/generate-app-list.js
+++ b/script/github-actions/generate-app-list.js
@@ -8,6 +8,7 @@ function exportAppList() {
       app.appName,
       app.entryName,
       app.filePath.substring(app.filePath.indexOf('src')),
+      app.rootUrl,
     ];
   });
   core.exportVariable('APPLICATION_LIST', applicationList);


### PR DESCRIPTION
## Description
This adds rootUrl to the manifest app list that is generated in CI for our data ingestion, so there is a way to associate product names to lighthouse test data. Additionally, it adds the step to generate the app list in the lighthouse workflow.
