### PR TITLE
35887: [FSR] edit view styling

### DIFF
--- a/src/applications/financial-status-report/components/ItemLoop.jsx
+++ b/src/applications/financial-status-report/components/ItemLoop.jsx
@@ -142,7 +142,7 @@ const InputSection = ({
               {showCancel && (
                 <button
                   aria-label={`Cancel ${title}`}
-                  className="usa-button-secondary"
+                  className="usa-button-secondary vads-u-margin-left--2"
                   onClick={() => handleCancel(index)}
                   type="button"
                 >

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -30,6 +30,7 @@
 .debt-card {
   padding: 24px;
   label {
+    display: inline-block !important;
     user-select: none;
   }
   [type="checkbox"]:checked + label::before {

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -58,9 +58,9 @@
     table-layout: fixed;
   }
   .item-loop {
-    padding: 5px 15px 20px;
+    padding: 15px 30px;
     background-color: $color-gray-lightest;
-    .horizontal-field-container .schemaform-field-container {
+    .horizontal-field-container {
       display: flex;
       align-items: center;
       margin: 20px 0;


### PR DESCRIPTION
## Description
fixes styling issues for the item loop edit view and selected debt card buttons

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35887

## Screenshots
list loop styling
![Financial Status Report  Veterans Affairs 2022-02-11 13-22-02](https://user-images.githubusercontent.com/7518899/153647977-1a4767d0-1957-4637-a70a-ca3c1715e824.png)

available debts
![Financial Status Report  Veterans Affairs 2022-02-11 13-23-01](https://user-images.githubusercontent.com/7518899/153648138-052028eb-075c-4486-8a7c-9501292d81a5.png)

## Acceptance criteria
- [x] edit view for the list loop should render correctly
- [x] available debt card buttons should be styled correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
