### PR TITLE
NOD/HLR v2: Always show free form input

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -6,9 +6,9 @@ import preSubmitInfo from 'platform/forms/preSubmitInfo';
 import FormFooter from 'platform/forms/components/FormFooter';
 
 import migrations from '../migrations';
-import prefillTransformer from '../config/prefill-transformer';
-import { transform } from '../config/submit-transformer';
-import submitForm from '../config/submitForm';
+import prefillTransformer from './prefill-transformer';
+import { transform } from './submit-transformer';
+import submitForm from './submitForm';
 
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -38,7 +38,8 @@ export const MAX_ISSUE_NAME_LENGTH = 180;
 export const MAX_DISAGREEMENT_REASON_LENGTH = 90;
 
 // Using MAX_DISAGREEMENT_REASON_LENGTH (90) and with all checkboxes selected,
-// this string is submitted - the numbers constitute the "other" typed in value
+// this string is submitted - the numbers constitute the "something else" typed
+// in value
 // "service connection,effective date,disability evaluation,1234567890123456789012345678901234"
 export const SUBMITTED_DISAGREEMENTS = {
   serviceConnection: 'service connection',

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -5,9 +5,7 @@ import { getIssueName, getIssueDate } from '../utils/helpers';
 import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 
 export const missingAreaOfDisagreementErrorMessage =
-  'Please choose an area of disagreement';
-export const missingAreaOfDisagreementOtherErrorMessage =
-  'Please enter a reason for disagreement';
+  'Please choose or enter a reason for disagreement';
 
 // formContext.pagePerItemIndex is undefined here? Use index added to data :(
 export const issueName = ({ formData, formContext } = {}) => {
@@ -62,14 +60,12 @@ const titles = {
   serviceConnection: 'The service connection',
   effectiveDate: 'The effective date of award',
   evaluation: 'Your evaluation of my condition',
-  other: 'Something else',
 };
 
-export const serviceConnection = titles.serviceConnection;
-export const effectiveDate = titles.effectiveDate;
-export const evaluation = titles.evaluation;
-export const other = titles.other;
-export const otherLabel = 'Tell us what you disagree with:';
+export const { serviceConnection } = titles;
+export const { effectiveDate } = titles;
+export const { evaluation } = titles;
+export const otherLabel = 'Something else:';
 // Includes _{index} which is appended by the TextWidget
 export const otherDescription = ({ index }) => (
   <div

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -17,6 +17,7 @@ import {
   otherTypeSelected,
   calculateOtherMaxLength,
 } from '../utils/disagreement';
+import { $ } from '../utils/ui';
 import { getIssueName } from '../utils/helpers';
 
 export default {
@@ -60,14 +61,26 @@ export default {
           'ui:title': otherLabel,
           'ui:description': otherDescription,
           'ui:required': otherTypeSelected,
+          'ui:disabled': true,
           'ui:options': {
-            hideIf: (formData, index) => !otherTypeSelected(formData, index),
-            updateSchema: (formData, _schema, uiSchema, index) => ({
-              type: 'string',
-              maxLength: calculateOtherMaxLength(
-                formData.areaOfDisagreement[index],
-              ),
-            }),
+            updateSchema: (formData, _schema, uiSchema, index) => {
+              // Toggle input "disabled" instead of hidding, because of a11y
+              // recommendations
+              const selected = otherTypeSelected(formData, index);
+              const input = $('input[id^="root_otherEntry"]');
+              if (input) {
+                input.disabled = !selected;
+                const wrap = input.closest('.schemaform-field-template');
+                wrap?.classList.toggle('other-selected', selected);
+              }
+
+              return {
+                type: 'string',
+                maxLength: calculateOtherMaxLength(
+                  formData.areaOfDisagreement[index],
+                ),
+              };
+            },
             // index is appended to this ID in the TextWidget
             ariaDescribedby: 'other_hint_text',
           },

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -4,20 +4,14 @@ import {
   serviceConnection,
   effectiveDate,
   evaluation,
-  other,
   AreaOfDisagreementReviewField,
   otherLabel,
   otherDescription,
   missingAreaOfDisagreementErrorMessage,
-  missingAreaOfDisagreementOtherErrorMessage,
 } from '../content/areaOfDisagreement';
 
 import { areaOfDisagreementRequired } from '../validations';
-import {
-  otherTypeSelected,
-  calculateOtherMaxLength,
-} from '../utils/disagreement';
-import { $ } from '../utils/ui';
+import { calculateOtherMaxLength } from '../utils/disagreement';
 import { getIssueName } from '../utils/helpers';
 
 export default {
@@ -52,40 +46,19 @@ export default {
             'ui:title': evaluation,
             'ui:reviewField': AreaOfDisagreementReviewField,
           },
-          other: {
-            'ui:title': other,
-            'ui:reviewField': AreaOfDisagreementReviewField,
-          },
         },
         otherEntry: {
           'ui:title': otherLabel,
           'ui:description': otherDescription,
-          'ui:required': otherTypeSelected,
-          'ui:disabled': true,
           'ui:options': {
-            updateSchema: (formData, _schema, uiSchema, index) => {
-              // Toggle input "disabled" instead of hidding, because of a11y
-              // recommendations
-              const selected = otherTypeSelected(formData, index);
-              const input = $('input[id^="root_otherEntry"]');
-              if (input) {
-                input.disabled = !selected;
-                const wrap = input.closest('.schemaform-field-template');
-                wrap?.classList.toggle('other-selected', selected);
-              }
-
-              return {
-                type: 'string',
-                maxLength: calculateOtherMaxLength(
-                  formData.areaOfDisagreement[index],
-                ),
-              };
-            },
+            updateSchema: (formData, _schema, _uiSchema, index) => ({
+              type: 'string',
+              maxLength: calculateOtherMaxLength(
+                formData.areaOfDisagreement[index],
+              ),
+            }),
             // index is appended to this ID in the TextWidget
             ariaDescribedby: 'other_hint_text',
-          },
-          'ui:errorMessages': {
-            required: missingAreaOfDisagreementOtherErrorMessage,
           },
         },
       },
@@ -111,9 +84,6 @@ export default {
                   type: 'boolean',
                 },
                 evaluation: {
-                  type: 'boolean',
-                },
-                other: {
                   type: 'boolean',
                 },
               },

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -186,18 +186,33 @@ article[data-location="review-and-submit"] div[name="areaOfDisagreementFollowUp0
     margin-top: 0;
     margin-bottom: 0;
   }
-  .schemaform-field-template {
-    border-left: .5rem solid var(--color-gray-light);
-    padding-left: 2rem;
-  }
-  .schemaform-field-template.other-selected {
-    border-left-color: var(--color-primary-alt-dark);
+  .area-of-disagreement-label.usa-input-error ~ div {
+    /* add left red border to 2 associated divs */
+    border-left: 4px solid var(--color-secondary-dark);
+    position: relative;
+    right: 1.9rem;
+    padding-left: 1.9rem;
+
+    .vads-u-margin-y--2 {
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+    #root_otherEntry-label {
+      margin-top: 0 !important;
+      padding-top: 2rem;
+    }
+    label[for="root_disagreementOptions_evaluation"] {
+      margin-bottom: 0;
+    }
   }
 }
 
 /* override formation to maintain margin between checkboxes */
 .usa-input-error label {
   margin-top: 3rem;
+}
+#root_otherEntry-label {
+  margin-top: 2rem;
 }
 .usa-input-error > label {
   margin-top: 0;
@@ -236,5 +251,8 @@ article[data-location="review-and-submit"] {
   }
   dt strong.opt-in-title {
     font-weight: normal;
+  }
+  dd {
+    word-break: break-all;
   }
 }

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -179,13 +179,22 @@ article[data-location="opt-in"] {
   margin: 2rem 0;
 }
 
-article[data-location^="area-of-disagreement"] {
+article[data-location^="area-of-disagreement"],
+article[data-location="review-and-submit"] div[name="areaOfDisagreementFollowUp0ScrollElement"] + form {
   .schemaform-block-header,
   .schemaform-block-header + .usa-input-error {
     margin-top: 0;
     margin-bottom: 0;
   }
+  .schemaform-field-template {
+    border-left: .5rem solid var(--color-gray-light);
+    padding-left: 2rem;
+  }
+  .schemaform-field-template.other-selected {
+    border-left-color: var(--color-primary-alt-dark);
+  }
 }
+
 /* override formation to maintain margin between checkboxes */
 .usa-input-error label {
   margin-top: 3rem;

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -101,8 +101,7 @@
         "disagreementOptions": {
           "serviceConnection": true,
           "effectiveDate": true,
-          "evaluation": true,
-          "other": true
+          "evaluation": true
         },
         "otherEntry": "this is an other entry"
       },
@@ -120,8 +119,7 @@
       {
         "issue": "right shoulder",
         "disagreementOptions": {
-          "evaluation": true,
-          "other": true
+          "evaluation": true
         },
         "otherEntry": "this is another other entry"
       }

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -41,7 +41,8 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    expect(form.find('input[type="checkbox"]').length).to.equal(4);
+    expect(form.find('input[type="checkbox"]').length).to.equal(3);
+    expect(form.find('input[type="text"]').length).to.equal(1);
     expect(form.find('h3').text()).to.equal('Tinnitus (January 1, 2021)');
     form.unmount();
   });
@@ -64,26 +65,7 @@ describe('area of disagreement page', () => {
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });
-  it('should not allow submit when other is checked with no additional text', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={{}}
-        arrayPath={arrayPath}
-        pagePerItemIndex={0}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={data}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    selectCheckbox(form, 'root_disagreementOptions_other', true);
-    form.find('form').simulate('submit');
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
-  it('should allow submit when an area (not other) is checked', () => {
+  it('should allow submit when a checkbox is checked', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -102,7 +84,7 @@ describe('area of disagreement page', () => {
     expect(onSubmit.called).to.be.true;
     form.unmount();
   });
-  it('should allow submit when other is checked with additional text', () => {
+  it('should allow submit when additional text is included', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -116,7 +98,6 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    selectCheckbox(form, 'root_disagreementOptions_other', true);
     fillData(form, '[name="root_otherEntry"]', 'foo');
     form.find('form').simulate('submit');
     expect(onSubmit.called).to.be.true;

--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -196,9 +196,8 @@ describe('addAreaOfDisagreement', () => {
         {
           disagreementOptions: {
             effectiveDate: true,
-            other: false,
           },
-          otherEntry: 'test',
+          otherEntry: '',
         },
       ],
     };
@@ -220,7 +219,7 @@ describe('addAreaOfDisagreement', () => {
             effectiveDate: true,
             evaluation: true,
           },
-          otherEntry: 'test',
+          otherEntry: '',
         },
       ],
     };
@@ -237,7 +236,6 @@ describe('addAreaOfDisagreement', () => {
             serviceConnection: true,
             effectiveDate: true,
             evaluation: true,
-            other: true,
           },
           otherEntry: 'this is an other entry',
         },

--- a/src/applications/appeals/10182/tests/validations/index.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/index.unit.spec.js
@@ -73,10 +73,10 @@ describe('areaOfDisagreementRequired', () => {
     areaOfDisagreementRequired(errors);
     expect(errors.addError.called).to.be.true;
   });
-  it('should show an error with other selected, but no entry text', () => {
+  it('should show an error with no entry text in other', () => {
     const errors = { addError: sinon.spy() };
     areaOfDisagreementRequired(errors, {
-      disagreementOptions: { other: true },
+      disagreementOptions: {},
     });
     expect(errors.addError.called).to.be.true;
   });
@@ -85,10 +85,10 @@ describe('areaOfDisagreementRequired', () => {
     areaOfDisagreementRequired(errors, { disagreementOptions: { foo: true } });
     expect(errors.addError.called).to.be.false;
   });
-  it('should not show an error with other selected with entry text', () => {
+  it('should not show an error with other entry text', () => {
     const errors = { addError: sinon.spy() };
     areaOfDisagreementRequired(errors, {
-      disagreementOptions: { other: true },
+      disagreementOptions: {},
       otherEntry: 'foo',
     });
     expect(errors.addError.called).to.be.false;

--- a/src/applications/appeals/10182/utils/disagreement.js
+++ b/src/applications/appeals/10182/utils/disagreement.js
@@ -10,22 +10,18 @@ import { getIssueName } from './helpers';
  * @property {boolean} serviceConnection
  * @property {boolean} effectiveDate
  * @property {boolean} evaluation
- * @property {boolean} other
  */
 /**
  * @typedef AreaOfDisagreement~Page
  * @type {object}
  * @property {object} attributes - Attributes of issue
  * @property {AreaOfDisagreement~Options} disagreementOptions
- * @property {string} otherEntry - Free text entered when "other" is selected
+ * @property {string} otherEntry - Free text input
  */
 /**
  * @typedef FormData~AreaOfDisagreement
  * @type {AreaOfDisagreement~Page[]}
  */
-
-export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
-  areaOfDisagreement?.[index]?.disagreementOptions?.other;
 
 /**
  * Compare currently selected issues with previously selected issues and copy
@@ -63,7 +59,7 @@ export const calculateOtherMaxLength = formData => {
   // free-text "other reason" input to use up the remaining characters
   const options = formData?.disagreementOptions || {};
   const stringLength = Object.keys(options).reduce((totalLength, key) => {
-    if (key !== 'other' && options[key]) {
+    if (options[key]) {
       // add one for the comma
       return totalLength + SUBMITTED_DISAGREEMENTS[key].length + 1;
     }

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -37,6 +37,11 @@ export const getSelected = formData => {
 export const getSelectedCount = (formData, items) =>
   getSelected({ ...formData, additionalIssues: items }).length;
 
+/**
+ * Get issue name/title from either a manually added issue or issue loaded from
+ * the API
+ * @param {AdditionalIssueItem|ContestableIssueItem}
+ */
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;
 

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -222,7 +222,7 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
     const entry = areaOfDisagreement[index];
     const reasons = Object.entries(entry.disagreementOptions)
       .map(([key, value]) => value && keywords[key](entry))
-      .concat(entry.otherEntry)
+      .concat((entry?.otherEntry || '').trim())
       .filter(Boolean);
     return {
       ...issue,

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -217,12 +217,12 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
     serviceConnection: () => SUBMITTED_DISAGREEMENTS.serviceConnection,
     effectiveDate: () => SUBMITTED_DISAGREEMENTS.effectiveDate,
     evaluation: () => SUBMITTED_DISAGREEMENTS.evaluation,
-    other: disagreementOptions => disagreementOptions.otherEntry,
   };
   return issues.map((issue, index) => {
     const entry = areaOfDisagreement[index];
     const reasons = Object.entries(entry.disagreementOptions)
       .map(([key, value]) => value && keywords[key](entry))
+      .concat(entry.otherEntry)
       .filter(Boolean);
     return {
       ...issue,

--- a/src/applications/appeals/10182/utils/ui.js
+++ b/src/applications/appeals/10182/utils/ui.js
@@ -37,9 +37,5 @@ export const areaOfDisagreementWorkAround = (hasSelection, index) => {
   if (label) {
     const showError = label.dataset.submitted === 'true' && !hasSelection;
     label.classList.toggle('usa-input-error', showError);
-    label.parentElement.nextElementSibling.classList.toggle(
-      'usa-input-error',
-      showError,
-    );
   }
 };

--- a/src/applications/appeals/10182/validations/index.js
+++ b/src/applications/appeals/10182/validations/index.js
@@ -1,9 +1,6 @@
 import { areaOfDisagreementWorkAround } from '../utils/ui';
 import { optInErrorMessage } from '../content/OptIn';
-import {
-  missingAreaOfDisagreementErrorMessage,
-  missingAreaOfDisagreementOtherErrorMessage,
-} from '../content/areaOfDisagreement';
+import { missingAreaOfDisagreementErrorMessage } from '../content/areaOfDisagreement';
 
 export const contactInfoValidation = (errors, _fieldData, formData) => {
   const { veteran = {}, homeless } = formData;
@@ -28,16 +25,14 @@ export const areaOfDisagreementRequired = (
   arrayIndex, // always null?!
 ) => {
   const keys = Object.keys(disagreementOptions || {});
-  const hasSelection = keys.some(key => disagreementOptions[key]);
+  const hasChoice = keys.some(key => disagreementOptions[key]) || otherEntry;
 
-  if (!hasSelection) {
+  if (!hasChoice) {
     errors.addError(missingAreaOfDisagreementErrorMessage);
-  } else if (disagreementOptions.other && !otherEntry) {
-    errors.addError(missingAreaOfDisagreementOtherErrorMessage);
   }
 
   // work-around for error message not showing :(
-  areaOfDisagreementWorkAround(hasSelection, arrayIndex || index);
+  areaOfDisagreementWorkAround(hasChoice, arrayIndex || index);
 };
 
 export const optInValidation = (errors, value) => {

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -125,7 +125,8 @@ export const MAX_ISSUE_NAME_LENGTH = 140;
 export const MAX_DISAGREEMENT_REASON_LENGTH = 90;
 
 // Using MAX_DISAGREEMENT_REASON_LENGTH (90) and with all checkboxes selected,
-// this string is submitted - the numbers constitute the "other" typed in value
+// this string is submitted - the numbers constitute the "somethubg else" typed
+// in value
 // "service connection,effective date,disability evaluation,1234567890123456789012345678901234"
 export const SUBMITTED_DISAGREEMENTS = {
   serviceConnection: 'service connection',

--- a/src/applications/disability-benefits/996/content/areaOfDisagreement.jsx
+++ b/src/applications/disability-benefits/996/content/areaOfDisagreement.jsx
@@ -5,9 +5,7 @@ import { getIssueName, getIssueDate } from '../utils/helpers';
 import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 
 export const missingAreaOfDisagreementErrorMessage =
-  'Please choose an area of disagreement';
-export const missingAreaOfDisagreementOtherErrorMessage =
-  'Please enter a reason for disagreement';
+  'Please choose or enter a reason for disagreement';
 
 const titlePrefix = 'What do you disagree with regarding';
 
@@ -85,14 +83,12 @@ const titles = {
   serviceConnection: 'The service connection',
   effectiveDate: 'The effective date of award',
   evaluation: 'Your evaluation of my condition',
-  other: 'Something else',
 };
 
-export const serviceConnection = titles.serviceConnection;
-export const effectiveDate = titles.effectiveDate;
-export const evaluation = titles.evaluation;
-export const other = titles.other;
-export const otherLabel = 'Tell us what you disagree with:';
+export const { serviceConnection } = titles;
+export const { effectiveDate } = titles;
+export const { evaluation } = titles;
+export const otherLabel = 'Something else:';
 // Includes _{index} which is appended by the TextWidget
 export const otherDescription = ({ index }) => (
   <div

--- a/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
+++ b/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
@@ -4,20 +4,14 @@ import {
   serviceConnection,
   effectiveDate,
   evaluation,
-  other,
   AreaOfDisagreementReviewField,
   otherLabel,
   otherDescription,
   missingAreaOfDisagreementErrorMessage,
-  missingAreaOfDisagreementOtherErrorMessage,
 } from '../content/areaOfDisagreement';
 
 import { areaOfDisagreementRequired } from '../validations/issues';
-import {
-  otherTypeSelected,
-  calculateOtherMaxLength,
-} from '../utils/disagreement';
-import { $ } from '../utils/ui';
+import { calculateOtherMaxLength } from '../utils/disagreement';
 import { getIssueName } from '../utils/helpers';
 
 export default {
@@ -52,39 +46,19 @@ export default {
             'ui:title': evaluation,
             'ui:reviewField': AreaOfDisagreementReviewField,
           },
-          other: {
-            'ui:title': other,
-            'ui:reviewField': AreaOfDisagreementReviewField,
-          },
         },
         otherEntry: {
           'ui:title': otherLabel,
           'ui:description': otherDescription,
-          'ui:required': otherTypeSelected,
           'ui:options': {
-            updateSchema: (formData, _schema, uiSchema, index) => {
-              // Toggle input "disabled" instead of hidding, because of a11y
-              // recommendations
-              const selected = otherTypeSelected(formData, index);
-              const input = $('input[id^="root_otherEntry"]');
-              if (input) {
-                input.disabled = !selected;
-                const wrap = input.closest('.schemaform-field-template');
-                wrap?.classList.toggle('other-selected', selected);
-              }
-
-              return {
-                type: 'string',
-                maxLength: calculateOtherMaxLength(
-                  formData.areaOfDisagreement[index],
-                ),
-              };
-            },
+            updateSchema: (formData, _schema, uiSchema, index) => ({
+              type: 'string',
+              maxLength: calculateOtherMaxLength(
+                formData.areaOfDisagreement[index],
+              ),
+            }),
             // index is appended to this ID in the TextWidget
             ariaDescribedby: 'other_hint_text',
-          },
-          'ui:errorMessages': {
-            required: missingAreaOfDisagreementOtherErrorMessage,
           },
         },
       },
@@ -110,9 +84,6 @@ export default {
                   type: 'boolean',
                 },
                 evaluation: {
-                  type: 'boolean',
-                },
-                other: {
                   type: 'boolean',
                 },
               },

--- a/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
+++ b/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
@@ -17,6 +17,7 @@ import {
   otherTypeSelected,
   calculateOtherMaxLength,
 } from '../utils/disagreement';
+import { $ } from '../utils/ui';
 import { getIssueName } from '../utils/helpers';
 
 export default {
@@ -61,13 +62,24 @@ export default {
           'ui:description': otherDescription,
           'ui:required': otherTypeSelected,
           'ui:options': {
-            hideIf: (formData, index) => !otherTypeSelected(formData, index),
-            updateSchema: (formData, _schema, uiSchema, index) => ({
-              type: 'string',
-              maxLength: calculateOtherMaxLength(
-                formData.areaOfDisagreement[index],
-              ),
-            }),
+            updateSchema: (formData, _schema, uiSchema, index) => {
+              // Toggle input "disabled" instead of hidding, because of a11y
+              // recommendations
+              const selected = otherTypeSelected(formData, index);
+              const input = $('input[id^="root_otherEntry"]');
+              if (input) {
+                input.disabled = !selected;
+                const wrap = input.closest('.schemaform-field-template');
+                wrap?.classList.toggle('other-selected', selected);
+              }
+
+              return {
+                type: 'string',
+                maxLength: calculateOtherMaxLength(
+                  formData.areaOfDisagreement[index],
+                ),
+              };
+            },
             // index is appended to this ID in the TextWidget
             ariaDescribedby: 'other_hint_text',
           },

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -335,6 +335,21 @@ article[data-location="add-issue"] {
 label[for^="root_disagreementOptions"] {
   margin-top: 3rem;
 }
+article[data-location^="area-of-disagreement"],
+article[data-location="review-and-submit"] div[name="areaOfDisagreementFollowUp0ScrollElement"] + form {
+  .schemaform-block-header,
+  .schemaform-block-header + .usa-input-error {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .schemaform-field-template {
+    border-left: .5rem solid var(--color-gray-light);
+    padding-left: 2rem;
+  }
+  .schemaform-field-template.other-selected {
+    border-left-color: var(--color-primary-alt-dark);
+  }
+}
 
 /* Step 3 */
 /* Informal conference */

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -335,20 +335,16 @@ article[data-location="add-issue"] {
 label[for^="root_disagreementOptions"] {
   margin-top: 3rem;
 }
-article[data-location^="area-of-disagreement"],
-article[data-location="review-and-submit"] div[name="areaOfDisagreementFollowUp0ScrollElement"] + form {
-  .schemaform-block-header,
-  .schemaform-block-header + .usa-input-error {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-  .schemaform-field-template {
-    border-left: .5rem solid var(--color-gray-light);
-    padding-left: 2rem;
-  }
-  .schemaform-field-template.other-selected {
-    border-left-color: var(--color-primary-alt-dark);
-  }
+
+/* override formation to maintain margin between checkboxes */
+.usa-input-error label {
+  margin-top: 3rem;
+}
+#root_otherEntry-label {
+  margin-top: 2rem;
+}
+.usa-input-error > label {
+  margin-top: 0;
 }
 
 /* Step 3 */
@@ -373,11 +369,31 @@ article[data-contact-choice] .contact-choice {
   display: none;
 }
 
-article[data-location^="area-of-disagreement"] {
+article[data-location^="area-of-disagreement"],
+article[data-location="review-and-submit"] div[name="areaOfDisagreementFollowUp0ScrollElement"] + form {
   .schemaform-block-header,
   .schemaform-block-header + .usa-input-error {
     margin-top: 0;
     margin-bottom: 0;
+  }
+  .area-of-disagreement-label.usa-input-error ~ div {
+    /* add left red border to 2 associated divs */
+    border-left: 4px solid var(--color-secondary-dark);
+    position: relative;
+    right: 1.9rem;
+    padding-left: 1.9rem;
+
+    .vads-u-margin-y--2 {
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+    #root_otherEntry-label {
+      margin-top: 0 !important;
+      padding-top: 2rem;
+    }
+    label[for="root_disagreementOptions_evaluation"] {
+      margin-bottom: 0;
+    }
   }
 }
 
@@ -411,6 +427,9 @@ article[data-location="review-and-submit"] {
       width: 0;
       min-width: 0;
     }
+  }
+  dd {
+    word-break: break-all;
   }
 }
 

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -95,8 +95,7 @@
         "disagreementOptions": {
           "serviceConnection": true,
           "effectiveDate": true,
-          "evaluation": true,
-          "other": true
+          "evaluation": true
         },
         "otherEntry": "this is an other entry"
       },
@@ -114,8 +113,7 @@
       {
         "issue": "right shoulder",
         "disagreementOptions": {
-          "evaluation": true,
-          "other": true
+          "evaluation": true
         },
         "otherEntry": "this is another other entry"
       }

--- a/src/applications/disability-benefits/996/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -41,13 +41,14 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    expect(form.find('input[type="checkbox"]').length).to.equal(4);
+    expect(form.find('input[type="checkbox"]').length).to.equal(3);
+    expect(form.find('input[type="text"]').length).to.equal(1);
     expect(form.find('h3').text()).to.contain('Tinnitus');
     expect(form.find('.decision-date').text()).to.contain('January 1, 2021');
     form.unmount();
   });
 
-  it('should not allow submit when nothing is checked', () => {
+  it('should not allow submit when nothing is checked and the input is blank', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -65,26 +66,7 @@ describe('area of disagreement page', () => {
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });
-  it('should not allow submit when other is checked with no additional text', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={{}}
-        arrayPath={arrayPath}
-        pagePerItemIndex={0}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={data}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    selectCheckbox(form, 'root_disagreementOptions_other', true);
-    form.find('form').simulate('submit');
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
-  it('should allow submit when an area (not other) is checked', () => {
+  it('should allow submit when an area is checked', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -103,7 +85,7 @@ describe('area of disagreement page', () => {
     expect(onSubmit.called).to.be.true;
     form.unmount();
   });
-  it('should allow submit when other is checked with additional text', () => {
+  it('should allow submit with additional text', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -117,7 +99,6 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    selectCheckbox(form, 'root_disagreementOptions_other', true);
     fillData(form, '[name="root_otherEntry"]', 'foo');
     form.find('form').simulate('submit');
     expect(onSubmit.called).to.be.true;

--- a/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
@@ -118,9 +118,8 @@ describe('addAreaOfDisagreement', () => {
         {
           disagreementOptions: {
             effectiveDate: true,
-            other: false,
           },
-          otherEntry: 'test',
+          otherEntry: '',
         },
       ],
     };
@@ -142,7 +141,7 @@ describe('addAreaOfDisagreement', () => {
             effectiveDate: true,
             evaluation: true,
           },
-          otherEntry: 'test',
+          otherEntry: '',
         },
       ],
     };
@@ -159,7 +158,6 @@ describe('addAreaOfDisagreement', () => {
             serviceConnection: true,
             effectiveDate: true,
             evaluation: true,
-            other: true,
           },
           otherEntry: 'this is an other entry',
         },

--- a/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
@@ -133,7 +133,7 @@ describe('areaOfDisagreementRequired', () => {
     areaOfDisagreementRequired(errors);
     expect(errors.addError.called).to.be.true;
   });
-  it('should show an error with other selected, but no entry text', () => {
+  it('should show an error with no selections, and no entry text', () => {
     const errors = { addError: sinon.spy() };
     areaOfDisagreementRequired(errors, {
       disagreementOptions: {},
@@ -151,6 +151,14 @@ describe('areaOfDisagreementRequired', () => {
     areaOfDisagreementRequired(errors, {
       disagreementOptions: {},
       otherEntry: 'foo',
+    });
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should not show an error with a selection and entry text', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, {
+      disagreementOptions: { foo: true },
+      otherEntry: 'bar',
     });
     expect(errors.addError.called).to.be.false;
   });

--- a/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
@@ -136,7 +136,8 @@ describe('areaOfDisagreementRequired', () => {
   it('should show an error with other selected, but no entry text', () => {
     const errors = { addError: sinon.spy() };
     areaOfDisagreementRequired(errors, {
-      disagreementOptions: { other: true },
+      disagreementOptions: {},
+      otherEntry: '',
     });
     expect(errors.addError.called).to.be.true;
   });
@@ -145,10 +146,10 @@ describe('areaOfDisagreementRequired', () => {
     areaOfDisagreementRequired(errors, { disagreementOptions: { foo: true } });
     expect(errors.addError.called).to.be.false;
   });
-  it('should not show an error with other selected with entry text', () => {
+  it('should not show an error with entry text', () => {
     const errors = { addError: sinon.spy() };
     areaOfDisagreementRequired(errors, {
-      disagreementOptions: { other: true },
+      disagreementOptions: {},
       otherEntry: 'foo',
     });
     expect(errors.addError.called).to.be.false;

--- a/src/applications/disability-benefits/996/utils/disagreement.js
+++ b/src/applications/disability-benefits/996/utils/disagreement.js
@@ -10,22 +10,18 @@ import { getIssueName } from './helpers';
  * @property {boolean} serviceConnection
  * @property {boolean} effectiveDate
  * @property {boolean} evaluation
- * @property {boolean} other
  */
 /**
  * @typedef AreaOfDisagreement~Page
  * @type {object}
  * @property {object} attributes - Attributes of issue
  * @property {AreaOfDisagreement~Options} disagreementOptions
- * @property {string} otherEntry - Free text entered when "other" is selected
+ * @property {string} otherEntry - Free text input
  */
 /**
  * @typedef FormData~AreaOfDisagreement
  * @type {AreaOfDisagreement~Page[]}
  */
-
-export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
-  areaOfDisagreement?.[index]?.disagreementOptions?.other;
 
 /**
  * Compare currently selected issues with previously selected issues and copy
@@ -63,7 +59,7 @@ export const calculateOtherMaxLength = formData => {
   // free-text "other reason" input to use up the remaining characters
   const options = formData?.disagreementOptions || {};
   const stringLength = Object.keys(options).reduce((totalLength, key) => {
-    if (key !== 'other' && options[key]) {
+    if (options[key]) {
       // add one for the comma
       return totalLength + SUBMITTED_DISAGREEMENTS[key].length + 1;
     }

--- a/src/applications/disability-benefits/996/utils/helpers.js
+++ b/src/applications/disability-benefits/996/utils/helpers.js
@@ -134,86 +134,6 @@ export const mayHaveLegacyAppeals = ({
   additionalIssues,
 } = {}) => legacyCount > 0 || additionalIssues?.length > 0;
 
-/**
- * Get issue name/title from either a manually added issue or issue loaded from
- * the API
- * @param {AdditionalIssueItem|ContestableIssueItem}
- */
-export const getIssueName = (entry = {}) =>
-  entry.issue || entry.attributes?.ratingIssueSubjectText;
-
-export const getIssueDate = (entry = {}) =>
-  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
-
-export const getIssueNameAndDate = (entry = {}) =>
-  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
-    entry.attributes?.approxDecisionDate ||
-    ''}`;
-
-// getEligibleContestableIssues will remove deferred issues and issues > 1 year
-// past their decision date. This function removes issues with no title & sorts
-// the list by descending (newest first) decision date
-export const processContestableIssues = contestableIssues => {
-  const regexDash = /-/g;
-  const getDate = entry =>
-    (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
-
-  // remove issues with no title & sort by date - see
-  // https://dsva.slack.com/archives/CSKKUL36K/p1623956682119300
-  return (contestableIssues || [])
-    .filter(issue => getIssueName(issue))
-    .sort((a, b) => {
-      const dateA = getDate(a);
-      const dateB = getDate(b);
-      if (dateA === dateB) {
-        // If the dates are the same, sort by title
-        return getIssueName(a) > getIssueName(b) ? 1 : -1;
-      }
-      // YYYYMMDD string comparisons will work in place of using moment
-      return dateA > dateB ? -1 : 1;
-    });
-};
-
-export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
-  if (loadedIssues.length !== existingIssues.length) {
-    return true;
-  }
-  // sort both arrays so we don't end up in an endless loop
-  const issues = processContestableIssues(existingIssues);
-  return !processContestableIssues(loadedIssues).every(
-    ({ attributes }, index) => {
-      const existing = issues[index]?.attributes || {};
-      return (
-        attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
-        attributes.approxDecisionDate === existing.approxDecisionDate
-      );
-    },
-  );
-};
-
-/**
- * Convert an array into a readable list of items
- * @param {String[]} list - Array of items. Empty entries are stripped out
- * @returns {String}
- * @example
- * readableList(['1', '2', '3', '4', 'five'])
- * // => '1, 2, 3, 4 and five'
- */
-export const readableList = list => {
-  const cleanedList = list.filter(Boolean);
-  return [cleanedList.slice(0, -1).join(', '), cleanedList.slice(-1)[0]].join(
-    cleanedList.length < 2 ? '' : ' and ',
-  );
-};
-
-export const appStateSelector = state => ({
-  // Validation functions are provided the pageData and not the
-  // formData on the review & submit page. For more details
-  // see https://dsva.slack.com/archives/CBU0KDSB1/p1614182869206900
-  contestedIssues: state.form?.data?.contestedIssues || [],
-  additionalIssues: state.form?.data?.additionalIssues || [],
-});
-
 export const someSelected = issues =>
   (issues || []).some(issue => issue[SELECTED]);
 
@@ -238,6 +158,22 @@ export const getSelected = formData => {
 // the formData is updated
 export const getSelectedCount = (formData, items) =>
   getSelected({ ...formData, additionalIssues: items }).length;
+
+/**
+ * Get issue name/title from either a manually added issue or issue loaded from
+ * the API
+ * @param {AdditionalIssueItem|ContestableIssueItem}
+ */
+export const getIssueName = (entry = {}) =>
+  entry.issue || entry.attributes?.ratingIssueSubjectText;
+
+export const getIssueDate = (entry = {}) =>
+  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
+
+export const getIssueNameAndDate = (entry = {}) =>
+  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
+    entry.attributes?.approxDecisionDate ||
+    ''}`;
 
 const processIssues = (array = []) =>
   array
@@ -280,12 +216,76 @@ export const setInitialEditMode = (formData = {}) => {
   });
 };
 
+// getEligibleContestableIssues will remove deferred issues and issues > 1 year
+// past their decision date. This function removes issues with no title & sorts
+// the list by descending (newest first) decision date
+export const processContestableIssues = contestableIssues => {
+  const regexDash = /-/g;
+  const getDate = entry =>
+    (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
+
+  // remove issues with no title & sort by date - see
+  // https://dsva.slack.com/archives/CSKKUL36K/p1623956682119300
+  return (contestableIssues || [])
+    .filter(issue => getIssueName(issue))
+    .sort((a, b) => {
+      const dateA = getDate(a);
+      const dateB = getDate(b);
+      if (dateA === dateB) {
+        // If the dates are the same, sort by title
+        return getIssueName(a) > getIssueName(b) ? 1 : -1;
+      }
+      // YYYYMMDD string comparisons will work in place of using moment
+      return dateA > dateB ? -1 : 1;
+    });
+};
+
+export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
+  if (loadedIssues.length !== existingIssues.length) {
+    return true;
+  }
+  // sort both arrays so we don't end up in an endless loop
+  const issues = processContestableIssues(existingIssues);
+  return !processContestableIssues(loadedIssues).every(
+    ({ attributes }, index) => {
+      const existing = issues[index]?.attributes || {};
+      return (
+        attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
+        attributes.approxDecisionDate === existing.approxDecisionDate
+      );
+    },
+  );
+};
+
+export const appStateSelector = state => ({
+  // Validation functions are provided the pageData and not the
+  // formData on the review & submit page. For more details
+  // see https://dsva.slack.com/archives/CBU0KDSB1/p1614182869206900
+  contestedIssues: state.form?.data?.contestedIssues || [],
+  additionalIssues: state.form?.data?.additionalIssues || [],
+});
+
 export const getItemSchema = (schema, index) => {
   const itemSchema = schema;
   if (itemSchema.items.length > index) {
     return itemSchema.items[index];
   }
   return itemSchema.additionalItems;
+};
+
+/**
+ * Convert an array into a readable list of items
+ * @param {String[]} list - Array of items. Empty entries are stripped out
+ * @returns {String}
+ * @example
+ * readableList(['1', '2', '3', '4', 'five'])
+ * // => '1, 2, 3, 4 and five'
+ */
+export const readableList = list => {
+  const cleanedList = list.filter(Boolean);
+  return [cleanedList.slice(0, -1).join(', '), cleanedList.slice(-1)[0]].join(
+    cleanedList.length < 2 ? '' : ' and ',
+  );
 };
 
 /**

--- a/src/applications/disability-benefits/996/utils/submit.js
+++ b/src/applications/disability-benefits/996/utils/submit.js
@@ -207,12 +207,12 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
     serviceConnection: () => SUBMITTED_DISAGREEMENTS.serviceConnection,
     effectiveDate: () => SUBMITTED_DISAGREEMENTS.effectiveDate,
     evaluation: () => SUBMITTED_DISAGREEMENTS.evaluation,
-    other: disagreementOptions => disagreementOptions.otherEntry,
   };
   return issues.map((issue, index) => {
     const entry = areaOfDisagreement[index];
     const reasons = Object.entries(entry.disagreementOptions)
       .map(([key, value]) => value && keywords[key](entry))
+      .concat((entry?.otherEntry || '').trim())
       .filter(Boolean);
     return {
       ...issue,

--- a/src/applications/disability-benefits/996/utils/ui.js
+++ b/src/applications/disability-benefits/996/utils/ui.js
@@ -36,12 +36,6 @@ export const areaOfDisagreementWorkAround = (hasSelection, index) => {
   const label = $(`#area-of-disagreement-label-${index}`);
   if (label) {
     const showError = label.dataset.submitted === 'true' && !hasSelection;
-    const wrapper = label?.nextElementSibling;
     label.classList.toggle('usa-input-error', showError);
-    if (wrapper) {
-      wrapper.classList.toggle('usa-input-error', showError);
-      // remove 3rem top margin added by usa-input-error
-      wrapper.classList.add('vads-u-margin-top--0');
-    }
   }
 };

--- a/src/applications/disability-benefits/996/validations/issues.js
+++ b/src/applications/disability-benefits/996/validations/issues.js
@@ -10,10 +10,7 @@ import {
   noneSelected,
   maxSelectedErrorMessage,
 } from '../content/contestableIssues';
-import {
-  missingAreaOfDisagreementErrorMessage,
-  missingAreaOfDisagreementOtherErrorMessage,
-} from '../content/areaOfDisagreement';
+import { missingAreaOfDisagreementErrorMessage } from '../content/areaOfDisagreement';
 import {
   FORMAT_YMD,
   MAX_SELECTIONS,
@@ -142,14 +139,12 @@ export const areaOfDisagreementRequired = (
   arrayIndex, // always null?!
 ) => {
   const keys = Object.keys(disagreementOptions || {});
-  const hasSelection = keys.some(key => disagreementOptions[key]);
+  const hasChoice = keys.some(key => disagreementOptions[key]) || otherEntry;
 
-  if (!hasSelection) {
+  if (!hasChoice) {
     errors.addError(missingAreaOfDisagreementErrorMessage);
-  } else if (disagreementOptions.other && !otherEntry) {
-    errors.addError(missingAreaOfDisagreementOtherErrorMessage);
   }
 
   // work-around for error message not showing :(
-  areaOfDisagreementWorkAround(hasSelection, arrayIndex || index);
+  areaOfDisagreementWorkAround(hasChoice, arrayIndex || index);
 };


### PR DESCRIPTION
## Description

Both the Notice of Disagreement and Higher-Level Review v2 forms have an "Something else" checkbox on the area of disagreement page of the form. When checked, an input is revealed. This isn't ideal for accessibility. From recommendations, this PR removes the "Something else" checkbox and reveals the extra input.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36150

## Testing done

- Updated unit tests
- Updated e2e test mock data

## Screenshots

<details><summary>Area of disagreement current layout</summary>

![something else checkbox reveals free form input](https://user-images.githubusercontent.com/136959/151592676-64dba377-b965-4196-b9fa-c84cf67071c5.png)</details>

<details><summary>Area of disagreement new layout</summary>

![something else checkbox removed and input always visible](https://user-images.githubusercontent.com/136959/153016162-a39e9198-804f-4602-9644-9c58f8e459ac.png)</details>

<details><summary>Area of disagreement showing error state</summary>

![Appropriately aligned border showing error state around all parts of the page](https://user-images.githubusercontent.com/136959/153016160-7818111f-036d-4f40-8b6b-d085846e4c6e.png)</details>

## Acceptance criteria
- [x] NOD & HLR area of disagreement pages have "Something else" checkbox removed & text input always visible
- [x] All tests updated & passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
