### PR TITLE
Turn off new custom ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -100,7 +100,7 @@ module.exports = {
       },
     ],
     'va/correct-apostrophe': 1,
-    'va/prefer-web-component-library': 1,
+    'va/prefer-web-component-library': 0,
 
     /* || fp plugin || */
     'fp/no-proxy': 2, // IE 11 has no polyfill for Proxy


### PR DESCRIPTION
## Description

The new linting rule is trying to look at the `name` property for an Object passed as the `pattern` prop for the `<Telephone>` component:

https://github.com/department-of-veterans-affairs/vets-website/blob/1404d4dc607f3898a2ca15e4d47008627d2b3d61/script/eslint-plugin-va/rules/prefer-web-component-library.js#L15-L16

This fails when the `pattern` doesn't use the `PATTERNS` object:

https://github.com/department-of-veterans-affairs/vets-website/blob/cd4f8a06e4fc112609e5bf0892662050ab84449d/src/applications/appeals/10182/content/GetFormHelp.jsx#L20

This turns the rule off for now until we can fix the rule to make it more capable of handling edge cases.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done

- Linting the `GetFormHelp` file locally with the new rule caused a runtime error
- Linting the same file with the rule disabled didn't cause errors

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
