### PR TITLE
331440 authd delete field context change check

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -100,7 +100,7 @@ const checkRemovalWhileEditingModal = options => {
 };
 
 describe('Modals for removal of field', () => {
-  it('should show edit notive modal when attempting to remove field after editing another field', () => {
+  it('should show edit notice modal when attempting to remove field after editing another field', () => {
     setup(false);
 
     checkRemovalWhileEditingModal({
@@ -117,6 +117,8 @@ describe('Modals for removal of field', () => {
       editSectionName: 'mailing address',
       removalSectionName: 'contact email address',
     });
+
+    cy.axeCheck();
   });
 });
 
@@ -158,6 +160,8 @@ describe('Modals on the personal information and content page', () => {
       editLineId: 'root_emailAddress',
       sectionName: 'contact email address',
     });
+
+    cy.axeCheck();
   });
 
   it('should render as expected on Mobile', () => {
@@ -197,6 +201,8 @@ describe('Modals on the personal information and content page', () => {
       editLineId: 'root_emailAddress',
       sectionName: 'contact email address',
     });
+
+    cy.axeCheck();
   });
 });
 
@@ -232,6 +238,8 @@ describe('Modals on the personal information and content page after editing', ()
 
     // verify input exists
     cy.findByLabelText(/email address/i);
+
+    cy.axeCheck();
   });
 });
 
@@ -270,6 +278,8 @@ describe('when moving to other profile sections', () => {
     cy.findByRole('button', {
       name: new RegExp(`edit ${sectionName}`, 'i'),
     }).should('exist');
+
+    cy.axeCheck();
   });
 });
 
@@ -295,5 +305,7 @@ describe('Modals on the personal information and content page when they error', 
 
     // expect an error to be shown
     cy.findByTestId('edit-error-alert').should('exist');
+
+    cy.axeCheck();
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -67,6 +67,59 @@ const checkModals = options => {
   });
 };
 
+const checkRemovalWhileEditingModal = options => {
+  const { editSectionName, removalSectionName } = options;
+
+  // Open edit view
+  cy.findByRole('button', {
+    name: new RegExp(`edit ${editSectionName}`, 'i'),
+  }).click({
+    force: true,
+  });
+
+  // Attempt to remove a different field
+  cy.findByRole('button', {
+    name: new RegExp(`remove ${removalSectionName}`, 'i'),
+  }).click({
+    force: true,
+  });
+
+  // Modal appears
+  cy.get('.va-modal').within(() => {
+    cy.contains(`You’re currently editing your ${editSectionName}`).should(
+      'exist',
+    );
+    cy.findByRole('button', { name: /OK/i }).click({
+      force: true,
+    });
+  });
+
+  cy.findByTestId('cancel-edit-button').click({
+    force: true,
+  });
+};
+
+describe('Modals for removal of field', () => {
+  it('should show edit notive modal when attempting to remove field after editing another field', () => {
+    setup(false);
+
+    checkRemovalWhileEditingModal({
+      editSectionName: 'mailing address',
+      removalSectionName: 'home address',
+    });
+
+    checkRemovalWhileEditingModal({
+      editSectionName: 'home phone number',
+      removalSectionName: 'mobile phone number',
+    });
+
+    checkRemovalWhileEditingModal({
+      editSectionName: 'mailing address',
+      removalSectionName: 'contact email address',
+    });
+  });
+});
+
 describe('Modals on the personal information and content page', () => {
   it('should render as expected on Desktop', () => {
     setup();

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -19,6 +19,8 @@ const setup = (mobile = false) => {
   // and then the loading indicator should be removed
   cy.findByText(/loading your information/i).should('not.exist');
   cy.findByRole('progressbar').should('not.exist');
+
+  cy.injectAxe();
 };
 
 const checkModals = options => {

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -253,6 +253,10 @@ class ProfileInformationFieldController extends React.Component {
   };
 
   openRemoveModal = () => {
+    if (this.props.blockEditMode) {
+      this.setState({ showCannotEditModal: true });
+      return;
+    }
     this.props.openModal(`remove-${this.props.fieldName}`);
   };
 


### PR DESCRIPTION
## Description
When deleting a field, we need to check that no current fields are currently in an 'edit state' before prompting to confirm deletion, or else the user would lose any mid-edit changes that had been made. This PR checks for edit state and shows the appropriate edit alert modal if needed.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31440


## Testing done
Added e2e test for this logic

## Acceptance criteria
- [x] Editing modal is displayed when field deletion is attempted mid-edit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
