### PR TITLE
Prevent JS error with null address

### DIFF
--- a/src/platform/forms/address/helpers.js
+++ b/src/platform/forms/address/helpers.js
@@ -1,5 +1,5 @@
-import ADDRESS_DATA from './data';
 import countries from '@@vap-svc/constants/countries.json';
+import ADDRESS_DATA from './data';
 
 const STATE_NAMES = ADDRESS_DATA.states;
 
@@ -80,7 +80,7 @@ export function formatAddress(address) {
     province,
     stateCode,
     zipCode,
-  } = address;
+  } = address || {};
 
   let cityStateZip = '';
 
@@ -126,7 +126,7 @@ export function formatAddress(address) {
       break;
 
     default:
-      cityStateZip = address.city;
+      cityStateZip = address?.city || '';
   }
 
   return { street, cityStateZip, country };

--- a/src/platform/forms/tests/address.unit.spec.js
+++ b/src/platform/forms/tests/address.unit.spec.js
@@ -1,5 +1,5 @@
-import * as addressUtils from '../address/helpers';
 import { expect } from 'chai';
+import * as addressUtils from '../address/helpers';
 
 // Examples from:
 // https://github.com/department-of-veterans-affairs/vets-api/blob/1efd2c206859b1a261e762a50cdb44dc8b66462d/spec/factories/pciu_address.rb#L34
@@ -41,6 +41,15 @@ const military = {
 };
 
 describe('formatAddress', () => {
+  it('should not throw an error with a null address', () => {
+    const expectedResult = {
+      street: '',
+      cityStateZip: '',
+      country: '',
+    };
+
+    expect(addressUtils.formatAddress(null)).to.deep.equal(expectedResult);
+  });
   it('formats domestic addresses with three street lines', () => {
     const expectedResult = {
       street: '140 Rock Creek Church Rd NW, Apt 57, Area Name',


### PR DESCRIPTION
## Description

While logged into a mock user (Mark Webb) in staging, the contact info page in both the Higher-Level Review & Notice of Disagreement forms threw a JS error. The profile mailing address is set as `null`, and the call to the `formatAddress` function (in `src/platform/forms/address/helpers.js`) does not account for `null` values.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36948

## Testing done

Updated unit test

## Screenshots

<details><summary>User data showing <code>null</code> mailing address</summary>

<!-- leave a blank line above -->
![null mailing address in vet 360 Contact Information data](https://user-images.githubusercontent.com/136959/154151660-7c48d7f2-e30b-4d5f-9b18-4ebc938c16c0.png)</details>

<details><summary>Error logged into <code>vets.gov.user+189@gmail.com</code></summary>

<!-- leave a blank line above -->
![Cannot read properties of null (reading 'addressLine1')](https://user-images.githubusercontent.com/136959/154151346-b3380507-953a-40ee-9ee7-f555eec2755b.png)</details>

## Acceptance criteria
- [x] Fallback to empty object for falsy address values
- [x] Added unit test
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
