### PR TITLE
pre-need update to use va-additional-info

### DIFF
--- a/src/applications/pre-need/components/SupportingDocumentsDescription.jsx
+++ b/src/applications/pre-need/components/SupportingDocumentsDescription.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import { isVeteran, isUnmarriedChild } from '../utils/helpers';
 
 export default function SupportingDocumentsDescription(props) {
@@ -51,7 +50,7 @@ export default function SupportingDocumentsDescription(props) {
         If you have supporting documents readily available, you can upload them
         to help us make a determination quickly.
       </p>
-      <AdditionalInfo triggerText="What kinds of documents should I provide?">
+      <va-additional-info trigger="What kinds of documents should I provide?">
         {desc}
         <p>
           If you’re applying on behalf of someone else, you’ll need to provide
@@ -74,8 +73,8 @@ export default function SupportingDocumentsDescription(props) {
             applicant is being cared for
           </li>
         </ul>
-      </AdditionalInfo>
-      <AdditionalInfo triggerText="Can I mail or fax documents?">
+      </va-additional-info>
+      <va-additional-info trigger="Can I mail or fax documents?">
         <p>
           We can process your request more quickly if you upload your documents
           here. If you can’t upload your documents:
@@ -95,7 +94,7 @@ export default function SupportingDocumentsDescription(props) {
             <p>Fax (toll-free): 855-840-8299</p>
           </li>
         </ol>
-      </AdditionalInfo>
+      </va-additional-info>
       File types you can upload: PDF
       <br />
       Maximum file size: 15MB

--- a/src/applications/pre-need/tests/components/SupportingDocumentDescription.unit.spec.jsx
+++ b/src/applications/pre-need/tests/components/SupportingDocumentDescription.unit.spec.jsx
@@ -24,14 +24,11 @@ describe('<SupportingDocumentsDescription>', () => {
       />,
     );
 
-    tree
-      .find('a')
+    const info = tree
+      .find('va-additional-info')
       .first()
-      .simulate('click');
-
-    expect(tree.find('.additional-info-content').text()).to.contain(
-      'your DD214',
-    );
+      .html();
+    expect(info).to.contain('your DD214');
     tree.unmount();
   });
   it('should render sponsor text', () => {
@@ -47,14 +44,11 @@ describe('<SupportingDocumentsDescription>', () => {
       />,
     );
 
-    tree
-      .find('a')
+    const info = tree
+      .find('va-additional-info')
       .first()
-      .simulate('click');
-
-    expect(tree.find('.additional-info-content').text()).to.contain(
-      'sponsor’s DD214',
-    );
+      .html();
+    expect(info).to.contain('sponsor’s DD214');
     tree.unmount();
   });
   it('should render child text', () => {
@@ -70,17 +64,12 @@ describe('<SupportingDocumentsDescription>', () => {
       />,
     );
 
-    tree
-      .find('a')
+    const info = tree
+      .find('va-additional-info')
       .first()
-      .simulate('click');
-
-    expect(tree.find('.additional-info-content').text()).to.contain(
-      'sponsor’s DD214',
-    );
-    expect(tree.find('.additional-info-content').text()).to.contain(
-      'need to provide supporting documents',
-    );
+      .html();
+    expect(info).to.contain('sponsor’s DD214');
+    expect(info).to.contain('need to provide supporting documents');
     tree.unmount();
   });
 });

--- a/src/applications/pre-need/tests/components/SupportingDocumentDescription.unit.spec.jsx
+++ b/src/applications/pre-need/tests/components/SupportingDocumentDescription.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('<SupportingDocumentsDescription>', () => {
   it('should render', () => {
     const tree = shallow(<SupportingDocumentsDescription />);
 
-    expect(tree.find('AdditionalInfo').length).to.equal(2);
+    expect(tree.find('va-additional-info').length).to.equal(2);
     tree.unmount();
   });
   it('should render service member text', () => {


### PR DESCRIPTION
## Description
The pre-need form still includes the deprecated `AdditionalInfo` component. It needs to be updated to use the `va-additional-info` web component.

## Original issue(s)
closes department-of-veterans-affairs/va.gov-team#36659


## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Updated preneed to use va-additional-info web component
- [x] All tests passing 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
