### PR TITLE
Unused CSS Removal v4

### DIFF
--- a/src/applications/proxy-rewrite/sass/_m-vet-nav-px.scss
+++ b/src/applications/proxy-rewrite/sass/_m-vet-nav-px.scss
@@ -375,18 +375,6 @@ body.va-pos-fixed {
   }
 }
 
-@include media($medium-large-screen) {
-  #vetnav-explore {
-    height: 415px;
-    padding-top: 8px;
-    width: 540px;
-  }
-
-  #vetnav-benefits {
-    width: 276.47px;
-  }
-}
-
 .vet-toolbar {
   align-items: center;
   flex: 1 1 100%;

--- a/src/platform/site-wide/sass/modules/_m-layers.scss
+++ b/src/platform/site-wide/sass/modules/_m-layers.scss
@@ -11,9 +11,6 @@
 #preview-site-alert {
   z-index: $low-layer;
 }
-#modal-crisis-line {
-  z-index: $modal-layer;
-}
 #session-timeout-modal {
   // Needs to show up over everything because the user is about to get signed out
   z-index: 9999;

--- a/src/platform/site-wide/sass/modules/_m-vet-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-vet-nav.scss
@@ -375,18 +375,6 @@ body.va-pos-fixed {
   }
 }
 
-@include media($medium-large-screen) {
-  #vetnav-explore {
-    height: 415px;
-    padding-top: 0.8rem;
-    width: 540px;
-  }
-
-  #vetnav-benefits {
-    width: 276.47px;
-  }
-}
-
 .vet-toolbar {
   align-items: center;
   flex: 1 1 100%;
@@ -444,11 +432,6 @@ body.va-pos-fixed {
   > .va-flex {
     align-items: center;
   }
-}
-
-.child-menu-opened {
-  height: 0;
-  overflow: hidden;
 }
 
 @include media($medium-screen) {

--- a/src/platform/site-wide/sass/modules/_m-veteran-banner.scss
+++ b/src/platform/site-wide/sass/modules/_m-veteran-banner.scss
@@ -1,5 +1,3 @@
-$veteran-banner-desktop-width: 1280px;
-
 .veteran-banner {
   @include linear-gradient-background($white, $mm-gray);
   margin: 1.5em auto 0;
@@ -16,7 +14,7 @@ $veteran-banner-desktop-width: 1280px;
 }
 
 .veteran-banner-container {
-  max-width: $veteran-banner-desktop-width;
+  max-width: 1280px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Description
Removing unused CSS classes based on [audit](https://docs.google.com/document/d/1WfMzLFpIZwe35hrmhXl2-ii2DjWaik352vHWfp3RJ7Q/edit#) 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35384


## Testing done
Testing was done using BackStop. Each CSS change was tested 5 different times for accuracy. They were tested in phone and desktop viewports.


## Used URLs
- http://localhost:8888/
- http://localhost:8888/find-locations
- http://localhost:8888/health-care/apply/application
- http://localhost:8888/resources/
- http://localhost:8888/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/
- http://localhost:8888/education/how-to-apply/
- http://localhost:8888/disability/about-disability-ratings/
- http://localhost:8888/find-forms/
- http://localhost:8888/resources/find-apps-you-can-use/
- http://localhost:8888/claim-or-appeal-status/

## Screenshots
![BackstopJS Report](https://user-images.githubusercontent.com/55560129/156781948-7f227586-024e-43d8-8f32-84808f23caf9.png)

[BackstopJS Report.pdf](https://github.com/department-of-veterans-affairs/vets-website/files/8186568/BackstopJS.Report.pdf)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
