### PR TITLE
Add `#gha-test-status` Slack notification for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -394,7 +394,7 @@ jobs:
         with:
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 
-      - name: Notify Slack
+      - name: Notify Slack - \#status-vets-website
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         env:
@@ -402,5 +402,16 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Full E2E test suite run in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Notify Slack - \#gha-test-status
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Full E2E test suite run in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+          channel_id: C026PD47Z19 #gha-test-status
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description
This PR adds Slack notifications to the `#gha-test-status` channel for the new E2E test workflow. This is the channel that the QA standards team monitors for Cypress failures in the `master` branch.

## Acceptance criteria
- [ ] CI passes.