### PR TITLE
Bump component-library to v6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^6.0.2",
+    "@department-of-veterans-affairs/component-library": "^6.1.1",
     "@department-of-veterans-affairs/formation": "6.17.5",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,13 +2130,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-6.0.2.tgz#0af8574535ce7ad7486fcfbae90414daadd8ba40"
-  integrity sha512-D2v7KkbHXQYPcXH8httl9esJxnOp+fMebJpE6QNGLPcDhlWBzM3enj9lCjnOx9TeEOZHk9/xaM2+N85KyJe1TQ==
+"@department-of-veterans-affairs/component-library@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-6.1.1.tgz#0c2cb425233e7abddc148308dc14244a6764d7de"
+  integrity sha512-vdVI64A3T5KIB8/D+wpCKSnTIpXy3R5zmrdjbtBZGnhmqOd8Eq0rD8Vl14gQclI5gLL7kS/h2NZ0AZH8A4H7BA==
   dependencies:
-    "@department-of-veterans-affairs/react-components" "4.0.2"
-    "@department-of-veterans-affairs/web-components" "2.0.2"
+    "@department-of-veterans-affairs/react-components" "4.0.3"
+    "@department-of-veterans-affairs/web-components" "2.1.0"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
@@ -2167,10 +2167,10 @@
     yeoman-generator "^4.11.0"
     yosay "^2.0.1"
 
-"@department-of-veterans-affairs/react-components@4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-4.0.2.tgz#4cdc74617f80878a05db3b47f24f69c7f01ca481"
-  integrity sha512-mM9k6bB9rpZBTjAwPZKax+E7ulF0Hg6jaM0LGwPEoHxe7oiY559v708wbLbE8kklCez2K669r8qDYymk5ISwoA==
+"@department-of-veterans-affairs/react-components@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-4.0.3.tgz#366cd022691cd8ce81426b4687fc83cd78d1f646"
+  integrity sha512-yFPSsWt9ohvUe87aXmzpmsEKel8ZyDSRBDQoq6HKggwx+Mj8+PbFLYZZcj9YC5/M34GjrOLioJQ3CSp2TneH4A==
   dependencies:
     classnames "^2.2.6"
     number-to-words "^1.2.4"
@@ -2192,10 +2192,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-2.0.2.tgz#8e4a566315b2d8e0dacdf9766997b326bd84ad13"
-  integrity sha512-J0RJO7nJiAANt8dKXKnHLuBrCoJhKhdcTD5w3OxLrpO4mqfZbGXa1vVBytiCIs9jfrLd88llReBxKleDWU1vUw==
+"@department-of-veterans-affairs/web-components@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-2.1.0.tgz#d2cba7ad3553f6c29164ec264bcdcaf6bcc6b103"
+  integrity sha512-Jl4DpBSL+/e2Is7+Uxm4Un49Y6CUkmgNtOy3X4K8BhzgkeHRnPzfxHB7kGHhxIzIxEk0fNhPt3OyaRcttRO3qg==
   dependencies:
     "@stencil/core" "^2.10.0"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

Bump the version of the component library. This will aid with the `<Telephone>` => `<va-telephone>` migration since teams will be able to import `CONTACTS` from the root of `component-library` instead of from the `/Telephone` subpath. The old import will still work, but they may not want to import from `/Telephone` after they've removed the default import.


**TLDR**: teams can go from this:

```js
import Telephone, {
  CONTACTS,
} from '@department-of-veterans-affairs/component-library/Telephone';
```

to this:

```js
import { CONTACTS } from '@department-of-veterans-affairs/component-library';
```

---

### Release notes

#### [v6.1.0](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v6.1.0)

> **New Features & Components :tada:**
> - Add process list web component (:shushing_face: will announce soon: https://github.com/department-of-veterans-affairs/va.gov-team/issues/35097)

#### [v6.1.1](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v6.1.1)

> **Fixes**
> - Fix va-alert heading to not announce as clickable when using NVDA
> - ~~Fix Storybook stories render~~
> - Update va-progress-bar aria-label when percent is used to round
> - Fix va-additional-info content overflow
> - ~~533 Storybook React RadioButtons Error Message Display~~
> - Move CONTACTS table to telephone web component story

^^ This last item is why we're making this PR now, and what I will be testing for.

####

## Original issue(s)
N/A

## Testing done

- Tested to make sure `CONTACTS` import worked


## Screenshots

Here is my local diff:

```diff
diff --git a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
index 365c6650fb..5623bda040 100644
--- a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 import recordEvent from 'platform/monitoring/record-event';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 import ProgressButton from '@department-of-veterans-affairs/component-library/ProgressButton';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
@@ -10,6 +11,8 @@ import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { modalContents } from './privacyDataHelper';
 
+console.log('CONTACTS', CONTACTS);
+
 const alreadyReceivingCarePath =
   '/health-care/covid-19-vaccine/stay-informed/form';
 const newlyEligiblePath = `/eligibility`;
 ```

![CONTACTS logged as a result of the diff](https://user-images.githubusercontent.com/2008881/154585352-d28bc942-6432-4eac-ac55-f4804a343a0a.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
