### PR TITLE
Wrap Legacy & V2 header layouts in global header element

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -2,101 +2,104 @@ import { replaceWithStagingDomain } from 'platform/utilities/environment/staging
 
 export default `
   <!-- Header -->
-  <div
-    data-widget-type="header"
-    data-show="{{ !noHeader }}"
-    data-show-nav-login="{{ !noNavOrLogin }}"
-    data-show-mega-menu="{{ !noMegamenu }}"
-    id="header-v2"
-  ></div>
+  <header class="header merger" role="banner">
+    <!-- Mobile Layout -->
+    <div
+      data-widget-type="header"
+      data-show="{{ !noHeader }}"
+      data-show-nav-login="{{ !noNavOrLogin }}"
+      data-show-mega-menu="{{ !noMegamenu }}"
+      id="header-v2"
+    ></div>
 
-  <!-- Legacy Header -->
-  <header class="header merger" id="legacy-header" role="banner">
-    <div class="incompatible-browser-warning">
-      <div class="row full">
-        <div class="small-12">
-          Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
+    <!-- Tablet/Desktop Layout -->
+    <div id="legacy-header" class="vads-u-display--none">
+      <div class="incompatible-browser-warning">
+        <div class="row full">
+          <div class="small-12">
+            Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
+          </div>
         </div>
       </div>
-    </div>
 
-    <div id="preview-site-alert"></div>
+      <div id="preview-site-alert"></div>
 
-    <div class="va-notice--banner">
-      <div class="va-notice--banner-inner">
-        <!-- /va-gov/includes/usa-website-header.html -->
-        <div class="usa-banner">
-          <div class="usa-accordion">
-            <div class="usa-banner-header">
-              <div class="usa-grid usa-banner-inner">
-              <img src="${replaceWithStagingDomain(
-                'https://www.va.gov/img/tiny-usa-flag.png',
-              )}" alt="U.S. flag">
-              <p>An official website of the United States government</p>
-              <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
-                <span class="usa-banner-button-text">Here&rsquo;s how you know</span>
-              </button>
-              </div>
-            </div>
-            <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
-              <div class="usa-banner-guidance-gov usa-width-one-half">
-                <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
-                  'https://www.va.gov/img/icon-dot-gov.svg',
-                )}" alt="Dot gov">
-                <div class="usa-media_block-body">
-                  <p>
-                    <strong>The .gov means it&rsquo;s official.</strong>
-                    <br>
-                    Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
-                  </p>
+      <div class="va-notice--banner">
+        <div class="va-notice--banner-inner">
+          <!-- /va-gov/includes/usa-website-header.html -->
+          <div class="usa-banner">
+            <div class="usa-accordion">
+              <div class="usa-banner-header">
+                <div class="usa-grid usa-banner-inner">
+                <img src="${replaceWithStagingDomain(
+                  'https://www.va.gov/img/tiny-usa-flag.png',
+                )}" alt="U.S. flag">
+                <p>An official website of the United States government</p>
+                <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
+                  <span class="usa-banner-button-text">Here&rsquo;s how you know</span>
+                </button>
                 </div>
               </div>
-              <div class="usa-banner-guidance-ssl usa-width-one-half">
-                <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
-                  'https://www.va.gov/img/icon-https.svg',
-                )}" alt="SSL">
-                <div class="usa-media_block-body">
-                  <p>
-                    <strong>The site is secure.</strong>
-                    <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
-                  </p>
+              <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
+                <div class="usa-banner-guidance-gov usa-width-one-half">
+                  <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
+                    'https://www.va.gov/img/icon-dot-gov.svg',
+                  )}" alt="Dot gov">
+                  <div class="usa-media_block-body">
+                    <p>
+                      <strong>The .gov means it&rsquo;s official.</strong>
+                      <br>
+                      Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
+                    </p>
+                  </div>
+                </div>
+                <div class="usa-banner-guidance-ssl usa-width-one-half">
+                  <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
+                    'https://www.va.gov/img/icon-https.svg',
+                  )}" alt="SSL">
+                  <div class="usa-media_block-body">
+                    <p>
+                      <strong>The site is secure.</strong>
+                      <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
+          <!-- /va-gov/includes/usa-website-header.html -->
         </div>
-        <!-- /va-gov/includes/usa-website-header.html -->
+        <div class="va-crisis-line-container">
+          <button data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
+            <div class="va-crisis-line-inner">
+              <span class="va-crisis-line-icon" aria-hidden="true"></span>
+              <span class="va-crisis-line-text">Talk to the <strong>Veterans Crisis Line</strong> now</span>
+              <img class="va-crisis-line-arrow" src="${replaceWithStagingDomain(
+                'https://www.va.gov/img/arrow-right-white.svg',
+              )}" aria-hidden="true"></img>
+            </div>
+          </button>
+        </div>
       </div>
-      <div class="va-crisis-line-container">
-        <button data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
-          <div class="va-crisis-line-inner">
-            <span class="va-crisis-line-icon" aria-hidden="true"></span>
-            <span class="va-crisis-line-text">Talk to the <strong>Veterans Crisis Line</strong> now</span>
-            <img class="va-crisis-line-arrow" src="${replaceWithStagingDomain(
-              'https://www.va.gov/img/arrow-right-white.svg',
-            )}" aria-hidden="true"></img>
-          </div>
-        </button>
-      </div>
-    </div>
-    <!-- /header alert box -->
+      <!-- /header alert box -->
 
-    <div class="row va-flex usa-grid" id="va-header-logo-menu">
-      <div class="va-header-logo-wrapper">
-        <a href="${replaceWithStagingDomain(
-          'https://www.va.gov',
-        )}" class="va-header-logo">
-        <img src="${replaceWithStagingDomain(
-          'https://www.va.gov/img/header-logo.png',
-        )}" alt="Go to VA.gov"/>
-        </a>
+      <div class="row va-flex usa-grid" id="va-header-logo-menu">
+        <div class="va-header-logo-wrapper">
+          <a href="${replaceWithStagingDomain(
+            'https://www.va.gov',
+          )}" class="va-header-logo">
+          <img src="${replaceWithStagingDomain(
+            'https://www.va.gov/img/header-logo.png',
+          )}" alt="Go to VA.gov"/>
+          </a>
+        </div>
+        <div id="va-nav-controls"></div>
+        <div id="login-root" class="vet-toolbar"></div>
       </div>
-      <div id="va-nav-controls"></div>
-      <div id="login-root" class="vet-toolbar"></div>
-    </div>
-    <div class="usa-grid usa-grid-full">
-      <div class="menu-rule usa-one-whole"></div>
-      <div id="mega-menu"></div>
+      <div class="usa-grid usa-grid-full">
+        <div class="menu-rule usa-one-whole"></div>
+        <div id="mega-menu"></div>
+      </div>
     </div>
   </header>
 `;

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -57,89 +57,93 @@
     <a class="show-on-focus" href="#content" onclick="focusContent(event)">Skip to Content</a>
 
     <!-- Header -->
-    <div
-      data-widget-type="header"
-      data-show="{{ !noHeader }}"
-      data-show-nav-login="{{ !noNavOrLogin }}"
-      data-show-mega-menu="{{ !noMegamenu }}"
-      id="header-v2"
-    ></div>
+    <header class="header" role="banner">
+      <!-- Mobile Layout -->
+      <div
+        data-widget-type="header"
+        data-show="{{ !noHeader }}"
+        data-show-nav-login="{{ !noNavOrLogin }}"
+        data-show-mega-menu="{{ !noMegamenu }}"
+        id="header-v2"
+      ></div>
 
-    <!-- Legacy Header -->
-    <header class="header" id="legacy-header" role="banner">
-      <div class="incompatible-browser-warning">
-        <div class="row full">
-          <div class="small-12">
-            Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
+      <!-- Tablet/Desktop Layout -->
+      <div id="legacy-header" class="vads-u-display--none">
+        <div class="incompatible-browser-warning">
+          <div class="row full">
+            <div class="small-12">
+              Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
+            </div>
           </div>
         </div>
-      </div>
 
-      <!-- USA website banner -->
-      <div class="va-notice--banner">
-        <div class="va-notice--banner-inner">
-          <div class="usa-banner">
-            <div class="usa-accordion">
-              <div class="usa-banner-header">
-                <div class="usa-grid usa-banner-inner">
-                  <img src="/img/tiny-usa-flag.png" alt="U.S. flag">
-                  <p>An official website of the United States government</p>
-                  <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
-                    <span class="usa-banner-button-text">Here’s how you know</span>
-                  </button>
-                </div>
-              </div>
-              <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
-                <div class="usa-banner-guidance-gov usa-width-one-half">
-                  <img class="usa-banner-icon usa-media_block-img" src="/img/icon-dot-gov.svg" alt="Dot gov">
-                  <div class="usa-media_block-body">
-                    <p>
-                      <strong>The .gov means it’s official.</strong>
-                      <br>
-                      Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
-                    </p>
+        <!-- USA website banner -->
+        <div class="va-notice--banner">
+          <div class="va-notice--banner-inner">
+            <div class="usa-banner">
+              <div class="usa-accordion">
+                <div class="usa-banner-header">
+                  <div class="usa-grid usa-banner-inner">
+                    <img src="/img/tiny-usa-flag.png" alt="U.S. flag">
+                    <p>An official website of the United States government</p>
+                    <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
+                      <span class="usa-banner-button-text">Here’s how you know</span>
+                    </button>
                   </div>
                 </div>
-                <div class="usa-banner-guidance-ssl usa-width-one-half">
-                  <img class="usa-banner-icon usa-media_block-img" src="/img/icon-https.svg" alt="SSL">
-                  <div class="usa-media_block-body">
-                    <p>
-                      <strong>The site is secure.</strong>
-                      <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
-                    </p>
+                <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
+                  <div class="usa-banner-guidance-gov usa-width-one-half">
+                    <img class="usa-banner-icon usa-media_block-img" src="/img/icon-dot-gov.svg" alt="Dot gov">
+                    <div class="usa-media_block-body">
+                      <p>
+                        <strong>The .gov means it’s official.</strong>
+                        <br>
+                        Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
+                      </p>
+                    </div>
+                  </div>
+                  <div class="usa-banner-guidance-ssl usa-width-one-half">
+                    <img class="usa-banner-icon usa-media_block-img" src="/img/icon-https.svg" alt="SSL">
+                    <div class="usa-media_block-body">
+                      <p>
+                        <strong>The site is secure.</strong>
+                        <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-        </div>        </div>
-        <div class="va-crisis-line-container">
-          <button onclick="recordEvent({ event: 'nav-crisis-header' })" data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
-            <div class="va-crisis-line-inner">
-              <span class="va-crisis-line-icon" aria-hidden="true"></span>
-              <span class="va-crisis-line-text" onClick="recordEvent({ event: 'nav-jumplink-click' });">Talk to the <strong>Veterans Crisis Line</strong> now</span>
-              <img class="va-crisis-line-arrow" src="/img/arrow-right-white.svg" aria-hidden="true"/>
-            </div>
-          </button>
+          </div>
+          <div class="va-crisis-line-container">
+            <button onclick="recordEvent({ event: 'nav-crisis-header' })" data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
+              <div class="va-crisis-line-inner">
+                <span class="va-crisis-line-icon" aria-hidden="true"></span>
+                <span class="va-crisis-line-text" onClick="recordEvent({ event: 'nav-jumplink-click' });">Talk to the <strong>Veterans Crisis Line</strong> now</span>
+                <img class="va-crisis-line-arrow" src="/img/arrow-right-white.svg" aria-hidden="true"/>
+              </div>
+            </button>
+          </div>
         </div>
-      </div>
-      <!-- End USA website banner -->
+        <!-- End USA website banner -->
 
-      <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
-        <div class="va-header-logo-wrapper">
-          <a href="/" class="va-header-logo">
-            <img src="/img/header-logo.png" alt="Go to VA.gov"/>
-          </a>
+        <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
+          <div class="va-header-logo-wrapper">
+            <a href="/" class="va-header-logo">
+              <img src="/img/header-logo.png" alt="Go to VA.gov"/>
+            </a>
+          </div>
+          <div id="va-nav-controls"></div>
+          <div class="medium-screen:vads-u-display--none usa-grid usa-grid-full">
+            <div class="menu-rule usa-one-whole"></div>
+            <div class="mega-menu" id="mega-menu-mobile"></div>
+          </div>
+          <div id="login-root" class="vet-toolbar"></div>
         </div>
-        <div id="va-nav-controls"></div>
-        <div class="medium-screen:vads-u-display--none usa-grid usa-grid-full">
+        <div class="usa-grid usa-grid-full">
           <div class="menu-rule usa-one-whole"></div>
-          <div class="mega-menu" id="mega-menu-mobile"></div>
+          <div id="mega-menu"></div>
         </div>
-        <div id="login-root" class="vet-toolbar"></div>
-      </div>
-      <div class="usa-grid usa-grid-full">
-        <div class="menu-rule usa-one-whole"></div>
-        <div id="mega-menu"></div>
       </div>
     </header>
 

--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -19,10 +19,7 @@ export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
   }, []);
 
   return (
-    <header
-      className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0"
-      role="banner"
-    >
+    <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0">
       {/* Official government website banner */}
       <OfficialGovtWebsite />
 
@@ -44,7 +41,7 @@ export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
           showMegaMenu={showMegaMenu}
         />
       </nav>
-    </header>
+    </div>
   );
 };
 

--- a/src/platform/site-wide/sass/modules/_m-header.scss
+++ b/src/platform/site-wide/sass/modules/_m-header.scss
@@ -1,0 +1,14 @@
+//Site Header Overrides
+.header {
+    min-height: 121px;
+}
+
+#legacy-header {
+    min-height: 189.19px;
+}
+
+@media screen and (min-width: 481px) {
+  #legacy-header {
+    min-height: 167.19px;
+  }
+}

--- a/src/platform/site-wide/sass/style.scss
+++ b/src/platform/site-wide/sass/style.scss
@@ -32,6 +32,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "modules/m-vet-nav";
 @import "modules/m-downtime-notification";
 @import "modules/m-layers";
+@import "modules/m-header";
 @import "modules/m-homepage";
 @import "modules/m-veteran-banner";
 @import "modules/m-cta-widget";


### PR DESCRIPTION
## Description
This PR corrects a header layout shift during page load between the tablet/desktop layout and mobile layout. We momentarily see the legacy layout before the reactive mobile header component loads and chooses which layout is appropriate, based on the user's viewport width. This PR wraps both layouts in a global header element and hides the legacy layout with CSS while the reactive element loads and chooses which layout needs displayed. This PR will also have an associated PR in the Content-Build repo.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35933

## Associated PR
https://github.com/department-of-veterans-affairs/content-build/pull/986

## Testing done
- [x] Unit tests

## Acceptance criteria
- [x] No layout shifts occur during page load

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
