### PR TITLE
37040 authd semicolon separated values

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-read-only-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-read-only-state.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Content on the personal information page', () => {
     cy.findByText('Wes').should('exist');
 
     // Check pronouns
-    cy.findByText('He/him/his, They/them/theirs, Other/pronouns/here').should(
+    cy.findByText('He/him/his; They/them/theirs; Other/pronouns/here').should(
       'exist',
     );
 
@@ -49,7 +49,7 @@ describe('Content on the personal information page', () => {
     cy.findByText('Man').should('exist');
 
     // Check sexual orientation
-    cy.findByText('Straight or heterosexual, Some other orientation').should(
+    cy.findByText('Straight or heterosexual; Some other orientation').should(
       'exist',
     );
 

--- a/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
@@ -18,7 +18,7 @@ describe('formatMultiSelectAndText utility', () => {
     ).to.equal('He/him/his');
   });
 
-  it('returns comma separated pronouns', () => {
+  it('returns semicolon separated pronouns', () => {
     expect(
       formatMultiSelectAndText(
         { pronouns: ['heHimHis', 'theyThemTheirs'] },
@@ -36,13 +36,13 @@ describe('formatMultiSelectAndText utility', () => {
     ).to.equal('custom pronouns');
   });
 
-  it('returns comma separated list including pronounsNotListedText', () => {
+  it('returns semicolon separated list including pronounsNotListedText', () => {
     expect(
       formatMultiSelectAndText(
         { pronouns: ['heHimHis'], pronounsNotListedText: 'custom pronouns' },
         'pronouns',
       ),
-    ).to.equal('He/him/his, custom pronouns');
+    ).to.equal('He/him/his; custom pronouns');
   });
 
   it('returns null if fields do not have values', () => {

--- a/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
@@ -24,7 +24,7 @@ describe('formatMultiSelectAndText utility', () => {
         { pronouns: ['heHimHis', 'theyThemTheirs'] },
         'pronouns',
       ),
-    ).to.equal('He/him/his, They/them/theirs');
+    ).to.equal('He/him/his; They/them/theirs');
   });
 
   it('returns pronounsNotListedText value', () => {

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -167,7 +167,7 @@ export const formatMultiSelectAndText = (data, fieldName) => {
     ...(data?.[notListedTextKey] ? [data[notListedTextKey]] : []),
   ];
 
-  if (mergedValues.length > 0) return mergedValues.join(', ');
+  if (mergedValues.length > 0) return mergedValues.join('; ');
 
   return null;
 };


### PR DESCRIPTION
## Description
Very minimal change that just updates the display of personal information to be separated by semicolons instead of commas.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/37040

## Testing done
Updated unit and e2e tests


## Acceptance criteria
- [x] multiple entries separated by semicolons instead of commas

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
