### PR TITLE
35399 - [Debt Letters] Refactor alerts to use va-alert

### DIFF
--- a/src/applications/debt-letters/components/Alerts.jsx
+++ b/src/applications/debt-letters/components/Alerts.jsx
@@ -80,10 +80,7 @@ export const DowntimeMessage = () => {
 };
 
 export const ErrorMessage = () => (
-  <section
-    className="usa-alert usa-alert-error vads-u-margin-top--0 vads-u-padding--3"
-    role="alert"
-  >
+  <va-alert class="vads-u-margin-top--0 vads-u-padding--3" status="error">
     <div className="usa-alert-body">
       <h3 className="usa-alert-heading">
         Information about your current debts is unavailable.
@@ -100,14 +97,11 @@ export const ErrorMessage = () => (
         <Telephone className="vads-u-margin-left--0p5" contact="8008270648" />.
       </p>
     </div>
-  </section>
+  </va-alert>
 );
 
 export const ErrorAlert = () => (
-  <div
-    className="usa-alert usa-alert-error vads-u-margin-top--0 vads-u-padding--3"
-    role="alert"
-  >
+  <va-alert class="vads-u-margin-top--0 vads-u-padding--3" status="error">
     <div className="usa-alert-body">
       <h3 className="usa-alert-heading">
         Your debt letters are currently unavailable.
@@ -123,14 +117,11 @@ export const ErrorAlert = () => (
         find out more information about how to resolve your debt.
       </p>
     </div>
-  </div>
+  </va-alert>
 );
 
 export const DependentDebt = () => (
-  <div
-    className="usa-alert usa-alert-error vads-u-margin-top--0 vads-u-padding--3"
-    role="alert"
-  >
+  <va-alert class="vads-u-margin-top--0 vads-u-padding--3" status="error">
     <div className="usa-alert-body">
       <h3 className="usa-alert-heading">
         Your debt letters are currently unavailable.
@@ -145,11 +136,11 @@ export const DependentDebt = () => (
         Debt Management Center at <Telephone contact="8008270648" />.
       </p>
     </div>
-  </div>
+  </va-alert>
 );
 
 export const NoDebtLinks = () => (
-  <div className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--2">
+  <va-alert class="vads-u-padding--3 vads-u-margin-bottom--2" status="error">
     <div className="usa-alert-body">
       <h3 className="usa-alert-heading">You don’t have any VA debt letters</h3>
       <p className="vads-u-font-family--sans">
@@ -165,5 +156,5 @@ export const NoDebtLinks = () => (
         page to learn about your payment options.
       </p>
     </div>
-  </div>
+  </va-alert>
 );


### PR DESCRIPTION
## Description
Refactored alerts in Debt Letters to use `va-alert` over custom html.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35399


## Screenshots
<img width="1024" alt="Screen Shot 2022-02-28 at 1 15 51 PM" src="https://user-images.githubusercontent.com/29178824/156036853-a284a354-823a-4fc0-8ba5-2c5122af6fc0.png">

## Acceptance criteria
- [ X] All Alerts in Debt Letters now use `va-alert` for component rather than custom html.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
