### PR TITLE
36354 authd profile remove other checkboxes

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -75,7 +75,6 @@ const checkPersonalInfoFields = () => {
   cy.findByText('They/them/theirs').should('exist');
   cy.findByText('Ze/zir/zirs').should('exist');
   cy.findByText('Use my preferred name').should('exist');
-  cy.findByText('Pronouns not listed here').should('exist');
   cy.findByText(
     'If not listed, please provide your preferred pronouns (255 characters maximum)',
   ).should('exist');
@@ -134,7 +133,6 @@ const checkPersonalInfoFields = () => {
   cy.findByText('Prefer not to answer (un-checks other options)').should(
     'exist',
   );
-  cy.findByText('A sexual orientation not listed here').should('exist');
 
   cy.findAllByTestId('cancel-edit-button')
     .should('exist')

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -23,6 +23,14 @@ export const createUiTitlePropertiesFromOptions = obj => {
   }, {});
 };
 
+const pronounsLabels = {
+  heHimHis: 'He/him/his',
+  sheHerHers: 'She/her/hers',
+  theyThemTheirs: 'They/them/theirs',
+  zeZirZirs: 'Ze/zir/zirs',
+  useMyPreferredName: 'Use my preferred name',
+};
+
 const genderLabels = {
   woman: 'Woman',
   man: 'Man',
@@ -40,16 +48,6 @@ const sexualOrientationLabels = {
   queer: 'Queer',
   dontKnow: 'Don’t know',
   preferNotToAnswer: 'Prefer not to answer (un-checks other options)',
-  sexualOrientationNotListed: 'A sexual orientation not listed here',
-};
-
-const pronounsLabels = {
-  heHimHis: 'He/him/his',
-  sheHerHers: 'She/her/hers',
-  theyThemTheirs: 'They/them/theirs',
-  zeZirZirs: 'Ze/zir/zirs',
-  useMyPreferredName: 'Use my preferred name',
-  pronounsNotListed: 'Pronouns not listed here',
 };
 
 const allLabels = {


### PR DESCRIPTION
## Description
We are removing checkboxes for 'other' options for Pronouns and Sexual Orientation, and just using the open text field for people to enter in any custom values.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36354


## Testing done
E2E test updated


## Acceptance criteria
- [x] Checkboxes removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
