### PR TITLE
coding object is now null checked prior to accessing member

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { getPatientInstruction } from '../appointment';
+import { getPatientInstruction } from '.';
 import {
   APPOINTMENT_TYPES,
   PURPOSE_TEXT,
@@ -13,9 +13,11 @@ import { getTypeOfCareById } from '../../utils/appointment';
 function getAppointmentType(appt) {
   if (appt.kind === 'cc' && appt.start) {
     return APPOINTMENT_TYPES.ccAppointment;
-  } else if (appt.kind === 'cc' && appt.requestedPeriods?.length) {
+  }
+  if (appt.kind === 'cc' && appt.requestedPeriods?.length) {
     return APPOINTMENT_TYPES.ccRequest;
-  } else if (appt.kind !== 'cc' && appt.requestedPeriods?.length) {
+  }
+  if (appt.kind !== 'cc' && appt.requestedPeriods?.length) {
     return APPOINTMENT_TYPES.request;
   }
 
@@ -64,7 +66,7 @@ export function isPastAppointment(appt) {
  * @returns {String} returns format data
  */
 function getAtlasLocation(appt) {
-  const atlas = appt.telehealth.atlas;
+  const { atlas } = appt.telehealth;
   return {
     id: atlas.siteCode,
     resourceType: 'Location',
@@ -151,7 +153,7 @@ export function transformVAOSAppointment(appt) {
     resourceType: 'Appointment',
     id: appt.id,
     status: appt.status,
-    cancelationReason: appt.cancelationReason?.coding[0].code || null,
+    cancelationReason: appt.cancelationReason?.coding?.[0].code || null,
     start: !isRequest ? start.format() : null,
     // This contains the vista status for v0 appointments, but
     // we don't have that for v2, so this is a made up status


### PR DESCRIPTION
## Description
Adding a null check to reasonCode.coding. Prior to this the front-end logic assumed that the coding field would always be present in the response body for cancelationReason, but that is not the case if the code isn't present. This was causing an error in the front-end when attempting to read a canceled appointment.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
