### PR TITLE
NOD: Fix submitted profile data length

### DIFF
--- a/src/applications/appeals/10182/components/AddIssue.jsx
+++ b/src/applications/appeals/10182/components/AddIssue.jsx
@@ -12,7 +12,7 @@ import { setData } from 'platform/forms-system/src/js/actions';
 import { isDirtyDate } from 'platform/forms/validations';
 
 import { getSelected, calculateIndexOffset } from '../utils/helpers';
-import { SELECTED, MAX_SELECTIONS, LAST_NOD_ITEM } from '../constants';
+import { SELECTED, MAX_LENGTH, LAST_NOD_ITEM } from '../constants';
 
 import { validateDate } from '../validations/date';
 import {
@@ -103,7 +103,7 @@ const AddIssue = props => {
         issue: fieldObj.value,
         decisionDate: getIsoDateFromSimpleDate(date),
         // select new item, if the max number isn't already selected
-        [SELECTED]: selectedCount <= MAX_SELECTIONS,
+        [SELECTED]: selectedCount <= MAX_LENGTH.SELECTIONS,
       };
       setFormData({ ...data, additionalIssues: issues });
       goToPath(returnPath);

--- a/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
@@ -7,7 +7,7 @@ import set from 'platform/utilities/data/set';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { IssueCard } from './IssueCard';
-import { SELECTED, MAX_SELECTIONS, LAST_NOD_ITEM } from '../constants';
+import { SELECTED, MAX_LENGTH, LAST_NOD_ITEM } from '../constants';
 import {
   NoneSelectedAlert,
   MaxSelectionsAlert,
@@ -85,7 +85,7 @@ const ContestableIssuesWidget = props => {
 
     onChange: (index, event) => {
       let { checked } = event.target;
-      if (checked && getSelected(formData).length + 1 > MAX_SELECTIONS) {
+      if (checked && getSelected(formData).length + 1 > MAX_LENGTH.SELECTIONS) {
         setShowErrorModal(true);
         event.preventDefault(); // prevent checking
         checked = false;

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -30,14 +30,29 @@ export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 export const MAX_FILE_SIZE_MB = 100;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
-export const MAX_SELECTIONS = 100;
-
-// Values from Lighthouse maintained schema
+// Values from Lighthouse maintained schema v1
 // see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v1/10182.json
-export const MAX_ISSUE_NAME_LENGTH = 180;
-export const MAX_DISAGREEMENT_REASON_LENGTH = 90;
+export const MAX_LENGTH = {
+  SELECTIONS: 100, // submitted issues (not in schema)
+  ISSUE_NAME: 180,
+  DISAGREEMENT_REASON: 90,
+  EMAIL: 255,
+  COUNTRY_CODE: 3,
+  AREA_CODE: 4,
+  PHONE_NUMBER: 14,
+  PHONE_NUMBER_EXT: 10,
+  ADDRESS_LINE1: 60,
+  ADDRESS_LINE2: 30,
+  ADDRESS_LINE3: 10,
+  CITY: 60,
+  COUNTRY: 2,
+  ZIP_CODE5: 5,
+  POSTAL_CODE: 16,
+  REP_NAME: 120,
+  // EXTENSION_REASON: 2300, // in v2 schema
+};
 
-// Using MAX_DISAGREEMENT_REASON_LENGTH (90) and with all checkboxes selected,
+// Using MAX_LENGTH.DISAGREEMENT_REASON (90) and with all checkboxes selected,
 // this string is submitted - the numbers constitute the "something else" typed
 // in value
 // "service connection,effective date,disability evaluation,1234567890123456789012345678901234"

--- a/src/applications/appeals/10182/content/addIssue.jsx
+++ b/src/applications/appeals/10182/content/addIssue.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
-import { MAX_ISSUE_NAME_LENGTH } from '../constants';
+import { MAX_LENGTH } from '../constants';
 
 export const issueErrorMessages = {
   missingIssue: 'Please add the name of an issue',
   uniqueIssue: 'Please enter a unique condition name',
-  maxLength: `Please enter less than ${MAX_ISSUE_NAME_LENGTH} characters for this issue name`,
+  maxLength: `Please enter less than ${
+    MAX_LENGTH.ISSUE_NAME
+  } characters for this issue name`,
 
   invalidDate: 'Please provide a valid date',
   missingDecisionDate: 'Please enter a decision date',

--- a/src/applications/appeals/10182/content/contestableIssues.jsx
+++ b/src/applications/appeals/10182/content/contestableIssues.jsx
@@ -4,7 +4,7 @@ import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import { scrollAndFocus } from 'platform/utilities/ui';
 
-import { MAX_SELECTIONS } from '../constants';
+import { MAX_LENGTH } from '../constants';
 
 // We shouldn't ever see the couldn't find contestable issues message since we
 // prevent the user from navigating past the intro page; but it's here just in
@@ -66,10 +66,10 @@ export const MaxSelectionsAlert = ({ closeModal }) => (
     onClose={closeModal}
     visible
   >
-    You are limited to {MAX_SELECTIONS} selected issues for each Notice of
-    Disagreement request. If you would like to select more than
-    {MAX_SELECTIONS}, please submit this request and create a new request for
-    the remaining issues.
+    You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each Notice
+    of Disagreement request. If you would like to select more than{' '}
+    {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
+    for the remaining issues.
   </Modal>
 );
 

--- a/src/applications/appeals/10182/pages/addIssue.js
+++ b/src/applications/appeals/10182/pages/addIssue.js
@@ -1,4 +1,4 @@
-import { SELECTED } from '../constants';
+import { SELECTED, MAX_LENGTH } from '../constants';
 
 /**
  * A CustomPage only needs/uses minimal uiSchema/schema
@@ -24,7 +24,7 @@ export default {
     properties: {
       addIssue: {
         type: 'array',
-        maxItems: 100,
+        maxItems: MAX_LENGTH.SELECTIONS,
         minItems: 1,
         items: {
           type: 'object',
@@ -32,7 +32,7 @@ export default {
           properties: {
             issue: {
               type: 'string',
-              maxLength: 140,
+              maxLength: MAX_LENGTH.ISSUE_NAME,
             },
             decisionDate: {
               type: 'string',

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -13,6 +13,11 @@ import {
 import { areaOfDisagreementRequired } from '../validations';
 import { calculateOtherMaxLength } from '../utils/disagreement';
 import { getIssueName } from '../utils/helpers';
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
+
+// add 1 for last comma
+const allDisagreementsLength =
+  Object.values(SUBMITTED_DISAGREEMENTS).join(',').length + 1;
 
 export default {
   uiSchema: {
@@ -91,7 +96,8 @@ export default {
             otherEntry: {
               type: 'string',
               // disagreementArea limited to 90 chars max
-              maxLength: 34,
+              maxLength:
+                MAX_LENGTH.DISAGREEMENT_REASON - allDisagreementsLength,
             },
           },
         },

--- a/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
@@ -1,0 +1,168 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { AddIssue } from '../../components/AddIssue';
+import { issueErrorMessages } from '../../content/addIssue';
+import { MAX_LENGTH, LAST_NOD_ITEM } from '../../constants';
+import { getDate } from '../../utils/dates';
+import { $, $$ } from '../../utils/ui';
+
+describe('<AddIssue>', () => {
+  const validDate = getDate({ offset: { months: -2 } });
+  const contestableIssues = [
+    {
+      type: 'contestableIssue',
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: validDate,
+      },
+    },
+  ];
+  const setup = ({
+    index = null,
+    setFormData = () => {},
+    goToPath = () => {},
+    data = {},
+    onReviewPage = false,
+  } = {}) => {
+    if (index !== null) {
+      window.sessionStorage.setItem(LAST_NOD_ITEM, index);
+    } else {
+      window.sessionStorage.removeItem(LAST_NOD_ITEM);
+    }
+    return (
+      <div>
+        <AddIssue
+          setFormData={setFormData}
+          data={data}
+          goToPath={goToPath}
+          onReviewPage={onReviewPage}
+          testingIndex={index}
+          appStateData={data}
+        />
+      </div>
+    );
+  };
+
+  afterEach(() => {
+    window.sessionStorage.removeItem(LAST_NOD_ITEM);
+  });
+
+  it('should render', () => {
+    const { container } = render(setup());
+    const textInput = $('input[name="add-nod-issue"]', container);
+    expect(textInput).to.exist;
+    expect($('.usa-datefields', container)).to.exist;
+  });
+  it('should prevent submission when empty', () => {
+    const goToPathSpy = sinon.spy();
+    const { container } = render(setup({ goToPath: goToPathSpy }));
+    $('button#submit', container).click();
+    const errors = $$('.usa-input-error-message', container);
+
+    expect(errors[0].textContent).to.contain(issueErrorMessages.missingIssue);
+    expect(errors[1].textContent).to.contain(
+      issueErrorMessages.missingDecisionDate,
+    );
+    expect(goToPathSpy.called).to.be.false;
+  });
+  it('should navigate on cancel', () => {
+    const goToPathSpy = sinon.spy();
+    const { container } = render(setup({ goToPath: goToPathSpy }));
+    $('button#cancel', container).click();
+
+    expect(goToPathSpy.called).to.be.true;
+  });
+
+  it('should show error when issue name is too long', () => {
+    const issue = 'abcdef '.repeat(MAX_LENGTH.ISSUE_NAME / 6);
+    const { container } = render(
+      setup({
+        data: { contestableIssues, additionalIssues: [{ issue }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const error = $('.usa-input-error-message', container);
+    expect(error.textContent).to.contain(issueErrorMessages.maxLength);
+  });
+  it('should show error when issue date is not in range', () => {
+    const decisionDate = getDate({ offset: { years: +200 } });
+    const { container } = render(
+      setup({
+        data: { contestableIssues, additionalIssues: [{ decisionDate }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const error = $('fieldset[id] .usa-input-error-message', container);
+    expect(error.textContent).to.contain(
+      // partial match
+      issueErrorMessages.invalidDateRange('xxxx', '').split('xxxx')[0],
+    );
+  });
+  it('should show an error when the issue date is > 1 year in the future', () => {
+    const decisionDate = getDate({ offset: { months: +13 } });
+    const { container } = render(
+      setup({
+        data: { contestableIssues, additionalIssues: [{ decisionDate }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const error = $('fieldset[id] .usa-input-error-message', container);
+    expect(error.textContent).to.contain(issueErrorMessages.pastDate);
+  });
+  it('should show an error when the issue date is > 1 year in the past', () => {
+    const decisionDate = getDate({ offset: { months: -13 } });
+    const { container } = render(
+      setup({
+        data: { contestableIssues, additionalIssues: [{ decisionDate }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const error = $('fieldset[id] .usa-input-error-message', container);
+    expect(error.textContent).to.contain(issueErrorMessages.newerDate);
+  });
+
+  it('should show an error when the issue is not unique', () => {
+    const goToPathSpy = sinon.spy();
+    const additionalIssues = [{ issue: 'test', decisionDate: validDate }];
+    const { container } = render(
+      setup({
+        goToPath: goToPathSpy,
+        data: { contestableIssues, additionalIssues },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const error = $('.usa-input-error-message', container);
+    expect(error.textContent).to.contain(issueErrorMessages.uniqueIssue);
+  });
+
+  it('should submit when everything is valid', () => {
+    const goToPathSpy = sinon.spy();
+    const additionalIssues = [
+      { issue: 'test', decisionDate: getDate({ offset: { months: -3 } }) },
+    ];
+    const { container } = render(
+      setup({
+        goToPath: goToPathSpy,
+        data: { contestableIssues, additionalIssues },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    expect($('.usa-input-error-message', container)).to.not.exist;
+    expect(goToPathSpy.called).to.be.true;
+  });
+});

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -6,7 +6,7 @@
       "address": {
         "addressLine1": "123 Main St",
         "addressLine2": "Suite #1200",
-        "addressLine3": "Box 4",
+        "addressLine3": "Box 45678901234",
         "city": "New York",
         "countryName": "United States",
         "stateCode": "NY",

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
@@ -7,7 +7,7 @@
         "address": {
           "addressLine1": "123 Main St",
           "addressLine2": "Suite #1200",
-          "addressLine3": "Box 4",
+          "addressLine3": "Box 456789",
           "city": "New York",
           "countryName": "United States",
           "stateCode": "NY",

--- a/src/applications/appeals/10182/tests/utils/disagreement.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/disagreement.unit.spec.js
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  MAX_DISAGREEMENT_REASON_LENGTH,
-  SUBMITTED_DISAGREEMENTS,
-} from '../../constants';
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../../constants';
 import {
   copyAreaOfDisagreementOptions,
   calculateOtherMaxLength,
@@ -75,11 +72,11 @@ describe('calculateOtherMaxLength', () => {
   const calcLength = settings => {
     const string = values.filter((value, index) => settings[index]).join(',');
     // add 1 to string length for the final comma
-    return MAX_DISAGREEMENT_REASON_LENGTH - (string.length + 1);
+    return MAX_LENGTH.DISAGREEMENT_REASON - (string.length + 1);
   };
   it('should return max length when nothing is selected', () => {
     expect(calculateOtherMaxLength(getData([]))).to.eq(
-      MAX_DISAGREEMENT_REASON_LENGTH,
+      MAX_LENGTH.DISAGREEMENT_REASON,
     );
   });
   it('should return appropriate length with 1 selection', () => {

--- a/src/applications/appeals/10182/tests/validations/issues.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/issues.unit.spec.js
@@ -2,11 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { getDate } from '../../utils/dates';
-import {
-  SELECTED,
-  MAX_SELECTIONS,
-  MAX_ISSUE_NAME_LENGTH,
-} from '../../constants';
+import { SELECTED, MAX_LENGTH } from '../../constants';
 
 import {
   selectionRequired,
@@ -84,7 +80,7 @@ describe('maxIssues', () => {
       [SELECTED]: true,
     };
     maxIssues(errors, _, _, _, _, _, {
-      contestableIssues: new Array(MAX_SELECTIONS).fill(template),
+      contestableIssues: new Array(MAX_LENGTH.SELECTIONS).fill(template),
       additionalIssues: [template],
     });
     expect(errors.addError.called).to.be.true;
@@ -143,7 +139,7 @@ describe('missingIssueName', () => {
 describe('maxNameLength', () => {
   it('should show an error when a name is too long', () => {
     const errors = { addError: sinon.spy() };
-    maxNameLength(errors, 'ab '.repeat(MAX_ISSUE_NAME_LENGTH / 2));
+    maxNameLength(errors, 'ab '.repeat(MAX_LENGTH.ISSUE_NAME / 2));
     expect(errors.addError.called).to.be.true;
   });
   it('should show an error when a name is not too long', () => {

--- a/src/applications/appeals/10182/utils/disagreement.js
+++ b/src/applications/appeals/10182/utils/disagreement.js
@@ -1,7 +1,4 @@
-import {
-  MAX_DISAGREEMENT_REASON_LENGTH,
-  SUBMITTED_DISAGREEMENTS,
-} from '../constants';
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
 import { getIssueName } from './helpers';
 
 /**
@@ -65,5 +62,5 @@ export const calculateOtherMaxLength = formData => {
     }
     return totalLength;
   }, 0);
-  return MAX_DISAGREEMENT_REASON_LENGTH - stringLength;
+  return MAX_LENGTH.DISAGREEMENT_REASON - stringLength;
 };

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -1,11 +1,6 @@
 import moment from 'moment';
 
-import {
-  SELECTED,
-  MAX_ISSUE_NAME_LENGTH,
-  MAX_DISAGREEMENT_REASON_LENGTH,
-  SUBMITTED_DISAGREEMENTS,
-} from '../constants';
+import { SELECTED, MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
 
 /**
  * @typedef FormData
@@ -101,7 +96,7 @@ export const createIssueName = ({ attributes } = {}) => {
   ]
     .filter(part => part)
     .join(' - ')
-    .substring(0, MAX_ISSUE_NAME_LENGTH);
+    .substring(0, MAX_LENGTH.ISSUE_NAME);
 };
 
 /**
@@ -230,7 +225,7 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
         ...issue.attributes,
         disagreementArea: reasons
           .join(',')
-          .substring(0, MAX_DISAGREEMENT_REASON_LENGTH), // max length in schema
+          .substring(0, MAX_LENGTH.DISAGREEMENT_REASON), // max length in schema
       },
     };
   });
@@ -313,30 +308,40 @@ export const removeEmptyEntries = object =>
  * @param {Veteran} veteran - Veteran formData object
  * @returns {Object} submittable address
  */
-export const getAddress = ({ veteran = {} } = {}) =>
-  removeEmptyEntries({
-    addressLine1: veteran.address?.addressLine1 || '',
-    addressLine2: veteran.address?.addressLine2 || '',
-    addressLine3: veteran.address?.addressLine3 || '',
-    city: veteran.address?.city || '',
+export const getAddress = ({ veteran = {} } = {}) => {
+  const truncate = (value, max) =>
+    (veteran.address?.[value] || '').substring(0, max);
+  return removeEmptyEntries({
+    addressLine1: truncate('addressLine1', MAX_LENGTH.ADDRESS_LINE1),
+    addressLine2: truncate('addressLine2', MAX_LENGTH.ADDRESS_LINE2),
+    addressLine3: truncate('addressLine3', MAX_LENGTH.ADDRESS_LINE3),
+    city: truncate('city', MAX_LENGTH.CITY),
     stateCode: veteran.address?.stateCode || '',
-    zipCode5: veteran.address?.zipCode || '',
+    zipCode5: truncate('zipCode', MAX_LENGTH.ZIP_CODE5),
     countryName: veteran.address?.countryName || '',
-    internationalPostalCode: veteran.address?.internationalPostalCode || '',
+    // countryCodeISO2: truncate('countryCodeIso2', MAX_LENGTH.COUNTRY), // v2
+    internationalPostalCode: truncate(
+      'internationalPostalCode',
+      MAX_LENGTH.POSTAL_CODE,
+    ),
   });
+};
 
 /**
  * Strip out extra profile phone data
  * @param {Veteran} veteran - Veteran formData object
  * @returns {Object} submittable address
  */
-export const getPhone = ({ veteran = {} } = {}) =>
-  removeEmptyEntries({
-    countryCode: veteran.phone?.countryCode || '',
-    areaCode: veteran.phone?.areaCode || '',
-    phoneNumber: veteran.phone?.phoneNumber || '',
-    phoneNumberExt: veteran.phone?.phoneNumberExt || '',
+export const getPhone = ({ veteran = {} } = {}) => {
+  const truncate = (value, max) =>
+    (veteran.phone?.[value] || '').substring(0, max);
+  return removeEmptyEntries({
+    countryCode: truncate('countryCode', MAX_LENGTH.COUNTRY_CODE),
+    areaCode: truncate('areaCode', MAX_LENGTH.AREA_CODE),
+    phoneNumber: truncate('phoneNumber', MAX_LENGTH.PHONE_NUMBER),
+    phoneNumberExt: truncate('phoneNumberExt', MAX_LENGTH.PHONE_NUMBER_EXT),
   });
+};
 
 /**
  * Get user's current time zone

--- a/src/applications/appeals/10182/validations/issues.js
+++ b/src/applications/appeals/10182/validations/issues.js
@@ -4,7 +4,7 @@ import {
   noneSelected,
   maxSelectedErrorMessage,
 } from '../content/contestableIssues';
-import { MAX_SELECTIONS, MAX_ISSUE_NAME_LENGTH } from '../constants';
+import { MAX_LENGTH } from '../constants';
 
 /**
  *
@@ -64,7 +64,7 @@ export const maxIssues = (
   _index,
   appStateData,
 ) => {
-  if (getSelected(appStateData || formData).length > MAX_SELECTIONS) {
+  if (getSelected(appStateData || formData).length > MAX_LENGTH.SELECTIONS) {
     errors.addError(maxSelectedErrorMessage);
   }
 };
@@ -76,7 +76,7 @@ export const missingIssueName = (errors, data) => {
 };
 
 export const maxNameLength = (errors, data) => {
-  if (data.length > MAX_ISSUE_NAME_LENGTH) {
+  if (data.length > MAX_LENGTH.ISSUE_NAME) {
     errors.addError(issueErrorMessages.maxLength);
   }
 };


### PR DESCRIPTION
## Description

The Notice of Disagreement form uses the profile email, mobile phone and mailing address. The lengths of these values don't all match the [NOD schema](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/10182.json)

Because of this inconsistency, changes for all submitted email, phone and address need to be truncated to fit these requirements

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/38326

## Testing done

Updated unit tests & mock data

## Screenshots

N/A

## Acceptance criteria
- [x] Submitted profile data is truncated to fit NOD's schema
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
