### PR TITLE
37678 - LTR - Add Veteran facing alert to notify them of missing letters

### DIFF
--- a/src/applications/debt-letters/components/Alerts.jsx
+++ b/src/applications/debt-letters/components/Alerts.jsx
@@ -11,12 +11,15 @@ export const DownloadLettersAlert = () => (
     status="warning"
   >
     <h3 slot="headline">
-      Downloadable letters have incorrect repayment plan terms
+      Letters sent after December 9th, 2021 are unavailable for download
     </h3>
     <p className="vads-u-font-size--base vads-u-font-family--sans">
-      We’re sorry. The length of time listed for repayment plans in these
-      letters is too short. Use the letters you get in the mail to find the
-      correct repayment plan terms. If you have any questions, call us at
+      We’re sorry. Because the letters sent after this date are unavailable for
+      download right now, we need to refer you to the letters you receive by
+      mail.
+    </p>
+    <p className="vads-u-font-size--base vads-u-font-family--sans">
+      If you have any questions, call us at
       <Telephone contact="800-827-0648" className="vads-u-margin-x--0p5" />
       (or
       <Telephone


### PR DESCRIPTION
## Description
Per updated mock and ticket request, replaced warning with updated one.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37678

## Screenshots
<img width="1237" alt="Screen Shot 2022-03-07" src="https://user-images.githubusercontent.com/29178824/157094567-50543945-ae88-44d8-8255-7cfad356218a.png">


## Acceptance criteria
- [ X] Warning text and header replaced

## Definition of done
- [X ] Events are logged appropriately
- [ X] Documentation has been updated, if applicable
- [X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
