### PR TITLE
Check in/spike/36606/edit routing

### DIFF
--- a/src/applications/check-in/actions/edit/index.js
+++ b/src/applications/check-in/actions/edit/index.js
@@ -1,18 +1,10 @@
 export const EDITING_FIELD = 'EDITING_FIELD';
 
-export const createEditFieldAction = ({
-  originatingPage,
-  key,
-  value,
-  title,
-}) => {
+export const createEditFieldAction = data => {
   return {
     type: EDITING_FIELD,
     payload: {
-      originatingPage,
-      key,
-      value,
-      title,
+      ...data,
     },
   };
 };

--- a/src/applications/check-in/actions/edit/index.js
+++ b/src/applications/check-in/actions/edit/index.js
@@ -1,0 +1,18 @@
+export const EDITING_FIELD = 'EDITING_FIELD';
+
+export const createEditFieldAction = ({
+  originatingPage,
+  key,
+  value,
+  title,
+}) => {
+  return {
+    type: EDITING_FIELD,
+    payload: {
+      originatingPage,
+      key,
+      value,
+      title,
+    },
+  };
+};

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -27,7 +27,10 @@ const responses = {
     if (!last4 || !lastName) {
       return res.status(400).json(sessions.post.createMockFailedResponse());
     }
-    if (last4 !== mockUser.last4 || lastName !== mockUser.lastName) {
+    if (
+      last4 !== mockUser.last4 ||
+      lastName.toLowerCase() !== mockUser.lastName.toLowerCase()
+    ) {
       return res
         .status(400)
         .json(sessions.post.createMockValidateErrorResponse());

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
@@ -65,7 +65,7 @@ const createAppointment = (
   appointmentIen = 'some-ien',
   clinicFriendlyName = 'TEST CLINIC',
 ) => {
-  const startTime = new Date();
+  let startTime = new Date();
   const checkInWindowStart = new Date();
   const checkInWindowEnd = new Date();
 
@@ -78,6 +78,7 @@ const createAppointment = (
   }
   checkInWindowStart.setHours(startTime.getHours() - 1);
   checkInWindowEnd.getMinutes(startTime.getMinutes() + 10);
+  startTime = '2022-02-14T14:00:00';
   return {
     facility: 'LOMA LINDA VA CLINIC',
     clinicPhoneNumber: '5551234567',
@@ -197,6 +198,22 @@ const createMultipleAppointments = (
       `TEST CLINIC-E`,
     ),
   );
+
+  rv.payload.appointments.push({
+    clinicName: 'JC-ST CLR CHIR B',
+    appointmentIEN: 999999,
+    patientDFN: '123456',
+    stationNo: 657,
+    checkedInTime: '2022-02-14T13a:50:39',
+    eligibility: 'INELIGIBLE_ALREADY_CHECKED_IN',
+    clinicPhoneNumber: '(314)289-6583',
+    clinicFriendlyName: 'St. Clair County Chiropractor',
+    startTime: '2022-02-14T14:00:00',
+    facility: 'ST. CLAIR CNTY VA CLINIC-STL',
+    checkInWindowEnd: '2022-02-14T14:15:00.000-06:00',
+    status: '',
+    checkInWindowStart: '2022-02-14T13:30:00.000-06:00',
+  });
 
   return rv;
 };

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -4,7 +4,7 @@ const generateFeatureToggles = (toggles = {}) => {
     preCheckInEnabled = true,
     checkInExperienceUpdateInformationPageEnabled = false,
     checkInExperienceEditingDayOfEnabled = false,
-    checkInExperienceEditingPreCheckInEnabled = false,
+    checkInExperienceEditingPreCheckInEnabled = true,
   } = toggles;
 
   return {

--- a/src/applications/check-in/components/BackToHome.jsx
+++ b/src/applications/check-in/components/BackToHome.jsx
@@ -4,19 +4,30 @@ import { useSelector } from 'react-redux';
 import withOnlyOnLocal from '../containers/withOnlyOnLocal';
 import { makeSelectApp } from '../selectors';
 
+import { APP_NAMES } from '../utils/appConstants';
+
 function BackToHome() {
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
-  let restartURL =
+  const preCheckInUrl =
     '/health-care/appointment-pre-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-  if (app !== 'preCheckIn') {
-    restartURL =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-  }
+  const checkInUrl =
+    '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
+  const restartURL =
+    app === APP_NAMES.PRE_CHECK_IN ? preCheckInUrl : checkInUrl;
+
   return (
     <div className="vads-l-grid-container vads-u-padding-bottom--5 vads-u-padding-top--2 ">
       <a data-testid="back-to-home-button" href={restartURL}>
         Start again
+      </a>
+      |
+      <a data-testid="back-to-home-button" href={preCheckInUrl}>
+        Start PRE CHECK IN
+      </a>
+      |
+      <a data-testid="back-to-home-button" href={checkInUrl}>
+        Start CHECK IN
       </a>
     </div>
   );

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -44,19 +44,20 @@ const ConfirmablePage = ({
                     'Not available'
                   )}
                 </dd>
-                {isEditEnabled && (
-                  <div>
-                    <button
-                      // eslint-disable-next-line react/jsx-no-bind
-                      onClick={() =>
-                        editHandler({ ...field, value: data[field.key] })
-                      }
-                      type="button"
-                    >
-                      edit
-                    </button>
-                  </div>
-                )}
+                {isEditEnabled &&
+                  field.editAction && (
+                    <div>
+                      <button
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onClick={() =>
+                          editHandler({ ...field, value: data[field.key] })
+                        }
+                        type="button"
+                      >
+                        edit
+                      </button>
+                    </div>
+                  )}
               </React.Fragment>
             );
           })}

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { focusElement } from 'platform/utilities/ui';
 import PropTypes from 'prop-types';
 import DemographicItem from '../../DemographicItem';
@@ -13,10 +13,16 @@ const ConfirmablePage = ({
   isLoading = false,
   LoadingMessage = () => <va-loading-indicator message="Loading..." />,
   Footer,
+  isEditEnabled,
 }) => {
   useEffect(() => {
     focusElement('h1');
   }, []);
+
+  const editHandler = useCallback(dataToEdit => {
+    dataToEdit.editAction(dataToEdit);
+  }, []);
+
   return (
     <div className="vads-l-grid-container vads-u-padding-bottom--6 vads-u-padding-top--2 confirmable-page">
       <h1 data-testid="header">{header}</h1>
@@ -27,18 +33,33 @@ const ConfirmablePage = ({
       )}
       <div className="vads-u-border-color--primary vads-u-border-left--5px vads-u-margin-left--0p5 vads-u-padding-left--2">
         <dl data-testid="demographics-fields">
-          {dataFields.map(field => (
-            <React.Fragment key={field.key}>
-              <dt className="vads-u-font-weight--bold">{field.title}</dt>
-              <dd>
-                {field.key in data && data[field.key] ? (
-                  <DemographicItem demographic={data[field.key]} />
-                ) : (
-                  'Not available'
+          {dataFields.map(field => {
+            return (
+              <React.Fragment key={field.key}>
+                <dt className="vads-u-font-weight--bold">{field.title}</dt>
+                <dd>
+                  {field.key in data && data[field.key] ? (
+                    <DemographicItem demographic={data[field.key]} />
+                  ) : (
+                    'Not available'
+                  )}
+                </dd>
+                {isEditEnabled && (
+                  <div>
+                    <button
+                      // eslint-disable-next-line react/jsx-no-bind
+                      onClick={() =>
+                        editHandler({ ...field, value: data[field.key] })
+                      }
+                      type="button"
+                    >
+                      edit
+                    </button>
+                  </div>
                 )}
-              </dd>
-            </React.Fragment>
-          ))}
+              </React.Fragment>
+            );
+          })}
         </dl>
       </div>
       {isLoading ? (

--- a/src/applications/check-in/components/pages/Edit/Address.jsx
+++ b/src/applications/check-in/components/pages/Edit/Address.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Address() {
+  return <div>Edit address</div>;
+}

--- a/src/applications/check-in/components/pages/Edit/Email.jsx
+++ b/src/applications/check-in/components/pages/Edit/Email.jsx
@@ -1,0 +1,40 @@
+import React, { useMemo, useCallback } from 'react';
+
+import { useSelector } from 'react-redux';
+import { useFormRouting } from '../../../hooks/useFormRouting';
+import { makeSelectEdit } from '../../../selectors';
+import BackToHome from '../../BackToHome';
+
+export default function Email(props) {
+  const { router } = props;
+  const { jumpToPage } = useFormRouting(router);
+  const selectEdit = useMemo(makeSelectEdit, []);
+  const { edit } = useSelector(selectEdit);
+
+  const cancelButton = useCallback(
+    () => {
+      jumpToPage(edit.originatingPage);
+    },
+    [edit.originatingPage, jumpToPage],
+  );
+  const updateButton = useCallback(
+    () => {
+      jumpToPage(edit.originatingPage);
+    },
+    [edit.originatingPage, jumpToPage],
+  );
+
+  return (
+    <>
+      <h1>Email: Edit your {edit.title}</h1>
+      <h2>current value: {edit.value}</h2>
+      <button onClick={updateButton} type="button">
+        Update
+      </button>
+      <button onClick={cancelButton} type="button">
+        Cancel
+      </button>
+      <BackToHome />
+    </>
+  );
+}

--- a/src/applications/check-in/components/pages/Edit/PhoneNumber.jsx
+++ b/src/applications/check-in/components/pages/Edit/PhoneNumber.jsx
@@ -1,0 +1,40 @@
+import React, { useMemo, useCallback } from 'react';
+
+import { useSelector } from 'react-redux';
+import { useFormRouting } from '../../../hooks/useFormRouting';
+import { makeSelectEdit } from '../../../selectors';
+import BackToHome from '../../BackToHome';
+
+export default function PhoneNumber(props) {
+  const { router } = props;
+  const { jumpToPage } = useFormRouting(router);
+  const selectEdit = useMemo(makeSelectEdit, []);
+  const { edit } = useSelector(selectEdit);
+
+  const cancelButton = useCallback(
+    () => {
+      jumpToPage(edit.originatingPage);
+    },
+    [edit.originatingPage, jumpToPage],
+  );
+  const updateButton = useCallback(
+    () => {
+      jumpToPage(edit.originatingPage);
+    },
+    [edit.originatingPage, jumpToPage],
+  );
+
+  return (
+    <>
+      <h1>Edit your {edit.title}</h1>
+      <h2>{edit.value}</h2>
+      <button onClick={updateButton} type="button">
+        Update
+      </button>
+      <button onClick={cancelButton} type="button">
+        Cancel
+      </button>
+      <BackToHome />
+    </>
+  );
+}

--- a/src/applications/check-in/components/pages/Edit/index.js
+++ b/src/applications/check-in/components/pages/Edit/index.js
@@ -1,0 +1,5 @@
+import Address from './Address';
+import Email from './Email';
+import PhoneNumber from './PhoneNumber';
+
+export default { Address, Email, PhoneNumber };

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
@@ -40,7 +40,8 @@ export default function DemographicsDisplay({
       key: 'mobilePhone',
       editAction: field => {
         const dataForEdit = {
-          originatingPage: URLS.DEMOGRAPHICS,
+          originatingUrl: URLS.DEMOGRAPHICS,
+          thingToUpdate: 'demographics',
           ...field,
         };
         // update redux with {where we came from, what we want to edit, }

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import ConfirmablePage from '../ConfirmablePage';
+
+import { URLS } from '../../../utils/navigation';
+
+import { createEditFieldAction } from '../../../actions/edit';
 
 export default function DemographicsDisplay({
   header = 'Is this your current contact information?',
@@ -9,14 +14,68 @@ export default function DemographicsDisplay({
   yesAction = () => {},
   noAction = () => {},
   Footer,
+  jumpToPage,
+  isEditEnabled = false,
 }) {
+  const dispatch = useDispatch();
   const demographicFields = [
-    { title: 'Mailing address', key: 'mailingAddress' },
-    { title: 'Home address', key: 'homeAddress' },
-    { title: 'Home phone', key: 'homePhone' },
-    { title: 'Mobile phone', key: 'mobilePhone' },
-    { title: 'Work phone', key: 'workPhone' },
-    { title: 'Email address', key: 'emailAddress' },
+    { title: 'Mailing address', key: 'mailingAddress', editAction: () => {} },
+    { title: 'Home address', key: 'homeAddress', editAction: () => {} },
+    {
+      title: 'Home phone',
+      key: 'homePhone',
+      editAction: field => {
+        const dataForEdit = {
+          originatingPage: URLS.DEMOGRAPHICS,
+          ...field,
+        };
+        // update redux with {where we came from, what we want to edit, }
+        dispatch(createEditFieldAction(dataForEdit));
+        // go to next page
+        jumpToPage(URLS.EDIT_PHONE_NUMBER);
+      },
+    },
+    {
+      title: 'Mobile phone',
+      key: 'mobilePhone',
+      editAction: field => {
+        const dataForEdit = {
+          originatingPage: URLS.DEMOGRAPHICS,
+          ...field,
+        };
+        // update redux with {where we came from, what we want to edit, }
+        dispatch(createEditFieldAction(dataForEdit));
+        // go to next page
+        jumpToPage(URLS.EDIT_PHONE_NUMBER);
+      },
+    },
+    {
+      title: 'Work phone',
+      key: 'workPhone',
+      editAction: field => {
+        const dataForEdit = {
+          originatingPage: URLS.DEMOGRAPHICS,
+          ...field,
+        };
+        // update redux with {where we came from, what we want to edit, }
+        dispatch(createEditFieldAction(dataForEdit));
+        jumpToPage(URLS.EDIT_PHONE_NUMBER);
+      },
+    },
+    {
+      title: 'Email address',
+      key: 'emailAddress',
+      editAction: field => {
+        const dataForEdit = {
+          originatingPage: URLS.DEMOGRAPHICS,
+          ...field,
+        };
+        // update redux with {where we came from, what we want to edit, }
+        dispatch(createEditFieldAction(dataForEdit));
+        // go to next page
+        jumpToPage(URLS.EDIT_EMAIL);
+      },
+    },
   ];
   return (
     <>
@@ -28,6 +87,7 @@ export default function DemographicsDisplay({
         yesAction={yesAction}
         noAction={noAction}
         Footer={Footer}
+        isEditEnabled={isEditEnabled}
       />
     </>
   );
@@ -40,4 +100,5 @@ DemographicsDisplay.propTypes = {
   noAction: PropTypes.func,
   subtitle: PropTypes.string,
   yesAction: PropTypes.func,
+  jumpToPage: PropTypes.func,
 };

--- a/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.jsx
+++ b/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.jsx
@@ -17,17 +17,18 @@ export default function EmergencyContactDisplay({
   jumpToPage,
   isEditEnabled,
 }) {
+  const originatingPage = URLS.EMERGENCY_CONTACT;
   const dispatch = useDispatch();
   const dataFields = [
-    { title: 'Name', key: 'name', editAction: () => {} },
-    { title: 'Relationship', key: 'relationship', editAction: () => {} },
-    { title: 'Address', key: 'address', editAction: () => {} },
+    { title: 'Name', key: 'name' },
+    { title: 'Relationship', key: 'relationship' },
+    { title: 'Address', key: 'address' },
     {
       title: 'Phone',
       key: 'phone',
       editAction: field => {
         const dataForEdit = {
-          originatingPage: URLS.DEMOGRAPHICS,
+          originatingPage,
           ...field,
         };
         // update redux with {where we came from, what we want to edit, }
@@ -41,7 +42,7 @@ export default function EmergencyContactDisplay({
       key: 'workPhone',
       editAction: field => {
         const dataForEdit = {
-          originatingPage: URLS.DEMOGRAPHICS,
+          originatingPage,
           ...field,
         };
         // update redux with {where we came from, what we want to edit, }

--- a/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.jsx
+++ b/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+
 import ConfirmablePage from '../ConfirmablePage';
+
+import { URLS } from '../../../utils/navigation';
+
+import { createEditFieldAction } from '../../../actions/edit';
 
 export default function EmergencyContactDisplay({
   data = {},
@@ -8,13 +14,42 @@ export default function EmergencyContactDisplay({
   noAction = () => {},
   isLoading,
   Footer,
+  jumpToPage,
+  isEditEnabled,
 }) {
+  const dispatch = useDispatch();
   const dataFields = [
-    { title: 'Name', key: 'name' },
-    { title: 'Relationship', key: 'relationship' },
-    { title: 'Address', key: 'address' },
-    { title: 'Phone', key: 'phone' },
-    { title: 'Work phone', key: 'workPhone' },
+    { title: 'Name', key: 'name', editAction: () => {} },
+    { title: 'Relationship', key: 'relationship', editAction: () => {} },
+    { title: 'Address', key: 'address', editAction: () => {} },
+    {
+      title: 'Phone',
+      key: 'phone',
+      editAction: field => {
+        const dataForEdit = {
+          originatingPage: URLS.DEMOGRAPHICS,
+          ...field,
+        };
+        // update redux with {where we came from, what we want to edit, }
+        dispatch(createEditFieldAction(dataForEdit));
+        // go to next page
+        jumpToPage(URLS.EDIT_PHONE_NUMBER);
+      },
+    },
+    {
+      title: 'Work phone',
+      key: 'workPhone',
+      editAction: field => {
+        const dataForEdit = {
+          originatingPage: URLS.DEMOGRAPHICS,
+          ...field,
+        };
+        // update redux with {where we came from, what we want to edit, }
+        dispatch(createEditFieldAction(dataForEdit));
+        // go to next page
+        jumpToPage(URLS.EDIT_PHONE_NUMBER);
+      },
+    },
   ];
   return (
     <>
@@ -26,6 +61,7 @@ export default function EmergencyContactDisplay({
         noAction={noAction}
         Footer={Footer}
         isLoading={isLoading}
+        isEditEnabled={isEditEnabled}
       />
     </>
   );

--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -8,12 +8,17 @@ import Footer from '../../components/Footer';
 import { seeStaffMessageUpdated } from '../../actions/day-of';
 import DemographicsDisplay from '../../components/pages/demographics/DemographicsDisplay';
 import { makeSelectVeteranData } from '../../selectors';
+import { makeSelectFeatureToggles } from '../../utils/selectors/feature-toggles';
 
 import { URLS } from '../../utils/navigation';
 
 const Demographics = props => {
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { demographics } = useSelector(selectVeteranData);
+
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isEditingDayOfEnabled } = useSelector(selectFeatureToggles);
+
   const { router } = props;
   const { goToNextPage, jumpToPage, goToErrorPage } = useFormRouting(router);
 
@@ -68,6 +73,7 @@ const Demographics = props => {
         yesAction={yesClick}
         noAction={noClick}
         Footer={Footer}
+        isEditEnabled={isEditingDayOfEnabled}
       />
       <BackToHome />
     </>

--- a/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
@@ -12,10 +12,12 @@ import { recordAnswer } from '../../../actions/pre-check-in';
 
 import { makeSelectVeteranData } from '../../../selectors';
 
+import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
+
 const Demographics = props => {
   const dispatch = useDispatch();
   const { router } = props;
-  const { goToNextPage, goToPreviousPage } = useFormRouting(router);
+  const { goToNextPage, goToPreviousPage, jumpToPage } = useFormRouting(router);
   const yesClick = useCallback(
     () => {
       recordEvent({
@@ -44,6 +46,9 @@ const Demographics = props => {
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { demographics } = useSelector(selectVeteranData);
 
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isEditingPreCheckInEnabled } = useSelector(selectFeatureToggles);
+
   return (
     <>
       <BackButton action={goToPreviousPage} router={router} />
@@ -53,6 +58,8 @@ const Demographics = props => {
         subtitle={subtitle}
         demographics={demographics}
         Footer={Footer}
+        jumpToPage={jumpToPage}
+        isEditEnabled={isEditingPreCheckInEnabled}
       />
       <BackToHome />
     </>

--- a/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
@@ -15,6 +15,8 @@ import { useFormRouting } from '../../../hooks/useFormRouting';
 
 import { makeSelectVeteranData } from '../../../selectors';
 
+import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
+
 const EmergencyContact = props => {
   const { router } = props;
 
@@ -25,7 +27,7 @@ const EmergencyContact = props => {
   const { emergencyContact } = demographics;
   const dispatch = useDispatch();
 
-  const { goToNextPage, goToPreviousPage } = useFormRouting(router);
+  const { goToNextPage, goToPreviousPage, jumpToPage } = useFormRouting(router);
 
   const buttonClick = useCallback(
     async answer => {
@@ -57,6 +59,9 @@ const EmergencyContact = props => {
     [buttonClick],
   );
 
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isEditingPreCheckInEnabled } = useSelector(selectFeatureToggles);
+
   return (
     <>
       <BackButton action={goToPreviousPage} router={router} />
@@ -66,6 +71,8 @@ const EmergencyContact = props => {
         noAction={noClick}
         isLoading={isSendingData}
         Footer={Footer}
+        jumpToPage={jumpToPage}
+        isEditEnabled={isEditingPreCheckInEnabled}
       />
       <BackToHome />
     </>

--- a/src/applications/check-in/pre-check-in/routes.jsx
+++ b/src/applications/check-in/pre-check-in/routes.jsx
@@ -10,6 +10,7 @@ import Confirmation from './pages/Confirmation';
 import Landing from './pages/Landing';
 import Error from './pages/Error';
 import ErrorTest from './pages/ErrorTest';
+import Edit from '../components/pages/Edit';
 import { URLS } from '../utils/navigation';
 
 import withFeatureFlip from '../containers/withFeatureFlip';
@@ -73,6 +74,22 @@ const routes = [
   {
     path: URLS.ERROR,
     component: Error,
+  },
+  {
+    path: URLS.EDIT_EMAIL,
+    component: Edit.Email,
+    permissions: {
+      requiresForm: true,
+      requireAuthorization: true,
+    },
+  },
+  {
+    path: URLS.EDIT_PHONE_NUMBER,
+    component: Edit.PhoneNumber,
+    permissions: {
+      requiresForm: true,
+      requireAuthorization: true,
+    },
   },
 ];
 

--- a/src/applications/check-in/reducers/edit/index.js
+++ b/src/applications/check-in/reducers/edit/index.js
@@ -1,0 +1,11 @@
+const editPageInitialize = (state, action) => {
+  return {
+    ...state,
+    edit: {
+      ...state.edit,
+      ...action.payload,
+    },
+  };
+};
+
+export { editPageInitialize };

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -19,6 +19,9 @@ import {
 
 import { recordAnswerHandler, setVeteranDataHandler } from './pre-check-in';
 
+import { EDITING_FIELD } from '../actions/edit';
+import { editPageInitialize } from './edit';
+
 import {
   APPOINTMENT_WAS_CHECKED_INTO,
   RECEIVED_APPOINTMENT_DETAILS,
@@ -61,6 +64,8 @@ const handler = Object.freeze({
   [UPDATE_PRE_CHECK_IN_FORM]: updateFormHandler,
   [UPDATE_DAY_OF_CHECK_IN_FORM]: updateFormHandler,
   [SET_APP]: setAppHandler,
+
+  [EDITING_FIELD]: editPageInitialize,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -64,9 +64,7 @@ const handler = Object.freeze({
   [UPDATE_PRE_CHECK_IN_FORM]: updateFormHandler,
   [UPDATE_DAY_OF_CHECK_IN_FORM]: updateFormHandler,
   [SET_APP]: setAppHandler,
-
   [EDITING_FIELD]: editPageInitialize,
-
   default: state => {
     return { ...state };
   },

--- a/src/applications/check-in/selectors/index.js
+++ b/src/applications/check-in/selectors/index.js
@@ -58,6 +58,17 @@ const selectApp = createSelector(
 
 const makeSelectApp = () => selectApp;
 
+const selectEdit = createSelector(
+  state => {
+    return {
+      edit: state.checkInData.edit,
+    };
+  },
+  edit => edit,
+);
+
+const makeSelectEdit = () => selectEdit;
+
 export {
   makeSelectCurrentContext,
   makeSelectForm,
@@ -65,4 +76,5 @@ export {
   makeSelectConfirmationData,
   makeSelectSeeStaffMessage,
   makeSelectApp,
+  makeSelectEdit,
 };

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -77,6 +77,9 @@ const URLS = Object.freeze({
   UPDATE_INSURANCE: 'update-information',
   VALIDATION_NEEDED: 'verify',
   LOADING: 'loading-appointments',
+  EDIT_ADDRESS: 'edit-address',
+  EDIT_PHONE_NUMBER: 'edit-phone-number',
+  EDIT_EMAIL: 'edit-email',
 });
 
 export { updateFormPages, URLS };


### PR DESCRIPTION
## Description
- Prototype for editing pages and routing

## Overall solution

Since the editing forms branch off the main trunk of the form flow, this allows us to have branched off that flow and have a returning point back to the main flow. 

## Key Concepts
- Edits are their own page added to the router
- Currently group into editing a Phone Number, An Email, and An address (not hooked up) 
- On the individual app page level, we are passing in whether or not the editing is enabled and the current routing context ([example](https://github.com/department-of-veterans-affairs/vets-website/pull/20264/files#diff-693cf8041644982981a7071de9e636630456f45162e945e876420556682ab500R49)) 
- For the shared component, in addition to a `title` and `key`, each field is getting an `editAction` function. This function dispatches an action to Redux (that stores both the data we are editing, and a breadcrumb back to the `originatingPage`) and redirects to the page to actually edit the data. NOTE: this is where the fun with full auth comes into play. [Example](https://github.com/department-of-veterans-affairs/vets-website/pull/20264/files#diff-a80a1960305dc84fd64b929e8454b783d3a1e88bf5e040d0c87dac218421f0d7R42)
- On the  confirmable page, we added an edit button with checks not to show if the feature is disabled or if there is no `editAction`


Notes:
- No actual edit UI, that is the easy part (famous last words)
- There are no tests this is just a proof of concept
- There is so much room for refactoring and simplification before this can be done for real, examples are 
  - better redux structure
  - reuse of editing components
  - folder structure could use some love




## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
