### PR TITLE
Changes language on Virtual Agent Disclaimer button text

### DIFF
--- a/src/applications/virtual-agent/components/chatbox/ChatboxDisclaimer.jsx
+++ b/src/applications/virtual-agent/components/chatbox/ChatboxDisclaimer.jsx
@@ -26,7 +26,7 @@ export const ChatboxDisclaimer = () => {
           className={'usa-button-primary'}
           onClick={() => dispatch({ type: ACCEPTED })}
         >
-          Accept
+          Accept & Start Chat
         </button>
       </div>
     </va-alert>


### PR DESCRIPTION
## Description
Changes the accept button to say 'Accept & Start Chat'

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#376


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
