### PR TITLE
Fix my edu benefits direct deposit edit break bug

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -18,7 +18,7 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import environment from 'platform/utilities/environment';
 import merge from 'lodash/merge';
 import bankAccountUI from 'platform/forms/definitions/bankAccount';
-import { vagovprod } from 'site/constants/buckets';
+import { vagovprod, VAGOVSTAGING } from 'site/constants/buckets';
 import fullSchema from '../22-1990-schema.json';
 
 // In a real app this would not be imported directly; instead the schema you
@@ -347,6 +347,10 @@ function transform(metaData, form) {
   const submission = createSubmissionForm(form.data);
   return JSON.stringify(submission);
 }
+
+const checkImageSrc = environment.isStaging()
+  ? `${VAGOVSTAGING}/img/check-sample.png`
+  : `${vagovprod}/img/check-sample.png`;
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -1300,14 +1304,14 @@ const formConfig = {
                   'accountType',
                   'accountNumber',
                   'routingNumber',
-                  'learnMore',
+                  // 'learnMore',
                 ],
                 learnMore: {
                   'ui:description': (
                     <>
                       <img
                         style={{ marginTop: '1rem' }}
-                        src={`${vagovprod}/img/check-sample.png`}
+                        src={checkImageSrc}
                         alt="Example of a check showing where the account and routing numbers are"
                       />
                       <p>Where can I find these numbers?</p>


### PR DESCRIPTION
## Description
Fixes a bug in form 22-1990 , when user reaches /education/apply-for-benefits-form-22-1990/review-and-submit, upon clicking on EDIT for the Direct Deposit, the entire UI breaks, related to the ui:order list

Also adds a condition for the check image, to load pro or staging image source.

## Definition of done
- [X] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
