### PR TITLE
Show eligibility relinquishment option when eligibility is null

### DIFF
--- a/src/applications/my-education-benefits/reducers/index.js
+++ b/src/applications/my-education-benefits/reducers/index.js
@@ -44,7 +44,8 @@ export default {
             action?.response?.data?.attributes?.eligibility
               ?.filter(
                 benefit =>
-                  benefit.veteranIsEligible &&
+                  (benefit.veteranIsEligible === true ||
+                    benefit.veteranIsEligible === null) &&
                   benefit.chapter !== ELIGIBILITY.CHAPTER33,
               )
               .map(benefit => benefit.chapter) || [],


### PR DESCRIPTION
- A value of null (as opposed to true and false) has a distinct meaning of "undetermined eligibility". Per feedback from PO, we should treat this the same as if the claimant was eligible, so they can relinquish.

## Description


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
