### PR TITLE
adding past and pending click event for GA

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import recordEvent from 'platform/monitoring/record-event';
 import { updateBreadcrumb } from '../redux/actions';
 import { selectFeatureStatusImprovement } from '../../redux/selectors';
+import { GA_PREFIX } from '../../utils/constants';
 
 function handleClick({ history, dispatch, callback }) {
   return event => {
@@ -11,8 +13,14 @@ function handleClick({ history, dispatch, callback }) {
       history.push('/pending');
       callback(true);
       dispatch(updateBreadcrumb({ title: 'Pending', path: 'pending' }));
+      recordEvent({
+        event: `${GA_PREFIX}-status-pending-link-clicked`,
+      });
     }
     if (event.target.id === 'past') {
+      recordEvent({
+        event: `${GA_PREFIX}-status-past-link-clicked`,
+      });
       history.push('/past');
       callback(true);
       dispatch(updateBreadcrumb({ title: 'Past', path: 'past' }));

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
@@ -318,6 +318,12 @@ describe('VAOS <AppointmentsPageV2>', () => {
 
       // and status dropdown should not be displayed
       expect(screen.queryByLabelText('Show by status')).not.to.exists;
+
+      expect(
+        global.window.dataLayer.some(
+          e => e === `vaos-status-pending-link-clicked`,
+        ),
+      );
     });
 
     it('should display updated past appointment page', async () => {
@@ -383,6 +389,12 @@ describe('VAOS <AppointmentsPageV2>', () => {
 
       // and status dropdown should not be displayed
       expect(screen.queryByLabelText('Show by status')).not.to.exists;
+
+      expect(
+        global.window.dataLayer.some(
+          e => e === `vaos-status-past-link-clicked`,
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds two new GA events when the user clicks the past or pending links on the vaos home page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35463


## Testing done
Manual and unit

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/154123586-a57c2b4a-6251-4029-871f-b48c80ffa11c.png)


## Acceptance criteria
- [ ] Given a user lands on the VAOS homepage
When a user clicks Pending
Then vaos-status-pending-link-clicked event fires

- [ ] Given a user lands on the VAOS homepage
When a user clicks Past
Then vaos-status-past-link-clicked event fires

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
