### PR TITLE
Send eligibility check only after claimant info load succeeds.

### DIFF
--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -26,7 +26,9 @@ export const App = ({
         if (!firstName) {
           getPersonalInfo();
         }
-        if (!eligibility) {
+        // the firstName check ensures that eligibility only gets called after we have obtained claimant info
+        // we need this to avoid a race condition when a user is being loaded freshly from VADIR on DGIB
+        if (!eligibility && firstName) {
           getEligibility();
         } else if (!formData.eligibility) {
           setFormData({


### PR DESCRIPTION
- Turns out that if a user is freshly being loaded from VADIR, we should send the eligibility check only after the claimant info fetch has finished. If we send both fetches at same time, we end up in a race condition that ends up creating 2 LTS records for the same person.

## Description


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
