### PR TITLE
Enable Cypress test selection in the `master` branch in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -390,7 +390,6 @@ jobs:
 
       - name: Get changed apps for header test
         id: get-changed-apps
-        if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           echo ::set-output name=app_urls::$(node script/github-actions/get-changed-apps.js --output-type url)
           echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -366,7 +366,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.tests.outputs.selected }}
-      is_master_build: ${{ env.IS_MASTER_BUILD }}
       app_urls: ${{ steps.get-changed-apps.outputs.app_urls }}
 
     steps:
@@ -406,6 +405,8 @@ jobs:
 
       - name: Set TESTS variable
         run: node script/github-actions/select-cypress-tests.js
+        env:
+          RUN_FULL_SUITE: false
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.app_urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.app_entries }}
@@ -883,7 +884,7 @@ jobs:
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
+          IS_MASTER_BUILD: false
           TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -382,7 +382,7 @@ jobs:
         id: changed-files
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-            echo ::set-output name=all_changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ commit_sha }})
+            echo ::set-output name=all_changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
           else
             echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
           fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,12 +381,12 @@ jobs:
       - name: List changed files
         id: changed-files
         if: ${{ github.ref != 'refs/heads/master' }}
-        run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
-
-      - name: List changed files - master
-        id: changed-files-master
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+            echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
+          else
+            echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+          fi
 
       - name: Get changed apps for header test
         id: get-changed-apps
@@ -402,14 +402,6 @@ jobs:
         env:
           RUN_FULL_SUITE: false
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
-          APP_URLS: ${{ steps.get-changed-apps.outputs.app_urls }}
-          APP_ENTRIES: ${{ steps.get-changed-apps.outputs.app_entries }}
-
-      - name: Set TESTS variable - master
-        run: node script/github-actions/select-cypress-tests.js
-        env:
-          RUN_FULL_SUITE: false
-          CHANGED_FILE_PATHS: ${{ steps.changed-files-master.outputs.all_changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.app_urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.app_entries }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -380,7 +380,6 @@ jobs:
 
       - name: List changed files
         id: changed-files
-        if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
             echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,13 @@ jobs:
 
       - name: List changed files
         id: changed-files
+        if: ${{ github.ref != 'refs/heads/master' }}
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+
+      - name: List changed files
+        id: changed-files
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
 
       - name: Get app entries for changed files
         id: get-changed-apps
@@ -379,17 +385,15 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Set IS_MASTER_BUILD
-        run: |
-          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-              echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
-          else
-              echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
-          fi
+      - name: List changed files
+        id: changed-files
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
 
       - name: List changed files
         id: changed-files
-        run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
 
       - name: Get changed apps for header test
         id: get-changed-apps
@@ -402,8 +406,6 @@ jobs:
 
       - name: Set TESTS variable
         run: node script/github-actions/select-cypress-tests.js
-        env:
-          IS_MASTER_BUILD: ${{ env.IS_MASTER_BUILD }}
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.app_urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.app_entries }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -390,6 +390,7 @@ jobs:
 
       - name: Get changed apps for header test
         id: get-changed-apps
+        if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           echo ::set-output name=app_urls::$(node script/github-actions/get-changed-apps.js --output-type url)
           echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,8 +48,8 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
 
-      - name: List changed files
-        id: changed-files
+      - name: List changed files - master
+        id: changed-files-master
         if: ${{ github.ref == 'refs/heads/master' }}
         run: echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
 
@@ -60,11 +60,26 @@ jobs:
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
+      - name: Get app entries for changed files - master
+        id: get-changed-apps-master
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)
+        env:
+          CHANGED_FILE_PATHS: ${{ steps.changed-files-master.outputs.all_changed_files }}
+
       - name: Build
+        if: ${{ github.ref != 'refs/heads/master' }}
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
         timeout-minutes: 30
         env:
           ENTRY: ${{ steps.get-changed-apps.outputs.app_entries }}
+
+      - name: Build
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
+        timeout-minutes: 30
+        env:
+          ENTRY: ${{ steps.get-changed-apps-master.outputs.app_entries }}
 
       - name: Generate build details
         run: |
@@ -389,8 +404,8 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
 
-      - name: List changed files
-        id: changed-files
+      - name: List changed files - master
+        id: changed-files-master
         if: ${{ github.ref == 'refs/heads/master' }}
         run: echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
 
@@ -408,6 +423,14 @@ jobs:
         env:
           RUN_FULL_SUITE: false
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
+          APP_URLS: ${{ steps.get-changed-apps.outputs.app_urls }}
+          APP_ENTRIES: ${{ steps.get-changed-apps.outputs.app_entries }}
+
+      - name: Set TESTS variable - master
+        run: node script/github-actions/select-cypress-tests.js
+        env:
+          RUN_FULL_SUITE: false
+          CHANGED_FILE_PATHS: ${{ steps.changed-files-master.outputs.all_changed_files }}
           APP_URLS: ${{ steps.get-changed-apps.outputs.app_urls }}
           APP_ENTRIES: ${{ steps.get-changed-apps.outputs.app_entries }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -382,7 +382,7 @@ jobs:
         id: changed-files
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-            echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
+            echo ::set-output name=all_changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ commit_sha }})
           else
             echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
           fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,13 +45,7 @@ jobs:
 
       - name: List changed files
         id: changed-files
-        if: ${{ github.ref != 'refs/heads/master' }}
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
-
-      - name: List changed files - master
-        id: changed-files-master
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: echo ::set-output name=all_changed_files::$(git diff --name-only HEAD~)
 
       - name: Get app entries for changed files
         id: get-changed-apps
@@ -60,26 +54,11 @@ jobs:
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Get app entries for changed files - master
-        id: get-changed-apps-master
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)
-        env:
-          CHANGED_FILE_PATHS: ${{ steps.changed-files-master.outputs.all_changed_files }}
-
       - name: Build
-        if: ${{ github.ref != 'refs/heads/master' }}
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
         timeout-minutes: 30
         env:
           ENTRY: ${{ steps.get-changed-apps.outputs.app_entries }}
-
-      - name: Build
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
-        timeout-minutes: 30
-        env:
-          ENTRY: ${{ steps.get-changed-apps-master.outputs.app_entries }}
 
       - name: Generate build details
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Set TESTS variable
         run: node script/github-actions/select-cypress-tests.js
         env:
-          IS_MASTER_BUILD: true
+          RUN_FULL_SUITE: true
           CHANGED_FILE_PATHS: ''
 
       - name: Set output of TESTS
@@ -142,8 +142,7 @@ jobs:
     needs: [set-commit-sha, build, cypress-tests-prep]
     if: |
       needs.build.result == 'success' &&
-      needs.cypress-tests-prep.result == 'success' &&
-      needs.cypress-tests-prep.outputs.tests != '[]'
+      needs.cypress-tests-prep.result == 'success'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share
@@ -353,7 +352,7 @@ jobs:
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
+          IS_MASTER_BUILD: true
           TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -3,8 +3,8 @@ const core = require('@actions/core');
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
-const { integrationFolder, testFiles } = require('../../config/cypress.json');
 const findImports = require('find-imports');
+const { integrationFolder, testFiles } = require('../../config/cypress.json');
 
 const IS_MASTER_BUILD = process.env.IS_MASTER_BUILD === 'true';
 const IS_CHANGED_APPS_BUILD = Boolean(process.env.APP_ENTRIES);
@@ -30,7 +30,8 @@ function getAppNameFromFilePath(filePath) {
 function getImportPath(filePathAsArray, importRef) {
   if (importRef.startsWith('applications/')) {
     return `src/${importRef}`;
-  } else if (importRef.startsWith('../')) {
+  }
+  if (importRef.startsWith('../')) {
     const numDirsUp = importRef.split('/').filter(str => str === '..').length;
 
     return importRef.replace(
@@ -182,37 +183,33 @@ function allTests() {
 }
 
 function selectTests(graph, pathsOfChangedFiles) {
-  if (IS_MASTER_BUILD) {
-    return allTests();
-  } else {
-    let allMdFiles = true;
-    let allMdAndOrSrcApplicationsFiles = true;
+  let allMdFiles = true;
+  let allMdAndOrSrcApplicationsFiles = true;
 
-    for (let i = 0; i < pathsOfChangedFiles.length; i += 1) {
-      if (!pathsOfChangedFiles[i].endsWith('.md')) {
-        allMdFiles = false;
-      }
-
-      if (
-        !pathsOfChangedFiles[i].endsWith('.md') &&
-        !pathsOfChangedFiles[i].startsWith('src/applications')
-      ) {
-        allMdAndOrSrcApplicationsFiles = false;
-      }
-
-      if (allMdFiles === false && allMdAndOrSrcApplicationsFiles === false) {
-        break;
-      }
+  for (let i = 0; i < pathsOfChangedFiles.length; i += 1) {
+    if (!pathsOfChangedFiles[i].endsWith('.md')) {
+      allMdFiles = false;
     }
 
-    if (allMdFiles) {
-      return [];
-    } else if (allMdAndOrSrcApplicationsFiles) {
-      return selectedTests(graph, pathsOfChangedFiles);
-    } else {
-      return allTests();
+    if (
+      !pathsOfChangedFiles[i].endsWith('.md') &&
+      !pathsOfChangedFiles[i].startsWith('src/applications')
+    ) {
+      allMdAndOrSrcApplicationsFiles = false;
+    }
+
+    if (allMdFiles === false && allMdAndOrSrcApplicationsFiles === false) {
+      break;
     }
   }
+
+  if (allMdFiles) {
+    return [];
+  }
+  if (allMdAndOrSrcApplicationsFiles) {
+    return selectedTests(graph, pathsOfChangedFiles);
+  }
+  return allTests();
 }
 
 function exportVariables(tests) {

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -6,7 +6,7 @@ const glob = require('glob');
 const findImports = require('find-imports');
 const { integrationFolder, testFiles } = require('../../config/cypress.json');
 
-const IS_MASTER_BUILD = process.env.IS_MASTER_BUILD === 'true';
+const RUN_FULL_SUITE = process.env.RUN_FULL_SUITE === 'true';
 const IS_CHANGED_APPS_BUILD = Boolean(process.env.APP_ENTRIES);
 const APPS_HAVE_URLS = Boolean(process.env.APP_URLS);
 
@@ -183,6 +183,9 @@ function allTests() {
 }
 
 function selectTests(graph, pathsOfChangedFiles) {
+  if (RUN_FULL_SUITE) {
+    return allTests();
+  }
   let allMdFiles = true;
   let allMdAndOrSrcApplicationsFiles = true;
 
@@ -223,7 +226,7 @@ function run() {
   exportVariables(tests);
 }
 
-if (process.env.CHANGED_FILE_PATHS || IS_MASTER_BUILD) {
+if (process.env.CHANGED_FILE_PATHS || RUN_FULL_SUITE) {
   run();
 }
 


### PR DESCRIPTION
## Description
This PR enables test selection in `master` branch CI. Files changed between the current commit and previous commit are used in test selection.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/37921

## Acceptance criteria
- [ ] CI passes.