### PR TITLE
36314: Rework startReactApp root logic

### DIFF
--- a/src/platform/startup/react.js
+++ b/src/platform/startup/react.js
@@ -10,10 +10,13 @@ import ReactDOM from 'react-dom';
  * VetsGov object on window.
  *
  * @param {ReactElement} component The React element you want to mount
- * @param {Element} [root=null] A DOM element to mount the react application into. By default,
+ * @param {Element} [root] A DOM element to mount the react application into. By default,
  * this will be the element with an id of 'react-root'.
  */
-export default function startReactApp(component, root = null) {
+export default function startReactApp(
+  component,
+  root = document.getElementById('react-root'),
+) {
   // Detect if this is a child frame. If yes, initialize the react devtools hook to work around
   //   https://github.com/facebook/react-devtools/issues/57
   // This must occur before any react code is loaded.
@@ -35,17 +38,18 @@ export default function startReactApp(component, root = null) {
       smooth: true,
     },
   };
-
-  let mountElement = root;
-  if (!mountElement) {
-    mountElement = document.getElementById('react-root');
+  // If the specified root element is null/undefined, we don't know where to place the component,
+  // therfore we discard it. This prevents components who have a specified root from being placed
+  // on the page unintentionally.
+  if (!root) {
+    return;
   }
 
   if (document.readyState !== 'loading') {
-    ReactDOM.render(component, mountElement);
+    ReactDOM.render(component, root);
   } else {
     document.addEventListener('DOMContentLoaded', () => {
-      ReactDOM.render(component, mountElement);
+      ReactDOM.render(component, root);
     });
   }
 }

--- a/src/platform/startup/tests/react.unit.spec.js
+++ b/src/platform/startup/tests/react.unit.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+import startReactApp from '../react';
+
+const FakeWidget = () => <div id="fake-widget">Widget</div>;
+
+describe('startReactApp', () => {
+  let renderStub;
+  let sandbox;
+  let reactRoot;
+  let widgetRoot;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    renderStub = sandbox.stub(ReactDOM, 'render').resolves(() => {});
+
+    reactRoot = document.createElement('div');
+    reactRoot.setAttribute('id', 'react-root');
+    document.body.appendChild(reactRoot);
+
+    widgetRoot = document.createElement('div');
+    widgetRoot.setAttribute('id', 'widget-root');
+    document.body.appendChild(widgetRoot);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    renderStub.restore();
+    document.body.removeChild(reactRoot);
+    document.body.removeChild(widgetRoot);
+  });
+
+  it('should render the component to #react-root when root argument is not provided', () => {
+    startReactApp(FakeWidget);
+    expect(renderStub.calledWith(FakeWidget, reactRoot)).to.be.true;
+  });
+
+  it('should render the component to the provided root argument when it exists', () => {
+    startReactApp(FakeWidget, document.getElementById('widget-root'));
+    expect(renderStub.calledWith(FakeWidget, widgetRoot)).to.be.true;
+  });
+
+  it('should not render the component if the provided root argument does not exist', () => {
+    startReactApp(FakeWidget, document.getElementById('another-widget-root'));
+    expect(renderStub.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Description
A recent bug on the `/sign-in page` shed light on another bug within the `startReactApp` function. Specifically, when placing site-wide widgets on the `/sign-in` page, where the `div#va-nav-controls` element does not exist, `startReactApp` would default `root` to `div#react-root`. This led to placing the `MobileMenuButton` within the main section of the page, only to later be replaced with the `LoginContainer` that loaded later in the timeline.

A, now reverted, change that lazy-loaded the `MobileMenuButton` led to the `LoginContainer` loading first, then being replaced by the `MobileMenuButton`, thus being the final and only thing rendered in `div#react-root` on the `/sign-in` page.

you can read a full write-up on this issue in the [post mortem here](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Postmortems/2022-01-27-sign-in-page-rendered-wrong-component.md).

### Bug Fix Assumption
The fix in this PR assumes that if `startReactApp` is called with a specified `root` argument, then the component being loaded must load into that node or not at all.

To maintain the default `div#react-root` behavior, we move the `document.getElementById('react-root')` into the argument default location, which will let us have an accurate `null/undefined` reference for when the desired node is missing in the DOM.

With this change, we can be assured that anything utilizing `startReactApp` will not unintentionally render into `div#react-root` when its desired parent element has been removed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36314


## Testing done
- Added unit testing

## Screenshots


## Acceptance criteria
- [ ] Apps/Widgets using `startReactApp` without a specified `root` argument still default to rendering in `div#react-root`
- [ ] Apps/widgets using `startReactApp` with a specified `root` argument will not render at all if that `root` node does not exist

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
