### PR TITLE
reverting prior change that was causing VA requests to incorrectly fo…

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -109,9 +109,7 @@ export function transformFormToVAOSVARequest(state) {
           code,
         },
       ],
-      text: {
-        type: code,
-      },
+      text: code,
     },
     comment: data.reasonAdditionalInfo,
     contact: {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -350,7 +350,7 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
       comment: 'I need an appt',
       reasonCode: {
         coding: [{ code: 'Routine Follow-up' }],
-        text: { type: 'Routine Follow-up' },
+        text: 'Routine Follow-up',
       },
       contact: {
         telecom: [

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
@@ -183,7 +183,7 @@ describe('VAOS V2 data transformation', () => {
         serviceType: 'cpap',
         reasonCode: {
           coding: [{ code: 'Routine Follow-up' }],
-          text: { type: 'Routine Follow-up' },
+          text: 'Routine Follow-up',
         },
         comment: 'Testing',
         contact: {


### PR DESCRIPTION
## Description
Reverting prior change that was causing VA requests to incorrectly format the reasonCode.text field

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36580


## Testing done
Unit tests were updated to reflect this change.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
