### PR TITLE
33804: [Debt Letters]: enable cypress tests

### DIFF
--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -1,12 +1,14 @@
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
+import mockDebtsVBMS from './fixtures/mocks/debtsVBMS.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 
-describe.skip('Debt Letters', () => {
+describe('Debt Letters', () => {
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.intercept('GET', '/v0/debts', mockDebts);
+    cy.intercept('GET', '/v0/debt_letters', mockDebtsVBMS);
     cy.visit('/manage-va-debt/your-debt/');
     cy.injectAxe();
   });

--- a/src/applications/debt-letters/tests/e2e/diary-codes-next-step.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/diary-codes-next-step.cypress.spec.js
@@ -1,12 +1,14 @@
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
+import mockDebtsVBMS from './fixtures/mocks/debtsVBMS.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 
-describe.skip('Diary Codes - Next Steps', () => {
+describe('Diary Codes - Next Steps', () => {
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.intercept('GET', '/v0/debts', mockDebts);
+    cy.intercept('GET', '/v0/debt_letters', mockDebtsVBMS);
     cy.visit('/manage-va-debt/your-debt/');
     cy.injectAxe();
   });

--- a/src/applications/debt-letters/tests/e2e/fixtures/mocks/mock-user.json
+++ b/src/applications/debt-letters/tests/e2e/fixtures/mocks/mock-user.json
@@ -9,32 +9,24 @@
         "edu-benefits",
         "form-save-in-progress",
         "form-prefill",
-        "rx",
-        "health-records",
-        "mhv-accounts",
         "evss-claims",
-        "add-person",
+        "form526",
         "user-profile",
         "appeals-status",
-        "id-card",
-        "identity-proofed",
-        "vet360",
-        "dashboard",
-        "claim_increase",
-        "all_claims"
+        "identity-proofed"
       ],
       "account": {
-        "accountUuid": "7fca941b-2f5f-47d5-bacb-f0f8d994a7e0"
+        "accountUuid": "6af59b36-f14d-482e-88b4-3d7820422343"
       },
       "profile": {
-        "email": "vets.gov.user+1@gmail.com",
-        "firstName": "GREG",
-        "middleName": "A",
-        "lastName": "ANDERSON",
-        "birthDate": "1933-04-05",
+        "email": "vets.gov.user+228@gmail.com",
+        "firstName": "MARK",
+        "middleName": null,
+        "lastName": "WEBB",
+        "birthDate": "1950-10-04",
         "gender": "M",
-        "zip": "80129-6676",
-        "lastSignedIn": "2021-07-26T18:34:14.097Z",
+        "zip": null,
+        "lastSignedIn": "2020-06-18T21:15:19.664Z",
         "loa": {
           "current": 3,
           "highest": 3
@@ -45,495 +37,43 @@
           "serviceName": "idme",
           "accountType": "N/A"
         },
-        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3"
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3/vets"
       },
       "vaProfile": {
         "status": "OK",
-        "birthDate": "19330405",
-        "familyName": "Anderson",
+        "birthDate": "19501004",
+        "familyName": "Webb-ster",
         "gender": "M",
-        "givenNames": [
-          "Greg",
-          "A"
-        ],
+        "givenNames": ["Mark"],
         "isCernerPatient": false,
         "facilities": [
           {
-            "facilityId": "987",
+            "facilityId": "556",
+            "isCerner": false
+          },
+          {
+            "facilityId": "668",
             "isCerner": false
           }
         ],
         "vaPatient": true,
-        "mhvAccountState": "OK"
+        "mhvAccountState": "NONE"
       },
-      "veteranStatus": {
-        "status": "OK",
-        "isVeteran": true,
-        "servedInMilitary": true
-      },
-      "inProgressForms": [
-        {
-          "form": "HC-QSTNR",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/reason-for-visit",
-            "savedAt": 1608147143961,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1613331144,
-            "lastUpdated": 1608147144,
-            "inProgressFormId": 5029
-          },
-          "lastUpdated": 1608147144
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b6",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/demographics",
-            "savedAt": 1610473036990,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615657037,
-            "lastUpdated": 1610473037,
-            "inProgressFormId": 5383
-          },
-          "lastUpdated": 1610473037
-        },
-        {
-          "form": "686C-674",
-          "metadata": {
-            "expiresAt": 1626185969,
-            "lastUpdated": 1621001969,
-            "inProgressFormId": 10424
-          },
-          "lastUpdated": 1621001969
-        },
-        {
-          "form": "HC-QSTNR-195bc02c0518870fc6b1e302cfc326b6",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/demographics",
-            "savedAt": 1609254721106,
-            "expiresAt": 1614438721,
-            "lastUpdated": 1609254721,
-            "inProgressFormId": 5317
-          },
-          "lastUpdated": 1609254721
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b59",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/prepare-for-your-appointment",
-            "savedAt": 1612967644433,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1618065244,
-            "lastUpdated": 1612967644,
-            "inProgressFormId": 9292
-          },
-          "lastUpdated": 1612967644
-        },
-        {
-          "form": "HC-QSTNR_I2-3PYJBEU2DIBW5RZT2XI3PASYGM7YYRD5TFQCLHQXK6YBXREQK5VQ0007_7d93011b-29de-492a-b802-f6dc863c5c6b",
-          "metadata": {
-            "savedAt": 1618616729547,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": 1618616729541,
-              "hasAttemptedSubmit": true
-            },
-            "expiresAt": 1619739929,
-            "lastUpdated": 1618616729,
-            "inProgressFormId": 10208
-          },
-          "lastUpdated": 1618616729
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b4",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/reason-for-visit",
-            "savedAt": 1610480767408,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615664767,
-            "lastUpdated": 1610480767,
-            "inProgressFormId": 5387
-          },
-          "lastUpdated": 1610480767
-        },
-        {
-          "form": "HC-QSTNR_I2-3PYJBEU2DIBW5RZT2XI3PASYGM7YYRD5TFQCLHQXK6YBXREQK5VQ0006_7d93011b-29de-492a-b802-f6dc863c5c6b",
-          "metadata": {
-            "savedAt": 1618616916295,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": 1618616916287,
-              "hasAttemptedSubmit": true
-            },
-            "expiresAt": 1619394516,
-            "lastUpdated": 1618616916,
-            "inProgressFormId": 10209
-          },
-          "lastUpdated": 1618616916
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b2",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/demographics",
-            "savedAt": 1610480807244,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615664807,
-            "lastUpdated": 1610480807,
-            "inProgressFormId": 5388
-          },
-          "lastUpdated": 1610480807
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b45",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/prepare-for-your-appointment",
-            "savedAt": 1610656626171,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1612471026,
-            "lastUpdated": 1610656626,
-            "inProgressFormId": 5421
-          },
-          "lastUpdated": 1610656626
-        },
-        {
-          "form": "HC-QSTNR-195bc02c0518870fc6b1e302cfc326b4",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/reason-for-visit",
-            "savedAt": 1610030115014,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615214115,
-            "lastUpdated": 1610030115,
-            "inProgressFormId": 5368
-          },
-          "lastUpdated": 1610030115
-        },
-        {
-          "form": "HC-QSTNR_195bc72cfc326b4",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/veteran-information",
-            "savedAt": 1610481870592,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615665870,
-            "lastUpdated": 1610481870,
-            "inProgressFormId": 5390
-          },
-          "lastUpdated": 1610481870
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b61",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/prepare-for-your-appointment",
-            "savedAt": 1613589905529,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1614972313,
-            "lastUpdated": 1613589913,
-            "inProgressFormId": 9296
-          },
-          "lastUpdated": 1613589913
-        },
-        {
-          "form": "28-1900",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/veteran-information-review",
-            "savedAt": 1621871280779,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": 1621871280770,
-              "hasAttemptedSubmit": true
-            },
-            "expiresAt": 1627055280,
-            "lastUpdated": 1621871280,
-            "inProgressFormId": 10527
-          },
-          "lastUpdated": 1621871280
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b65",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/prepare-for-your-appointment",
-            "savedAt": 1611671981487,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1611758381,
-            "lastUpdated": 1611671981,
-            "inProgressFormId": 5392
-          },
-          "lastUpdated": 1611671981
-        },
-        {
-          "form": "HC-QSTNR_195bc02csdfsdfsdf",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/prepare-for-your-appointment",
-            "savedAt": 1610550618415,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615734618,
-            "lastUpdated": 1610550618,
-            "inProgressFormId": 5393
-          },
-          "lastUpdated": 1610550618
-        },
-        {
-          "form": "21-22",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/claimant-information",
-            "savedAt": 1610394824128,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1615578824,
-            "lastUpdated": 1610394824,
-            "inProgressFormId": 5378
-          },
-          "lastUpdated": 1610394824
-        },
-        {
-          "form": "HC-QSTNR_195bc02c0518870fc6b1e302cfc326b60",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/prepare-for-your-appointment",
-            "savedAt": 1612967679824,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1617287680,
-            "lastUpdated": 1612967680,
-            "inProgressFormId": 9394
-          },
-          "lastUpdated": 1612967680
-        },
-        {
-          "form": "22-1990S",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/apply",
-            "savedAt": 1623433065015,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1628617065,
-            "lastUpdated": 1623433065,
-            "inProgressFormId": 10620
-          },
-          "lastUpdated": 1623433065
-        },
-        {
-          "form": "10182",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/evidence-submission/upload",
-            "savedAt": 1624881818528,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1630065818,
-            "lastUpdated": 1624881818,
-            "inProgressFormId": 10654
-          },
-          "lastUpdated": 1624881818
-        },
-        {
-          "form": "22-10203",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/benefits/program-details",
-            "savedAt": 1625058972644,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1630242972,
-            "lastUpdated": 1625058972,
-            "inProgressFormId": 10660
-          },
-          "lastUpdated": 1625058972
-        },
-        {
-          "form": "22-1990",
-          "metadata": {
-            "version": 1,
-            "returnUrl": "/military-history/rotc-history",
-            "savedAt": 1626291495462,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1631475495,
-            "lastUpdated": 1626291495,
-            "inProgressFormId": 10700
-          },
-          "lastUpdated": 1626291495
-        },
-        {
-          "form": "5655",
-          "metadata": {
-            "version": 0,
-            "returnUrl": "/real-estate-asset-records",
-            "savedAt": 1626814446174,
-            "submission": {
-              "status": false,
-              "errorMessage": false,
-              "id": false,
-              "timestamp": false,
-              "hasAttemptedSubmit": false
-            },
-            "expiresAt": 1631998446,
-            "lastUpdated": 1626814446,
-            "inProgressFormId": 10732
-          },
-          "lastUpdated": 1626814446
-        }
-      ],
-      "prefillsAvailable": [
-        "21-686C",
-        "40-10007",
-        "0873",
-        "22-1990",
-        "22-1990N",
-        "22-1990E",
-        "22-1995",
-        "22-5490",
-        "22-5495",
-        "22-0993",
-        "22-0994",
-        "FEEDBACK-TOOL",
-        "22-10203",
-        "22-1990S",
-        "21-526EZ",
-        "1010ez",
-        "21P-530",
-        "21P-527EZ",
-        "686C-674",
-        "20-0996",
-        "10182",
-        "MDOT",
-        "5655",
-        "28-8832",
-        "28-1900"
-      ],
-      "vet360ContactInformation": {
-        "email": null,
-        "residentialAddress": null,
-        "mailingAddress": null,
-        "mobilePhone": null,
-        "homePhone": null,
-        "workPhone": null,
-        "temporaryPhone": null,
-        "faxNumber": null,
-        "textPermission": null
-      },
-      "session": {
-        "ssoe": true,
-        "transactionid": "G5RGEHXsNRo3Fwccav2RENSgPs9cffXNr2wvsmPa8AQ="
-      }
+      "veteranStatus": null,
+      "inProgressForms": [],
+      "prefillsAvailable": ["5655"],
+      "vet360ContactInformation": {}
     }
   },
   "meta": {
-    "errors": null
+    "errors": [
+      {
+        "externalService": "EMIS",
+        "startTime": "2020-06-18T21:15:34Z",
+        "endTime": null,
+        "description": "IOError, Betamocks default response requested but none exist. Please create one at: [/cache/emis/veteran_status/default.yml]., Betamocks default response requested but none exist. Please create one at: [/cache/emis/veteran_status/default.yml].",
+        "status": 503
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description
Re-enable cypress tests for Debt Letters that were previously skipped due flaky tests
- Tests should be using `vets.gov.user+228@gmail.com`
- Tests were missing a mock API call to VBMS

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33804

platform ticket
department-of-veterans-affairs/va.gov-team/issues/36910

## Acceptance criteria
- [x] all cypress tests should be passing

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
