### PR TITLE
Attempt #2 to fix keepalive bug

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -34,19 +34,13 @@ const logToSentry = data => {
   return isCaptured;
 };
 
-export const sanitizeAuthn = (authnCtx = 'NOT_FOUND') => {
+export const sanitizeAuthn = authnCtx => {
   const emptyString = '';
-  return authnCtx === null || !authnCtx.length
-    ? 'NOT_FOUND'
+  return !authnCtx
+    ? undefined
     : authnCtx
         .replace(SKIP_DUPE_QUERY.SINGLE_QUERY, emptyString)
         .replace(SKIP_DUPE_QUERY.MULTIPLE_QUERIES, emptyString);
-};
-
-export const defaultKeepAliveResponse = {
-  ttl: 0,
-  transactionid: null,
-  authn: undefined,
 };
 
 export default async function keepAlive() {
@@ -68,11 +62,6 @@ export default async function keepAlive() {
     await resp.text();
 
     const alive = resp.headers.get(AUTHN_HEADERS.ALIVE);
-
-    // If no CSP or session-alive headers, return early
-    if (resp.headers.get(AUTHN_HEADERS.CSP) === null || alive !== 'true') {
-      return defaultKeepAliveResponse;
-    }
 
     /**
      * Uses mapped authncontext for DS Logon and MHV

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -398,7 +398,7 @@ describe('keepAlive', () => {
       generateMockKeepAliveResponse({
         headers: {
           [ALIVE]: 'false',
-          [TIMEOUT]: '900',
+          [TIMEOUT]: 900,
           [TRANSACTIONID]: 'g',
           [AUTHN_CONTEXT]: '/loa1',
         },
@@ -526,9 +526,9 @@ describe('sanitizeAuthn', () => {
   });
 
   it('should return a `NOT_FOUND` string when passed nothing', () => {
-    expect(keepAliveMod.sanitizeAuthn('')).to.eql('NOT_FOUND');
-    expect(keepAliveMod.sanitizeAuthn(null)).to.eql('NOT_FOUND');
-    expect(keepAliveMod.sanitizeAuthn(undefined)).to.eql('NOT_FOUND');
+    expect(keepAliveMod.sanitizeAuthn('')).to.eql(undefined);
+    expect(keepAliveMod.sanitizeAuthn(null)).to.eql(undefined);
+    expect(keepAliveMod.sanitizeAuthn(undefined)).to.eql(undefined);
   });
 
   it('should strip out the `?skip_dupe` query param', () => {


### PR DESCRIPTION
## Description
Removes the early return in the `keepAliveSSO` method, updates unit tests as necessary

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36575


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] Keepalive functions as necessary

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
