### PR TITLE
36549 - [Debt Letters] Replace deprecated AdditionalInfo component

### DIFF
--- a/src/applications/debt-letters/components/DebtDetails.jsx
+++ b/src/applications/debt-letters/components/DebtDetails.jsx
@@ -7,7 +7,6 @@ import head from 'lodash/head';
 import last from 'lodash/last';
 import first from 'lodash/first';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
@@ -115,9 +114,9 @@ const DebtDetails = ({ selectedDebt, debts }) => {
             {additionalInfo.nextStep}
           </va-alert>
           {whyContent && (
-            <AdditionalInfo triggerText="Why might I have this debt?">
+            <va-additional-info trigger="Why might I have this debt?">
               {whyContent}
-            </AdditionalInfo>
+            </va-additional-info>
           )}
           <OnThisPageLinks isDetailsPage hasHistory={hasFilteredHistory} />
           {hasFilteredHistory && (


### PR DESCRIPTION
## Description
Replaced deprecated component (`AdditionalInfo`) with platform equivalent `va-additional-info`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36549


## Testing done


## Screenshots

![Screen Shot 2022-02-22 at 2 01 09 PM](https://user-images.githubusercontent.com/29178824/155202482-e3d14efd-5046-4e6c-b2fe-c6cdd66be451.png)

## Acceptance criteria
- [ X] Component replaced

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
