### PR TITLE
Fix Polling End Time and Claimant Name on Confirmation Page

### DIFF
--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -36,8 +36,10 @@ export const ELIGIBILITY = {
   CHAPTER1606: 'Chapter1606',
 };
 
-const ONE_MINUTE_IN_THE_FUTURE = new Date(new Date().getTime() + 60000);
 const FIVE_SECONDS = 5000;
+const ONE_MINUTE_IN_THE_FUTURE = () => {
+  return new Date(new Date().getTime() + 60000);
+};
 
 export function fetchPersonalInformation() {
   return async dispatch => {
@@ -63,7 +65,7 @@ const poll = ({
   endpoint,
   validate = response => response && response.data,
   interval = FIVE_SECONDS,
-  endTime = ONE_MINUTE_IN_THE_FUTURE,
+  endTime = ONE_MINUTE_IN_THE_FUTURE(),
   dispatch,
   timeoutResponse,
   successDispatchType,

--- a/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
@@ -45,7 +45,7 @@ const approvedPage = (claimantName, confirmationDate) => (
 
     <div className="feature">
       <h3>Application for VA education benefits (Form 22-1990)</h3>
-      <p>For {claimantName}</p>
+      {claimantName.trim() ? <p>For {claimantName}</p> : <></>}
       <dl>
         <dt>Date received</dt>
         <dd>{confirmationDate}</dd>
@@ -145,7 +145,7 @@ const deniedPage = (claimantName, confirmationDate) => (
 
     <div className="feature">
       <h3>Application for VA education benefits (Form 22-1990)</h3>
-      <p>For {claimantName}</p>
+      {claimantName.trim() ? <p>For {claimantName}</p> : <></>}
       <dl>
         <dt>Date received</dt>
         <dd>{confirmationDate}</dd>
@@ -197,7 +197,7 @@ const pendingPage = (claimantName, confirmationDate) => (
 
     <div className="feature">
       <h3>Application for VA education benefits (Form 22-1990)</h3>
-      <p>For {claimantName}</p>
+      {claimantName.trim() ? <p>For {claimantName}</p> : <></>}
       <dl>
         <dt>Date received</dt>
         <dd>{confirmationDate}</dd>
@@ -307,9 +307,8 @@ export const ConfirmationPage = ({
   const confirmationDate = claimStatus?.receivedDate
     ? format(new Date(claimStatus?.receivedDate), 'MMMM d, yyyy')
     : undefined;
-  const claimantName = `${userFullName.first} ${userFullName.middle} ${
-    userFullName.last
-  } ${userFullName.suffix}`;
+  const claimantName = `${userFullName?.first || ''} ${userFullName?.middle ||
+    ''} ${userFullName?.last || ''} ${userFullName?.suffix || ''}`;
 
   switch (confirmationResult) {
     case CLAIM_STATUS_RESPONSE_ELIGIBLE: {


### PR DESCRIPTION
## Description
Fix the polling end time to be calculated when the polling starts rather than when the file is loaded into memory. Also, don't display undefined on the confirmation page when name parts are missing.