### PR TITLE
Add isolated user dropdown panel for Header V2

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropDownPanel.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropDownPanel.jsx
@@ -1,0 +1,113 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+
+export default class PersonalizationDropDownPanel extends React.Component {
+  componentDidMount() {
+    document.body.addEventListener('click', this.handleDocumentClick, false);
+  }
+
+  componentWillUnmount() {
+    document.body.removeEventListener('click', this.handleDocumentClick, false);
+  }
+
+  handleDocumentClick = event => {
+    // If this dropdown is open, and it's not an element within this dropdown being clicked,
+    // then the user clicked elsewhere and we should invoke the click handler to toggle this
+    // dropdown to closed.
+    if (this.props.isOpen && !this.dropdownDiv.contains(event.target)) {
+      this.toggleDropDown(event);
+    }
+  };
+
+  toggleDropDown = event => {
+    event.stopPropagation();
+    this.props.clickHandler();
+  };
+
+  render() {
+    const buttonClasses = classNames(
+      this.props.cssClass,
+      { 'va-btn-withicon': this.props.icon },
+      'va-dropdown-trigger',
+    );
+
+    return (
+      <div
+        className="va-dropdown"
+        ref={div => {
+          this.dropdownDiv = div;
+        }}
+      >
+        <button
+          className={buttonClasses}
+          aria-controls={this.props.id}
+          aria-expanded={this.props.isOpen}
+          disabled={this.props.disabled}
+          onClick={this.toggleDropDown}
+        >
+          <span>
+            {this.props.icon}
+            {this.props.buttonText}
+          </span>
+        </button>
+        <div
+          className={`va-dropdown-panel ${this.props.dropdownPanelClassNames}`}
+          id={this.props.id}
+          hidden={!this.props.isOpen}
+        >
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}
+
+PersonalizationDropDownPanel.propTypes = {
+  /**
+   * The text of the drop down button.
+   */
+  buttonText: PropTypes.string.isRequired,
+
+  /**
+   * A function called when the drop down button is clicked. This is often used
+   * to set the open state in the parent component, which passes down the new
+   * isOpen prop.
+   */
+  clickHandler: PropTypes.func.isRequired,
+
+  /**
+   * Any CSS classes to apply to the button itself.
+   */
+  cssClass: PropTypes.string,
+
+  /**
+   * The string of classnames for the dropdown panel container.
+   */
+  dropdownPanelClassNames: PropTypes.string,
+
+  /**
+   * An SVG icon to render before the button text.
+   */
+  icon: PropTypes.node,
+
+  /**
+   * The ID of the <div> surrounding the children.
+   */
+  id: PropTypes.string,
+
+  /**
+   * Whether the drop down panel is open.
+   */
+  isOpen: PropTypes.bool.isRequired,
+
+  /**
+   * The disabled state of the drop down button.
+   */
+  disabled: PropTypes.bool,
+};
+
+PersonalizationDropDownPanel.defaultProps = {
+  dropdownPanelClassNames: '',
+  disabled: false,
+};

--- a/src/platform/site-wide/user-nav/components/SignInProfileMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SignInProfileMenu.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import DropDownPanel from '@department-of-veterans-affairs/component-library/DropDownPanel';
 import IconUser from '@department-of-veterans-affairs/component-library/IconUser';
 
+import PersonalizationDropDownPanel from './PersonalizationDropDownPanel';
 import PersonalizationDropdown from './PersonalizationDropdown';
 
 function SignInProfileMenu({ greeting, clickHandler, isOpen, disabled }) {
@@ -10,7 +10,7 @@ function SignInProfileMenu({ greeting, clickHandler, isOpen, disabled }) {
 
   return (
     <div>
-      <DropDownPanel
+      <PersonalizationDropDownPanel
         buttonText={greeting}
         clickHandler={clickHandler}
         cssClass="sign-in-drop-down-panel-button"
@@ -20,7 +20,7 @@ function SignInProfileMenu({ greeting, clickHandler, isOpen, disabled }) {
         isOpen={isOpen}
       >
         <PersonalizationDropdown />
-      </DropDownPanel>
+      </PersonalizationDropDownPanel>
     </div>
   );
 }

--- a/src/platform/site-wide/user-nav/tests/components/PersonalizationDropDownPanel.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/PersonalizationDropDownPanel.unit.spec.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import DropDown from '../../components/PersonalizationDropDownPanel';
+
+describe('<PersonalizationDropDownPanel>', () => {
+  let dropDown;
+  let clickHandler;
+  let div;
+  let props;
+
+  beforeEach(() => {
+    sinon.spy(document.body, 'addEventListener');
+    sinon.spy(document.body, 'removeEventListener');
+
+    clickHandler = sinon.spy();
+
+    props = {
+      buttonText: 'Button text',
+      clickHandler,
+      cssClass: 'testClass',
+      isOpen: true,
+      icon: (
+        <svg>
+          <rect x="50" y="50" width="50" height="50" />
+        </svg>
+      ),
+      id: 'testId',
+    };
+
+    div = document.createElement('div');
+    div.setAttribute('id', 'dropdownContainer');
+    div.setAttribute(
+      'aria-label',
+      `Component ${Math.floor(Math.random() * Math.floor(100))}`,
+    );
+
+    // axe just needs a role on a containing element
+    div.setAttribute('role', 'region');
+    document.body.appendChild(div);
+
+    dropDown = mount(
+      <DropDown {...props}>
+        <h1>Hi</h1>
+      </DropDown>,
+      {
+        attachTo: div,
+      },
+    );
+  });
+
+  afterEach(() => {
+    document.body.addEventListener.restore();
+    document.body.removeEventListener.restore();
+    document.body.removeChild(div);
+  });
+
+  it('should render', () => {
+    expect(dropDown.find('.va-dropdown-panel').text()).to.equal('Hi');
+    expect(dropDown.find('.va-dropdown-trigger').text()).to.equal(
+      'Button text',
+    );
+  });
+
+  it('should register event listeners on the parent element', () => {
+    expect(document.body.addEventListener.called).to.be.true;
+  });
+
+  it("should call clickHandler when the parent element's click event occurs", () => {
+    expect(clickHandler.called).to.be.false;
+    document.body.dispatchEvent(new window.MouseEvent('click'));
+    expect(clickHandler.called).to.be.true;
+  });
+
+  it('should unregister event listeners on the parent element', () => {
+    dropDown.unmount();
+    expect(document.body.removeEventListener.called).to.be.true;
+  });
+});

--- a/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
@@ -61,7 +61,7 @@ describe('<SearchHelpSignIn>', () => {
     const dropdown = wrapper
       .find('SignInProfileMenu')
       .dive()
-      .find('DropDownPanel')
+      .find('PersonalizationDropDownPanel')
       .dive();
     expect(dropdown.text()).to.contain(defaultProps.userGreeting);
     wrapper.unmount();


### PR DESCRIPTION
## Description
The PR addresses an issue of event bubbling with multiple DropDownPanel components in the legacy header and header v2 components in the site template. We are creating and adding an isolated component for the user dropdown in header V2 that prevents event bubbling that is causing our current dropdown component to never open. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36322

## Testing done
- [x] Unit Tests

## Screenshots
<img width="483" alt="Screen Shot 2022-02-22 at 11 40 08 AM" src="https://user-images.githubusercontent.com/6738544/155177780-8a900698-249c-4fdb-8fb1-dd96ac1c726f.png">

## Acceptance criteria
- [x] Create isolated user dropdown

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
