### PR TITLE
Update Labs & Tests deeplink route

### DIFF
--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -1,8 +1,8 @@
 // Relative imports.
 import backendServices from 'platform/user/profile/constants/backendServices';
-import { MHV_ACCOUNT_TYPES } from './constants';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import { getAppUrl } from 'platform/utilities/registry-helpers';
+import { MHV_ACCOUNT_TYPES } from './constants';
 
 const viewDependentsUrl = getAppUrl('dependents-view-dependents');
 
@@ -162,7 +162,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.LAB_AND_TEST_RESULTS]: {
     id: CTA_WIDGET_TYPES.LAB_AND_TEST_RESULTS,
     deriveToolUrlDetails: authenticatedWithSSOe => ({
-      url: mhvUrl(authenticatedWithSSOe, 'labs-tests'),
+      url: mhvUrl(authenticatedWithSSOe, 'web/myhealthevet/labs-tests'),
       redirect: false,
     }),
     hasRequiredMhvAccount: accountLevel =>

--- a/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.js
+++ b/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.js
@@ -2,8 +2,8 @@
 import { expect } from 'chai';
 // Relative imports.
 import environment from 'platform/utilities/environment';
-import { CTA_WIDGET_TYPES, ctaWidgetsLookup } from '../ctaWidgets';
 import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
+import { CTA_WIDGET_TYPES, ctaWidgetsLookup } from '../ctaWidgets';
 
 describe('CTA widgets', () => {
   describe('a signed-in SSO user', () => {
@@ -69,7 +69,7 @@ describe('CTA widgets', () => {
       ).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
-        }eauth.va.gov/mhv-portal-web/eauth`,
+        }eauth.va.gov/mhv-portal-web/eauth?deeplinking=labs_tests`,
       );
     });
   });
@@ -120,7 +120,9 @@ describe('CTA widgets', () => {
         ctaWidgetsLookup?.[
           CTA_WIDGET_TYPES?.LAB_AND_TEST_RESULTS
         ]?.deriveToolUrlDetails()?.url,
-      ).to.equal('https://mhv-syst.myhealth.va.gov/mhv-portal-web/labs-tests');
+      ).to.equal(
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/labs-tests',
+      );
     });
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -5,10 +5,10 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 // Relative imports.
-import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import ServiceProvidersList from 'platform/user/authentication/components/ServiceProvidersList';
+import CernerCallToAction from '../../../components/CernerCallToAction';
 
 export const AuthContent = ({
   authenticatedWithSSOe,
@@ -20,7 +20,10 @@ export const AuthContent = ({
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="View lab and test results from:"
-      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'labs-tests')}
+      myHealtheVetLink={mhvUrl(
+        authenticatedWithSSOe,
+        'web/myhealthevet/labs-tests',
+      )}
       myVAHealthLink={getCernerURL('/pages/health_record/results/labs')}
     />
     <div>

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -11,7 +11,7 @@ const mhvToEauthRoutes = {
   'secure-messaging': 'eauth?deeplinking=secure_messaging',
   appointments: 'eauth?deeplinking=appointments',
   home: 'eauth',
-  'labs-tests': 'eauth?deeplinking=labs_tests',
+  'web/myhealthevet/labs-tests': 'eauth?deeplinking=labs_tests',
 };
 
 // An MHV URL is a function of the following parameters:

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -4,7 +4,6 @@ import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
 const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
 
-// TODO: Update labs-and-tests route once deep link is provided
 const mhvToEauthRoutes = {
   'download-my-data': 'eauth?deeplinking=download_my_data',
   'web/myhealthevet/refill-prescriptions':
@@ -12,7 +11,7 @@ const mhvToEauthRoutes = {
   'secure-messaging': 'eauth?deeplinking=secure_messaging',
   appointments: 'eauth?deeplinking=appointments',
   home: 'eauth',
-  'labs-tests': 'eauth',
+  'labs-tests': 'eauth?deeplinking=labs_tests',
 };
 
 // An MHV URL is a function of the following parameters:


### PR DESCRIPTION
## Description
This PR updates a missing deep link from the MHV Labs & Tests CTA. This link was not originally provided to the team during build, so this PR adds that in.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38198

## Acceptance criteria
- [x] Widget redirects to deep link

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
