### PR TITLE
Add footer padding with promo banner to offset fixed position

### DIFF
--- a/src/platform/site-wide/promoBanners/components/App/index.js
+++ b/src/platform/site-wide/promoBanners/components/App/index.js
@@ -19,6 +19,9 @@ export const App = ({ href, id, text, type }) => {
 
   // On dismiss, add the promo banner to local storage.
   const onClose = () => {
+    // Remove class that pads the site footer
+    document.body.classList.remove('va-pad-promo-banner');
+
     // Set our state to dismissed.
     setIsDismissed(true);
 
@@ -34,6 +37,9 @@ export const App = ({ href, id, text, type }) => {
   if (isDismissed) {
     return null;
   }
+
+  // Add class to body to pad the site footer
+  document.body.classList.add('va-pad-promo-banner');
 
   // Render the promo banner.
   return <PromoBanner onClose={onClose} href={href} text={text} type={type} />;

--- a/src/platform/site-wide/sass/modules/_m-footer.scss
+++ b/src/platform/site-wide/sass/modules/_m-footer.scss
@@ -28,6 +28,14 @@
   }
 }
 
+body.va-pad-promo-banner .footer-inner {
+  padding-bottom: 5.75rem;
+
+  @include media($medium-screen) {
+    padding-bottom: 3.75rem;
+  }
+}
+
 [class^="va-footer-linkgroup"] {
   padding-left: 0;
   li {


### PR DESCRIPTION
## Description
This PR address footer links not being fully visible when a promo banner is assigned to the site. While this banner is designed to stay fixed to the bottom of the viewport, the expectation is when we scroll to the very bottom of the content, we should still be able to view that content without having to dismiss the banner. The PR adds padding equal to the height of the banner to the bottom of the footer to allow the content to be viewed without dismissing the banner. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37430

## Screenshots
![Screen Shot 2022-02-22 at 3 03 48 PM](https://user-images.githubusercontent.com/70410912/155236266-3661c641-7a6c-4f4e-a0fd-41df890ab7d8.png)

## Acceptance criteria
- [x] All content can be viewed when banner is present

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
