### PR TITLE
[COE] fix UploadRequirements component

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
+++ b/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 // Abbreviation keys:
@@ -23,7 +24,7 @@ const DOCUMENT_REQUIREMENTS = {
 };
 
 const UploadRequirements = ({ formData }) => {
-  const { identity, existingLoan } = formData;
+  const { identity, vaLoanIndicator } = formData;
 
   return (
     <div>
@@ -36,7 +37,7 @@ const UploadRequirements = ({ formData }) => {
           DOCUMENT_REQUIREMENTS[identity].map((req, index) => (
             <li key={index}>{req}</li>
           ))}
-        {existingLoan && <li>Evidence a VA loan was paid in full</li>}
+        {vaLoanIndicator && <li>Evidence a VA loan was paid in full</li>}
       </ul>
     </div>
   );
@@ -45,6 +46,10 @@ const UploadRequirements = ({ formData }) => {
 const mapStateToProps = state => ({
   formData: state?.form?.data,
 });
+
+UploadRequirements.propTypes = {
+  formData: PropTypes.object,
+};
 
 export default connect(
   mapStateToProps,


### PR DESCRIPTION
## Description
When making changes to the schema in `vets-json-schema` we changed the property `existingLoan` to `vaLoanIndicator` to more closely align with what LGY expects to receive from our backend. This affects the `UploadRequirements` components, which used `existingLoan` to conditionally render some content. This component needs to be updated to use `vaLoanIndicator`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37085

## Acceptance criteria
- [x] `UploadRequirements` uses `vaLoanIndicator` for rendering logic

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
