### PR TITLE
Updated last updated to check for 3 days instead of 24 hours.

### DIFF
--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -1,8 +1,7 @@
 import { differenceInCalendarDays } from 'date-fns';
 
-const now = Date.now();
 const isWithInDays = (days, pageLastUpdated) => {
-  const daysAgo = differenceInCalendarDays(now, pageLastUpdated);
+  const daysAgo = differenceInCalendarDays(Date.now(), pageLastUpdated);
   return daysAgo <= days;
 };
 

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -1,11 +1,9 @@
-import { differenceInHours } from 'date-fns';
+import { differenceInCalendarDays } from 'date-fns';
 
 const now = Date.now();
-
-const isWithInHours = (hours, pageLastUpdated) => {
-  const hoursAgo = differenceInHours(now, pageLastUpdated);
-
-  return hoursAgo <= hours;
+const isWithInDays = (days, pageLastUpdated) => {
+  const daysAgo = differenceInCalendarDays(now, pageLastUpdated);
+  return daysAgo <= days;
 };
 
 const updateFormPages = (
@@ -52,7 +50,7 @@ const updateFormPages = (
       : null;
     if (
       pageLastUpdated &&
-      isWithInHours(24, pageLastUpdated) &&
+      isWithInDays(3, pageLastUpdated) &&
       page.needsUpdate === false
     ) {
       skippedPages.push(page.url);

--- a/src/applications/check-in/utils/navigation/navigation.unit.spec.js
+++ b/src/applications/check-in/utils/navigation/navigation.unit.spec.js
@@ -6,6 +6,10 @@ import { updateFormPages } from './index';
 describe('Global check in', () => {
   describe('navigation utils', () => {
     describe('updateFormPages', () => {
+      afterEach(() => {
+        MockDate.reset();
+      });
+
       const now = Date.now();
       const today = new Date(now);
       const testPages = [
@@ -86,7 +90,6 @@ describe('Global check in', () => {
           URLS,
         );
         expect(form.find(page => page === URLS.EMERGENCY_CONTACT)).to.exist;
-        MockDate.reset();
       });
       it('should not skip a page that has no last updated date string', () => {
         const patientDemographicsStatus = {
@@ -123,8 +126,6 @@ describe('Global check in', () => {
         );
         expect(form.find(page => page === URLS.EMERGENCY_CONTACT)).to.be
           .undefined;
-
-        MockDate.reset();
       });
       it('should skip a page that has been updated less than 72 hours ago', () => {
         MockDate.set('2022-01-04T06:00:00.000-05:00');
@@ -144,8 +145,6 @@ describe('Global check in', () => {
         );
         expect(form.find(page => page === URLS.EMERGENCY_CONTACT)).to.be
           .undefined;
-
-        MockDate.reset();
       });
     });
   });


### PR DESCRIPTION
## Description
Update skipping logic to use days instead of hours and set the length to 3 days.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37408

## Testing done
Verified unit tests still work.


