### PR TITLE
35482 Remove m-progress-bar sass from Vets-Website

### DIFF
--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/ask-a-question/styles/ask-a-question.scss
+++ b/src/applications/ask-a-question/styles/ask-a-question.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/burials/sass/burials.scss
+++ b/src/applications/burials/sass/burials.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/caregivers/sass/caregivers.scss
+++ b/src/applications/caregivers/sass/caregivers.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -2,7 +2,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
 
 .claim-list {

--- a/src/applications/coronavirus-research/sign-up/sass/covid-research-volunteer.scss
+++ b/src/applications/coronavirus-research/sign-up/sass/covid-research-volunteer.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/coronavirus-research/update/sass/covid-research-volunteer.scss
+++ b/src/applications/coronavirus-research/update/sass/covid-research-volunteer.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/coronavirus-vaccination-expansion/sass/covid-vaccine.scss
+++ b/src/applications/coronavirus-vaccination-expansion/sass/covid-vaccine.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/disability-benefits/686c-674/sass/new-686.scss
+++ b/src/applications/disability-benefits/686c-674/sass/new-686.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -3,7 +3,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 // @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 // @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/edu-benefits/10203/sass/10203_stem.scss
+++ b/src/applications/edu-benefits/10203/sass/10203_stem.scss
@@ -3,7 +3,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/edu-benefits/1990s/sass/1990s.scss
+++ b/src/applications/edu-benefits/1990s/sass/1990s.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -3,7 +3,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/src/applications/hca/sass/hca.scss
+++ b/src/applications/hca/sass/hca.scss
@@ -3,7 +3,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/health-care-questionnaire/questionnaire/sass/confirm.scss
+++ b/src/applications/health-care-questionnaire/questionnaire/sass/confirm.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/health-care-questionnaire/questionnaire/sass/footer.scss
+++ b/src/applications/health-care-questionnaire/questionnaire/sass/footer.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss
+++ b/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/health-care-questionnaire/questionnaire/sass/review.scss
+++ b/src/applications/health-care-questionnaire/questionnaire/sass/review.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/letters/sass/letters.scss
+++ b/src/applications/letters/sass/letters.scss
@@ -1,6 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 
 @mixin schemaform-padding {
   // query borrowed from _m-schemaform.scss

--- a/src/applications/lgy/coe/form/sass/coe.scss
+++ b/src/applications/lgy/coe/form/sass/coe.scss
@@ -3,7 +3,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../../platform/forms/sass/m-form-confirmation";
 @import "../../../../../platform/forms/sass/m-schemaform";
 

--- a/src/applications/mock-sip-form/sass/mock-sip-form.scss
+++ b/src/applications/mock-sip-form/sass/mock-sip-form.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/my-education-benefits/sass/my-education-benefits.scss
+++ b/src/applications/my-education-benefits/sass/my-education-benefits.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/pensions/sass/pensions.scss
+++ b/src/applications/pensions/sass/pensions.scss
@@ -3,7 +3,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/personalization/search-representative/sass/search-representative.scss
+++ b/src/applications/personalization/search-representative/sass/search-representative.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/pre-need/sass/pre-need.scss
+++ b/src/applications/pre-need/sass/pre-need.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/sah/sahg/sass/sahg.scss
+++ b/src/applications/sah/sahg/sass/sahg.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/veteran-representative/sass/veteran-representative.scss
+++ b/src/applications/veteran-representative/sass/veteran-representative.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/vre/28-1900/sass/28-1900-chapter-31.scss
+++ b/src/applications/vre/28-1900/sass/28-1900-chapter-31.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/vre/28-8832/sass/28-8832-planning-and-career-guidance.scss
+++ b/src/applications/vre/28-8832/sass/28-8832-planning-and-career-guidance.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";

--- a/src/applications/vre/sass/vre.scss
+++ b/src/applications/vre/sass/vre.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";


### PR DESCRIPTION
## Description
The `<ProgressBar>` and `<SegmentedProgressBar>` React components have been replaced with web components and are [removed from the component library](https://github.com/department-of-veterans-affairs/component-library/pull/263). They relied on [styles from formation](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/709690c0678775139fd091fb982ced92bc603ec0/packages/formation/sass/modules/_m-progress-bar.scss#L1) and application code is still importing these now-unused styles.

The goal with this ticket is to remove this import from the 32 application SASS files:

```scss
@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
```

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35482

## Related PR
https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/774

## Acceptance criteria
- [X] Remove import in [`my-education-benefits`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/my-education-benefits/sass/my-education-benefits.scss#L4)
- [X] Remove import in [`pre-need`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/pre-need/sass/pre-need.scss#L4)
- [X] Remove import in [`edu-benefits`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/edu-benefits/sass/edu-benefits.scss#L6)
- [X] Remove import in [`veteran-representative`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/veteran-representative/sass/veteran-representative.scss#L4)
- [X] Remove import in [`pensions`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/pensions/sass/pensions.scss#L6)
- [X] Remove import in [`vre`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/vre/sass/vre.scss#L4)
- [X] Remove import in [`hca`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/hca/sass/hca.scss#L6)
- [X] Remove import in [`financial-status-report`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/financial-status-report/sass/financial-status-report.scss#L4)
- [X] Remove import in [`burials`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/burials/sass/burials.scss#L4)
- [X] Remove import in [`letters`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/letters/sass/letters.scss#L3)
- [X] Remove import in [`claims-status`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/claims-status/sass/claims-status.scss#L5)
- [X] Remove import in [`coronavirus-vaccination-expansion`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/coronavirus-vaccination-expansion/sass/covid-vaccine.scss#L4)
- [X] Remove import in [`ask-a-question`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/ask-a-question/styles/ask-a-question.scss#L4)
- [X] Remove import in [`caregivers`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/caregivers/sass/caregivers.scss#L4)
- [X] Remove import in [`disability-benefits/686c-674`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/disability-benefits/686c-674/sass/new-686.scss#L4)
- [X] Remove import in [`disability-benefits/996`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss#L4)
- [X] Remove import in [`disability-benefits/all-claims`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss#L6)
- [X] Remove import in [`disability-benefits/2346`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/disability-benefits/2346/sass/form-2346.scss#L4)
- [X] Remove import in [`appeals`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/appeals/10182/sass/10182-nod.scss#L4)
- [X] Remove import in [`edu-benefits/1990s`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/edu-benefits/1990s/sass/1990s.scss#L4)
- [X] Remove import in [`edu-benefits/10203`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/edu-benefits/10203/sass/10203_stem.scss#L6)
- [X] Remove import in [`personalization`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/personalization/search-representative/sass/search-representative.scss#L4)
- [X] Remove import in [`health-care-questionnaire/.../review`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/health-care-questionnaire/questionnaire/sass/review.scss#L4)
- [X] Remove import in [`health-care-questionnaire/.../questionnaire`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss#L4)
- [X] Remove import in [`health-care-questionnaire/.../footer`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/health-care-questionnaire/questionnaire/sass/footer.scss#L4)
- [X] Remove import in [`health-care-questionnaire/.../confirm`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/health-care-questionnaire/questionnaire/sass/confirm.scss#L4)
- [X] Remove import in [`sah`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/sah/sahg/sass/sahg.scss#L4)
- [X] Remove import in [`coronavirus-research`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/coronavirus-research/sign-up/sass/covid-research-volunteer.scss#L4)
- [X] Remove import in [`vre/28-8832`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/vre/28-8832/sass/28-8832-planning-and-career-guidance.scss#L4)
- [X] Remove import in [`vre/28-1900`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/vre/28-1900/sass/28-1900-chapter-31.scss#L4)
- [X] Remove import in [`lgy`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/lgy/coe/form/sass/coe.scss#L6)
- [X] Remove import in [`coronavirus-research/update`](https://github.com/department-of-veterans-affairs/vets-website/blob/c5e4f22bde62316194cbba0895c6db81e4f1b9a0/src/applications/coronavirus-research/update/sass/covid-research-volunteer.scss#L4)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
