### PR TITLE
[COE] Fix issue with loan history list loop

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -15,18 +15,27 @@ import { loanHistory } from '../../schemaImports';
 const stateLabels = createUSAStateLabels(states);
 
 const PreviousLoanView = ({ formData }) => {
-  const { street, city, state, postalCode } = formData.address;
+  const {
+    propertyAddress1,
+    propertyCity,
+    propertyState,
+    propertyZip,
+  } = formData.propertyAddress;
   let from = '';
   let to = '';
   if (formData.dateRange) {
-    from = formatReviewDate(formData.dateRange.from);
-    to = formatReviewDate(formData.dateRange.to);
+    from = formatReviewDate(formData.dateRange.startDate);
+    to = formatReviewDate(formData.dateRange.paidOffDate);
   }
 
   return (
     <div>
-      <strong>{`${street}, ${city}, ${state}, ${postalCode}`}</strong> <br />
-      {to ? `${from} - ${to}` : `${from} - present`}
+      <div>
+        <strong>
+          {`${propertyAddress1}, ${propertyCity}, ${propertyState}, ${propertyZip}`}
+        </strong>
+      </div>
+      <div>{to ? `${from} - ${to}` : `${from} - present`}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Description
The list loop for previous VA-backed home loans is breaking because the `PreviousLoanView` component wasn't updated when the properties in the schema were updated. This PR uses the proper schema properties.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38174

## Acceptance criteria
- [x] `PreviousLoanView` component is updated to use correct schema properties

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
