### PR TITLE
Change "is incorrect" to "isn't correct"

### DIFF
--- a/src/applications/enrollment-verification/components/EnrollmentVerificationAlert.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationAlert.jsx
@@ -46,7 +46,7 @@ const pausedScoAlert = (
       enrollment information
     </h3>
     <p>
-      You’ve verified that your monthly enrollment has changed or is incorrect,
+      You’ve verified that your monthly enrollment has changed or isn’t correct,
       but you haven’t updated it yet.
     </p>
     <p>

--- a/src/applications/enrollment-verification/components/EnrollmentVerificationPageWrapper.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationPageWrapper.jsx
@@ -25,5 +25,5 @@ export default function EnrollmentVerificationPageWrapper({ children }) {
 }
 
 EnrollmentVerificationPageWrapper.propTypes = {
-  children: PropTypes.object,
+  children: PropTypes.any,
 };

--- a/src/applications/enrollment-verification/components/MonthReviewCard.jsx
+++ b/src/applications/enrollment-verification/components/MonthReviewCard.jsx
@@ -25,7 +25,7 @@ const incorrectText = (
       className="fas fa-exclamation-circle vads-u-color--secondary-dark vads-u-margin-right--1 vads-u-margin-top--1"
       aria-hidden="true"
     />{' '}
-    You verified that this month’s enrollment information is incorrect
+    You verified that this month’s enrollment information isn’t correct
   </p>
 );
 

--- a/src/applications/enrollment-verification/components/ReviewSkippedAheadAlert.jsx
+++ b/src/applications/enrollment-verification/components/ReviewSkippedAheadAlert.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { formatReadableMonthYear } from '../helpers';
 
-export default function ReviewSkippedAheadAlert() {
+export default function ReviewSkippedAheadAlert({ incorrectMonth }) {
   return (
     <va-alert
       background-only
@@ -10,7 +12,11 @@ export default function ReviewSkippedAheadAlert() {
       visible
     >
       We skipped you ahead to the review step because you selected "No, this
-      information is incorrect" for September 2021.
+      information isn’t correct" for {formatReadableMonthYear(incorrectMonth)}.
     </va-alert>
   );
 }
+
+ReviewSkippedAheadAlert.propTypes = {
+  incorrectMonth: PropTypes.string.isRequired,
+};

--- a/src/applications/enrollment-verification/components/VerifyEnrollments.jsx
+++ b/src/applications/enrollment-verification/components/VerifyEnrollments.jsx
@@ -80,7 +80,7 @@ VerifyEnrollments.propTypes = {
   onFinishVerifyingLater: PropTypes.func.isRequired,
   onForwardButtonClick: PropTypes.func.isRequired,
   backButtonText: PropTypes.any,
-  children: PropTypes.object,
+  children: PropTypes.any,
   forwardButtonText: PropTypes.any,
   progressTitlePostfix: PropTypes.any,
 };

--- a/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
+++ b/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
@@ -254,7 +254,9 @@ export const VerifyEnrollmentsPage = ({
       >
         {informationIncorrectMonth &&
         currentMonth !== unverifiedMonths.length ? (
-          <ReviewSkippedAheadAlert />
+          <ReviewSkippedAheadAlert
+            incorrectMonth={informationIncorrectMonth.month}
+          />
         ) : (
           <></>
         )}
@@ -291,7 +293,7 @@ export const VerifyEnrollmentsPage = ({
           },
           {
             value: VERIFICATION_STATUS_INCORRECT,
-            label: 'No, this information is incorrect',
+            label: 'No, this information isn’t correct',
           },
         ]}
         required
@@ -304,7 +306,7 @@ export const VerifyEnrollmentsPage = ({
         status="info"
         visible
       >
-        If you select "<em>No, this information is incorrect</em>"{' '}
+        If you select "<em>No, this information isn’t correct</em>"{' '}
         <strong>
           we will pause your monthly housing payment until your information is
           updated


### PR DESCRIPTION
## Description
Change "is incorrect" text to "isn't correct". Also, fix the hard-coded invalid month in the skip-ahead alert and a couple of propTypes definitions.