### PR TITLE
Display type of care for COVID-19 appts

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import VAFacilityLocation from '../../../components/VAFacilityLocation';
 import { getVAAppointmentLocationId } from '../../../services/appointment';
 import AppointmentDateTime from '../AppointmentDateTime';
@@ -17,11 +18,11 @@ import { getTypeOfCareById } from '../../../utils/appointment';
 function formatHeader(appointment) {
   if (appointment.vaos.isCOVIDVaccine) {
     return 'COVID-19 vaccine';
-  } else if (appointment.vaos.isPhoneAppointment) {
-    return 'VA appointment over the phone';
-  } else {
-    return 'VA appointment';
   }
+  if (appointment.vaos.isPhoneAppointment) {
+    return 'VA appointment over the phone';
+  }
+  return 'VA appointment';
 }
 
 export default function DetailsVA({
@@ -38,7 +39,22 @@ export default function DetailsVA({
   const serviceType = useV2
     ? appointment.vaos.apiData.serviceType
     : appointment.vaos.apiData.vdsAppointments[0]?.clinic?.stopCode;
-  const typeOfCare = getTypeOfCareById(serviceType)?.name;
+
+  // v0 does not return a stopCode for covid as serviceType, instead we check for isCovid
+  // remove the check for isCovid when we migrate entirely to v2
+  const ShowTypeOfCare = () => {
+    const typeOfCare = isCovid
+      ? 'COVID-19 vaccine'
+      : getTypeOfCareById(serviceType)?.name;
+    return (
+      <>
+        <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
+          Type of care:
+        </h2>
+        <div className="vads-u-display--inline"> {typeOfCare}</div>
+      </>
+    );
+  };
 
   return (
     <>
@@ -49,14 +65,7 @@ export default function DetailsVA({
         <AppointmentDateTime appointment={appointment} />
       </h1>
       <StatusAlert appointment={appointment} facility={facility} />
-      {typeOfCare && (
-        <>
-          <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
-            Type of care:
-          </h2>
-          <div className="vads-u-display--inline"> {typeOfCare}</div>
-        </>
-      )}
+      <ShowTypeOfCare />
       <TypeHeader>{header}</TypeHeader>
       <PhoneInstructions appointment={appointment} />
       <VAFacilityLocation
@@ -77,3 +86,9 @@ export default function DetailsVA({
     </>
   );
 }
+
+DetailsVA.propTypes = {
+  appointment: PropTypes.object.isRequired,
+  facilityData: PropTypes.object.isRequired,
+  useV2: PropTypes.bool,
+};

--- a/src/applications/vaos/covid-19-vaccine/components/ConfirmationPageV2.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ConfirmationPageV2.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
-import moment from '../../lib/moment-tz.js';
 import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event.js';
+import moment from '../../lib/moment-tz.js';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 import {
   getTimezoneAbbrByFacilityId,
@@ -42,7 +43,6 @@ function ConfirmationPageV2({
     : moment(slot.start);
 
   const appointmentLength = moment(slot.end).diff(slot.start, 'minutes');
-
   return (
     <div>
       <h1 className="vads-u-font-size--h2">
@@ -68,8 +68,13 @@ function ConfirmationPageV2({
           <Link to="/new-appointment">Schedule a new appointment</Link>
         </div>
       </InfoAlert>
+      <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
+        Type of care:
+      </h2>
+      <div className="vads-u-display--inline"> COVID-19 vaccine</div>
+
       <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
-        <div className="vads-u-flex--1 vads-u-margin-top--2 vads-u-margin-right--1 vaos-u-word-break--break-word">
+        <div className="vads-u-flex--1 vads-u-margin-right--1 vaos-u-word-break--break-word">
           <h2
             className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0"
             data-cy="va-appointment-details-header"
@@ -123,3 +128,11 @@ function ConfirmationPageV2({
 }
 
 export default connect(selectConfirmationPage)(ConfirmationPageV2);
+
+ConfirmationPageV2.propTypes = {
+  clinic: PropTypes.object,
+  data: PropTypes.object,
+  facilityDetails: PropTypes.object,
+  slot: PropTypes.object,
+  submitStatus: PropTypes.string,
+};

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -35,6 +35,40 @@
       }
     },
     {
+      "id": "00C19456va",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "437",
+        "comment": "Follow-up/Routine: I have a headache",
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming COVID-19 appointment",
+        "end": "2022-03-21T18:19:34",
+        "id": "00aa456va",
+        "kind": "clinic",
+        "locationId": "983",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "practitioners": [],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reason": "Routine Follow-up",
+        "requestedPeriods": null,
+        "serviceType": "covid",
+        "slot": null,
+        "start": "2022-03-21T18:19:34",
+        "status": "booked",
+        "telehealth": null
+      }
+    },
+    {
       "id": "01aa456cc",
       "type": "cc_appointments",
       "attributes": {

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -1010,7 +1010,7 @@
       "id": "4227b97525d391317233f4d129d53106",
       "type": "va_appointments",
       "attributes": {
-        "startDate": "2021-06-14T15:00:00Z",
+        "startDate": "2022-06-14T15:00:00Z",
         "clinicId": "1140",
         "clinicFriendlyName": "COVID Vaccine",
         "facilityId": "983",

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -467,7 +467,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     });
 
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
-    expect(await screen.findByText(/COVID-19 vaccine/i)).to.exist;
+    expect(await screen.findAllByText('COVID-19 vaccine')).to.exist;
 
     expect(screen.baseElement).not.to.contain.text('Cancel appointment');
 

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -29,7 +29,7 @@ describe('VAOS community care flow', () => {
 
     cy.injectAxe();
     // Select primary care
-    cy.get('input[value="323"]')
+    cy.get('input[value="323"]', { timeout: Timeouts.slow })
       .should('exist')
       .then(checkbox => {
         cy.wrap(checkbox)

--- a/src/applications/vaos/tests/e2e/covid19-vaccine.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/covid19-vaccine.cypress.spec.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import Timeouts from 'platform/testing/e2e/timeouts';
 import {
   initAppointmentListMock,
   initVaccineAppointmentMock,
@@ -46,7 +47,7 @@ describe('VAOS COVID-19 vaccine appointment flow', () => {
     cy.findByText(/Continue/).click();
 
     // Choose Clinic
-    cy.url().should('include', '/choose-clinic');
+    cy.url().should('include', '/choose-clinic', { timeout: Timeouts.slow });
     cy.axeCheckBestPractice();
     cy.findByText(/Choose where you’d like to get your vaccine/);
     cy.get('#root_clinicId_0')

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -1,9 +1,10 @@
 import moment from 'moment';
+import Timeouts from 'platform/testing/e2e/timeouts';
 
 const today = moment();
 
 export function chooseTypeOfCareTest(label) {
-  cy.url().should('include', '/new-appointment');
+  cy.url().should('include', '/new-appointment', { timeout: Timeouts.slow });
   cy.axeCheckBestPractice();
   cy.findByLabelText(label)
     .focus()


### PR DESCRIPTION
## Description
When the user makes a new COVID-19 appointment or view an existing COVID-19  then the veteran will see the type of care on the appointment details page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36434


## Testing done
unit and manual

## Screenshots
----
Confirmation Covid-19 Appt

![image](https://user-images.githubusercontent.com/54327023/154106197-2173983c-26e8-40e4-874e-43dabd72ae78.png)
----
Detail Page
![image](https://user-images.githubusercontent.com/54327023/154106526-eb72628d-399f-4883-824c-145c80b1a7aa.png)

## Acceptance criteria
- [ ] Displays COVID-19 vaccine in the confirmation page on newly booked covid appt for v0 and v2
- [ ] Displays COVID-19 vaccine in the details page for existing covid appt for v0 and v2

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
