### PR TITLE
36590: [Burials] eslint fixes

### DIFF
--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -4,7 +4,7 @@ import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import PropTypes, { shape } from 'prop-types';
+import PropTypes from 'prop-types';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -136,9 +136,9 @@ class IntroductionPage extends React.Component {
 }
 
 IntroductionPage.propTypes = {
-  route: shape({
+  route: PropTypes.shape({
     pageList: PropTypes.array,
-    formConfig: shape({
+    formConfig: PropTypes.shape({
       prefillEnabled: PropTypes.bool,
       downtime: PropTypes.object,
     }),

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -4,23 +4,28 @@ import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import PropTypes, { shape } from 'prop-types';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
   }
+
   goForward = () => {
-    this.props.router.push(this.props.route.pageList[1].path);
+    const { route, router } = this.props;
+    router.push(route.pageList[1].path);
   };
+
   render() {
+    const { route } = this.props;
     return (
       <div className="schemaform-intro">
         <FormTitle title="Apply for burial benefits" />
         <p>Equal to VA Form 21P-530 (Application for Burial Benefits).</p>
         <SaveInProgressIntro
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
-          pageList={this.props.route.pageList}
-          downtime={this.props.route.formConfig.downtime}
+          prefillEnabled={route.formConfig.prefillEnabled}
+          pageList={route.pageList}
+          downtime={route.formConfig.downtime}
           startText="Start the Burial Benefits Application"
         />
         <div className="process schemaform-process schemaform-process-sip">
@@ -117,10 +122,10 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
-          pageList={this.props.route.pageList}
+          prefillEnabled={route.formConfig.prefillEnabled}
+          pageList={route.pageList}
           startText="Start the Burial Benefits Application"
-          downtime={this.props.route.formConfig.downtime}
+          downtime={route.formConfig.downtime}
         />
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={15} ombNumber="2900-0003" expDate="04/30/2020" />
@@ -130,6 +135,15 @@ class IntroductionPage extends React.Component {
   }
 }
 
-export default IntroductionPage;
+IntroductionPage.propTypes = {
+  route: shape({
+    pageList: PropTypes.array,
+    formConfig: shape({
+      prefillEnabled: PropTypes.bool,
+      downtime: PropTypes.object,
+    }),
+  }),
+  router: PropTypes.object,
+};
 
-export { IntroductionPage };
+export default IntroductionPage;

--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -9,23 +9,6 @@ import fullSchemaBurials from 'vets-json-schema/dist/21P-530-schema.json';
 
 import applicantDescription from 'platform/forms/components/ApplicantDescription';
 
-import IntroductionPage from '../components/IntroductionPage';
-import ConfirmationPage from '../containers/ConfirmationPage';
-import ErrorText from '../components/ErrorText';
-
-import {
-  burialDateWarning,
-  fileHelp,
-  transportationWarning,
-  serviceRecordNotification,
-  serviceRecordWarning,
-  submit,
-} from '../helpers';
-import {
-  relationshipLabels,
-  locationOfDeathLabels,
-  allowanceLabels,
-} from '../labels.jsx';
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import { isFullDate } from 'platform/forms/validations';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
@@ -42,9 +25,26 @@ import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import toursOfDutyUI from '../definitions/toursOfDuty';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
+import toursOfDutyUI from '../definitions/toursOfDuty';
+import IntroductionPage from '../components/IntroductionPage';
+import ConfirmationPage from '../containers/ConfirmationPage';
+import ErrorText from '../components/ErrorText';
+
+import {
+  burialDateWarning,
+  fileHelp,
+  transportationWarning,
+  serviceRecordNotification,
+  serviceRecordWarning,
+  submit,
+} from '../helpers';
+import {
+  relationshipLabels,
+  locationOfDeathLabels,
+  allowanceLabels,
+} from '../labels';
 import {
   validateBurialAndDeathDates,
   validateCentralMailPostalCode,


### PR DESCRIPTION
## Description
IndroductionPage in burials is throwing new warnings
New eslint rules requiring lines between class components, destructuring prop assignments, and propType validation.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36590

## Screenshot
![image](https://user-images.githubusercontent.com/25368370/153469553-782be79c-f30a-468a-a932-065b4714f835.png)

## Acceptance criteria
- [x] Burial Introduction page is no longer showing eslint warnings

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
