### PR TITLE
Adds the MHV Inherited Proofing Success page

### DIFF
--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -5,6 +5,8 @@ export const TOGGLE_LOGIN_MODAL = 'TOGGLE_LOGIN_MODAL';
 export const UPDATE_SEARCH_HELP_USER_MENU = 'UPDATE_SEARCH_HELP_USER_MENU';
 export const TOGGLE_ACCOUNT_TRANSITION_MODAL =
   'TOGGLE_ACCOUNT_TRANSITION_MODAL';
+export const TOGGLE_ACCOUNT_TRANSITION_SUCCESS_MODAL =
+  'TOGGLE_ACCOUNT_TRANSITION_SUCCESS_MODAL';
 
 export function toggleFormSignInModal(isOpen) {
   return { type: TOGGLE_FORM_SIGN_IN_MODAL, isOpen };
@@ -12,6 +14,10 @@ export function toggleFormSignInModal(isOpen) {
 
 export function toggleAccountTransitionModal(isOpen) {
   return { type: TOGGLE_ACCOUNT_TRANSITION_MODAL, isOpen };
+}
+
+export function toggleAccountTransitionSuccessModal(isOpen) {
+  return { type: TOGGLE_ACCOUNT_TRANSITION_SUCCESS_MODAL, isOpen };
 }
 
 export function toggleLoginModal(isOpen, context) {

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -10,6 +10,7 @@ import FormSignInModal from 'platform/forms/save-in-progress/FormSignInModal';
 import SessionTimeoutModal from 'platform/user/authentication/components/SessionTimeoutModal';
 import SignInModal from 'platform/user/authentication/components/SignInModal';
 import AccountTransitionModal from 'platform/user/authentication/components/account-transition/TransitionModal';
+import AccountTransitionSuccessModal from 'platform/user/authentication/components/account-transition/TransitionSuccessModal';
 import { SAVE_STATUSES } from 'platform/forms/save-in-progress/actions';
 import { getBackendStatuses } from 'platform/monitoring/external-services/actions';
 import { hasSession } from 'platform/user/profile/utilities';
@@ -25,6 +26,7 @@ import {
   toggleFormSignInModal,
   toggleLoginModal,
   toggleAccountTransitionModal,
+  toggleAccountTransitionSuccessModal,
   toggleSearchHelpUserMenu,
 } from 'platform/site-wide/user-nav/actions';
 import { updateLoggedInStatus } from 'platform/user/authentication/actions';
@@ -51,7 +53,7 @@ export class Main extends Component {
 
   componentDidUpdate() {
     const { currentlyLoggedIn, user } = this.props;
-    const { mhvTransitionEligible } = user || {};
+    const { mhvTransitionEligible, mhvTransitionComplete } = user || {};
     const accountTransitionPreviouslyDismissed = localStorage.getItem(
       ACCOUNT_TRANSITION_DISMISSED,
     );
@@ -62,6 +64,10 @@ export class Main extends Component {
 
       if (mhvTransitionEligible && !accountTransitionPreviouslyDismissed) {
         this.props.toggleAccountTransitionModal(true);
+      }
+
+      if (mhvTransitionComplete) {
+        this.props.toggleAccountTransitionSuccessModal(true);
       }
     }
   }
@@ -162,6 +168,10 @@ export class Main extends Component {
     localStorage.setItem(ACCOUNT_TRANSITION_DISMISSED, true);
   };
 
+  closeAccountTransitionSuccessModal = () => {
+    this.props.toggleAccountTransitionSuccessModal(false);
+  };
+
   closeModals = () => {
     if (this.props.showFormSignInModal) this.closeFormSignInModal();
     if (this.props.showLoginModal) this.closeLoginModal();
@@ -216,6 +226,10 @@ export class Main extends Component {
           visible={this.props.showAccountTransitionModal}
           history={history}
         />
+        <AccountTransitionSuccessModal
+          onClose={this.closeAccountTransitionSuccessModal}
+          visible={this.props.showAccountTransitionSuccessModal}
+        />
         <SessionTimeoutModal
           isLoggedIn={this.props.currentlyLoggedIn}
           onExtendSession={this.props.initializeProfile}
@@ -259,6 +273,7 @@ const mapDispatchToProps = {
   toggleFormSignInModal,
   toggleLoginModal,
   toggleAccountTransitionModal,
+  toggleAccountTransitionSuccessModal,
   toggleSearchHelpUserMenu,
   updateLoggedInStatus,
 };
@@ -273,6 +288,7 @@ Main.propTypes = {
   getBackendStatuses: PropTypes.func.isRequired,
   initializeProfile: PropTypes.func.isRequired,
   toggleAccountTransitionModal: PropTypes.func.isRequired,
+  toggleAccountTransitionSuccessModal: PropTypes.func.isRequired,
   toggleFormSignInModal: PropTypes.func.isRequired,
   toggleLoginModal: PropTypes.func.isRequired,
   toggleSearchHelpUserMenu: PropTypes.func.isRequired,
@@ -285,6 +301,8 @@ Main.propTypes = {
   shouldConfirmLeavingForm: PropTypes.bool,
   showFormSignInModal: PropTypes.bool,
   showLoginModal: PropTypes.bool,
+  showAccountTransitionModal: PropTypes.bool,
+  showAccountTransitionSuccessModal: PropTypes.bool,
   userGreeting: PropTypes.array,
   utilitiesMenuIsOpen: PropTypes.object,
 };

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -16,6 +16,7 @@ import { getBackendStatuses } from 'platform/monitoring/external-services/action
 import { hasSession } from 'platform/user/profile/utilities';
 import { initializeProfile } from 'platform/user/profile/actions';
 import { isInProgressPath } from 'platform/forms/helpers';
+import { signInServiceName as signInServiceNameSelector } from 'platform/user/authentication/selectors';
 import {
   isLoggedIn,
   isProfileLoading,
@@ -66,7 +67,10 @@ export class Main extends Component {
         this.props.toggleAccountTransitionModal(true);
       }
 
-      if (mhvTransitionComplete) {
+      if (
+        this.props.signInServiceName === 'logingov' &&
+        mhvTransitionComplete
+      ) {
         this.props.toggleAccountTransitionSuccessModal(true);
       }
     }
@@ -261,6 +265,7 @@ export const mapStateToProps = state => {
     isLOA3: isLOA3(state),
     isProfileLoading: isProfileLoading(state),
     user: selectUser(state),
+    signInServiceName: signInServiceNameSelector(state),
     shouldConfirmLeavingForm,
     userGreeting: selectUserGreeting(state),
     ...state.navigation,
@@ -299,10 +304,10 @@ Main.propTypes = {
   isLOA3: PropTypes.bool,
   isProfileLoading: PropTypes.bool,
   shouldConfirmLeavingForm: PropTypes.bool,
-  showFormSignInModal: PropTypes.bool,
-  showLoginModal: PropTypes.bool,
   showAccountTransitionModal: PropTypes.bool,
   showAccountTransitionSuccessModal: PropTypes.bool,
+  showFormSignInModal: PropTypes.bool,
+  showLoginModal: PropTypes.bool,
   userGreeting: PropTypes.array,
   utilitiesMenuIsOpen: PropTypes.object,
 };

--- a/src/platform/site-wide/user-nav/reducers/index.js
+++ b/src/platform/site-wide/user-nav/reducers/index.js
@@ -5,12 +5,14 @@ import {
   TOGGLE_LOGIN_MODAL,
   UPDATE_SEARCH_HELP_USER_MENU,
   TOGGLE_ACCOUNT_TRANSITION_MODAL,
+  TOGGLE_ACCOUNT_TRANSITION_SUCCESS_MODAL,
 } from '../actions';
 
 const initialState = {
   showFormSignInModal: false,
   showLoginModal: false,
   showAccountTransitionModal: false,
+  showAccountTransitionSuccessModal: false,
   utilitiesMenuIsOpen: {
     search: false,
     help: false,
@@ -40,6 +42,9 @@ export default function userNavReducer(state = initialState, action) {
 
     case TOGGLE_ACCOUNT_TRANSITION_MODAL:
       return set('showAccountTransitionModal', action.isOpen, state);
+
+    case TOGGLE_ACCOUNT_TRANSITION_SUCCESS_MODAL:
+      return set('showAccountTransitionSuccessModal', action.isOpen, state);
 
     default:
       return state;

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -18,16 +18,16 @@ describe('<Main>', () => {
     userGreeting: null,
     showFormSignInModal: false,
     showLoginModal: false,
-    utilitiesMenuIsOpen: {
-      search: false,
-      help: false,
-      account: false,
-    },
+    showTransitionSuccessModal: false,
+    showTransitionModal: false,
+    utilitiesMenuIsOpen: { search: false, help: false, account: false },
     getBackendStatuses: sinon.spy(),
     toggleFormSignInModal: sinon.spy(),
     toggleLoginModal: sinon.spy(),
     toggleAccountTransitionModal: sinon.spy(),
     closeAccountTransitionModal: sinon.spy(),
+    toggleAccountTransitionSuccessModal: sinon.spy(),
+    closeAccountTransitionSuccessModal: sinon.spy(),
     toggleSearchHelpUserMenu: sinon.spy(),
     updateLoggedInStatus: sinon.spy(),
     initializeProfile: sinon.spy(),
@@ -54,6 +54,8 @@ describe('<Main>', () => {
     props.toggleLoginModal.reset();
     props.toggleAccountTransitionModal.reset();
     props.closeAccountTransitionModal.reset();
+    props.toggleAccountTransitionSuccessModal.reset();
+    props.closeAccountTransitionSuccessModal.reset();
     props.toggleSearchHelpUserMenu.reset();
     props.updateLoggedInStatus.reset();
     props.initializeProfile.reset();
@@ -176,6 +178,21 @@ describe('<Main>', () => {
       expect(props.toggleAccountTransitionModal.notCalled).to.be.true;
       wrapper.unmount();
     });
+  });
+
+  it('should open the `TransitionSuccessModal` when `mhvTransitionComplete` is true and `signIn.serviceName` is `logingov`', () => {
+    const mutatedProps = {
+      ...props,
+      currentlyLoggedIn: true,
+      user: { mhvTransitionComplete: true },
+      signInServiceName: 'logingov',
+    };
+    const wrapper = shallow(<Main {...props} />);
+    global.window.simulate('load');
+    wrapper.setProps(mutatedProps);
+    expect(props.toggleAccountTransitionSuccessModal.calledWith(true)).to.be
+      .true;
+    wrapper.unmount();
   });
 
   it('should ignore any storage changes if the user is already logged out', () => {

--- a/src/platform/user/authentication/components/account-transition/TransitionSuccessModal.jsx
+++ b/src/platform/user/authentication/components/account-transition/TransitionSuccessModal.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import recordEvent from 'platform/monitoring/record-event';
+
+export default function TransitionSucessModal({ visible, onClose }) {
+  const primaryButton = {
+    action: () => {
+      recordEvent({ event: `login-account-transition-success-modal-dismiss` });
+      onClose();
+    },
+    text: 'Continue to VA.gov',
+  };
+
+  useEffect(
+    () => {
+      recordEvent({
+        event: `login-account-transition-success-modal-${
+          visible ? 'opened' : 'closed'
+        }`,
+      });
+    },
+    [visible],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      focusSelector="button"
+      onClose={onClose}
+      id="account-transition-success-modal"
+      primaryButton={primaryButton}
+      status="success"
+      title="You're using a Login.gov account"
+    >
+      <div className="container">
+        <div className="row">
+          <p>
+            Congratulations! You have sucessfully signed in with your newly
+            created <strong>Login.gov</strong> account. This account will give
+            you acess to the same benefits and services you would normally use
+            on VA.gov or My HealtheVet.
+          </p>
+          <p>
+            It is recommended that you continue to use this account as your
+            preferred credential.
+          </p>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+TransitionSucessModal.propTypes = {
+  visible: PropTypes.bool,
+  onClose: PropTypes.func,
+};

--- a/src/platform/user/tests/authentication/components/TransitionSuccessModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/TransitionSuccessModal.unit.spec.js
@@ -1,0 +1,13 @@
+// import React from 'react';
+// import { expect } from 'chai';
+// import { mount } from 'enzyme';
+// import sinon from 'sinon';
+
+// import * as authUtilities from '../../../authentication/utilities';
+// import LoginActions from '../../../authentication/components/LoginActions';
+// import { CSP_IDS } from '../../../authentication/constants';
+
+// describe('', () => {
+//   it('should display when `` is set to true');
+//   it('should')
+// });

--- a/src/platform/user/tests/authentication/components/TransitionSuccessModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/TransitionSuccessModal.unit.spec.js
@@ -1,13 +1,35 @@
-// import React from 'react';
-// import { expect } from 'chai';
-// import { mount } from 'enzyme';
-// import sinon from 'sinon';
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+import TransitionSuccessModal from '../../../authentication/components/account-transition/TransitionSuccessModal';
 
-// import * as authUtilities from '../../../authentication/utilities';
-// import LoginActions from '../../../authentication/components/LoginActions';
-// import { CSP_IDS } from '../../../authentication/constants';
+describe('', () => {
+  let wrapper;
+  const props = { visible: false, onClose: sinon.spy() };
 
-// describe('', () => {
-//   it('should display when `` is set to true');
-//   it('should')
-// });
+  beforeEach(() => {
+    wrapper = shallow(<TransitionSuccessModal {...props} />);
+  });
+  it('should display when `visible` is set to true', () => {
+    expect(wrapper.prop('visible')).to.be.false;
+    wrapper.setProps({ visible: true });
+    expect(wrapper.prop('visible')).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should include `Congratulations` in the modal', () => {
+    expect(wrapper.find('.container').text()).to.include('Congratulations');
+    wrapper.unmount();
+  });
+
+  it('should close the modal when primaryButton action is called', () => {
+    wrapper = mount(<TransitionSuccessModal {...props} />);
+    const mutatedProps = { visible: true, onClose: sinon.spy() };
+    wrapper.setProps(mutatedProps);
+
+    wrapper.find('.usa-button').simulate('click');
+    expect(wrapper.prop('onClose').calledOnce).to.be.true;
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This PR adds a success modal to inform the user they have successfully completed the MHV Inherited Proofing / account transition.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34961


## Testing done
Unit testing

## Screenshots
<img width="1111" alt="Screen Shot 2022-03-08 at 12 54 46 PM" src="https://user-images.githubusercontent.com/67602137/157297809-9180aa71-43f4-4ca0-a3a0-a582cecc7c95.png">


## Acceptance criteria
- [ ] A MHV Inherited Proofing success Modal is displayed when a user is authenticated with Login.gov AND `mhvTransitionComplete` on the User Model is set to true
- [ ] Clicking the `Continue to VA.gov` or `Close icon` will close the modal

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
