### PR TITLE
Fix downloadUrl not working on introduction page

### DIFF
--- a/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
@@ -31,7 +31,7 @@ const IntroductionPage = ({ coe, downloadUrl, loggedIn, route, status }) => {
       <>
         <COEIntroPageBox
           applicationCreateDate={coe.applicationCreateDate}
-          downloadURL={downloadUrl}
+          downloadUrl={downloadUrl}
           status={coe.status}
         />
         {coe.status !== COE_ELIGIBILITY_STATUS.denied && (
@@ -61,14 +61,14 @@ IntroductionPage.propTypes = {
 
 const mapStateToProps = state => ({
   coe: state.certificateOfEligibility.coe,
-  downloadURL: state.certificateOfEligibility.downloadURL,
+  downloadUrl: state.certificateOfEligibility.downloadUrl,
   loggedIn: isLoggedIn(state),
   status: state.certificateOfEligibility.generateAutoCoeStatus,
 });
 
 IntroductionPage.propTypes = {
   coe: PropTypes.object,
-  downloadURL: PropTypes.string,
+  downloadUrl: PropTypes.string,
   loggedIn: PropTypes.bool,
   route: PropTypes.object,
   status: PropTypes.string,

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -56,11 +56,11 @@ const App = ({
   ) {
     switch (coe.status) {
       case COE_ELIGIBILITY_STATUS.available:
-        content = <CoeAvailable downloadURL={downloadUrl} />;
+        content = <CoeAvailable downloadUrl={downloadUrl} />;
         break;
       case COE_ELIGIBILITY_STATUS.eligible:
         content = (
-          <CoeEligible clickHandler={clickHandler} downloadURL={downloadUrl} />
+          <CoeEligible clickHandler={clickHandler} downloadUrl={downloadUrl} />
         );
         break;
       case COE_ELIGIBILITY_STATUS.ineligible:


### PR DESCRIPTION
## Description
The `downloadUrl` prop being passed into the `COEIntroPageBox` was miscapitalized (`downloadURL` instead of `downloadUrl`) which was causing it to not function properly. Since this has happened before, I checked the whole application to make sure there weren't any other issues

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Acceptance criteria
- [x] Correct props are being passed to `COEIntroPageBox` component
