### PR TITLE
Fix custom linting rule for component migration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -100,7 +100,7 @@ module.exports = {
       },
     ],
     'va/correct-apostrophe': 1,
-    'va/prefer-web-component-library': 0,
+    'va/prefer-web-component-library': 1,
 
     /* || fp plugin || */
     'fp/no-proxy': 2, // IE 11 has no polyfill for Proxy

--- a/script/eslint-plugin-va/rules/prefer-web-component-library.js
+++ b/script/eslint-plugin-va/rules/prefer-web-component-library.js
@@ -13,7 +13,7 @@ const telephoneTransformer = (context, node) => {
 
   const stripHyphens = contactValue?.type === 'Literal';
   const international =
-    patternNode?.value.expression.property.name === 'OUTSIDE_US';
+    patternNode?.value.expression?.property?.name === 'OUTSIDE_US';
 
   context.report({
     node,

--- a/script/eslint-plugin-va/tests/lib/rules/prefer-web-component-library.js
+++ b/script/eslint-plugin-va/tests/lib/rules/prefer-web-component-library.js
@@ -93,6 +93,26 @@ ruleTester.run('prefer-web-component-library', rule, {
     {
       code: mockFile(
         'Telephone',
+        'const phone = () => (<Telephone pattern="###" contact={phoneContact} />)',
+      ),
+      errors: [
+        {
+          suggestions: [
+            {
+              desc: 'Migrate component',
+              output: mockFile(
+                'Telephone',
+                'const phone = () => (<va-telephone  contact={phoneContact} />)',
+              ),
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      code: mockFile(
+        'Telephone',
         'const phone = () => (<Telephone contact={"800-456-5432"} />)',
       ),
       errors: [


### PR DESCRIPTION
## Description
This is a follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/20178 and https://github.com/department-of-veterans-affairs/vets-website/pull/20002

This uses additional optional chaining to not assume that the `<Telephone>`'s `pattern` prop will contain an object


## Testing done

- Unit tested the linting rule with `yarn test:unit script/eslint-plugin-va/`
- Ran linting on an actual file with no runtime errors

## Screenshots

![Peek 2022-02-09 10-50](https://user-images.githubusercontent.com/2008881/153269590-716df216-4ae6-4731-814b-1d46237d7b05.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
