### PR TITLE
Fix error with ServiceProvidersText component

### DIFF
--- a/src/platform/user/authentication/components/ServiceProvidersText.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersText.jsx
@@ -25,12 +25,12 @@ const ServiceProviders = React.memo(({ isBold }) => {
     const renderCSP = isBold ? <strong>{csp}</strong> : csp;
 
     return (
-      <>
+      <React.Fragment key={i}>
         {or && 'or '}
         {renderCSP}
         {comma && ','}
         {!last && ' '}
-      </>
+      </React.Fragment>
     );
   });
 });


### PR DESCRIPTION
## Description
The `ServiceProvidersText` component emits an error related to needing a `key` prop for jsx elements that are in a list.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38327

## Screenshots
![image](https://user-images.githubusercontent.com/13838621/157547977-0b293c3c-8491-4063-8d1d-3c00188c7b0d.png)

## Acceptance criteria
- [ ] `ServiceProvidersText` component no longer emits an error about children in list needing `key` prop

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
