### PR TITLE
35233 key off of cancellable

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -3,6 +3,8 @@ import { Link, useParams } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import moment from 'moment';
+import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+import recordEvent from 'platform/monitoring/record-event';
 import {
   APPOINTMENT_STATUS,
   APPOINTMENT_TYPES,
@@ -29,8 +31,6 @@ import {
   confirmCancelAppointment,
   fetchRequestDetails,
 } from '../redux/actions';
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
-import recordEvent from 'platform/monitoring/record-event';
 import RequestedStatusAlert from './RequestedStatusAlert';
 
 const TIME_TEXT = {
@@ -53,6 +53,8 @@ export default function RequestedAppointmentDetailsPage() {
     shallowEqual,
   );
 
+  const isCanceledStatus = appointment.status === APPOINTMENT_STATUS.cancelled;
+
   useEffect(() => {
     dispatch(fetchRequestDetails(id));
   }, []);
@@ -60,13 +62,12 @@ export default function RequestedAppointmentDetailsPage() {
   useEffect(
     () => {
       if (appointment) {
-        const isCanceled = appointment.status === APPOINTMENT_STATUS.cancelled;
         const isCC = appointment.vaos.isCommunityCare;
         const typeOfCareText = lowerCase(
           appointment?.type?.coding?.[0]?.display,
         );
 
-        const title = `${isCanceled ? 'Canceled' : 'Pending'} ${
+        const title = `${isCanceledStatus ? 'Canceled' : 'Pending'} ${
           isCC ? 'Community care' : 'VA'
         } ${typeOfCareText} appointment`;
 
@@ -123,7 +124,7 @@ export default function RequestedAppointmentDetailsPage() {
     );
   }
 
-  const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
+  const canceled = !appointment.cancellable;
   const isCC = appointment.vaos.isCommunityCare;
   const typeOfVisit = appointment.requestVisitType;
   const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
@@ -144,7 +145,7 @@ export default function RequestedAppointmentDetailsPage() {
       </Breadcrumbs>
 
       <h1>
-        {canceled ? 'Canceled' : 'Pending'} {typeOfCareText} appointment
+        {isCanceledStatus ? 'Canceled' : 'Pending'} {typeOfCareText} appointment
       </h1>
       <RequestedStatusAlert appointment={appointment} facility={facility} />
       {!isCCRequest && (

--- a/src/applications/vaos/appointment-list/components/RequestedStatusAlert.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedStatusAlert.jsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import recordEvent from 'platform/monitoring/record-event';
-import InfoAlert from '../../components/InfoAlert';
-import {
-  APPOINTMENT_STATUS,
-  CANCELLATION_REASONS,
-  GA_PREFIX,
-} from '../../utils/constants';
 import { useDispatch } from 'react-redux';
+import InfoAlert from '../../components/InfoAlert';
+import { CANCELLATION_REASONS, GA_PREFIX } from '../../utils/constants';
 import { startNewAppointmentFlow } from '../redux/actions';
 
 export default function RequestedStatusAlert({ appointment, facility }) {
@@ -16,7 +12,7 @@ export default function RequestedStatusAlert({ appointment, facility }) {
   const showConfirmMsg = queryParams.get('confirmMsg');
   const dispatch = useDispatch();
 
-  const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
+  const canceled = !appointment.cancellable;
 
   const canceler = new Map([
     [CANCELLATION_REASONS.patient, 'You'],
@@ -63,7 +59,8 @@ export default function RequestedStatusAlert({ appointment, facility }) {
         )}
       </InfoAlert>
     );
-  } else if (!showConfirmMsg) {
+  }
+  if (!showConfirmMsg) {
     return (
       <InfoAlert backgroundOnly status={canceled ? 'error' : 'info'}>
         {!canceled &&

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -35,14 +35,14 @@ import { getTypeOfCareById } from '../../utils/appointment';
 function getAppointmentType(appt) {
   if (appt.typeOfCareId?.startsWith('CC')) {
     return APPOINTMENT_TYPES.ccRequest;
-  } else if (appt.typeOfCareId) {
+  }
+  if (appt.typeOfCareId) {
     return APPOINTMENT_TYPES.request;
-  } else if (
-    appt.vvsAppointments?.length ||
-    (appt.clinicId && !appt.communityCare)
-  ) {
+  }
+  if (appt.vvsAppointments?.length || (appt.clinicId && !appt.communityCare)) {
     return APPOINTMENT_TYPES.vaAppointment;
-  } else if (appt.appointmentTime || appt.communityCare === true) {
+  }
+  if (appt.appointmentTime || appt.communityCare === true) {
     return APPOINTMENT_TYPES.ccAppointment;
   }
 
@@ -102,9 +102,11 @@ function getRequestStatus(request, isExpressCare) {
   if (isExpressCare) {
     if (request.status === 'Submitted') {
       return APPOINTMENT_STATUS.proposed;
-    } else if (request.status === 'Cancelled') {
+    }
+    if (request.status === 'Cancelled') {
       return APPOINTMENT_STATUS.cancelled;
-    } else if (request.status.startsWith('Escalated')) {
+    }
+    if (request.status.startsWith('Escalated')) {
       return APPOINTMENT_STATUS.pending;
     }
 
@@ -113,7 +115,8 @@ function getRequestStatus(request, isExpressCare) {
 
   if (request.status === 'Booked' || request.status === 'Resolved') {
     return APPOINTMENT_STATUS.booked;
-  } else if (request.status === 'Cancelled') {
+  }
+  if (request.status === 'Cancelled') {
     return APPOINTMENT_STATUS.cancelled;
   }
 
@@ -490,6 +493,7 @@ export function transformPendingAppointment(appt) {
     resourceType: 'Appointment',
     id: appt.id,
     status: getRequestStatus(appt, isExpressCare),
+    cancellable: appt.status !== APPOINTMENT_STATUS.cancelled,
     created,
     cancelationReason:
       appt.appointmentRequestDetailCode?.[0]?.detailCode.code === 'DETCODE8'

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -153,6 +153,7 @@ export function transformVAOSAppointment(appt) {
     resourceType: 'Appointment',
     id: appt.id,
     status: appt.status,
+    cancellable: appt.cancellable,
     cancelationReason: appt.cancelationReason?.coding?.[0].code || null,
     start: !isRequest ? start.format() : null,
     // This contains the vista status for v0 appointments, but

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -637,6 +637,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const appointment = getVAOSRequestMock();
     appointment.id = '1234';
     appointment.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [
@@ -744,6 +745,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const ccAppointmentRequest = getVAOSRequestMock();
     ccAppointmentRequest.id = '1234';
     ccAppointmentRequest.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [
@@ -867,6 +869,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const appointment = getVAOSRequestMock();
     appointment.id = '1234';
     appointment.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [
@@ -940,6 +943,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const appointment = getVAOSRequestMock();
     appointment.id = '1234';
     appointment.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -1,8 +1,8 @@
 /**
  * @module testing/mocks/data
  */
-import moment from '../../lib/moment-tz';
 import omit from 'platform/utilities/data/omit';
+import moment from '../../lib/moment-tz';
 import { VIDEO_TYPES, APPOINTMENT_STATUS } from '../../utils/constants';
 
 /**
@@ -217,6 +217,7 @@ export function createMockAppointmentByVersion({
       type: 'appointments',
       attributes: {
         id,
+        cancellable: true,
         cancelationReason: null,
         clinic: null,
         comment: null,
@@ -310,7 +311,8 @@ export function createMockClinicByVersion({
         char4: null,
       },
     };
-  } else if (version === 0) {
+  }
+  if (version === 0) {
     return {
       id,
       type: 'clinic',

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -7,13 +7,13 @@ import {
   setFetchJSONResponse,
   setFetchJSONFailure,
 } from 'platform/testing/unit/helpers';
+import sinon from 'sinon';
 import {
   getVAAppointmentMock,
   getExpressCareRequestCriteriaMock,
   getRequestEligibilityCriteriaMock,
   getDirectBookingEligibilityCriteriaMock,
-} from '../mocks/v0';
-import sinon from 'sinon';
+} from './v0';
 import { createMockFacilityByVersion } from './data';
 import { mockFacilitiesFetchByVersion } from './fetch';
 
@@ -303,7 +303,8 @@ export function mockRequestCancelFetch(appointment) {
         ...appointment,
         attributes: {
           ...appointment.attributes,
-          status: 'Cancelled',
+          cancellable: false,
+          status: 'cancelled',
           appointmentRequestDetailCode: [{ detailCode: { code: 'DETCODE8' } }],
         },
       },

--- a/src/applications/vaos/tests/mocks/helpers.v2.js
+++ b/src/applications/vaos/tests/mocks/helpers.v2.js
@@ -134,6 +134,7 @@ export function mockAppointmentCancelFetch({ appointment, error = false }) {
         ...appointment,
         attributes: {
           ...appointment.attributes,
+          cancellable: false,
           status: 'cancelled',
           cancelationReason: { coding: [{ code: 'pat' }] },
         },

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -67,6 +67,7 @@ describe('VAOS Appointment service', () => {
             path: ['location', 'clinicName'],
             value: 'Friendly clinic name',
           }, // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -122,6 +123,7 @@ describe('VAOS Appointment service', () => {
             path: ['description'],
             value: 'CANCELLED BY PATIENT',
           },
+          { op: 'remove', path: ['cancellable'] },
           { op: 'remove', path: ['practitioners'] },
           { op: 'replace', path: ['cancelationReason'], value: 'pat' },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -172,6 +174,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'CHECKED OUT' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -222,6 +225,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'CHECKED OUT' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -273,6 +277,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'CHECKED OUT' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -332,6 +337,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -404,6 +410,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -457,6 +464,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -510,6 +518,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -562,6 +571,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -614,6 +624,7 @@ describe('VAOS Appointment service', () => {
       expect(differences).to.have.deep.members(
         [
           // The v2 endpoint doesn't send us the vista status
+          { op: 'remove', path: ['cancellable'] },
           { op: 'replace', path: ['description'], value: 'FUTURE' },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
@@ -691,6 +702,7 @@ describe('VAOS Appointment service', () => {
             path: ['practitioners'],
           },
           { op: 'remove', path: ['vaos', 'facilityData'] },
+          { op: 'remove', path: ['cancellable'] },
         ],
         'Transformers for v0 and v2 appointment data are out of sync',
       );


### PR DESCRIPTION
## Description
For V2, the way we determine if an appointment is cancelled is slightly different than v0.  In v0 we key off the status='cancelled' field, in v2 we key off the cancellable: false field.  The code was updated so that both v0 and v2 will correctly handle this change.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35233


## Testing done
Associated unit tests for updated to reflect this change

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
