### PR TITLE
Fix `cy.expandAccordions()` command

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/expandAccordions.js
+++ b/src/platform/testing/e2e/cypress/support/commands/expandAccordions.js
@@ -46,10 +46,12 @@ Cypress.Commands.add('expandAccordions', () => {
     // Check if AdditionalInfo and/or Accordion React Components exist
     // Check that the component is not already expanded
     if ($main.find('button[aria-expanded=false]').length > 0) {
-      cy.get('button[aria-expanded=false]').each(button => {
-        // Click to open Accordion or Additional Info
-        cy.wrap(button).click({ force: true });
-      });
+      cy.get('main')
+        .find('button[aria-expanded=false]')
+        .each(button => {
+          // Click to open Accordion or Additional Info
+          cy.wrap(button).click({ force: true });
+        });
     }
   });
 });


### PR DESCRIPTION
## Description
This PR fixes an issue with the Cypress `cy.expandAccordions()` command where the command would expand all expandable items on the page and not just accordions.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36512

## Testing done
Local testing.

## Acceptance criteria
- [ ] CI passes.