### PR TITLE
Update component-library dep to 7.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^7.3.2",
+    "@department-of-veterans-affairs/component-library": "^7.4.0",
     "@department-of-veterans-affairs/formation": "7.0.0",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,13 +2130,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^7.3.2":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-7.3.2.tgz#7387dce0a5e857ae15609588d3be527a57d8ac25"
-  integrity sha512-85xbcPaH2nRncQi0+jeD0vgmvZKbdF5KUPzs33Xb4GJjZLYbP9NxcEW0++qCmRZFA9wHyVBdlRY7FDcNv5/Stg==
+"@department-of-veterans-affairs/component-library@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-7.4.0.tgz#342161805bf4f4410f8fe62bf735918163d71c72"
+  integrity sha512-+gZuJR5TQJ+1jq9IuARQ1x5YxxeYXu30TUDZfCWI23VjX3wW+dP5uvcwyitikSu0DxejN8w4vKaUwTt3WKX5Ug==
   dependencies:
     "@department-of-veterans-affairs/react-components" "5.0.0"
-    "@department-of-veterans-affairs/web-components" "2.5.2"
+    "@department-of-veterans-affairs/web-components" "2.6.0"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
@@ -2191,13 +2191,16 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-2.5.2.tgz#4e02a0d094838e583fb7c4332b764e0a189f7e29"
-  integrity sha512-eF/3dTofRR9a9rTtTnyDwO+k5F9hIVFZPd1JXa2wcvak3qZKAnlB13EZTvDNskJ0BeSkE+i42PSH+zZopFYTTg==
+"@department-of-veterans-affairs/web-components@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-2.6.0.tgz#f9b9c537100a5a60379b902dd97545438a97632c"
+  integrity sha512-UZWO3oTH/WS9vZsp+RnyALpemA2ZppXSSRs3zxNVx9JZ0KfpwtuvvhTRuxvfZjpmaCx4FYmhL2LEyi5uGylNHA==
   dependencies:
     "@stencil/core" "^2.10.0"
+    aria-hidden "^1.1.3"
+    body-scroll-lock "^4.0.0-beta.0"
     classnames "^2.3.1"
+    focus-trap "^6.8.0-beta.0"
     intersection-observer "^0.12.0"
 
 "@discoveryjs/json-ext@^0.5.0":
@@ -4112,6 +4115,13 @@ aria-hidden@^1.1.2:
   dependencies:
     tslib "^1.0.0"
 
+aria-hidden@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
+  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+  dependencies:
+    tslib "^1.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz"
@@ -4761,6 +4771,11 @@ body-parser@1.19.0, body-parser@^1.15.2, body-parser@^1.18.2:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+body-scroll-lock@^4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
+  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
 
 bonjour@^3.5.0:
   version "3.5.0"
@@ -8891,6 +8906,13 @@ focus-lock@^0.9.2:
   integrity sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==
   dependencies:
     tslib "^2.0.3"
+
+focus-trap@^6.8.0-beta.0:
+  version "6.8.0-beta.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.8.0-beta.1.tgz#c47dfa06cd1c1313cb5fe0fc0f4da16aa53fb45a"
+  integrity sha512-crIXEu5DVlkzFIfwF8Fn8rC7e56FvNe9DdKVl9+IkncsjNLsjlz5mgYHWeeNRHXe0xrvHVif2ySfZQg08pr+XA==
+  dependencies:
+    tabbable "5.3.0-beta.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.8"
@@ -17896,6 +17918,11 @@ syntax-error@^1.1.1:
   integrity sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==
   dependencies:
     acorn-node "^1.2.0"
+
+tabbable@5.3.0-beta.0:
+  version "5.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.0-beta.0.tgz#2840539883f236f2887312431fbfe07dc305bce5"
+  integrity sha512-zNNUKn79Qve4JNB3/tP38EdS8eA4Phjh6go1TQ1/o2QcQDoTBVbS4hDYwj6jF4242fCMseo1fLBfaeAQqVgOcA==
 
 table-layout@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Description
This PR updates component-library to 7.4.0 which includes the new `va-modal` web component.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35255


## Acceptance criteria
- [x] Update component-library dependency to 7.4.0

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
