### PR TITLE
Get commit sha from event

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Get commit sha from workflow_run
         if: ${{ github.event_name == 'workflow_run' }}
-        run: echo 'COMMIT_SHA=${{ github.event.head_sha }}' >> $GITHUB_ENV
+        run: echo 'COMMIT_SHA=${{ github.event.workflow_run.head_sha }}' >> $GITHUB_ENV
 
       - name: Get commit sha from workflow_dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Description
Get commit sha from `workflow_run` event.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34866

## Testing done
Will monitor once merged

## Acceptance criteria
- [x] `workflow_run` triggers should use the commit sha from the event.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
