### PR TITLE
[FSR] Confirmation page download

### DIFF
--- a/src/applications/financial-status-report/actions/index.js
+++ b/src/applications/financial-status-report/actions/index.js
@@ -94,22 +94,3 @@ export const fetchDebts = () => async (dispatch, getState) => {
     throw new Error(error);
   }
 };
-
-export const downloadPDF = () => {
-  const options = {
-    method: 'GET',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Key-Inflection': 'camel',
-      'Source-App-Name': window.appName,
-    },
-  };
-
-  return fetch(
-    `${environment.API_URL}/v0/financial_status_reports/download_pdf`,
-    options,
-  ).catch(error => {
-    throw new Error(error);
-  });
-};

--- a/src/applications/financial-status-report/components/DownloadFormPDF.jsx
+++ b/src/applications/financial-status-report/components/DownloadFormPDF.jsx
@@ -1,0 +1,30 @@
+import React, { useCallback } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
+
+const DownloadFormPDF = () => {
+  const handleDownloadClick = useCallback(() => {
+    return recordEvent({
+      event: 'debt-fsr-pdf-download',
+    });
+  }, []);
+
+  const pdfStatementUri = encodeURI(
+    `${environment.API_URL}/v0/financial_status_reports/download_pdf`,
+  );
+
+  return (
+    <a
+      onClick={handleDownloadClick()}
+      href={pdfStatementUri}
+      type="application/pdf"
+      aria-label="Download completed FSR form"
+      className="usa-button button"
+      rel="noreferrer"
+    >
+      <span>Download completed form</span>
+    </a>
+  );
+};
+
+export default DownloadFormPDF;

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
@@ -11,7 +10,7 @@ import ServiceProvidersText, {
 } from 'platform/user/authentication/components/ServiceProvidersText';
 import GetFormHelp from '../components/GetFormHelp';
 import { deductionCodes } from '../../debt-letters/const/deduction-codes';
-import { downloadPDF } from '../actions';
+import DownloadFormPDF from '../components/DownloadFormPDF';
 
 const { scroller } = Scroll;
 const scrollToTop = () => {
@@ -22,9 +21,9 @@ const scrollToTop = () => {
   });
 };
 
-const RequestDetailsCard = ({ data, response, download }) => {
+const RequestDetailsCard = ({ data, response }) => {
   const name = data.personalData?.veteranFullName;
-  const downloadClick = useCallback(() => download(), [download]);
+  const windowPrint = useCallback(() => window.print(), []);
 
   return (
     <div className="inset">
@@ -62,16 +61,10 @@ const RequestDetailsCard = ({ data, response, download }) => {
         <p className="vads-u-margin-y--0">P.O. Box 11930</p>
         <p className="vads-u-margin-y--0">St. Paul, MN 55111-0930</p>
         <p>
-          <button
-            className="usa-button button"
-            onClick={downloadClick}
-            type="button"
-          >
-            Download completed form
-          </button>
+          <DownloadFormPDF />
           <button
             className="usa-button-secondary button vads-u-background-color--white"
-            onClick={() => window.print()}
+            onClick={windowPrint()}
             type="button"
           >
             Print this page
@@ -191,11 +184,4 @@ const mapStateToProps = state => {
   };
 };
 
-const mapDispatchToProps = dispatch => ({
-  ...bindActionCreators({ download: downloadPDF }, dispatch),
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ConfirmationPage);
+export default connect(mapStateToProps)(ConfirmationPage);

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -23,7 +23,9 @@ const scrollToTop = () => {
 
 const RequestDetailsCard = ({ data, response }) => {
   const name = data.personalData?.veteranFullName;
-  const windowPrint = useCallback(() => window.print(), []);
+  const windowPrint = useCallback(() => {
+    window.print();
+  }, []);
 
   return (
     <div className="inset">
@@ -64,7 +66,7 @@ const RequestDetailsCard = ({ data, response }) => {
           <DownloadFormPDF />
           <button
             className="usa-button-secondary button vads-u-background-color--white"
-            onClick={windowPrint()}
+            onClick={windowPrint}
             type="button"
           >
             Print this page

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import moment from 'moment';
@@ -22,8 +22,9 @@ const scrollToTop = () => {
   });
 };
 
-const RequestDetailsCard = ({ data, response }) => {
+const RequestDetailsCard = ({ data, response, download }) => {
   const name = data.personalData?.veteranFullName;
+  const downloadClick = useCallback(() => download(), [download]);
 
   return (
     <div className="inset">
@@ -62,6 +63,13 @@ const RequestDetailsCard = ({ data, response }) => {
         <p className="vads-u-margin-y--0">St. Paul, MN 55111-0930</p>
         <p>
           <button
+            className="usa-button button"
+            onClick={downloadClick}
+            type="button"
+          >
+            Download completed form
+          </button>
+          <button
             className="usa-button-secondary button vads-u-background-color--white"
             onClick={() => window.print()}
             type="button"
@@ -76,6 +84,7 @@ const RequestDetailsCard = ({ data, response }) => {
 
 RequestDetailsCard.propTypes = {
   data: PropTypes.object,
+  download: PropTypes.func,
   response: PropTypes.object,
 };
 


### PR DESCRIPTION
## Description
Added Download button back to FSR confirmation page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38191

## Screenshots
<details><summary>Download button back in menu</summary>

<img width="659" alt="image" src="https://user-images.githubusercontent.com/25368370/158905333-fc6f9045-69b8-4abb-8692-b7b807b53b6c.png">

</details>

## Acceptance criteria
- [x] Download button is back on confirmation page and functioning

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
