### PR TITLE
[COE] Remove static reference number

### DIFF
--- a/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
@@ -12,7 +12,6 @@ import LoggedInContent from './introduction-content/loggedInContent';
 import { CALLSTATUS, COE_ELIGIBILITY_STATUS } from '../../shared/constants';
 
 const IntroductionPage = ({ coe, downloadUrl, loggedIn, route, status }) => {
-  const referenceNumber = 'XXXXXXXX';
   let content;
 
   useEffect(() => {
@@ -32,7 +31,7 @@ const IntroductionPage = ({ coe, downloadUrl, loggedIn, route, status }) => {
       <>
         <COEIntroPageBox
           downloadUrl={downloadUrl}
-          referenceNumber={referenceNumber}
+          referenceNumber={coe.referenceNumber}
           requestDate={coe.applicationCreateDate}
           status={coe.status}
         />

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -33,7 +33,6 @@ const App = ({
   loggedIn,
   user,
 }) => {
-  const referenceNumber = 'XXXXXXXX';
   const clickHandler = useCallback(
     () => {
       getCoe('skip');
@@ -71,7 +70,7 @@ const App = ({
           <Eligible
             clickHandler={clickHandler}
             downloadUrl={downloadUrl}
-            referenceNumber={referenceNumber}
+            referenceNumber={coe.referenceNumber}
           />
         );
         break;
@@ -79,13 +78,13 @@ const App = ({
         content = <Ineligible />;
         break;
       case COE_ELIGIBILITY_STATUS.denied:
-        content = <Denied referenceNumber={referenceNumber} />;
+        content = <Denied referenceNumber={coe.referenceNumber} />;
         break;
       case COE_ELIGIBILITY_STATUS.pending:
         content = (
           <Pending
             notOnUploadPage
-            referenceNumber={referenceNumber}
+            referenceNumber={coe.referenceNumber}
             requestDate={coe.applicationCreateDate}
             status={coe.status}
           />
@@ -94,7 +93,7 @@ const App = ({
       case COE_ELIGIBILITY_STATUS.pendingUpload:
         content = (
           <Pending
-            referenceNumber={referenceNumber}
+            referenceNumber={coe.referenceNumber}
             requestDate={coe.applicationCreateDate}
             status={coe.status}
             uploadsNeeded


### PR DESCRIPTION
## Description
The introduction and status pages for the COE app include `va-alert` components that inform the veteran of the status of their request. These include a reference number, which until recently we were not receiving from `vets-api`. `vets-api` now includes the reference number so we need to start using it instead of static data.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#36627

## Acceptance criteria
- [x] Reference number is no longer static

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
