### PR TITLE
NOD: switch to `va-telephone`

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import AddressView from '@@vap-svc/components/AddressField/AddressView';
 
 import { selectProfile } from 'platform/user/selectors';
@@ -52,7 +51,7 @@ export const ContactInfoDescription = ({ formContext, profile, homeless }) => {
   const contactSection = (
     <>
       <h4 className="vads-u-font-size--h3">Mobile phone number</h4>
-      <Telephone contact={phoneNumber} extension={phoneExt} notClickable />
+      <va-telephone contact={phoneNumber} extension={phoneExt} not-clickable />
       <p>
         <Link to="/edit-mobile-phone" aria-label="Edit mobile phone number">
           Edit

--- a/src/applications/appeals/10182/components/ReviewDescription.jsx
+++ b/src/applications/appeals/10182/components/ReviewDescription.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
-
 import { ADDRESS_TYPES } from 'platform/forms/address/helpers';
 import titleCase from 'platform/utilities/data/titleCase';
 
@@ -25,10 +23,10 @@ const ReviewDescription = ({ veteran }) => {
   const display = {
     [phoneType]: () =>
       phone && (
-        <Telephone
+        <va-telephone
           contact={`${phone?.areaCode}${phone?.phoneNumber}`}
           extension={phone?.extension || ''}
-          notClickable
+          not-clickable
         />
       ),
     'Email address': () => email,

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 
 import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';
@@ -57,7 +55,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
       <br />
       <p>
         <strong>Note:</strong> If you need to update your personal information,
-        please call us at <Telephone contact={CONTACTS.VA_BENEFITS} />. We’re
+        please call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />. We’re
         here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>

--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -6,9 +6,7 @@ import { connect } from 'react-redux';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import { selectProfile } from 'platform/user/selectors';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 
 import { FORMAT_READABLE } from '../constants';
 import { getSelected, getIssueName } from '../utils/helpers';
@@ -97,7 +95,7 @@ export class ConfirmationPage extends React.Component {
         <p>
           If you requested an appeal and haven’t heard back from us yet, please
           don’t request another appeal. Call us at{' '}
-          <Telephone contact={CONTACTS.VA_BENEFITS} />.
+          <va-telephone contact={CONTACTS.VA_BENEFITS} />.
         </p>
         <br />
         <a

--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import { selectProfile } from 'platform/user/selectors';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { FORMAT_READABLE } from '../constants';
 import { getSelected, getIssueName } from '../utils/helpers';

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -122,7 +122,7 @@ export const FormApp = ({
 };
 
 FormApp.propTypes = {
-  children: PropTypes.array,
+  children: PropTypes.object,
   contestableIssues: PropTypes.shape({
     issues: PropTypes.array,
     status: PropTypes.string,

--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -156,7 +156,7 @@ IntroductionPage.propTypes = {
       savedFormMessages: PropTypes.shape({}),
       downtime: PropTypes.shape({}),
     }),
-    pageList: PropTypes.string,
+    pageList: PropTypes.array,
   }),
 };
 

--- a/src/applications/appeals/10182/content/GetFormHelp.jsx
+++ b/src/applications/appeals/10182/content/GetFormHelp.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
@@ -10,12 +8,12 @@ const GetFormHelp = () => (
     <p className="help-talk">
       If you have questions or need help filling out this form, please call our{' '}
       {srSubstitute('MYVA411', 'My V. A. 4 1 1.')} main information line at{' '}
-      <Telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
+      <va-telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
       {srSubstitute('24/7', '24 hours a day, 7 days a week')}.
     </p>
     <p className="u-vads-margin-bottom--0">
       If you have hearing loss, call TTY:{' '}
-      <Telephone contact={CONTACTS['711']} pattern="###" ariaLabel="7 1 1." />.
+      <va-telephone contact={CONTACTS['711']} />.
     </p>
   </>
 );

--- a/src/applications/appeals/10182/content/GetFormHelp.jsx
+++ b/src/applications/appeals/10182/content/GetFormHelp.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 

--- a/src/applications/appeals/10182/content/evidenceIntro.jsx
+++ b/src/applications/appeals/10182/content/evidenceIntro.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
 export const evidenceUploadIntroTitle = 'Additional evidence';
 
@@ -19,7 +18,8 @@ export const evidenceUploadIntroDescription = (
           <br />
           Washington, D.C. 20038
         </p>
-        You can also fax it to <Telephone notClickable contact="844-678-8979" />
+        You can also fax it to{' '}
+        <va-telephone not-clickable contact="8446788979" />
       </va-additional-info>
     </div>
   </>

--- a/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
@@ -49,7 +49,7 @@ describe('Contact information review content', () => {
     const data = getData({ loopPages: true });
     const tree = shallow(<ContactInfoDescription {...data} />);
 
-    expect(tree.find('Telephone')).to.exist;
+    expect(tree.find('va-telephone')).to.exist;
     expect(tree.find('AddressView')).to.exist;
     expect(tree.find('Link').length).to.eq(3);
 

--- a/src/applications/appeals/10182/tests/components/ReviewDescription.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ReviewDescription.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('<ReviewDescription>', () => {
     const wrapper = shallow(<ReviewDescription veteran={veteran} />);
     const text = wrapper.find('dl.review').text();
     const { email, phone, address } = veteran;
-    const phoneProps = wrapper.find('Telephone').props();
+    const phoneProps = wrapper.find('va-telephone').props();
 
     expect(wrapper.find('h4').text()).to.eq('Contact information');
     expect(wrapper.find('a').props().href).to.contain(PROFILE_URL);


### PR DESCRIPTION
## Description

Update `<Telephone>` React component to the new `<va-telephone>` web component in the Notice of Disagreement form

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36941

## Testing done

Updated unit test

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] All Telephone React components replaced with a `va-telephone` web component
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
