### PR TITLE
Move codeowners for manifests to bottom of file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,6 @@
 
 # VSP
 *       @department-of-veterans-affairs/frontend-review-group
-*/manifest.json @department-of-veterans-affairs/qa-standards
 src/platform/forms        @department-of-veterans-affairs/vsp-design-system-fe
 src/platform/forms-system @department-of-veterans-affairs/vsp-design-system-fe
 script/component-migration @department-of-veterans-affairs/vsp-design-system-fe
@@ -104,3 +103,6 @@ src/applications/virtual-agent @department-of-veterans-affairs/orchid
 src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-admin
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe
 src/applications/third-party-app-directory @department-of-veterans-affairs/lighthouse-bilby
+
+*/manifest.json @department-of-veterans-affairs/qa-standards
+


### PR DESCRIPTION
## Description
Our prior PR had our declaration higher up in the file and it was being superseded by lower codeowners declarations. We've moved this to the bottom of the file.

https://github.com/department-of-veterans-affairs/vets-website/pull/20103 original issue here