### PR TITLE
Fix note for prefill information

### DIFF
--- a/src/applications/edu-benefits/0994/components/PaymentView.jsx
+++ b/src/applications/edu-benefits/0994/components/PaymentView.jsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import environment from 'platform/utilities/environment';
 import { maskBankInformation, hasNewBankInformation } from '../utils';
 
 export const accountTitleLabels = {
@@ -28,6 +29,9 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
   } = bankAccount;
 
   const hasNewBankAccountInfo = hasNewBankInformation(bankAccount);
+  const hasOriginalBankAccountInfo =
+    originalData.bankAccountType !== undefined ||
+    originalData.bankAccountType !== null;
 
   const bankAccountType = hasNewBankAccountInfo
     ? newAccountType
@@ -46,6 +50,13 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
           <strong>
             {accountTitleLabels[(bankAccountType || '').toUpperCase()]}
           </strong>
+          {!environment.isProduction() &&
+            (hasNewBankAccountInfo || hasOriginalBankAccountInfo) && (
+              <p>
+                This is the bank account information we have on file for you.
+                We’ll send your housing payment to this account.
+              </p>
+            )}
         </p>
         <p>Account number: {maskBankInformation(bankAccountNumber, 4)}</p>
         <p>Bank routing number: {maskBankInformation(bankRoutingNumber, 4)}</p>


### PR DESCRIPTION
## Description
AC 2B of issuedepartment-of-veterans-affairs/va.gov-team#23485

## Original issue(s)
department-of-veterans-affairs/va.gov-team#23485


## Testing done
Locally

## Screenshots
<img width="571" alt="Screen Shot 2022-03-07 at 12 00 35 PM" src="https://user-images.githubusercontent.com/86262790/157318225-54e9643e-eda0-4991-b78b-11ce8ed434ee.png">

## Acceptance criteria
- [x] Note shows in payment view when bank information is present (using a prefill test user)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
