### PR TITLE
NOD: fix JS error

### DIFF
--- a/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
@@ -134,22 +134,22 @@ const ContestableIssuesWidget = props => {
     const itemIsSelected = !!item?.[SELECTED];
     const hideCard = (inReviewMode && !itemIsSelected) || isEmptyObject(item);
 
+    const cardProps = {
+      id,
+      index,
+      item,
+      key: index,
+      options,
+      showCheckbox,
+      onChange: handlers.onChange,
+      // Don't allow editing or removing API-loaded issues
+      onRemove: item.ratingIssueSubjectText
+        ? null
+        : () => handlers.onRemoveIssue(index),
+    };
+
     // Don't show un-selected ratings in review mode
-    return hideCard ? null : (
-      <IssueCard
-        id={id}
-        key={index}
-        index={index}
-        item={item}
-        options={options}
-        onChange={handlers.onChange}
-        showCheckbox={showCheckbox}
-        onRemove={
-          // Don't allow editing or removing API-loaded issues
-          item.ratingIssueSubjectText ? null : handlers.onRemoveIssue(index)
-        }
-      />
-    );
+    return hideCard ? null : <IssueCard {...cardProps} />;
   });
 
   return (

--- a/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -11,6 +11,7 @@ describe('<ContestableIssuesWidget>', () => {
     review = false,
     submitted = false,
     onChange = () => {},
+    setFormData = () => {},
   } = {}) => ({
     id: 'id',
     value: [
@@ -24,7 +25,7 @@ describe('<ContestableIssuesWidget>', () => {
       reviewMode: review,
       submitted,
     },
-    setFormData: () => {},
+    setFormData,
   });
 
   it('should render a list of check boxes (IssueCard component)', () => {
@@ -120,6 +121,22 @@ describe('<ContestableIssuesWidget>', () => {
     expect(wrapper.find('dt').text()).to.contain(
       'at least one issue, so we can process your request',
     );
+    wrapper.unmount();
+  });
+  it('should remove additional item', () => {
+    const setFormData = sinon.spy();
+    const props = getProps({ setFormData });
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+
+    expect(props.additionalIssues.length).to.equal(1);
+
+    wrapper
+      .find('button.remove-issue')
+      .props()
+      .onClick({ preventDefault: () => {} });
+
+    expect(setFormData.called).to.be.true;
+    expect(setFormData.args[0][0].additionalIssues.length).to.equal(0);
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description

While fixing linting warnings in the Notice of Disagreement form, a JS error was introduced. This PR fixes it and adds a unit test. Luckily this form is not yet in production.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36584

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Fix JS error
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
