### PR TITLE
Removes Sign in button in Header v2 on Unified Sign in Page

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -162,36 +162,37 @@ export class Main extends Component {
   };
 
   render() {
-    const displayProfileNav = loginAppUrlRE.test(window.location.pathname);
+    // checks if on Unified Sign in Page
+    if (loginAppUrlRE.test(window.location.pathname)) {
+      return null;
+    }
     return (
-      !displayProfileNav && (
-        <div className="profile-nav-container">
-          <SearchHelpSignIn
-            isHeaderV2={this.props.isHeaderV2}
-            isLOA3={this.props.isLOA3}
-            isLoggedIn={this.props.currentlyLoggedIn}
-            isMenuOpen={this.props.utilitiesMenuIsOpen}
-            isProfileLoading={this.props.isProfileLoading}
-            onSignInSignUp={this.signInSignUp}
-            toggleMenu={this.props.toggleSearchHelpUserMenu}
-            userGreeting={this.props.userGreeting}
-          />
-          <FormSignInModal
-            onClose={this.closeFormSignInModal}
-            onSignIn={this.openLoginModal}
-            visible={this.props.showFormSignInModal}
-          />
-          <SignInModal
-            onClose={this.closeLoginModal}
-            visible={this.props.showLoginModal}
-          />
-          <SessionTimeoutModal
-            isLoggedIn={this.props.currentlyLoggedIn}
-            onExtendSession={this.props.initializeProfile}
-          />
-          <AutoSSO />
-        </div>
-      )
+      <div className="profile-nav-container">
+        <SearchHelpSignIn
+          isHeaderV2={this.props.isHeaderV2}
+          isLOA3={this.props.isLOA3}
+          isLoggedIn={this.props.currentlyLoggedIn}
+          isMenuOpen={this.props.utilitiesMenuIsOpen}
+          isProfileLoading={this.props.isProfileLoading}
+          onSignInSignUp={this.signInSignUp}
+          toggleMenu={this.props.toggleSearchHelpUserMenu}
+          userGreeting={this.props.userGreeting}
+        />
+        <FormSignInModal
+          onClose={this.closeFormSignInModal}
+          onSignIn={this.openLoginModal}
+          visible={this.props.showFormSignInModal}
+        />
+        <SignInModal
+          onClose={this.closeLoginModal}
+          visible={this.props.showLoginModal}
+        />
+        <SessionTimeoutModal
+          isLoggedIn={this.props.currentlyLoggedIn}
+          onExtendSession={this.props.initializeProfile}
+        />
+        <AutoSSO />
+      </div>
     );
   }
 }

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -5,9 +5,7 @@ import { connect } from 'react-redux';
 import appendQuery from 'append-query';
 import URLSearchParams from 'url-search-params';
 // Relative imports.
-import AutoSSO from './AutoSSO';
 import FormSignInModal from 'platform/forms/save-in-progress/FormSignInModal';
-import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import SessionTimeoutModal from 'platform/user/authentication/components/SessionTimeoutModal';
 import SignInModal from 'platform/user/authentication/components/SignInModal';
 import { SAVE_STATUSES } from 'platform/forms/save-in-progress/actions';
@@ -16,35 +14,18 @@ import { hasSession } from 'platform/user/profile/utilities';
 import { initializeProfile } from 'platform/user/profile/actions';
 import { isInProgressPath } from 'platform/forms/helpers';
 import { isLoggedIn, isProfileLoading, isLOA3 } from 'platform/user/selectors';
-import { selectUserGreeting } from '../selectors';
 import {
   toggleFormSignInModal,
   toggleLoginModal,
   toggleSearchHelpUserMenu,
 } from 'platform/site-wide/user-nav/actions';
 import { updateLoggedInStatus } from 'platform/user/authentication/actions';
+import { loginAppUrlRE } from 'platform/user/authentication/utilities';
+import SearchHelpSignIn from '../components/SearchHelpSignIn';
+import AutoSSO from './AutoSSO';
+import { selectUserGreeting } from '../selectors';
 
 export class Main extends Component {
-  static propTypes = {
-    isHeaderV2: PropTypes.bool,
-    // From mapStateToProps.
-    currentlyLoggedIn: PropTypes.bool,
-    isLOA3: PropTypes.bool,
-    isProfileLoading: PropTypes.bool,
-    shouldConfirmLeavingForm: PropTypes.bool,
-    showFormSignInModal: PropTypes.bool,
-    showLoginModal: PropTypes.bool,
-    userGreeting: PropTypes.array,
-    utilitiesMenuIsOpen: PropTypes.object,
-    // From mapDispatchToProps.
-    getBackendStatuses: PropTypes.func.isRequired,
-    initializeProfile: PropTypes.func.isRequired,
-    toggleFormSignInModal: PropTypes.func.isRequired,
-    toggleLoginModal: PropTypes.func.isRequired,
-    toggleSearchHelpUserMenu: PropTypes.func.isRequired,
-    updateLoggedInStatus: PropTypes.func.isRequired,
-  };
-
   componentDidMount() {
     // Close any open modals when navigating to different routes within an app.
     window.addEventListener('popstate', this.closeModals);
@@ -181,33 +162,36 @@ export class Main extends Component {
   };
 
   render() {
+    const displayProfileNav = loginAppUrlRE.test(window.location.pathname);
     return (
-      <div className="profile-nav-container">
-        <SearchHelpSignIn
-          isHeaderV2={this.props.isHeaderV2}
-          isLOA3={this.props.isLOA3}
-          isLoggedIn={this.props.currentlyLoggedIn}
-          isMenuOpen={this.props.utilitiesMenuIsOpen}
-          isProfileLoading={this.props.isProfileLoading}
-          onSignInSignUp={this.signInSignUp}
-          toggleMenu={this.props.toggleSearchHelpUserMenu}
-          userGreeting={this.props.userGreeting}
-        />
-        <FormSignInModal
-          onClose={this.closeFormSignInModal}
-          onSignIn={this.openLoginModal}
-          visible={this.props.showFormSignInModal}
-        />
-        <SignInModal
-          onClose={this.closeLoginModal}
-          visible={this.props.showLoginModal}
-        />
-        <SessionTimeoutModal
-          isLoggedIn={this.props.currentlyLoggedIn}
-          onExtendSession={this.props.initializeProfile}
-        />
-        <AutoSSO />
-      </div>
+      !displayProfileNav && (
+        <div className="profile-nav-container">
+          <SearchHelpSignIn
+            isHeaderV2={this.props.isHeaderV2}
+            isLOA3={this.props.isLOA3}
+            isLoggedIn={this.props.currentlyLoggedIn}
+            isMenuOpen={this.props.utilitiesMenuIsOpen}
+            isProfileLoading={this.props.isProfileLoading}
+            onSignInSignUp={this.signInSignUp}
+            toggleMenu={this.props.toggleSearchHelpUserMenu}
+            userGreeting={this.props.userGreeting}
+          />
+          <FormSignInModal
+            onClose={this.closeFormSignInModal}
+            onSignIn={this.openLoginModal}
+            visible={this.props.showFormSignInModal}
+          />
+          <SignInModal
+            onClose={this.closeLoginModal}
+            visible={this.props.showLoginModal}
+          />
+          <SessionTimeoutModal
+            isLoggedIn={this.props.currentlyLoggedIn}
+            onExtendSession={this.props.initializeProfile}
+          />
+          <AutoSSO />
+        </div>
+      )
     );
   }
 }
@@ -251,3 +235,23 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
 )(Main);
+
+Main.propTypes = {
+  // From mapDispatchToProps.
+  getBackendStatuses: PropTypes.func.isRequired,
+  initializeProfile: PropTypes.func.isRequired,
+  toggleFormSignInModal: PropTypes.func.isRequired,
+  toggleLoginModal: PropTypes.func.isRequired,
+  toggleSearchHelpUserMenu: PropTypes.func.isRequired,
+  updateLoggedInStatus: PropTypes.func.isRequired,
+  // From mapStateToProps.
+  currentlyLoggedIn: PropTypes.bool,
+  isHeaderV2: PropTypes.bool,
+  isLOA3: PropTypes.bool,
+  isProfileLoading: PropTypes.bool,
+  shouldConfirmLeavingForm: PropTypes.bool,
+  showFormSignInModal: PropTypes.bool,
+  showLoginModal: PropTypes.bool,
+  userGreeting: PropTypes.array,
+  utilitiesMenuIsOpen: PropTypes.object,
+};

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -63,6 +63,14 @@ describe('<Main>', () => {
     wrapper.unmount();
   });
 
+  it('should NOT render on the Unified Sign in Page (USiP)', () => {
+    global.window.location.pathname = '/sign-in';
+    const wrapper = shallow(<Main {...props} />);
+    expect(wrapper.find('SearchHelpSignIn').exists()).to.be.false;
+    expect(wrapper.find(SignInModal).exists()).to.be.false;
+    wrapper.unmount();
+  });
+
   describe('checkLoggedInStatus', () => {
     it('should set logged in status to false if there is no active session', () => {
       const wrapper = shallow(<Main {...props} />);


### PR DESCRIPTION
## Description
This PR conditionally renders the `profile-nav-container` in the Main.jsx based on if the URL is on the Unified Sign in Page (USiP).  This PR will ensure users are not confused by which Sign in buttons to use.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit testing

## Screenshots


## Acceptance criteria
- [ ] Navigation to `/sign-in` will not display the Sign in button in either headers (Legacy or V2)
- [ ] Navigation to `/sign-in?application=[ebenefits | mhv | etc]` will not display the Sign in button in either headers (Legacy or V2)
- [ ] Adds unit testing to `user-nav/Main.jsx` to ensure it is not rendered on Unified Sign in Page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
