### PR TITLE
lazy load mega-menu widget

### DIFF
--- a/src/platform/site-wide/mega-menu/index.js
+++ b/src/platform/site-wide/mega-menu/index.js
@@ -9,14 +9,17 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import startReactApp from '../../startup/react';
-import Main from './containers/Main';
 
 /**
  * Sets up the login widget with the given store at login-root
  *
  * @param {Redux.Store} store The common store used on the site
  */
-export default function startMegaMenuWidget(data, store) {
+export default async function startMegaMenuWidget(data, store) {
+  const {
+    default: Main,
+  } = await import(/* webpackChunkName: "mega-menu-widget" */ './containers/Main');
+
   startReactApp(
     <Provider store={store}>
       <Main megaMenuData={data} />


### PR DESCRIPTION
## Description
The mega menu widget could not be made to load lazily until VSP-identity completed work [on an issue](https://github.com/department-of-veterans-affairs/vets-website/pull/20131). Now that the issue has been fixed this widget can be lazy loaded.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
manual testing

## Screenshots


## Acceptance criteria
- [ ] widget lazy loads and performs to spec

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
