### PR TITLE
Add contact chatbot CTA widget 

### DIFF
--- a/src/applications/gi-sandbox/tests/e2e/mock-feature_toggles.js
+++ b/src/applications/gi-sandbox/tests/e2e/mock-feature_toggles.js
@@ -732,6 +732,14 @@ export const mockTogglesResponse = {
         value: true,
       },
       {
+        name: 'showContactChatbot',
+        value: true,
+      },
+      {
+        name: 'show_contact_chatbot',
+        value: true,
+      },
+      {
         name: 'showEduBenefits0994Wizard',
         value: false,
       },

--- a/src/applications/static-pages/contact-chatbot-cta/components/App/index.js
+++ b/src/applications/static-pages/contact-chatbot-cta/components/App/index.js
@@ -1,0 +1,45 @@
+// Node modules.
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+export const App = ({ show }) => {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <va-alert status="info">
+      {/* Title */}
+      <h2 slot="headline" className="vads-u-font-size--h3">
+        VA Virtual Agent
+      </h2>
+
+      {/* Explanation */}
+      <p>
+        Use our virtual agent (chatbot) to get answers to your questions about
+        VA benefits and services, and helpful links to find more information on
+        our site.
+      </p>
+
+      {/* Call to action link */}
+      <a
+        className="vads-c-action-link--blue vads-u-margin-top--2"
+        href="/virtual-agent-study/"
+      >
+        Chat with our Virtual Agent
+      </a>
+    </va-alert>
+  );
+};
+
+App.propTypes = {
+  // From mapStateToProps.
+  show: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  show: state?.featureToggles?.showChatbot,
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/static-pages/contact-chatbot-cta/components/App/index.js
+++ b/src/applications/static-pages/contact-chatbot-cta/components/App/index.js
@@ -12,22 +12,21 @@ export const App = ({ show }) => {
     <va-alert status="info">
       {/* Title */}
       <h2 slot="headline" className="vads-u-font-size--h3">
-        VA Virtual Agent
+        VA virtual agent
       </h2>
 
       {/* Explanation */}
       <p>
-        Use our virtual agent (chatbot) to get answers to your questions about
-        VA benefits and services, and helpful links to find more information on
-        our site.
+        You can also use our virtual agent (chatbot) to get information about VA
+        benefits and services.
       </p>
 
       {/* Call to action link */}
       <a
         className="vads-c-action-link--blue vads-u-margin-top--2"
-        href="/virtual-agent-study/"
+        href="/contact-us/virtual-agent/"
       >
-        Chat with our Virtual Agent
+        Go to the virtual agent
       </a>
     </va-alert>
   );
@@ -39,7 +38,7 @@ App.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  show: state?.featureToggles?.showChatbot,
+  show: state?.featureToggles?.showContactChatbot,
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/applications/static-pages/contact-chatbot-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/contact-chatbot-cta/components/App/index.unit.spec.js
@@ -13,17 +13,18 @@ describe('Contact Chatbot CTA <App>', () => {
   });
 
   it('renders what we expect', () => {
-    const expectedHref = '/virtual-agent-study/';
     const wrapper = shallow(<App show />);
     expect(wrapper.type()).to.not.equal(null);
-    expect(wrapper.text()).includes('VA Virtual Agent');
+    expect(wrapper.text()).includes('VA virtual agent');
     expect(wrapper.text()).includes(
-      'Use our virtual agent (chatbot) to get answers to your questions about VA benefits and services, and helpful links to find more information on our site.',
+      'You can also use our virtual agent (chatbot) to get information about VA benefits and services.',
     );
-    expect(wrapper.find(`a[href="${expectedHref}"]`)).be.have.lengthOf(1);
-    expect(wrapper.find(`a[href="${expectedHref}"]`).text()).to.equal(
-      'Chat with our Virtual Agent',
-    );
+    expect(
+      wrapper.find(`a[href="/contact-us/virtual-agent/"]`),
+    ).be.have.lengthOf(1);
+    expect(
+      wrapper.find(`a[href="/contact-us/virtual-agent/"]`).text(),
+    ).to.equal('Go to the virtual agent');
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/contact-chatbot-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/contact-chatbot-cta/components/App/index.unit.spec.js
@@ -1,0 +1,29 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from '.';
+
+describe('Contact Chatbot CTA <App>', () => {
+  it('does not render when feature toggle is falsey', () => {
+    const wrapper = shallow(<App show={false} />);
+    expect(wrapper.type()).to.equal(null);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect', () => {
+    const expectedHref = '/virtual-agent-study/';
+    const wrapper = shallow(<App show />);
+    expect(wrapper.type()).to.not.equal(null);
+    expect(wrapper.text()).includes('VA Virtual Agent');
+    expect(wrapper.text()).includes(
+      'Use our virtual agent (chatbot) to get answers to your questions about VA benefits and services, and helpful links to find more information on our site.',
+    );
+    expect(wrapper.find(`a[href="${expectedHref}"]`)).be.have.lengthOf(1);
+    expect(wrapper.find(`a[href="${expectedHref}"]`).text()).to.equal(
+      'Chat with our Virtual Agent',
+    );
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/contact-chatbot-cta/index.js
+++ b/src/applications/static-pages/contact-chatbot-cta/index.js
@@ -1,0 +1,21 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+
+  if (root) {
+    import(/* webpackChunkName: "contact-chatbot-cta" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -36,6 +36,7 @@ import createAskVAWidget from './ask-va';
 import createApplicationStatus from './widget-creators/createApplicationStatus';
 import createCOEAccess from './coe-access/createCOEAccess';
 import createCallToActionWidget from './widget-creators/createCallToActionWidget';
+import createContactChatbotCTA from './contact-chatbot-cta';
 import createCoronavirusChatbot from '../coronavirus-chatbot/createCoronavirusChatbot';
 import createCovidVaccineUpdatesWidget from './covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget';
 import createDependencyVerification from './dependency-verification/createDependencyVerification';
@@ -117,6 +118,7 @@ createApplicationStatus(store, {
   widgetType: widgetTypes.HEALTH_CARE_APP_STATUS,
 });
 createCallToActionWidget(store, widgetTypes.CTA);
+createContactChatbotCTA(store, widgetTypes.CONTACT_CHATBOT_CTA);
 createEducationApplicationStatus(store, widgetTypes.EDUCATION_APP_STATUS);
 createOptOutApplicationStatus(store, widgetTypes.OPT_OUT_APP_STATUS);
 createHigherLevelReviewApplicationStatus(

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -7,6 +7,7 @@ export default {
   CHAPTER_31_WIZARD: 'chapter-31-Wizard',
   CHAPTER_36_CTA: 'chapter-36-cta',
   COE_ACCESS: 'coe_access',
+  CONTACT_CHATBOT_CTA: 'contact-chatbot-cta',
   CORONAVIRUS_CHATBOT: 'va-coronavirus-chatbot',
   COVID_VACCINE_UPDATES_CTA: 'va-covid-vaccine-updates-cta',
   CTA: 'cta',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -77,6 +77,7 @@ export default Object.freeze({
   searchDropdownComponentEnabled: 'search_dropdown_component_enabled',
   show526Wizard: 'show526_wizard',
   showPaymentAndDebtSection: 'show_payment_and_debt_section',
+  showContactChatbot: 'show_contact_chatbot',
   showDashboardNotifications: 'show_dashboard_notifications',
   showEduBenefits0994Wizard: 'show_edu_benefits_0994_wizard',
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',


### PR DESCRIPTION
## Description

This PR adds the Virtual Agent (Chatbot) CTA widget. It renders `null` when the `show_contact_chatbot` feature toggle is disabled. This widget is meant for use by content editors who drop react widgets into a page in Drupal.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36319

## Testing done
- [x] Unit tests

## Screenshots
<img width="695" alt="Screen Shot 2022-02-22 at 12 41 54 PM" src="https://user-images.githubusercontent.com/6738544/155188124-b8a07b2c-83f7-4455-8e87-58906659331d.png">

## Acceptance criteria
- [x] Create contact chatbot CTA

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
