### PR TITLE
Add Slack groups to apps on allowlist

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -17,12 +17,14 @@
         "entryName": "terms-and-conditions"
       },
       {
-        "entryName": "vaos"
+        "entryName": "vaos",
+        "slackGroup": "@vaos-fe-dev"
       }
     ],
     "groupedApps": [
       {
-        "rootFolder": "check-in"
+        "rootFolder": "check-in",
+        "slackGroup": "@check-in-fe"
       }
     ]
   }


### PR DESCRIPTION
## Description
Adds the Slack group for apps on the allowlist that have one.

## Acceptance criteria
- [x] Apps on the allowlist with a Slack group should have it in the changed app build cofig

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
