### PR TITLE
front-end will now handle CC cancelled appointments correctly

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -5,6 +5,7 @@ import {
   PURPOSE_TEXT,
   TYPE_OF_VISIT,
   COVID_VACCINE_ID,
+  APPOINTMENT_STATUS,
 } from '../../utils/constants';
 import { getTimezoneByFacilityId } from '../../utils/timezone';
 import { transformFacilityV2 } from '../location/transformers.v2';
@@ -153,7 +154,20 @@ export function transformVAOSAppointment(appt) {
   return {
     resourceType: 'Appointment',
     id: appt.id,
-    status: appt.status,
+    /*
+      When cancelling a CC appointment request in V2 the appointment status remains in 
+      a state of proposed until the scheduler cancels it. Typically the status is immediately 
+      set to cancelled as is the case with a standard VA request.  In order to maintain
+      consistent behavior for both VA and CC requests on the RequestedAppointmentDetailsPage
+      we are setting the CC appointment request status to cancelled using the logic below.
+
+      Cancellable is a new field on the appointment object that *is* set immediately upon cancellation
+      of the appointment.
+    */
+    status:
+      isCC && appt.status === APPOINTMENT_STATUS.proposed && !appt.cancellable
+        ? APPOINTMENT_STATUS.cancelled
+        : appt.status,
     cancelationReason: appt.cancelationReason?.coding?.[0].code || null,
     start: !isRequest ? start.format() : null,
     // This contains the vista status for v0 appointments, but

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -637,6 +637,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const appointment = getVAOSRequestMock();
     appointment.id = '1234';
     appointment.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [
@@ -744,6 +745,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const ccAppointmentRequest = getVAOSRequestMock();
     ccAppointmentRequest.id = '1234';
     ccAppointmentRequest.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [
@@ -867,6 +869,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const appointment = getVAOSRequestMock();
     appointment.id = '1234';
     appointment.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [
@@ -940,6 +943,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     const appointment = getVAOSRequestMock();
     appointment.id = '1234';
     appointment.attributes = {
+      cancellable: true,
       comment: 'A message from the patient',
       contact: {
         telecom: [

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -841,6 +841,7 @@ describe('VAOS Appointment service', () => {
       // Given CC appointment request
       const data = {
         id: '1234',
+        cancellable: true,
         email: 'test@va.gov',
         phone: '2125551212',
         kind: 'cc',


### PR DESCRIPTION
## Description
For V2, the way we determine if an appointment is cancelled is slightly different than v0. In v0 we key off the status='cancelled' field, in v2 we key off the cancellable: false field. The code was updated so that both v0 and v2 will correctly handle this change.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35233


## Testing done
Unit tests were updated to reflect this change.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
