### PR TITLE
1010/feature/38164/ez fix confirmation page

### DIFF
--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -26,8 +26,7 @@ export class ConfirmationPage extends React.Component {
     let name;
     if (hasSession()) {
       // authenticated user, get name from profile
-      const { profie } = this.props;
-      const { user } = profie;
+      const { user } = this.props;
       name = user.userFullName;
     } else {
       // unauthenticated user, get name from form data
@@ -187,5 +186,5 @@ export default connect(mapStateToProps)(ConfirmationPage);
 
 ConfirmationPage.propTypes = {
   form: PropTypes.object,
-  profie: PropTypes.object,
+  user: PropTypes.object,
 };

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -68,7 +68,7 @@ export class ConfirmationPage extends React.Component {
             Health Care Benefit Claim{' '}
             <span className="additional">(Form 10-10EZ)</span>
           </h5>
-          <span key={name}>
+          <span>
             for {first} {middle} {last} {suffix}
           </span>
 
@@ -102,7 +102,7 @@ export class ConfirmationPage extends React.Component {
           </p>
           <p>
             Please don’t apply again. Instead, please call our toll-free hotline
-            at <a href="tel:+18772228387">877-222-8387</a>. We’re here Monday
+            at <va-telephone contact="877-222-8387" />. We’re here Monday
             through Friday, 8:00 am to 8:00 pm ET.
           </p>
           <h4 className="confirmation-guidance-heading">
@@ -170,8 +170,8 @@ export class ConfirmationPage extends React.Component {
             What if I have more questions?
           </h4>
           <p className="confirmation-guidance-message">
-            Please call <a href="tel:+18772228387">877-222-8387</a> and select
-            2. We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            Please call <va-telephone contact="877-222-8387" /> and select 2.
+            We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
           </p>
         </div>
       </div>

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -32,6 +32,10 @@ export class ConfirmationPage extends React.Component {
       // unauthenticated user, get name from form data
       name = data.veteranFullName;
     }
+    const first = name.first || '';
+    const middle = name.middle || '';
+    const last = name.last || '';
+    const suffix = name.suffix || '';
 
     let emailMessage;
 
@@ -65,7 +69,7 @@ export class ConfirmationPage extends React.Component {
             <span className="additional">(Form 10-10EZ)</span>
           </h5>
           <span>
-            for {name?.first} {name?.middle} {name?.last} {name?.suffix}
+            for {first} {middle} {last} {suffix}
           </span>
 
           {response && (

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
 
@@ -9,6 +10,8 @@ import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
 
+import { hasSession } from 'platform/user/profile/utilities';
+
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
     focusElement('.schemaform-title > h1');
@@ -16,9 +19,20 @@ export class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const { submission, data } = this.props.form;
+    const { form } = this.props;
+    const { submission, data } = form;
     const { response } = submission;
-    const name = data.veteranFullName;
+
+    let name;
+    if (hasSession()) {
+      // authenticated user, get name from profile
+      const { profie } = this.props;
+      const { user } = profie;
+      name = user.userFullName;
+    } else {
+      // unauthenticated user, get name from form data
+      name = data.veteranFullName;
+    }
 
     let emailMessage;
 
@@ -165,7 +179,13 @@ export class ConfirmationPage extends React.Component {
 function mapStateToProps(state) {
   return {
     form: state.form,
+    user: state.user.profile,
   };
 }
 
 export default connect(mapStateToProps)(ConfirmationPage);
+
+ConfirmationPage.propTypes = {
+  form: PropTypes.object,
+  profie: PropTypes.object,
+};

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -68,7 +68,7 @@ export class ConfirmationPage extends React.Component {
             Health Care Benefit Claim{' '}
             <span className="additional">(Form 10-10EZ)</span>
           </h5>
-          <span>
+          <span key={name}>
             for {first} {middle} {last} {suffix}
           </span>
 


### PR DESCRIPTION
## Description
As a Veteran, I need to avoid inappropriate modifications to MPI so that my data remains accurate.

If the user is authenticated, we pre-populate some of the fields for them, based on the values in the Master Person Index (MPI). However, these fields are editable, and may be changed by the user.

Fix confirmation page, to display veteran name in successful confirmation message, for authenticated and unauthenticated users. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-website/pull/20192
