### PR TITLE
Adds eBenefits application to USiP

### DIFF
--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import environment from '../../utilities/environment';
-import { eauthEnvironmentPrefixes } from '../../utilities/sso/constants';
 import LoginGovSVG from 'platform/user/authentication/components/LoginGovSVG';
 import IDMeSVG from 'platform/user/authentication/components/IDMeSVG';
+import environment from '../../utilities/environment';
+import { eauthEnvironmentPrefixes } from '../../utilities/sso/constants';
 
 export const API_VERSION = 'v1';
 
@@ -45,22 +45,28 @@ export const AUTHN_SETTINGS = {
 export const EXTERNAL_APPS = {
   MHV: CSP_IDS.MHV,
   MY_VA_HEALTH: 'myvahealth',
+  EBENEFITS: 'ebenefits',
 };
 
-export const MY_VA_HEALTH_LINKS = {
-  STAGING: 'https://staging-patientportal.myhealth.va.gov',
-  PRODUCTION: 'https://patientportal.myhealth.va.gov',
-};
-
-export const MHV_LINK = `https://${
+export const eAuthURL = `https://${
   eauthEnvironmentPrefixes[environment.BUILDTYPE]
-}eauth.va.gov/mhv-portal-web/eauth`;
+}eauth.va.gov`;
+
+export const EXTERNAL_LINKS = {
+  MY_VA_HEALTH: {
+    STAGING: 'https://staging-patientportal.myhealth.va.gov',
+    PRODUCTION: 'https://patientportal.myhealth.va.gov',
+  },
+  MHV: `${eAuthURL}/mhv-portal-web/eauth`,
+  EBENEFITS: `${eAuthURL}/ebenefits`,
+};
 
 export const EXTERNAL_REDIRECTS = {
   [EXTERNAL_APPS.MY_VA_HEALTH]: environment.isProduction()
-    ? MY_VA_HEALTH_LINKS.PRODUCTION
-    : MY_VA_HEALTH_LINKS.STAGING,
-  [EXTERNAL_APPS.MHV]: MHV_LINK,
+    ? EXTERNAL_LINKS.MY_VA_HEALTH.PRODUCTION
+    : EXTERNAL_LINKS.MY_VA_HEALTH.STAGING,
+  [EXTERNAL_APPS.MHV]: EXTERNAL_LINKS.MHV,
+  [EXTERNAL_APPS.EBENEFITS]: EXTERNAL_LINKS.EBENEFITS,
 };
 
 export const VAGOV_TRACKING_IDS = ['UA-50123418-16', 'UA-50123418-17'];

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -38,6 +38,7 @@ export const getQueryParams = () => {
 };
 
 const fixUrl = (url, path) => {
+  if (!url) return null;
   const updatedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
   return `${updatedUrl}${path}`.replace('\r\n', ''); // Prevent CRLF injection.
 };
@@ -93,11 +94,19 @@ function redirectWithGAClientId(redirectUrl) {
   }
 }
 
-const generatePath = (app, to) => {
-  if (app === EXTERNAL_APPS.MHV) {
-    return `?deeplinking=${to}`;
+export const generatePath = (app, to) => {
+  function generateDefaultTo() {
+    return app === EXTERNAL_APPS.EBENEFITS ? '/profilepostauth' : '';
   }
-  return to.startsWith('/') ? to : `/${to}`;
+
+  function generateTo() {
+    if (app === EXTERNAL_APPS.MHV) {
+      return `?deeplinking=${to}`;
+    }
+    return to.startsWith('/') ? to : `/${to}`;
+  }
+
+  return !to ? generateDefaultTo() : generateTo();
 };
 
 export function createExternalRedirectUrl({ base, returnUrl, application }) {
@@ -112,13 +121,11 @@ export function createExternalRedirectUrl({ base, returnUrl, application }) {
 
 export function standaloneRedirect() {
   const { application, to } = getQueryParams();
-  let url = EXTERNAL_REDIRECTS[application] || null;
 
-  if (url && to) {
-    url = fixUrl(url, generatePath(application, to));
-  }
-
-  return url;
+  return fixUrl(
+    EXTERNAL_REDIRECTS[application] ?? null,
+    generatePath(application, to),
+  );
 }
 
 export function redirect(redirectUrl, clickedEvent) {

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -106,6 +106,7 @@ export function createExternalRedirectUrl({ base, returnUrl, application }) {
       SKIP_DUPE_QUERY.SINGLE_QUERY
     }&redirect=${returnUrl}&postLogin=true`,
     [EXTERNAL_APPS.MY_VA_HEALTH]: `${base}`,
+    [EXTERNAL_APPS.EBENEFITS]: `${base}`,
   }[application];
 }
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -225,13 +225,18 @@ describe('standaloneRedirect', () => {
     expect(authUtilities.standaloneRedirect()).to.be.null;
   });
 
-  it('should return a plain url when no `to` search query is provided', () => {
-    Object.keys(EXTERNAL_APPS).forEach(app => {
-      global.window.location.search = `?application=${EXTERNAL_APPS[app]}`;
-      expect(authUtilities.standaloneRedirect()).to.equal(
-        EXTERNAL_REDIRECTS[EXTERNAL_APPS[app]],
-      );
-    });
+  it('should return a plain url for (MHV & Cerner) when no `to` search query is provided', () => {
+    global.window.location.search = `?application=${EXTERNAL_APPS.MHV}`;
+    expect(authUtilities.standaloneRedirect()).to.equal(
+      EXTERNAL_REDIRECTS[EXTERNAL_APPS.MHV],
+    );
+  });
+
+  it('should return the default `/profilepostauth` for (eBenefits) when no `to` search query is provided', () => {
+    global.window.location.search = `?application=${EXTERNAL_APPS.EBENEFITS}`;
+    expect(authUtilities.standaloneRedirect()).to.equal(
+      `${EXTERNAL_REDIRECTS[EXTERNAL_APPS.EBENEFITS]}/profilepostauth`,
+    );
   });
 
   it('should strip any CRLF characters from the "to" parameter', () => {
@@ -253,5 +258,28 @@ describe('loginAppUrlRE', () => {
   it('should not resolve to a login app url', () => {
     expect(authUtilities.loginAppUrlRE.test('/sign-in-faq')).to.be.false;
     expect(authUtilities.loginAppUrlRE.test('/sign-in-faq/')).to.be.false;
+  });
+});
+
+describe('generatePath', () => {
+  it('should default to an empty string if `to` is null/undefined', () => {
+    expect(authUtilities.generatePath('mhv')).to.eql('');
+    expect(authUtilities.generatePath('myvahealth')).to.eql('');
+  });
+  it('should default to `/profilepostauth` for eBenefits', () => {
+    expect(authUtilities.generatePath('ebenefits')).to.eql('/profilepostauth');
+  });
+  it('should default to having a `/` regardless if `to` query params has it for (eBenefits or Cerner)', () => {
+    expect(authUtilities.generatePath('myvahealth', 'secure_messaging')).to.eql(
+      '/secure_messaging',
+    );
+    expect(
+      authUtilities.generatePath('ebenefits', '/profile_dashboard'),
+    ).to.eql('/profile_dashboard');
+  });
+  it('should create deeplinking query param for mhv if `to` provided', () => {
+    expect(authUtilities.generatePath('mhv', 'some_random_link')).to.eql(
+      '?deeplinking=some_random_link',
+    );
   });
 });


### PR DESCRIPTION
## Description
This PR adds eBenefits application to the Unified Sign-in Page (USiP).  This will enable eBenefits to utilize our sign in service to authenticate users.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#36840


## Testing done
Unit testing / manual

## Screenshots
n/a

## Acceptance criteria
- [x] On the USiP with the URL: `/sign-in/?application=ebenefits`, after authenticating I am redirected to `[env].eauth.va.gov/ebenefits/profilepostauth`
- [x] On the USiP with the URL: `/sign-in/?application=ebenefits&to=[someplaceelse]`, after authenticating I am redirected to `[env].eauth.va.gov/ebenefits/[someplaceelse]`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
