### PR TITLE
Add VA Letters Mobile CTA Widget

### DIFF
--- a/src/applications/static-pages/letters-mobile-cta/components/App/index.js
+++ b/src/applications/static-pages/letters-mobile-cta/components/App/index.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const appleStoreUrl =
+  'https://apps.apple.com/us/app/va-health-and-benefits/id1559609596';
+const googlePlayUrl =
+  'https://play.google.com/store/apps/details?id=gov.va.mobileapp';
+
+export const STORAGE_KEY = 'va-letters-mobile-app-message';
+
+const createLink = (href, name) => (
+  <p className="vads-u-margin-bottom--0">
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      Get the VA: Health and Benefits app from the {name}
+    </a>
+  </p>
+);
+
+export const App = ({ mockUserAgent }) => {
+  const [isHidden, setIsHidden] = useState(
+    (sessionStorage.getItem(STORAGE_KEY) || '') !== '',
+  );
+
+  const userAgent =
+    mockUserAgent || navigator.userAgent || navigator.vendor || window.opera;
+  const devices = {
+    ios: {
+      detect: /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream,
+      link: createLink(appleStoreUrl, 'Apple App Store'),
+    },
+    android: {
+      // https://stackoverflow.com/a/21742107
+      detect: /android/i.test(userAgent),
+      link: createLink(googlePlayUrl, 'Google Play store'),
+    },
+  };
+
+  const detectedDevice = Object.keys(devices).filter(os => devices[os].detect);
+  const storeLinks =
+    detectedDevice.length !== 0 ? (
+      devices[detectedDevice].link
+    ) : (
+      <>
+        {devices.ios.link}
+        {devices.android.link}
+      </>
+    );
+
+  return isHidden ? null : (
+    <va-alert
+      status="info"
+      closeable
+      onClose={() => {
+        setIsHidden(true);
+        sessionStorage.setItem(STORAGE_KEY, 'hidden');
+      }}
+    >
+      <h2 slot="headline">Download your VA letters on your mobile device</h2>
+      <p>
+        You can use our new mobile app to download your VA letters on your
+        mobile device. To get started, download the{' '}
+        <strong>VA: Health and Benefits</strong> mobile app.
+      </p>
+      {storeLinks}
+    </va-alert>
+  );
+};
+
+App.propTypes = {
+  mockUserAgent: PropTypes.string,
+};

--- a/src/applications/static-pages/letters-mobile-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/letters-mobile-cta/components/App/index.unit.spec.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { App, STORAGE_KEY } from '.';
+
+describe('<App>', () => {
+  beforeEach(() => {
+    sessionStorage.removeItem(STORAGE_KEY);
+  });
+
+  it('should render', () => {
+    const wrapper = shallow(<App mockUserAgent="blah" />);
+    expect(wrapper.length).to.equal(1);
+    expect(wrapper.props().status).to.equal('info');
+    const links = wrapper.find('a[target="_blank"]');
+    expect(links.length).to.equal(2);
+    expect(links.first().text()).to.eq(
+      'Get the VA: Health and Benefits app from the Apple App Store',
+    );
+    expect(links.last().text()).to.eq(
+      'Get the VA: Health and Benefits app from the Google Play store',
+    );
+    wrapper.unmount();
+  });
+  it('should hide the alert initially', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'hidden');
+    const wrapper = shallow(<App />);
+    expect(wrapper).to.be.empty;
+    wrapper.unmount();
+  });
+  it('should hide the alert', () => {
+    const wrapper = shallow(<App />);
+    expect(wrapper.length).to.equal(1);
+
+    wrapper.props().onClose();
+    expect(wrapper).to.be.empty;
+    expect(sessionStorage.getItem(STORAGE_KEY)).to.equal('hidden');
+    wrapper.unmount();
+  });
+
+  it('should show app store link for iOS device', () => {
+    const wrapper = shallow(<App mockUserAgent="iPhone" />);
+    const link = wrapper.find('a[target="_blank"]');
+    expect(link.length).to.equal(1);
+    expect(link.text()).to.eq(
+      'Get the VA: Health and Benefits app from the Apple App Store',
+    );
+    wrapper.unmount();
+  });
+  it('should show Google play store link for android device', () => {
+    const wrapper = shallow(<App mockUserAgent="android" />);
+    const link = wrapper.find('a[target="_blank"]');
+    expect(link.length).to.equal(1);
+    expect(link.text()).to.eq(
+      'Get the VA: Health and Benefits app from the Google Play store',
+    );
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/letters-mobile-cta/index.js
+++ b/src/applications/static-pages/letters-mobile-cta/index.js
@@ -1,0 +1,21 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+
+  if (root) {
+    import(/* webpackChunkName: "letters-mobile-cta" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -51,6 +51,7 @@ import createFindVaForms, {
   findVaFormsWidgetReducer,
 } from '../find-forms/createFindVaForms';
 import createFindVaFormsPDFDownloadHelper from '../find-forms/widgets/createFindVaFormsPDFDownloadHelper';
+import createLettersMobileCTA from './letters-mobile-cta';
 import createManageVADebtCTA from './manage-va-debt/createManageVADebtCTA';
 import createMedicalCopaysCTA from './medical-copays-cta';
 import createMyVALoginWidget from './widget-creators/createMyVALoginWidget';
@@ -188,6 +189,7 @@ createViewPaymentHistoryCTA(store, widgetTypes.VIEW_PAYMENT_HISTORY);
 createI18Select(store, widgetTypes.I_18_SELECT);
 createDependencyVerification(store, widgetTypes.DEPENDENCY_VERIFICATION);
 createCOEAccess(store, widgetTypes.COE_ACCESS);
+createLettersMobileCTA(store, widgetTypes.LETTERS_MOBILE_CTA);
 createManageVADebtCTA(store, widgetTypes.MANAGE_VA_DEBT_CTA);
 
 // Create the My VA Login widget only on the homepage.

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -34,6 +34,7 @@ export default {
   HIGHER_LEVEL_REVIEW_APP_STATUS: 'higher-level-review-status',
   HOMEPAGE_BANNER: 'homepage-banner',
   I_18_SELECT: 'i18-select',
+  LETTERS_MOBILE_CTA: 'letters-mobile-cta',
   MAINTENANCE_BANNER: 'maintenance-banner',
   MANAGE_VA_DEBT_CTA: 'manage-va-debt-cta',
   MEDICAL_COPAYS_CTA: 'medical-copays-cta',


### PR DESCRIPTION
## Description
This PR adds the VA Letters Mobile CTA widget. The widget is designed to target mobile users to download the VA Health & Benefits app to their device to view their letters. This widget is meant for use by content editors who drop react widgets into a page in Drupal.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35382

## Testing done
- [x] Unit tests

## Screenshots
<img width="657" alt="Screen Shot 2022-02-23 at 3 06 17 PM" src="https://user-images.githubusercontent.com/6738544/155410485-e1b7c880-c58d-40ac-90a9-1eb207c72a7b.png">


## Acceptance criteria
- [x] Create VA Letters Mobile CTA

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
