### PR TITLE
CST: status color fix

### DIFF
--- a/src/applications/claims-status/components/StemClaimListItem.jsx
+++ b/src/applications/claims-status/components/StemClaimListItem.jsx
@@ -14,6 +14,21 @@ export default function StemClaimListItem({ claim }) {
   const formattedReceiptDate = moment(claim.attributes.submittedAt).format(
     'MMMM D, YYYY',
   );
+
+  const handlers = {
+    openClaimClick: () =>
+      recordEvent({
+        event: 'cta-action-link-click',
+        'action-link-type': 'secondary',
+        'action-link-click-label': 'View details',
+        'action-link-icon-color': 'blue',
+        'claim-type': 'STEM Scholarship',
+        'claim-last-updated-date': formattedDeniedAtDate,
+        'claim-submitted-date': formattedDeniedAtDate,
+        'claim-status': 'Denied',
+      }),
+  };
+
   return (
     <div className="claim-list-item-container">
       <h2 className="claim-list-item-header-v2 vads-u-font-size--h3">
@@ -22,7 +37,7 @@ export default function StemClaimListItem({ claim }) {
         updated on {formattedDeniedAtDate}
       </h2>
       <div className="card-status">
-        <div className={`status-circle closed`} />
+        <div className="status-circle closed-claim" />
         <p>
           <strong>Status:</strong> Denied
         </p>
@@ -36,18 +51,7 @@ export default function StemClaimListItem({ claim }) {
         aria-label={`View details of claim received ${formattedReceiptDate}`}
         className="vads-c-action-link--blue"
         to={`your-stem-claims/${claim.id}/status`}
-        onClick={() =>
-          recordEvent({
-            event: 'cta-action-link-click',
-            'action-link-type': 'secondary',
-            'action-link-click-label': 'View details',
-            'action-link-icon-color': 'blue',
-            'claim-type': 'STEM Scholarship',
-            'claim-last-updated-date': formattedDeniedAtDate,
-            'claim-submitted-date': formattedDeniedAtDate,
-            'claim-status': 'Denied',
-          })
-        }
+        onClick={handlers.openClaimClick}
       >
         View details
       </Link>

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -88,7 +88,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
         {!external && (
           <div
             className={`status-circle ${
-              appeal.attributes.active ? 'open' : 'closed'
+              appeal.attributes.active ? 'open-claim' : 'closed-claim'
             }`}
           />
         )}
@@ -136,6 +136,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
 
 AppealListItem.propTypes = {
   appeal: PropTypes.shape({
+    id: PropTypes.number,
     attributes: PropTypes.shape({
       status: PropTypes.shape({
         type: PropTypes.string.isRequired,
@@ -152,11 +153,12 @@ AppealListItem.propTypes = {
       issues: PropTypes.array.isRequired,
       description: PropTypes.string.isRequired,
     }),
+    type: PropTypes.string,
   }),
+  external: PropTypes.bool,
   name: PropTypes.shape({
     first: PropTypes.string,
     middle: PropTypes.string,
     last: PropTypes.string,
   }),
-  external: PropTypes.bool,
 };

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -29,7 +29,7 @@ export default function ClaimsListItem({ claim }) {
       <div className="card-status">
         <div
           className={`status-circle ${
-            claim.attributes.open ? 'open' : 'closed'
+            claim.attributes.open ? 'open-claim' : 'closed-claim'
           }`}
         />
         <p>

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -111,12 +111,12 @@
     margin-right: 0.8rem;
     margin-top: 0.5rem;
 
-    &.open {
+    &.open-claim {
       background-color: $color-green;
     }
 
-    &.closed {
-      background-color: $color-gray-light;
+    &.closed-claim {
+      background-color: $color-gray;
     }
   }
 
@@ -743,7 +743,7 @@ h1:focus {
 }
 
 .current-status {
-  &.closed {
+  &.closed-claim {
     .current-status-content {
       border-left-color: transparent;
 

--- a/src/applications/claims-status/tests/components/StemClaimListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/StemClaimListItem.unit.spec.jsx
@@ -59,8 +59,8 @@ describe('<StemClaimListItem>', () => {
   it('should render a status circle with the `closed` class', () => {
     const tree = shallow(<StemClaimListItem claim={defaultClaim} />);
     const circle = tree.find('.status-circle').first();
-    expect(circle.hasClass('open')).to.be.false;
-    expect(circle.hasClass('closed')).to.be.true;
+    expect(circle.hasClass('open-claim')).to.be.false;
+    expect(circle.hasClass('closed-claim')).to.be.true;
     tree.unmount();
   });
 });

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -62,16 +62,16 @@ describe('<AppealListItemV2/>', () => {
 
   it('should append open class to status-circle div when status active', () => {
     const wrapper = shallow(<AppealListItemV2 {...defaultProps} />);
-    expect(wrapper.find('div.open').length).to.equal(1);
-    expect(wrapper.find('div.closed').length).to.equal(0);
+    expect(wrapper.find('div.open-claim').length).to.equal(1);
+    expect(wrapper.find('div.closed-claim').length).to.equal(0);
     wrapper.unmount();
   });
 
   it('should append closed class to status-circle div when status inactive', () => {
     const closedProps = set('appeal.attributes.active', false, defaultProps);
     const wrapper = shallow(<AppealListItemV2 {...closedProps} />);
-    expect(wrapper.find('div.closed').length).to.equal(1);
-    expect(wrapper.find('div.open').length).to.equal(0);
+    expect(wrapper.find('div.closed-claim').length).to.equal(1);
+    expect(wrapper.find('div.open-claim').length).to.equal(0);
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -130,8 +130,8 @@ describe('<ClaimsListItemV2>', () => {
     };
     const tree = shallow(<ClaimsListItemV2 claim={claim} />);
     const circle = tree.find('.status-circle').first();
-    expect(circle.hasClass('open')).to.be.true;
-    expect(circle.hasClass('closed')).to.be.false;
+    expect(circle.hasClass('open-claim')).to.be.true;
+    expect(circle.hasClass('closed-claim')).to.be.false;
     tree.unmount();
   });
 
@@ -145,8 +145,8 @@ describe('<ClaimsListItemV2>', () => {
     };
     const tree = shallow(<ClaimsListItemV2 claim={claim} />);
     const circle = tree.find('.status-circle').first();
-    expect(circle.hasClass('open')).to.be.false;
-    expect(circle.hasClass('closed')).to.be.true;
+    expect(circle.hasClass('open-claim')).to.be.false;
+    expect(circle.hasClass('closed-claim')).to.be.true;
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description

The Claim status tools status color appears to be pink in the current view. This looks to be caused by a definition change in the `site-wide` folder which defines a background color of `color-red-lightest` for the `.closed` class. It uses an `!important` flag to over-ride all other definitions.

In this PR, the `closed` class used for the status has been renamed to `closed-claim`

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36831

## Testing done

Visual

## Screenshots

<details><summary>Current (pink) status color</summary>

![pink dot next to status](https://user-images.githubusercontent.com/136959/153648808-48c36fe6-e00b-4846-a07d-5286ccef4668.png)</details>

<details><summary>Restored (grey) status color</summary>

![dark grey dot next to status](https://user-images.githubusercontent.com/136959/153648868-9344b844-1a0d-4b7a-b075-efd77da12083.png)</details>

## Acceptance criteria
- [x] Restore closed status color
- [x] All tests passing 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
