### PR TITLE
Check in/35976/linting fix up

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -1,5 +1,5 @@
 import session from '../mocks/v2/sessions';
-import preCheckInData from '../mocks/v2/pre-check-in-data/';
+import preCheckInData from '../mocks/v2/pre-check-in-data';
 import checkInData from '../mocks/v2/check-in-data';
 import featureToggles from '../mocks/v2/feature-toggles';
 
@@ -40,6 +40,7 @@ class ApiInitializer {
       );
     },
   };
+
   initializeSessionGet = {
     withSuccessfulNewSession: () => {
       cy.intercept('GET', '/check_in/v2/sessions/*', req => {

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -34,18 +34,16 @@ const responses = {
     if (hasBeenValidated) {
       hasBeenValidated = false;
       return res.json(checkInData.get.createMultipleAppointments(uuid, 3));
-    } else {
-      return res.json(checkInData.get.createMultipleAppointments(uuid));
     }
+    return res.json(checkInData.get.createMultipleAppointments(uuid));
   },
   'POST /check_in/v2/patient_check_ins/': (req, res) => {
     const { uuid, appointmentIen, facilityId } =
       req.body?.patientCheckIns || {};
     if (!uuid || !appointmentIen || !facilityId) {
       return res.status(500).json(checkInData.post.createMockFailedResponse());
-    } else {
-      return res.json(checkInData.post.createMockSuccessResponse({}));
     }
+    return res.json(checkInData.post.createMockSuccessResponse({}));
   },
   'GET /check_in/v2/pre_check_ins/:uuid': (req, res) => {
     // TODO??: add check for queryString "/pre_check_ins/<uuid>?checkInType=preCheckIn"
@@ -58,9 +56,8 @@ const responses = {
       return res
         .status(500)
         .json(preCheckInData.post.createMockFailedResponse());
-    } else {
-      return res.json(preCheckInData.post.createMockSuccessResponse({}));
     }
+    return res.json(preCheckInData.post.createMockSuccessResponse({}));
   },
 };
 

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
@@ -179,7 +179,7 @@ const createMultipleAppointments = (
       },
     },
   };
-  for (let i = 0; i < numberOfCheckInAbledAppointments; i++) {
+  for (let i = 0; i < numberOfCheckInAbledAppointments; i += 1) {
     rv.payload.appointments.push(
       createAppointment(
         'ELIGIBLE',

--- a/src/applications/check-in/components/AddressBlock.jsx
+++ b/src/applications/check-in/components/AddressBlock.jsx
@@ -29,9 +29,9 @@ const AddressBlock = ({ address }) => {
       {lineTwo}
       {lineThree}
       <br />
-      <span data-testid="address-city-state-and-zip">{`${address.city}, ${
-        address.state
-      } ${address.zip.substring(0, 5)}`}</span>
+      <span data-testid="address-city-state-and-zip">
+        {`${address.city}, ${address.state} ${address.zip.substring(0, 5)}`}
+      </span>
     </>
   );
 };

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentLocation.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentLocation.unit.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import AppointmentLocation from '../AppointmentLocation';
-
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+
+import AppointmentLocation from '../AppointmentLocation';
 
 describe('check-in', () => {
   describe('AppointmentLocation', () => {

--- a/src/applications/check-in/components/BackButton.jsx
+++ b/src/applications/check-in/components/BackButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
@@ -7,15 +7,17 @@ import { createAnalyticsSlug } from '../utils/analytics';
 
 const BackButton = props => {
   const { action, path } = props;
-
-  const handleClick = e => {
-    e.preventDefault();
-    recordEvent({
-      event: createAnalyticsSlug('back-button-clicked'),
-      fromPage: path,
-    });
-    action();
-  };
+  const handleClick = useCallback(
+    e => {
+      e.preventDefault();
+      recordEvent({
+        event: createAnalyticsSlug('back-button-clicked'),
+        fromPage: path,
+      });
+      action();
+    },
+    [path, action],
+  );
   return (
     <>
       <nav
@@ -25,7 +27,7 @@ const BackButton = props => {
       >
         <ul className="row va-nav-breadcrumbs-list columns">
           <li>
-            <a onClick={e => handleClick(e)} href="#" data-testid="back-button">
+            <a onClick={handleClick} href="#back" data-testid="back-button">
               Back to last screen
             </a>
           </li>

--- a/src/applications/check-in/components/BackToAppointments.jsx
+++ b/src/applications/check-in/components/BackToAppointments.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { withRouter } from 'react-router';
 
 import PropTypes from 'prop-types';
 
@@ -6,20 +7,22 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import { createAnalyticsSlug } from '../utils/analytics';
 import { useFormRouting } from '../hooks/useFormRouting';
-import { withRouter } from 'react-router';
 
 import { URLS } from '../utils/navigation';
 
 const BackToAppointments = ({ router, triggerRefresh }) => {
   const { jumpToPage } = useFormRouting(router);
-  const handleClick = e => {
-    e.preventDefault();
-    recordEvent({
-      event: createAnalyticsSlug('back-button-clicked'),
-    });
-    triggerRefresh();
-    jumpToPage(URLS.DETAILS);
-  };
+  const handleClick = useCallback(
+    e => {
+      e.preventDefault();
+      recordEvent({
+        event: createAnalyticsSlug('back-button-clicked'),
+      });
+      triggerRefresh();
+      jumpToPage(URLS.DETAILS);
+    },
+    [jumpToPage, triggerRefresh],
+  );
   return (
     <>
       <nav
@@ -27,8 +30,8 @@ const BackToAppointments = ({ router, triggerRefresh }) => {
         className="va-nav-breadcrumbs va-nav-breadcrumbs--mobile vads-u-margin-top--2 vads-u-padding-left--0"
       >
         <a
-          onClick={e => handleClick(e)}
-          href="#"
+          onClick={handleClick}
+          href="#appointments"
           data-testid="go-to-appointments-button"
         >
           Go to another appointment

--- a/src/applications/check-in/components/pages/ConfirmablePage/ConfirmablePage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/ConfirmablePage.unit.spec.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
-import ConfirmablePage from './index';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import ConfirmablePage from './index';
 
 describe('pre-check-in experience', () => {
   describe('shared components', () => {
@@ -13,6 +13,7 @@ describe('pre-check-in experience', () => {
       });
       it('renders the footer if footer is supplied', () => {
         const { getByText } = render(
+          // eslint-disable-next-line react/jsx-no-bind
           <ConfirmablePage Footer={() => <div>foo</div>} />,
         );
         expect(getByText('foo')).to.exist;
@@ -28,6 +29,7 @@ describe('pre-check-in experience', () => {
       });
       it('renders custom loading message when loading', () => {
         const { getByText } = render(
+          // eslint-disable-next-line react/jsx-no-bind
           <ConfirmablePage isLoading LoadingMessage={() => <div>foo</div>} />,
         );
         expect(getByText('foo')).to.exist;

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.unit.spec.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
-import DemographicsDisplay from './DemographicsDisplay';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import DemographicsDisplay from './DemographicsDisplay';
 
 describe('pre-check-in experience', () => {
   describe('shared components', () => {
@@ -22,6 +22,7 @@ describe('pre-check-in experience', () => {
       });
       it('renders the footer if footer is supplied', () => {
         const { getByText } = render(
+          // eslint-disable-next-line react/jsx-no-bind
           <DemographicsDisplay Footer={() => <div>foo</div>} />,
         );
         expect(getByText('foo')).to.exist;

--- a/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.unit.spec.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
-import EmergencyContactDisplay from './EmergencyContactDisplay';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import EmergencyContactDisplay from './EmergencyContactDisplay';
 
 describe('pre-check-in experience', () => {
   describe('shared components', () => {
@@ -17,6 +17,7 @@ describe('pre-check-in experience', () => {
       });
       it('renders the footer if footer is supplied', () => {
         const { getByText } = render(
+          // eslint-disable-next-line react/jsx-no-bind
           <EmergencyContactDisplay Footer={() => <div>foo</div>} />,
         );
         expect(getByText('foo')).to.exist;

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import propTypes from 'prop-types';
 import ConfirmablePage from '../ConfirmablePage';
 
@@ -18,7 +18,7 @@ export default function NextOfKinDisplay({
     { title: 'Phone', key: 'phone' },
     { title: 'Work phone', key: 'workPhone' },
   ];
-  const loadingMessage = () => {
+  const loadingMessage = useCallback(() => {
     return (
       <>
         <va-loading-indicator
@@ -27,7 +27,7 @@ export default function NextOfKinDisplay({
         />
       </>
     );
-  };
+  }, []);
   return (
     <>
       <ConfirmablePage

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.unit.spec.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
-import NextOfKinDisplay from './NextOfKinDisplay';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import NextOfKinDisplay from './NextOfKinDisplay';
 
 describe('pre-check-in experience', () => {
   describe('shared components', () => {
@@ -19,6 +19,7 @@ describe('pre-check-in experience', () => {
       });
       it('renders the footer if footer is supplied', () => {
         const { getByText } = render(
+          // eslint-disable-next-line react/jsx-no-bind
           <NextOfKinDisplay Footer={() => <div>foo</div>} />,
         );
         expect(getByText('foo')).to.exist;

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import propTypes from 'prop-types';
 
 import { VaTextInput } from 'web-components/react-bindings';
@@ -12,17 +12,32 @@ export default function ValidateDisplay({
   last4Input: { last4ErrorMessage, setLast4Ssn, last4Ssn } = {},
   Footer,
 }) {
+  const updateField = useCallback(
+    event => {
+      switch (event.target.name) {
+        case 'last-name':
+          setLastName(event.detail.value);
+          break;
+        case 'last-4-ssn':
+          setLast4Ssn(event.detail.value);
+          break;
+        default:
+          break;
+      }
+    },
+    [setLastName, setLast4Ssn],
+  );
   return (
     <div className="vads-l-grid-container vads-u-padding-bottom--5 vads-u-padding-top--2 ">
       <h1>{header}</h1>
       <p>{subtitle}</p>
-      <form className="vads-u-margin-bottom--2p5" onSubmit={() => false}>
+      <form className="vads-u-margin-bottom--2p5" onSubmit={validateHandler}>
         <VaTextInput
           autoCorrect="false"
           error={lastNameErrorMessage}
           label="Your last name"
           name="last-name"
-          onVaChange={event => setLastName(event.detail.value)}
+          onVaChange={updateField}
           required
           spellCheck="false"
           value={lastName}
@@ -33,7 +48,7 @@ export default function ValidateDisplay({
           inputmode="numeric"
           label="Last 4 digits of your Social Security number"
           maxlength="4"
-          onVaChange={event => setLast4Ssn(event.detail.value)}
+          onVaChange={updateField}
           name="last-4-ssn"
           required
           value={last4Ssn}
@@ -59,9 +74,9 @@ export default function ValidateDisplay({
 ValidateDisplay.propTypes = {
   Footer: propTypes.elementType,
   header: propTypes.string,
+  isLoading: propTypes.bool,
+  last4Input: propTypes.object,
+  lastNameInput: propTypes.object,
   subtitle: propTypes.string,
   validateHandler: propTypes.func,
-  isLoading: propTypes.bool,
-  lastNameInput: propTypes.object,
-  last4Input: propTypes.object,
 };

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import ValidateDisplay from './ValidateDisplay';
 import sinon from 'sinon';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import ValidateDisplay from './ValidateDisplay';
 
 describe('check-in experience', () => {
   describe('shared components', () => {
@@ -23,6 +23,7 @@ describe('check-in experience', () => {
       });
       it('renders the footer if footer is supplied', () => {
         const { getByText } = render(
+          // eslint-disable-next-line react/jsx-no-bind
           <ValidateDisplay Footer={() => <div>foo</div>} />,
         );
 

--- a/src/applications/check-in/containers/withAppName.jsx
+++ b/src/applications/check-in/containers/withAppName.jsx
@@ -7,7 +7,8 @@ export const withAppName = Component => {
     const selectApp = useMemo(makeSelectApp, []);
     const { app } = useSelector(selectApp);
     const isPreCheckIn = app === 'preCheckIn';
-
+    // Allowing for HOC
+    // eslint-disable-next-line react/jsx-props-no-spreading
     return <Component isPreCheckIn={isPreCheckIn} {...props} />;
   };
 };

--- a/src/applications/check-in/containers/withAuthorization.jsx
+++ b/src/applications/check-in/containers/withAuthorization.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import propTypes from 'prop-types';
 
 import { makeSelectCurrentContext } from '../selectors';
 
@@ -10,8 +11,8 @@ import { SCOPES } from '../utils/token-format-validator';
 import { URLS } from '../utils/navigation';
 
 const withAuthorization = (Component, options) => {
-  const { isPreCheckIn } = options;
-  return props => {
+  const WrappedComponent = props => {
+    const { isPreCheckIn } = options;
     const { router } = props;
     const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
     const { token, permissions } = useSelector(selectCurrentContext);
@@ -38,10 +39,18 @@ const withAuthorization = (Component, options) => {
 
     return (
       <>
+        {/* Allowing for HOC */}
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <Component {...props} />
       </>
     );
   };
+
+  WrappedComponent.propTypes = {
+    router: propTypes.object,
+  };
+
+  return WrappedComponent;
 };
 
 export default withAuthorization;

--- a/src/applications/check-in/containers/withFeatureFlip.jsx
+++ b/src/applications/check-in/containers/withFeatureFlip.jsx
@@ -20,17 +20,19 @@ const withFeatureFlip = (Component, options) => {
           <va-loading-indicator message="Loading your check in experience" />
         </>
       );
-    } else if (!appEnabled) {
+    }
+    if (!appEnabled) {
       window.location.replace('/');
       return <></>;
-    } else {
-      return (
-        <>
-          <meta name="robots" content="noindex" />
-          <Component {...props} {...featureToggles} />
-        </>
-      );
     }
+    return (
+      <>
+        <meta name="robots" content="noindex" />
+        {/* Allowing for HOC */}
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <Component {...props} {...featureToggles} />
+      </>
+    );
   };
 };
 

--- a/src/applications/check-in/containers/withForm.jsx
+++ b/src/applications/check-in/containers/withForm.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import propTypes from 'prop-types';
 
 import { makeSelectForm } from '../selectors';
 
@@ -9,8 +10,8 @@ import { useFormRouting } from '../hooks/useFormRouting';
 import { URLS } from '../utils/navigation';
 
 const withForm = (Component, options = {}) => {
-  const { isPreCheckIn } = options;
-  return props => {
+  const WrappedComponent = props => {
+    const { isPreCheckIn } = options;
     const { router } = props;
     const selectForm = useMemo(makeSelectForm, []);
     const form = useSelector(selectForm);
@@ -33,10 +34,18 @@ const withForm = (Component, options = {}) => {
 
     return (
       <>
+        {/* Allowing for HOC */}
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <Component {...props} />
       </>
     );
   };
+
+  WrappedComponent.propTypes = {
+    router: propTypes.object,
+  };
+
+  return WrappedComponent;
 };
 
 export default withForm;

--- a/src/applications/check-in/containers/withOnlyOnLocal.jsx
+++ b/src/applications/check-in/containers/withOnlyOnLocal.jsx
@@ -6,9 +6,10 @@ import environment from 'platform/utilities/environment';
 const withOnlyOnLocal = WrappedComponent => props => {
   if (!environment.isLocalhost()) {
     return <></>;
-  } else {
-    return <WrappedComponent {...props} />;
   }
+  // Allowing for HOC
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <WrappedComponent {...props} />;
 };
 
 const composedWrapper = compose(withOnlyOnLocal);

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import format from 'date-fns/format';
 import recordEvent from 'platform/monitoring/record-event';
@@ -20,14 +20,17 @@ const DisplayMultipleAppointments = props => {
     focusElement('h1');
   }, []);
 
-  const handleClick = () => {
-    recordEvent({
-      event: createAnalyticsSlug('refresh-appointments-button-clicked'),
-    });
+  const handleClick = useCallback(
+    () => {
+      recordEvent({
+        event: createAnalyticsSlug('refresh-appointments-button-clicked'),
+      });
 
-    getMultipleAppointments();
-    focusElement('h1');
-  };
+      getMultipleAppointments();
+      focusElement('h1');
+    },
+    [getMultipleAppointments],
+  );
   const { goToPreviousPage } = useFormRouting(router);
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);

--- a/src/applications/check-in/day-of/pages/CheckIn/index.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/index.jsx
@@ -50,18 +50,17 @@ const CheckIn = props => {
 
   if (!appointment) {
     return (
-      <va-loading-indicator message={'Loading your appointments for today'} />
-    );
-  } else {
-    return (
-      <DisplayMultipleAppointments
-        router={router}
-        token={token}
-        appointments={appointments}
-        getMultipleAppointments={getMultipleAppointments}
-      />
+      <va-loading-indicator message="Loading your appointments for today" />
     );
   }
+  return (
+    <DisplayMultipleAppointments
+      router={router}
+      token={token}
+      appointments={appointments}
+      getMultipleAppointments={getMultipleAppointments}
+    />
+  );
 };
 
 CheckIn.propTypes = {

--- a/src/applications/check-in/day-of/pages/Confirmation/MultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/MultipleAppointments.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import format from 'date-fns/format';
 
@@ -17,9 +17,9 @@ const MultipleAppointments = props => {
   const appointment = selectedAppointment;
   const appointmentDateTime = new Date(appointment.startTime);
   const appointmentTime = format(appointmentDateTime, 'h:mm aaaa');
-  const focusOnLoad = () => {
+  const focusOnLoad = useCallback(() => {
     focusElement('h1');
-  };
+  }, []);
   return (
     <div
       className="vads-l-grid-container vads-u-padding-y--5"

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -42,9 +42,12 @@ const Landing = props => {
     [dispatch],
   );
 
-  useEffect(() => {
-    dispatch(setApp(APP_NAMES.CHECK_IN));
-  }, []);
+  useEffect(
+    () => {
+      dispatch(setApp(APP_NAMES.CHECK_IN));
+    },
+    [dispatch],
+  );
   useEffect(
     () => {
       const token = getTokenFromLocation(location);

--- a/src/applications/check-in/day-of/pages/LoadingPage/index.jsx
+++ b/src/applications/check-in/day-of/pages/LoadingPage/index.jsx
@@ -95,8 +95,8 @@ const LoadingPage = props => {
 
 LoadingPage.propTypes = {
   isSessionLoading: PropTypes.bool,
-  router: PropTypes.object,
   isUpdatePageEnabled: PropTypes.bool,
+  router: PropTypes.object,
 };
 
 export default LoadingPage;

--- a/src/applications/check-in/day-of/pages/SeeStaff.jsx
+++ b/src/applications/check-in/day-of/pages/SeeStaff.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import { focusElement } from 'platform/utilities/ui';
 import BackToHome from '../../components/BackToHome';
 import Footer from '../../components/Footer';
-import { focusElement } from 'platform/utilities/ui';
 import BackButton from '../../components/BackButton';
 
 import { makeSelectSeeStaffMessage } from '../../selectors';

--- a/src/applications/check-in/day-of/pages/UpdateInformationQuestion.jsx
+++ b/src/applications/check-in/day-of/pages/UpdateInformationQuestion.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
@@ -16,21 +16,27 @@ const UpdateInformationQuestion = props => {
   const { router } = props;
   const { jumpToPage, goToNextPage } = useFormRouting(router);
 
-  const noButtonClicked = () => {
-    recordEvent({
-      event: 'cta-button-click',
-      'button-click-label': 'no-to-update-information',
-    });
-    goToNextPage();
-  };
+  const noButtonClicked = useCallback(
+    () => {
+      recordEvent({
+        event: 'cta-button-click',
+        'button-click-label': 'no-to-update-information',
+      });
+      goToNextPage();
+    },
+    [goToNextPage],
+  );
 
-  const yesButtonClicked = () => {
-    recordEvent({
-      event: 'cta-button-click',
-      'button-click-label': 'yes-to-update-information',
-    });
-    jumpToPage(URLS.SEE_STAFF);
-  };
+  const yesButtonClicked = useCallback(
+    () => {
+      recordEvent({
+        event: 'cta-button-click',
+        'button-click-label': 'yes-to-update-information',
+      });
+      jumpToPage(URLS.SEE_STAFF);
+    },
+    [jumpToPage],
+  );
 
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 update-information">
@@ -45,14 +51,16 @@ const UpdateInformationQuestion = props => {
         <button
           data-testid="yes-button"
           className="usa-button-secondary usa-button-big"
-          onClick={() => yesButtonClicked()}
+          onClick={yesButtonClicked}
+          type="button"
         >
           Yes
         </button>
         <button
           data-testid="no-button"
           className="usa-button-secondary usa-button-big"
-          onClick={() => noButtonClicked()}
+          onClick={noButtonClicked}
+          type="button"
         >
           No
         </button>

--- a/src/applications/check-in/day-of/routes.jsx
+++ b/src/applications/check-in/day-of/routes.jsx
@@ -109,9 +109,11 @@ const createRoutesWithStore = () => {
       {routes.map((route, i) => {
         const options = { isPreCheckIn: false };
         let component = props => (
+          /* eslint-disable react/jsx-props-no-spreading */
           <ErrorBoundary {...props}>
             <route.component {...props} />
           </ErrorBoundary>
+          /* eslint-disable react/jsx-props-no-spreading */
         );
         if (route.permissions) {
           const { requiresForm, requireAuthorization } = route.permissions;

--- a/src/applications/check-in/day-of/tests/e2e/already-validated-user/returning.user.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/already-validated-user/returning.user.cypress.spec.js
@@ -5,7 +5,7 @@ import Appointments from '../pages/Appointments';
 import Confirmation from '../pages/Confirmation';
 
 describe('Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/app-enabled/disabled.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/app-enabled/disabled.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 
 describe('Check In Experience', () => {
   describe('application behind feature toggle', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       ApiInitializer.initializeFeatureToggle.withAppsDisabled();
     });
     afterEach(() => {

--- a/src/applications/check-in/day-of/tests/e2e/app-enabled/enabled.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/app-enabled/enabled.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
   describe('application behind feature toggle', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
       initializeFeatureToggle.withCurrentFeatures();
       initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/already.checked.in.appointment.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/already.checked.in.appointment.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience', () => {
   describe('Appointment display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [
         {
           startTime: '2021-08-19T03:00:00',

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.bad.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.bad.status.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience', () => {
   describe('Appointment display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [{ eligibility: 'INELIGIBLE_BAD_STATUS' }];
 
       const {

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.eligible.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.eligible.status.cypress.spec.js
@@ -8,7 +8,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience', () => {
   describe('Appointment display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [{ eligibility: 'ELIGIBLE' }];
       const {
         initializeFeatureToggle,

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.page.is.refreshed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.page.is.refreshed.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [
         { startTime: '2021-08-19T03:00:00' },
         { startTime: '2021-08-19T13:00:00' },

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.early.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.early.status.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience', () => {
   describe('Appointment display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [
         {
           eligibility: 'INELIGIBLE_TOO_EARLY',

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.late.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.late.status.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [{ eligibility: 'INELIGIBLE_TOO_LATE' }];
       const {
         initializeFeatureToggle,

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.unknown.reason.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.unknown.reason.status.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience', () => {
   describe('Appointment display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [{ eligibility: 'INELIGIBLE_UNKNOWN_REASON' }];
       const {
         initializeFeatureToggle,

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointments.are.sorted.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointments.are.sorted.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [
         { startTime: '2021-08-19T03:00:00' },
         { startTime: '2021-08-19T13:00:00' },

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/bad.formatted.datetime.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/bad.formatted.datetime.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const appointments = [
         {
           startTime: '2021-08-19T03:00:00',

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/posting.appointment.data.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/posting.appointment.data.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Check In Experience', () => {
   describe('Appointment display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/back-button/back.button.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/back-button/back.button.cypress.spec.js
@@ -8,7 +8,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Check In Experience', () => {
   describe('happy path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Check In Experience -- ', () => {
   describe('Confirmation display -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/demographics-display/demographics.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/demographics-display/demographics.display.cypress.spec.js
@@ -6,7 +6,7 @@ import Demographics from '../../../../tests/e2e/pages/Demographics';
 
 describe('Check In Experience', () => {
   describe('Demographics Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/emergency-contact-display/emergency-contact.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/emergency-contact-display/emergency-contact.display.cypress.spec.js
@@ -7,7 +7,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Check In Experience', () => {
   describe('emergency contact display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
@@ -9,7 +9,7 @@ import Appointments from '../pages/Appointments';
 import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/errors/malformed.token.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/malformed.token.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
   });

--- a/src/applications/check-in/day-of/tests/e2e/errors/no.token.provided.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/no.token.provided.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
   });

--- a/src/applications/check-in/day-of/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
@@ -8,7 +8,7 @@ import NextOfKin from '../../../../../tests/e2e/pages/NextOfKin';
 import EmergencyContact from '../../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Check In Experience ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.403.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.403.on.check-in.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeCheckInDataGet,

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.404.on.validate.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.404.on.validate.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withFailure(404);

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.check-in.cypress.spec.js
@@ -10,7 +10,7 @@ import Error from '../pages/Error';
 import Appointments from '../pages/Appointments';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.validate.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.validate.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withFailure(500);

--- a/src/applications/check-in/day-of/tests/e2e/errors/token.is.not.valid.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/token.is.not.valid.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withFailure(200);

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
   describe('extra validation -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -6,7 +6,7 @@ import Demographics from '../../../../tests/e2e/pages/Demographics';
 
 describe('Check In Experience -- ', () => {
   describe('extra validation -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
@@ -6,7 +6,7 @@ import Demographics from '../../../../tests/e2e/pages/Demographics';
 
 describe('Check In Experience', () => {
   describe('extra validation', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
   describe('extra validation -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -27,6 +27,7 @@ describe('Check In Experience -- ', () => {
       ValidateVeteran.typeLast4('12345');
       ValidateVeteran.validateTypedLast4();
       ValidateVeteran.validateMax4Text();
+      cy.injectAxeThenAxeCheck();
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
   describe('extra validation -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -6,7 +6,7 @@ import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
   describe('extra validation -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Check In Experience', () => {
   describe('happy path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
@@ -11,7 +11,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Check In Experience', () => {
   describe('everything path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/next-of-kin-display/next-of-kin-display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/next-of-kin-display/next-of-kin-display.cypress.spec.js
@@ -8,7 +8,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Check In Experience', () => {
   describe('Next of kin Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -1,21 +1,21 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 class Confirmation {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('va-alert > h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('include.text', 'checked in');
-  }
+  };
 
-  validateBackButton() {
+  validateBackButton = () => {
     cy.get('[data-testid=go-to-appointments-button]', {
       timeout: Timeouts.slow,
     })
       .should('be.visible')
       .and('include.text', 'Go to another appointment');
-  }
+  };
 
-  validateBTSSSLink() {
+  validateBTSSSLink = () => {
     cy.get('a[data-testid="btsss-link"]').should(
       'have.text',
       'Find out how to request travel pay reimbursement',
@@ -23,7 +23,7 @@ class Confirmation {
     cy.get('a[data-testid="btsss-link"]')
       .invoke('attr', 'href')
       .should('contain', '/health-care/get-reimbursed-for-travel-pay/');
-  }
+  };
 }
 
 export default new Confirmation();

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -6,6 +6,7 @@ class Confirmation {
       .should('be.visible')
       .and('include.text', 'checked in');
   }
+
   validateBackButton() {
     cy.get('[data-testid=go-to-appointments-button]', {
       timeout: Timeouts.slow,
@@ -13,6 +14,7 @@ class Confirmation {
       .should('be.visible')
       .and('include.text', 'Go to another appointment');
   }
+
   validateBTSSSLink() {
     cy.get('a[data-testid="btsss-link"]').should(
       'have.text',

--- a/src/applications/check-in/day-of/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Error.js
@@ -18,6 +18,7 @@ class Error {
       .should('be.visible')
       .contains('You can pre-check in online until');
   }
+
   validateURL() {
     cy.url().should('match', /error/);
   }

--- a/src/applications/check-in/day-of/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Error.js
@@ -1,7 +1,7 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 class Error {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'We couldn’t check you in');
@@ -11,17 +11,17 @@ class Error {
         'have.text',
         'We’re sorry. Something went wrong on our end. Check in with a staff member.',
       );
-  }
+  };
 
-  validateDatePreCheckInDateShows() {
+  validateDatePreCheckInDateShows = () => {
     cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .contains('You can pre-check in online until');
-  }
+  };
 
-  validateURL() {
+  validateURL = () => {
     cy.url().should('match', /error/);
-  }
+  };
 }
 
 export default new Error();

--- a/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
@@ -1,28 +1,28 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 class SeeStaff {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in with a staff member');
-  }
+  };
 
-  validateMessage(
+  validateMessage = (
     message = 'Our staff can help you update your contact information.If you don’t live at a fixed address right now, we’ll help you find the best way to stay connected with us.',
-  ) {
+  ) => {
     cy.get('h1')
       .next()
       .should('be.visible')
       .and('have.text', message);
-  }
+  };
 
-  validateBackButton() {
+  validateBackButton = () => {
     cy.get('[data-testid=back-button]')
       .should('be.visible')
       .and('have.text', 'Back to last screen');
-  }
+  };
 
-  validateBTSSSLink() {
+  validateBTSSSLink = () => {
     cy.get('a[data-testid="btsss-link"]').should(
       'have.text',
       'Find out how to request travel pay reimbursement',
@@ -30,11 +30,11 @@ class SeeStaff {
     cy.get('a[data-testid="btsss-link"]')
       .invoke('attr', 'href')
       .should('contain', '/health-care/get-reimbursed-for-travel-pay/');
-  }
+  };
 
-  selectBackButton() {
+  selectBackButton = () => {
     cy.get('[data-testid="back-button"]').click();
-  }
+  };
 }
 
 export default new SeeStaff();

--- a/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
@@ -6,6 +6,7 @@ class SeeStaff {
       .should('be.visible')
       .and('have.text', 'Check in with a staff member');
   }
+
   validateMessage(
     message = 'Our staff can help you update your contact information.If you don’t live at a fixed address right now, we’ll help you find the best way to stay connected with us.',
   ) {
@@ -14,11 +15,13 @@ class SeeStaff {
       .should('be.visible')
       .and('have.text', message);
   }
+
   validateBackButton() {
     cy.get('[data-testid=back-button]')
       .should('be.visible')
       .and('have.text', 'Back to last screen');
   }
+
   validateBTSSSLink() {
     cy.get('a[data-testid="btsss-link"]').should(
       'have.text',
@@ -28,6 +31,7 @@ class SeeStaff {
       .invoke('attr', 'href')
       .should('contain', '/health-care/get-reimbursed-for-travel-pay/');
   }
+
   selectBackButton() {
     cy.get('[data-testid="back-button"]').click();
   }

--- a/src/applications/check-in/day-of/tests/e2e/pages/UpdateInformation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/UpdateInformation.js
@@ -6,6 +6,7 @@ class UpdateInformation {
       .should('be.visible')
       .and('include.text', 'Do you need to update any information?');
   }
+
   attemptToGoToNextPage(button = 'yes') {
     cy.get(`button[data-testid="${button}-button"]`).click();
   }

--- a/src/applications/check-in/day-of/tests/e2e/pages/UpdateInformation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/UpdateInformation.js
@@ -1,15 +1,15 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 class UpdateInformation {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('include.text', 'Do you need to update any information?');
-  }
+  };
 
-  attemptToGoToNextPage(button = 'yes') {
+  attemptToGoToNextPage = (button = 'yes') => {
     cy.get(`button[data-testid="${button}-button"]`).click();
-  }
+  };
 }
 
 export default new UpdateInformation();

--- a/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.display.cypress.spec.js
@@ -9,7 +9,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Check In Experience', () => {
   describe('See Staff display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.routing.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.routing.cypress.spec.js
@@ -9,7 +9,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Check In Experience', () => {
   describe('See Staff display', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/session/no.data.in.redux.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/no.data.in.redux.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/day-of/tests/e2e/session/no.session.to.reload.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/no.session.to.reload.on.refresh.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/day-of/tests/e2e/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/session.is.saved.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/day-of/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/day-of/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
@@ -6,7 +6,7 @@ import Appointments from '../pages/Appointments';
 
 describe('Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const now = Date.now();
       const today = new Date(now);
       const {

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
@@ -9,7 +9,7 @@ import Appointments from '../pages/Appointments';
 
 describe('Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.demographics.only.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.demographics.only.path.cypress.spec.js
@@ -7,7 +7,7 @@ import Appointments from '../pages/Appointments';
 
 describe('Check In Experience -- ', () => {
   describe('update skip path -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.next.of.kin.only.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.next.of.kin.only.path.cypress.spec.js
@@ -7,7 +7,7 @@ import Appointments from '../pages/Appointments';
 
 describe('Check In Experience -- ', () => {
   describe('update skip path -- ', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import propTypes from 'prop-types';
 import { useFormRouting } from '../../useFormRouting';
 
 export default function TestComponent({ router }) {
@@ -16,31 +17,43 @@ export default function TestComponent({ router }) {
       <h1>Test component for the useFormRouting hook</h1>
       <div data-testid="current-page">{currentPage}</div>
       <div data-testid="all-pages">{pages.join(',')}</div>
-      <button onClick={goToPreviousPage} data-testid="prev-button">
+      <button
+        type="button"
+        onClick={goToPreviousPage}
+        data-testid="prev-button"
+      >
         Prev
       </button>
-      <button onClick={goToNextPage} data-testid="next-button">
+      <button type="button" onClick={goToNextPage} data-testid="next-button">
         Next
       </button>
-      <button onClick={goToErrorPage} data-testid="error-button">
+      <button type="button" onClick={goToErrorPage} data-testid="error-button">
         Error
       </button>
       <button
-        onClick={() => jumpToPage('introduction')}
+        onClick={useCallback(() => jumpToPage('introduction'), [jumpToPage])}
         data-testid="jump-button"
+        type="button"
       >
         Jump
       </button>
       <button
-        onClick={() =>
-          jumpToPage('introduction', {
-            params: { url: { id: '1234', query: 'some-query' } },
-          })
-        }
+        onClick={useCallback(
+          () =>
+            jumpToPage('introduction', {
+              params: { url: { id: '1234', query: 'some-query' } },
+            }),
+          [jumpToPage],
+        )}
         data-testid="jump-with-params-button"
+        type="button"
       >
         Jump with params
       </button>
     </div>
   );
 }
+
+TestComponent.propTypes = {
+  router: propTypes.object,
+};

--- a/src/applications/check-in/hooks/tests/useSessionStorage/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useSessionStorage/TestComponent.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
+import propTypes from 'prop-types';
 import { useSessionStorage } from '../../useSessionStorage';
 
 export default function TestComponent({ window, isPreCheckIn, token }) {
@@ -13,26 +14,38 @@ export default function TestComponent({ window, isPreCheckIn, token }) {
       <h1>Test component for the useSessionStorage hook</h1>
 
       <button
-        onClick={() => {
-          clearCurrentSession(window);
-        }}
+        onClick={useCallback(
+          () => {
+            clearCurrentSession(window);
+          },
+          [clearCurrentSession, window],
+        )}
         data-testid="clear-button"
+        type="button"
       >
         clear
       </button>
       <button
-        onClick={() => {
-          setFromSession(getCurrentToken(window));
-        }}
+        onClick={useCallback(
+          () => {
+            setFromSession(getCurrentToken(window));
+          },
+          [setFromSession, getCurrentToken, window],
+        )}
         data-testid="get-button"
+        type="button"
       >
         get
       </button>
       <button
-        onClick={() => {
-          setCurrentToken(window, token);
-        }}
+        onClick={useCallback(
+          () => {
+            setCurrentToken(window, token);
+          },
+          [setCurrentToken, window, token],
+        )}
         data-testid="set-button"
+        type="button"
       >
         set
       </button>
@@ -42,3 +55,9 @@ export default function TestComponent({ window, isPreCheckIn, token }) {
     </div>
   );
 }
+
+TestComponent.propTypes = {
+  isPreCheckIn: propTypes.bool,
+  token: propTypes.string,
+  window: propTypes.object,
+};

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-
 import URLSearchParams from 'url-search-params';
 
 import { makeSelectForm } from '../selectors';

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -20,55 +20,54 @@ const Confirmation = () => {
   const hasUpdates = Object.values(formData).includes('no');
   if (appointments.length === 0) {
     return <></>;
-  } else {
-    return (
-      <div
-        className="vads-l-grid-container vads-u-padding-bottom--3 vads-u-padding-top--3"
-        data-testid="confirmation-wrapper"
-      >
-        <h1 tabIndex="-1" className="vads-u-margin-top--2">
-          You’ve completed pre-check-in
-        </h1>
-        <AppointmentBlock appointments={appointments} />
-        {hasUpdates ? (
-          <va-alert
-            background-only
-            status="info"
-            show-icon
-            data-testid="confirmation-update-alert"
-          >
-            <div>
-              A staff member will help you on the day of your appointment to
-              update your information.
-            </div>
-          </va-alert>
-        ) : (
-          <></>
-        )}
-        <p className={hasUpdates ? `vads-u-padding-left--2` : ``}>
-          <a href="https://va.gov/health-care/schedule-view-va-appointments/appointments/">
-            Go to your appointment
-          </a>
-        </p>
-        <p className={hasUpdates ? `vads-u-padding-left--2` : ``}>
-          Please bring your insurance cards with you to your appointment.
-        </p>
-        <h3 data-testid="appointment-questions">
-          What if I have questions about my appointment?
-        </h3>
-        <p>Call your VA health care team:</p>
-        {appointments.map((appointment, index) => {
-          return (
-            <p key={index}>
-              {appointment.clinicFriendlyName || appointment.clinicName} at{' '}
-              <Telephone contact={appointment.clinicPhoneNumber} />
-            </p>
-          );
-        })}
-        <BackToHome />
-      </div>
-    );
   }
+  return (
+    <div
+      className="vads-l-grid-container vads-u-padding-bottom--3 vads-u-padding-top--3"
+      data-testid="confirmation-wrapper"
+    >
+      <h1 tabIndex="-1" className="vads-u-margin-top--2">
+        You’ve completed pre-check-in
+      </h1>
+      <AppointmentBlock appointments={appointments} />
+      {hasUpdates ? (
+        <va-alert
+          background-only
+          status="info"
+          show-icon
+          data-testid="confirmation-update-alert"
+        >
+          <div>
+            A staff member will help you on the day of your appointment to
+            update your information.
+          </div>
+        </va-alert>
+      ) : (
+        <></>
+      )}
+      <p className={hasUpdates ? `vads-u-padding-left--2` : ``}>
+        <a href="https://va.gov/health-care/schedule-view-va-appointments/appointments/">
+          Go to your appointment
+        </a>
+      </p>
+      <p className={hasUpdates ? `vads-u-padding-left--2` : ``}>
+        Please bring your insurance cards with you to your appointment.
+      </p>
+      <h3 data-testid="appointment-questions">
+        What if I have questions about my appointment?
+      </h3>
+      <p>Call your VA health care team:</p>
+      {appointments.map((appointment, index) => {
+        return (
+          <p key={index}>
+            {appointment.clinicFriendlyName || appointment.clinicName} at{' '}
+            <Telephone contact={appointment.clinicPhoneNumber} />
+          </p>
+        );
+      })}
+      <BackToHome />
+    </div>
+  );
 };
 
 export default Confirmation;

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -28,21 +28,23 @@ const Error = () => {
       testId: 'date-message',
     });
   }
+  const combinedMessage = (
+    <>
+      {messages.map((message, index) => {
+        return (
+          <p key={index} data-testid={message.testId}>
+            {message.text}
+          </p>
+        );
+      })}
+    </>
+  );
+
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">
       <ErrorMessage
         header="We couldn't complete pre-check-in"
-        message={
-          <>
-            {messages.map((message, index) => {
-              return (
-                <p key={index} data-testid={message.testId}>
-                  {message.text}
-                </p>
-              );
-            })}
-          </>
-        }
+        message={combinedMessage}
       />
       <Footer />
       <BackToHome />

--- a/src/applications/check-in/pre-check-in/pages/ErrorTest/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/ErrorTest/index.jsx
@@ -1,16 +1,21 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import BackToHome from '../../../components/BackToHome';
 
 const ErrorTest = () => {
   const [value, setValue] = useState({
     item: { thing: { display: 'click to throw render error' } },
   });
-  const throwError = () => {
-    setValue({});
-  };
+  const throwError = useCallback(
+    () => {
+      setValue({});
+    },
+    [setValue],
+  );
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">
-      <button onClick={throwError}>{value.item.thing.display}</button>
+      <button type="button" onClick={throwError}>
+        {value.item.thing.display}
+      </button>
       <BackToHome />
     </div>
   );

--- a/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react';
+import React, { useMemo, useEffect, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { format, subDays } from 'date-fns';
@@ -81,17 +81,17 @@ const IntroductionDisplay = props => {
     >
       <a
         className="vads-c-action-link--green"
-        href="#"
-        onKeyDown={e => {
+        href="#answer"
+        onKeyDown={useCallback(e => {
           if (e.key === ' ') {
             e.preventDefault();
             goToNextPage();
           }
-        }}
-        onClick={e => {
+        }, [])}
+        onClick={useCallback(e => {
           e.preventDefault();
           goToNextPage();
-        }}
+        }, [])}
       >
         Answer questions
       </a>
@@ -150,11 +150,14 @@ const IntroductionDisplay = props => {
         </span>
         <br />
         <a
-          href="#"
-          onClick={e => {
-            e.preventDefault();
-            setPrivacyActModalOpen(true);
-          }}
+          href="#privacy-modal"
+          onClick={useCallback(
+            e => {
+              e.preventDefault();
+              setPrivacyActModalOpen(true);
+            },
+            [setPrivacyActModalOpen],
+          )}
         >
           Privacy Act Statement
         </a>
@@ -162,7 +165,9 @@ const IntroductionDisplay = props => {
       <Footer message={additionalFooterInfo} />
       <BackToHome />
       <Modal
-        onClose={() => setPrivacyActModalOpen(false)}
+        onClose={useCallback(() => setPrivacyActModalOpen(false), [
+          setPrivacyActModalOpen,
+        ])}
         visible={privacyActModalOpen}
         focusSelector="button"
         cssClass=""

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -59,9 +59,8 @@ const Introduction = props => {
   );
   if (isLoading) {
     return <va-loading-indicator message="Loading your appointment details" />;
-  } else {
-    return <IntroductionDisplay router={router} />;
   }
+  return <IntroductionDisplay router={router} />;
 };
 
 Introduction.propTypes = {

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import propTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -43,9 +44,12 @@ export default function Index(props) {
   const { router } = props;
   const { goToErrorPage, jumpToPage } = useFormRouting(router);
   const { clearCurrentSession, setCurrentToken } = useSessionStorage();
-  useEffect(() => {
-    dispatch(setApp(APP_NAMES.PRE_CHECK_IN));
-  }, []);
+  useEffect(
+    () => {
+      dispatch(setApp(APP_NAMES.PRE_CHECK_IN));
+    },
+    [dispatch],
+  );
   useEffect(
     () => {
       const token = getTokenFromLocation(router.location);
@@ -109,3 +113,7 @@ export default function Index(props) {
     </>
   );
 }
+
+Index.propTypes = {
+  router: propTypes.object,
+};

--- a/src/applications/check-in/pre-check-in/pages/NextOfKin/tests/NextOfKin.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/NextOfKin/tests/NextOfKin.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
-import NextOfKin from '../';
+import NextOfKin from '..';
 
 import { createMockRouter } from '../../../../tests/unit/mocks/router';
 

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -4,7 +4,6 @@ import propTypes from 'prop-types';
 
 import { focusElement } from 'platform/utilities/ui';
 
-import PropTypes from 'prop-types';
 import { api } from '../../../api';
 
 import { createSetSession } from '../../../actions/authentication';
@@ -101,7 +100,7 @@ const Index = ({ router }) => {
 };
 
 Index.propTypes = {
-  router: PropTypes.object,
+  router: propTypes.object,
 };
 
 export default Index;

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import propTypes from 'prop-types';
 
 import { focusElement } from 'platform/utilities/ui';
 

--- a/src/applications/check-in/pre-check-in/routes.jsx
+++ b/src/applications/check-in/pre-check-in/routes.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
+import environment from 'platform/utilities/environment';
 import Validate from './pages/Validate';
 import Introduction from './pages/Introduction';
 import Demographics from './pages/Demographics';
@@ -16,8 +17,6 @@ import withAuthorization from '../containers/withAuthorization';
 import withForm from '../containers/withForm';
 
 import ErrorBoundary from '../components/errors/ErrorBoundary';
-
-import environment from 'platform/utilities/environment';
 
 const routes = [
   {
@@ -83,9 +82,11 @@ const createRoutesWithStore = () => {
       {routes.map((route, i) => {
         const options = { isPreCheckIn: true };
         let component = props => (
+          /* eslint-disable react/jsx-props-no-spreading */
           <ErrorBoundary {...props}>
             <route.component {...props} />
           </ErrorBoundary>
+          /* eslint-disable react/jsx-props-no-spreading */
         );
         if (route.permissions) {
           const { requiresForm, requireAuthorization } = route.permissions;
@@ -107,7 +108,9 @@ const createRoutesWithStore = () => {
       })}
       {!environment.isProduction() && (
         <Route
-          path={`/sentry/test`}
+          path="/sentry/test"
+          // Disable for test scenario
+          // eslint-disable-next-line react/jsx-no-bind
           component={() => (
             <ErrorBoundary>
               <ErrorTest />

--- a/src/applications/check-in/pre-check-in/tests/e2e/app-enabled/disabled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/app-enabled/disabled.cypress.spec.js
@@ -3,7 +3,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import '../../../../tests/e2e/commands';
 
 describe('Pre-Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     ApiInitializer.initializeFeatureToggle.withAppsDisabled();
   });
   afterEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/app-enabled/enabled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/app-enabled/enabled.cypress.spec.js
@@ -3,7 +3,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre-Check In Experience', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/pre-check-in/tests/e2e/back-button/back.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/back-button/back.button.cypress.spec.js
@@ -9,7 +9,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Pre-Check In Experience ', () => {
   let apiData = {};
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre-Check In Experience', () => {
   describe('Next of kin Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/confirmation-display/confirmation.reloads.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/confirmation-display/confirmation.reloads.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre-Check In Experience', () => {
   describe('Next of kin Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
@@ -7,7 +7,7 @@ import Demographics from '../../../../tests/e2e/pages/Demographics';
 
 describe('Pre-Check In Experience', () => {
   describe('Demographics Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec.js
@@ -8,7 +8,7 @@ import Error from '../../pages/Error';
 describe('Pre-Check In Experience ', () => {
   describe('Error handling', () => {
     describe('GET /check_in/v2/pre_check_ins/', () => {
-      beforeEach(function() {
+      beforeEach(() => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/non.200.status.code.cypress.spec.js
@@ -7,7 +7,7 @@ import Error from '../../pages/Error';
 describe('Pre-Check In Experience ', () => {
   describe('Error handling', () => {
     describe('GET /check_in/v2/pre_check_ins/', () => {
-      beforeEach(function() {
+      beforeEach(() => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/error.in.body.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/error.in.body.cypress.spec.js
@@ -29,6 +29,7 @@ describe('Pre-Check In Experience ', () => {
         cy.visitPreCheckInWithUUID();
 
         Error.validatePageLoaded();
+        cy.injectAxeThenAxeCheck();
       });
     });
   });

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/error.in.body.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/error.in.body.cypress.spec.js
@@ -6,7 +6,7 @@ import Error from '../../pages/Error';
 describe('Pre-Check In Experience ', () => {
   describe('Error handling', () => {
     describe('GET /check_in/v2/session/', () => {
-      beforeEach(function() {
+      beforeEach(() => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/non.200.status.code.cypress.spec.js
@@ -23,6 +23,7 @@ describe('Pre-Check In Experience ', () => {
         cy.visitPreCheckInWithUUID();
 
         Error.validatePageLoaded();
+        cy.injectAxeThenAxeCheck();
       });
     });
   });

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-session/non.200.status.code.cypress.spec.js
@@ -6,7 +6,7 @@ import Error from '../../pages/Error';
 describe('Pre-Check In Experience ', () => {
   describe('Error handling', () => {
     describe('GET /check_in/v2/session/', () => {
-      beforeEach(function() {
+      beforeEach(() => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec.js
@@ -12,7 +12,7 @@ describe('Pre-Check In Experience ', () => {
   describe('Error handling', () => {
     describe('POST /check_in/v2/pre_check_ins/', () => {
       let apiData = {};
-      beforeEach(function() {
+      beforeEach(() => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/non.200.status.code.cypress.spec.js
@@ -12,7 +12,7 @@ describe('Pre-Check In Experience ', () => {
   describe('Error handling', () => {
     describe('POST /check_in/v2/pre_check_ins/', () => {
       let apiData = {};
-      beforeEach(function() {
+      beforeEach(() => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../../tests/e2e/pages/ValidateVeteran';
 import Error from '../../pages/Error';
 
 describe('Pre-Check In Experience ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre-Check In Experience', () => {
   describe('validation page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -6,7 +6,7 @@ import Introduction from '../pages/Introduction';
 
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
@@ -6,7 +6,7 @@ import Introduction from '../pages/Introduction';
 
 describe('Pre-Check In Experience', () => {
   describe('Validation Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -7,7 +7,7 @@ import Error from '../pages/Error';
 describe('Pre-Check In Experience', () => {
   // @TODO: un-skip when the error page is created.
   describe('Validate Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre-Check In Experience ', () => {
   let apiData = {};
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
@@ -6,7 +6,7 @@ import Introduction from '../pages/Introduction';
 
 describe('Pre-Check In Experience', () => {
   describe('Introduction Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/intro-display/expiration.date.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/intro-display/expiration.date.display.cypress.spec.js
@@ -7,7 +7,7 @@ import Introduction from '../pages/Introduction';
 describe('Pre-Check In Experience', () => {
   describe('Introduction Page', () => {
     let apiData = {};
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/intro-display/multiple.appointments.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/intro-display/multiple.appointments.display.cypress.spec.js
@@ -6,7 +6,7 @@ import Introduction from '../pages/Introduction';
 
 describe('Pre-Check In Experience', () => {
   describe('Introduction Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/loading-session/new.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/loading-session/new.session.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre-Check In Experience ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();

--- a/src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
@@ -1,10 +1,10 @@
 import '../../../../tests/e2e/commands';
 
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
-import Introduction from '../../../tests/e2e/pages/Introduction';
+import Introduction from '../pages/Introduction';
 
 describe('Pre-Check In Experience ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/next-of-kin-display/next.of.kin.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/next-of-kin-display/next.of.kin.display.cypress.spec.js
@@ -9,7 +9,7 @@ import Demographics from '../../../../tests/e2e/pages/Demographics';
 
 describe('Pre-Check In Experience', () => {
   describe('Next of kin Page', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
@@ -1,13 +1,13 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 class Confirmation {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'You’ve completed pre-check-in');
-  }
+  };
 
-  validatePageContent() {
+  validatePageContent = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'You’ve completed pre-check-in');
@@ -17,20 +17,20 @@ class Confirmation {
     cy.get("h3[data-testid='appointment-questions']")
       .should('be.visible')
       .and('have.text', 'What if I have questions about my appointment?');
-  }
+  };
 
-  validateConfirmWithUpdates() {
+  validateConfirmWithUpdates = () => {
     cy.get("[data-testid='confirmation-update-alert']")
       .should('be.visible')
       .and(
         'have.text',
         'A staff member will help you on the day of your appointment to update your information.',
       );
-  }
+  };
 
-  validateConfirmNoUpdates() {
+  validateConfirmNoUpdates = () => {
     cy.get("[data-testid='confirmation-update-alert']").should('not.exist');
-  }
+  };
 }
 
 export default new Confirmation();

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
@@ -1,7 +1,7 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 class Error {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', "We couldn't complete pre-check-in");
@@ -10,16 +10,17 @@ class Error {
       .contains(
         'We’re sorry. Something went wrong on our end. Please try again.',
       );
-  }
+  };
 
-  validateDatePreCheckInDateShows() {
+  validateDatePreCheckInDateShows = () => {
     cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .contains('You can pre-check in online until');
-  }
-  validateURL() {
+  };
+
+  validateURL = () => {
     cy.url().should('match', /error/);
-  }
+  };
 }
 
 export default new Error();

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
@@ -2,34 +2,38 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 import { format, subDays } from 'date-fns';
 
 class Introduction {
-  validatePageLoaded() {
+  validatePageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Answer pre-check-in questions');
-  }
-  validateMultipleAppointmentIntroText(appointmentDate = new Date()) {
+  };
+
+  validateMultipleAppointmentIntroText = (appointmentDate = new Date()) => {
     cy.get('p[data-testid="appointment-day-location"]').contains(
       `Your appointments are on ${format(
         appointmentDate,
         'MMMM dd, Y',
       )} at LOMA LINDA VA CLINIC.`,
     );
-  }
-  validateSingleAppointmentIntroText(appointmentDate = new Date()) {
+  };
+
+  validateSingleAppointmentIntroText = (appointmentDate = new Date()) => {
     cy.get('p[data-testid="appointment-day-location"]').contains(
       `Your appointment on ${format(
         appointmentDate,
         'MMMM dd, Y',
       )} at LOMA LINDA VA CLINIC.`,
     );
-  }
-  countAppointmentList(expectedLength) {
+  };
+
+  countAppointmentList = expectedLength => {
     cy.get('ol[data-testid="appointment-list"] li').should(
       'have.length',
       expectedLength,
     );
-  }
-  toggleAccordion(accordionIndex, open) {
+  };
+
+  toggleAccordion = (accordionIndex, open) => {
     if (open) {
       cy.get('[data-testid="intro-accordion-item"]')
         .shadow()
@@ -61,17 +65,19 @@ class Introduction {
         .eq(accordionIndex)
         .should('not.be.visible');
     }
-  }
-  validateExpirationDate(appointmentTime) {
+  };
+
+  validateExpirationDate = appointmentTime => {
     cy.get('[data-testid="expiration-date"]').contains(
       format(subDays(appointmentTime, 1), 'M/dd/Y'),
     );
-  }
-  attemptToGoToNextPage() {
+  };
+
+  attemptToGoToNextPage = () => {
     cy.get('div[data-testid="intro-wrapper"] div[data-testid="start-button"] a')
       .eq(0)
       .click();
-  }
+  };
 }
 
 export default new Introduction();

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre-Check In Experience ', () => {
   let apiData = {};
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.yes.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.yes.to.three.questions.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre-Check In Experience ', () => {
   let apiData = {};
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/requires-form/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/requires-form/session.reloads.on.refresh.cypress.spec.js
@@ -6,7 +6,7 @@ import Introduction from '../pages/Introduction';
 
 describe('Pre Check In Experience', () => {
   describe('requires form', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/routing/browser.back.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/routing/browser.back.button.cypress.spec.js
@@ -10,7 +10,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre-Check In Experience ', () => {
   let apiData = {};
-  beforeEach(function() {
+  beforeEach(() => {
     const {
       initializeFeatureToggle,
       initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/no.data.in.redux.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/no.data.in.redux.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre Check In Experience', () => {
   describe('session', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/no.session.to.reload.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/no.session.to.reload.on.refresh.cypress.spec.js
@@ -6,7 +6,7 @@ import Error from '../pages/Error';
 
 describe('Pre Check In Experience', () => {
   describe('session', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const { initializeFeatureToggle } = ApiInitializer;
       initializeFeatureToggle.withCurrentFeatures();
     });

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.is.saved.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre Check In Experience', () => {
   describe('session', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre Check In Experience', () => {
   describe('session', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
@@ -5,7 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Pre Check In Experience', () => {
   describe('session', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const {
         initializeFeatureToggle,
         initializeSessionGet,

--- a/src/applications/check-in/pre-check-in/tests/e2e/token-validation/malformed.token.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/token-validation/malformed.token.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Pre-Check In Experience ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
   });

--- a/src/applications/check-in/pre-check-in/tests/e2e/token-validation/no.token.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/token-validation/no.token.cypress.spec.js
@@ -4,7 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Error from '../pages/Error';
 
 describe('Pre-Check In Experience ', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     const { initializeFeatureToggle } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
   });

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
@@ -7,7 +7,7 @@ import Confirmation from '../pages/Confirmation';
 
 describe('Pre Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const now = Date.now();
       const today = new Date(now);
       const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.demographics.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.demographics.path.cypress.spec.js
@@ -9,7 +9,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Pre Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const now = Date.now();
       const today = new Date(now);
       const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.emergency.contact.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.emergency.contact.path.cypress.spec.js
@@ -9,7 +9,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 
 describe('Pre Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const now = Date.now();
       const today = new Date(now);
       const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.next.of.kin.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.next.of.kin.path.cypress.spec.js
@@ -9,7 +9,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Pre Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const now = Date.now();
       const today = new Date(now);
       const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
@@ -10,7 +10,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 
 describe('Pre Check In Experience', () => {
   describe('update skip path', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       const now = Date.now();
       const today = new Date(now);
       const {

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -46,7 +46,7 @@ import { SET_SESSION } from '../actions/authentication';
 
 import { setSessionHandler } from './authentication';
 
-import { SET_APP } from '../actions/universal/index.js';
+import { SET_APP } from '../actions/universal';
 
 const handler = Object.freeze({
   [INIT_FORM]: initFormHandler,

--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -35,13 +35,13 @@ class ValidateVeteran {
       .find('input');
   };
 
-  typeLastName(lastName = 'Smith') {
+  typeLastName = (lastName = 'Smith') => {
     this.getLastNameInput().type(lastName);
-  }
+  };
 
-  typeLast4(last4 = '1234') {
+  typeLast4 = (last4 = '1234') => {
     this.getLast4Input().type(last4);
-  }
+  };
 
   attemptToGoToNextPage = () => {
     cy.get('[data-testid=check-in-button]').click({ waitForAnimations: true });


### PR DESCRIPTION
## Description
Ran a full es-lint audit of the check-in app and fixed all errors and warnings.

I disabled linting in a couple of spots, one area is in HOCs and routers where we need to spread props and pass them down. You can see in the docs that HOCs is a place to not use the rule 
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md

Also disabled the linters in a couple of testing scenarios. Seemed like the best approach for those non-runtime things but open to some feedback on a better way to resolve that.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35976


## Testing done
updated unit and e2e tests


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
