### PR TITLE
Use my location activating when using Enter key to search

### DIFF
--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -196,13 +196,19 @@ export function KeywordSearch({
 }
 
 KeywordSearch.propTypes = {
+  className: PropTypes.string,
   error: PropTypes.string,
+  inputValue: PropTypes.string,
   label: PropTypes.string,
-  onFetchAutocompleteSuggestions: PropTypes.func,
-  onSelection: PropTypes.func,
-  onUpdateAutocompleteSearchTerm: PropTypes.func,
+  labelAdditional: PropTypes.object,
+  required: PropTypes.any,
+  suggestions: PropTypes.object,
   validateSearchTerm: PropTypes.func,
   version: PropTypes.string,
+  onFetchAutocompleteSuggestions: PropTypes.func,
+  onPressEnter: PropTypes.func,
+  onSelection: PropTypes.func,
+  onUpdateAutocompleteSearchTerm: PropTypes.func,
 };
 
 export default KeywordSearch;

--- a/src/applications/gi/containers/search/LocationSearchForm.jsx
+++ b/src/applications/gi/containers/search/LocationSearchForm.jsx
@@ -1,11 +1,13 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/jsx-no-bind */
-/* eslint-disable react/button-has-type */
 /* eslint-disable react/jsx-wrap-multilines */
-/* eslint-disable import/order */
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { useHistory } from 'react-router-dom';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 import Dropdown from '../../components/Dropdown';
 import {
   fetchLocationAutocompleteSuggestions,
@@ -18,12 +20,9 @@ import {
 } from '../../actions';
 import KeywordSearch from '../../components/search/KeywordSearch';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
-import { useHistory } from 'react-router-dom';
 import { updateUrlParams } from '../../selectors/search';
 import { TABS } from '../../constants';
 import { INITIAL_STATE } from '../../reducers/search';
-import recordEvent from 'platform/monitoring/record-event';
 
 export function LocationSearchForm({
   autocomplete,
@@ -228,7 +227,17 @@ export function LocationSearchForm({
                     </div>
                   ) : (
                     <button
+                      type="button"
+                      name="use-my-location"
                       onClick={() => {
+                        // eslint-disable-next-line sonarjs/no-collapsible-if
+                        if (!environment.isProduction()) {
+                          if (
+                            document.activeElement.name !== 'use-my-location'
+                          ) {
+                            return;
+                          }
+                        }
                         recordEvent({
                           event: 'map-use-my-location',
                         });


### PR DESCRIPTION
## Description
When performing a Search by location, if the search is repeated by pressing the Enter/Return key, the "Use my location" option is triggered.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#37015](https://github.com/department-of-veterans-affairs/va.gov-team/issues/37015)


## Testing done
local environment

## Acceptance criteria
- [ ] use my location no longer activates when pressing enter on the search input.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
