### PR TITLE
Fix: Keepalive bug

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -66,6 +66,7 @@ export default async function keepAlive() {
     });
 
     await resp.text();
+
     const alive = resp.headers.get(AUTHN_HEADERS.ALIVE);
 
     // If no CSP or session-alive headers, return early

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -65,6 +65,7 @@ export default async function keepAlive() {
       cache: 'no-store',
     });
 
+    await resp.text();
     const alive = resp.headers.get(AUTHN_HEADERS.ALIVE);
 
     // If no CSP or session-alive headers, return early
@@ -72,7 +73,6 @@ export default async function keepAlive() {
       return defaultKeepAliveResponse;
     }
 
-    await resp.text();
     /**
      * Uses mapped authncontext for DS Logon and MHV
      * Uses `authncontextclassref` lookup for ID.me and Login.gov


### PR DESCRIPTION
## Description
This PR addresses a race condition bug found in the `keepAlive` method in which referencing headers before the response `text()` method promise can resolve.  This would effective prevent an active session from being maintained. An example of this is if a user navigated to ID.me to verify and hit the back button (this was actively caught in DataDog as a test case)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36575


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] (ID.me LOA1 authenticated) When navigating from the ID.me verify page back to VA.gov I am kept logged in

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
