### PR TITLE
Add telephone contacts to platform

### DIFF
--- a/src/platform/site-wide/contacts.js
+++ b/src/platform/site-wide/contacts.js
@@ -1,0 +1,102 @@
+/**
+ * Map of phone numbers to descriptions. This is only intended for documentation
+ * purposes. Use CONTACTS.<key> to get the actual phone number.
+ */
+export const contactsMap = Object.freeze({
+  '222_VETS': { phoneNumber: '8772228387', description: 'VA Help Line' },
+  '4AID_VET': {
+    phoneNumber: '8774243838',
+    description: 'National Call Center for Homeless Veterans',
+  },
+  711: { phoneNumber: '711', description: 'Telecommunications Relay Service' },
+  911: { phoneNumber: '911', description: '911' },
+  CAREGIVER: {
+    phoneNumber: '8552603274',
+    description: 'VA National Caregiver Support Line',
+  },
+  CRISIS_LINE: {
+    phoneNumber: '8002738255',
+    description: 'Veterans Crisis hotline',
+  },
+  CRISIS_TTY: {
+    phoneNumber: '8007994889',
+    description: 'Veterans Crisis hotline TTY',
+  },
+  DMC: { phoneNumber: '8008270648', description: 'Debt Management Center' },
+  DMC_OVERSEAS: {
+    phoneNumber: '6127136415',
+    description: 'Debt Management Center (Overseas)',
+  },
+  DMDC_DEERS: {
+    phoneNumber: '8663632883',
+    description:
+      'Defense Manpower Data Center (DMDC) | Defense Enrollment Eligibility Reporting System (DEERS) Support Office',
+  },
+  DS_LOGON: {
+    phoneNumber: '8005389552',
+    description: 'Defense Manpower Data Center',
+  },
+  DS_LOGON_TTY: {
+    phoneNumber: '8663632883',
+    description: 'Defense Manpower Data Center TTY',
+  },
+  FEDERAL_RELAY_SERVICE: {
+    phoneNumber: '8008778339',
+    description: 'Federal Relay Service',
+  },
+  GI_BILL: {
+    phoneNumber: '8884424551',
+    description: 'Education Call Center (1-888-GI-BILL-1)',
+  },
+  GO_DIRECT: {
+    phoneNumber: '8003331795',
+    description: 'Go Direct/Direct Express (Treasury)',
+  },
+  HELP_DESK: { phoneNumber: '8006982411', description: 'VA Help desk' },
+  HEALTHCARE_ELIGIBILITY_CENTER: {
+    phoneNumber: '8554888440',
+    description: 'VA Healthcare Eligibility Center (Eligibility Division)',
+  },
+  HELP_TTY: { phoneNumber: '8008778339', description: 'VA Help Desk TTY' },
+  MY_HEALTHEVET: {
+    phoneNumber: '8773270022',
+    description: 'My HealtheVet help desk',
+  },
+  NCA: {
+    phoneNumber: '8005351117',
+    description: 'National Cemetery Scheduling Office',
+  },
+  SUICIDE_PREVENTION_LIFELINE: {
+    phoneNumber: '8007994889',
+    description: 'Suicide Prevention Line',
+  },
+  TESC: {
+    phoneNumber: '8882242950',
+    description: 'U.S. Treasury Electronic Payment Solution Center',
+  },
+  TREASURY_DMS: {
+    phoneNumber: '8888263127',
+    description: 'U.S. Department of the Treasury (Debt Management Services)',
+  },
+  // VA_311 used before the number changed to include 411
+  VA_311: { phoneNumber: '8006982411', description: 'VA Help desk (VA411)' },
+  VA_411: { phoneNumber: '8006982411', description: 'VA Help desk (VA411)' },
+  VA_BENEFITS: {
+    phoneNumber: '8008271000',
+    description: 'Veterans Benefits Assistance',
+  },
+});
+
+/**
+ * Map of phone numbers. CONTACTS.GI_BILL, for example, will return the phone
+ * number defined in contactsMap.
+ */
+export const CONTACTS = Object.freeze(
+  Object.entries(contactsMap).reduce(
+    (allContacts, currentContact) => ({
+      ...allContacts,
+      [currentContact[0]]: currentContact[1].phoneNumber,
+    }),
+    {},
+  ),
+);


### PR DESCRIPTION
## Description

The component library `<Telephone>` component includes a list of contact telephone numbers. Which proved to be useful in preventing mis-typed telephone numbers. Since the new `<va-telephone>` web component does not include this list of `CONTACTS` and with the React component being deprecated, it would be nice to move this list to a new home in the platform code.

Contact numbers are not restricted to forms, so maybe moving it to `platform/site-wide` would be appropriate?

Source: https://github.com/department-of-veterans-affairs/component-library/blob/master/packages/react-components/src/components/Telephone/contacts.js

cc: @department-of-veterans-affairs/vsp-design-system-team 

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/37061

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Include telephone contact list for use with `<va-telephone>` web component

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
