### PR TITLE
covid-19 direct bookings no longer include slot.start or slot.end fie…

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
@@ -14,7 +14,7 @@ export function transformFormToVAOSAppointment(state) {
     kind: 'clinic',
     status: 'booked',
     clinic: getClinicId(clinic),
-    slot,
+    slot: { id: slot.id },
     extension: {
       desiredDate: slot.start,
     },

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -260,6 +260,7 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
           availableSlots: [
             {
               start: start.format(),
+              id: 'test',
               end: start
                 .clone()
                 .add(30, 'minutes')
@@ -328,7 +329,9 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
           },
         ],
       },
-      slot: store.getState().covid19Vaccine.newBooking.availableSlots[0],
+      slot: {
+        id: store.getState().covid19Vaccine.newBooking.availableSlots[0].id,
+      },
     });
   });
 });


### PR DESCRIPTION
covid-19 direct bookings no longer include slot.start or slot.end fields in the request body



## Original issue(s)
department-of-veterans-affairs/va.gov-team#36396


## Testing done
Unit tests have been updated to reflect this change.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
