### PR TITLE
Feature/education inbox letters UI

### DIFF
--- a/src/applications/education-inbox/actions/index.js
+++ b/src/applications/education-inbox/actions/index.js
@@ -1,0 +1,5 @@
+import environment from 'platform/utilities/environment';
+
+export const CLAIMANT_STATUS_ENDPOINT = `${
+  environment.API_URL
+}/meb_api/v0/claimant_status`;

--- a/src/applications/education-inbox/actions/index.js
+++ b/src/applications/education-inbox/actions/index.js
@@ -1,5 +1,5 @@
 import environment from 'platform/utilities/environment';
 
-export const CLAIMANT_STATUS_ENDPOINT = `${
+export const FETCH_CLAIM_STATUS = `${
   environment.API_URL
-}/meb_api/v0/claimant_status`;
+}/meb_api/v0/claim_status`;

--- a/src/applications/education-inbox/app-entry.jsx
+++ b/src/applications/education-inbox/app-entry.jsx
@@ -1,8 +1,7 @@
 import 'platform/polyfills';
 import './sass/education-inbox.scss';
 
-import startApp from 'platform/startup';
-
+import startApp from 'platform/startup/router';
 import routes from './routes';
 import reducer from './reducers';
 import manifest from './manifest.json';

--- a/src/applications/education-inbox/components/Layout.jsx
+++ b/src/applications/education-inbox/components/Layout.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+
+const Layout = ({ children }) => {
+  return (
+    <>
+      <Breadcrumbs>
+        <a href="/">Home</a>
+        <a href="/education/">Eduction and training</a>
+        <a href="/education/education-inbox">Check your VA education inbox</a>
+      </Breadcrumbs>
+      <main id="main" className="main">
+        <div className="usa-grid usa-grid-full">
+          <div className="usa-width-three-fourths">
+            <article className="usa-content vads-u-padding-bottom--0">
+              {children}
+            </article>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default Layout;

--- a/src/applications/education-inbox/components/Layout.jsx
+++ b/src/applications/education-inbox/components/Layout.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 const Layout = ({ children, clsName = '' }) => {
   const classNa = `main ${clsName}`;
   return (
     <>
-      <Breadcrumbs>
+      <va-breadcrumbs>
         <a href="/">Home</a>
         <a href="/education/">Eduction and training</a>
         <a href="/education/education-inbox">Check your VA education inbox</a>
-      </Breadcrumbs>
+      </va-breadcrumbs>
       <main id="main" className={classNa}>
         <div className="usa-grid usa-grid-full">
           <div className="usa-width-three-fourths">

--- a/src/applications/education-inbox/components/Layout.jsx
+++ b/src/applications/education-inbox/components/Layout.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
-const Layout = ({ children }) => {
+const Layout = ({ children, clsName = '' }) => {
+  const classNa = `main ${clsName}`;
   return (
     <>
       <Breadcrumbs>
@@ -9,7 +10,7 @@ const Layout = ({ children }) => {
         <a href="/education/">Eduction and training</a>
         <a href="/education/education-inbox">Check your VA education inbox</a>
       </Breadcrumbs>
-      <main id="main" className="main">
+      <main id="main" className={classNa}>
         <div className="usa-grid usa-grid-full">
           <div className="usa-width-three-fourths">
             <article className="usa-content vads-u-padding-bottom--0">

--- a/src/applications/education-inbox/containers/App.jsx
+++ b/src/applications/education-inbox/containers/App.jsx
@@ -13,7 +13,7 @@ const App = ({ toggleLoginModal, user }) => {
     toggleLoginModal(true, 'cta-form');
   }
 
-  const NotLoggedIn = (
+  const notLoggedInUI = (
     <va-alert
       close-btn-aria-label="Close notification"
       status="continue"
@@ -30,6 +30,32 @@ const App = ({ toggleLoginModal, user }) => {
     </va-alert>
   );
 
+  function renderUI() {
+    if (!user?.login?.currentlyLoggedIn && !user?.login?.hasCheckedKeepAlive) {
+      return (
+        <div className="vads-u-margin-y--5">
+          <va-loading-indicator
+            label="Loading"
+            message="Please wait while we load the application for you."
+            set-focus
+          />
+        </div>
+      );
+    }
+    if (user?.login?.currentlyLoggedIn) {
+      return (
+        <Link
+          className="usa-button-primary va-button-primary"
+          type="button"
+          to="/preview"
+        >
+          Check your VA education inbox
+        </Link>
+      );
+    }
+    return notLoggedInUI;
+  }
+
   return (
     <>
       <Layout clsName="introduction-page">
@@ -41,17 +67,7 @@ const App = ({ toggleLoginModal, user }) => {
           how to sign in.
         </p>
 
-        {user?.login?.currentlyLoggedIn ? (
-          <Link
-            className="usa-button-primary va-button-primary"
-            type="button"
-            to="/preview"
-          >
-            Check your VA education inbox
-          </Link>
-        ) : (
-          NotLoggedIn
-        )}
+        {renderUI()}
 
         <div>
           <h2>Can I use this tool?</h2>

--- a/src/applications/education-inbox/containers/App.jsx
+++ b/src/applications/education-inbox/containers/App.jsx
@@ -42,7 +42,11 @@ const App = ({ toggleLoginModal, user }) => {
         </p>
 
         {user?.login?.currentlyLoggedIn ? (
-          <Link className="va-button-primary" type="button" to="/preview">
+          <Link
+            className="usa-button-primary va-button-primary"
+            type="button"
+            to="/preview"
+          >
             Check your VA education inbox
           </Link>
         ) : (
@@ -85,7 +89,11 @@ const App = ({ toggleLoginModal, user }) => {
             <div>
               At this time, we’re only able to show decision letters that you
               received after <b>Month Day, 2022</b>. If you’re looking for an
-              older decision letter, <a href="/">contact us using Ask VA</a>.
+              older decision letter,{' '}
+              <a href="https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fask.va.gov%2F&data=04%7C01%7Cherbert.anagho%40accenturefederal.com%7C5b0be35e33a2487d4a0c08d9ecb991bc%7C0ee6c63b4eab4748b74ad1dc22fc1a24%7C0%7C0%7C637801104030719343%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=QuGxWs9osAHjaGwInFjQO5cwEQ%2BK84u9J3XH2QcwZNk%3D&reserved=0">
+                contact us using Ask VA
+              </a>
+              .
             </div>
           </va-alert>
           <p>

--- a/src/applications/education-inbox/containers/App.jsx
+++ b/src/applications/education-inbox/containers/App.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import Layout from '../components/Layout';
 import { fetchUser } from '../../my-education-benefits/selectors/userDispatch';
 
@@ -29,15 +30,9 @@ const App = ({ toggleLoginModal, user }) => {
     </va-alert>
   );
 
-  const IsLoggedIn = (
-    <button className="va-button-primary" type="button">
-      Check your VA education inbox
-    </button>
-  );
-
   return (
     <>
-      <Layout>
+      <Layout clsName="introduction-page">
         <FormTitle title="Check your VA education inbox" />
 
         <p className="va-introtext">
@@ -46,7 +41,13 @@ const App = ({ toggleLoginModal, user }) => {
           how to sign in.
         </p>
 
-        {user?.login?.currentlyLoggedIn ? IsLoggedIn : NotLoggedIn}
+        {user?.login?.currentlyLoggedIn ? (
+          <Link className="va-button-primary" type="button" to="/preview">
+            Check your VA education inbox
+          </Link>
+        ) : (
+          NotLoggedIn
+        )}
 
         <div>
           <h2>Can I use this tool?</h2>

--- a/src/applications/education-inbox/containers/App.jsx
+++ b/src/applications/education-inbox/containers/App.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
-
 import PropTypes from 'prop-types';
+import Layout from '../components/Layout';
 import { fetchUser } from '../../my-education-benefits/selectors/userDispatch';
 
 const App = ({ toggleLoginModal, user }) => {
@@ -38,80 +37,67 @@ const App = ({ toggleLoginModal, user }) => {
 
   return (
     <>
-      <Breadcrumbs>
-        <a href="/">Home</a>
-        <a href="/education/">Eduction and training</a>
-        <a href="/education/education-inbox">Check your VA education inbox</a>
-      </Breadcrumbs>
-      <main id="main" className="main">
-        <div className="usa-grid usa-grid-full">
-          <div className="usa-width-three-fourths">
-            <article className="usa-content vads-u-padding-bottom--0">
-              <FormTitle title="Check your VA education inbox" />
+      <Layout>
+        <FormTitle title="Check your VA education inbox" />
 
-              <p className="va-introtext">
-                Download important documents about your education benefits here,
-                including your decision letter. Find out if you can use this
-                tool and how to sign in.
-              </p>
+        <p className="va-introtext">
+          Download important documents about your education benefits here,
+          including your decision letter. Find out if you can use this tool and
+          how to sign in.
+        </p>
 
-              {user?.login?.currentlyLoggedIn ? IsLoggedIn : NotLoggedIn}
+        {user?.login?.currentlyLoggedIn ? IsLoggedIn : NotLoggedIn}
 
-              <div>
-                <h2>Can I use this tool?</h2>
-                <p>
-                  You can use this tool if you meet all of the requirements
-                  listed below.
-                </p>
-                <p>
-                  <b>Both of these must be true. You:</b>
-                </p>
-                <ul>
-                  <li>
-                    Applied for Post-9/11 GI Bill benefits, <b>and</b>
-                  </li>
-                  <li>
-                    Received a decision from us on your application after Month
-                    Day, Year
-                  </li>
-                </ul>
-                <p>
-                  <b>Note:</b> At this time, the VA education inbox isn’t
-                  available online to family members and dependents.
-                </p>
-              </div>
-
-              <div style={{ marginBottom: '6.4rem' }}>
-                <h2>What information will I be able to see?</h2>
-                <va-alert
-                  background-only
-                  close-btn-aria-label="Close notification"
-                  show-icon
-                  status="info"
-                  visible
-                >
-                  <div>
-                    At this time, we’re only able to show decision letters that
-                    you received after <b>Month Day, 2022</b>. If you’re looking
-                    for an older decision letter,{' '}
-                    <a href="/">contact us using Ask VA</a>.
-                  </div>
-                </va-alert>
-                <p>
-                  <b>In your VA education inbox, you’ll find:</b>
-                </p>
-                <ul>
-                  <li>
-                    Important VA documents, including your Certificate of
-                    Eligibility or Denial Letter if you’ve applied for the
-                    Post-9/11 GI Bill
-                  </li>
-                </ul>
-              </div>
-            </article>
-          </div>
+        <div>
+          <h2>Can I use this tool?</h2>
+          <p>
+            You can use this tool if you meet all of the requirements listed
+            below.
+          </p>
+          <p>
+            <b>Both of these must be true. You:</b>
+          </p>
+          <ul>
+            <li>
+              Applied for Post-9/11 GI Bill benefits, <b>and</b>
+            </li>
+            <li>
+              Received a decision from us on your application after Month Day,
+              Year
+            </li>
+          </ul>
+          <p>
+            <b>Note:</b> At this time, the VA education inbox isn’t available
+            online to family members and dependents.
+          </p>
         </div>
-      </main>
+
+        <div style={{ marginBottom: '6.4rem' }}>
+          <h2>What information will I be able to see?</h2>
+          <va-alert
+            background-only
+            close-btn-aria-label="Close notification"
+            show-icon
+            status="info"
+            visible
+          >
+            <div>
+              At this time, we’re only able to show decision letters that you
+              received after <b>Month Day, 2022</b>. If you’re looking for an
+              older decision letter, <a href="/">contact us using Ask VA</a>.
+            </div>
+          </va-alert>
+          <p>
+            <b>In your VA education inbox, you’ll find:</b>
+          </p>
+          <ul>
+            <li>
+              Important VA documents, including your Certificate of Eligibility
+              or Denial Letter if you’ve applied for the Post-9/11 GI Bill
+            </li>
+          </ul>
+        </div>
+      </Layout>
     </>
   );
 };

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -1,10 +1,64 @@
 import React from 'react';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import Layout from '../components/Layout';
 
 const InboxPage = () => {
   return (
-    <Layout>
-      <h1>Inbox Page</h1>
+    <Layout clsName="inbox-page">
+      <FormTitle title="VA education inbox" />
+      <p className="va-introtext">
+        Download important documents about your education benefits here,
+        including your decision letter.
+      </p>
+      <article>
+        <va-on-this-page />
+        <h2 id="your-edu-benf-letter">Your education benefit letters</h2>
+        <div className="edu-certi-eligibility">
+          <span className="usa-label">New</span>
+          <h3 style={{ marginTop: '1rem' }}>
+            Education Certificate of Eligibility
+          </h3>
+          <p>
+            This letter is proof of your eligibility for VA education benefits.
+            It includes details of our decision, including benefit program,
+            amount, and level.
+          </p>
+          <div className="vads-u-display--flex vads-u-align-items--center">
+            <a className="vads-u-flex--1" href="/">
+              <i className="fa fa-download vads-u-display--inline-block vads-u-margin-right--1" />
+              Post-9/11 GI Bill Certificate of Eligibility (PDF)
+            </a>
+            <p className="vads-u-flex--auto">
+              You applied for this on July 7, 2022
+            </p>
+          </div>
+        </div>
+        <h2 id="how-do-i-download-letter">How do I download a letter?</h2>
+        <p>
+          To download a letter, you’ll need to have Adobe Acrobat Reader
+          installed on your computer. You can then download or save the letter
+          to your device. Open Acrobat Reader, and from the file menu, choose
+          Open. Select the PDF.
+        </p>{' '}
+        <p>
+          If you‘re still having trouble opening the letter, you may have an
+          older version of Adobe Acrobat Reader. You’ll need to{' '}
+          <a href="/">download the latest version</a>. It’s free.
+        </p>
+        <h2 id="letter-isnt-listed">What if I my letter isn’t listed here?</h2>
+        <p>
+          At this time, we’re only able to show Post-9/11 GI Bill decision
+          letters that you received after <b>Month Day, 2022</b>.
+        </p>{' '}
+        <p>
+          If you have questions about your education benefits, call our
+          Education Call Center at{' '}
+          <a href="tel:+18884424551;ext=711">1-888-442-4551 (711)</a>. We’re
+          here Monday through Friday, 8:00 a.m. to 7:00 p.m. ET. If you’re
+          outside the U.S., call us at{' '}
+          <a href="tel:001-918-781-5678">001-918-781-5678</a>.
+        </p>
+      </article>
     </Layout>
   );
 };

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { apiRequest } from 'platform/utilities/api';
-import moment from 'moment';
+import { format } from 'date-fns';
 import { FETCH_CLAIM_STATUS } from '../actions';
 import Layout from '../components/Layout';
 
@@ -17,8 +17,9 @@ const InboxPage = () => {
           .then(response => {
             setClaimantId(response?.data?.attributes?.claimantId);
             setReceivedDate(
-              moment(response?.data?.attributes?.receivedDate).format(
-                'MMMM D, YYYY',
+              format(
+                new Date(response?.data?.attributes?.receivedDate),
+                'MMMM d, yyyy',
               ),
             );
             setLoading(false);

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -22,6 +22,61 @@ const InboxPage = ({ letters }) => {
     [letters.message],
   );
 
+  const HasLetters = (
+    <>
+      <va-on-this-page />
+      <h2 id="your-edu-benf-letter">Your education benefit letters</h2>
+      <div className="edu-certi-eligibility">
+        <span className="usa-label">New</span>
+        <h3 style={{ marginTop: '1rem' }}>
+          Education Certificate of Eligibility
+        </h3>
+        <p>
+          This letter is proof of your eligibility for VA education benefits. It
+          includes details of our decision, including benefit program, amount,
+          and level.
+        </p>
+        <div className="vads-u-display--flex vads-u-align-items--center">
+          <a
+            className="vads-u-flex--1"
+            download
+            href={`${environment.API_URL}/meb_api/v0/claim_status`}
+          >
+            <i className="fa fa-download vads-u-display--inline-block vads-u-margin-right--1" />
+            Post-9/11 GI Bill Certificate of Eligibility (PDF)
+          </a>
+          <p className="vads-u-flex--auto">
+            You applied for this on July 7, 2022
+          </p>
+        </div>
+      </div>
+      <h2 id="how-do-i-download-letter">How do I download a letter?</h2>
+      <p>
+        To download a letter, you’ll need to have Adobe Acrobat Reader installed
+        on your computer. You can then download or save the letter to your
+        device. Open Acrobat Reader, and from the file menu, choose Open. Select
+        the PDF.
+      </p>{' '}
+      <p>
+        If you‘re still having trouble opening the letter, you may have an older
+        version of Adobe Acrobat Reader. You’ll need to{' '}
+        <a href="/">download the latest version</a>. It’s free.
+      </p>
+      <h2 id="letter-isnt-listed">What if I my letter isn’t listed here?</h2>
+      <p>
+        At this time, we’re only able to show Post-9/11 GI Bill decision letters
+        that you received after <b>Month Day, 2022</b>.
+      </p>{' '}
+      <p>
+        If you have questions about your education benefits, call our Education
+        Call Center at{' '}
+        <a href="tel:+18884424551;ext=711">1-888-442-4551 (711)</a>. We’re here
+        Monday through Friday, 8:00 a.m. to 7:00 p.m. ET. If you’re outside the
+        U.S., call us at <a href="tel:001-918-781-5678">001-918-781-5678</a>.
+      </p>
+    </>
+  );
+
   return (
     <Layout clsName="inbox-page">
       <FormTitle title="VA education inbox" />
@@ -30,57 +85,26 @@ const InboxPage = ({ letters }) => {
         including your decision letter.
       </p>
       <article>
-        <va-on-this-page />
-        <h2 id="your-edu-benf-letter">Your education benefit letters</h2>
-        <div className="edu-certi-eligibility">
-          <span className="usa-label">New</span>
-          <h3 style={{ marginTop: '1rem' }}>
-            Education Certificate of Eligibility
-          </h3>
-          <p>
-            This letter is proof of your eligibility for VA education benefits.
-            It includes details of our decision, including benefit program,
-            amount, and level.
-          </p>
-          <div className="vads-u-display--flex vads-u-align-items--center">
-            <a
-              className="vads-u-flex--1"
-              download
-              href={`${environment.API_URL}/meb_api/v0/claim_status`}
-            >
-              <i className="fa fa-download vads-u-display--inline-block vads-u-margin-right--1" />
-              Post-9/11 GI Bill Certificate of Eligibility (PDF)
-            </a>
-            <p className="vads-u-flex--auto">
-              You applied for this on July 7, 2022
-            </p>
-          </div>
-        </div>
-        <h2 id="how-do-i-download-letter">How do I download a letter?</h2>
-        <p>
-          To download a letter, you’ll need to have Adobe Acrobat Reader
-          installed on your computer. You can then download or save the letter
-          to your device. Open Acrobat Reader, and from the file menu, choose
-          Open. Select the PDF.
-        </p>{' '}
-        <p>
-          If you‘re still having trouble opening the letter, you may have an
-          older version of Adobe Acrobat Reader. You’ll need to{' '}
-          <a href="/">download the latest version</a>. It’s free.
-        </p>
-        <h2 id="letter-isnt-listed">What if I my letter isn’t listed here?</h2>
-        <p>
-          At this time, we’re only able to show Post-9/11 GI Bill decision
-          letters that you received after <b>Month Day, 2022</b>.
-        </p>{' '}
-        <p>
-          If you have questions about your education benefits, call our
-          Education Call Center at{' '}
-          <a href="tel:+18884424551;ext=711">1-888-442-4551 (711)</a>. We’re
-          here Monday through Friday, 8:00 a.m. to 7:00 p.m. ET. If you’re
-          outside the U.S., call us at{' '}
-          <a href="tel:001-918-781-5678">001-918-781-5678</a>.
-        </p>
+        {letters?.attributes ? (
+          HasLetters
+        ) : (
+          <va-alert full-width status="info">
+            <h3 slot="headline">
+              We don’t have any letters on file for you at this time
+            </h3>
+            <div>
+              <p>
+                At this time, we’re only able to show decision letters that you
+                received after <b>Month Day, 2022</b>.
+              </p>
+              If you’re looking for an older decision letter,
+              <a href="https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fask.va.gov%2F&data=04%7C01%7Cherbert.anagho%40accenturefederal.com%7C5b0be35e33a2487d4a0c08d9ecb991bc%7C0ee6c63b4eab4748b74ad1dc22fc1a24%7C0%7C0%7C637801104030719343%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=QuGxWs9osAHjaGwInFjQO5cwEQ%2BK84u9J3XH2QcwZNk%3D&reserved=0">
+                contact us using Ask VA
+              </a>
+              .
+            </div>
+          </va-alert>
+        )}
       </article>
     </Layout>
   );

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -2,19 +2,26 @@ import React, { useEffect, useState } from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { apiRequest } from 'platform/utilities/api';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { FETCH_CLAIM_STATUS } from '../actions';
 import Layout from '../components/Layout';
 
 const InboxPage = () => {
   const [claimantId, setClaimantId] = useState(null);
   const [isLoading, setLoading] = useState(true);
+  const [receivedDate, setReceivedDate] = useState(null);
 
   useEffect(
     () => {
       const checkIfClaimantHasLetters = async () =>
         apiRequest(FETCH_CLAIM_STATUS)
           .then(response => {
-            setClaimantId(response.data.attributes.claimantId);
+            setClaimantId(response?.data?.attributes?.claimantId);
+            setReceivedDate(
+              moment(response?.data?.attributes?.receivedDate).format(
+                'MMMM D, YYYY',
+              ),
+            );
             setLoading(false);
             return response?.data?.attributes?.claimantId;
           })
@@ -49,7 +56,7 @@ const InboxPage = () => {
             Post-9/11 GI Bill Certificate of Eligibility (PDF)
           </a>
           <p className="vads-u-flex--auto">
-            You applied for this on July 7, 2022
+            You applied for this on {receivedDate}
           </p>
         </div>
       </div>

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { apiRequest } from 'platform/utilities/api';
-import PropTypes from 'prop-types';
 import moment from 'moment';
 import { FETCH_CLAIM_STATUS } from '../actions';
 import Layout from '../components/Layout';
@@ -25,7 +24,10 @@ const InboxPage = () => {
             setLoading(false);
             return response?.data?.attributes?.claimantId;
           })
-          .catch(err => err);
+          .catch(err => {
+            window.location.href = '/education/education-inbox/';
+            return err;
+          });
 
       checkIfClaimantHasLetters().then(r => r);
     },
@@ -133,15 +135,5 @@ const InboxPage = () => {
     </Layout>
   );
 };
-
-InboxPage.propTypes = {
-  letters: PropTypes.object,
-};
-
-// const mapStateToProps = state => ({
-//   letters: {},
-// });
-
-// export default connect(mapStateToProps)(InboxPage);
 
 export default InboxPage;

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Layout from '../components/Layout';
+
+const InboxPage = () => {
+  return (
+    <Layout>
+      <h1>Inbox Page</h1>
+    </Layout>
+  );
+};
+
+export default InboxPage;

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -3,6 +3,7 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { connect } from 'react-redux';
 import { apiRequest } from 'platform/utilities/api';
 import PropTypes from 'prop-types';
+import environment from 'platform/utilities/environment';
 import { FETCH_CLAIM_STATUS } from '../actions';
 import Layout from '../components/Layout';
 
@@ -42,7 +43,11 @@ const InboxPage = ({ letters }) => {
             amount, and level.
           </p>
           <div className="vads-u-display--flex vads-u-align-items--center">
-            <a className="vads-u-flex--1" href="/">
+            <a
+              className="vads-u-flex--1"
+              download
+              href={`${environment.API_URL}/meb_api/v0/claim_status`}
+            >
               <i className="fa fa-download vads-u-display--inline-block vads-u-margin-right--1" />
               Post-9/11 GI Bill Certificate of Eligibility (PDF)
             </a>

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -3,14 +3,14 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { connect } from 'react-redux';
 import { apiRequest } from 'platform/utilities/api';
 import PropTypes from 'prop-types';
-import { CLAIMANT_STATUS_ENDPOINT } from '../actions';
+import { FETCH_CLAIM_STATUS } from '../actions';
 import Layout from '../components/Layout';
 
 const InboxPage = ({ letters }) => {
   useEffect(
     () => {
       const checkIfClaimantHasLetters = async () =>
-        apiRequest(CLAIMANT_STATUS_ENDPOINT)
+        apiRequest(FETCH_CLAIM_STATUS)
           .then(response => {
             return response;
           })

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -1,25 +1,28 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import { connect } from 'react-redux';
 import { apiRequest } from 'platform/utilities/api';
 import PropTypes from 'prop-types';
-import environment from 'platform/utilities/environment';
 import { FETCH_CLAIM_STATUS } from '../actions';
 import Layout from '../components/Layout';
 
-const InboxPage = ({ letters }) => {
+const InboxPage = () => {
+  const [claimantId, setClaimantId] = useState(null);
+  const [isLoading, setLoading] = useState(true);
+
   useEffect(
     () => {
       const checkIfClaimantHasLetters = async () =>
         apiRequest(FETCH_CLAIM_STATUS)
           .then(response => {
-            return response;
+            setClaimantId(response.data.attributes.claimantId);
+            setLoading(false);
+            return response?.data?.attributes?.claimantId;
           })
           .catch(err => err);
 
       checkIfClaimantHasLetters().then(r => r);
     },
-    [letters.message],
+    [claimantId],
   );
 
   const HasLetters = (
@@ -40,7 +43,7 @@ const InboxPage = ({ letters }) => {
           <a
             className="vads-u-flex--1"
             download
-            href={`${environment.API_URL}/meb_api/v0/claim_status`}
+            href="http://localhost:3000/meb_api/v0/claim_letter"
           >
             <i className="fa fa-download vads-u-display--inline-block vads-u-margin-right--1" />
             Post-9/11 GI Bill Certificate of Eligibility (PDF)
@@ -77,6 +80,41 @@ const InboxPage = ({ letters }) => {
     </>
   );
 
+  const renderInbox = () => {
+    if (!isLoading) {
+      if (claimantId) {
+        return HasLetters;
+      }
+      return (
+        <va-alert full-width status="info">
+          <h3 slot="headline">
+            We don’t have any letters on file for you at this time
+          </h3>
+          <div>
+            <p>
+              At this time, we’re only able to show decision letters that you
+              received after <b>Month Day, 2022</b>.
+            </p>
+            If you’re looking for an older decision letter,
+            <a href="https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fask.va.gov%2F&data=04%7C01%7Cherbert.anagho%40accenturefederal.com%7C5b0be35e33a2487d4a0c08d9ecb991bc%7C0ee6c63b4eab4748b74ad1dc22fc1a24%7C0%7C0%7C637801104030719343%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=QuGxWs9osAHjaGwInFjQO5cwEQ%2BK84u9J3XH2QcwZNk%3D&reserved=0">
+              contact us using Ask VA
+            </a>
+            .
+          </div>
+        </va-alert>
+      );
+    }
+    return (
+      <div className="vads-u-margin-y--5">
+        <va-loading-indicator
+          label="Loading"
+          message="Please wait while we load the application for you."
+          set-focus
+        />
+      </div>
+    );
+  };
+
   return (
     <Layout clsName="inbox-page">
       <FormTitle title="VA education inbox" />
@@ -84,28 +122,7 @@ const InboxPage = ({ letters }) => {
         Download important documents about your education benefits here,
         including your decision letter.
       </p>
-      <article>
-        {letters?.attributes ? (
-          HasLetters
-        ) : (
-          <va-alert full-width status="info">
-            <h3 slot="headline">
-              We don’t have any letters on file for you at this time
-            </h3>
-            <div>
-              <p>
-                At this time, we’re only able to show decision letters that you
-                received after <b>Month Day, 2022</b>.
-              </p>
-              If you’re looking for an older decision letter,
-              <a href="https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fask.va.gov%2F&data=04%7C01%7Cherbert.anagho%40accenturefederal.com%7C5b0be35e33a2487d4a0c08d9ecb991bc%7C0ee6c63b4eab4748b74ad1dc22fc1a24%7C0%7C0%7C637801104030719343%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=QuGxWs9osAHjaGwInFjQO5cwEQ%2BK84u9J3XH2QcwZNk%3D&reserved=0">
-                contact us using Ask VA
-              </a>
-              .
-            </div>
-          </va-alert>
-        )}
-      </article>
+      <article>{renderInbox()}</article>
     </Layout>
   );
 };
@@ -114,8 +131,10 @@ InboxPage.propTypes = {
   letters: PropTypes.object,
 };
 
-const mapStateToProps = () => ({
-  letters: {},
-});
+// const mapStateToProps = state => ({
+//   letters: {},
+// });
 
-export default connect(mapStateToProps)(InboxPage);
+// export default connect(mapStateToProps)(InboxPage);
+
+export default InboxPage;

--- a/src/applications/education-inbox/containers/InboxPage.jsx
+++ b/src/applications/education-inbox/containers/InboxPage.jsx
@@ -1,8 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import { connect } from 'react-redux';
+import { apiRequest } from 'platform/utilities/api';
+import PropTypes from 'prop-types';
+import { CLAIMANT_STATUS_ENDPOINT } from '../actions';
 import Layout from '../components/Layout';
 
-const InboxPage = () => {
+const InboxPage = ({ letters }) => {
+  useEffect(
+    () => {
+      const checkIfClaimantHasLetters = async () =>
+        apiRequest(CLAIMANT_STATUS_ENDPOINT)
+          .then(response => {
+            return response;
+          })
+          .catch(err => err);
+
+      checkIfClaimantHasLetters().then(r => r);
+    },
+    [letters.message],
+  );
+
   return (
     <Layout clsName="inbox-page">
       <FormTitle title="VA education inbox" />
@@ -63,4 +81,12 @@ const InboxPage = () => {
   );
 };
 
-export default InboxPage;
+InboxPage.propTypes = {
+  letters: PropTypes.object,
+};
+
+const mapStateToProps = () => ({
+  letters: {},
+});
+
+export default connect(mapStateToProps)(InboxPage);

--- a/src/applications/education-inbox/reducers/index.js
+++ b/src/applications/education-inbox/reducers/index.js
@@ -1,1 +1,5 @@
+// import { FETCH_CLAIM_STATUS } from '../actions';
+
+// const initialState = {};
+
 export default {};

--- a/src/applications/education-inbox/routes.jsx
+++ b/src/applications/education-inbox/routes.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
-import { Route } from 'react-router';
-import App from './containers/App.jsx';
+import { Switch, Route } from 'react-router-dom';
+import App from './containers/App';
+import InboxPage from './containers/InboxPage';
 
-const routes = <Route path="/" component={App} />;
+// const routes =
+
+const routes = (
+  <Switch>
+    <Route path="/" component={App} />,
+    <Route exact path="/preview" component={InboxPage} key="/intro" />,
+  </Switch>
+);
 
 export default routes;

--- a/src/applications/education-inbox/routes.jsx
+++ b/src/applications/education-inbox/routes.jsx
@@ -3,12 +3,15 @@ import { Switch, Route } from 'react-router-dom';
 import App from './containers/App';
 import InboxPage from './containers/InboxPage';
 
-// const routes =
-
 const routes = (
   <Switch>
-    <Route path="/" component={App} />,
-    <Route exact path="/preview" component={InboxPage} key="/intro" />,
+    <Route exact path="/" key="/intro">
+      <App />
+    </Route>
+    <Route exact path="/preview" key="/preview">
+      <InboxPage />
+    </Route>
+    ,
   </Switch>
 );
 

--- a/src/applications/education-inbox/sass/education-inbox.scss
+++ b/src/applications/education-inbox/sass/education-inbox.scss
@@ -1,1 +1,10 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
+.edu-certi-eligibility {
+  background: $color-gray-lightest;
+  padding: 1em
+}
+
+#your-edu-benf-letter {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Description
Built the UI for /education/education-inbox

## Original issue(s)
[Original PR](https://github.com/department-of-veterans-affairs/vets-website/pull/20164)

## Testing Notes
From the list of acceptable test users >
- After setting up AIO, create a user on LTS apache with service record of more than 10 year, honorable, and end of terms.
- After go to postman and test users ssn on the POST endpoint **Claimant Info Exist in LTS and assiociate**
- After add user to DBeaver and SQLDeveloper, in DBeaver you have to currently manually add the submission_date, after claimant id and status 
- After testing your user on the GET letters endpoint, you should get a PDF.
- After you can checkout my branch, run yarn install, then yarn watch.

## Testing done
- [x] In progress
- [ ] Done

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
