### PR TITLE
Add users as placeholders for Slack groups

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -2,16 +2,20 @@
   "allow": {
     "singleApps": [
       {
-        "entryName": "education-inbox"
+        "entryName": "education-inbox",
+        "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>"
       },
       {
-        "entryName": "enrollment-verification"
+        "entryName": "enrollment-verification",
+        "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>"
       },
       {
-        "entryName": "login-page"
+        "entryName": "login-page",
+        "slackGroup": "<@U01AAA2T1JT> <@U018M85FA2K> <@U02KJQ9DMB2>"
       },
       {
-        "entryName": "medical-copays"
+        "entryName": "medical-copays",
+        "slackGroup": "<@U0329KDCJ0Y> <@U031KTDNYEP>"
       },
       {
         "entryName": "terms-and-conditions"


### PR DESCRIPTION
## Description
This PR adds Slack users as placeholders for teams with apps on the changed app build config that don't have a Slack user group yet.

## Acceptance criteria
- [x] Applications on the allowlist that have an owner, should have either a user(s) or Slack group in the changed app build config.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
