### PR TITLE
Add FE feature flag Deomographics Flags in Day Of

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -5,6 +5,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceUpdateInformationPageEnabled = false,
     checkInExperienceEditingDayOfEnabled = false,
     checkInExperienceEditingPreCheckInEnabled = false,
+    checkInExperienceDayOfDemographicsFlagsEnabled = false,
   } = toggles;
 
   return {
@@ -30,6 +31,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'check_in_experience_editing_pre_check_in_enabled',
           value: checkInExperienceEditingPreCheckInEnabled,
+        },
+        {
+          name: 'check_in_experience_day_of_demographics_flags_enabled',
+          value: checkInExperienceDayOfDemographicsFlagsEnabled,
         },
       ],
     },

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -141,6 +141,8 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: when we expand to multiple facilities and address the edge cases around it
 - `check_in_experience_editing_day_of_enabled` : Enables or disabled editing the demographics information for the day of
   - when to sunset: once we have successfully tested this feature in production with users
+- `check_in_experience_day_of_demographics_flags_enabled` : Enables the capture of user responses to demographics up-to-date questions (demographics, emergency contact, and next of kin)
+  - when to sunset: once we have successfully tested this feature in production with users
 
 ### How to test this?
 

--- a/src/applications/check-in/utils/selectors/feature-toggles.js
+++ b/src/applications/check-in/utils/selectors/feature-toggles.js
@@ -21,6 +21,9 @@ const selectFeatureToggles = createSelector(
     isEditingPreCheckInEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.checkInExperienceEditingPreCheckInEnabled
     ],
+    isDayOfDemographicsFlagsEnabled: toggleValues(state)[
+      FEATURE_FLAG_NAMES.checkInExperienceDayOfDemographicsFlagsEnabled
+    ],
   }),
   toggles => toggles,
 );

--- a/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
+++ b/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
@@ -14,6 +14,7 @@ describe('check-in', () => {
         check_in_experience_next_of_kin_enabled: false,
         check_in_experience_editing_day_of_enabled: false,
         check_in_experience_editing_pre_check_in_enabled: false,
+        check_in_experience_day_of_demographics_flags_enabled: false,
         loading: false,
       },
     };
@@ -28,6 +29,7 @@ describe('check-in', () => {
           isUpdatePageEnabled: true,
           isEditingPreCheckInEnabled: false,
           isEditingDayOfEnabled: false,
+          isDayOfDemographicsFlagsEnabled: false,
         });
       });
     });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -18,6 +18,7 @@ export default Object.freeze({
     'check_in_experience_update_information_page_enabled',
   checkInExperienceEditingDayOfEnabled: 'check_in_experience_editing_day_of_enabled',
   checkInExperienceEditingPreCheckInEnabled:'check_in_experience_editing_pre_check_in_enabled',
+  checkInExperienceDayOfDemographicsFlagsEnabled: 'check_in_experience_day_of_demographics_flags_enabled',
   coeAccess: 'coe_access',
   covidVaccineSchedulingFrontend: 'covid_vaccine_scheduling_frontend',
   covidVaccineUpdatesCTA: 'covid_vaccine_registration_frontend_cta',


### PR DESCRIPTION
## Description
Add FE feature flag for capturing demographics update flags in day-of check-in experience.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36803


## Testing done
Update unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
