### PR TITLE
contact field is no longer preset on covid-19 direct booking request

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
@@ -20,17 +20,5 @@ export function transformFormToVAOSAppointment(state) {
     },
     locationId: data.vaFacility,
     comment: '',
-    contact: {
-      telecom: [
-        {
-          type: 'phone',
-          value: data.phoneNumber,
-        },
-        {
-          type: 'email',
-          value: data.email,
-        },
-      ],
-    },
   };
 }

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -317,18 +317,6 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
         desiredDate: store.getState().covid19Vaccine.newBooking
           .availableSlots[0].start,
       },
-      contact: {
-        telecom: [
-          {
-            type: 'phone',
-            value: '2234567890',
-          },
-          {
-            type: 'email',
-            value: 'joeblow@gmail.com',
-          },
-        ],
-      },
       slot: {
         id: store.getState().covid19Vaccine.newBooking.availableSlots[0].id,
       },


### PR DESCRIPTION
## Description
The contact field is not allowed on covid-19 direct bookings, this ticket is to remove it from the request body.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36940


## Testing done
Tests were updated to reflect this change.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
