### PR TITLE
Update component-library to 6.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^6.1.1",
+    "@department-of-veterans-affairs/component-library": "^6.2.1",
     "@department-of-veterans-affairs/formation": "6.17.5",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,13 +2130,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-6.1.1.tgz#0c2cb425233e7abddc148308dc14244a6764d7de"
-  integrity sha512-vdVI64A3T5KIB8/D+wpCKSnTIpXy3R5zmrdjbtBZGnhmqOd8Eq0rD8Vl14gQclI5gLL7kS/h2NZ0AZH8A4H7BA==
+"@department-of-veterans-affairs/component-library@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-6.2.1.tgz#2d47cbd9858726222e04fc48bf689f39ec3c88e5"
+  integrity sha512-et2+yOoPWOF5Y34sC/52URjVIc/qiMXut1/GT5Bq0eELCJU+3BAM+ZPAj1FV4SfrmuyiLa82Do6hG1xfePAFCg==
   dependencies:
     "@department-of-veterans-affairs/react-components" "4.0.3"
-    "@department-of-veterans-affairs/web-components" "2.1.0"
+    "@department-of-veterans-affairs/web-components" "2.2.1"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
@@ -2192,10 +2192,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-2.1.0.tgz#d2cba7ad3553f6c29164ec264bcdcaf6bcc6b103"
-  integrity sha512-Jl4DpBSL+/e2Is7+Uxm4Un49Y6CUkmgNtOy3X4K8BhzgkeHRnPzfxHB7kGHhxIzIxEk0fNhPt3OyaRcttRO3qg==
+"@department-of-veterans-affairs/web-components@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-2.2.1.tgz#02155181e3d7b685e09d44f95a2a74bd4e9f4b81"
+  integrity sha512-v4hJFHTBP3N0qGDL8mJdHq6ZIVmZEkw41gzpUuHlRut6uGmXybkyW1wBjC9h+Wx5iT31lWHREpCg/XitM3rnpw==
   dependencies:
     "@stencil/core" "^2.10.0"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/635

### Release notes

#### [v6.2.1](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v6.2.1)

> **Fixes**
> * Fix va-breadcrumbs page reload when using Link elements

#### [v6.2.0](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v6.2.0)

> **New Features & Components 🎉**
> * Add va-pagination component

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
