### PR TITLE
CST: More a11y fixes

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -18,11 +18,12 @@ import {
   checkIsEncryptedPdf,
   FILE_TYPE_MISMATCH_ERROR,
 } from 'platform/forms-system/src/js/utilities/file';
+import scrollTo from 'platform/utilities/ui/scrollTo';
+import { getScrollOptions } from 'platform/utilities/ui';
 
 import UploadStatus from './UploadStatus';
 import mailMessage from './MailMessage';
 import { displayFileSize, DOC_TYPES, getTopPosition } from '../utils/helpers';
-import { getScrollOptions } from 'platform/utilities/ui';
 import {
   validateIfDirty,
   isNotBlank,
@@ -38,7 +39,6 @@ import {
 } from '../utils/validations';
 import { setFocus } from '../utils/page';
 import { uploadPdfLimitFeature } from '../utils/appeals-v2-helpers';
-import scrollTo from 'platform/utilities/ui/scrollTo';
 
 const displayTypes = FILE_TYPES.join(', ');
 
@@ -55,7 +55,7 @@ const scrollToError = () => {
     errors[0].querySelector('label').focus();
   }
 };
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 class AddFilesForm extends React.Component {
   state = {
@@ -176,7 +176,7 @@ class AddFilesForm extends React.Component {
                 Select files to upload
               </span>
             }
-            accept={FILE_TYPES.map(type => `.${type}`).join(',')}
+            accept={FILE_TYPES.map(type => `.${type}`).join(', ')}
             onChange={this.add}
             buttonText="Add Files"
             name="fileUpload"
@@ -234,7 +234,7 @@ class AddFilesForm extends React.Component {
                           : 'Please provide a password to decrypt this file'
                       }
                       name="password"
-                      label={'PDF password'}
+                      label="PDF password"
                       field={password}
                       onValueChange={update => {
                         this.props.onFieldChange(
@@ -281,9 +281,7 @@ class AddFilesForm extends React.Component {
               <div className="vads-u-padding-top--1">
                 To submit supporting documents for a new disability claim,
                 please visit our{' '}
-                <a href={`/disability/how-to-file-claim`}>
-                  How to File a Claim
-                </a>{' '}
+                <a href="/disability/how-to-file-claim">How to File a Claim</a>{' '}
                 page.
               </div>
             </div>

--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 
-import TabNav from '../components/TabNav';
-import ClaimSyncWarning from '../components/ClaimSyncWarning';
-import AskVAQuestions from '../components/AskVAQuestions';
-import AddingDetails from '../components/AddingDetails';
-import Notification from '../components/Notification';
+import TabNav from './TabNav';
+import ClaimSyncWarning from './ClaimSyncWarning';
+import AskVAQuestions from './AskVAQuestions';
+import AddingDetails from './AddingDetails';
+import Notification from './Notification';
 import ClaimsBreadcrumbs from './ClaimsBreadcrumbs';
-import ClaimsUnavailable from '../components/ClaimsUnavailable';
+import ClaimsUnavailable from './ClaimsUnavailable';
 import { isPopulatedClaim, getClaimType } from '../utils/helpers';
 
 const MAX_CONTENTIONS = 3;
@@ -139,9 +139,12 @@ export default function ClaimDetailLayout(props) {
 }
 
 ClaimDetailLayout.propTypes = {
+  children: PropTypes.any,
   claim: PropTypes.object,
+  clearNotification: PropTypes.func,
+  currentTab: PropTypes.string,
+  id: PropTypes.string,
   loading: PropTypes.bool,
   message: PropTypes.object,
-  clearNotification: PropTypes.func,
   synced: PropTypes.bool,
 };

--- a/src/applications/claims-status/components/ClaimEstimate.jsx
+++ b/src/applications/claims-status/components/ClaimEstimate.jsx
@@ -12,9 +12,9 @@ export default function ClaimEstimate({
   if (showCovidMessage) {
     return (
       <va-alert status="warning">
-        <h3 slot="headline">
+        <h5 slot="headline">
           Claim completion dates aren’t available right now
-        </h3>
+        </h5>
         <p className="vads-u-font-size--base">
           We can’t provide an estimated date on when your claim will be complete
           due to the affect that COVID-19 has had on scheduling in-person claim

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -130,19 +130,25 @@ export default class ClaimPhase extends React.Component {
           ? activityList
           : take(activityList, INITIAL_ACTIVITY_ROWS);
 
-      const activityListContent = limitedList.map((singleActivity, index) => (
-        <div key={index} className="claims-evidence">
-          <div className="claims-evidence-date">
-            {moment(singleActivity.date).format('MMM D, YYYY')}
-          </div>
-          {this.getEventDescription(singleActivity)}
-        </div>
-      ));
+      const activityListContent = (
+        <ol className="claims-evidence-list">
+          {limitedList.map((singleActivity, index) => (
+            <li key={index}>
+              <div className="claims-evidence">
+                <div className="claims-evidence-date">
+                  {moment(singleActivity.date).format('MMM D, YYYY')}
+                </div>
+                {this.getEventDescription(singleActivity)}
+              </div>
+            </li>
+          ))}
+        </ol>
+      );
 
       if (!showAll && activityList.length > INITIAL_ACTIVITY_ROWS) {
         return (
-          <div>
-            <div>{activityListContent}</div>
+          <>
+            activityListContent}
             <button
               type="button"
               className="claim-older-updates usa-button-secondary"
@@ -151,7 +157,7 @@ export default class ClaimPhase extends React.Component {
               See older updates&nbsp;
               <i className="fa fa-chevron-down" />
             </button>
-          </div>
+          </>
         );
       }
 
@@ -218,7 +224,7 @@ export default class ClaimPhase extends React.Component {
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <li className={`${getClasses(phase, current)}`}>
         {expandCollapseIcon}
-        <h3 className="section-header vads-u-font-size--h4">{title}</h3>
+        <h4 className="section-header vads-u-font-size--h4">{title}</h4>
         {open || (current !== COMPLETE_PHASE && phase === COMPLETE_PHASE) ? (
           <div>
             {children}

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -148,7 +148,7 @@ export default class ClaimPhase extends React.Component {
       if (!showAll && activityList.length > INITIAL_ACTIVITY_ROWS) {
         return (
           <>
-            activityListContent}
+            {activityListContent}
             <button
               type="button"
               className="claim-older-updates usa-button-secondary"

--- a/src/applications/claims-status/components/ClaimsTimeline.jsx
+++ b/src/applications/claims-status/components/ClaimsTimeline.jsx
@@ -22,69 +22,73 @@ export default function ClaimsTimeline(props) {
   const activityByPhase = groupTimelineActivity(events);
 
   return (
-    <ol className="process form-process claim-timeline">
-      <ClaimPhase
-        phase={1}
-        current={userPhase}
-        activity={activityByPhase}
-        id={id}
-      />
-      <ClaimPhase
-        phase={2}
-        current={userPhase}
-        activity={activityByPhase}
-        id={id}
-      >
-        <p>
-          Your claim has been assigned to a reviewer who is determining if
-          additional information is needed.
-        </p>
-      </ClaimPhase>
-      <ClaimPhase
-        phase={3}
-        current={userPhase}
-        activity={activityByPhase}
-        id={id}
-      >
-        <p>
-          If we need more information, we’ll request it from you, health care
-          providers, governmental agencies, or others. Once we have all the
-          information we need, we’ll review it and send your claim to the rating
-          specialist for a decision.
-          {everPhaseBack &&
-            ' There may be times when a claim moves forward to “Preparation for notification” and then briefly back to this stage for more processing.'}
-        </p>
-        {currentPhaseBack &&
-          phase === LAST_EVIDENCE_GATHERING_PHASE && <PhaseBackWarning />}
-      </ClaimPhase>
-      <ClaimPhase
-        phase={4}
-        current={userPhase}
-        activity={activityByPhase}
-        id={id}
-      >
-        <p>We are preparing your claim decision packet to be mailed.</p>
-      </ClaimPhase>
-      <ClaimPhase
-        phase={5}
-        current={userPhase}
-        activity={activityByPhase}
-        id={id}
-      >
-        {userPhase !== 5 ? (
-          <ClaimEstimate maxDate={estimatedDate} id={id} />
-        ) : (
-          <CompleteDetails />
-        )}
-      </ClaimPhase>
-    </ol>
+    <>
+      <h3 className="vads-u-visibility--screen-reader">Claim status</h3>
+      <ol className="process form-process claim-timeline">
+        <ClaimPhase
+          phase={1}
+          current={userPhase}
+          activity={activityByPhase}
+          id={id}
+        />
+        <ClaimPhase
+          phase={2}
+          current={userPhase}
+          activity={activityByPhase}
+          id={id}
+        >
+          <p>
+            Your claim has been assigned to a reviewer who is determining if
+            additional information is needed.
+          </p>
+        </ClaimPhase>
+        <ClaimPhase
+          phase={3}
+          current={userPhase}
+          activity={activityByPhase}
+          id={id}
+        >
+          <p>
+            If we need more information, we’ll request it from you, health care
+            providers, governmental agencies, or others. Once we have all the
+            information we need, we’ll review it and send your claim to the
+            rating specialist for a decision.
+            {everPhaseBack &&
+              ' There may be times when a claim moves forward to “Preparation for notification” and then briefly back to this stage for more processing.'}
+          </p>
+          {currentPhaseBack &&
+            phase === LAST_EVIDENCE_GATHERING_PHASE && <PhaseBackWarning />}
+        </ClaimPhase>
+        <ClaimPhase
+          phase={4}
+          current={userPhase}
+          activity={activityByPhase}
+          id={id}
+        >
+          <p>We are preparing your claim decision packet to be mailed.</p>
+        </ClaimPhase>
+        <ClaimPhase
+          phase={5}
+          current={userPhase}
+          activity={activityByPhase}
+          id={id}
+        >
+          {userPhase !== 5 ? (
+            <ClaimEstimate maxDate={estimatedDate} id={id} />
+          ) : (
+            <CompleteDetails />
+          )}
+        </ClaimPhase>
+      </ol>
+    </>
   );
 }
 
 ClaimsTimeline.propTypes = {
-  events: PropTypes.array,
-  phase: PropTypes.number.isRequired,
   id: PropTypes.string.isRequired,
+  phase: PropTypes.number.isRequired,
   currentPhaseBack: PropTypes.bool,
+  estimatedDate: PropTypes.string,
+  events: PropTypes.array,
   everPhaseBack: PropTypes.bool,
 };

--- a/src/applications/claims-status/components/CompleteDetails.jsx
+++ b/src/applications/claims-status/components/CompleteDetails.jsx
@@ -8,7 +8,7 @@ export default function CompleteDetails({ className }) {
         are received within 10 days, but this is dependent upon U.S. Postal
         Service timeframes.
       </p>
-      <h4>Payments</h4>
+      <h5 className="vads-u-font-size--h4">Payments</h5>
       <p>
         If you are entitled to back payment (based on an effective date), you
         can expect to receive payment within 1 month of your claim’s decision

--- a/src/applications/claims-status/components/EvidenceWarning.jsx
+++ b/src/applications/claims-status/components/EvidenceWarning.jsx
@@ -2,16 +2,14 @@ import React from 'react';
 
 export default function EvidenceWarning() {
   return (
-    <div className="usa-alert usa-alert-warning claims-alert">
-      <div className="usa-alert-body">
-        <h4 className="usa-alert-heading">
-          Please only submit additional evidence that supports this claim
-        </h4>
-        <p className="usa-alert-text">
-          To help us review and process your claim faster, please upload any new
-          supporting evidence for this claim only.
-        </p>
-      </div>
-    </div>
+    <va-alert className="claims-alert" status="warning">
+      <h3 slot="headline">
+        Please only submit additional evidence that supports this claim
+      </h3>
+      <p>
+        To help us review and process your claim faster, please upload any new
+        supporting evidence for this claim only.
+      </p>
+    </va-alert>
   );
 }

--- a/src/applications/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/applications/claims-status/components/RequestedFilesInfo.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 
-import DueDate from '../components/DueDate';
+import DueDate from './DueDate';
 import { truncateDescription, stripHtml } from '../utils/helpers';
 
 import AdditionalEvidencePage from '../containers/AdditionalEvidencePage';
@@ -84,7 +84,7 @@ export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
 }
 
 RequestedFilesInfo.propTypes = {
-  id: PropTypes.string.isRequired,
   filesNeeded: PropTypes.array.isRequired,
+  id: PropTypes.string.isRequired,
   optionalFiles: PropTypes.array.isRequired,
 };

--- a/src/applications/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Expander.jsx
@@ -15,7 +15,7 @@ const missingEventsAlert = (
 );
 
 const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
-  const title = expanded ? 'Hide past events' : 'See past events';
+  const title = expanded ? 'Hide past events' : 'Reveal past events';
   const cssClass = expanded ? 'section-expanded' : 'section-unexpanded';
   const separator =
     expanded && !missingEvents ? <div className="separator" /> : null;
@@ -23,13 +23,16 @@ const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-    <li
-      className={`past-events-expander process-step clickable ${cssClass}`}
-      onClick={onToggle}
-    >
+    <li className={`past-events-expander process-step ${cssClass}`}>
       {/* Giving this a margin top to help center the text to the li bullet */}
-      <button className="va-button-link" onClick={onToggle}>
-        <h3 style={{ color: 'inherit' }}>{title}</h3>
+      <button
+        type="button"
+        className="va-button-link"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-controls="appeal-timeline"
+      >
+        <h2 className="vads-u-font-size--h3">{title}</h2>
       </button>
       <div className="appeal-event-date">{dateRange}</div>
       {alert}
@@ -39,10 +42,10 @@ const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
 };
 
 Expander.propTypes = {
-  expanded: PropTypes.bool.isRequired,
   dateRange: PropTypes.string.isRequired,
-  onToggle: PropTypes.func.isRequired, // Make sure this does event.stopPropagation()
+  expanded: PropTypes.bool.isRequired,
   missingEvents: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired, // Make sure this does event.stopPropagation()
 };
 
 export default Expander;

--- a/src/applications/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Timeline.jsx
@@ -33,6 +33,7 @@ class Timeline extends React.Component {
 
   render() {
     const { events, missingEvents } = this.props;
+    const { expanded } = this.state;
     let pastEventsList = [];
     if (events.length) {
       pastEventsList = events
@@ -59,16 +60,14 @@ class Timeline extends React.Component {
         .filter(e => !!e); // Filter out the nulls
     }
 
-    const downArrow = this.state.expanded ? (
-      <div className="down-arrow" />
-    ) : null;
-    const displayedEvents = this.state.expanded ? pastEventsList : [];
+    const downArrow = expanded ? <div className="down-arrow" /> : null;
+    const displayedEvents = expanded ? pastEventsList : [];
 
     return (
       <div>
-        <ol className="form-process appeal-timeline">
+        <ol id="appeal-timeline" className="form-process appeal-timeline">
           <Expander
-            expanded={this.state.expanded}
+            expanded={expanded}
             key="expander"
             dateRange={this.formatDateRange()}
             onToggle={this.toggleExpanded}

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import Scroll from 'react-scroll';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
+import { getScrollOptions } from 'platform/utilities/ui';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import scrollTo from 'platform/utilities/ui/scrollTo';
 import AddFilesForm from '../components/AddFilesForm';
 import Notification from '../components/Notification';
 import EvidenceWarning from '../components/EvidenceWarning';
 import { setPageFocus, setUpPage } from '../utils/page';
-import { getScrollOptions } from 'platform/utilities/ui';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import scrollTo from 'platform/utilities/ui/scrollTo';
 
 import {
   addFile,
@@ -26,7 +26,7 @@ const scrollToError = () => {
   const options = getScrollOptions({ offset: -25 });
   scrollTo('uploadError', options);
 };
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 class AdditionalEvidencePage extends React.Component {
   componentDidMount() {
@@ -38,12 +38,14 @@ class AdditionalEvidencePage extends React.Component {
       scrollToTop();
     }
   }
+
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(props) {
     if (props.uploadComplete) {
       this.goToFilesPage();
     }
   }
+
   componentDidUpdate(prevProps) {
     if (this.props.message && !prevProps.message) {
       scrollToError();
@@ -52,15 +54,18 @@ class AdditionalEvidencePage extends React.Component {
       setPageFocus();
     }
   }
+
   componentWillUnmount() {
     if (!this.props.uploadComplete) {
       this.props.clearAdditionalEvidenceNotification();
     }
   }
+
   goToFilesPage() {
     this.props.getClaimDetail(this.props.claim.id);
     this.props.router.push(`your-claims/${this.props.claim.id}/files`);
   }
+
   render() {
     const filesPath = `your-claims/${this.props.params.id}/additional-evidence`;
     let content;
@@ -73,7 +78,7 @@ class AdditionalEvidencePage extends React.Component {
         />
       );
     } else {
-      const message = this.props.message;
+      const { message } = this.props;
 
       content = (
         <div className="claim-container">

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
+
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
 import { getClaimType } from '../utils/helpers';
 import { setUpPage, isTab, setFocus } from '../utils/page';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 class DetailsPage extends React.Component {
   componentDidMount() {
@@ -19,6 +21,7 @@ class DetailsPage extends React.Component {
       setFocus('.va-tab-trigger--current');
     }
   }
+
   componentDidUpdate(prevProps) {
     if (
       !this.props.loading &&
@@ -31,11 +34,13 @@ class DetailsPage extends React.Component {
       this.setTitle();
     }
   }
+
   setTitle() {
     document.title = this.props.loading
       ? 'Details - Your Claim'
       : `Details - Your ${getClaimType(this.props.claim)} Claim`;
   }
+
   render() {
     const { claim, loading, synced } = this.props;
 
@@ -43,9 +48,13 @@ class DetailsPage extends React.Component {
     if (!loading) {
       content = (
         <dl className="claim-details">
-          <dt className="claim-detail-label">Claim type</dt>
+          <dt className="claim-detail-label">
+            <h3 className="vads-u-font-size--h4">Claim type</h3>
+          </dt>
           <dd>{claim.attributes.claimType || 'Not Available'}</dd>
-          <dt className="claim-detail-label">What you’ve claimed</dt>
+          <dt className="claim-detail-label">
+            <h3 className="vads-u-font-size--h4">What you’ve claimed</h3>
+          </dt>
           <dd>
             {claim.attributes.contentionList &&
             claim.attributes.contentionList.length ? (
@@ -60,10 +69,14 @@ class DetailsPage extends React.Component {
               'Not Available'
             )}
           </dd>
-          <dt className="claim-detail-label">Date received</dt>
+          <dt className="claim-detail-label">
+            <h3 className="vads-u-font-size--h4">Date received</h3>
+          </dt>
           <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
           <dt className="claim-detail-label">
-            Your representative for VA claims
+            <h3 className="vads-u-font-size--h4">
+              Your representative for VA claims
+            </h3>
           </dt>
           <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
         </dl>

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -48,14 +48,14 @@ class DetailsPage extends React.Component {
     if (!loading) {
       content = (
         <>
-          <h2 className="vads-u-visibility--screen-reader">Claim details</h2>
+          <h3 className="vads-u-visibility--screen-reader">Claim details</h3>
           <dl className="claim-details">
             <dt className="claim-detail-label">
-              <h3 className="vads-u-font-size--h4">Claim type</h3>
+              <h4>Claim type</h4>
             </dt>
             <dd>{claim.attributes.claimType || 'Not Available'}</dd>
             <dt className="claim-detail-label">
-              <h3 className="vads-u-font-size--h4">What you’ve claimed</h3>
+              <h4>What you’ve claimed</h4>
             </dt>
             <dd>
               {claim.attributes.contentionList &&
@@ -72,13 +72,11 @@ class DetailsPage extends React.Component {
               )}
             </dd>
             <dt className="claim-detail-label">
-              <h3 className="vads-u-font-size--h4">Date received</h3>
+              <h4>Date received</h4>
             </dt>
             <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
             <dt className="claim-detail-label">
-              <h3 className="vads-u-font-size--h4">
-                Your representative for VA claims
-              </h3>
+              <h4>Your representative for VA claims</h4>
             </dt>
             <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
           </dl>

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -47,39 +47,42 @@ class DetailsPage extends React.Component {
     let content = null;
     if (!loading) {
       content = (
-        <dl className="claim-details">
-          <dt className="claim-detail-label">
-            <h3 className="vads-u-font-size--h4">Claim type</h3>
-          </dt>
-          <dd>{claim.attributes.claimType || 'Not Available'}</dd>
-          <dt className="claim-detail-label">
-            <h3 className="vads-u-font-size--h4">What you’ve claimed</h3>
-          </dt>
-          <dd>
-            {claim.attributes.contentionList &&
-            claim.attributes.contentionList.length ? (
-              <ul className="claim-detail-list">
-                {claim.attributes.contentionList.map((contention, index) => (
-                  <li key={index} className="claim-detail-list-item">
-                    {contention}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              'Not Available'
-            )}
-          </dd>
-          <dt className="claim-detail-label">
-            <h3 className="vads-u-font-size--h4">Date received</h3>
-          </dt>
-          <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
-          <dt className="claim-detail-label">
-            <h3 className="vads-u-font-size--h4">
-              Your representative for VA claims
-            </h3>
-          </dt>
-          <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
-        </dl>
+        <>
+          <h2 className="vads-u-visibility--screen-reader">Claim details</h2>
+          <dl className="claim-details">
+            <dt className="claim-detail-label">
+              <h3 className="vads-u-font-size--h4">Claim type</h3>
+            </dt>
+            <dd>{claim.attributes.claimType || 'Not Available'}</dd>
+            <dt className="claim-detail-label">
+              <h3 className="vads-u-font-size--h4">What you’ve claimed</h3>
+            </dt>
+            <dd>
+              {claim.attributes.contentionList &&
+              claim.attributes.contentionList.length ? (
+                <ul className="claim-detail-list">
+                  {claim.attributes.contentionList.map((contention, index) => (
+                    <li key={index} className="claim-detail-list-item">
+                      {contention}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                'Not Available'
+              )}
+            </dd>
+            <dt className="claim-detail-label">
+              <h3 className="vads-u-font-size--h4">Date received</h3>
+            </dt>
+            <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
+            <dt className="claim-detail-label">
+              <h3 className="vads-u-font-size--h4">
+                Your representative for VA claims
+              </h3>
+            </dt>
+            <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
+          </dl>
+        </>
       );
     }
 

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
 import AskVAToDecide from '../components/AskVAToDecide';
 import AdditionalEvidenceItem from '../components/AdditionalEvidenceItem';
@@ -10,7 +11,6 @@ import RequestedFilesInfo from '../components/RequestedFilesInfo';
 import { clearNotification } from '../actions/index.jsx';
 import { getClaimType } from '../utils/helpers';
 import { setUpPage, isTab, setFocus } from '../utils/page';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 const NEED_ITEMS_STATUS = 'NEEDED';
 const FIRST_GATHERING_EVIDENCE_PHASE = 3;
@@ -28,6 +28,7 @@ class FilesPage extends React.Component {
       setFocus('.va-tab-trigger--current');
     }
   }
+
   componentDidUpdate(prevProps) {
     if (
       !this.props.loading &&
@@ -40,14 +41,17 @@ class FilesPage extends React.Component {
       this.setTitle();
     }
   }
+
   componentWillUnmount() {
     this.props.clearNotification();
   }
+
   setTitle() {
     document.title = this.props.loading
       ? 'Files - Your claim'
       : `Files - Your ${getClaimType(this.props.claim)} claim`;
   }
+
   render() {
     const { claim, loading, message, synced } = this.props;
 

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -685,10 +685,30 @@ h1:focus {
   // Only let the (+) and "See / Hide past events" be clickable
   .past-events-expander {
     pointer-events: none;
+    position: relative;
 
-    &:before,
     button {
       pointer-events: all;
+    }
+
+    h2::before {
+      position: absolute;
+      /*
+      left: 2.5rem;
+      width: 3.5rem;
+      text-indent: 0.5rem;
+      */
+      font-size: 1.3em;
+      font-weight: 700;
+      text-align: center;
+      width: 1.6em;
+      top: -0.2em;
+      margin-left: -2.15em;
+      font-family: "Font Awesome 5 Free";
+      color: $color-primary;
+      background-color: $color-white;
+      border: 4px $color-primary solid;
+      border-radius: 50%;
     }
   }
 
@@ -698,23 +718,16 @@ h1:focus {
       padding-left: calc(2em + 5px);
     }
 
-    &::before {
-      font-family: "Font Awesome 5 Free";
+    h2::before {
       content: "\f067";
-      color: $color-primary;
-      background-color: $color-white;
-      border-color: $color-primary;
     }
   }
 
   .section-expanded {
     border-left: 5px solid $color-gray-lighter;
-    &::before {
-      font-family: "Font Awesome 5 Free";
+
+    h2::before {
       content: "\f068";
-      color: $color-primary;
-      background-color: $color-white;
-      border-color: $color-primary;
     }
   }
 
@@ -830,6 +843,12 @@ h1:focus {
   margin-bottom: 0;
 }
 
+.claims-evidence-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .claims-evidence {
   border-bottom: 1px solid $color-gray-light;
   padding: 1em 0;
@@ -881,6 +900,10 @@ h1:focus {
   font-size: 0.9em;
   line-height: 1.5;
   font-weight: bold;
+
+  h3 {
+    margin: 0;
+  }
 }
 
 .submitted-files-list {

--- a/src/applications/claims-status/tests/components/appeals-v2/Expander.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/Expander.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('<Expander/>', () => {
     const wrapper = shallow(<Expander {...props} />);
     expect(
       wrapper
-        .find('h3')
+        .find('h2')
         .first()
         .text(),
     ).to.equal('Hide past events');
@@ -52,10 +52,10 @@ describe('<Expander/>', () => {
     const wrapper = shallow(<Expander {...defaultProps} />);
     expect(
       wrapper
-        .find('h3')
+        .find('h2')
         .first()
         .text(),
-    ).to.equal('See past events');
+    ).to.equal('Reveal past events');
     expect(wrapper.find('.section-unexpanded').exists()).to.be.true;
     wrapper.unmount();
   });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -160,10 +160,9 @@ class TrackClaimsPage {
         cy.get('li.list-one .claims-evidence', {
           timeout: Timeouts.slow,
         }).should('be.visible');
-        cy.get('.claims-evidence:nth-child(3) .claims-evidence-item').should(
-          'contain',
-          'Your claim is closed',
-        );
+        cy.get(
+          '.claims-evidence-list li:nth-child(3) .claims-evidence-item',
+        ).should('contain', 'Your claim is closed');
         cy.get('.claim-older-updates').should('exist');
       });
     cy.get('li.list-one .claims-evidence', {
@@ -202,7 +201,7 @@ class TrackClaimsPage {
   }
 
   verifyClaimEvidence(claimId, claimStatus) {
-    cy.get('.submit-additional-evidence .usa-alert').should('be.visible');
+    cy.get('.submit-additional-evidence va-alert').should('be.visible');
     cy.get(
       `.submitted-file-list-item:nth-child(${claimId}) .submission-status`,
     ).should('contain', `${claimStatus}`);

--- a/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
@@ -36,7 +36,7 @@ export const AddPerson = props => {
       return <MissingServices title={props.title} />;
     case MVI_ADD_SUCCEEDED:
       // remove 'add-person' user.profile.services here?
-      return null;
+      return <MissingServices title={props.title} />;
     default:
       return null;
   }


### PR DESCRIPTION
## Description

Additional accessibility fix recommended by Angela for the claim status tab is to add a "Claim status" `h3` within the tab content, and change all the timeline headers to `h4`s
-  I ended up making this `h2` only visible for 

While examining the page, I found more problems:
- The timeline expand/collapse functionality was applied to the timeline `<li>` elements:
  - I moved the icon inside the button and styled it to maintain it's previous appearance
  - Added `aria-expanded` and `aria-controls` to button
- Change the "See" text of the expand button to "Reveal" to make it more inclusive
- The lists within the timeline were within `<div>` elements, so I wrapped them in a list.
- Updated the "completed" section of the timeline:
  - The alert header was changed to an `h5` to move it a child of the complete section
  - The "Payments" `h4` was changed to an `h5` for the same reason
- On the details tab, a description list (`dl`) includes content, but isn't obvious when looking at the header list
  - Added an screen reader visible `h2` with "Claim details"
  - Added `h3` inside the `dt` element

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/37923

## Testing done

Manual axe tests

## Screenshots

<details><summary>Status tab headers</summary>

<!-- leave a blank line above -->

![headers list of the claim status tab with new "claim status" h2 and timelines elements below it as h3s, the payments header in the complete section is now an h5](https://user-images.githubusercontent.com/136959/157111677-3844a4bd-bfd9-443f-8f9a-ec7310bf377a.png)</details>

<details><summary>Details tab headers</summary>

<!-- leave a blank line above -->
Headers list of the claim details tab with new6 (visually hidden) "claim details" h3 and all description term h4

**Note:** the header levels in this description have been updated, but not the screenshot
![headers list of the claim details tab with new "claim details" h3 and all description term h4](https://user-images.githubusercontent.com/136959/157111676-5e8df8eb-f5fe-4758-acdd-383d0b1f826c.png)</details>

## Acceptance criteria
- [x] Claim status tool accessibility improvements applied
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
