### PR TITLE
Unused CSS Removal v4

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -6,10 +6,6 @@
   width: 50px;
 }
 
-.va-u-box-shadow--none {
-  box-shadow: none !important;
-}
-
 .va-u-background--image {
   background-position: center;
   background-repeat: no-repeat;

--- a/src/platform/site-wide/sass/modules/_m-crisis-line.scss
+++ b/src/platform/site-wide/sass/modules/_m-crisis-line.scss
@@ -149,17 +149,3 @@ button.va-crisis-line {
   width: 90vw;
   max-width: 75rem;
 }
-
-.va-footer-vcl-trigger {
-  background: transparent;
-  color: inherit;
-  font-size: inherit;
-  font-weight: normal;
-  text-decoration: underline;
-
-  &:hover {
-    background: inherit;
-    color: $color-gold;
-    text-decoration: inherit;
-  }
-}

--- a/src/platform/site-wide/sass/modules/_m-footer.scss
+++ b/src/platform/site-wide/sass/modules/_m-footer.scss
@@ -205,9 +205,3 @@
   color: $color-white;
 }
 
-.va-footer-link-label {
-  display: block;
-  font-weight: bold;
-  color: $color-white;
-  margin-top: 15px;
-}

--- a/src/platform/site-wide/sass/modules/facilities/_m-facilities.scss
+++ b/src/platform/site-wide/sass/modules/facilities/_m-facilities.scss
@@ -1,14 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
 // Facilities Hub
-.vads-facility-main-cta {
-  border-left: 4px solid $color-link-default;
-  background-color: $color-primary-alt-lightest;
-  min-height: 40px;
-  padding: 8px 14px;
-  a {
-    text-decoration: none;
-  }
-}
 .vads-facility-hub-cta {
   border-top: 1px solid $color-primary-alt-light;
   height: 73px;

--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -554,22 +554,6 @@ $medium-phone-screen: 375px;
   clear: both;
 }
 
-.image-detail {
-  width: 25%;
-  @media (max-width: $small-screen) {
-    width: 100%;
-  }
-  .alt-text-container {
-    min-height: 200px;
-  }
-}
-
-.image-desc {
-  width: 50%;
-  @media (max-width: $small-screen) {
-    width: 100%;
-  }
-}
 ._acs._acsbadge--default {
   background-color: $color-black !important;
 }


### PR DESCRIPTION
## Description
Removing unused CSS classes based on [audit](https://docs.google.com/document/d/1WfMzLFpIZwe35hrmhXl2-ii2DjWaik352vHWfp3RJ7Q/edit#) 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35384


## Testing done
Testing was done using BackStop. Each CSS change was tested 5 different times for accuracy. They were tested in phone and desktop viewports.


## Used URLs
- http://localhost:8888/
- http://localhost:8888/find-locations
- http://localhost:8888/health-care/apply/application
- http://localhost:8888/resources/
- http://localhost:8888/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/
- http://localhost:8888/education/how-to-apply/
- http://localhost:8888/disability/about-disability-ratings/
- http://localhost:8888/find-forms/
- http://localhost:8888/resources/find-apps-you-can-use/
- http://localhost:8888/claim-or-appeal-status/

## Screenshots
![BackstopJS Report](https://user-images.githubusercontent.com/55560129/156781948-7f227586-024e-43d8-8f32-84808f23caf9.png)

[BackstopJS Report.pdf](https://github.com/department-of-veterans-affairs/vets-website/files/8186568/BackstopJS.Report.pdf)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
