### PR TITLE
33888 remove ignore react button lint

### DIFF
--- a/src/applications/gi/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi/containers/search/LocationSearchResults.jsx
@@ -1,14 +1,17 @@
+/* eslint-disable react/button-has-type */
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable react/prop-types */
 import React, { useEffect, useRef, useState } from 'react';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import mapboxgl from 'mapbox-gl';
 import { focusElement, getScrollOptions } from 'platform/utilities/ui';
+// eslint-disable-next-line deprecate/import
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import scrollTo from 'platform/utilities/ui/scrollTo';
 import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
 import ResultCard from './ResultCard';
 import { mapboxToken } from '../../utils/mapboxToken';
 import { MapboxInit, MAX_SEARCH_AREA_DISTANCE, TABS } from '../../constants';
@@ -41,7 +44,6 @@ function LocationSearchResults({
   const { count, results } = search.location;
   const { location, streetAddress } = search.query;
   const map = useRef(null);
-  // const mapContainer = useRef(null);
   const [markers, setMarkers] = useState([]);
   const [mapState, setMapState] = useState({ changed: false, distance: null });
   const [usedFilters, setUsedFilters] = useState(filtersChanged);
@@ -51,8 +53,6 @@ function LocationSearchResults({
   const [activeMarker, setActiveMarker] = useState(null);
   const [myLocation, setMyLocation] = useState(null);
   const usingUserLocation = () => {
-    if (environment.isProduction()) return true;
-
     const currentPositions = document.getElementsByClassName(
       'current-position',
     );

--- a/src/applications/gi/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi/containers/search/LocationSearchResults.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/button-has-type */
 /* eslint-disable react/jsx-no-bind */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/prop-types */
@@ -622,6 +621,7 @@ function LocationSearchResults({
                 className="mapboxgl-ctrl-top-center"
               >
                 <button
+                  type="button"
                   id="search-area-control"
                   className="usa-button"
                   onClick={searchArea}


### PR DESCRIPTION
## Description
The mileage (distance) shown above each item in the search by location search results appears to be inaccurate and/or irrelevant. If I do not choose to use my location, it is providing a distance based on what? I'm in MN, but search for AZ and the first search result showed a distance of 49.12 miles from me in the state of Arizona. It's also not accurately locating me.

Specifically addressing this (https://github.com/department-of-veterans-affairs/vets-website/pull/20231#discussion_r806944371) comment after merge of https://github.com/department-of-veterans-affairs/vets-website/pull/20231

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33888
https://github.com/department-of-veterans-affairs/vets-website/pull/20191

## Acceptance criteria
- [x] Remove 'eslint-disable react/button-has-type' and added type=button to affected button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
