### PR TITLE
Add login app to allowlist

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -3,6 +3,7 @@
     "entryNames": [
       "education-inbox",
       "enrollment-verification",
+      "login-page",
       "medical-copays",
       "vaos"
     ],


### PR DESCRIPTION
## Description
This PR adds the login app to the allowlist.

## Testing done
- Verified the login app is isolated
- Verified the header test passes

## Acceptance criteria
- [x] The login app should be on the allowlist

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
