### PR TITLE
Update prefer-web-component-library ESLint rule (Modal to va-modal)

### DIFF
--- a/script/eslint-plugin-va/rules/prefer-web-component-library.js
+++ b/script/eslint-plugin-va/rules/prefer-web-component-library.js
@@ -86,6 +86,7 @@ const modalTransformer = (context, node) => {
   const contentsNode = getPropNode(node, 'contents');
   const contentsValue = contentsNode?.value.expression || contentsNode?.value;
   const cssClassNode = getPropNode(node, 'cssClass');
+  const hideCloseButtonNode = getPropNode(node, 'hideCloseButton');
 
   const manuallyUpdateProps =
     getPropNode(node, 'primaryButton') || getPropNode(node, 'secondaryButton');
@@ -140,6 +141,9 @@ const modalTransformer = (context, node) => {
 
             // Remove focusSelectorNode prop if it exists
             focusSelectorNode && fixer.remove(focusSelectorNode),
+
+            // Remove focusSelectorNode prop if it exists
+            hideCloseButtonNode && fixer.remove(hideCloseButtonNode),
 
             // Remove self-closing tag slash if component is self-closing initially
             !closingTagNode &&

--- a/script/eslint-plugin-va/tests/lib/rules/prefer-web-component-library.js
+++ b/script/eslint-plugin-va/tests/lib/rules/prefer-web-component-library.js
@@ -271,7 +271,7 @@ ruleTester.run('prefer-web-component-library', rule, {
     {
       code: mockFile(
         'Modal',
-        'const SampleModal = () => (<Modal title="test" onClose={closeModal} primaryButton={primaryButton} secondaryButton={secondaryButton}>HELLO</Modal>)',
+        'const SampleModal = () => (<Modal title="test" onClose={closeModal} primaryButton={primaryButton} secondaryButton={secondaryButton} hideCloseButton>HELLO</Modal>)',
       ),
       errors: [
         {
@@ -280,7 +280,7 @@ ruleTester.run('prefer-web-component-library', rule, {
               desc: 'Migrate component',
               output: mockFile(
                 'Modal',
-                'const SampleModal = () => (<VaModal modalTitle="test" onCloseEvent={closeModal} primaryButton={primaryButton} secondaryButton={secondaryButton}>HELLO</VaModal>)',
+                'const SampleModal = () => (<VaModal modalTitle="test" onCloseEvent={closeModal} primaryButton={primaryButton} secondaryButton={secondaryButton} >HELLO</VaModal>)',
               ),
             },
           ],


### PR DESCRIPTION
## Description
This PR updates an ESLint warning rule to remove the hideCloseButton node when migrating from the component-library's React `Modal` component to `va-modal` web component.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35260


## Testing done
<img width="679" alt="Screen Shot 2022-03-10 at 16 02 53" src="https://user-images.githubusercontent.com/36863582/157754309-d9b7b2af-8596-4dea-849f-01119a3c0898.png">


## Acceptance criteria
- [x] Update prefer-web-component-library ESLint rule to remove hideCloseButton node (Modal to va-modal)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
