### PR TITLE
Updating version of vets-json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#9eebc8fcdb40e8ff4a2e4cebe20722cfcbd2d31a",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee3c19a0714b6b77101f79aec86af4bc9c460bba",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/src/applications/lgy/coe/form/config/chapters/service/history.js
+++ b/src/applications/lgy/coe/form/config/chapters/service/history.js
@@ -25,7 +25,7 @@ export const uiSchema = {
       'ui:options': {
         itemName: 'Military service history',
       },
-      militaryBranch: {
+      serviceBranch: {
         'ui:title': 'Branch of service',
       },
       dateRange: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18974,9 +18974,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#9eebc8fcdb40e8ff4a2e4cebe20722cfcbd2d31a":
-  version "20.19.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#9eebc8fcdb40e8ff4a2e4cebe20722cfcbd2d31a"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee3c19a0714b6b77101f79aec86af4bc9c460bba":
+  version "20.19.2"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee3c19a0714b6b77101f79aec86af4bc9c460bba"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
Updating `vets-json-schema` to reflect the latest version after changes were made to update the service branches the verteran can select when filling out their service history in the COE application

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37508

## Acceptance criteria
- [x] `vets-json-schema` is update to latest version in package.json and yarn.lock
