### PR TITLE
HLR/NOD current day is an invalid decision date

### DIFF
--- a/src/applications/appeals/10182/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/date.unit.spec.js
@@ -37,6 +37,12 @@ describe('validateDate & isValidDate', () => {
     expect(errorMessage).to.contain('past decision date');
     expect(isValidDate(date)).to.be.false;
   });
+  it('should throw an error for todays date', () => {
+    const date = getDate();
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('past decision date');
+    expect(isValidDate(date)).to.be.false;
+  });
   it('should throw an error for dates more than a year in the past', () => {
     const date = getDate({ offset: { weeks: -60 } });
     validateDate(errors, date);

--- a/src/applications/appeals/10182/validations/date.js
+++ b/src/applications/appeals/10182/validations/date.js
@@ -12,7 +12,7 @@ const minDate = moment()
   .subtract(1, 'year')
   .startOf('day');
 
-const maxDate = moment().endOf('day');
+const maxDate = moment().startOf('day');
 
 export const validateDate = (errors, dateString) => {
   const { day, month, year } = parseISODate(dateString);
@@ -25,7 +25,8 @@ export const validateDate = (errors, dateString) => {
     errors.addError(
       issueErrorMessages.invalidDateRange(minDate.year(), maxDate.year()),
     );
-  } else if (date.isAfter(maxDate)) {
+  } else if (date.isSameOrAfter(maxDate)) {
+    // Lighthouse won't accept same day (as submission) decision date
     errors.addError(issueErrorMessages.pastDate);
   } else if (date.isBefore(minDate)) {
     errors.addError(issueErrorMessages.newerDate);

--- a/src/applications/disability-benefits/996/tests/validations/date.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/date.unit.spec.js
@@ -37,6 +37,12 @@ describe('validateDate & isValidDate', () => {
     expect(errorMessage).to.contain('past decision date');
     expect(isValidDate(date)).to.be.false;
   });
+  it('should throw an error for todays date', () => {
+    const date = getDate();
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('past decision date');
+    expect(isValidDate(date)).to.be.false;
+  });
   it('should throw an error for dates more than a year in the past', () => {
     const date = getDate({ offset: { weeks: -60 } });
     validateDate(errors, date);

--- a/src/applications/disability-benefits/996/validations/date.js
+++ b/src/applications/disability-benefits/996/validations/date.js
@@ -12,7 +12,7 @@ const minDate = moment()
   .subtract(1, 'year')
   .startOf('day');
 
-const maxDate = moment().endOf('day');
+const maxDate = moment().startOf('day');
 
 export const validateDate = (errors, dateString) => {
   const { day, month, year } = parseISODate(dateString);
@@ -25,7 +25,8 @@ export const validateDate = (errors, dateString) => {
     errors.addError(
       issueErrorMessages.invalidDateRange(minDate.year(), maxDate.year()),
     );
-  } else if (date.isAfter(maxDate)) {
+  } else if (date.isSameOrAfter(maxDate)) {
+    // Lighthouse won't accept same day (as submission) decision date
     errors.addError(issueErrorMessages.pastDate);
   } else if (date.isBefore(minDate)) {
     errors.addError(issueErrorMessages.newerDate);


### PR DESCRIPTION
## Description

Lighthouse is rejecting decision dates with the current date. The FE was previously allowing it, but this fix will now prevent same-day decision dates.

[Sentry error](http://sentry.vfs.va.gov/organizations/vsp/issues/74396/?environment=production&project=1&project=3&project=4&query=HigherLevelReviewsController&statsPeriod=14d) dated "Mar 8, 2022 11:58:35 PM UTC":

```
{
  errors: [
    {
      detail: included[0].attributes.decisionDate isn't in the past: "2022-03-08", 
      status: 422
    } 
  ]
}
```

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/38362

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Current date for decision date shows an error
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
