### PR TITLE
workflow protection test against the scheduler

### DIFF
--- a/.github/workflows/test-on-demand-runner.yml
+++ b/.github/workflows/test-on-demand-runner.yml
@@ -1,5 +1,7 @@
 on:
-  workflow_dispatch
+  workflow_dispatch:
+  schedule:
+   - cron: '*/5 * * * *'
 
 name: Test On-Demand Runner
 env:

--- a/.github/workflows/test-on-demand-runner.yml
+++ b/.github/workflows/test-on-demand-runner.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   start-runner:
     runs-on: ubuntu-latest
+    environment: dev-test
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
## Description
testing a start runner job's workflow with an inclusion of workflow protection with an option of review/approve as a github environment. The intention is to have this not raise a trigger for approval for auto scheduled job.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37940


## Testing done
tested for individual branches. this is a test for master branch

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [X] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
