### PR TITLE
Add education benefit apps to allowlist

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -1,6 +1,11 @@
 {
   "allow": {
-    "entryNames": ["vaos", "medical-copays"],
+    "entryNames": [
+      "education-inbox",
+      "enrollment-verification",
+      "medical-copays",
+      "vaos"
+    ],
     "rootAppFolders": ["check-in"]
   }
 }


### PR DESCRIPTION
## Description
Add the Education Inbox and Enrollment Verification apps to the allowlist.

## Testing done
Tested both apps with `yarn check-app-imports` and `yarn cy:run --spec src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js --env app_url`

## Acceptance criteria
- [x] Education Inbox and Enrollment Verification should be on the allowlist

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
