### PR TITLE
[36539] Fix "Use my location" bug

### DIFF
--- a/src/applications/gi/containers/search/LocationSearchForm.jsx
+++ b/src/applications/gi/containers/search/LocationSearchForm.jsx
@@ -24,6 +24,7 @@ import { updateUrlParams } from '../../selectors/search';
 import { TABS } from '../../constants';
 import { INITIAL_STATE } from '../../reducers/search';
 import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 
 export function LocationSearchForm({
   autocomplete,
@@ -233,6 +234,7 @@ export function LocationSearchForm({
                           event: 'map-use-my-location',
                         });
                         dispatchGeolocateUser();
+                        if (environment.isProduction()) doSearch(null);
                       }}
                       className="use-my-location-link"
                     >

--- a/src/applications/gi/containers/search/LocationSearchForm.jsx
+++ b/src/applications/gi/containers/search/LocationSearchForm.jsx
@@ -23,9 +23,6 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import { updateUrlParams } from '../../selectors/search';
 import { TABS } from '../../constants';
 import { INITIAL_STATE } from '../../reducers/search';
-import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
-
 
 export function LocationSearchForm({
   autocomplete,


### PR DESCRIPTION
## Description

- When a user clicks "Use my location" on the GI Bill Comparison Tool, the system should search once the field is filled

## Original issue(s)

department-of-veterans-affairs/va.gov-team#36539

## Testing done

- local

## Acceptance criteria
- [ ] The form does a search once the  "Use my location" link is clicked and an address is procured

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
