### PR TITLE
Adds extra SaveInProgressIntro to IntroductionPage content

### DIFF
--- a/src/applications/lgy/coe/form/components/SubwayMap.jsx
+++ b/src/applications/lgy/coe/form/components/SubwayMap.jsx
@@ -70,7 +70,7 @@ const SubwayMap = () => (
             of your honorable service.
           </li>
         </ul>
-        <va-additional-info trigger="What's a statement of service?">
+        <va-additional-info trigger="What’s a statement of service?">
           <p>hey</p>
         </va-additional-info>
       </li>

--- a/src/applications/lgy/coe/form/components/SubwayMap.jsx
+++ b/src/applications/lgy/coe/form/components/SubwayMap.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+const SubwayMap = () => (
+  <div className="process schemaform-process">
+    <ol>
+      <li className="process-step list-one">
+        <h3>Check your service requirements</h3>
+        <p>
+          Make sure you meet our VA home loan eligibility requirements before
+          you request a COE. You may be able to get a COE if you:
+        </p>
+        <ul>
+          <li>
+            Didn’t receive a dishonorable discharge, <strong>and</strong>
+          </li>
+          <li>Meet the minimum service requirement based on when you served</li>
+        </ul>
+        <a href="/">Eligibility requirements for VA home loan programs</a>
+      </li>
+      <li className="process-step list-two">
+        <h3>Gather your information</h3>
+        <p>Here’s what you’ll need to request a COE:</p>
+        <ul>
+          <li>
+            Your Social Security number, date of birth and current contact
+            information.
+          </li>
+          <li>
+            The property location and dates of past VA loans (if you have or had
+            a VA-backed loan)
+          </li>
+          <li>
+            <strong>If you’re a Veteran,</strong> you’ll need a copy of your
+            discharge or separation papers (DD214).
+          </li>
+          <li>
+            <strong>If you’re an active-duty service member,</strong> you’ll
+            need a statement of service—signed by your commander, adjutant, or
+            personnel officer.
+          </li>
+          <li>
+            <strong>
+              If you’re a current or former activated National Guard or Reserve
+              member,
+            </strong>{' '}
+            you’ll need a copy of your discharge or separation papers (DD214).
+          </li>
+          <li>
+            <strong>
+              If you’re a current member of the National Guard or Reserves who’s
+              never been activated,
+            </strong>{' '}
+            you’ll need a statement of service—signed by your commander,
+            adjutant, or personnel officer.
+          </li>
+          <li>
+            <strong>
+              If you’re a discharged member of the National Guard and were never
+              activated,
+            </strong>{' '}
+            you’ll need your Report of Separation and Record of Service (NGB
+            Form 22) and your Retirement Points Statement (NGB Form 23).
+          </li>
+          <li>
+            <strong>
+              If you’re a discharged member of the Reserves who has never been
+              activated,
+            </strong>{' '}
+            you’ll need a copy of your latest annual retirement points and proof
+            of your honorable service.
+          </li>
+        </ul>
+        <va-additional-info trigger="What's a statement of service?">
+          <p>hey</p>
+        </va-additional-info>
+      </li>
+      <li className="process-step list-three">
+        <h3>Start your request</h3>
+        <p>
+          Complete the form to request a VA home loan Certificate of
+          Eligibility. It should take about 15 minutes.
+        </p>
+        <va-additional-info trigger="What happens after I request a COE?">
+          <p>hey</p>
+        </va-additional-info>
+      </li>
+    </ol>
+  </div>
+);
+
+export default SubwayMap;

--- a/src/applications/lgy/coe/form/components/statuses/Ineligible.jsx
+++ b/src/applications/lgy/coe/form/components/statuses/Ineligible.jsx
@@ -10,9 +10,6 @@ const Ineligible = () => (
       without your lender’s assistance, please continue to start the request
       process.
     </p>
-    <h2 className="vads-u-margin-top--5">
-      Follow these steps to request a VA home loan COE
-    </h2>
   </>
 );
 

--- a/src/applications/lgy/coe/form/components/statuses/Pending.jsx
+++ b/src/applications/lgy/coe/form/components/statuses/Pending.jsx
@@ -27,9 +27,6 @@ const Pending = ({ referenceNumber, requestDate, status }) => (
         case management team recommends that you do this.
       </p>
     </div>
-    <h2 className="vads-u-margin-top--6">
-      Follow these steps to make another request for a VA home loan COE
-    </h2>
   </>
 );
 

--- a/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
@@ -37,7 +37,7 @@ const IntroductionPage = ({ coe, downloadUrl, loggedIn, route, status }) => {
           status={coe.status}
         />
         {coe.status !== COE_ELIGIBILITY_STATUS.denied && (
-          <LoggedInContent route={route} />
+          <LoggedInContent route={route} status={coe.status} />
         )}
       </>
     );

--- a/src/applications/lgy/coe/form/containers/introduction-content/loggedInContent.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/loggedInContent.jsx
@@ -4,114 +4,50 @@ import PropTypes from 'prop-types';
 
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
-const LoggedInContent = ({ route }) => (
+import SubwayMap from '../../components/SubwayMap';
+
+const shouldShowHeader = status => {
+  const showStatuses = ['ineligible', 'pending', 'pending-upload'];
+
+  return showStatuses.includes(status);
+};
+
+const LoggedInContent = ({ route, status }) => (
   <>
-    <div className="process schemaform-process">
-      <ol>
-        <li className="process-step list-one">
-          <h3>Check your service requirements</h3>
-          <p>
-            Make sure you meet our VA home loan eligibility requirements before
-            you request a COE. You may be able to get a COE if you:
-          </p>
-          <ul>
-            <li>
-              Didn’t receive a dishonorable discharge, <strong>and</strong>
-            </li>
-            <li>
-              Meet the minimum service requirement based on when you served
-            </li>
-          </ul>
-          <a href="/">Eligibility requirements for VA home loan programs</a>
-        </li>
-        <li className="process-step list-two">
-          <h3>Gather your information</h3>
-          <p>Here’s what you’ll need to request a COE:</p>
-          <ul>
-            <li>
-              Your Social Security number, date of birth and current contact
-              information.
-            </li>
-            <li>
-              The property location and dates of past VA loans (if you have or
-              had a VA-backed loan)
-            </li>
-            <li>
-              <strong>If you’re a Veteran,</strong> you’ll need a copy of your
-              discharge or separation papers (DD214).
-            </li>
-            <li>
-              <strong>If you’re an active-duty service member,</strong> you’ll
-              need a statement of service—signed by your commander, adjutant, or
-              personnel officer.
-            </li>
-            <li>
-              <strong>
-                If you’re a current or former activated National Guard or
-                Reserve member,
-              </strong>{' '}
-              you’ll need a copy of your discharge or separation papers (DD214).
-            </li>
-            <li>
-              <strong>
-                If you’re a current member of the National Guard or Reserves
-                who’s never been activated,
-              </strong>{' '}
-              you’ll need a statement of service—signed by your commander,
-              adjutant, or personnel officer.
-            </li>
-            <li>
-              <strong>
-                If you’re a discharged member of the National Guard and were
-                never activated,
-              </strong>{' '}
-              you’ll need your Report of Separation and Record of Service (NGB
-              Form 22) and your Retirement Points Statement (NGB Form 23).
-            </li>
-            <li>
-              <strong>
-                If you’re a discharged member of the Reserves who has never been
-                activated,
-              </strong>{' '}
-              you’ll need a copy of your latest annual retirement points and
-              proof of your honorable service.
-            </li>
-          </ul>
-          <va-additional-info trigger="What's a statement of service?">
-            <p>hey</p>
-          </va-additional-info>
-        </li>
-        <li className="process-step list-three">
-          <h3>Start your request</h3>
-          <p>
-            Complete the form to request a VA home loan Certificate of
-            Eligibility. It should take about 15 minutes.
-          </p>
-          <va-additional-info trigger="What happens after I request a COE?">
-            <p>hey</p>
-          </va-additional-info>
-        </li>
-      </ol>
-      <div className="vads-u-margin-bottom--4">
-        <SaveInProgressIntro
-          buttonOnly
-          testActionLink
-          prefillEnabled={route.formConfig.prefillEnabled}
-          messages={route.formConfig.savedFormMessages}
-          formConfig={route.formConfig}
-          pageList={route.pageList}
-          downtime={route.formConfig.downtime}
-          startText="Request a Certificate of Eligibility"
-          headingLevel={2}
-        />
-      </div>
-      <OMBInfo expDate="11/30/2022" ombNumber="2900-0086" resBurden={15} />
+    <SaveInProgressIntro
+      testActionLink
+      prefillEnabled={route.formConfig.prefillEnabled}
+      messages={route.formConfig.savedFormMessages}
+      formConfig={route.formConfig}
+      pageList={route.pageList}
+      downtime={route.formConfig.downtime}
+      startText="Request a Certificate of Eligibility"
+      headingLevel={2}
+    />
+    {shouldShowHeader(status) && (
+      <h2>Follow these steps to request a VA home loan COE</h2>
+    )}
+    <SubwayMap />
+    <div className="vads-u-margin-bottom--4">
+      <SaveInProgressIntro
+        buttonOnly
+        testActionLink
+        prefillEnabled={route.formConfig.prefillEnabled}
+        messages={route.formConfig.savedFormMessages}
+        formConfig={route.formConfig}
+        pageList={route.pageList}
+        downtime={route.formConfig.downtime}
+        startText="Request a Certificate of Eligibility"
+        headingLevel={2}
+      />
     </div>
+    <OMBInfo expDate="11/30/2022" ombNumber="2900-0086" resBurden={15} />
   </>
 );
 
 LoggedInContent.propTypes = {
   route: PropTypes.object,
+  status: PropTypes.string,
 };
 
 export default LoggedInContent;


### PR DESCRIPTION
## Description
This PR adds an extra `SaveInProgressIntro` component towards the top of the Introduction page. Some of the content also had to be adjusted because some statuses that include the subway map have a header between the `SaveInProgressIntro` and some don't.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37812

## Screenshots
### Before
<img width="795" alt="Screen Shot 2022-03-02 at 3 20 05 PM" src="https://user-images.githubusercontent.com/13838621/156451534-e62aed69-77f6-4e56-80f9-4bc00d209af8.png">

### After
<img width="734" alt="Screen Shot 2022-03-02 at 3 18 09 PM" src="https://user-images.githubusercontent.com/13838621/156451547-d59d5327-ad7e-426c-8bca-6bef0d147d7f.png">

## Acceptance criteria
- [x] `SaveInProgressIntro` has been added to top of Introduction page for status that need it
