### PR TITLE
33946: [MCP] Content update 

### DIFF
--- a/src/applications/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/medical-copays/components/BalanceCard.jsx
@@ -16,10 +16,10 @@ const CurrentContent = ({ id, date }) => (
   <p>
     Your balance was updated on {formatDate(date)}. Pay your full balance or
     request financial help before
-    <strong className="vads-u-margin-x--0p5" data-testid={`due-date-${id}`}>
+    <strong className="vads-u-margin-left--0p5" data-testid={`due-date-${id}`}>
       {calcDueDate(date, 30)}
     </strong>
-    to avoid late charges, interest, or collection actions.
+    , to avoid late charges, interest, or collection actions.
   </p>
 );
 


### PR DESCRIPTION
## Description
Added missing comma after date on balance cards. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33946

## Screenshot
![image](https://user-images.githubusercontent.com/25368370/152870720-7783eb99-a893-4b11-97c2-8decb9015d83.png)

## Acceptance criteria
- [x] Card should render comma after date

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
