### PR TITLE
HLR: switch to `va-telephone`

### DIFF
--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import AddressView from '@@vap-svc/components/AddressField/AddressView';
 
 import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
@@ -66,7 +65,7 @@ export const ContactInfoDescription = ({
   const contactSection = loopPages ? (
     <>
       <h4 className="vads-u-font-size--h3">Mobile phone number</h4>
-      <Telephone contact={phoneNumber} extension={phoneExt} notClickable />
+      <va-telephone contact={phoneNumber} extension={phoneExt} not-clickable />
       <p>
         <Link to="/edit-mobile-phone" aria-label="Edit mobile phone number">
           Edit

--- a/src/applications/disability-benefits/996/components/ReviewDescription.jsx
+++ b/src/applications/disability-benefits/996/components/ReviewDescription.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
-
 import { ADDRESS_TYPES } from 'platform/forms/address/helpers';
 import titleCase from 'platform/utilities/data/titleCase';
 
@@ -25,10 +23,10 @@ const ReviewDescription = ({ veteran }) => {
   const display = {
     [phoneType]: () =>
       phone && (
-        <Telephone
+        <va-telephone
           contact={`${phone?.areaCode}${phone?.phoneNumber}`}
           extension={phone?.extension || ''}
-          notClickable
+          not-clickable
         />
       ),
     'Email address': () => email,

--- a/src/applications/disability-benefits/996/components/VeteranInformation.jsx
+++ b/src/applications/disability-benefits/996/components/VeteranInformation.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';
@@ -61,7 +59,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
       <p>
         <strong>Note:</strong> If you need to update your personal information,
         please call Veterans Benefits Assistance toll free at{' '}
-        <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
+        <va-telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
         8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -6,9 +6,7 @@ import PropTypes from 'prop-types';
 import { focusElement } from 'platform/utilities/ui';
 import { selectProfile } from 'platform/user/selectors';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { SAVED_CLAIM_TYPE, WIZARD_STATUS, FORMAT_READABLE } from '../constants';
 import { getSelected, getIssueName } from '../utils/helpers';
@@ -106,7 +104,7 @@ export class ConfirmationPage extends React.Component {
         <p>
           If you requested a decision review and haven’t heard back from VA yet,
           please don’t request another review. Call VA at{' '}
-          <Telephone contact={CONTACTS.VA_BENEFITS} />.
+          <va-telephone contact={CONTACTS.VA_BENEFITS} />.
         </p>
         <br />
         <a

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -3,9 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
@@ -177,7 +175,7 @@ export class IntroductionPage extends React.Component {
                 If you need help requesting a Higher-Level Review, you can
                 contact a VA regional office and ask to speak to a
                 representative. To find the nearest regional office, please call{' '}
-                <Telephone contact={CONTACTS.VA_BENEFITS} />
+                <va-telephone contact={CONTACTS.VA_BENEFITS} />
                 {' or '}
                 <a href={FACILITY_LOCATOR_URL}>
                   visit our facility locator tool

--- a/src/applications/disability-benefits/996/content/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/content/GetFormHelp.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
@@ -10,17 +8,12 @@ const GetFormHelp = () => (
     <p className="help-talk">
       If you have questions or need help filling out this form, please call our{' '}
       {srSubstitute('MYVA411', 'My V. A. 4 1 1.')} main information line at{' '}
-      <Telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
+      <va-telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
       {srSubstitute('24/7', '24 hours a day, 7 days a week')}.
     </p>
     <p className="u-vads-margin-bottom--0">
       If you have hearing loss, call TTY:{' '}
-      <Telephone
-        contact={CONTACTS['711']}
-        pattern={'###'}
-        ariaLabel={'7 1 1.'}
-      />
-      .
+      <va-telephone contact={CONTACTS['711']} />.
     </p>
   </>
 );

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -12,7 +10,7 @@ import { PROFILE_URL } from '../constants';
 const noIssuesMessage = (
   <p className="vads-u-font-size--base">
     If you think this is an error, please call us at{' '}
-    <Telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday through
+    <va-telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday through
     Friday, 8:00 a.m. to 9:00 p.m. ET.
     {disabilitiesExplanationAlert}
   </p>

--- a/src/applications/disability-benefits/996/content/contestableIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssues.jsx
@@ -1,9 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { scrollAndFocus } from 'platform/utilities/ui';
 
@@ -100,7 +98,7 @@ const disabilitiesList = (
       To learn more about decision review options, please visit our{' '}
       <a href={DECISION_REVIEWS_URL}>decision reviews and appeals</a>{' '}
       information page. You can call us at{' '}
-      <Telephone contact={CONTACTS.VA_BENEFITS} /> or work with an accredited
+      <va-telephone contact={CONTACTS.VA_BENEFITS} /> or work with an accredited
       representative to{' '}
       <a href="/disability/get-help-filing-claim/">get help with your claim</a>.
     </p>

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
@@ -149,7 +147,7 @@ const disabilitiesList = (
       To learn more about decision review options, please visit our{' '}
       <a href={DECISION_REVIEWS_URL}>decision reviews and appeals</a>{' '}
       information page. You can call us at{' '}
-      <Telephone contact={CONTACTS.VA_BENEFITS} /> or work with an accredited
+      <va-telephone contact={CONTACTS.VA_BENEFITS} /> or work with an accredited
       representative to{' '}
       <a href="/disability/get-help-filing-claim/">get help with your claim</a>.
     </p>

--- a/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
@@ -76,7 +76,7 @@ describe('Veteran information review content', () => {
     const data = getData({ loopPages: true });
     const tree = shallow(<ContactInfoDescription {...data} />);
 
-    expect(tree.find('Telephone')).to.exist;
+    expect(tree.find('va-telephone')).to.exist;
     expect(tree.find('AddressView')).to.exist;
     expect(tree.find('Link').length).to.eq(3);
 

--- a/src/applications/disability-benefits/996/tests/components/ReviewDescription.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ReviewDescription.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('<ReviewDescription>', () => {
     const wrapper = shallow(<ReviewDescription veteran={veteran} />);
     const text = wrapper.find('dl.review').text();
     const { email, phone, address } = veteran;
-    const phoneProps = wrapper.find('Telephone').props();
+    const phoneProps = wrapper.find('va-telephone').props();
 
     expect(wrapper.find('h4').text()).to.eq('Contact information');
     expect(wrapper.find('a').props().href).to.contain(PROFILE_URL);


### PR DESCRIPTION
## Description

Update `<Telephone>` React component to the new `<va-telephone>` web component in the Higher-Level Review form

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36942

## Testing done

Updated unit test

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] All Telephone React components replaced with a `va-telephone` web component
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
