### PR TITLE
Added functionality for back button to not render if on page after lo…

### DIFF
--- a/src/applications/check-in/components/BackButton.jsx
+++ b/src/applications/check-in/components/BackButton.jsx
@@ -4,20 +4,31 @@ import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { createAnalyticsSlug } from '../utils/analytics';
+import { useFormRouting } from '../hooks/useFormRouting';
 
 const BackButton = props => {
-  const { action, path } = props;
+  const { action, router } = props;
+  const { getCurrentPageFromRouter, pages } = useFormRouting(router);
+
+  const currentPage = getCurrentPageFromRouter();
+  const positionInForm = pages.indexOf(currentPage);
+  const previousPage = pages[positionInForm - 1];
+
   const handleClick = useCallback(
     e => {
       e.preventDefault();
       recordEvent({
         event: createAnalyticsSlug('back-button-clicked'),
-        fromPage: path,
+        fromPage: currentPage,
       });
       action();
     },
-    [path, action],
+    [currentPage, action],
   );
+
+  if (previousPage === 'loading-appointments') {
+    return '';
+  }
   return (
     <>
       <nav
@@ -39,7 +50,7 @@ const BackButton = props => {
 
 BackButton.propTypes = {
   action: PropTypes.func,
-  path: PropTypes.string,
+  router: PropTypes.object,
 };
 
 export default BackButton;

--- a/src/applications/check-in/components/BackButton.jsx
+++ b/src/applications/check-in/components/BackButton.jsx
@@ -5,14 +5,17 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import { createAnalyticsSlug } from '../utils/analytics';
 import { useFormRouting } from '../hooks/useFormRouting';
+import { URLS } from '../utils/navigation';
 
 const BackButton = props => {
   const { action, router } = props;
-  const { getCurrentPageFromRouter, pages } = useFormRouting(router);
+  const {
+    getCurrentPageFromRouter,
+    getPreviousPageFromRouter,
+  } = useFormRouting(router);
 
   const currentPage = getCurrentPageFromRouter();
-  const positionInForm = pages.indexOf(currentPage);
-  const previousPage = pages[positionInForm - 1];
+  const previousPage = getPreviousPageFromRouter();
 
   const handleClick = useCallback(
     e => {
@@ -26,7 +29,7 @@ const BackButton = props => {
     [currentPage, action],
   );
 
-  if (previousPage === 'loading-appointments') {
+  if (previousPage && previousPage === URLS.LOADING) {
     return '';
   }
   return (

--- a/src/applications/check-in/components/tests/BackButton.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/BackButton.unit.spec.jsx
@@ -3,14 +3,45 @@ import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
 import BackButton from '../BackButton';
 
 describe('check-in', () => {
   describe('BackButton', () => {
+    let store;
+    beforeEach(() => {
+      const middleware = [];
+      const mockStore = configureStore(middleware);
+      const initState = {
+        checkInData: {
+          context: {
+            token: '',
+          },
+          form: {
+            pages: [
+              'loading-appointments',
+              'second-page',
+              'third-page',
+              'fourth-page',
+            ],
+          },
+        },
+      };
+      store = mockStore(initState);
+    });
+    const mockRouterThirdPage = {
+      location: {
+        pathname: '/third-page',
+      },
+    };
     it('Renders', () => {
       const goBack = sinon.spy();
-
-      const screen = render(<BackButton action={goBack} path="/test/path" />);
+      const screen = render(
+        <Provider store={store}>
+          <BackButton action={goBack} router={mockRouterThirdPage} />
+        </Provider>,
+      );
 
       expect(screen.getByTestId('back-button')).to.exist;
       expect(screen.getByTestId('back-button')).to.have.text(
@@ -19,11 +50,29 @@ describe('check-in', () => {
     });
     it('click fires router goBack', () => {
       const goBack = sinon.spy();
-      const screen = render(<BackButton action={goBack} path="/test/path" />);
+      const screen = render(
+        <Provider store={store}>
+          <BackButton action={goBack} router={mockRouterThirdPage} />
+        </Provider>,
+      );
 
       expect(screen.getByTestId('back-button')).to.exist;
       fireEvent.click(screen.getByTestId('back-button'));
       expect(goBack.calledOnce).to.be.true;
+    });
+    it("doesn't render if it is the first confirmation", () => {
+      const mockRouter = {
+        location: {
+          pathname: '/second-page',
+        },
+      };
+      const goBack = sinon.spy();
+      const screen = render(
+        <Provider store={store}>
+          <BackButton action={goBack} router={mockRouter} />
+        </Provider>,
+      );
+      expect(screen.queryByTestId('back-button')).to.not.exist;
     });
   });
 });

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -36,47 +36,49 @@ const DisplayMultipleAppointments = props => {
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
   const today = format(new Date(), 'MMMM dd, yyyy');
   return (
-    <div className="vads-l-grid-container vads-u-padding-bottom--5 vads-u-padding-top--2 appointment-check-in">
+    <>
       <BackButton router={router} action={goToPreviousPage} />
-      <h1 tabIndex="-1" className="vads-u-margin-top--2">
-        Your appointments
-      </h1>
-      <p data-testid="date-text">
-        {`Here are your appointments for today: ${today}.`}
-      </p>
-      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-      <ol
-        className="appointment-list vads-u-padding--0 vads-u-margin--0 vads-u-margin-bottom--2"
-        role="list"
-      >
-        {sortedAppointments.map((appointment, index) => {
-          return (
-            <AppointmentListItem
-              appointment={appointment}
-              key={index}
-              router={router}
-              token={token}
-            />
-          );
-        })}
-      </ol>
-      <p data-testid="update-text">
-        <strong>Latest update:</strong>{' '}
-        {format(new Date(), "MMMM d, yyyy 'at' h:mm aaaa")}
-      </p>
-      <p data-testid="refresh-link">
-        <button
-          className="usa-button-secondary"
-          onClick={handleClick}
-          data-testid="refresh-appointments-button"
-          type="button"
+      <div className="vads-l-grid-container vads-u-padding-bottom--5 vads-u-padding-top--2 appointment-check-in">
+        <h1 tabIndex="-1" className="vads-u-margin-top--2">
+          Your appointments
+        </h1>
+        <p data-testid="date-text">
+          {`Here are your appointments for today: ${today}.`}
+        </p>
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+        <ol
+          className="appointment-list vads-u-padding--0 vads-u-margin--0 vads-u-margin-bottom--2"
+          role="list"
         >
-          Refresh
-        </button>
-      </p>
-      <Footer />
-      <BackToHome />
-    </div>
+          {sortedAppointments.map((appointment, index) => {
+            return (
+              <AppointmentListItem
+                appointment={appointment}
+                key={index}
+                router={router}
+                token={token}
+              />
+            );
+          })}
+        </ol>
+        <p data-testid="update-text">
+          <strong>Latest update:</strong>{' '}
+          {format(new Date(), "MMMM d, yyyy 'at' h:mm aaaa")}
+        </p>
+        <p data-testid="refresh-link">
+          <button
+            className="usa-button-secondary"
+            onClick={handleClick}
+            data-testid="refresh-appointments-button"
+            type="button"
+          >
+            Refresh
+          </button>
+        </p>
+        <Footer />
+        <BackToHome />
+      </div>
+    </>
   );
 };
 

--- a/src/applications/check-in/day-of/pages/CheckIn/tests/CheckIn.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/tests/CheckIn.test.unit.spec.jsx
@@ -12,6 +12,14 @@ import CheckIn from '../index';
 describe('check-in', () => {
   describe('CheckIn component', () => {
     let store;
+    const mockRouter = {
+      params: {
+        token: 'token-123',
+      },
+      location: {
+        pathname: '/third-page',
+      },
+    };
     beforeEach(() => {
       const middleware = [];
       const mockStore = configureStore(middleware);
@@ -37,11 +45,6 @@ describe('check-in', () => {
       store = mockStore(initState);
     });
     it('passes axeCheck', () => {
-      const mockRouter = {
-        params: {
-          token: 'token-123',
-        },
-      };
       axeCheck(
         <Provider store={store}>
           <CheckIn
@@ -60,12 +63,6 @@ describe('check-in', () => {
     });
 
     it('refresh appointments button exists', () => {
-      const mockRouter = {
-        params: {
-          token: 'token-123',
-        },
-      };
-
       const screen = render(
         <Provider store={store}>
           <CheckIn

--- a/src/applications/check-in/day-of/pages/CheckIn/tests/DisplayMultipleAppointments.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/tests/DisplayMultipleAppointments.unit.spec.jsx
@@ -26,13 +26,15 @@ describe('check-in', () => {
       };
       store = mockStore(initState);
     });
+    const mockRouter = {
+      params: {
+        token: 'token-123',
+      },
+      location: {
+        pathname: '/third-page',
+      },
+    };
     it('show appointment details progress', () => {
-      const mockRouter = {
-        params: {
-          token: 'token-123',
-        },
-      };
-
       const token = 'token-123';
       const appointments = [
         {
@@ -73,11 +75,6 @@ describe('check-in', () => {
       );
     });
     it('passes axeCheck', () => {
-      const mockRouter = {
-        params: {
-          token: 'token-123',
-        },
-      };
       const appointments = [
         {
           clinicPhone: '555-867-5309',
@@ -98,12 +95,6 @@ describe('check-in', () => {
     });
     describe('back button visibility based on update page', () => {
       it('shows the back button if update page is enabled', () => {
-        const mockRouter = {
-          params: {
-            token: 'token-123',
-          },
-        };
-
         const token = 'token-123';
         const appointments = [
           {
@@ -126,12 +117,6 @@ describe('check-in', () => {
         expect(checkIn.getByTestId('back-button')).to.exist;
       });
       it('shows the back button if demographics page is enabled', () => {
-        const mockRouter = {
-          params: {
-            token: 'token-123',
-          },
-        };
-
         const token = 'token-123';
         const appointments = [
           {
@@ -155,12 +140,6 @@ describe('check-in', () => {
       });
 
       it('shows the date & time the appointments were loaded & a refresh link', () => {
-        const mockRouter = {
-          params: {
-            token: 'token-123',
-          },
-        };
-
         const token = 'token-123';
         const appointments = [
           {

--- a/src/applications/check-in/day-of/pages/tests/EmergencyContact.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/EmergencyContact.unit.spec.jsx
@@ -21,6 +21,7 @@ describe('check in', () => {
         },
         form: {
           pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
+          currentPage: 'first-page',
         },
         veteranData: {
           demographics: {
@@ -43,14 +44,28 @@ describe('check in', () => {
     };
     const middleware = [];
     const mockStore = configureStore(middleware);
+    const routerObject = {
+      params: {
+        token: 'token-123',
+      },
+      location: {
+        pathname: '/first-page',
+      },
+    };
+
     beforeEach(() => {
       store = mockStore(initState);
     });
 
     it('renders', () => {
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       const component = render(
         <Provider store={store}>
-          <EmergencyContact />
+          <EmergencyContact router={mockRouter} />
         </Provider>,
       );
 
@@ -59,6 +74,11 @@ describe('check in', () => {
     });
 
     it('shows emergency contact felids, with message for empty data', () => {
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       const updatedStore = {
         checkInData: {
           context: {
@@ -82,7 +102,7 @@ describe('check in', () => {
       };
       const component = render(
         <Provider store={mockStore(updatedStore)}>
-          <EmergencyContact />
+          <EmergencyContact router={mockRouter} />
         </Provider>,
       );
 
@@ -94,9 +114,14 @@ describe('check in', () => {
     });
 
     it('passes axeCheck', () => {
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       axeCheck(
         <Provider store={store}>
-          <EmergencyContact />
+          <EmergencyContact router={mockRouter} />
         </Provider>,
       );
     });
@@ -105,7 +130,7 @@ describe('check in', () => {
       const push = sinon.spy();
       const mockRouter = createMockRouter({
         push,
-        params: {},
+        routerObject,
       });
       const updatedStore = {
         checkInData: {
@@ -132,13 +157,10 @@ describe('check in', () => {
 
     it('has a clickable no button', () => {
       const push = sinon.spy();
-      const mockRouter = {
+      const mockRouter = createMockRouter({
         push,
-        params: {
-          token: 'token-123',
-        },
-      };
-
+        routerObject,
+      });
       const component = render(
         <Provider store={store}>
           <EmergencyContact router={mockRouter} />
@@ -153,11 +175,8 @@ describe('check in', () => {
       const push = sinon.spy();
       const mockRouter = createMockRouter({
         push,
-        params: {
-          token: 'token-123',
-        },
+        routerObject,
       });
-
       const component = render(
         <Provider store={store}>
           <EmergencyContact router={mockRouter} />

--- a/src/applications/check-in/day-of/pages/tests/NextOfKin.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/NextOfKin.unit.spec.jsx
@@ -21,6 +21,7 @@ describe('check in', () => {
         },
         form: {
           pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
+          currentPage: 'first-page',
         },
         veteranData: {
           demographics: {
@@ -43,14 +44,27 @@ describe('check in', () => {
     };
     const middleware = [];
     const mockStore = configureStore(middleware);
+    const routerObject = {
+      params: {
+        token: 'token-123',
+      },
+      location: {
+        pathname: '/first-page',
+      },
+    };
     beforeEach(() => {
       store = mockStore(initState);
     });
 
     it('renders', () => {
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       const component = render(
         <Provider store={store}>
-          <NextOfKin />
+          <NextOfKin router={mockRouter} />
         </Provider>,
       );
 
@@ -83,10 +97,14 @@ describe('check in', () => {
           },
         },
       };
-
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       const component = render(
         <Provider store={mockStore(updatedStore)}>
-          <NextOfKin />
+          <NextOfKin router={mockRouter} />
         </Provider>,
       );
 
@@ -101,19 +119,19 @@ describe('check in', () => {
     });
 
     it('passes axeCheck', () => {
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       axeCheck(
         <Provider store={store}>
-          <NextOfKin />
+          <NextOfKin router={mockRouter} />
         </Provider>,
       );
     });
 
     it('goes to the error page when the next of kin data is unavailable', () => {
-      const push = sinon.spy();
-      const mockRouter = createMockRouter({
-        push,
-        params: {},
-      });
       const updatedStore = {
         checkInData: {
           context: {
@@ -128,6 +146,11 @@ describe('check in', () => {
           },
         },
       };
+      const push = sinon.spy();
+      const mockRouter = createMockRouter({
+        push,
+        routerObject,
+      });
       render(
         <Provider store={mockStore(updatedStore)}>
           <NextOfKin router={mockRouter} />
@@ -141,11 +164,8 @@ describe('check in', () => {
       const push = sinon.spy();
       const mockRouter = createMockRouter({
         push,
-        params: {
-          token: 'token-123',
-        },
+        routerObject,
       });
-
       const component = render(
         <Provider store={store}>
           <NextOfKin router={mockRouter} />
@@ -156,17 +176,15 @@ describe('check in', () => {
         component.getByText('Is this your current next of kin information?'),
       ).to.exist;
       component.getByTestId('no-button').click();
+      sinon.assert.calledOnce(push);
     });
 
     it('has a clickable yes button', () => {
       const push = sinon.spy();
       const mockRouter = createMockRouter({
         push,
-        params: {
-          token: 'token-123',
-        },
+        routerObject,
       });
-
       const component = render(
         <Provider store={store}>
           <NextOfKin router={mockRouter} />
@@ -177,17 +195,15 @@ describe('check in', () => {
         component.getByText('Is this your current next of kin information?'),
       ).to.exist;
       component.getByTestId('yes-button').click();
+      sinon.assert.calledOnce(push);
     });
 
     it('has a clickable yes button with update page enabled', () => {
       const push = sinon.spy();
       const mockRouter = createMockRouter({
         push,
-        params: {
-          token: 'token-123',
-        },
+        routerObject,
       });
-
       const component = render(
         <Provider store={store}>
           <NextOfKin isUpdatePageEnabled router={mockRouter} />
@@ -198,16 +214,14 @@ describe('check in', () => {
         component.getByText('Is this your current next of kin information?'),
       ).to.exist;
       component.getByTestId('yes-button').click();
+      sinon.assert.calledOnce(push);
     });
     it('has a clickable yes button', () => {
       const push = sinon.spy();
       const mockRouter = createMockRouter({
         push,
-        params: {
-          token: 'token-123',
-        },
+        routerObject,
       });
-
       const component = render(
         <Provider store={store}>
           <NextOfKin router={mockRouter} />
@@ -218,6 +232,7 @@ describe('check in', () => {
         component.getByText('Is this your current next of kin information?'),
       ).to.exist;
       component.getByTestId('yes-button').click();
+      sinon.assert.calledOnce(push);
     });
   });
 });

--- a/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
@@ -5,6 +5,7 @@ import { useFormRouting } from '../../useFormRouting';
 export default function TestComponent({ router }) {
   const {
     getCurrentPageFromRouter,
+    getPreviousPageFromRouter,
     goToPreviousPage,
     goToNextPage,
     goToErrorPage,
@@ -12,10 +13,16 @@ export default function TestComponent({ router }) {
     pages,
   } = useFormRouting(router);
   const currentPage = getCurrentPageFromRouter();
+  const previousPage = getPreviousPageFromRouter();
   return (
     <div>
       <h1>Test component for the useFormRouting hook</h1>
       <div data-testid="current-page">{currentPage}</div>
+      {previousPage ? (
+        <div data-testid="previous-page">{previousPage}</div>
+      ) : (
+        ''
+      )}
       <div data-testid="all-pages">{pages.join(',')}</div>
       <button
         type="button"

--- a/src/applications/check-in/hooks/tests/useFormRouting/useFormRouting.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/useFormRouting.unit.spec.jsx
@@ -29,7 +29,7 @@ describe('check-in', () => {
         store = mockStore(initState);
       });
 
-      it('should get the current pages from router', () => {
+      it('should get the current page from router', () => {
         const component = render(
           <Provider store={store}>
             <TestComponent
@@ -46,6 +46,23 @@ describe('check-in', () => {
         );
         expect(component.queryByTestId('all-pages').textContent).to.equal(
           'first-page,second-page,third-page,fourth-page',
+        );
+      });
+
+      it('should get the previous page from router', () => {
+        const component = render(
+          <Provider store={store}>
+            <TestComponent
+              router={createMockRouter({
+                push: () => {},
+                currentPage: 'third-page',
+              })}
+            />
+          </Provider>,
+        );
+
+        expect(component.queryByTestId('previous-page').textContent).to.equal(
+          'second-page',
         );
       });
     });

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -56,7 +56,7 @@ const useFormRouting = (router = {}) => {
       const positionInForm = pages.indexOf(currentPage);
       return pages[positionInForm - 1];
     },
-    [router],
+    [router, getCurrentPageFromRouter, pages],
   );
 
   const goToNextPage = useCallback(

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -50,6 +50,15 @@ const useFormRouting = (router = {}) => {
     [router],
   );
 
+  const getPreviousPageFromRouter = useCallback(
+    () => {
+      const currentPage = getCurrentPageFromRouter();
+      const positionInForm = pages.indexOf(currentPage);
+      return pages[positionInForm - 1];
+    },
+    [router],
+  );
+
   const goToNextPage = useCallback(
     () => {
       const here = getCurrentPageFromRouter();
@@ -71,6 +80,7 @@ const useFormRouting = (router = {}) => {
 
   return {
     getCurrentPageFromRouter,
+    getPreviousPageFromRouter,
     goToErrorPage,
     jumpToPage,
     goToPreviousPage,

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -56,7 +56,7 @@ const useFormRouting = (router = {}) => {
       const positionInForm = pages.indexOf(currentPage);
       return pages[positionInForm - 1];
     },
-    [router, getCurrentPageFromRouter, pages],
+    [getCurrentPageFromRouter, pages],
   );
 
   const goToNextPage = useCallback(

--- a/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
@@ -15,12 +15,7 @@ import { makeSelectVeteranData } from '../../../selectors';
 const Demographics = props => {
   const dispatch = useDispatch();
   const { router } = props;
-  const {
-    goToNextPage,
-    goToPreviousPage,
-    getCurrentPageFromRouter,
-  } = useFormRouting(router);
-  const currentPage = getCurrentPageFromRouter();
+  const { goToNextPage, goToPreviousPage } = useFormRouting(router);
   const yesClick = useCallback(
     () => {
       recordEvent({
@@ -51,7 +46,7 @@ const Demographics = props => {
 
   return (
     <>
-      <BackButton action={goToPreviousPage} path={currentPage} />
+      <BackButton action={goToPreviousPage} router={router} />
       <DemographicsDisplay
         yesAction={yesClick}
         noAction={noClick}

--- a/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
@@ -25,12 +25,7 @@ const EmergencyContact = props => {
   const { emergencyContact } = demographics;
   const dispatch = useDispatch();
 
-  const {
-    getCurrentPageFromRouter,
-    goToNextPage,
-    goToPreviousPage,
-  } = useFormRouting(router);
-  const currentPage = getCurrentPageFromRouter();
+  const { goToNextPage, goToPreviousPage } = useFormRouting(router);
 
   const buttonClick = useCallback(
     async answer => {
@@ -64,7 +59,7 @@ const EmergencyContact = props => {
 
   return (
     <>
-      <BackButton action={goToPreviousPage} path={currentPage} />
+      <BackButton action={goToPreviousPage} router={router} />
       <EmergencyContactDisplay
         data={emergencyContact}
         yesAction={yesClick}

--- a/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
@@ -39,13 +39,9 @@ const NextOfKin = props => {
 
   const dispatch = useDispatch();
 
-  const {
-    getCurrentPageFromRouter,
-    goToErrorPage,
-    goToNextPage,
-    goToPreviousPage,
-  } = useFormRouting(router);
-  const currentPage = getCurrentPageFromRouter();
+  const { goToErrorPage, goToNextPage, goToPreviousPage } = useFormRouting(
+    router,
+  );
 
   const buttonClick = useCallback(
     async answer => {
@@ -104,7 +100,7 @@ const NextOfKin = props => {
 
   return (
     <>
-      <BackButton action={goToPreviousPage} path={currentPage} />
+      <BackButton action={goToPreviousPage} router={router} />
       <NextOfKinDisplay
         Footer={Footer}
         header={header}


### PR DESCRIPTION
…ading screen.

## Description
The back button should not exist on the first page after logging into the day-of check-in app. It isn't rendered on the demographics page at all but if this page is skipped, it is included in the next page. This change adds the ability for the back button to look back in the router and decide if it should be rendered. 

This is not an issue on pre-check-in since we have the introduction page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35247

## Testing done
Updated unit test for back button to include checking if it should render.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
