### PR TITLE
Enable unit tests for changed app builds in master

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,11 +107,15 @@ jobs:
 
       - name: List changed files
         id: changed-files
-        run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+            echo ::set-output name=all_changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
+          else
+            echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+          fi
 
       - name: Get app folders for changed files
         id: get-changed-apps
-        if: ${{ github.ref != 'refs/heads/master' }}
         run: echo ::set-output name=app_folders::$(node script/github-actions/get-changed-apps.js --output-type folder)
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
@@ -166,7 +170,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' && steps.get-changed-apps.outputs.app_folders == '' }}
         run: aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -17,6 +17,8 @@ const getManifests = filePath => {
   const rootAppFolder = filePath.split('/')[2];
   const fullAppPath = path.join(root, './src/applications', rootAppFolder);
 
+  if (!fs.existsSync(fullAppPath)) return [];
+
   return find
     .fileSync(/manifest\.(json|js)$/, fullAppPath)
     .map(file => JSON.parse(fs.readFileSync(file)));


### PR DESCRIPTION
## Description
Enables unit tests to only run for changed apps in changed app builds in `master`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34865

## Acceptance criteria
- [x] Changed app builds in `master` should only run unit tests on the changed apps.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
