### PR TITLE
CST a11y fixes

### DIFF
--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -210,7 +210,7 @@ export default class ClaimPhase extends React.Component {
           aria-expanded={open}
           onClick={handler.getDescriptionClick}
         >
-          {getUserPhaseDescription(phase)}
+          {titleText}
         </button>
       );
 

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -199,20 +199,26 @@ export default class ClaimPhase extends React.Component {
       },
     };
 
+    const titleText = getUserPhaseDescription(phase);
+    const title =
+      current < phase ? (
+        <div className="section-header-title">{titleText}</div>
+      ) : (
+        <button
+          type="button"
+          className="section-header-button"
+          aria-expanded={open}
+          onClick={handler.getDescriptionClick}
+        >
+          {getUserPhaseDescription(phase)}
+        </button>
+      );
+
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <li className={`${getClasses(phase, current)}`}>
         {expandCollapseIcon}
-        <h3 className="section-header vads-u-font-size--h4">
-          <button
-            type="button"
-            className="section-header-button"
-            aria-expanded={open}
-            onClick={handler.getDescriptionClick}
-          >
-            {getUserPhaseDescription(phase)}
-          </button>
-        </h3>
+        <h3 className="section-header vads-u-font-size--h4">{title}</h3>
         {open || (current !== COMPLETE_PHASE && phase === COMPLETE_PHASE) ? (
           <div>
             {children}

--- a/src/applications/claims-status/components/MobileAppMessage.jsx
+++ b/src/applications/claims-status/components/MobileAppMessage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { VaAlert } from 'web-components/react-bindings';
 
 const appleStoreUrl =
   'https://apps.apple.com/app/apple-store/id1559609596?pt=545860&ct=gov.va.claimstatus&mt=8';
@@ -54,7 +55,7 @@ export default function MobileAppMessage({ mockUserAgent }) {
   };
 
   return isHidden ? null : (
-    <va-alert status="info" closeable onClose={handlers.closeModal}>
+    <VaAlert status="info" closeable onCloseEvent={handlers.closeModal}>
       <h2 id="track-your-status-on-mobile" slot="headline">
         Track your claim or appeal on your mobile device
       </h2>
@@ -64,7 +65,7 @@ export default function MobileAppMessage({ mockUserAgent }) {
         <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
       {storeLinks}
-    </va-alert>
+    </VaAlert>
   );
 }
 

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -81,9 +81,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
 
   return (
     <div className="claim-list-item-container">
-      <h2 className="claim-list-item-header-v2 vads-u-font-size--h3">
-        {appealTitle}
-      </h2>
+      <h3 className="claim-list-item-header-v2">{appealTitle}</h3>
       <div className="card-status">
         {!external && (
           <div

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -20,12 +20,12 @@ export default function ClaimsListItem({ claim }) {
   );
   return (
     <div className="claim-list-item-container">
-      <h2 className="claim-list-item-header-v2 vads-u-font-size--h3">
+      <h3 className="claim-list-item-header-v2">
         Claim for {getClaimType(claim)}
         <br />
         updated on{' '}
         {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
-      </h2>
+      </h3>
       <div className="card-status">
         <div
           className={`status-circle ${

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -547,7 +547,7 @@ h1:focus {
 .claim-timeline {
   padding-top: 0;
 
-  .section-header-button {
+  .section-header-button, .section-header-title {
     width: 100%;
     position: relative;
     top: -1rem;

--- a/src/applications/claims-status/tests/components/MobileAppMessage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/MobileAppMessage.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('<MobileAppMessage>', () => {
   });
 
   it('should render', () => {
-    const wrapper = shallow(<MobileAppMessage mockUserAgent={'blah'} />);
+    const wrapper = shallow(<MobileAppMessage mockUserAgent="blah" />);
     expect(wrapper.length).to.equal(1);
     expect(wrapper.props().status).to.equal('info');
     const links = wrapper.find('a[target="_blank"]');
@@ -30,21 +30,21 @@ describe('<MobileAppMessage>', () => {
     const wrapper = shallow(<MobileAppMessage />);
     expect(wrapper.length).to.equal(1);
 
-    wrapper.props().onClose();
+    wrapper.props().onCloseEvent();
     expect(wrapper).to.be.empty;
     expect(sessionStorage.getItem(STORAGE_KEY)).to.equal('hidden');
     wrapper.unmount();
   });
 
   it('should show app store link for iOS device', () => {
-    const wrapper = shallow(<MobileAppMessage mockUserAgent={'iPhone'} />);
+    const wrapper = shallow(<MobileAppMessage mockUserAgent="iPhone" />);
     const link = wrapper.find('a[target="_blank"]');
     expect(link.length).to.equal(1);
     expect(link.text()).to.eq('Download the app from the App Store');
     wrapper.unmount();
   });
   it('should show Google play store link for android device', () => {
-    const wrapper = shallow(<MobileAppMessage mockUserAgent={'android'} />);
+    const wrapper = shallow(<MobileAppMessage mockUserAgent="android" />);
     const link = wrapper.find('a[target="_blank"]');
     expect(link.length).to.equal(1);
     expect(link.text()).to.eq('Download the app from Google Play');

--- a/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -179,7 +179,7 @@ describe('<ClaimsListItemV2>', () => {
       },
     };
     const tree = shallow(<ClaimsListItemV2 claim={claim} />);
-    expect(tree.find('h2').text()).to.contain('updated on August 20, 2019');
+    expect(tree.find('h3').text()).to.contain('updated on August 20, 2019');
     expect(
       tree
         .find('p')


### PR DESCRIPTION
## Description

Three issues were identified by Angela:

- Main list of claims or appeals should have h3 headers (currently h2s)
- When viewing details, the timeline may include disabled entries. These are still clickable and focusable, and shouldn't be
- The Mobile alert on the main list page is no longer closable

This PR fixes them and updates associated tests

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/37923

## Testing done

Unit & e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Change header levels of main list to `h3`
- [x] Make mobile alert closable
- [x] Use div instead of button in timeline with no info (no clickable)
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
