### PR TITLE
Include file upload size in card

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -1,11 +1,11 @@
 import * as Sentry from '@sentry/browser';
 import moment from 'moment';
-import { transformForSubmit } from './helpers';
 import recordEvent from 'platform/monitoring/record-event';
-import { timeFromNow } from './utilities/date';
 import localStorage from 'platform/utilities/storage/localStorage';
 import { displayFileSize } from 'platform/utilities/ui/index';
 import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from 'platform/forms-system/src/js/constants';
+import { timeFromNow } from './utilities/date';
+import { transformForSubmit } from './helpers';
 
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';
 export const SET_DATA = 'SET_DATA';
@@ -314,9 +314,8 @@ export function uploadFile(
       if (req.status >= 200 && req.status < 300) {
         const body = 'response' in req ? req.response : req.responseText;
         const fileData = uiOptions.parseResponse(JSON.parse(body), file);
-
         recordEvent({ event: `${trackingPrefix}file-uploaded` });
-        onChange({ ...fileData, isEncrypted: !!password });
+        onChange({ ...fileData, size: file.size, isEncrypted: !!password });
       } else {
         let errorMessage = req.statusText;
         try {
@@ -337,11 +336,12 @@ export function uploadFile(
           onChange({
             file, // return file object to allow resubmit
             name: file.name,
+            size: file.size,
             errorMessage,
             isEncrypted: true,
           });
         } else {
-          onChange({ name: file.name, errorMessage });
+          onChange({ name: file.name, size: file.size, errorMessage });
         }
         Sentry.captureMessage(`vets_upload_error: ${errorMessage}`);
         onError();

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -2,12 +2,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { displayFileSize } from 'platform/utilities/ui';
+import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from 'platform/forms-system/src/js/constants';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
 import unset from '../../../../utilities/data/unset';
-import classNames from 'classnames';
-
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 import { focusElement } from '../utilities/ui';
 import {
@@ -19,7 +20,6 @@ import {
   checkIsEncryptedPdf,
   FILE_TYPE_MISMATCH_ERROR,
 } from '../utilities/file';
-import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from 'platform/forms-system/src/js/constants';
 
 class FileField extends React.Component {
   constructor(props) {
@@ -29,6 +29,7 @@ class FileField extends React.Component {
     };
     this.uploadRequest = null;
   }
+
   fileInputRef = React.createRef();
 
   /* eslint-disable-next-line camelcase */
@@ -94,7 +95,7 @@ class FileField extends React.Component {
       } = this.props;
       const uiOptions = uiSchema['ui:options'];
       // needed for FileField unit tests
-      const mockReadAndCheckFile = uiOptions.mockReadAndCheckFile;
+      const { mockReadAndCheckFile } = uiOptions;
 
       let idx = index;
       if (idx === null) {
@@ -260,7 +261,7 @@ class FileField extends React.Component {
     const uiOptions = uiSchema?.['ui:options'];
     const files = formData || [];
     const maxItems = schema.maxItems || Infinity;
-    const SchemaField = registry.fields.SchemaField;
+    const { SchemaField } = registry.fields;
     const attachmentIdRequired = schema.additionalItems.required
       ? schema.additionalItems.required.includes('attachmentId')
       : false;
@@ -395,7 +396,12 @@ class FileField extends React.Component {
                     </div>
                   )}
                   {description && <p>{description}</p>}
-                  {!file.uploading && <strong id={fileId}>{file.name}</strong>}
+                  {!file.uploading && (
+                    <>
+                      <strong id={fileId}>{file.name}</strong>
+                      {file?.size && <div> {displayFileSize(file.size)}</div>}
+                    </>
+                  )}
                   {(showPasswordInput || showPasswordSuccess) && (
                     <PasswordLabel />
                   )}

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -493,12 +493,12 @@ describe('Schemaform actions:', () => {
       const thunk = uploadFile(
         {
           name: 'jpg',
-          size: 0,
+          size: 1234,
         },
         {
           endpoint: '/v0/endpoint',
           fileTypes: ['JPG'],
-          maxSize: 5,
+          maxSize: 5000,
           createPayload: f => f,
           parseResponse: f => f.data.attributes,
         },
@@ -572,7 +572,7 @@ describe('Schemaform actions:', () => {
           data: {
             attributes: {
               name: 'Test name',
-              size: 1234,
+              size: 10,
               confirmationCode: 'Test code',
             },
           },
@@ -585,7 +585,7 @@ describe('Schemaform actions:', () => {
       });
       expect(onChange.secondCall.args[0]).to.eql({
         name: 'Test name',
-        size: 1234,
+        size: 10,
         confirmationCode: 'Test code',
         isEncrypted: false,
       });
@@ -596,7 +596,7 @@ describe('Schemaform actions:', () => {
       const thunk = uploadFile(
         {
           name: 'jpg',
-          size: 0,
+          size: 1,
         },
         {
           fileTypes: ['jpg'],
@@ -628,6 +628,7 @@ describe('Schemaform actions:', () => {
       });
       expect(onChange.secondCall.args[0]).to.eql({
         name: 'jpg',
+        size: 1,
         errorMessage: 'Bad Request',
       });
     });
@@ -680,11 +681,11 @@ describe('Schemaform actions:', () => {
       const thunk = uploadFile(
         {
           name: 'jpg',
-          size: 0,
+          size: 42,
         },
         {
           fileTypes: ['jpg'],
-          maxSize: 5,
+          maxSize: 50,
           createPayload: f => f,
           parseResponse: f => f.data.attributes,
         },
@@ -709,6 +710,7 @@ describe('Schemaform actions:', () => {
       });
       expect(onChange.secondCall.args[0]).to.eql({
         name: 'jpg',
+        size: 42,
         errorMessage: 'Internal Server Error',
       });
     });

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -11,10 +11,10 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 
-import { FileField } from '../../../src/js/fields/FileField';
-import fileUploadUI, { fileSchema } from '../../../src/js/definitions/file';
 import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from 'platform/forms-system/src/js/constants';
 import { fileTypeSignatures } from 'platform/forms-system/src/js/utilities/file';
+import { FileField } from '../../../src/js/fields/FileField';
+import fileUploadUI, { fileSchema } from '../../../src/js/definitions/file';
 
 const formContext = {
   setTouched: sinon.spy(),
@@ -446,6 +446,7 @@ describe('Schemaform <FileField>', () => {
       {
         confirmationCode: 'asdfds',
         name: 'Test file name',
+        size: 12345678,
       },
     ];
     const registry = {
@@ -468,6 +469,10 @@ describe('Schemaform <FileField>', () => {
 
     expect(tree.find('label').exists()).to.be.true;
     expect(tree.find('button.usa-button-secondary').exists()).to.be.true;
+
+    const text = tree.text();
+    expect(text).to.include('Test file name');
+    expect(text).to.include('12MB');
     tree.unmount();
   });
 
@@ -665,6 +670,7 @@ describe('Schemaform <FileField>', () => {
       {
         confirmationCode: 'asdfds',
         name: 'Test file name.pdf',
+        size: 54321,
       },
     ];
     const registry = {
@@ -685,7 +691,9 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect(tree.find('li').text()).to.contain('Test file name.pdf');
+    const text = tree.find('li').text();
+    expect(text).to.contain('Test file name.pdf');
+    expect(text).to.contain('53KB');
     expect(tree.find('SchemaField').prop('schema')).to.equal(
       schema.items[0].properties.attachmentId,
     );
@@ -731,6 +739,7 @@ describe('Schemaform <FileField>', () => {
       {
         confirmationCode: 'asdfds',
         name: 'Test file name',
+        size: 987654,
       },
     ];
     const registry = {
@@ -751,14 +760,16 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect(tree.find('li').text()).to.contain('Test file name');
+    const text = tree.find('li').text();
+    expect(text).to.contain('Test file name');
+    expect(text).to.contain('965KB');
     expect(tree.find('button').prop('aria-describedby')).to.eq(
       'field_file_name_0',
     );
 
     // check ids & index passed into SchemaField
     const schemaProps = tree.find('SchemaField').props();
-    const widgetProps = schemaProps.uiSchema['ui:options'].widgetProps;
+    const { widgetProps } = schemaProps.uiSchema['ui:options'];
     expect(schemaProps.schema).to.equal(schema.items[0].properties.name);
     expect(schemaProps.registry.formContext.pagePerItemIndex).to.eq(0);
     expect(widgetProps['aria-describedby']).to.eq('field_file_name_0');
@@ -832,7 +843,7 @@ describe('Schemaform <FileField>', () => {
 
     // check ids & index passed into SchemaField
     const schemaProps = tree.find('SchemaField').props();
-    const widgetProps = schemaProps.uiSchema['ui:options'].widgetProps;
+    const { widgetProps } = schemaProps.uiSchema['ui:options'];
     expect(schemaProps.schema).to.equal(
       schema.items[0].properties.attachmentId,
     );


### PR DESCRIPTION
## Description

The Claims Status Tools includes a file size under the uploaded file name

<details><summary>Claim Status Tool upload card</summary>

<!-- leave a blank line above -->
![CST upload with file name & size](https://user-images.githubusercontent.com/136959/153884765-908bd6fd-2048-4fb1-a8ef-a6ccd46f8607.png)</details>

But the platform file upload card only includes the file name

<details><summary>Form 526 upload card (uses platform code)</summary>

<!-- leave a blank line above -->
<img width="538" alt="526 upload card showing file name only" src="https://user-images.githubusercontent.com/136959/153885609-05378e80-e695-4232-95ea-983dee5c4d6d.png"></details>

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36861

## Testing done


## Screenshots

<details><summary>Form 526 upload card (after)</summary>

<!-- leave a blank line above -->
![526 upload card showing file name & size](https://user-images.githubusercontent.com/136959/153884919-e6271a3b-4bbc-42c9-aab1-29b6b3b832a5.png)</details>

## Acceptance criteria
- [x] Include file size in upload card to help differentiate similar or same-named files
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
