### PR TITLE
comment field is not longer present in the direct booking request body

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/helpers/formSubmitTransformers.v2.js
@@ -19,6 +19,5 @@ export function transformFormToVAOSAppointment(state) {
       desiredDate: slot.start,
     },
     locationId: data.vaFacility,
-    comment: '',
   };
 }

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -139,13 +139,13 @@ export function transformFormToVAOSVARequest(state) {
   };
 }
 
-function getUserMessage(data) {
-  const label = PURPOSE_TEXT.find(
-    purpose => purpose.id === data.reasonForAppointment,
-  ).short;
+// function getUserMessage(data) {
+//   const label = PURPOSE_TEXT.find(
+//     purpose => purpose.id === data.reasonForAppointment,
+//   ).short;
 
-  return `${label}: ${data.reasonAdditionalInfo}`;
-}
+//   return `${label}: ${data.reasonAdditionalInfo}`;
+// }
 
 export function transformFormToVAOSAppointment(state) {
   const data = getFormData(state);
@@ -165,6 +165,7 @@ export function transformFormToVAOSAppointment(state) {
       desiredDate: `${data.preferredDate}T00:00:00+00:00`,
     },
     locationId: data.vaFacility,
-    comment: getUserMessage(data),
+    // removing this for now, it's preventing QA from testing, will re-introduce when the team figures out how we're handling the comment field
+    // comment: getUserMessage(data),
   };
 }

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -312,7 +312,7 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
       status: 'booked',
       locationId: '983',
       clinic: '455',
-      comment: '',
+      // comment: '',
       extension: {
         desiredDate: store.getState().covid19Vaccine.newBooking
           .availableSlots[0].start,

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -393,7 +393,7 @@ describe('VAOS <ReviewPage> direct scheduling with v2 api', () => {
       status: 'booked',
       locationId: '983',
       clinic: '455',
-      comment: 'Follow-up/Routine: I need an appt',
+      // comment: 'Follow-up/Routine: I need an appt',
       extension: {
         desiredDate: '2021-05-06T00:00:00+00:00',
       },

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
@@ -113,7 +113,7 @@ describe('VAOS V2 data transformation', () => {
         },
         extension: { desiredDate: '2019-12-02T00:00:00+00:00' },
         locationId: '983',
-        comment: 'Follow-up/Routine: asdfasdf',
+        // comment: 'Follow-up/Routine: asdfasdf',
       });
     });
   });


### PR DESCRIPTION
## Description
Temporarily removing the comments field from the direct booking request body because it's preventing QA from eoe testing.  Will reintroduce when the team determines how we want to handle this data.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit tests were updated to reflect this change.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
