### PR TITLE
[COE] Update recommended doc list option

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
+++ b/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
@@ -37,7 +37,9 @@ const UploadRequirements = ({ formData }) => {
           DOCUMENT_REQUIREMENTS[identity].map((req, index) => (
             <li key={index}>{req}</li>
           ))}
-        {vaLoanIndicator && <li>Evidence a VA loan was paid in full</li>}
+        {vaLoanIndicator && (
+          <li>Evidence a VA loan was paid in full (if applicable)</li>
+        )}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Description
Updating the text for one of the recommended document list options from `Evidence a VA loan was paid in full` -> `Evidence a VA loan was paid in full (if applicable)`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37723

## Acceptance criteria
- [x] VA-backed loan options text changed from `Evidence a VA loan was paid in full` to `Evidence a VA loan was paid in full (if applicable)`

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
