### PR TITLE
Revert Profile changes & disable e2e tests

### DIFF
--- a/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
@@ -100,6 +100,7 @@ describe('NOD contact info loop', () => {
     cy.location('pathname').should('eq', contactPageUrl);
 
     // update phone
+    /*
     cy.get('a[href$="phone"]').click();
     cy.location('pathname').should('eq', `${BASE_URL}/edit-mobile-phone`);
     cy.findByLabelText(/extension/i)
@@ -109,6 +110,7 @@ describe('NOD contact info loop', () => {
       .first()
       .click();
     cy.location('pathname').should('eq', contactPageUrl);
+    */
 
     // Email loops *****
     cy.get('a[href$="email-address"]').click();
@@ -121,6 +123,7 @@ describe('NOD contact info loop', () => {
     cy.location('pathname').should('eq', contactPageUrl);
 
     // update email
+    /*
     cy.get('a[href$="email-address"]').click();
     cy.location('pathname').should('eq', `${BASE_URL}/edit-email-address`);
     cy.findByLabelText(/email address/i)
@@ -130,6 +133,7 @@ describe('NOD contact info loop', () => {
       .first()
       .click();
     cy.location('pathname').should('eq', contactPageUrl);
+    */
 
     // Mailing address loops *****
     cy.get('a[href$="mailing-address"]').click();
@@ -142,6 +146,7 @@ describe('NOD contact info loop', () => {
     cy.location('pathname').should('eq', contactPageUrl);
 
     // update address
+    /*
     cy.get('a[href$="mailing-address"]').click();
     cy.location('pathname').should('eq', `${BASE_URL}/edit-mailing-address`);
     cy.findByLabelText(/address line 2/i).clear(); // remove "c/o Pixar"
@@ -149,6 +154,7 @@ describe('NOD contact info loop', () => {
       .first()
       .click();
     cy.wait('@getAddressValidation');
+    */
     /*
     Not including address validation intermediate page because it hates me
     cy.findByText(/^use this address$/i, { selector: 'button' }).should('be.visible');

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -155,8 +155,8 @@ class ProfileInformationFieldController extends React.Component {
     } else if (
       forceEditView &&
       typeof successCallback === 'function' &&
-      prevProps.transactionRequest?.isPending &&
-      !this.props.transactionRequest?.isPending
+      prevProps.transactionRequest &&
+      !this.props.transactionRequest
     ) {
       // Success callback (non-address) after updating a field
       successCallback();


### PR DESCRIPTION
## Description

Adding `.isPending` to the profile code is not working in staging/dev - the updated field is not updating the field upon return to the contact info page. Reverting this change pending further investigation and disabling associated e2e test loops

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/37050
- https://github.com/department-of-veterans-affairs/vets-website/pull/20257

## Testing done

Manual testing in staging & dev

## Screenshots

N/A

## Acceptance criteria
- [x] Revery recent changes pending further investigation

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
