### PR TITLE
CST: Design update

### DIFF
--- a/src/applications/claims-status/components/AskVAQuestions.jsx
+++ b/src/applications/claims-status/components/AskVAQuestions.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
@@ -11,17 +9,26 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 import openOmniChannel, { OMNI_CHANNEL_URL } from '../utils/omniChannel';
 
 export function AskVAQuestions({ showOmniChannelLink }) {
+  const handler = {
+    clickChatLink: event => {
+      // prevent left mouse click & keyboard Enter from opening
+      // link in the same tab
+      if (event.button === 0 || event.key === 'Enter') {
+        event.preventDefault();
+      }
+      openOmniChannel();
+    },
+  };
+
   return (
     <div>
-      <h2 className="help-heading">Need help?</h2>
-      <p>Call Veterans Affairs Benefits and Services:</p>
+      <h2 id="need-help">Need help?</h2>
       <p>
-        <Telephone contact={CONTACTS.VA_BENEFITS} />
-      </p>
-      <p>Monday through Friday, 8:00 a.m. to 9:00 p.m. ET</p>
-      <p>
+        If you have questions, please call us at{' '}
+        <va-telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday
+        through Friday, 8:00 a.m. to 9:00 p.m. ET. You can also{' '}
         <a href="https://www.va.gov/contact-us/">
-          Contact us online through Ask VA
+          contact us online through Ask VA
         </a>
       </p>
       {showOmniChannelLink && (
@@ -29,14 +36,7 @@ export function AskVAQuestions({ showOmniChannelLink }) {
           <a
             id="live-chat"
             href={OMNI_CHANNEL_URL}
-            onClick={event => {
-              // prevent left mouse click & keyboard Enter from opening
-              // link in the same tab
-              if (event.button === 0 || event.key === 'Enter') {
-                event.preventDefault();
-              }
-              openOmniChannel();
-            }}
+            onClick={handler.clickChatLink}
           >
             Open a live chat
           </a>

--- a/src/applications/claims-status/components/ConsolidatedClaims.jsx
+++ b/src/applications/claims-status/components/ConsolidatedClaims.jsx
@@ -1,6 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+export const consolidatedClaimsContent = (
+  <div>
+    If you turn in a new claim while we’re reviewing another one from you, we’ll
+    add any new information to the original claim and close the new claim, with
+    no action required from you.
+  </div>
+);
+
 export default function ConsolidatedClaims({ onClose }) {
   return (
     <div>
@@ -18,11 +26,7 @@ export default function ConsolidatedClaims({ onClose }) {
       >
         <i className="fas fa-times-circle" />
       </button>
-      <div>
-        If you turn in a new claim while we’re reviewing another one from you,
-        we’ll add any new information to the original claim and close the new
-        claim, with no action required from you.
-      </div>
+      {consolidatedClaimsContent}
     </div>
   );
 }

--- a/src/applications/claims-status/components/FeaturesWarning.jsx
+++ b/src/applications/claims-status/components/FeaturesWarning.jsx
@@ -5,7 +5,7 @@ import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink
 export default function FeaturesWarning() {
   return (
     <div>
-      <h2 className="help-heading">Additional services</h2>
+      <h2 id="additional-services">Additional services</h2>
       <p>
         To update your personal information, get help filing claims or appeals,
         or view your uploaded documents, go to{' '}

--- a/src/applications/claims-status/components/MobileAppMessage.jsx
+++ b/src/applications/claims-status/components/MobileAppMessage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 
 const appleStoreUrl =
   'https://apps.apple.com/app/apple-store/id1559609596?pt=545860&ct=gov.va.claimstatus&mt=8';
@@ -45,16 +46,18 @@ export default function MobileAppMessage({ mockUserAgent }) {
       </>
     );
 
+  const handlers = {
+    closeModal: () => {
+      setIsHidden(true);
+      sessionStorage.setItem(STORAGE_KEY, 'hidden');
+    },
+  };
+
   return isHidden ? null : (
-    <va-alert
-      status="info"
-      closeable
-      onClose={() => {
-        setIsHidden(true);
-        sessionStorage.setItem(STORAGE_KEY, 'hidden');
-      }}
-    >
-      <h2 slot="headline">Track your claim or appeal on your mobile device</h2>
+    <va-alert status="info" closeable onClose={handlers.closeModal}>
+      <h2 id="track-your-status-on-mobile" slot="headline">
+        Track your claim or appeal on your mobile device
+      </h2>
       <p>
         You can use our new mobile app to check the status of your claims or
         appeals on your mobile device. Download the{' '}
@@ -64,3 +67,7 @@ export default function MobileAppMessage({ mockUserAgent }) {
     </va-alert>
   );
 }
+
+MobileAppMessage.propTypes = {
+  mockUserAgent: PropTypes.string,
+};

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -136,7 +136,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
 
 AppealListItem.propTypes = {
   appeal: PropTypes.shape({
-    id: PropTypes.number,
+    id: PropTypes.string,
     attributes: PropTypes.shape({
       status: PropTypes.shape({
         type: PropTypes.string.isRequired,

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -5,15 +5,17 @@ import { Link } from 'react-router';
 
 import moment from 'moment';
 
-import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
+
+import { getAppealsV2 as getAppealsV2Action } from '../actions';
 import AppealNotFound from '../components/appeals-v2/AppealNotFound';
-import { getAppealsV2 } from '../actions/index.jsx';
 import AppealHeader from '../components/appeals-v2/AppealHeader';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
+import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import CopyOfExam from '../components/CopyOfExam';
 import { setUpPage } from '../utils/page';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 import {
   APPEAL_TYPES,
@@ -23,7 +25,6 @@ import {
   AVAILABLE,
   getTypeName,
 } from '../utils/appeals-v2-helpers';
-import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 const capitalizeWord = word => {
   const capFirstLetter = word[0].toUpperCase();
@@ -60,10 +61,11 @@ const recordsNotFoundMessage = (
 
 export class AppealInfo extends React.Component {
   componentDidMount() {
-    if (!this.props.appeal) {
-      this.props.getAppealsV2();
+    const { appeal, appealsLoading, getAppealsV2 } = this.props;
+    if (!appeal) {
+      getAppealsV2();
     }
-    if (!this.props.appealsLoading) {
+    if (!appealsLoading) {
       setUpPage();
     } else {
       scrollToTop();
@@ -72,7 +74,8 @@ export class AppealInfo extends React.Component {
 
   createHeading = () => {
     let requestEventType;
-    switch (this.props.appeal.type) {
+    const { appeal } = this.props;
+    switch (appeal.type) {
       case APPEAL_TYPES.legacy:
         requestEventType = EVENT_TYPES.nod;
         break;
@@ -88,11 +91,11 @@ export class AppealInfo extends React.Component {
       default:
       // do nothing
     }
-    const requestEvent = this.props.appeal.attributes.events.find(
+    const requestEvent = appeal.attributes.events.find(
       event => event.type === requestEventType,
     );
 
-    let appealTitle = capitalizeWord(getTypeName(this.props.appeal));
+    let appealTitle = capitalizeWord(getTypeName(appeal));
 
     if (requestEvent) {
       appealTitle += ` received ${moment(requestEvent.date).format(
@@ -158,10 +161,7 @@ export class AppealInfo extends React.Component {
           <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
             <div className="vads-l-col--12">
               <ClaimsBreadcrumbs>
-                <Link
-                  to={`appeals/${this.props.params.id}`}
-                  key="claims-appeal"
-                >
+                <Link to={`appeals/${params.id}`} key="claims-appeal">
                   Status details
                 </Link>
               </ClaimsBreadcrumbs>
@@ -198,14 +198,16 @@ export class AppealInfo extends React.Component {
 }
 
 AppealInfo.propTypes = {
-  params: PropTypes.shape({ id: PropTypes.string.isRequired }).isRequired,
-  children: PropTypes.node.isRequired,
   appealsLoading: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+  getAppealsV2: PropTypes.func.isRequired,
+  params: PropTypes.shape({ id: PropTypes.string.isRequired }).isRequired,
   appeal: PropTypes.shape({
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     attributes: PropTypes.object.isRequired,
   }),
+  appealsAvailability: PropTypes.string,
   fullName: PropTypes.shape({
     first: PropTypes.string,
     middle: PropTypes.string,
@@ -227,7 +229,7 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-const mapDispatchToProps = { getAppealsV2 };
+const mapDispatchToProps = { getAppealsV2: getAppealsV2Action };
 
 export default connect(
   mapStateToProps,

--- a/src/applications/claims-status/tests/components/AskVAQuestions.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AskVAQuestions.unit.spec.jsx
@@ -7,8 +7,9 @@ import { AskVAQuestions } from '../../components/AskVAQuestions';
 describe('AskVAQuestions', () => {
   it('should render', () => {
     const wrapper = render(<AskVAQuestions showOmniChannelLink />);
-
-    expect(wrapper.getByText(/800-827-1000/)).to.exist;
+    expect(
+      wrapper.container.querySelector('va-telephone')?.getAttribute('contact'),
+    ).to.eq('8008271000');
     expect(wrapper.getByText(/Contact us/i)).to.exist;
     expect(wrapper.getByText(/live chat/i)).to.exist;
   });

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -129,16 +129,9 @@ describe('<YourClaimsPageV2>', () => {
     wrapper.unmount();
   });
 
-  // NOTE: We need to cover the actual opening and closing of the modal in an e2e test
-  //  since the logic to show / hide the modal is in the parent component.
-  it('should call `showConsolidatedMessage` when the relevant button is clicked', () => {
-    const messageSpy = sinon.spy();
-    const props = set('showConsolidatedMessage', messageSpy, defaultProps);
-    const wrapper = shallow(<YourClaimsPageV2 {...props} />);
-    wrapper
-      .find('.claims-combined')
-      .simulate('click', { preventDefault: () => {} });
-    expect(messageSpy.callCount).to.equal(1);
+  it('should include combined claims additional info', () => {
+    const wrapper = shallow(<YourClaimsPageV2 {...defaultProps} />);
+    expect(wrapper.find('.claims-combined').length).to.equal(1);
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealHelpSidebar.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealHelpSidebar.unit.spec.jsx
@@ -32,7 +32,7 @@ describe('<AppealHelpSidebar>', () => {
     );
 
     expect(wrapper.find('AskVAQuestions').text()).to.contain(
-      'Call Veterans Affairs Benefits and Services',
+      'Monday through Friday, 8:00 a.m. to 9:00 p.m. ET',
     );
     wrapper.unmount();
   });

--- a/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.cypress.spec.js
@@ -7,5 +7,7 @@ describe('Breadcrumb Test', () => {
     trackClaimsPage.loadPage(claimsList);
     trackClaimsPage.checkBreadcrumbs();
     trackClaimsPage.checkBreadcrumbsMobile();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/00.claims-list-empty.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-empty.cypress.spec.js
@@ -6,5 +6,7 @@ describe('Breadcrumb Test Empty List', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsListEmpty);
     trackClaimsPage.verifyNoClaims();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/00.claims-list.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.cypress.spec.js
@@ -1,11 +1,12 @@
 import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
-describe('Claimst List Test', () => {
+describe('Claims List Test', () => {
   it('Tests consolidated claim functionality', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList);
-    trackClaimsPage.checkConsolidatedClaimsModal();
+    cy.expandAccordions();
+    cy.axeCheck();
     trackClaimsPage.checkClaimsContent();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-decision.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-decision.cypress.spec.js
@@ -14,5 +14,7 @@ describe('Claim Status Decision', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyReadyClaim();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.cypress.spec.js
@@ -1,5 +1,6 @@
-import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import moment from 'moment';
+
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 let mockDetails = {};
@@ -23,5 +24,7 @@ describe('Claims status est current test', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyInProgressClaim();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.cypress.spec.js
@@ -1,5 +1,6 @@
-import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import moment from 'moment';
+
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 let mockDetails = {};
@@ -23,5 +24,7 @@ describe('Claims status est current test', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyInProgressClaim();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.cypress.spec.js
@@ -1,5 +1,6 @@
-import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import moment from 'moment';
+
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 let mockDetails = {};
@@ -23,5 +24,7 @@ describe('Claims status est current test', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyInProgressClaim();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
@@ -19,5 +19,7 @@ describe('Claims status test', () => {
     trackClaimsPage.verifyClosedClaim();
     trackClaimsPage.axeCheckClaimDetails();
     trackClaimsPage.verifyItemsNeedAttention(2);
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/02.claim-files.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.cypress.spec.js
@@ -17,5 +17,7 @@ describe('Claim Files Test', () => {
     trackClaimsPage.verifyNumberOfFiles(3);
     trackClaimsPage.verifyClaimEvidence(2, 'Reviewed by VA');
     trackClaimsPage.verifyClaimEvidence(4, 'Submitted');
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/03.claim-details.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/03.claim-details.cypress.spec.js
@@ -16,5 +16,7 @@ describe('Claim Details Test', () => {
     trackClaimsPage.checkClaimsContent();
     trackClaimsPage.claimDetailsTab();
     trackClaimsPage.verifyClaimDetails();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/04.claim-ask-va.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/04.claim-ask-va.cypress.spec.js
@@ -16,5 +16,7 @@ describe('Ask VA Claim Test', () => {
     trackClaimsPage.verifyInProgressClaim(false);
     trackClaimsPage.verifyNumberOfFiles(3);
     trackClaimsPage.askForClaimDecision();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.cypress.spec.js
@@ -15,6 +15,10 @@ describe('Claim Additional Evidence Test', () => {
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyInProgressClaim(false);
     trackClaimsPage.verifyNumberOfFiles(3);
+    cy.expandAccordions();
+    cy.axeCheck();
     trackClaimsPage.submitFilesForReview();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -15,6 +15,10 @@ describe('Claim Additional Evidence Test', () => {
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyInProgressClaim(false);
     trackClaimsPage.verifyNumberOfFiles(3);
+    cy.expandAccordions();
+    cy.axeCheck();
     trackClaimsPage.submitFilesForReview();
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.cypress.spec.js
@@ -29,5 +29,7 @@ describe('Claim Estimation Breadcrumb Test', () => {
     //     cy.wrap(breadcrumb).should('contain', 'Estimated decision date');
     //     cy.wrap(breadcrumb).should('have.css', 'pointer-events', 'none');
     //   });
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.cypress.spec.js
@@ -26,5 +26,7 @@ describe('Claim Estimation Breadcrumb Test', () => {
     // cy.get('.claims-status-content h1')
     //   .should('contain', 'How we come up with your estimated decision date')
     //
+    cy.expandAccordions();
+    cy.axeCheck();
   });
 });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -1,5 +1,6 @@
 const Timeouts = require('platform/testing/e2e/timeouts.js');
 
+/* eslint-disable class-methods-use-this */
 class TrackClaimsPage {
   loadPage(claimsList, mock = null, submitForm = false) {
     if (submitForm) {
@@ -13,7 +14,10 @@ class TrackClaimsPage {
     cy.intercept('GET', '/v0/evss_claims_async', claimsList);
     cy.login();
     cy.visit('/track-claims');
-    cy.title().should('eq', 'Track Claims: VA.gov');
+    cy.title().should(
+      'eq',
+      'Check your claim or appeal status | Veterans Affairs',
+    );
     if (claimsList.data.length) {
       cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
         'be.visible',
@@ -66,21 +70,6 @@ class TrackClaimsPage {
       'contain',
       'You do not have any submitted claims',
     );
-  }
-
-  checkConsolidatedClaimsModal() {
-    cy.get('button.claims-combined').click();
-    cy.get('.claims-status-upload-header').should('be.visible');
-    cy.injectAxeThenAxeCheck();
-    cy.get('.claims-status-upload-header').should(
-      'contain',
-      'A note about consolidated claims',
-    );
-    cy.get('.va-modal-close')
-      .first()
-      .click();
-    cy.get('.claims-status.upload-header').should('not.exist');
-    cy.axeCheck();
   }
 
   checkClaimsContent() {
@@ -300,3 +289,4 @@ class TrackClaimsPage {
 }
 
 export default TrackClaimsPage;
+/* eslint-enable class-methods-use-this */


### PR DESCRIPTION
## Description

Updated Claim Status Tool to match updated design
- Added "on this page" web component
- Replaced "Find out why we sometimes combine claims" link that opens a modal with an additional info web component
- Move side bar content under the list
- Fixed lint issues including switching some React components to use web components
  - Did not switch to `va-pagination` (needs updated react-bindings) 
  - Did not switch one `Telephone` component that needs a pattern

Note: The claims details & appeals details pages still have their side bar content.

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/37402
- Design: https://www.sketch.com/s/64bb337a-e31f-4a21-a92f-d89b50cba668/a/4aAdenq

## Testing done

- Updated unit & e2e tests
- Fix e2e tests lint issues (added axe checks)

## Screenshots

<details><summary>Claims & appeals list main page</summary>

<!-- leave a blank line above -->
![full page view of claim status tool issues page](https://user-images.githubusercontent.com/136959/156039281-37a2a977-74f6-4808-be8c-8bb0b4c050cd.png)</details>

## Acceptance criteria
- [x] Updated claims & appeals listing page design
- [x] Updated tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
