### PR TITLE
37809: Remove menu button on USiP

### DIFF
--- a/src/platform/site-wide/header/components/LogoRow/index.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.js
@@ -3,9 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
+import { loginAppUrlRE } from 'platform/user/authentication/utilities';
 import Logo from '../Logo';
 import UserNav from '../../../user-nav/containers/Main';
-import recordEvent from 'platform/monitoring/record-event';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
 export const LogoRow = ({
@@ -21,6 +22,8 @@ export const LogoRow = ({
     updateExpandedMenuID();
     setIsMenuOpen(!isMenuOpen);
   };
+
+  const isUnifiedSignInPage = loginAppUrlRE.test(window.location.pathname);
 
   return (
     <div className="header-logo-row vads-u-background-color--primary-darkest vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between vads-u-padding-y--1p5 vads-u-padding-left--1p5 vads-u-padding-right--1">
@@ -39,34 +42,36 @@ export const LogoRow = ({
         <UserNav isHeaderV2 />
 
         {/* Mobile menu button */}
-        <button
-          aria-controls="header-nav-items"
-          aria-expanded={isMenuOpen ? 'true' : 'false'}
-          className="header-menu-button usa-button vads-u-background-color--gray-lightest vads-u-color--link-default vads-u-padding-y--1 vads-u-padding-x--1p5 vads-u-margin--0 vads-u-margin-left--2 vads-u-position--relative"
-          onClick={onMenuToggle}
-          type="button"
-        >
-          {/* Menu | Close */}
-          {!isMenuOpen ? 'Menu' : 'Close'}
+        {!isUnifiedSignInPage && (
+          <button
+            aria-controls="header-nav-items"
+            aria-expanded={isMenuOpen ? 'true' : 'false'}
+            className="header-menu-button usa-button vads-u-background-color--gray-lightest vads-u-color--link-default vads-u-padding-y--1 vads-u-padding-x--1p5 vads-u-margin--0 vads-u-margin-left--2 vads-u-position--relative"
+            onClick={onMenuToggle}
+            type="button"
+          >
+            {/* Menu | Close */}
+            {!isMenuOpen ? 'Menu' : 'Close'}
 
-          {/* Menu bars icon | Close icon */}
-          {!isMenuOpen ? (
-            <i
-              aria-hidden="true"
-              className="fa fa-bars vads-u-margin-left--1 vads-u-font-size--sm"
-            />
-          ) : (
-            <i
-              aria-hidden="true"
-              className="fa fa-times vads-u-margin-left--1 vads-u-font-size--sm"
-            />
-          )}
+            {/* Menu bars icon | Close icon */}
+            {!isMenuOpen ? (
+              <i
+                aria-hidden="true"
+                className="fa fa-bars vads-u-margin-left--1 vads-u-font-size--sm"
+              />
+            ) : (
+              <i
+                aria-hidden="true"
+                className="fa fa-times vads-u-margin-left--1 vads-u-font-size--sm"
+              />
+            )}
 
-          {/* Styling overlay */}
-          {isMenuOpen && (
-            <div className="header-menu-button-overlay vads-u-background-color--gray-lightest vads-u-position--absolute vads-u-width--full" />
-          )}
-        </button>
+            {/* Styling overlay */}
+            {isMenuOpen && (
+              <div className="header-menu-button-overlay vads-u-background-color--gray-lightest vads-u-position--absolute vads-u-width--full" />
+            )}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/platform/site-wide/header/tests/components.js/LogoRow.spec.js
+++ b/src/platform/site-wide/header/tests/components.js/LogoRow.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import { mockEventListeners } from 'platform/testing/unit/helpers';
+import { LogoRow } from '../../components/LogoRow';
+
+describe('<LogoRow>', () => {
+  const props = {
+    isMenuOpen: false,
+    setIsMenuOpen: sinon.stub().resolves(true),
+    updateExpandedMenuID: sinon.stub().resolves(true),
+  };
+
+  let oldWindow = null;
+  beforeEach(() => {
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(
+      global.window,
+      mockEventListeners({
+        location: { pathname: '/' },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    global.window = oldWindow;
+  });
+
+  it('should render', () => {
+    const wrapper = shallow(<LogoRow {...props} />);
+    expect(wrapper.find('.header-logo-row').exists()).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should render Menu Button', () => {
+    const wrapper = shallow(<LogoRow {...props} />);
+    expect(wrapper.find('.header-menu-button').exists()).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should NOT render Menu Button on the Unified Sign in Page (USiP)', () => {
+    global.window.location.pathname = '/sign-in';
+    const wrapper = shallow(<LogoRow {...props} />);
+    expect(wrapper.find('.header-menu-button').exists()).to.be.false;
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
Removes the menu button on the `/sign-in` (USiP)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37809


## Testing done
- Unit tests created

## Screenshots
<img width="562" alt="image" src="https://user-images.githubusercontent.com/13320944/156206923-373da0c1-0ccd-4126-9ef5-0fc563a1b28c.png">


## Acceptance criteria
- [ ] Menu button does not render on mobile or desktop USiP (`/sign-in`)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
