### PR TITLE
Send only one claimant_info fetch during form load

### DIFF
--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -44,20 +44,26 @@ const ONE_MINUTE_IN_THE_FUTURE = () => {
 export function fetchPersonalInformation() {
   return async dispatch => {
     dispatch({ type: FETCH_PERSONAL_INFORMATION });
-
     return apiRequest(CLAIMANT_INFO_ENDPOINT)
-      .then(response =>
-        dispatch({
-          type: FETCH_PERSONAL_INFORMATION_SUCCESS,
-          response,
-        }),
-      )
-      .catch(errors =>
+      .then(response => {
+        if (!response?.data?.attributes?.claimant) {
+          window.location.href =
+            '/education/apply-for-education-benefits/application/1990/';
+        } else {
+          dispatch({
+            type: FETCH_PERSONAL_INFORMATION_SUCCESS,
+            response,
+          });
+        }
+      })
+      .catch(errors => {
         dispatch({
           type: FETCH_PERSONAL_INFORMATION_FAILED,
           errors,
-        }),
-      );
+        });
+        window.location.href =
+          '/education/apply-for-education-benefits/application/1990/';
+      });
   };
 }
 

--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -2,61 +2,39 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
-
 import { fetchPersonalInformation, fetchEligibility } from '../actions';
+import { fetchUser } from '../selectors/userDispatch';
+import { personalInfoFetchProgress } from '../selectors/personalInfoFetchInProgress';
 
 export const App = ({
-  // loggedIn,
-  // showNod,
   location,
   children,
-  // profile,
   formData,
   setFormData,
   getPersonalInfo,
   firstName,
   getEligibility,
   eligibility,
+  user,
+  personalInfoFetchInProgress,
 }) => {
   useEffect(
     () => {
-      // Do something like this to redirect The Veteran if there is
-      // an error when retrieving data.
-      // if (errors && errors.status === '404') {
-      //   // redirect
-      //   return;
-      // }
-      if (!firstName) {
-        getPersonalInfo();
+      if (user.login.currentlyLoggedIn && !personalInfoFetchInProgress) {
+        if (!firstName) {
+          getPersonalInfo();
+        }
+        if (!eligibility) {
+          getEligibility();
+        } else if (!formData.eligibility) {
+          setFormData({
+            ...formData,
+            eligibility,
+          });
+        }
       }
-      if (!eligibility) {
-        getEligibility();
-      } else if (!formData.eligibility) {
-        setFormData({
-          ...formData,
-          eligibility,
-        });
-      }
-      // The following works and sets data after the initial form load.
-      // However, we have to be careful to not wipe out manual from a saved form.
-      /* else if (
-        userFullName &&
-        !formData['view:userFullName'].userFullName.first
-      ) {
-        setFormData({
-          ...formData,
-          'view:userFullName': {
-            userFullName,
-          },
-        });
-      } */
-
-      // return () => {
-      //   cleanup
-      // }
     },
     [
       formData,
@@ -65,6 +43,8 @@ export const App = ({
       getPersonalInfo,
       getEligibility,
       eligibility,
+      user,
+      personalInfoFetchInProgress,
     ],
   );
 
@@ -72,8 +52,10 @@ export const App = ({
     <>
       <Breadcrumbs>
         <a href="/">Home</a>
-        <a href="#">Education and training</a>
-        <a href="#">Apply for education benefits</a>
+        <a href="/education">Education and training</a>
+        <a href="/education/apply-for-benefits-form-22-1990">
+          Apply for education benefits
+        </a>
       </Breadcrumbs>
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
         {children}
@@ -84,12 +66,17 @@ export const App = ({
 
 const mapStateToProps = state => {
   const formData = state.form?.data || {};
-  const firstName = state.data?.formData?.data?.claimant?.firstName;
+  const firstName = state.data?.formData?.data?.attributes?.claimant?.firstName;
   const eligibility = state.data?.eligibility;
-  // const showNod = noticeOfDisagreementFeature(state);
-  // const loggedIn = isLoggedIn(state);
-  // const { toursOfDuty } = state;
-  return { formData, firstName, eligibility };
+  const user = fetchUser(state);
+  const personalInfoFetchInProgress = personalInfoFetchProgress(state);
+  return {
+    formData,
+    firstName,
+    eligibility,
+    user,
+    personalInfoFetchInProgress,
+  };
 };
 
 const mapDispatchToProps = {

--- a/src/applications/my-education-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/my-education-benefits/containers/IntroductionPage.jsx
@@ -1,9 +1,6 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-
-import { apiRequest } from 'platform/utilities/api';
-import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { VA_FORM_IDS } from 'platform/forms/constants';
@@ -13,7 +10,6 @@ import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 
 import HowToApplyPost911GiBill from '../components/HowToApplyPost911GiBill';
 import { fetchUser } from '../selectors/userDispatch';
-import { CLAIMANT_INFO_ENDPOINT } from '../actions';
 
 export const IntroductionPage = ({ user, route }) => {
   const SaveInProgressComponent = (
@@ -26,29 +22,6 @@ export const IntroductionPage = ({ user, route }) => {
       hideUnauthedStartLink
       startText="Start your application"
     />
-  );
-
-  const handleRedirect = async response => {
-    if (!response?.data?.attributes?.claimant) {
-      window.location.href =
-        '/education/apply-for-education-benefits/application/1990/';
-    }
-    return response;
-  };
-
-  useEffect(
-    () => {
-      const checkIfClaimantExists = async () =>
-        apiRequest(CLAIMANT_INFO_ENDPOINT)
-          .then(response => handleRedirect(response))
-          .catch(err => err);
-
-      focusElement('.va-nav-breadcrumbs-list');
-      if (user.login.currentlyLoggedIn) {
-        checkIfClaimantExists().then(res => res);
-      }
-    },
-    [user.login.currentlyLoggedIn],
   );
 
   return (

--- a/src/applications/my-education-benefits/reducers/index.js
+++ b/src/applications/my-education-benefits/reducers/index.js
@@ -2,6 +2,7 @@ import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress
 import formConfig from '../config/form';
 
 import {
+  FETCH_PERSONAL_INFORMATION,
   FETCH_PERSONAL_INFORMATION_SUCCESS,
   FETCH_PERSONAL_INFORMATION_FAILED,
   FETCH_CLAIM_STATUS_SUCCESS,
@@ -22,12 +23,17 @@ export default {
   form: createSaveInProgressFormReducer(formConfig),
   data: (state = initialState, action) => {
     switch (action.type) {
+      case FETCH_PERSONAL_INFORMATION:
+        return {
+          ...state,
+          personalInfoFetchInProgress: true,
+        };
       case FETCH_PERSONAL_INFORMATION_SUCCESS:
       case FETCH_PERSONAL_INFORMATION_FAILED:
         return {
           ...state,
+          personalInfoFetchInProgress: false,
           formData: action?.response || {},
-          // errors: action?.response?.errors || {},
         };
       case FETCH_CLAIM_STATUS_SUCCESS:
       case FETCH_CLAIM_STATUS_FAILURE:

--- a/src/applications/my-education-benefits/selectors/personalInfoFetchInProgress.js
+++ b/src/applications/my-education-benefits/selectors/personalInfoFetchInProgress.js
@@ -1,0 +1,2 @@
+export const personalInfoFetchProgress = state =>
+  state.data.personalInfoFetchInProgress;


### PR DESCRIPTION
This fix ensures we get one, and only one claimant_info fetch rest call when starting the app. Conditions are:

- If we already have a claim_info call in progress, do not send a second fetch call. Wait for current one to finish.
- If we already have the claimant info, do not fetch claimant_info

This also fixes linting errors on breadcrumbs.

## Description


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
