### PR TITLE
CST: Update to `va-telephone` web component

### DIFF
--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -1,18 +1,16 @@
 import React from 'react';
-
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 
 function StemAskVAQuestions() {
-  const recordLinkClick = () => {
-    recordEvent({
-      event: 'nav-ask-va-questions-link-click',
-      'ask-va-questions-header': 'Need help',
-    });
+  const handler = {
+    recordLinkClick: () => {
+      recordEvent({
+        event: 'nav-ask-va-questions-link-click',
+        'ask-va-questions-header': 'Need help',
+      });
+    },
   };
 
   return (
@@ -22,7 +20,10 @@ function StemAskVAQuestions() {
         Ask a question
       </h3>
       <p className="vads-u-padding-top--1px">
-        <a href="https://www.va.gov/contact-us/" onClick={recordLinkClick}>
+        <a
+          href="https://www.va.gov/contact-us/"
+          onClick={handler.recordLinkClick}
+        >
           Contact us online through Ask VA
         </a>
       </p>
@@ -31,48 +32,24 @@ function StemAskVAQuestions() {
       </h3>
       <p className="vads-u-padding-top--1px">Veterans Crisis Line: </p>
       <p>
-        <Telephone onClick={recordLinkClick} contact={CONTACTS.CRISIS_LINE} />{' '}
-        and select 1
+        <va-telephone contact={CONTACTS.CRISIS_LINE} /> and select 1
       </p>
       <br />
       <p>Education Call Center:</p>
       <p>
-        <span
-          aria-describedby="inside-US-tele"
-          className="no-wrap"
-          href="tel:+18884424551"
-          aria-label="8 8 8. 4 4 2. 4 5 5 1."
-        >
-          <Telephone contact={CONTACTS.GI_BILL} onClick={recordLinkClick} />
-        </span>{' '}
+        <va-telephone contact={CONTACTS.GI_BILL} />
         <span id="inside-US-tele">(inside the U.S.)</span>
       </p>
       <p>
-        <span
-          aria-describedby="outside-US-tele"
-          className="no-wrap"
-          href="tel:+19187815678"
-          aria-label="9 1 8. 7 8 1. 5 6 7 8."
-        >
-          <Telephone
-            contact={'19187815678'}
-            pattern={PATTERNS.OUTSIDE_US}
-            onClick={recordLinkClick}
-          />
-        </span>{' '}
+        <va-telephone contact="19187815678" international />
         <span id="outside-US-tele">(outside the U.S.)</span>
       </p>
       <p>
-        TTY, Federal Relay:{' '}
-        <Telephone
-          contact={CONTACTS[711]}
-          pattern={PATTERNS['3_DIGIT']}
-          onClick={recordLinkClick}
-        />
+        TTY, Federal Relay: <va-telephone contact={CONTACTS[711]} />
       </p>
       <br />
       <p>
-        <a href="/find-locations" onClick={recordLinkClick}>
+        <a href="/find-locations" onClick={handler.recordLinkClick}>
           VA Regional Office Location
         </a>
       </p>

--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -175,8 +173,8 @@ const StemDeniedDetails = ({
         .
       </p>
       <p>
-        You can also contact us at <Telephone contact={CONTACTS.GI_BILL} /> to
-        request any of these forms.
+        You can also contact us at <va-telephone contact={CONTACTS.GI_BILL} />
+        to request any of these forms.
       </p>
       <p>
         <a href="https://www.va.gov/decision-reviews">

--- a/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as Sentry from '@sentry/browser';
+// remove this Telephone once the web component supports this pattern exception
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';


### PR DESCRIPTION
## Description

Updated `Telephone` React component to `va-telephone` web component (WC). The WC includes analytics, so it was removed from the code.

There is one telephone in the `AppealHelpSidebar` that was not modified because it uses a pattern that is not supported by the WC (`877-222-VETS (8387)`). See [telephone style guide for the exception](https://design.va.gov/content-style-guide/dates-and-numbers#phone-numbers) and mention in the [`va-telephone` component library pull request](https://github.com/department-of-veterans-affairs/component-library/pull/233). [Add support for vanity phone numbers ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/36964).

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/36944

## Testing done

All tests passing

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] Replace `Telephone` with `va-telephone`
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
