### PR TITLE
Add `ui:autocomplete` property to fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "@department-of-veterans-affairs/component-library": "^7.1.0",
     "@department-of-veterans-affairs/formation": "7.0.0",
     "@department-of-veterans-affairs/formulate": "0.0.1",
-    "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
+    "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@formatjs/intl-datetimeformat": "^4.2.3",
     "@formatjs/intl-getcanonicallocales": "^1.7.3",
     "@formatjs/intl-locale": "^2.4.37",

--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -23,13 +23,16 @@ export const uiSchema = {
     items: {
       first: {
         'ui:title': 'First name',
+        'ui:autocomplete': 'given-name',
         'ui:required': hasAlternateName,
       },
       middle: {
         'ui:title': 'Middle name',
+        'ui:autocomplete': 'additional-name',
       },
       last: {
         'ui:title': 'Last name',
+        'ui:autocomplete': 'family-name',
         'ui:required': hasAlternateName,
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -100,6 +100,7 @@ export const uiSchema = {
     },
     country: {
       'ui:title': 'Country',
+      'ui:autocomplete': 'country',
       'ui:options': {
         updateSchema: (formData, schema, uiSchemaCountry) => {
           const uiSchemaDisabled = uiSchemaCountry;
@@ -123,23 +124,27 @@ export const uiSchema = {
     },
     addressLine1: {
       'ui:title': 'Street address (20 characters maximum)',
+      'ui:autocomplete': 'address-line1',
       'ui:errorMessages': {
         required: 'Please enter a street address',
       },
     },
     addressLine2: {
       'ui:title': 'Street address line 2 (20 characters maximum)',
+      'ui:autocomplete': 'address-line2',
       'ui:errorMessages': {
         pattern: 'Please enter a valid street address',
       },
     },
     addressLine3: {
       'ui:title': 'Street address line 3 (20 characters maximum)',
+      'ui:autocomplete': 'address-line3',
       'ui:errorMessages': {
         pattern: 'Please enter a valid street address',
       },
     },
     city: {
+      'ui:autocomplete': 'address-level2',
       'ui:errorMessages': {
         pattern: 'Please enter a valid city',
         required: 'Please enter a city',
@@ -171,6 +176,7 @@ export const uiSchema = {
     },
     state: {
       'ui:title': 'State',
+      'ui:autocomplete': 'address-level1',
       'ui:options': {
         hideIf: formData =>
           !formData.mailingAddress?.['view:livesOnMilitaryBase'] &&
@@ -208,6 +214,7 @@ export const uiSchema = {
     },
     zipCode: {
       'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
       'ui:validations': [validateZIP],
       'ui:required': formData =>
         formData.mailingAddress?.['view:livesOnMilitaryBase'] ||

--- a/src/applications/disability-benefits/all-claims/pages/individualsInvolvedFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/individualsInvolvedFollowUp.js
@@ -1,12 +1,11 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import { ptsd781NameTitle } from '../content/ptsdClassification';
 import {
   individualsDescription,
   personDescriptionText,
 } from '../content/individualsInvolved';
 import IndividualsInvolvedCard from '../components/IndividualsInvolvedCard';
-
-import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
 const {
   personsInvolved,
@@ -39,18 +38,21 @@ export const uiSchema = index => ({
         name: {
           first: {
             'ui:title': 'First name',
+            'ui:autocomplete': 'off',
             'ui:errorMessages': {
               required: 'Please enter a first name',
             },
           },
           last: {
             'ui:title': 'Last name',
+            'ui:autocomplete': 'off',
             'ui:errorMessages': {
               required: 'Please enter a last name',
             },
           },
           middle: {
             'ui:title': 'Middle name',
+            'ui:autocomplete': 'off',
           },
         },
         description: {

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -1,6 +1,7 @@
 import _ from 'platform/utilities/data';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
+import { validateDate } from 'platform/forms-system/src/js/validation';
 import {
   recordReleaseDescription,
   limitedConsentTitle,
@@ -9,7 +10,6 @@ import {
 } from '../content/privateMedicalRecordsRelease';
 
 import PrivateProviderTreatmentView from '../components/PrivateProviderTreatmentView';
-import { validateDate } from 'platform/forms-system/src/js/validation';
 
 import { validateZIP } from '../validations';
 
@@ -19,7 +19,7 @@ const {
   providerFacilityName,
   providerFacilityAddress,
 } = form4142.properties.providerFacility.items.properties;
-const limitedConsent = form4142.properties.limitedConsent;
+const { limitedConsent } = form4142.properties;
 
 export const uiSchema = {
   'ui:description': recordReleaseDescription,
@@ -64,21 +64,27 @@ export const uiSchema = {
         ],
         country: {
           'ui:title': 'Country',
+          'ui:autocomplete': 'off',
         },
         street: {
           'ui:title': 'Street',
+          'ui:autocomplete': 'off',
         },
         street2: {
           'ui:title': 'Street 2',
+          'ui:autocomplete': 'off',
         },
         city: {
           'ui:title': 'City',
+          'ui:autocomplete': 'off',
         },
         state: {
           'ui:title': 'State',
+          'ui:autocomplete': 'off',
         },
         postalCode: {
           'ui:title': 'Postal code',
+          'ui:autocomplete': 'off',
           'ui:validations': [validateZIP],
           'ui:errorMessages': {
             pattern:

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -84,9 +84,11 @@ export const uiSchema = {
         'ui:order': ['country', 'state', 'city'],
         country: {
           'ui:title': 'Country',
+          'ui:autocomplete': 'off',
         },
         state: {
           'ui:title': 'State',
+          'ui:autocomplete': 'off',
           'ui:validations': [validateMilitaryTreatmentState],
           'ui:options': {
             expandUnder: 'country',
@@ -95,6 +97,7 @@ export const uiSchema = {
         },
         city: {
           'ui:title': 'City',
+          'ui:autocomplete': 'off',
           'ui:validations': [validateMilitaryTreatmentCity],
         },
       },

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -16,16 +16,12 @@ import { focusElement } from 'platform/utilities/ui';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
-import {
-  validateMilitaryCity,
-  validateMilitaryState,
-  validateZIP,
-} from '../validations';
 import ReviewCardField from 'platform/forms-system/src/js/components/ReviewCardField';
 import AddressViewField from 'platform/forms-system/src/js/components/AddressViewField';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
 
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import {
   DATA_PATHS,
   DISABILITY_526_V2_ROOT_URL,
@@ -52,7 +48,11 @@ import {
   PDF_SIZE_FEATURE,
   CHAR_LIMITS,
 } from '../constants';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import {
+  validateMilitaryCity,
+  validateMilitaryState,
+  validateZIP,
+} from '../validations';
 
 /**
  * Returns an object where all the fields are prefixed with `view:` if they aren't already
@@ -425,9 +425,11 @@ export const addressUISchema = (
     },
     country: {
       'ui:title': 'Country',
+      'ui:autocomplete': 'country',
     },
     addressLine1: {
       'ui:title': 'Street address',
+      'ui:autocomplete': 'address-line1',
       'ui:errorMessages': {
         pattern: 'Please enter a valid street address',
         required: 'Please enter a street address',
@@ -435,18 +437,21 @@ export const addressUISchema = (
     },
     addressLine2: {
       'ui:title': 'Street address line 2',
+      'ui:autocomplete': 'address-line2',
       'ui:errorMessages': {
         pattern: 'Please enter a valid street address',
       },
     },
     addressLine3: {
       'ui:title': 'Street address line 3',
+      'ui:autocomplete': 'address-line3',
       'ui:errorMessages': {
         pattern: 'Please enter a valid street address',
       },
     },
     city: {
       'ui:title': 'City',
+      'ui:autocomplete': 'address-level2',
       'ui:validations': [
         {
           options: { addressPath },
@@ -461,6 +466,7 @@ export const addressUISchema = (
     },
     state: {
       'ui:title': 'State',
+      'ui:autocomplete': 'address-level1',
       'ui:required': (formData, index) =>
         fieldsAreRequired &&
         _.get(`${pathWithIndex(addressPath, index)}.country`, formData, '') ===
@@ -488,6 +494,7 @@ export const addressUISchema = (
     },
     zipCode: {
       'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
       'ui:validations': [validateZIP],
       'ui:required': (formData, index) =>
         fieldsAreRequired &&

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -274,21 +274,27 @@ export function uiSchema(
     'ui:order': fieldOrder,
     country: {
       'ui:title': 'Country',
+      'ui:autocomplete': 'country',
     },
     street: {
       'ui:title': 'Street',
+      'ui:autocomplete': 'address-line1',
     },
     street2: {
       'ui:title': 'Line 2',
+      'ui:autocomplete': 'address-line2',
     },
     street3: {
       'ui:title': 'Line 3',
+      'ui:autocomplete': 'address-line3',
     },
     city: {
       'ui:title': 'City',
+      'ui:autocomplete': 'address-level2',
     },
     postalCode: {
       'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
       },

--- a/src/platform/forms-system/src/js/definitions/address.js
+++ b/src/platform/forms-system/src/js/definitions/address.js
@@ -1,14 +1,13 @@
-import get from '../../../../utilities/data/get';
-import set from '../../../../utilities/data/set';
-import unset from '../../../../utilities/data/unset';
 import { createSelector } from 'reselect';
-
 import {
   countries,
   states,
   isValidUSZipCode,
   isValidCanPostalCode,
 } from 'platform/forms/address';
+import get from '../../../../utilities/data/get';
+import set from '../../../../utilities/data/set';
+import unset from '../../../../utilities/data/unset';
 
 function validatePostalCodes(errors, address) {
   let isValidPostalCode = true;
@@ -272,21 +271,26 @@ export function uiSchema(
     'ui:order': fieldOrder,
     country: {
       'ui:title': 'Country',
+      'ui:autocomplete': 'country',
     },
     street: {
       'ui:title': 'Street',
+      'ui:autocomplete': 'address-line1',
       'ui:errorMessages': {
         required: 'Please enter a street address',
       },
     },
     street2: {
       'ui:title': 'Street address line 2',
+      'ui:autocomplete': 'address-line2',
     },
     street3: {
       'ui:title': 'Street address line 3',
+      'ui:autocomplete': 'address-line3',
     },
     city: {
       'ui:title': 'City',
+      'ui:autocomplete': 'address-level2',
       'ui:errorMessages': {
         required: 'Please enter a city',
       },
@@ -294,10 +298,12 @@ export function uiSchema(
     state: {
       'ui:errorMessages': {
         required: 'Please enter a state',
+        'ui:autocomplete': 'address-level1',
       },
     },
     postalCode: {
       'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
       },

--- a/src/platform/forms-system/src/js/definitions/confirmationEmail.js
+++ b/src/platform/forms-system/src/js/definitions/confirmationEmail.js
@@ -1,6 +1,7 @@
 export default function uiSchema(label, dataConstant) {
   return {
     'ui:title': `Re-enter ${label}  email address`,
+    'ui:autocomplete': 'email',
     'ui:widget': 'email',
     'ui:required': formData => !!formData[dataConstant],
     'ui:validations': [

--- a/src/platform/forms-system/src/js/definitions/email.js
+++ b/src/platform/forms-system/src/js/definitions/email.js
@@ -10,6 +10,7 @@ export default function uiSchema(title = 'Email address') {
       pattern: 'Please enter an email address using this format: X@X.com',
       required: 'Please enter an email address',
     },
+    'ui:autocomplete': 'email',
     'ui:options': {
       inputType: 'email',
     },

--- a/src/platform/forms-system/src/js/definitions/fullName.js
+++ b/src/platform/forms-system/src/js/definitions/fullName.js
@@ -1,21 +1,25 @@
 const uiSchema = {
   first: {
     'ui:title': 'First name',
+    'ui:autocomplete': 'given-name',
     'ui:errorMessages': {
       required: 'Please enter a first name',
     },
   },
   last: {
     'ui:title': 'Last name',
+    'ui:autocomplete': 'family-name',
     'ui:errorMessages': {
       required: 'Please enter a last name',
     },
   },
   middle: {
     'ui:title': 'Middle name',
+    'ui:autocomplete': 'additional-name',
   },
   suffix: {
     'ui:title': 'Suffix',
+    'ui:autocomplete': 'honorific-suffix',
     'ui:options': {
       widgetClassNames: 'form-select-medium',
     },

--- a/src/platform/forms-system/src/js/definitions/phone.js
+++ b/src/platform/forms-system/src/js/definitions/phone.js
@@ -11,6 +11,7 @@ export default function uiSchema(title = 'Phone') {
     'ui:widget': PhoneNumberWidget,
     'ui:reviewWidget': PhoneNumberReviewWidget,
     'ui:title': title,
+    'ui:autocomplete': 'tel',
     'ui:errorMessages': {
       pattern: 'Please enter a 10-digit phone number (with or without dashes)',
       minLength:

--- a/src/platform/forms-system/src/js/definitions/profileAddress.js
+++ b/src/platform/forms-system/src/js/definitions/profileAddress.js
@@ -134,6 +134,7 @@ export default function addressUiSchema(
     country: {
       'ui:required': uiRequiredCallback,
       'ui:title': 'Country',
+      'ui:autocomplete': 'country',
       'ui:options': {
         /**
          * This is needed because the country dropdown needs to be set to USA and disabled if a
@@ -167,6 +168,7 @@ export default function addressUiSchema(
     street: {
       'ui:required': uiRequiredCallback,
       'ui:title': 'Street address',
+      'ui:autocomplete': 'address-line1',
       'ui:errorMessages': {
         required: 'Street address is required',
         pattern: 'Please fill in a valid street address',
@@ -174,18 +176,21 @@ export default function addressUiSchema(
     },
     street2: {
       'ui:title': 'Street address line 2',
+      'ui:autocomplete': 'address-line2',
       'ui:options': {
         hideEmptyValueInReview: true,
       },
     },
     street3: {
       'ui:title': 'Street address line 3',
+      'ui:autocomplete': 'address-line3',
       'ui:options': {
         hideEmptyValueInReview: true,
       },
     },
     city: {
       'ui:required': uiRequiredCallback,
+      'ui:autocomplete': 'address-level2',
       'ui:errorMessages': {
         required: 'City is required',
       },
@@ -219,6 +224,7 @@ export default function addressUiSchema(
       },
     },
     state: {
+      'ui:autocomplete': 'address-level1',
       'ui:required': (formData, index) => {
         // Only required if the country is the United States;
         const formDataPath = getPath(path, index);
@@ -251,25 +257,26 @@ export default function addressUiSchema(
               enum: constants.militaryStates.map(state => state.value),
               enumNames: constants.militaryStates.map(state => state.label),
             };
-          } else if (!isMilitary && country === 'USA') {
+          }
+          if (!isMilitary && country === 'USA') {
             return {
               type: 'string',
               title: 'State',
               enum: filteredStates.map(state => state.value),
               enumNames: filteredStates.map(state => state.label),
             };
-          } else {
-            return {
-              type: 'string',
-              title: 'State/Province/Region',
-            };
           }
+          return {
+            type: 'string',
+            title: 'State/Province/Region',
+          };
         },
       },
     },
     postalCode: {
       'ui:required': uiRequiredCallback,
       'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
       'ui:errorMessages': {
         required: 'Postal code is required',
         pattern: 'Please enter a valid 5 digit US zip code',
@@ -284,11 +291,10 @@ export default function addressUiSchema(
               type: 'string',
               pattern: US_POSTAL_CODE_PATTERN,
             };
-          } else {
-            return {
-              type: 'string',
-            };
           }
+          return {
+            type: 'string',
+          };
         },
       },
     },

--- a/src/platform/forms-system/src/js/widgets/EmailWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/EmailWidget.jsx
@@ -2,5 +2,5 @@ import React from 'react';
 import TextWidget from './TextWidget';
 
 export default function EmailWidget(props) {
-  return <TextWidget type="email" {...props} />;
+  return <TextWidget type="email" autocomplete="email" {...props} />;
 }

--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -30,7 +30,8 @@ export default class PhoneNumberWidget extends React.Component {
     return (
       <TextWidget
         {...this.props}
-        type={'tel'}
+        type="tel"
+        autocomplete="tel"
         value={this.state.val}
         onChange={this.handleChange}
       />

--- a/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
@@ -39,6 +39,7 @@ export default function RadioWidget({
             <input
               type="radio"
               checked={checked}
+              autoComplete="off"
               id={`${id}_${i}`}
               name={`${id}`}
               value={option.value}

--- a/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
@@ -29,6 +29,7 @@ export default function YesNoWidget({
       <input
         type="radio"
         checked={value === values.Y}
+        autoComplete="off"
         id={`${id}Yes`}
         name={`${id}`}
         value="Y"
@@ -40,6 +41,7 @@ export default function YesNoWidget({
       <input
         type="radio"
         checked={value === values.N}
+        autoComplete="off"
         id={`${id}No`}
         name={`${id}`}
         value="N"

--- a/src/platform/forms-system/test/js/definitions/address.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/address.unit.spec.jsx
@@ -6,8 +6,8 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { schema, uiSchema } from '../../../src/js/definitions/address';
 import definitions from 'vets-json-schema/dist/definitions.json';
+import { schema, uiSchema } from '../../../src/js/definitions/address';
 
 const { address } = definitions;
 const addressSchema = {
@@ -26,6 +26,11 @@ describe('Schemaform definition address', () => {
     const inputs = form.find('input');
     const selects = form.find('select');
     expect(inputs.length).to.equal(4);
+    // address in definitions.json does not include address line 3
+    expect(inputs.first().props().autoComplete).to.equal('address-line1');
+    expect(inputs.at(1).props().autoComplete).to.equal('address-line2');
+    expect(inputs.at(2).props().autoComplete).to.equal('address-level2'); // city
+    expect(inputs.last().props().autoComplete).to.equal('postal-code');
     expect(selects.length).to.equal(2);
 
     // Postal code should be small

--- a/src/platform/forms-system/test/js/definitions/fullName.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/fullName.unit.spec.jsx
@@ -3,9 +3,10 @@ import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
-import uiSchema from '../../../src/js/definitions/fullName';
 import definitions from 'vets-json-schema/dist/definitions.json';
+
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import uiSchema from '../../../src/js/definitions/fullName';
 
 describe('Schemaform definition fullName', () => {
   it('should render fullName', () => {
@@ -20,5 +21,8 @@ describe('Schemaform definition fullName', () => {
     expect(inputs.length).to.equal(3);
     expect(selects.length).to.equal(1);
     expect(selects[0].classList.contains('form-select-medium')).to.be.true;
+    expect(inputs[0].autocomplete).to.equal('given-name');
+    expect(inputs[1].autocomplete).to.equal('additional-name');
+    expect(inputs[2].autocomplete).to.equal('family-name');
   });
 });

--- a/src/platform/forms-system/test/js/definitions/phone.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/phone.unit.spec.jsx
@@ -5,8 +5,8 @@ import ReactTestUtils from 'react-dom/test-utils';
 import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
-import uiSchema from '../../../src/js/definitions/phone';
 import definitions from 'vets-json-schema/dist/definitions.json';
+import uiSchema from '../../../src/js/definitions/phone';
 
 describe('Schemaform definition phone', () => {
   it('should render phone', () => {
@@ -25,6 +25,7 @@ describe('Schemaform definition phone', () => {
       expect(input.classList.contains(className)).to.be.true;
     });
     expect(input.type).to.equal('tel');
+    expect(input.autocomplete).to.equal('tel');
   });
   it('should render phone title', () => {
     const form = ReactTestUtils.renderIntoDocument(

--- a/src/platform/forms-system/test/js/widgets/EmailWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/EmailWidget.unit.spec.jsx
@@ -7,6 +7,8 @@ import EmailWidget from '../../../src/js/widgets/EmailWidget';
 describe('Schemaform <EmailWidget>', () => {
   it('should render', () => {
     const tree = SkinDeep.shallowRender(<EmailWidget />);
-    expect(tree.subTree('TextWidget').props.type).to.equal('email');
+    const { props } = tree.subTree('TextWidget');
+    expect(props.type).to.equal('email');
+    expect(props.autocomplete).to.equal('email');
   });
 });

--- a/src/platform/forms-system/test/js/widgets/PhoneNumberWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/PhoneNumberWidget.unit.spec.jsx
@@ -15,7 +15,9 @@ describe('Schemaform <PhoneNumberWidget>', () => {
 
   it('should render a "tel" type input', () => {
     const tree = SkinDeep.shallowRender(<PhoneNumberWidget />);
-    expect(tree.subTree('TextWidget').props.type).to.equal('tel');
+    const input = tree.subTree('TextWidget').props;
+    expect(input.type).to.equal('tel');
+    expect(input.autocomplete).to.equal('tel');
   });
 
   it('should strip anything that is not a number on change', () => {

--- a/src/platform/forms/definitions/address.js
+++ b/src/platform/forms/definitions/address.js
@@ -122,7 +122,8 @@ export function schema(
   return {
     type: 'object',
     required: isRequired ? requiredFields : [],
-    properties: Object.assign({}, addressSchema.properties, {
+    properties: {
+      ...addressSchema.properties,
       country: {
         default: 'USA',
         type: 'string',
@@ -138,7 +139,7 @@ export function schema(
         type: 'string',
         maxLength: 10,
       },
-    }),
+    },
   };
 }
 
@@ -301,32 +302,39 @@ export function uiSchema(
     'ui:order': fieldOrder,
     country: {
       'ui:title': 'Country',
+      'ui:autocomplete': 'country',
     },
     street: {
       'ui:title': 'Street',
+      'ui:autocomplete': 'address-line1',
       'ui:errorMessages': {
         required: 'Please enter a street address',
       },
     },
     street2: {
       'ui:title': 'Street address line 2',
+      'ui:autocomplete': 'address-line2',
     },
     street3: {
       'ui:title': 'Street address line 3',
+      'ui:autocomplete': 'address-line3',
     },
     city: {
       'ui:title': 'City',
+      'ui:autocomplete': 'address-level2',
       'ui:errorMessages': {
         required: 'Please enter a city',
       },
     },
     state: {
+      'ui:autocomplete': 'address-level1',
       'ui:errorMessages': {
         required: 'Please enter a state',
       },
     },
     postalCode: {
       'ui:title': 'Postal code',
+      'ui:autocomplete': 'postal-code',
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
       },

--- a/src/platform/forms/definitions/fullName.js
+++ b/src/platform/forms/definitions/fullName.js
@@ -10,21 +10,25 @@ const uiSchema = {
   'ui:validations': [validateName],
   first: {
     'ui:title': 'Your first name',
+    'ui:autocomplete': 'given-name',
     'ui:errorMessages': {
       required: 'Please enter a first name',
     },
   },
   last: {
     'ui:title': 'Your last name',
+    'ui:autocomplete': 'family-name',
     'ui:errorMessages': {
       required: 'Please enter a last name',
     },
   },
   middle: {
     'ui:title': 'Your middle name',
+    'ui:autocomplete': 'additional-name',
   },
   suffix: {
     'ui:title': 'Suffix',
+    'ui:autocomplete': 'honorific-suffix',
     'ui:options': {
       widgetClassNames: 'form-select-medium',
     },

--- a/src/platform/user/profile/vap-svc/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vap-svc/components/AddressField/address-schemas.js
@@ -104,6 +104,7 @@ const uiSchema = {
   },
   countryCodeIso3: {
     'ui:title': 'Country',
+    'ui:autocomplete': 'country',
     'ui:options': {
       updateSchema: formData => {
         if (formData['view:livesOnMilitaryBase']) {
@@ -131,6 +132,7 @@ const uiSchema = {
   },
   addressLine1: {
     'ui:title': `Street address (${STREET_LINE_MAX_LENGTH} characters maximum)`,
+    'ui:autocomplete': 'address-line1',
     'ui:errorMessages': {
       required: 'Street address is required',
       pattern: `Please enter a valid street address under ${STREET_LINE_MAX_LENGTH} characters`,
@@ -138,17 +140,20 @@ const uiSchema = {
   },
   addressLine2: {
     'ui:title': `Street address line 2 (${STREET_LINE_MAX_LENGTH} characters maximum)`,
+    'ui:autocomplete': 'address-line2',
     'ui:errorMessages': {
       pattern: `Please enter a valid street address under ${STREET_LINE_MAX_LENGTH} characters`,
     },
   },
   addressLine3: {
     'ui:title': `Street address line 3 (${STREET_LINE_MAX_LENGTH} characters maximum)`,
+    'ui:autocomplete': 'address-line3',
     'ui:errorMessages': {
       pattern: `Please enter a valid street address under ${STREET_LINE_MAX_LENGTH} characters`,
     },
   },
   city: {
+    'ui:autocomplete': 'address-level2',
     'ui:errorMessages': {
       required: 'City is required',
       pattern: `Please enter a valid city under 100 characters`,
@@ -174,6 +179,7 @@ const uiSchema = {
   },
   stateCode: {
     'ui:title': 'State',
+    'ui:autocomplete': 'address-level1',
     'ui:errorMessages': {
       required: 'State is required',
     },
@@ -197,6 +203,7 @@ const uiSchema = {
   },
   province: {
     'ui:title': 'State/Province/Region',
+    'ui:autocomplete': 'address-level1',
     'ui:errorMessages': {
       pattern: `Please enter a valid state, province, or region`,
     },
@@ -206,6 +213,7 @@ const uiSchema = {
   },
   zipCode: {
     'ui:title': 'Zip code',
+    'ui:autocomplete': 'postal-code',
     'ui:errorMessages': {
       required: 'Zip code is required',
       pattern: 'Zip code must be 5 digits',
@@ -219,6 +227,7 @@ const uiSchema = {
   },
   internationalPostalCode: {
     'ui:title': 'International postal code',
+    'ui:autocomplete': 'postal-code',
     'ui:errorMessages': {
       required: 'Postal code is required',
       pattern: 'Please enter a valid postal code',

--- a/src/platform/user/profile/vap-svc/components/EmailField/EmailField.jsx
+++ b/src/platform/user/profile/vap-svc/components/EmailField/EmailField.jsx
@@ -25,6 +25,7 @@ const formSchema = {
 const uiSchema = {
   emailAddress: {
     'ui:title': 'Email Address',
+    'ui:autocomplete': 'email',
     'ui:errorMessages': {
       required: 'Please enter your email address, using this format: X@X.com',
       pattern:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,10 +2180,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/react-jsonschema-form@^1.0.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-jsonschema-form/-/react-jsonschema-form-1.2.0.tgz#9080236759e920e30f10727055a9dc04f4a711a8"
-  integrity sha512-SuwcYn59fv3nWxmbfh43KUdrKmn4vcd7aMQuKlu0vcOjcArsl9n5YWPgUwBtLOoztSZl9D8sRlxBAPqmoXCsQA==
+"@department-of-veterans-affairs/react-jsonschema-form@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-jsonschema-form/-/react-jsonschema-form-1.2.5.tgz#56e759a185b1d3f92ca7bb9d1407b4b2a3b406b1"
+  integrity sha512-9KDb5O5GcLIjbKgjY30pUW8aY1do8Dyo6/GutYriBRLXYr2WGPtuBxlg2gN3Iq9k58kDboahA/gT5qqWxZGY3g==
   dependencies:
     jsonschema "^1.0.2"
     lodash.topath "^4.5.2"


### PR DESCRIPTION
## Description

When an `input` has the `autocomplete` property set, it will provide automated assistance in filling out form field values, as well as guidance to the browser as to the type of information expected in the field ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)).

Added `ui:autocomplete` to the form system (react-jsonschema-form) & updated the docs

This PR:
- Adds `ui:autocomplete` to platform address, phone, email and name definitions.
- Directly added `autocomplete` to the phone & email widget.
- Directly added `autocomplete="off"` to the radio & YesNo widgets. This fixes an issue reported when the browser back button is used (see https://github.com/department-of-veterans-affairs/va.gov-team/issues/26859)
- Add `ui:autocomplete` to form 526 contact info uiSchema

There are other forms that could have their uiSchema updated, but I didn't do an extensive search.

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/37849
- https://github.com/department-of-veterans-affairs/react-jsonschema-form/pull/14
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/779

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Platform definitions for address, email, phone and name definitions
- [x] Platform phone & email widgets updated
- [x] Add `autocomplete="off"` to radio widgets

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
