### PR TITLE
Remove duplicate output in unit test job in CI

### DIFF
--- a/config/mocha-multi-reporter.json
+++ b/config/mocha-multi-reporter.json
@@ -1,3 +1,6 @@
 {
-  "reporterEnabled": "min, mocha-junit-reporter, mochawesome"
+  "reporterEnabled": "mocha-junit-reporter, mochawesome",
+  "mochawesomeReporterOptions": {
+    "consoleReporter": "min"
+  }
 }


### PR DESCRIPTION
## Description
Mochawesome was [recently added](https://github.com/department-of-veterans-affairs/vets-website/pull/20163) as one of the enabled reporters for `mocha-multi-reporters`. By default, mochawesome outputs to the console using the spec reporter, which is causing [both the min and spec](https://github.com/department-of-veterans-affairs/vets-website/runs/5164476828?check_suite_focus=true) reporters to output to the console in CI.

This PR updates the [consoleReporter](https://github.com/adamgruber/mochawesome#available-options) option in mochawesome to use the min reporter, so that we don't have overlapping outputs.

## Testing done
Tested locally and in CI.


## Acceptance criteria
- [x] Only the min reporter should be outtting to the console when the `coverage` option is used for running unit tests.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
