### PR TITLE
36526: [Debt Letters] Loading Indicator

### DIFF
--- a/src/applications/debt-letters/components/DebtDetails.jsx
+++ b/src/applications/debt-letters/components/DebtDetails.jsx
@@ -9,7 +9,6 @@ import first from 'lodash/first';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
 import NeedHelp from './NeedHelp';
@@ -49,9 +48,10 @@ const DebtDetails = ({ selectedDebt, debts }) => {
     window.location.replace('/manage-va-debt/your-debt');
     return (
       <div className="vads-u-font-family--sans vads-u-margin--0 vads-u-padding--1">
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          label="Loading"
           message="Please wait while we load the application for you."
+          set-focus
         />
       </div>
     );

--- a/src/applications/debt-letters/components/DebtLettersWrapper.jsx
+++ b/src/applications/debt-letters/components/DebtLettersWrapper.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import { fetchDebtLetters } from '../actions';
@@ -28,9 +27,10 @@ const DebtLettersWrapper = ({
   if (isPending || isPendingVBMS || isProfileUpdating) {
     return (
       <div className="vads-u-margin--5">
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          label="Loading"
           message="Please wait while we load the application for you."
+          set-focus
         />
       </div>
     );
@@ -40,9 +40,10 @@ const DebtLettersWrapper = ({
     window.location.replace('/manage-va-debt');
     return (
       <div className="vads-u-margin--5">
-        <LoadingIndicator
-          setFocus
+        <va-loading-indicator
+          label="Loading"
           message="Please wait while we load the application for you."
+          set-focus
         />
       </div>
     );


### PR DESCRIPTION
## Description
Platform deprecated `<LoadingIndicator>`, suggesting we use `<va-loading-indicator>` instead.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36526

## Screenshot
![image](https://user-images.githubusercontent.com/25368370/154278351-eaa28755-0455-49a3-86b0-11db1241c372.png)

## Acceptance criteria
- [x] Deprecated `<LoadingIndicator>` has been replaced with `<va-loading-indicator>`. 
- [x] No additional warnings or errors associated with this change. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
