### PR TITLE
add workflow to auto close stale PRs

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -1,0 +1,14 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+      with:
+        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. It will be closed in 7 days if it does not recieve a comment or if the stale label is not removed.'
+        days-before-pr-stale: 30
+        days-before-pr-close: 7

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -1,7 +1,18 @@
 name: 'Close stale PRs'
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  # uncomment after testing is done
+  # schedule:
+  #   - cron: '0 0 * * *'
+  #remove the workflow_dispatch once testing is done and rely on cron job
+  workflow_dispatch:
+    inputs:
+      days_before_stale:
+        description: how many days a PR can be open without any activity before it is marked stale
+        required: true
+      days_until_close:
+        description: how many days before a stale PR is closed
+        required: true
+
 
 jobs:
   stale:
@@ -9,7 +20,13 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-pr-message: 'This PR is stale because it has been open 120 days with no activity. It will be closed in 7 days if it does not recieve a comment or if the stale label is not removed.'
-          days-before-pr-stale: 120
-          days-before-pr-close: 7
+          #uncomment these lines and delete the ones below after verifying that this workflow works
+          #stale-pr-message: 'This PR is stale because it has been open 120 days with no activity. It will recieve a stale label every day for 14 days before being closed unless it recieves a comment or the stale label is removed.'
+          #days-before-pr-stale: 120
+          #days-before-pr-close: 14
+
+          #remove these lines once testing is done
+          stale-pr-message: 'This PR is stale because it has been open ${{ github.event.inputs.days_before_stale }} days with no activity and will be closed in ${{ github.event.inputs.days_until_close }} days if it does not recieve a comment or if the stale label is not removed.'
+          days-before-pr-stale: ${{ github.event.inputs.days_before_stale }}
+          days-before-pr-close: ${{ github.event.inputs.days_until_close }}
           close-pr-label: 'do not archive'

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v4
-      with:
-        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. It will be closed in 7 days if it does not recieve a comment or if the stale label is not removed.'
-        days-before-pr-stale: 30
-        days-before-pr-close: 7
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 120 days with no activity. It will be closed in 7 days if it does not recieve a comment or if the stale label is not removed.'
+          days-before-pr-stale: 120
+          days-before-pr-close: 7
+          stale-pr-label: 'do not archive'

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -12,4 +12,4 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 120 days with no activity. It will be closed in 7 days if it does not recieve a comment or if the stale label is not removed.'
           days-before-pr-stale: 120
           days-before-pr-close: 7
-          stale-pr-label: 'do not archive'
+          close-pr-label: 'do not archive'


### PR DESCRIPTION
## Description
This PR adds a workflow to add a stale label to PRs that have seen no activity for 30 days, and to automatically close stale PRs after 7 days.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/30071)

## Testing done
none

## Screenshots


## Acceptance criteria
- [ ] PRs are marked stale after 30 days of inactivity; and stale PRs are automatically closed after 7 days.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
