### PR TITLE
33774 address change messaging help text and modal

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -4,6 +4,24 @@ import { connect } from 'react-redux';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { LastLocationProvider } from 'react-router-last-location';
 
+import {
+  fetchMilitaryInformation as fetchMilitaryInformationAction,
+  fetchHero as fetchHeroAction,
+  fetchPersonalInformation as fetchPersonalInformationAction,
+} from '@@profile/actions';
+import {
+  cnpDirectDepositAddressIsSetUp,
+  cnpDirectDepositInformation,
+  cnpDirectDepositIsBlocked,
+  cnpDirectDepositIsSetUp,
+  eduDirectDepositIsSetUp,
+  showProfileLGBTQEnhancements,
+} from '@@profile/selectors';
+import {
+  fetchCNPPaymentInformation as fetchCNPPaymentInformationAction,
+  fetchEDUPaymentInformation as fetchEDUPaymentInformationAction,
+} from '@@profile/actions/paymentInformation';
+import { CSP_IDS } from 'platform/user/authentication/constants';
 import DowntimeNotification, {
   externalServices,
   externalServiceStatus,
@@ -29,23 +47,6 @@ import {
 } from '~/platform/user/selectors';
 import { signInServiceName as signInServiceNameSelector } from '~/platform/user/authentication/selectors';
 import { fetchMHVAccount as fetchMHVAccountAction } from '~/platform/user/profile/actions';
-import {
-  fetchMilitaryInformation as fetchMilitaryInformationAction,
-  fetchHero as fetchHeroAction,
-  fetchPersonalInformation as fetchPersonalInformationAction,
-} from '@@profile/actions';
-import {
-  cnpDirectDepositAddressIsSetUp,
-  cnpDirectDepositInformation,
-  cnpDirectDepositIsBlocked,
-  cnpDirectDepositIsSetUp,
-  eduDirectDepositIsSetUp,
-  showProfileLGBTQEnhancements,
-} from '@@profile/selectors';
-import {
-  fetchCNPPaymentInformation as fetchCNPPaymentInformationAction,
-  fetchEDUPaymentInformation as fetchEDUPaymentInformationAction,
-} from '@@profile/actions/paymentInformation';
 
 import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from '~/applications/personalization/rated-disabilities/actions';
 
@@ -53,7 +54,6 @@ import getRoutes from '../routes';
 import { PROFILE_PATHS } from '../constants';
 
 import ProfileWrapper from './ProfileWrapper';
-import { CSP_IDS } from 'platform/user/authentication/constants';
 
 class Profile extends Component {
   componentDidMount() {

--- a/src/applications/personalization/profile/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoTable.jsx
@@ -63,6 +63,12 @@ const ProfileInfoTable = ({
     'width--auto',
   ]);
 
+  const tableRowTitleDescriptionClasses = prefixUtilityClasses([
+    'color--gray-medium',
+    'display--block',
+    'font-weight--normal',
+  ]);
+
   const tableRowValueClasses = prefixUtilityClasses([
     'margin--0',
     'width--full',
@@ -76,6 +82,10 @@ const ProfileInfoTable = ({
       ' ',
     ),
     tableRowTitle: tableRowTitleClasses.join(' '),
+    tableRowTitleDescription: [
+      ...tableRowValueClasses,
+      ...tableRowTitleDescriptionClasses,
+    ].join(' '),
     tableRowValue: tableRowValueClasses.join(' '),
   };
 
@@ -101,7 +111,14 @@ const ProfileInfoTable = ({
               id={row.id}
             >
               {row.title && (
-                <dfn className={classes.tableRowTitle}>{row.title}</dfn>
+                <dfn className={classes.tableRowTitle}>
+                  {row.title}
+                  {row.description && (
+                    <span className={classes.tableRowTitleDescription}>
+                      {row.description}
+                    </span>
+                  )}
+                </dfn>
               )}
 
               {/* In Account Security, we have some rows that need a checkmark when verified  */}

--- a/src/applications/personalization/profile/components/contact-information/addresses/AddressesTable.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/AddressesTable.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
+import {
+  FIELD_IDS,
+  FIELD_NAMES,
+  FIELD_TITLE_DESCRIPTIONS,
+  FIELD_TITLES,
+} from '@@vap-svc/constants';
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 
 import ProfileInfoTable from '../../ProfileInfoTable';
@@ -13,7 +18,8 @@ const AddressesTable = ({ className }) => (
     namedAnchor="addresses"
     data={[
       {
-        title: 'Mailing address',
+        title: FIELD_TITLES[FIELD_NAMES.MAILING_ADDRESS],
+        description: FIELD_TITLE_DESCRIPTIONS[FIELD_NAMES.MAILING_ADDRESS],
         id: FIELD_IDS[FIELD_NAMES.MAILING_ADDRESS],
         value: (
           <ProfileInformationFieldController
@@ -22,7 +28,8 @@ const AddressesTable = ({ className }) => (
         ),
       },
       {
-        title: 'Home address',
+        title: FIELD_TITLES[FIELD_NAMES.RESIDENTIAL_ADDRESS],
+        description: FIELD_TITLE_DESCRIPTIONS[FIELD_NAMES.RESIDENTIAL_ADDRESS],
         id: FIELD_IDS[FIELD_NAMES.RESIDENTIAL_ADDRESS],
         value: (
           <ProfileInformationFieldController

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
@@ -32,6 +32,7 @@ const CopyAddressModal = props => {
         },
         text: 'No',
       }}
+      id="copy-address-modal"
     >
       <>
         <p data-testid="modal-content">
@@ -40,7 +41,7 @@ const CopyAddressModal = props => {
             <AddressView data={mainAddress} />
           </span>
         </p>
-        <p className="vads-u-background-color--primary-alt-lightest vads-u-padding--1p5">
+        <va-featured-content>
           We have this mailing address on file for you:
           <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
             <AddressView data={addressToUpdate} />
@@ -49,7 +50,7 @@ const CopyAddressModal = props => {
           <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
             <AddressView data={mainAddress} />
           </span>
-        </p>
+        </va-featured-content>
         <button type="button" onClick={() => setUpdateStatus('failure')}>
           Trigger Mailing Address Failure
         </button>
@@ -85,7 +86,6 @@ const CopyAddressModal = props => {
       title="We've updated your mailing address"
       visible={updateStatus === 'success'}
       onClose={onClose}
-      status="success"
       primaryButton={{
         action: () => {
           setUpdateStatus(null);
@@ -115,9 +115,11 @@ const CopyAddressModal = props => {
 };
 
 CopyAddressModal.propTypes = {
+  addressToUpdate: PropTypes.object.isRequired,
   isVisible: PropTypes.bool.isRequired,
-  onYes: PropTypes.func.isRequired,
+  mainAddress: PropTypes.object.isRequired,
   onNo: PropTypes.func.isRequired,
+  onYes: PropTypes.func.isRequired,
 };
 
 export default CopyAddressModal;

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import AddressView from '@@vap-svc/components/AddressField/AddressView';
@@ -13,7 +13,9 @@ const CopyAddressModal = props => {
     addressToUpdate,
   } = props;
 
-  return (
+  const [updateStatus, setUpdateStatus] = useState();
+
+  const CopyAddressMainModal = () => (
     <Modal
       title="We've updated your home address"
       visible={isVisible}
@@ -21,7 +23,8 @@ const CopyAddressModal = props => {
       primaryButton={{
         action: () => {
           // console.log('YES!');
-          onYes();
+          setUpdateStatus('success');
+          // onYes();
         },
         text: 'Yes',
       }}
@@ -50,8 +53,69 @@ const CopyAddressModal = props => {
             <AddressView data={mainAddress} />
           </span>
         </p>
+        <button type="button" onClick={() => setUpdateStatus('failure')}>
+          Trigger Mailing Address Failure
+        </button>
       </>
     </Modal>
+  );
+
+  const UpdateErrorModal = () => (
+    <Modal
+      title="We can't update your mailing address"
+      visible={updateStatus === 'failure'}
+      onClose={onClose}
+      status="error"
+      primaryButton={{
+        action: () => {
+          // console.log('YES!');
+          setUpdateStatus(null);
+          onYes();
+        },
+        text: 'Close',
+      }}
+    >
+      <>
+        <p data-testid="modal-content">
+          We’re sorry. We can’t update your information right now. We’re working
+          to fix this problem. Please check back later.
+        </p>
+      </>
+    </Modal>
+  );
+
+  const UpdateSuccessModal = () => (
+    <Modal
+      title="We've updated your mailing address"
+      visible={updateStatus === 'success'}
+      onClose={onClose}
+      status="success"
+      primaryButton={{
+        action: () => {
+          // console.log('YES!');
+          setUpdateStatus(null);
+          onYes();
+        },
+        text: 'Close',
+      }}
+    >
+      <>
+        <p data-testid="modal-content">
+          We’ve updated your mailing address to match your home address.
+          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
+            <AddressView data={mainAddress} />
+          </span>
+        </p>
+      </>
+    </Modal>
+  );
+
+  return (
+    <>
+      {isVisible && !updateStatus && <CopyAddressMainModal />}
+      {isVisible && updateStatus === 'failure' && <UpdateErrorModal />}
+      {isVisible && updateStatus === 'success' && <UpdateSuccessModal />}
+    </>
   );
 };
 

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
@@ -9,19 +9,13 @@ const CopyAddressModal = props => {
     onClose,
     onYes,
     onNo,
-    optionalUpdateAddressType,
     mainAddress,
     addressToUpdate,
   } = props;
 
-  const mainAddressType =
-    optionalUpdateAddressType === 'mailing'
-      ? 'home'
-      : optionalUpdateAddressType;
-
   return (
     <Modal
-      title={`Do you also want to update your ${optionalUpdateAddressType} address?`}
+      title="We've updated your home address"
       visible={isVisible}
       onClose={onClose}
       primaryButton={{
@@ -41,23 +35,20 @@ const CopyAddressModal = props => {
     >
       <>
         <p data-testid="modal-content">
-          {`We’ve updated your ${mainAddressType} address to this address:`}
-          <br />
-          <strong>
+          Your updated home address:
+          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
             <AddressView data={mainAddress} />
-          </strong>
+          </span>
         </p>
-        <p>
-          We send your prescriptions and letters to your mailing address. This
-          is the mailing address we have on file for you:
-          <br />
-          <strong>
+        <p className="vads-u-background-color--primary-alt-lightest vads-u-padding--1p5">
+          We also have this mailing address on file for you:
+          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
             <AddressView data={addressToUpdate} />
-          </strong>
-        </p>
-        <p>
-          Do you want to update your mailing address to match your updated home
-          address?
+          </span>
+          Do you want to update your mailing address to match this home address?
+          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
+            <AddressView data={mainAddress} />
+          </span>
         </p>
       </>
     </Modal>

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModal.jsx
@@ -22,15 +22,12 @@ const CopyAddressModal = props => {
       onClose={onClose}
       primaryButton={{
         action: () => {
-          // console.log('YES!');
           setUpdateStatus('success');
-          // onYes();
         },
         text: 'Yes',
       }}
       secondaryButton={{
         action: () => {
-          // console.log('NO!');
           onNo();
         },
         text: 'No',
@@ -44,7 +41,7 @@ const CopyAddressModal = props => {
           </span>
         </p>
         <p className="vads-u-background-color--primary-alt-lightest vads-u-padding--1p5">
-          We also have this mailing address on file for you:
+          We have this mailing address on file for you:
           <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
             <AddressView data={addressToUpdate} />
           </span>
@@ -68,7 +65,6 @@ const CopyAddressModal = props => {
       status="error"
       primaryButton={{
         action: () => {
-          // console.log('YES!');
           setUpdateStatus(null);
           onYes();
         },
@@ -92,7 +88,6 @@ const CopyAddressModal = props => {
       status="success"
       primaryButton={{
         action: () => {
-          // console.log('YES!');
           setUpdateStatus(null);
           onYes();
         },

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -44,6 +44,10 @@
   }
 }
 
+#copy-address-modal .va-modal-body {
+  margin-right: 0px;
+}
+
 .no-wrap {
   white-space: nowrap;
 }

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -1,12 +1,10 @@
 import * as Sentry from '@sentry/browser';
 
+import { ADDRESS_POU, FIELD_NAMES } from '@@vap-svc/constants';
+import { showAddressValidationModal, inferAddressType } from '@@vap-svc/util';
 import { apiRequest } from '~/platform/utilities/api';
 import { refreshProfile } from '~/platform/user/profile/actions';
 import recordEvent from '~/platform/monitoring/record-event';
-
-import { ADDRESS_POU, FIELD_NAMES } from '@@vap-svc/constants';
-
-import { showAddressValidationModal, inferAddressType } from '@@vap-svc/util';
 
 import localVAProfileService, {
   isVAProfileServiceConfigured,
@@ -179,6 +177,8 @@ export function createTransaction(
       const transaction = isVAProfileServiceConfigured()
         ? await apiRequest(route, options)
         : await localVAProfileService.createTransaction();
+
+      // const transaction = await apiRequest(route, options);
 
       if (transaction?.errors) {
         const error = new Error('There was a transaction error');

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -1,7 +1,6 @@
 import constants from 'vets-json-schema/dist/constants.json';
-import countries from './countries.json';
-
 import ADDRESS_DATA from 'platform/forms/address/data';
+import countries from './countries.json';
 
 export const MILITARY_STATES = new Set(ADDRESS_DATA.militaryStates);
 
@@ -105,8 +104,16 @@ export const FIELD_TITLES = {
   [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
   [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
   [FIELD_NAMES.EMAIL]: 'Contact email address',
-  [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
-  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',
+  [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing',
+  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home',
+};
+
+// optional 'hint text' to display below field titles
+export const FIELD_TITLE_DESCRIPTIONS = {
+  [FIELD_NAMES.EMAIL]: 'We use this email to send you information.',
+  [FIELD_NAMES.MAILING_ADDRESS]:
+    'We send VA letters, bills, and any prescription medicines you may get from VA to this address.',
+  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'This is where you currently live.',
 };
 
 // These are intended to be used as values for HTML element id attributes

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -104,15 +104,15 @@ export const FIELD_TITLES = {
   [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
   [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
   [FIELD_NAMES.EMAIL]: 'Contact email address',
-  [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing',
-  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home',
+  [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
+  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',
 };
 
 // optional 'hint text' to display below field titles
 export const FIELD_TITLE_DESCRIPTIONS = {
   [FIELD_NAMES.EMAIL]: 'We use this email to send you information.',
   [FIELD_NAMES.MAILING_ADDRESS]:
-    'We send VA letters, bills, and any prescription medicines you may get from VA to this address.',
+    'We send your VA letters, bills, and prescriptions to this address.',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'This is where you currently live.',
 };
 


### PR DESCRIPTION
## Description
Displays the new designs for the 'copy home address to mailing' modal prototype. This is only going to be shown on staging behind a feature toggle, and isn't wired up to the appropriate api calls, so mostly just for design review and layout initial implementation.

Note on error modal: since api calls are going to be wired up in future ticket, there is a temporary button placed in the initial modal to trigger the error modal to show, but will be removed in the future.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33774

## Testing done
Visual manual testing, no real unit or e2e tests needed yet, but will be added once api calls are wired up.

## Screenshots
Updated hint text on read only display
![Screen Shot 2022-03-10 at 12 21 50 PM](https://user-images.githubusercontent.com/8332986/157741259-6c46fe2b-287a-48ca-8032-2d03f853b5d0.png)

Main modal
![Screen Shot 2022-03-10 at 12 23 45 PM](https://user-images.githubusercontent.com/8332986/157741020-c4744575-4de4-486d-a8ac-e6ef160222ef.png)

Success modal
![Screen Shot 2022-03-14 at 8 54 18 AM](https://user-images.githubusercontent.com/8332986/158215460-6d084259-1c57-4339-ab46-619da909caaf.png)

Error modal
![Screen Shot 2022-03-10 at 12 23 55 PM](https://user-images.githubusercontent.com/8332986/157740964-f044e244-083f-42cf-9db8-37a9d8cbf0a8.png)

## Acceptance criteria
- [x] New designs present on staging behind feature toggle


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
