### PR TITLE
Revise read only state formatting

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-read-only-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-read-only-state.cypress.spec.js
@@ -17,6 +17,9 @@ const setup = () => {
   cy.intercept('v0/profile/full_name', mockFullName);
   cy.intercept('v0/feature_toggles*', mockProfileEnhancementsToggles);
   mockGETEndpoints(['v0/mhv_account', 'v0/ppiu/payment_information']);
+};
+
+const visitProfileAndCheckLoading = () => {
   cy.visit(PROFILE_PATHS_LGBTQ_ENHANCEMENT.PERSONAL_INFORMATION);
   cy.injectAxe();
 
@@ -32,6 +35,8 @@ const setup = () => {
 describe('Content on the personal information page', () => {
   it('should render personal information as expected', () => {
     setup();
+    visitProfileAndCheckLoading();
+
     // Check preferred name
     cy.findByText('Wes').should('exist');
 
@@ -47,6 +52,25 @@ describe('Content on the personal information page', () => {
     cy.findByText('Straight or heterosexual, Some other orientation').should(
       'exist',
     );
+
+    cy.axeCheck();
+  });
+
+  it('should render preferNotToAnswer for Sexual Orientation with correctly formatted string', () => {
+    setup();
+
+    cy.intercept('v0/profile/personal_information', {
+      data: {
+        attributes: {
+          sexualOrientation: ['preferNotToAnswer'],
+        },
+      },
+    });
+
+    visitProfileAndCheckLoading();
+
+    // Check sexual orientation
+    cy.findByText('Prefer not to answer').should('exist');
 
     cy.axeCheck();
   });

--- a/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
@@ -6,6 +6,7 @@ import {
   renderGender,
   createBooleanSchemaPropertiesFromOptions,
   createUiTitlePropertiesFromOptions,
+  formatIndividualLabel,
 } from '@@profile/util/personal-information/personalInformationUtils';
 
 import { NOT_SET_TEXT } from '@@profile/constants';
@@ -111,5 +112,27 @@ describe('createUiTitlePropertiesFromOptions utility', () => {
     };
 
     expect(createUiTitlePropertiesFromOptions(input)).to.deep.equal(output);
+  });
+});
+
+describe('formatIndividualLabel utility', () => {
+  it('returns properly formatted string for "preferNotToAnswer" ', () => {
+    const key = 'preferNotToAnswer';
+
+    const label = 'Prefer not to answer (un-checks other options)';
+
+    const output = 'Prefer not to answer';
+
+    expect(formatIndividualLabel(key, label)).to.equal(output);
+  });
+
+  it('returns label unformatted for standard keys" ', () => {
+    const key = 'test';
+
+    const label = 'test string here';
+
+    const output = 'test string here';
+
+    expect(formatIndividualLabel(key, label)).to.equal(output);
   });
 });

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -145,6 +145,13 @@ export const personalInformationUiSchemas = {
   },
 };
 
+export const formatIndividualLabel = (key, label) => {
+  if (key === 'preferNotToAnswer') {
+    return label.replace('(un-checks other options)', '').trim();
+  }
+  return label;
+};
+
 export const formatMultiSelectAndText = (data, fieldName) => {
   const notListedTextKey = `${fieldName}NotListedText`;
 
@@ -156,7 +163,9 @@ export const formatMultiSelectAndText = (data, fieldName) => {
   }
 
   const mergedValues = [
-    ...data[fieldName].map(key => allLabels[fieldName][key]),
+    ...data[fieldName].map(key =>
+      formatIndividualLabel(key, allLabels[fieldName][key]),
+    ),
     ...(data?.[notListedTextKey] ? [data[notListedTextKey]] : []),
   ];
 


### PR DESCRIPTION
## Description
Add formatting for 'Prefer not to answer' when displaying the read-only state. Originally it would display the text "(un-checks other options)" next to Prefer not to answer, and this PR removes that from the read only state.


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/37040


## Testing done
E2E and Unit tests added to cover formatting and display of data

## Screenshots

Before:

![Screen Shot 2022-02-24 at 9 58 48 PM](https://user-images.githubusercontent.com/8332986/155656632-f9507c28-42c0-43c3-9518-9e40027d88b4.png)

After:

![Screen Shot 2022-02-24 at 9 57 37 PM](https://user-images.githubusercontent.com/8332986/155656647-7357a412-b779-4172-92a3-c8828c15b53b.png)


## Acceptance criteria
- [x] Prefer not to answer is formatted correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
