### PR TITLE
HLR: Fix submitted profile data length

### DIFF
--- a/src/applications/disability-benefits/996/components/AddIssue.jsx
+++ b/src/applications/disability-benefits/996/components/AddIssue.jsx
@@ -12,7 +12,7 @@ import { setData } from 'platform/forms-system/src/js/actions';
 import { isDirtyDate } from 'platform/forms/validations';
 
 import { getSelected, calculateIndexOffset } from '../utils/helpers';
-import { SELECTED, MAX_SELECTIONS, LAST_HLR_ITEM } from '../constants';
+import { SELECTED, MAX_LENGTH, LAST_HLR_ITEM } from '../constants';
 
 import {
   uniqueIssue,
@@ -103,7 +103,7 @@ const AddIssue = props => {
         issue: fieldObj.value,
         decisionDate: getIsoDateFromSimpleDate(date),
         // select new item, if the max number isn't already selected
-        [SELECTED]: selectedCount <= MAX_SELECTIONS,
+        [SELECTED]: selectedCount <= MAX_LENGTH.SELECTIONS,
       };
       setFormData({ ...data, additionalIssues: issues });
       goToPath(returnPath);

--- a/src/applications/disability-benefits/996/components/ContestableIssuesWidget.jsx
+++ b/src/applications/disability-benefits/996/components/ContestableIssuesWidget.jsx
@@ -7,7 +7,7 @@ import set from 'platform/utilities/data/set';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { IssueCard } from './IssueCardV2';
-import { SELECTED, MAX_SELECTIONS, LAST_HLR_ITEM } from '../constants';
+import { SELECTED, MAX_LENGTH, LAST_HLR_ITEM } from '../constants';
 import {
   NoneSelectedAlert,
   MaxSelectionsAlert,
@@ -82,7 +82,7 @@ const ContestableIssuesWidget = props => {
     closeModal: () => setShowErrorModal(false),
     onChange: (index, event) => {
       let { checked } = event.target;
-      if (checked && getSelected(formData).length + 1 > MAX_SELECTIONS) {
+      if (checked && getSelected(formData).length + 1 > MAX_LENGTH.SELECTIONS) {
         setShowErrorModal(true);
         event.preventDefault(); // prevent checking
         checked = false;

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -1,4 +1,5 @@
 import constants from 'vets-json-schema/dist/constants.json';
+// import schema from 'vets-json-schema/dist/20-0996-schema.json';
 
 // *** URLS ***
 export const HLR_INFO_URL = '/decision-reviews/higher-level-review/';
@@ -67,8 +68,6 @@ export const SAVED_CLAIM_TYPE = 'hlrClaimType';
 export const WIZARD_STATUS = 'wizardStatus996';
 export const LAST_HLR_ITEM = 'lastHlrItem'; // focus management across pages
 
-export const MAX_SELECTIONS = 100;
-
 // Values from benefitTypes in vets-json-schema constants
 const supportedBenefitTypes = [
   'compensation', // Phase 1
@@ -119,13 +118,30 @@ export const CONFERENCE_TIMES_V2 = {
   },
 };
 
-// Values from Lighthouse maintained schema
+// Values from Lighthouse maintained schema v2
 // see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json
-export const MAX_ISSUE_NAME_LENGTH = 140;
-export const MAX_DISAGREEMENT_REASON_LENGTH = 90;
+export const MAX_LENGTH = {
+  SELECTIONS: 100, // submitted issues (not in schema)
+  ISSUE_NAME: 140,
+  DISAGREEMENT_REASON: 90,
+  EMAIL: 255,
+  COUNTRY_CODE: 3,
+  AREA_CODE: 4,
+  PHONE_NUMBER: 14,
+  PHONE_NUMBER_EXT: 10,
+  ADDRESS_LINE1: 60,
+  ADDRESS_LINE2: 30,
+  ADDRESS_LINE3: 10,
+  CITY: 60,
+  COUNTRY: 2,
+  ZIP_CODE5: 5,
+  POSTAL_CODE: 16,
+  REP_FIRST_NAME: 30,
+  REP_LAST_NAME: 40,
+};
 
-// Using MAX_DISAGREEMENT_REASON_LENGTH (90) and with all checkboxes selected,
-// this string is submitted - the numbers constitute the "somethubg else" typed
+// Using MAX_LENGTH.DISAGREEMENT_REASON (90) and with all checkboxes selected,
+// this string is submitted - the numbers constitute the "something else" typed
 // in value
 // "service connection,effective date,disability evaluation,1234567890123456789012345678901234"
 export const SUBMITTED_DISAGREEMENTS = {

--- a/src/applications/disability-benefits/996/content/addIssue.jsx
+++ b/src/applications/disability-benefits/996/content/addIssue.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
-import { MAX_ISSUE_NAME_LENGTH } from '../constants';
+import { MAX_LENGTH } from '../constants';
 
 export const issueErrorMessages = {
   missingIssue: 'Please add the name of an issue',
   uniqueIssue: 'Please enter a unique condition name',
-  maxLength: `Please enter less than ${MAX_ISSUE_NAME_LENGTH} characters for this issue name`,
+  maxLength: `Please enter less than ${
+    MAX_LENGTH.ISSUE_NAME
+  } characters for this issue name`,
 
   invalidDate: 'Please provide a valid date',
   missingDecisionDate: 'Please enter a decision date',

--- a/src/applications/disability-benefits/996/content/contestableIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssues.jsx
@@ -9,7 +9,7 @@ import {
   BOARD_APPEALS_URL,
   COVID_FAQ_URL,
   DECISION_REVIEWS_URL,
-  MAX_SELECTIONS,
+  MAX_LENGTH,
 } from '../constants';
 import DownloadLink from './DownloadLink';
 
@@ -132,10 +132,10 @@ export const MaxSelectionsAlert = ({ closeModal }) => (
     onClose={closeModal}
     visible
   >
-    You are limited to {MAX_SELECTIONS} selected issues for each Higher-Level
-    Review request. If you would like to select more than {MAX_SELECTIONS},
-    please submit this request and create a new request for the remaining
-    issues.
+    You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each
+    Higher-Level Review request. If you would like to select more than{' '}
+    {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
+    for the remaining issues.
   </Modal>
 );
 

--- a/src/applications/disability-benefits/996/pages/addIssue.js
+++ b/src/applications/disability-benefits/996/pages/addIssue.js
@@ -1,4 +1,4 @@
-import { SELECTED } from '../constants';
+import { SELECTED, MAX_LENGTH } from '../constants';
 
 /**
  * A CustomPage only needs/uses minimal uiSchema/schema
@@ -25,7 +25,7 @@ export default {
     properties: {
       addIssue: {
         type: 'array',
-        maxItems: 100,
+        maxItems: MAX_LENGTH.SELECTIONS,
         minItems: 1,
         items: {
           type: 'object',
@@ -33,7 +33,7 @@ export default {
           properties: {
             issue: {
               type: 'string',
-              maxLength: 140,
+              maxLength: MAX_LENGTH.ISSUE_NAME,
             },
             decisionDate: {
               type: 'string',

--- a/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
+++ b/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
@@ -13,6 +13,11 @@ import {
 import { areaOfDisagreementRequired } from '../validations/issues';
 import { calculateOtherMaxLength } from '../utils/disagreement';
 import { getIssueName } from '../utils/helpers';
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
+
+// add 1 for last comma
+const allDisagreementsLength =
+  Object.values(SUBMITTED_DISAGREEMENTS).join(',').length + 1;
 
 export default {
   uiSchema: {
@@ -91,7 +96,8 @@ export default {
             otherEntry: {
               type: 'string',
               // disagreementArea limited to 90 chars max
-              maxLength: 34,
+              maxLength:
+                MAX_LENGTH.DISAGREEMENT_REASON - allDisagreementsLength,
             },
           },
         },

--- a/src/applications/disability-benefits/996/pages/informalConferenceRepV2.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceRepV2.js
@@ -2,7 +2,7 @@ import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberW
 import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 
-import { errorMessages } from '../constants';
+import { errorMessages, MAX_LENGTH } from '../constants';
 
 import {
   ContactRepresentativeTitle,
@@ -69,25 +69,30 @@ export default {
           },
           firstName: {
             type: 'string',
-            maxLength: 30,
+            maxLength: MAX_LENGTH.REP_FIRST_NAME,
           },
           lastName: {
             type: 'string',
-            maxLength: 40,
+            maxLength: MAX_LENGTH.REP_LAST_NAME,
           },
           phone: {
             type: 'string',
-            pattern: '[0-9]+',
+            pattern: '^[0-9]{3,21}$',
+            maxLength:
+              MAX_LENGTH.COUNTRY_CODE +
+              MAX_LENGTH.AREA_CODE +
+              MAX_LENGTH.PHONE_NUMBER,
           },
           extension: {
             type: 'string',
-            pattern: '^[0-9]{1,10}$',
+            pattern: '^[a-zA-Z0-9]{1,10}$',
+            maxLength: MAX_LENGTH.PHONE_NUMBER_EXT,
           },
           email: {
             type: 'string',
             format: 'email',
             minLength: 6,
-            maxLength: 255,
+            maxLength: MAX_LENGTH.EMAIL,
           },
         },
       },

--- a/src/applications/disability-benefits/996/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/components/AddIssue.unit.spec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import { AddIssue } from '../../components/AddIssue';
 import { issueErrorMessages } from '../../content/addIssue';
-import { MAX_ISSUE_NAME_LENGTH, LAST_HLR_ITEM } from '../../constants';
+import { MAX_LENGTH, LAST_HLR_ITEM } from '../../constants';
 import { getDate } from '../../utils/dates';
 import { $, $$ } from '../../utils/ui';
 
@@ -77,7 +77,7 @@ describe('<AddIssue>', () => {
   });
 
   it('should show error when issue name is too long', () => {
-    const issue = 'abcdef '.repeat(MAX_ISSUE_NAME_LENGTH / 6);
+    const issue = 'abcdef '.repeat(MAX_LENGTH.ISSUE_NAME / 6);
     const { container } = render(
       setup({
         data: { contestedIssues, additionalIssues: [{ issue }] },

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -7,7 +7,7 @@
       "address": {
         "addressLine1": "123 Main St",
         "addressLine2": "Suite #1200",
-        "addressLine3": "Box 4",
+        "addressLine3": "Box 45678901234",
         "city": "New York",
         "countryName": "United States",
         "countryCodeIso2": "US",

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -21,7 +21,7 @@
         "address": {
           "addressLine1": "123 Main St",
           "addressLine2": "Suite #1200",
-          "addressLine3": "Box 4",
+          "addressLine3": "Box 456789",
           "city": "New York",
           "countryCodeISO2": "US",
           "stateCode": "NY",

--- a/src/applications/disability-benefits/996/tests/utils/disagreement.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/disagreement.unit.spec.js
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  MAX_DISAGREEMENT_REASON_LENGTH,
-  SUBMITTED_DISAGREEMENTS,
-} from '../../constants';
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../../constants';
 import {
   copyAreaOfDisagreementOptions,
   calculateOtherMaxLength,
@@ -75,11 +72,11 @@ describe('calculateOtherMaxLength', () => {
   const calcLength = settings => {
     const string = values.filter((value, index) => settings[index]).join(',');
     // add 1 to string length for the final comma
-    return MAX_DISAGREEMENT_REASON_LENGTH - (string.length + 1);
+    return MAX_LENGTH.DISAGREEMENT_REASON - (string.length + 1);
   };
   it('should return max length when nothing is selected', () => {
     expect(calculateOtherMaxLength(getData([]))).to.eq(
-      MAX_DISAGREEMENT_REASON_LENGTH,
+      MAX_LENGTH.DISAGREEMENT_REASON,
     );
   });
   it('should return appropriate length with 1 selection', () => {

--- a/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
@@ -2,11 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { getDate } from '../../utils/dates';
-import {
-  SELECTED,
-  MAX_SELECTIONS,
-  MAX_ISSUE_NAME_LENGTH,
-} from '../../constants';
+import { SELECTED, MAX_LENGTH } from '../../constants';
 
 import {
   uniqueIssue,
@@ -84,7 +80,7 @@ describe('maxIssues', () => {
       [SELECTED]: true,
     };
     maxIssues(errors, {
-      contestedIssues: new Array(MAX_SELECTIONS + 1).fill(template),
+      contestedIssues: new Array(MAX_LENGTH.SELECTIONS + 1).fill(template),
     });
     expect(errors.addError.called).to.be.true;
   });
@@ -180,7 +176,7 @@ describe('missingIssueName', () => {
 describe('maxNameLength', () => {
   it('should show an error when a name is too long', () => {
     const errors = { addError: sinon.spy() };
-    maxNameLength(errors, 'ab '.repeat(MAX_ISSUE_NAME_LENGTH / 2));
+    maxNameLength(errors, 'ab '.repeat(MAX_LENGTH.ISSUE_NAME / 2));
     expect(errors.addError.called).to.be.true;
   });
   it('should show an error when a name is not too long', () => {

--- a/src/applications/disability-benefits/996/utils/disagreement.js
+++ b/src/applications/disability-benefits/996/utils/disagreement.js
@@ -1,7 +1,4 @@
-import {
-  MAX_DISAGREEMENT_REASON_LENGTH,
-  SUBMITTED_DISAGREEMENTS,
-} from '../constants';
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
 import { getIssueName } from './helpers';
 
 /**
@@ -65,5 +62,5 @@ export const calculateOtherMaxLength = formData => {
     }
     return totalLength;
   }, 0);
-  return MAX_DISAGREEMENT_REASON_LENGTH - stringLength;
+  return MAX_LENGTH.DISAGREEMENT_REASON - stringLength;
 };

--- a/src/applications/disability-benefits/996/utils/submit.js
+++ b/src/applications/disability-benefits/996/utils/submit.js
@@ -2,8 +2,7 @@ import {
   SELECTED,
   CONFERENCE_TIMES_V1,
   CONFERENCE_TIMES_V2,
-  MAX_ISSUE_NAME_LENGTH,
-  MAX_DISAGREEMENT_REASON_LENGTH,
+  MAX_LENGTH,
   SUBMITTED_DISAGREEMENTS,
 } from '../constants';
 import { apiVersion1 } from './helpers';
@@ -106,7 +105,7 @@ export const createIssueName = ({ attributes } = {}) => {
   ]
     .filter(part => part)
     .join(' - ')
-    .substring(0, MAX_ISSUE_NAME_LENGTH);
+    .substring(0, MAX_LENGTH.ISSUE_NAME);
 };
 
 /* submitted contested issue format
@@ -220,7 +219,7 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
         ...issue.attributes,
         disagreementArea: reasons
           .join(',')
-          .substring(0, MAX_DISAGREEMENT_REASON_LENGTH), // max length in schema
+          .substring(0, MAX_LENGTH.DISAGREEMENT_REASON), // max length in schema
       },
     };
   });
@@ -285,16 +284,21 @@ export const getAddress = formData => {
   if (apiVersion1(formData)) {
     return { zipCode5: zipCode5 || '00000' };
   }
+  const truncate = (value, max) =>
+    (veteran.address?.[value] || '').substring(0, max);
   return removeEmptyEntries({
-    addressLine1: veteran.address?.addressLine1 || '',
-    addressLine2: veteran.address?.addressLine2 || '',
-    addressLine3: veteran.address?.addressLine3 || '',
-    city: veteran.address?.city || '',
+    addressLine1: truncate('addressLine1', MAX_LENGTH.ADDRESS_LINE1),
+    addressLine2: truncate('addressLine2', MAX_LENGTH.ADDRESS_LINE2),
+    addressLine3: truncate('addressLine3', MAX_LENGTH.ADDRESS_LINE3),
+    city: truncate('city', MAX_LENGTH.CITY),
     stateCode: veteran.address?.stateCode || '',
-    countryCodeISO2: veteran.address?.countryCodeIso2 || '',
+    countryCodeISO2: truncate('countryCodeIso2', MAX_LENGTH.COUNTRY),
     // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json#L145
-    zipCode5: veteran.address?.zipCode || '',
-    internationalPostalCode: veteran.address?.internationalPostalCode || '',
+    zipCode5: truncate('zipCode', MAX_LENGTH.ZIP_CODE5),
+    internationalPostalCode: truncate(
+      'internationalPostalCode',
+      MAX_LENGTH.POSTAL_CODE,
+    ),
   });
 };
 
@@ -303,10 +307,13 @@ export const getAddress = formData => {
  * @param {Veteran} veteran - Veteran formData object
  * @returns {Object} submittable address
  */
-export const getPhone = ({ veteran = {} } = {}) =>
-  removeEmptyEntries({
-    countryCode: veteran.phone?.countryCode || '',
-    areaCode: veteran.phone?.areaCode || '',
-    phoneNumber: veteran.phone?.phoneNumber || '',
-    phoneNumberExt: veteran.phone?.phoneNumberExt || '',
+export const getPhone = ({ veteran = {} } = {}) => {
+  const truncate = (value, max) =>
+    (veteran.phone?.[value] || '').substring(0, max);
+  return removeEmptyEntries({
+    countryCode: truncate('countryCode', MAX_LENGTH.COUNTRY_CODE),
+    areaCode: truncate('areaCode', MAX_LENGTH.AREA_CODE),
+    phoneNumber: truncate('phoneNumber', MAX_LENGTH.PHONE_NUMBER),
+    phoneNumberExt: truncate('phoneNumberExt', MAX_LENGTH.PHONE_NUMBER_EXT),
   });
+};

--- a/src/applications/disability-benefits/996/validations/issues.js
+++ b/src/applications/disability-benefits/996/validations/issues.js
@@ -6,7 +6,7 @@ import {
   maxSelectedErrorMessage,
 } from '../content/contestableIssues';
 import { missingAreaOfDisagreementErrorMessage } from '../content/areaOfDisagreement';
-import { MAX_SELECTIONS, MAX_ISSUE_NAME_LENGTH } from '../constants';
+import { MAX_LENGTH } from '../constants';
 
 /**
  *
@@ -58,7 +58,7 @@ export const uniqueIssue = (
 };
 
 export const maxIssues = (error, data) => {
-  if (getSelected(data).length > MAX_SELECTIONS) {
+  if (getSelected(data).length > MAX_LENGTH.SELECTIONS) {
     error.addError(maxSelectedErrorMessage);
   }
 };
@@ -70,7 +70,7 @@ export const missingIssueName = (error, data) => {
 };
 
 export const maxNameLength = (error, data) => {
-  if (data.length > MAX_ISSUE_NAME_LENGTH) {
+  if (data.length > MAX_LENGTH.ISSUE_NAME) {
     error.addError(issueErrorMessages.maxLength);
   }
 };


### PR DESCRIPTION
## Description

The Higher-Level Review form passes un-modified profile data to Lighthouse, but the schema has length restrictions on the data - based on the physical form. For example, address line 3 has a max character length of 10 characters ([Sentry error with invalid `addressLine3` length](http://sentry.vfs.va.gov/organizations/vsp/discover/platform-api:064609d255d9452f8feb2d252ab00c10/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=Common%3A%3AClient%3A%3AErrors%3A%3AClientError%3A+the+server+responded+with+status+422&project=3&query=issue.id%3A74396&sort=-timestamp&statsPeriod=90d&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)). This PR truncates all profile data - email, phone and address - to ensure it fits the schema.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38317

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Submitted profile data is truncated to fit HLR's schema 
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
