### PR TITLE
CHORE: remove unused back to top style

### DIFF
--- a/src/platform/site-wide/sass/style.scss
+++ b/src/platform/site-wide/sass/style.scss
@@ -17,7 +17,6 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-hub-page-link-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-promo-banner";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-responsive-tables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-back-to-top";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "~@department-of-veterans-affairs/formation/sass/mobile-typography";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";


### PR DESCRIPTION
## Remove unused back to top style and javascript


## Original issue(s)
[department-of-veterans-affairs/va.gov-team#33995](https://github.com/department-of-veterans-affairs/va.gov-team/issues/33995)




## Acceptance criteria

- [x] Remove [back-to-top sass module import in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/700e7d144d26f65c58d220cbe3da87c122398092/src/platform/site-wide/sass/style.scss#L20).


