### PR TITLE
[DON'T MERGE] 37930: Make Login.gov visible by default and hide via flipper

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -7,7 +7,7 @@ export default function RenderErrorContainer({
   code = AUTH_ERROR.DEFAULT,
   auth = AUTH_LEVEL.FAIL,
   recordEvent = () => ({}),
-  loginGovEnabled = false,
+  loginGovOff = false,
   openLoginModal = () => ({}),
 }) {
   let alertContent;
@@ -38,7 +38,7 @@ export default function RenderErrorContainer({
             Please try again, and this time, select <strong>“Accept”</strong> on
             the final page of the identity verification process. Or, if you
             don’t want to verify your identity with{' '}
-            {loginGovEnabled && `Login.gov or `}
+            {!loginGovOff && `Login.gov or `}
             ID.me, you can try signing in with your premium DS Logon or premium
             My HealtheVet username and password.
           </p>
@@ -349,7 +349,7 @@ export default function RenderErrorContainer({
 RenderErrorContainer.propTypes = {
   auth: PropTypes.oneOf(Object.keys(AUTH_LEVEL)),
   code: PropTypes.oneOf(Object.keys(AUTH_ERROR)),
-  loginGovEnabled: PropTypes.bool,
+  loginGovOff: PropTypes.bool,
   openLoginModal: PropTypes.func,
   recordEvent: PropTypes.func,
 };

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/browser';
 
 import recordEvent from 'platform/monitoring/record-event';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
-import { loginGov } from 'platform/user/authentication/selectors';
+import { loginGovDisabled } from 'platform/user/authentication/selectors';
 import {
   AUTHN_SETTINGS,
   EXTERNAL_APPS,
@@ -186,13 +186,13 @@ export class AuthApp extends React.Component {
       code: this.props.location.query.code,
       auth: this.props.location.query.auth,
       recordEvent,
-      loginGovEnabled: this.props.loginGovEnabled,
+      loginGovOff: this.props.loginGovOff,
       openLoginModal: this.props.openLoginModal,
     };
     const view = this.state.error ? (
       <RenderErrorUI {...renderErrorProps} />
     ) : (
-      <va-loading-indicator message={`Signing in to VA.gov...`} />
+      <va-loading-indicator message="Signing in to VA.gov..." />
     );
 
     return <div className="row vads-u-padding-y--5">{view}</div>;
@@ -204,7 +204,7 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  loginGovEnabled: loginGov(state),
+  loginGovOff: loginGovDisabled(state),
 });
 
 export default connect(

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
@@ -34,7 +34,7 @@ describe('Medical Copays CTA <App>', () => {
     );
     expect(wrapper.text()).not.includes('Review your VA copay balances');
     expect(wrapper.text()).includes(
-      'If you don’t have any of these accounts, you can create a free ID.me account now. When you sign in or create an account, you’ll be able to:',
+      'If you don’t have any of these accounts, you can create a free Login.gov or ID.me account now. When you sign in or create an account, you’ll be able to:',
     );
     expect(wrapper.text()).not.includes('With this tool, you can:');
     expect(wrapper.text()).includes(

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -6,7 +6,6 @@ import LoginGovSVG from 'platform/user/authentication/components/LoginGovSVG';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import recordEvent from 'platform/monitoring/record-event';
 
-import { loginGov } from 'platform/user/authentication/selectors';
 import { verify } from 'platform/user/authentication/utilities';
 import { hasSession } from 'platform/user/profile/utilities';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
@@ -147,7 +146,6 @@ const mapStateToProps = state => {
   return {
     login: userState.login,
     profile: userState.profile,
-    loginGovEnabled: loginGov(state),
   };
 };
 

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -5,7 +5,7 @@ import CreateAccountLink from './CreateAccountLink';
 
 export default ({
   externalApplication,
-  loginGovEnabled,
+  loginGovOff,
   loginGovCreateAccountEnabled,
   loginGovMHVEnabled,
   loginGovMyVAHealthEnabled,
@@ -13,13 +13,13 @@ export default ({
   const externalLoginGovSupport = {
     [EXTERNAL_APPS.MHV]: loginGovMHVEnabled,
     [EXTERNAL_APPS.MY_VA_HEALTH]: loginGovMyVAHealthEnabled,
-    [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: loginGovEnabled,
-    [EXTERNAL_APPS.VA_OCC_MOBILE]: loginGovEnabled,
-    [EXTERNAL_APPS.EBENEFITS]: loginGovEnabled,
+    [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: !loginGovOff,
+    [EXTERNAL_APPS.VA_OCC_MOBILE]: !loginGovOff,
+    [EXTERNAL_APPS.EBENEFITS]: !loginGovOff,
   };
 
   const showLoginGov = () => {
-    if (!loginGovEnabled) {
+    if (loginGovOff) {
       return false;
     }
 

--- a/src/platform/user/authentication/components/LoginContainer.jsx
+++ b/src/platform/user/authentication/components/LoginContainer.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import {
   ssoe,
-  loginGov,
+  loginGovDisabled,
   loginGovCreateAccount,
   loginGovMyVAHealth,
   loginGovMHV,
@@ -23,7 +23,7 @@ export const LoginContainer = props => {
     externalApplication,
     isUnifiedSignIn,
     loggedOut,
-    loginGovEnabled,
+    loginGovOff,
     loginGovCreateAccountEnabled,
     loginGovMHVEnabled,
     loginGovMyVAHealthEnabled,
@@ -45,7 +45,7 @@ export const LoginContainer = props => {
           <LoginHeader loggedOut={loggedOut} />
           <LoginActions
             externalApplication={externalApplication}
-            loginGovEnabled={loginGovEnabled}
+            loginGovOff={loginGovOff}
             loginGovMHVEnabled={loginGovMHVEnabled}
             loginGovMyVAHealthEnabled={loginGovMyVAHealthEnabled}
             loginGovCreateAccountEnabled={loginGovCreateAccountEnabled}
@@ -60,7 +60,7 @@ export const LoginContainer = props => {
 function mapStateToProps(state) {
   return {
     useSSOe: ssoe(state),
-    loginGovEnabled: loginGov(state),
+    loginGovOff: loginGovDisabled(state),
     loginGovMHVEnabled: loginGovMHV(state),
     loginGovMyVAHealthEnabled: loginGovMyVAHealth(state),
     loginGovCreateAccountEnabled: loginGovCreateAccount(state),

--- a/src/platform/user/authentication/components/ServiceProvidersList.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersList.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { loginGov } from 'platform/user/authentication/selectors';
+import { loginGovDisabled } from 'platform/user/authentication/selectors';
 
 const ServiceProvidersList = React.memo(() => {
-  const loginGovEnabled = useSelector(state => loginGov(state));
+  const loginGovOff = useSelector(state => loginGovDisabled(state));
 
   return (
     <>
       <ul>
-        {loginGovEnabled && (
+        {!loginGovOff && (
           <li>
             A verified <strong>Login.gov</strong> account, <strong>or</strong>
           </li>
@@ -25,7 +25,7 @@ const ServiceProvidersList = React.memo(() => {
       </ul>
       <p>
         If you don’t have one of these accounts, you can create a free{' '}
-        {loginGovEnabled && (
+        {!loginGovOff && (
           <>
             <strong>Login.gov</strong> or{' '}
           </>

--- a/src/platform/user/authentication/components/ServiceProvidersText.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersText.jsx
@@ -1,20 +1,20 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { loginGov } from 'platform/user/authentication/selectors';
+import { loginGovDisabled } from 'platform/user/authentication/selectors';
 
 const initialCSPState = ['ID.me', 'DS Logon', 'My HealtheVet'];
 
 const ServiceProviders = React.memo(({ isBold }) => {
   const [serviceProviders, setCSPs] = useState(initialCSPState);
-  const loginGovEnabled = useSelector(state => loginGov(state));
+  const loginGovOff = useSelector(state => loginGovDisabled(state));
 
   useEffect(
     () => {
-      if (loginGovEnabled) {
+      if (!loginGovOff) {
         setCSPs(['Login.gov', ...initialCSPState]);
       }
     },
-    [loginGovEnabled],
+    [!loginGovOff],
   );
 
   return serviceProviders.map((csp, i) => {
@@ -37,12 +37,12 @@ const ServiceProviders = React.memo(({ isBold }) => {
 
 export const ServiceProvidersTextCreateAcct = React.memo(
   ({ isFormBased = false, hasExtraTodo = false }) => {
-    const loginGovEnabled = useSelector(state => loginGov(state));
+    const loginGovOff = useSelector(state => loginGovDisabled(state));
 
     const isFormComponent = isFormBased
       ? 'completed this form without signing in, and you '
       : null;
-    const showLoginGov = loginGovEnabled ? (
+    const showLoginGov = !loginGovOff ? (
       <>
         <strong>Login.gov</strong> or{' '}
       </>

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -5,6 +5,9 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 export const loginGov = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.loginGov];
 
+export const loginGovDisabled = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.loginGovDisabled];
+
 export const loginGovCreateAccount = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.loginGovCreateAccount];
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -60,6 +60,7 @@ export default Object.freeze({
   hlrv2: 'hlr_v2',
   loginGov: 'login_gov',
   loginGovCreateAccount: 'login_gov_create_account',
+  loginGovDisabled: 'login_gov_disabled',
   loginGovMHV: 'login_gov_mhv',
   loginGovMyVAHealth: 'login_gov_myvahealth',
   loopPages: 'loop_pages',


### PR DESCRIPTION
## Description
The current implementation has login.gov hidden by default, and the flipper feature will enable it.
This change will show login.gov by default, and the flipper feature will disable it.

Cannot be merged until: https://github.com/department-of-veterans-affairs/vets-api/pull/9282 is merged
Cannot be merged until Feb 11th

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37930


## Testing done


## Screenshots


## Acceptance criteria
- [ ] Login.gov buttons should be visible by default, and hidden by the new feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
