### PR TITLE
36168 handle no api data for personal info

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -1,18 +1,24 @@
 import { PROFILE_PATHS_LGBTQ_ENHANCEMENT } from '@@profile/constants';
 
 import { mockUser } from '@@profile/tests/fixtures/users/user';
+import mockPersonalInformation from '@@profile/tests/fixtures/personal-information-success.json';
 import mockPersonalInformationEnhanced from '@@profile/tests/fixtures/personal-information-success-enhanced.json';
 import mockServiceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import mockFullName from '@@profile/tests/fixtures/full-name-success.json';
 import mockProfileEnhancementsToggles from '@@profile/tests/fixtures/personal-information-feature-toggles.json';
 import { mockGETEndpoints } from '@@profile/tests/e2e/helpers';
 
-const setup = () => {
+const setup = (options = { mockEnhanced: false }) => {
+  const { mockEnhanced } = options;
   cy.login(mockUser);
-  cy.intercept(
-    'v0/profile/personal_information',
-    mockPersonalInformationEnhanced,
-  );
+  if (mockEnhanced) {
+    cy.intercept(
+      'v0/profile/personal_information',
+      mockPersonalInformationEnhanced,
+    );
+  } else {
+    cy.intercept('v0/profile/personal_information', mockPersonalInformation);
+  }
   cy.intercept('v0/profile/service_history', mockServiceHistory);
   cy.intercept('v0/profile/full_name', mockFullName);
   cy.intercept('v0/feature_toggles*', mockProfileEnhancementsToggles);
@@ -29,117 +35,129 @@ const setup = () => {
   cy.findByRole('progressbar').should('not.exist');
 };
 
+const checkPersonalInfoFields = () => {
+  // preferred name field
+  const nameEditButtonLabel = 'Edit Preferred name';
+  const nameEditInputLabel =
+    'Provide your preferred name (25 characters maximum)';
+  const nameEditInputField = 'input[name="root_preferredName"]';
+
+  cy.findByLabelText(nameEditButtonLabel)
+    .should('exist')
+    .click();
+
+  cy.findByText(nameEditInputLabel).should('exist');
+
+  cy.get(nameEditInputField).should('exist');
+
+  cy.findAllByTestId('cancel-edit-button')
+    .should('exist')
+    .click();
+
+  cy.findByText(nameEditInputLabel).should('not.exist');
+
+  cy.get(nameEditInputField).should('not.exist');
+
+  // pronoun fields
+  const pronounsEditButtonLabel = 'Edit Pronouns';
+  const pronounsEditInputLabel = 'Select all of your pronouns';
+  const pronounsEditInputField = 'input[name="root_pronounsNotListedText"]';
+
+  cy.findByLabelText(pronounsEditButtonLabel)
+    .should('exist')
+    .click();
+
+  cy.findByText(pronounsEditInputLabel).should('exist');
+
+  cy.get(pronounsEditInputField).should('exist');
+  cy.findByText('He/him/his').should('exist');
+  cy.findByText('She/her/hers').should('exist');
+  cy.findByText('They/them/theirs').should('exist');
+  cy.findByText('Ze/zir/zirs').should('exist');
+  cy.findByText('Use my preferred name').should('exist');
+  cy.findByText('Pronouns not listed here').should('exist');
+  cy.findByText(
+    'If not listed, please provide your preferred pronouns (255 characters maximum)',
+  ).should('exist');
+
+  cy.findAllByTestId('cancel-edit-button')
+    .should('exist')
+    .click();
+
+  cy.findByText(pronounsEditInputLabel).should('not.exist');
+
+  cy.get(pronounsEditInputField).should('not.exist');
+
+  // gender fields
+  const genderEditButtonLabel = 'Edit Gender identity';
+  const genderEditInputLabel = 'Select your gender identity';
+
+  cy.findByLabelText(genderEditButtonLabel)
+    .should('exist')
+    .click();
+
+  cy.findByText(genderEditInputLabel).should('exist');
+
+  cy.findByText('Woman').should('exist');
+  cy.findByText('Man').should('exist');
+  cy.findByText('Transgender woman').should('exist');
+  cy.findByText('Transgender man').should('exist');
+  cy.findByText('Non-binary').should('exist');
+  cy.findByText('Prefer not to answer (un-checks other options)').should(
+    'exist',
+  );
+  cy.findByText('A gender not listed here').should('exist');
+
+  cy.findAllByTestId('cancel-edit-button')
+    .should('exist')
+    .click();
+
+  cy.findByText(genderEditInputLabel).should('not.exist');
+
+  // sexual orientation fields
+  const sexualOrientationEditButtonLabel = 'Edit Sexual orientation';
+  const sexualOrientationEditInputLabel = 'Select your sexual orientation';
+  const sexualOrientationEditInputField =
+    'input[name="root_sexualOrientationNotListedText"]';
+
+  cy.findByLabelText(sexualOrientationEditButtonLabel)
+    .should('exist')
+    .click();
+
+  cy.get(sexualOrientationEditInputField).should('exist');
+  cy.findByText(sexualOrientationEditInputLabel).should('exist');
+  cy.findByText('Lesbian, gay, or homosexual').should('exist');
+  cy.findByText('Straight or heterosexual').should('exist');
+  cy.findByText('Bisexual').should('exist');
+  cy.findByText('Queer').should('exist');
+  cy.findByText('Don’t know').should('exist');
+  cy.findByText('Prefer not to answer (un-checks other options)').should(
+    'exist',
+  );
+  cy.findByText('A sexual orientation not listed here').should('exist');
+
+  cy.findAllByTestId('cancel-edit-button')
+    .should('exist')
+    .click();
+
+  cy.findByText(sexualOrientationEditInputLabel).should('not.exist');
+
+  cy.get(sexualOrientationEditInputField).should('not.exist');
+};
+
 describe('Content in EDIT state on the personal information page', () => {
-  it('should render each edit field with update/cancel buttons, and remove field on cancel', () => {
-    setup();
+  it('should render each edit field with update/cancel buttons and remove field on cancel, when enhanced api data is present.', () => {
+    setup({ mockEnhanced: true });
 
-    // preferred name field
-    const nameEditButtonLabel = 'Edit Preferred name';
-    const nameEditInputLabel =
-      'Provide your preferred name (25 characters maximum)';
-    const nameEditInputField = 'input[name="root_preferredName"]';
+    checkPersonalInfoFields();
 
-    cy.findByLabelText(nameEditButtonLabel)
-      .should('exist')
-      .click();
+    cy.axeCheck();
+  });
 
-    cy.findByText(nameEditInputLabel).should('exist');
+  it('should render each edit field with update/cancel buttons even when no applicable data is present', () => {
+    setup({ mockEnhanced: false });
 
-    cy.get(nameEditInputField).should('exist');
-
-    cy.findAllByTestId('cancel-edit-button')
-      .should('exist')
-      .click();
-
-    cy.findByText(nameEditInputLabel).should('not.exist');
-
-    cy.get(nameEditInputField).should('not.exist');
-
-    // pronoun fields
-    const pronounsEditButtonLabel = 'Edit Pronouns';
-    const pronounsEditInputLabel = 'Select all of your pronouns';
-    const pronounsEditInputField = 'input[name="root_pronounsNotListedText"]';
-
-    cy.findByLabelText(pronounsEditButtonLabel)
-      .should('exist')
-      .click();
-
-    cy.findByText(pronounsEditInputLabel).should('exist');
-
-    cy.get(pronounsEditInputField).should('exist');
-    cy.findByText('He/him/his').should('exist');
-    cy.findByText('She/her/hers').should('exist');
-    cy.findByText('They/them/theirs').should('exist');
-    cy.findByText('Ze/zir/zirs').should('exist');
-    cy.findByText('Use my preferred name').should('exist');
-    cy.findByText('Pronouns not listed here').should('exist');
-    cy.findByText(
-      'If not listed, please provide your preferred pronouns (255 characters maximum)',
-    ).should('exist');
-
-    cy.findAllByTestId('cancel-edit-button')
-      .should('exist')
-      .click();
-
-    cy.findByText(pronounsEditInputLabel).should('not.exist');
-
-    cy.get(pronounsEditInputField).should('not.exist');
-
-    // gender fields
-    const genderEditButtonLabel = 'Edit Gender identity';
-    const genderEditInputLabel = 'Select your gender identity';
-
-    cy.findByLabelText(genderEditButtonLabel)
-      .should('exist')
-      .click();
-
-    cy.findByText(genderEditInputLabel).should('exist');
-
-    cy.findByText('Woman').should('exist');
-    cy.findByText('Man').should('exist');
-    cy.findByText('Transgender woman').should('exist');
-    cy.findByText('Transgender man').should('exist');
-    cy.findByText('Non-binary').should('exist');
-    cy.findByText('Prefer not to answer (un-checks other options)').should(
-      'exist',
-    );
-    cy.findByText('A gender not listed here').should('exist');
-
-    cy.findAllByTestId('cancel-edit-button')
-      .should('exist')
-      .click();
-
-    cy.findByText(genderEditInputLabel).should('not.exist');
-
-    // sexual orientation fields
-    const sexualOrientationEditButtonLabel = 'Edit Sexual orientation';
-    const sexualOrientationEditInputLabel = 'Select your sexual orientation';
-    const sexualOrientationEditInputField =
-      'input[name="root_sexualOrientationNotListedText"]';
-
-    cy.findByLabelText(sexualOrientationEditButtonLabel)
-      .should('exist')
-      .click();
-
-    cy.get(sexualOrientationEditInputField).should('exist');
-    cy.findByText(sexualOrientationEditInputLabel).should('exist');
-    cy.findByText('Lesbian, gay, or homosexual').should('exist');
-    cy.findByText('Straight or heterosexual').should('exist');
-    cy.findByText('Bisexual').should('exist');
-    cy.findByText('Queer').should('exist');
-    cy.findByText('Don’t know').should('exist');
-    cy.findByText('Prefer not to answer (un-checks other options)').should(
-      'exist',
-    );
-    cy.findByText('A sexual orientation not listed here').should('exist');
-
-    cy.findAllByTestId('cancel-edit-button')
-      .should('exist')
-      .click();
-
-    cy.findByText(sexualOrientationEditInputLabel).should('not.exist');
-
-    cy.get(sexualOrientationEditInputField).should('not.exist');
+    checkPersonalInfoFields();
 
     cy.axeCheck();
   });

--- a/src/applications/personalization/profile/util/contact-information/formValues.js
+++ b/src/applications/personalization/profile/util/contact-information/formValues.js
@@ -19,7 +19,7 @@ const isOverseasMilitaryMailingAddress = data =>
   data?.addressType === ADDRESS_TYPES.OVERSEAS_MILITARY;
 
 const transformBooleanArrayToFormValues = valuesAsArray => {
-  return valuesAsArray.reduce((previous, current) => {
+  return valuesAsArray?.reduce((previous, current) => {
     const result = { ...previous };
     result[current] = true;
     return result;
@@ -93,16 +93,16 @@ export const getInitialFormValues = options => {
 
     if (fieldName === 'genderIdentity') {
       return transformInitialFormValues(
-        transformBooleanArrayToFormValues(data[fieldName]),
+        transformBooleanArrayToFormValues(data?.[fieldName]),
       );
     }
 
     const notListedTextKey = createNotListedTextKey(fieldName);
 
     return transformInitialFormValues({
-      ...transformBooleanArrayToFormValues(data[fieldName]),
+      ...transformBooleanArrayToFormValues(data?.[fieldName]),
       ...(data?.[notListedTextKey] &&
-        set({}, notListedTextKey, data[notListedTextKey])),
+        set({}, notListedTextKey, data?.[notListedTextKey])),
     });
   }
 


### PR DESCRIPTION
## Description
Handles edge case where the personal information endpoint would not return any applicable field data for the new sections of the profile, and therefore the edit mode of the fields would not render when edit button was clicked. This PR checks for that missing data and will render them regardless of data being present.

This will mostly be mitigated once vets-api starts actually returning this data live, but to cover this edge case and also to make it render on staging as-is we need these checks in place.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36168


## Testing done
Added e2e test to check both the mocked api data and no data returned edge case

## Screenshots


## Acceptance criteria
- [x] Fields render when no data for fields is returned from endpoint

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
