### PR TITLE
Fix meb direct deposit edit break bug

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -278,7 +278,7 @@ function AdditionalConsiderationTemplate(page, formField) {
     additionalInfoView = {
       [additionalInfoViewName]: {
         'ui:description': (
-          <va-additional-info triggerText={additionalInfo.triggerText}>
+          <va-additional-info trigger={additionalInfo.triggerText}>
             <p>{additionalInfo.info}</p>
           </va-additional-info>
         ),
@@ -1072,7 +1072,7 @@ const formConfig = {
                       application.
                     </strong>
                   </p>
-                  <va-additional-info triggerText="Why do I have to give up a benefit?">
+                  <va-additional-info trigger="Why do I have to give up a benefit?">
                     <p>
                       The law says if you are eligible for both the Post-9/11 GI
                       Bill and another education benefit based on the same

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -7,7 +7,6 @@ import { createSelector } from 'reselect';
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import preSubmitInfo from 'platform/forms/preSubmitInfo';
 import FormFooter from 'platform/forms/components/FormFooter';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
@@ -16,9 +15,8 @@ import dateUI from 'platform/forms-system/src/js/definitions/date';
 import * as address from 'platform/forms-system/src/js/definitions/address';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import environment from 'platform/utilities/environment';
-import merge from 'lodash/merge';
 import bankAccountUI from 'platform/forms/definitions/bankAccount';
-import { vagovprod } from 'site/constants/buckets';
+import { vagovprod, VAGOVSTAGING } from 'site/constants/buckets';
 import fullSchema from '../22-1990-schema.json';
 
 // In a real app this would not be imported directly; instead the schema you
@@ -60,7 +58,6 @@ import {
 } from '../utils/validation';
 
 import { createSubmissionForm } from '../utils/form-submit-transform';
-import createDirectDepositPage from '../../edu-benefits/pages/directDeposit';
 import { directDepositDescription } from '../../edu-benefits/1990/helpers';
 
 import { ELIGIBILITY } from '../actions';
@@ -281,9 +278,9 @@ function AdditionalConsiderationTemplate(page, formField) {
     additionalInfoView = {
       [additionalInfoViewName]: {
         'ui:description': (
-          <AdditionalInfo triggerText={additionalInfo.triggerText}>
+          <va-additional-info triggerText={additionalInfo.triggerText}>
             <p>{additionalInfo.info}</p>
-          </AdditionalInfo>
+          </va-additional-info>
         ),
       },
     };
@@ -347,6 +344,10 @@ function transform(metaData, form) {
   const submission = createSubmissionForm(form.data);
   return JSON.stringify(submission);
 }
+
+const checkImageSrc = environment.isStaging()
+  ? `${VAGOVSTAGING}/img/check-sample.png`
+  : `${vagovprod}/img/check-sample.png`;
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -850,7 +851,7 @@ const formConfig = {
             },
             'view:textMessagesAlert': {
               'ui:description': (
-                <va-alert onClose={function noRefCheck() {}} status="info">
+                <va-alert status="info">
                   <>
                     If you choose to get text message notifications from VA’s GI
                     Bill program, message and data rates may apply. Two messages
@@ -881,7 +882,7 @@ const formConfig = {
             },
             'view:noMobilePhoneAlert': {
               'ui:description': (
-                <va-alert onClose={function noRefCheck() {}} status="warning">
+                <va-alert status="warning">
                   <>
                     You can’t choose to get text message notifications because
                     we don’t have a mobile phone number on file for you.
@@ -902,7 +903,7 @@ const formConfig = {
             },
             'view:internationalTextMessageAlert': {
               'ui:description': (
-                <va-alert onClose={function noRefCheck() {}} status="warning">
+                <va-alert status="warning">
                   <>
                     You can’t choose to get text notifications because you have
                     an international mobile phone number. At this time, we can
@@ -1071,7 +1072,7 @@ const formConfig = {
                       application.
                     </strong>
                   </p>
-                  <AdditionalInfo triggerText="Why do I have to give up a benefit?">
+                  <va-additional-info triggerText="Why do I have to give up a benefit?">
                     <p>
                       The law says if you are eligible for both the Post-9/11 GI
                       Bill and another education benefit based on the same
@@ -1079,7 +1080,7 @@ const formConfig = {
                       qualifying period of active duty can only be used for one
                       VA education benefit.
                     </p>
-                  </AdditionalInfo>
+                  </va-additional-info>
                 </>
               ),
             },
@@ -1287,50 +1288,66 @@ const formConfig = {
     bankAccountInfoChapter: {
       title: 'Direct deposit',
       pages: {
-        [formPages.directDeposit]: merge(
-          {},
-          createDirectDepositPage(fullSchema),
-          {
-            path: 'direct-deposit',
-            uiSchema: {
-              'ui:description': directDepositDescription,
+        [formPages.directDeposit]: {
+          path: 'direct-deposit',
+          uiSchema: {
+            'ui:description': directDepositDescription,
+            bankAccount: {
+              ...bankAccountUI,
+              'ui:order': ['accountType', 'accountNumber', 'routingNumber'],
+            },
+            'view:learnMore': {
+              'ui:description': (
+                <>
+                  <img
+                    key="check-image-src"
+                    style={{ marginTop: '1rem' }}
+                    src={checkImageSrc}
+                    alt="Example of a check showing where the account and routing numbers are"
+                  />
+                  <p key="learn-more-title">Where can I find these numbers?</p>
+                  <p key="learn-more-description">
+                    The bank routing number is the first 9 digits on the bottom
+                    left corner of a printed check. Your account number is the
+                    second set of numbers on the bottom of a printed check, just
+                    to the right of the bank routing number.
+                  </p>
+                  <va-additional-info key="learn-more-btn" trigger="Learn More">
+                    <p key="btn-copy">
+                      If you don’t have a printed check, you can sign in to your
+                      online banking institution for this information
+                    </p>
+                  </va-additional-info>
+                </>
+              ),
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
               bankAccount: {
-                ...bankAccountUI,
-                'ui:order': [
-                  'accountType',
-                  'accountNumber',
-                  'routingNumber',
-                  'learnMore',
-                ],
-                learnMore: {
-                  'ui:description': (
-                    <>
-                      <img
-                        style={{ marginTop: '1rem' }}
-                        src={`${vagovprod}/img/check-sample.png`}
-                        alt="Example of a check showing where the account and routing numbers are"
-                      />
-                      <p>Where can I find these numbers?</p>
-                      <p>
-                        The bank routing number is the first 9 digits on the
-                        bottom left corner of a printed check. Your account
-                        number is the second set of numbers on the bottom of a
-                        printed check, just to the right of the bank routing
-                        number.
-                      </p>
-                      <va-additional-info trigger="Learn More">
-                        <p key="2b">
-                          If you don’t have a printed check, you can sign in to
-                          your online banking institution for this information
-                        </p>
-                      </va-additional-info>
-                    </>
-                  ),
+                type: 'object',
+                properties: {
+                  accountType: {
+                    type: 'string',
+                    enum: ['checking', 'savings'],
+                  },
+                  routingNumber: {
+                    type: 'string',
+                    pattern: '^\\d{9}$',
+                  },
+                  accountNumber: {
+                    type: 'string',
+                  },
                 },
+              },
+              'view:learnMore': {
+                type: 'object',
+                properties: {},
               },
             },
           },
-        ),
+        },
       },
     },
   },


### PR DESCRIPTION
## Description
Fixes a bug in form 22-1990 , when user reaches /education/apply-for-benefits-form-22-1990/review-and-submit, upon clicking on EDIT for the Direct Deposit, the entire UI breaks, related to the ui:order list

Also adds a condition for the check image, to load pro or staging image source.
Also updated deprecated <AdditionInfo/> to <va-additional-info>


## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
