### PR TITLE
NOD: set `socOptIn` to `false`

### DIFF
--- a/src/applications/appeals/10182/config/submit-transformer.js
+++ b/src/applications/appeals/10182/config/submit-transformer.js
@@ -24,7 +24,7 @@ export function transform(formConfig, form) {
           boardReviewOption: formData.boardReviewOption || '',
           hearingTypePreference: formData.hearingTypePreference || '',
           timezone: getTimeZone(),
-          socOptIn: true,
+          socOptIn: false,
         },
       },
       included: addAreaOfDisagreement(addIncludedIssues(formData), formData),

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -24,7 +24,7 @@
     "homeless": false,
     "boardReviewOption": "evidence_submission",
     "hearingTypePreference": "central_office",
-    "socOptIn": true,
+    "socOptIn": false,
     "view:additionalEvidence": true,
 
     "contestableIssues": [

--- a/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
@@ -24,7 +24,7 @@
     "homeless": false,
     "boardReviewOption": "hearing",
     "hearingTypePreference": "central_office",
-    "socOptIn": true,
+    "socOptIn": false,
     "view:additionalEvidence": false,
 
     "contestableIssues": [

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
@@ -24,7 +24,7 @@
       },
       "boardReviewOption": "evidence_submission",
       "timezone": "America/Los_Angeles",
-      "socOptIn": true
+      "socOptIn": false
     }
   },
   "included": [

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
@@ -25,7 +25,7 @@
       "boardReviewOption": "hearing",
       "hearingTypePreference": "central_office",
       "timezone": "America/Los_Angeles",
-      "socOptIn": true
+      "socOptIn": false
     }
   },
   "included": [

--- a/src/applications/appeals/10182/tests/schema/initialData.js
+++ b/src/applications/appeals/10182/tests/schema/initialData.js
@@ -7,7 +7,7 @@ export default {
   homeless: false,
   boardReviewOption: '',
   hearingTypePreference: '',
-  socOptIn: true,
+  socOptIn: false,
   'view:additionalEvidence': '',
 
   // Leave 'view:selected' set to false for unit testing

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -20,7 +20,7 @@ import {
  * @property {String} hearingTypePreference - Vetera selected hearing type -
  *   enum to "virtual_hearing", "video_conference" or "central_office"
  * @property {Boolean} socOptIn - check box indicating the Veteran has opted in
- *   to the new appeal process
+ *   to the new appeal process (always false)
  * @property {Boolean} view:additionalEvidence - Veteran choice to upload more
  *   evidence
  */


### PR DESCRIPTION
## Description

The legacy opt-in checkbox was removed from the online Notice of Disagreement form. It was set to submit a `true` value upon submission, but the Board would prefer if this were submitted as `false` - see https://dsva.slack.com/archives/CSKKUL36K/p1646066684092459?thread_ts=1645024816.097359&cid=CSKKUL36K

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/37779

## Testing done

Updated submit value & mock data

## Screenshots

N/A

## Acceptance criteria
- [x] Submit `socOptIn` value as `false`
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
