### PR TITLE
526: Enable review errors

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -1,3 +1,5 @@
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+
 import environment from 'platform/utilities/environment';
 
 import FormFooter from 'platform/forms/components/FormFooter';
@@ -127,8 +129,6 @@ import reviewErrors from '../reviewErrors';
 
 import manifest from '../manifest.json';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
@@ -179,8 +179,7 @@ const formConfig = {
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   errorText: ErrorText,
-  // Don't show error links on the review page in production
-  showReviewErrors: !environment.isProduction(),
+  showReviewErrors: true,
   reviewErrors,
   defaultDefinitions: {
     ...fullSchema.definitions,


### PR DESCRIPTION
## Description

Form 526 shows a generic error message when validation fails upon submission. We need to enable the error links which provide a path for the Veteran to the appropriate accordion & entry that needs editing.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36700

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Error links showing in production
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
