### PR TITLE
prefer not to answer option removed from pronouns on profile

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -72,7 +72,6 @@ describe('Content in EDIT state on the personal information page', () => {
     cy.findByText('They/them/theirs').should('exist');
     cy.findByText('Ze/zir/zirs').should('exist');
     cy.findByText('Use my preferred name').should('exist');
-    cy.findByText('Prefer not to answer').should('exist');
     cy.findByText('Pronouns not listed here').should('exist');
     cy.findByText(
       'If not listed, please provide your preferred pronouns (255 characters maximum)',

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -123,7 +123,6 @@ export const personalInformationUiSchemas = {
     theyThemTheirs: { 'ui:title': 'They/them/theirs' },
     zeZirZirs: { 'ui:title': 'Ze/zir/zirs' },
     useMyPreferredName: { 'ui:title': 'Use my preferred name' },
-    preferNotToAnswer: { 'ui:title': 'Prefer not to answer' },
     pronounsNotListed: {
       'ui:title': 'Pronouns not listed here',
     },


### PR DESCRIPTION
## Description
MPI does not support the 'prefer not to answer' option in the Pronouns field of profile, so this PR removes that checkbox

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36174


## Testing done
updated e2e test to match

## Acceptance criteria
- [x] option doesn't appear

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
