### PR TITLE
[COE] fix downloadUrl not working on status page

### DIFF
--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -56,11 +56,11 @@ const App = ({
   ) {
     switch (coe.status) {
       case COE_ELIGIBILITY_STATUS.available:
-        content = <CoeAvailable downloadURL={downloadUrl} />;
+        content = <CoeAvailable downloadUrl={downloadUrl} />;
         break;
       case COE_ELIGIBILITY_STATUS.eligible:
         content = (
-          <CoeEligible clickHandler={clickHandler} downloadURL={downloadUrl} />
+          <CoeEligible clickHandler={clickHandler} downloadUrl={downloadUrl} />
         );
         break;
       case COE_ELIGIBILITY_STATUS.ineligible:


### PR DESCRIPTION
## Description
The `downloadUrl` prop being passed into the `CoeAvailable` and `CoeEligible` components was miscapitalized (`downloadURL` instead of `downloadUrl`) which was causing it to not function properly.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Acceptance criteria
- [ ] Correct props are being passed to `CoeAvailable` and `CoeEligible` components
