### PR TITLE
Bump Formation Dependency to Latest Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "^6.2.1",
-    "@department-of-veterans-affairs/formation": "6.17.5",
+    "@department-of-veterans-affairs/formation": "7.0.0",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,10 +2141,10 @@
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/formation@6.17.5":
-  version "6.17.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.5.tgz#56f7c7fa59c52d3a82f7d741945139b6081f42bc"
-  integrity sha512-MvRIseS7tkz6QLPrF44HN59b/YnCEasfpot+6ctT+mrvf7aq4BcBelCFX3v1LXWzFGFQUR1JP20fkQK2goBj7A==
+"@department-of-veterans-affairs/formation@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.0.tgz#02246372198dcf50ffd98e7dcf075e6a0ebe0db3"
+  integrity sha512-ektA7Li9mAekw3ZxaIhv2Z/nT22YfcGuFcDDLAVn7enUEKwqTLzLiwQNgVxH3x/gm5CNHHP1IAWhGz54N7fznw==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Related PR
https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/776

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35482

## Description
Upgrades to Formation have been made to remove deprecated code which has been removed from Vets-Website in back-to-top and progress-bar related scss. The latest release of formation has the excess code removed.

## Acceptance criteria
- [X] Vets-website should use the latest version of Formation

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
