### PR TITLE
36514 update profile for react router v5

### DIFF
--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import AlertBox, {
@@ -20,24 +19,52 @@ import { AppDeletedAlert } from './AppDeletedAlert';
 import { ConnectedApp } from './ConnectedApp';
 
 export class ConnectedApps extends Component {
+  constructor(...args) {
+    super(...args);
+    this.connectedAppsEvent = this.connectedAppsEvent.bind(this);
+    this.faqEvent = this.faqEvent.bind(this);
+  }
+
   componentDidMount() {
+    const { loadConnectedApps: dispatchLoadConnectedApps } = this.props;
     focusElement('[data-focus-target]');
     document.title = `Connected Apps | Veterans Affairs`;
-    this.props.loadConnectedApps();
+    dispatchLoadConnectedApps();
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.loading && !this.props.loading) {
+    const { loading } = this.props;
+    if (prevProps.loading && !loading) {
       focusElement('[data-focus-target]');
     }
   }
 
   confirmDelete = appId => {
-    this.props.deleteConnectedApp(appId);
+    const { deleteConnectedApp: dispatchDeleteConnectedApp } = this.props;
+    dispatchDeleteConnectedApp(appId);
+  };
+
+  connectedAppsEvent = () => {
+    recordEvent({
+      event: 'go-to-app-directory',
+      'profile-action': 'view-link',
+      'profile-section': 'connected-apps',
+    });
   };
 
   dismissAlert = appId => {
-    this.props.dismissDeletedAppAlert(appId);
+    const {
+      dismissDeletedAppAlert: dispatchDismissDeletedAppAlert,
+    } = this.props;
+    dispatchDismissDeletedAppAlert(appId);
+  };
+
+  faqEvent = () => {
+    recordEvent({
+      event: 'profile-navigation',
+      'profile-action': 'view-link',
+      'profile-section': 'vets-faqs',
+    });
   };
 
   render() {
@@ -109,19 +136,13 @@ export class ConnectedApps extends Component {
         ))}
 
         {showHasNoConnectedApps && (
-          <Link
+          <a
             className="vads-u-margin-bottom--3"
             href="/resources/find-apps-you-can-use"
-            onClick={() =>
-              recordEvent({
-                event: 'go-to-app-directory',
-                'profile-action': 'view-link',
-                'profile-section': 'connected-apps',
-              })
-            }
+            onClick={this.connectedAppsEvent}
           >
             Go to app directory
-          </Link>
+          </a>
         )}
 
         {loading && (
@@ -168,13 +189,7 @@ export class ConnectedApps extends Component {
               to your profile,{' '}
               <a
                 href="/resources/find-apps-you-can-use"
-                onClick={() =>
-                  recordEvent({
-                    event: 'go-to-app-directory',
-                    'profile-action': 'view-link',
-                    'profile-section': 'connected-apps',
-                  })
-                }
+                onClick={this.connectedAppsEvent}
               >
                 go to the app directory
               </a>
@@ -189,13 +204,7 @@ export class ConnectedApps extends Component {
           <p>
             <a
               className="vads-u-color--primary-alt-darkest"
-              onClick={() =>
-                recordEvent({
-                  event: 'profile-navigation',
-                  'profile-action': 'view-link',
-                  'profile-section': 'vets-faqs',
-                })
-              }
+              onClick={this.faqEvent}
               href="/resources/connected-apps-faqs/"
             >
               Go to FAQs about connecting third-party apps to your VA.gov
@@ -238,11 +247,11 @@ ConnectedApps.propTypes = {
       }),
     }),
   ).isRequired,
-  loadConnectedApps: PropTypes.func.isRequired,
   deleteConnectedApp: PropTypes.func.isRequired,
   dismissDeletedAppAlert: PropTypes.func.isRequired,
-  loading: PropTypes.bool,
+  loadConnectedApps: PropTypes.func.isRequired,
   errors: PropTypes.array,
+  loading: PropTypes.bool,
 };
 
 export default connect(

--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import AlertBox, {
@@ -163,9 +163,7 @@ export class ConnectedApps extends Component {
 
         {!isEmpty(activeApps) && (
           <div className="vads-u-margin-y--3 available-connected-apps">
-            <AdditionalInfo
-              triggerText={`What other third-party apps can I connect to my profile?`}
-            >
+            <AdditionalInfo triggerText="What other third-party apps can I connect to my profile?">
               To find out what other third-party apps are available to connect
               to your profile,{' '}
               <a

--- a/src/applications/personalization/profile/profile-entry.jsx
+++ b/src/applications/personalization/profile/profile-entry.jsx
@@ -3,7 +3,7 @@ import 'platform/polyfills';
 import React from 'react';
 import Profile from '@@profile/components/Profile';
 import connectedApps from '@@profile/components/connected-apps/reducers/connectedApps';
-import startApp from 'platform/startup';
+import startApp from 'platform/startup/router';
 import manifest from './manifest.json';
 import reducer from './reducers';
 


### PR DESCRIPTION
## Description
Updates the Profile page to use the new `startApp` for react router v5 support. There was also an instance of `Link` that could have been changed to just an anchor tag. Aside from these changes some linting warnings were cleaned up as well.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36514

## Testing done
Unit tests and E2E tests still passing

## Acceptance criteria
- [x] application functions as expected and routes are able to be accessed.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
