### PR TITLE
Adds unit tests for LoginHeader

### DIFF
--- a/src/platform/user/authentication/components/DowntimeBanner.js
+++ b/src/platform/user/authentication/components/DowntimeBanner.js
@@ -56,7 +56,8 @@ export const DowntimeBanner = ({ dependencies, headline, status, message }) => (
   </ExternalServicesError>
 );
 
-export default () =>
-  downtimeBannersConfig.map((props, i) => (
+export default function DowntimeBanners() {
+  return downtimeBannersConfig.map((props, i) => (
     <DowntimeBanner {...props} key={`downtime-banner-${i}`} />
   ));
+}

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
 import DowntimeBanners from 'platform/user/authentication/components/DowntimeBanner';
 
-export const LoginHeader = ({ loggedOut }) => {
+export default function LoginHeader({ loggedOut }) {
   return (
     <>
       <div className="row">
@@ -17,7 +17,7 @@ export const LoginHeader = ({ loggedOut }) => {
       <DowntimeBanners />
     </>
   );
-};
+}
 
 LoginHeader.propTypes = {
   loggedOut: PropTypes.bool,

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
 import DowntimeBanners from 'platform/user/authentication/components/DowntimeBanner';
 
-export default ({ loggedOut }) => {
+export const LoginHeader = ({ loggedOut }) => {
   return (
     <>
       <div className="row">
@@ -17,4 +17,8 @@ export default ({ loggedOut }) => {
       <DowntimeBanners />
     </>
   );
+};
+
+LoginHeader.propTypes = {
+  loggedOut: PropTypes.bool,
 };

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-
-import LoginHeader from '../../../authentication/components/LoginHeader';
+import LoginHeader from 'platform/user/authentication/components/LoginHeader';
 
 describe('LoginHeader', () => {
   let wrapper;
@@ -12,9 +11,21 @@ describe('LoginHeader', () => {
     wrapper = shallow(<LoginHeader {...props} />);
   });
 
-  it('should render Sign in content', () => {
-    expect(wrapper.exists()).to.be.true;
+  afterEach(() => {
+    wrapper.unmount();
   });
-  it('should render a `LogoutAlert` if loggedOut is true', () => {});
-  it('should render `DowntimeBanners`', () => {});
+
+  it('should render', () => {
+    expect(wrapper.exists()).to.be.true;
+    expect(wrapper.find('h1').text()).to.include('Sign in');
+  });
+  it('should render a `LogoutAlert` if loggedOut is true', () => {
+    expect(wrapper.find('LogoutAlert').exists()).to.be.false;
+    wrapper.setProps({ loggedOut: true });
+    expect(wrapper.find('LogoutAlert').exists()).to.be.true;
+  });
+  it('should render `DowntimeBanners`', () => {
+    expect(wrapper.find('DowntimeBanners').exists()).to.be.true;
+    wrapper.unmount();
+  });
 });

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import LoginHeader from '../../../authentication/components/LoginHeader';
+
+describe('LoginHeader', () => {
+  let wrapper;
+  const props = { loggedOut: false };
+
+  beforeEach(() => {
+    wrapper = shallow(<LoginHeader {...props} />);
+  });
+
+  it('should render Sign in content', () => {
+    expect(wrapper.exists()).to.be.true;
+  });
+  it('should render a `LogoutAlert` if loggedOut is true', () => {});
+  it('should render `DowntimeBanners`', () => {});
+});

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -26,6 +26,5 @@ describe('LoginHeader', () => {
   });
   it('should render `DowntimeBanners`', () => {
     expect(wrapper.find('DowntimeBanners').exists()).to.be.true;
-    wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
This PR adds unit tests for the LoginHeader component
- Checks for the `Sign in` body copy on render
- Verifies the `LogoutAlert` is mounted/unmounted on the `loggedOut` prop
- Verifies the `DowntimeBanner` is mounted

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#37575


## Testing done
Unit test

## Screenshots
n/a

## Acceptance criteria
- [x] A unit test is created for the `LoginHeader` component

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
