### PR TITLE
35714 hide fields

### DIFF
--- a/src/applications/personalization/search-representative/config/chapters/basic-information/basicInformation.js
+++ b/src/applications/personalization/search-representative/config/chapters/basic-information/basicInformation.js
@@ -21,14 +21,26 @@ export const uiSchema = {
   'ui:description': 'Choose at least one',
   vso: {
     'ui:title': 'Veteran Service Organization (VS0)',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
   representativeOfVSO: {
     'ui:title': 'Representative in a Veteran Service Organization',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
   attorney: {
     'ui:title': 'Attorney (Lawyer)',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
   claimsAgent: {
     'ui:title': 'Claims agent',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
 };

--- a/src/applications/personalization/search-representative/config/chapters/basic-information/location.js
+++ b/src/applications/personalization/search-representative/config/chapters/basic-information/location.js
@@ -18,11 +18,20 @@ export const schema = {
 export const uiSchema = {
   city: {
     'ui:title': 'City',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
   state: {
     'ui:title': 'State',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
   postalCode: {
     'ui:title': 'Postal code',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
 };

--- a/src/applications/personalization/search-representative/config/chapters/basic-information/organizationName.js
+++ b/src/applications/personalization/search-representative/config/chapters/basic-information/organizationName.js
@@ -11,5 +11,8 @@ export const schema = {
 export const uiSchema = {
   organizationName: {
     'ui:title': 'Organization name',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
 };

--- a/src/applications/personalization/search-representative/config/chapters/basic-information/representative.js
+++ b/src/applications/personalization/search-representative/config/chapters/basic-information/representative.js
@@ -14,8 +14,14 @@ export const schema = {
 export const uiSchema = {
   lastNameOfRepresentative: {
     'ui:title': 'Last name of accredited representative',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
   firstNameOfRepresentative: {
     'ui:title': 'First name of accredited representative',
+    'ui:options': {
+      hideOnReview: true,
+    },
   },
 };

--- a/src/applications/personalization/search-representative/config/chapters/search/search.js
+++ b/src/applications/personalization/search-representative/config/chapters/search/search.js
@@ -1,4 +1,5 @@
 import SearchRepresentativeWidget from './searchRepresentativeWidget.jsx';
+import searchRepresentativeReviewWidget from './searchRepresentativeReviewWidget.jsx';
 
 export const schema = {
   type: 'object',
@@ -16,5 +17,6 @@ export const uiSchema = {
     'ui:options': {
       hideLabelText: true,
     },
+    'ui:reviewWidget': searchRepresentativeReviewWidget,
   },
 };

--- a/src/applications/personalization/search-representative/config/chapters/search/search.js
+++ b/src/applications/personalization/search-representative/config/chapters/search/search.js
@@ -1,5 +1,5 @@
-import SearchRepresentativeWidget from './searchRepresentativeWidget.jsx';
-import searchRepresentativeReviewWidget from './searchRepresentativeReviewWidget.jsx';
+import SearchRepresentativeWidget from './searchRepresentativeWidget';
+import searchRepresentativeReviewWidget from './searchRepresentativeReviewWidget';
 
 export const schema = {
   type: 'object',

--- a/src/applications/personalization/search-representative/config/chapters/search/searchRepresentativeReviewWidget.jsx
+++ b/src/applications/personalization/search-representative/config/chapters/search/searchRepresentativeReviewWidget.jsx
@@ -13,7 +13,7 @@ const SearchRepresentativeReviewWidget = props => {
           <>
             <div key={index} className="vads-u-display--flex">
               <p className="vads-u-flex--1 vads-u-text-align--left vads-u-font-weight--normal vads-u-margin-y--0">
-                {capitalizeFirstLetter(item)}:
+                {capitalizeFirstLetter(item)}
               </p>
               <p className="vads-u-flex--1 vads-u-margin-y--0">
                 {props.formData.representativeData[item]}

--- a/src/applications/personalization/search-representative/config/chapters/search/searchRepresentativeReviewWidget.jsx
+++ b/src/applications/personalization/search-representative/config/chapters/search/searchRepresentativeReviewWidget.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+const SearchRepresentativeReviewWidget = props => {
+  const capitalizeFirstLetter = string => {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
+
+  return (
+    <>
+      {Object.keys(props?.formData?.representativeData).map((item, index) => {
+        return (
+          <>
+            <div key={index} className="vads-u-display--flex">
+              <p className="vads-u-flex--1 vads-u-text-align--left vads-u-font-weight--normal vads-u-margin-y--0">
+                {capitalizeFirstLetter(item)}:
+              </p>
+              <p className="vads-u-flex--1 vads-u-margin-y--0">
+                {props.formData.representativeData[item]}
+              </p>
+            </div>
+            {index !== 4 ? <hr /> : ''}
+          </>
+        );
+      })}
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  formData: state.form?.data,
+});
+
+export default connect(
+  mapStateToProps,
+  {},
+)(SearchRepresentativeReviewWidget);

--- a/src/applications/personalization/search-representative/config/form.js
+++ b/src/applications/personalization/search-representative/config/form.js
@@ -42,7 +42,7 @@ const formConfig = {
   defaultDefinitions: {},
   chapters: {
     basicInformation: {
-      title: '',
+      title: 'Your selected representative',
       pages: {
         representativeType: {
           path: 'representative-type',

--- a/src/applications/personalization/search-representative/sass/search-representative.scss
+++ b/src/applications/personalization/search-representative/sass/search-representative.scss
@@ -1,9 +1,10 @@
-.form-review-panel-page:nth-of-type(1) dt {
+[data-chapter="basicInformation"] .review-row > dt {
   display: none;
 }
 
 .review-row {
   flex-direction: column !important;
+  padding: 2.5rem;
 }
 
 .form-review-panel-page-header-row:nth-of-type(1) .edit-btn {

--- a/src/applications/personalization/search-representative/sass/search-representative.scss
+++ b/src/applications/personalization/search-representative/sass/search-representative.scss
@@ -1,3 +1,15 @@
+.form-review-panel-page:nth-of-type(1) dt {
+  display: none;
+}
+
+.review-row {
+  flex-direction: column !important;
+}
+
+.form-review-panel-page-header-row:nth-of-type(1) .edit-btn {
+  display: none;
+}
+
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/35714)

On the Search and Appoint Representative form the mockup calls for all of the fields from the search data entered by the user to be hidden on the review page of the form. It also calls for the data from the user's chosen representative to be reformatted so that it has a cleaner look. This PR accomplishes both of these goals.

**One thing to note, the data in the app does not match the data in the mockup, this is because we are not sure as a team what data will be coming back from the API and there is no sense in us changing that until we know for sure**

## Screenshots

![Screen Shot 2022-02-04 at 10 08 53 AM](https://user-images.githubusercontent.com/1899695/152580709-dc6b1c3e-3d49-4387-9cfa-f628762d308d.png)


## Acceptance criteria
- [x] All information on the review page for the search portion of the search and appoint rep has been hidden aside from the. "chosen representative"
- [x] A PR has been submitted for review
