### PR TITLE
force eligibility check

### DIFF
--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -73,8 +73,6 @@ function isCovidVaccine(state) {
 }
 
 async function vaFacilityNext(state, dispatch) {
-  let eligibility = null;
-
   const location = getChosenFacilityInfo(state);
   const cernerSiteIds = selectRegisteredCernerFacilityIds(state);
   const isCerner = isCernerLocation(location?.id, cernerSiteIds);
@@ -83,18 +81,16 @@ async function vaFacilityNext(state, dispatch) {
     return 'scheduleCerner';
   }
 
-  // Fetch eligibility if we haven't already
-  if (!eligibility) {
-    const siteId = getSiteIdFromFacilityId(location.id);
+  const siteId = getSiteIdFromFacilityId(location.id);
 
-    eligibility = await dispatch(
-      checkEligibility({
-        location,
-        siteId,
-        showModal: true,
-      }),
-    );
-  }
+  const eligibility = await dispatch(
+    checkEligibility({
+      location,
+      siteId,
+      showModal: true,
+    }),
+  );
+  // }
 
   if (eligibility.direct) {
     dispatch(startDirectScheduleFlow());

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,3 +1,4 @@
+import recordEvent from 'platform/monitoring/record-event';
 import {
   selectHasVAPResidentialAddress,
   selectRegisteredCernerFacilityIds,
@@ -8,7 +9,6 @@ import {
   getNewAppointment,
   getTypeOfCare,
   selectCommunityCareSupportedSites,
-  selectEligibility,
 } from './redux/selectors';
 import {
   FACILITY_TYPES,
@@ -30,7 +30,6 @@ import {
   updateFacilityType,
   checkCommunityCareEligibility,
 } from './redux/actions';
-import recordEvent from 'platform/monitoring/record-event';
 import { startNewVaccineFlow } from '../appointment-list/redux/actions';
 
 const AUDIOLOGY = '203';
@@ -74,7 +73,7 @@ function isCovidVaccine(state) {
 }
 
 async function vaFacilityNext(state, dispatch) {
-  let eligibility = selectEligibility(state);
+  let eligibility = null;
 
   const location = getChosenFacilityInfo(state);
   const cernerSiteIds = selectRegisteredCernerFacilityIds(state);
@@ -133,12 +132,15 @@ export default {
         });
         dispatch(startNewVaccineFlow());
         return 'vaccineFlow';
-      } else if (isSleepCare(state)) {
+      }
+      if (isSleepCare(state)) {
         dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
         return 'typeOfSleepCare';
-      } else if (isEyeCare(state)) {
+      }
+      if (isEyeCare(state)) {
         return 'typeOfEyeCare';
-      } else if (isCommunityCare(state)) {
+      }
+      if (isCommunityCare(state)) {
         const isEligible = await dispatch(checkCommunityCareEligibility());
 
         if (isEligible && isPodiatry(state)) {
@@ -146,9 +148,11 @@ export default {
           dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
           dispatch(startRequestAppointmentFlow(true));
           return 'requestDateTime';
-        } else if (isEligible) {
+        }
+        if (isEligible) {
           return 'typeOfFacility';
-        } else if (isPodiatry(state)) {
+        }
+        if (isPodiatry(state)) {
           // If no CC enabled systems and toc is podiatry, show modal
           dispatch(showPodiatryAppointmentUnavailableModal());
           return 'typeOfCare';
@@ -259,7 +263,8 @@ export default {
       const supportedSites = selectCommunityCareSupportedSites(state);
       if (isCCFacility(state) && supportedSites.length > 1) {
         return 'ccClosestCity';
-      } else if (isCCFacility(state)) {
+      }
+      if (isCCFacility(state)) {
         return 'ccPreferences';
       }
 

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -90,7 +90,6 @@ async function vaFacilityNext(state, dispatch) {
       showModal: true,
     }),
   );
-  // }
 
   if (eligibility.direct) {
     dispatch(startDirectScheduleFlow());

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -5,7 +5,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2021-09-19T16:00:00Z",
-        "clinicId": "308",
+        "clinicId": "208",
         "clinicFriendlyName": "Neighborhood Clinic",
         "facilityId": "983",
         "sta6aid": "983GC",
@@ -33,7 +33,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2019-09-19T16:00:00Z",
-        "clinicId": "308",
+        "clinicId": "208",
         "clinicFriendlyName": null,
         "facilityId": "983",
         "sta6aid": "983GC",
@@ -62,7 +62,7 @@
       "attributes": {
         "startDate": "2022-02-14T12:52:00Z",
         "sta6aid": "983",
-        "clinicId": "848",
+        "clinicId": "949",
         "clinicFriendlyName": "CHY PC VAR2",
         "facilityId": "983",
         "communityCare": false,
@@ -105,7 +105,7 @@
                     "timeZoneName": "America/Denver"
                   },
                   "clinic": {
-                    "ien": "848",
+                    "ien": "949",
                     "name": "CHY PC VAR2"
                   }
                 },
@@ -129,7 +129,7 @@
                     "timeZoneName": "America/Denver"
                   },
                   "clinic": {
-                    "ien": "848",
+                    "ien": "949",
                     "name": "CHY PC VAR2"
                   }
                 },
@@ -259,7 +259,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2022-02-31T16:00:00Z",
-        "clinicId": "308",
+        "clinicId": "208",
         "clinicFriendlyName": "Jennie's Lab",
         "facilityId": "983",
         "sta6aid": "983GC",
@@ -287,7 +287,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2022-02-20T16:00:00Z",
-        "clinicId": "308",
+        "clinicId": "208",
         "clinicFriendlyName": null,
         "facilityId": "983",
         "sta6aid": "983",

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -5,7 +5,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2021-09-19T16:00:00Z",
-        "clinicId": "208",
+        "clinicId": "308",
         "clinicFriendlyName": "Neighborhood Clinic",
         "facilityId": "983",
         "sta6aid": "983GC",
@@ -33,7 +33,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2019-09-19T16:00:00Z",
-        "clinicId": "208",
+        "clinicId": "308",
         "clinicFriendlyName": null,
         "facilityId": "983",
         "sta6aid": "983GC",
@@ -62,7 +62,7 @@
       "attributes": {
         "startDate": "2022-02-14T12:52:00Z",
         "sta6aid": "983",
-        "clinicId": "949",
+        "clinicId": "848",
         "clinicFriendlyName": "CHY PC VAR2",
         "facilityId": "983",
         "communityCare": false,
@@ -105,7 +105,7 @@
                     "timeZoneName": "America/Denver"
                   },
                   "clinic": {
-                    "ien": "949",
+                    "ien": "848",
                     "name": "CHY PC VAR2"
                   }
                 },
@@ -129,7 +129,7 @@
                     "timeZoneName": "America/Denver"
                   },
                   "clinic": {
-                    "ien": "949",
+                    "ien": "848",
                     "name": "CHY PC VAR2"
                   }
                 },
@@ -259,7 +259,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2022-02-31T16:00:00Z",
-        "clinicId": "208",
+        "clinicId": "308",
         "clinicFriendlyName": "Jennie's Lab",
         "facilityId": "983",
         "sta6aid": "983GC",
@@ -287,7 +287,7 @@
       "type": "va_appointments",
       "attributes": {
         "startDate": "2022-02-20T16:00:00Z",
-        "clinicId": "208",
+        "clinicId": "308",
         "clinicFriendlyName": null,
         "facilityId": "983",
         "sta6aid": "983",

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -190,7 +190,7 @@ describe('VAOS newAppointmentFlow', () => {
           dispatch,
         );
 
-        const dataLayer = global.window.dataLayer;
+        const { dataLayer } = global.window;
         expect(dataLayer[0].event).to.equal('vaos-cc-eligible-yes');
 
         expect(nextState).to.equal('requestDateTime');
@@ -365,6 +365,15 @@ describe('VAOS newAppointmentFlow', () => {
                 direct: true,
               },
             },
+            facilities: [
+              {
+                '323': [
+                  {
+                    id: '983',
+                  },
+                ],
+              },
+            ],
           },
         };
         const dispatch = sinon.spy();

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -368,78 +368,21 @@ describe('VAOS newAppointmentFlow', () => {
             facilities: {
               '323': [
                 {
-                  resourceType: 'Location',
                   id: '983',
-                  vistaId: '983',
-                  name: 'Cheyenne VA Medical Center',
-                  identifier: [
-                    {
-                      system: 'http://med.va.gov/fhir/urn',
-                      value: 'urn:va:division:983:983',
-                    },
-                    {
-                      system: 'urn:oid:2.16.840.1.113883.6.233',
-                      value: '983',
-                    },
-                  ],
-                  telecom: [
-                    {
-                      system: 'phone',
-                      value: '307-778-7550',
-                    },
-                  ],
-                  position: {
-                    longitude: -104.786159,
-                    latitude: 41.148179,
-                  },
-                  address: {
-                    line: ['2360 East Pershing Boulevard'],
-                    city: 'Cheyenne',
-                    state: 'WY',
-                    postalCode: '82001-5356',
-                  },
                   legacyVAR: {
                     settings: {
                       '323': {
                         id: '323',
                         name: 'Primary Care',
-                        stopCodes: [
-                          {
-                            primary: '322',
-                          },
-                          {
-                            primary: '323',
-                          },
-                          {
-                            primary: '350',
-                          },
-                        ],
                         direct: {
-                          patientHistoryRequired: false,
-                          canCancel: true,
                           enabled: true,
                         },
                         request: {
-                          patientHistoryRequired: false,
-                          patientHistoryDuration: 0,
-                          submittedRequestLimit: 1,
-                          enterpriseSubmittedRequestLimit: 1,
-                          enabled: true,
+                          enabled: false,
                         },
                       },
                     },
-                    distanceFromResidentialAddress: 950.7,
                   },
-                },
-              ],
-            },
-            clinics: {
-              '983_323': [
-                {
-                  id: '983_308',
-                  stationId: '983',
-                  stationName: 'CHYSHR-Cheyenne VA Medical Center',
-                  serviceName: 'Green Team Clinic1',
                 },
               ],
             },
@@ -450,15 +393,10 @@ describe('VAOS newAppointmentFlow', () => {
           facilityId: '983',
           typeOfCareId: 'primaryCare',
           pastClinics: true,
-          requestPastVisits: true,
-          directPastVisits: true,
           limit: true,
           clinics: [
             {
               id: '983_308',
-              stationId: '983',
-              stationName: 'CHYSHR-Cheyenne VA Medical Center',
-              serviceName: 'Green Team Clinic1',
             },
           ],
         };
@@ -489,78 +427,17 @@ describe('VAOS newAppointmentFlow', () => {
             facilities: {
               '323': [
                 {
-                  resourceType: 'Location',
                   id: '983',
-                  vistaId: '983',
-                  name: 'Cheyenne VA Medical Center',
-                  identifier: [
-                    {
-                      system: 'http://med.va.gov/fhir/urn',
-                      value: 'urn:va:division:983:983',
-                    },
-                    {
-                      system: 'urn:oid:2.16.840.1.113883.6.233',
-                      value: '983',
-                    },
-                  ],
-                  telecom: [
-                    {
-                      system: 'phone',
-                      value: '307-778-7550',
-                    },
-                  ],
-                  position: {
-                    longitude: -104.786159,
-                    latitude: 41.148179,
-                  },
-                  address: {
-                    line: ['2360 East Pershing Boulevard'],
-                    city: 'Cheyenne',
-                    state: 'WY',
-                    postalCode: '82001-5356',
-                  },
                   legacyVAR: {
                     settings: {
                       '323': {
-                        id: '323',
-                        name: 'Primary Care',
-                        stopCodes: [
-                          {
-                            primary: '322',
-                          },
-                          {
-                            primary: '323',
-                          },
-                          {
-                            primary: '350',
-                          },
-                        ],
-                        direct: {
-                          patientHistoryRequired: false,
-                          canCancel: true,
-                          enabled: false,
-                        },
+                        direct: {},
                         request: {
-                          patientHistoryRequired: false,
-                          patientHistoryDuration: 0,
-                          submittedRequestLimit: 1,
-                          enterpriseSubmittedRequestLimit: 1,
                           enabled: true,
                         },
                       },
                     },
-                    distanceFromResidentialAddress: 950.7,
                   },
-                },
-              ],
-            },
-            clinics: {
-              '983_323': [
-                {
-                  id: '983_308',
-                  stationId: '983',
-                  stationName: 'CHYSHR-Cheyenne VA Medical Center',
-                  serviceName: 'Green Team Clinic1',
                 },
               ],
             },
@@ -570,9 +447,6 @@ describe('VAOS newAppointmentFlow', () => {
         const eligibility = {
           facilityId: '983',
           typeOfCareId: 'primaryCare',
-          pastClinics: true,
-          requestPastVisits: true,
-          directPastVisits: true,
           limit: true,
         };
 

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -14,7 +14,10 @@ import parentFacilities from '../../services/mocks/var/facilities.json';
 import newAppointmentFlow from '../../new-appointment/newAppointmentFlow';
 import { FACILITY_TYPES } from '../../utils/constants';
 import { mockParentSites, mockSupportedCCSites } from '../mocks/helpers';
-import { mockFacilitiesFetchByVersion } from '../mocks/fetch';
+import {
+  mockFacilitiesFetchByVersion,
+  mockEligibilityFetchesByVersion,
+} from '../mocks/fetch';
 import { getParentSiteMock } from '../mocks/v0';
 
 const userState = {
@@ -316,6 +319,8 @@ describe('VAOS newAppointmentFlow', () => {
         loading: false,
         vaOnlineSchedulingDirect: true,
         vaOnlineSchedulingCommunityCare: true,
+        vaOnlineSchedulingVAOSServiceRequests: true,
+        vaOnlineSchedulingVAOSServiceVAAppointments: true,
       },
       newAppointment: {
         data: {
@@ -360,48 +365,224 @@ describe('VAOS newAppointmentFlow', () => {
           ...defaultState,
           newAppointment: {
             ...defaultState.newAppointment,
-            eligibility: {
-              '983_323': {
-                direct: true,
-              },
-            },
-            facilities: [
-              {
-                '323': [
-                  {
-                    id: '983',
+            facilities: {
+              '323': [
+                {
+                  resourceType: 'Location',
+                  id: '983',
+                  vistaId: '983',
+                  name: 'Cheyenne VA Medical Center',
+                  identifier: [
+                    {
+                      system: 'http://med.va.gov/fhir/urn',
+                      value: 'urn:va:division:983:983',
+                    },
+                    {
+                      system: 'urn:oid:2.16.840.1.113883.6.233',
+                      value: '983',
+                    },
+                  ],
+                  telecom: [
+                    {
+                      system: 'phone',
+                      value: '307-778-7550',
+                    },
+                  ],
+                  position: {
+                    longitude: -104.786159,
+                    latitude: 41.148179,
                   },
-                ],
-              },
-            ],
+                  address: {
+                    line: ['2360 East Pershing Boulevard'],
+                    city: 'Cheyenne',
+                    state: 'WY',
+                    postalCode: '82001-5356',
+                  },
+                  legacyVAR: {
+                    settings: {
+                      '323': {
+                        id: '323',
+                        name: 'Primary Care',
+                        stopCodes: [
+                          {
+                            primary: '322',
+                          },
+                          {
+                            primary: '323',
+                          },
+                          {
+                            primary: '350',
+                          },
+                        ],
+                        direct: {
+                          patientHistoryRequired: false,
+                          canCancel: true,
+                          enabled: true,
+                        },
+                        request: {
+                          patientHistoryRequired: false,
+                          patientHistoryDuration: 0,
+                          submittedRequestLimit: 1,
+                          enterpriseSubmittedRequestLimit: 1,
+                          enabled: true,
+                        },
+                      },
+                    },
+                    distanceFromResidentialAddress: 950.7,
+                  },
+                },
+              ],
+            },
+            clinics: {
+              '983_323': [
+                {
+                  id: '983_308',
+                  stationId: '983',
+                  stationName: 'CHYSHR-Cheyenne VA Medical Center',
+                  serviceName: 'Green Team Clinic1',
+                },
+              ],
+            },
           },
         };
-        const dispatch = sinon.spy();
+
+        const eligibility = {
+          facilityId: '983',
+          typeOfCareId: 'primaryCare',
+          pastClinics: true,
+          requestPastVisits: true,
+          directPastVisits: true,
+          limit: true,
+          clinics: [
+            {
+              id: '983_308',
+              stationId: '983',
+              stationName: 'CHYSHR-Cheyenne VA Medical Center',
+              serviceName: 'Green Team Clinic1',
+            },
+          ],
+        };
+
+        mockEligibilityFetchesByVersion({
+          ...eligibility,
+          version: 2,
+        });
+
+        const getState = () => state;
+        const dispatch = action =>
+          typeof action === 'function' ? action(sinon.spy(), getState) : null;
 
         const nextState = await newAppointmentFlow.vaFacilityV2.next(
           state,
           dispatch,
         );
-        expect(dispatch.firstCall.args[0].type).to.equal(
-          'newAppointment/START_DIRECT_SCHEDULE_FLOW',
-        );
         expect(nextState).to.equal('clinicChoice');
       });
+
       it('should be requestDateTime if not direct eligible', async () => {
+        mockFetch();
         const state = {
           ...defaultState,
+
           newAppointment: {
             ...defaultState.newAppointment,
-            eligibility: {
-              '983_323': {
-                direct: false,
-                request: true,
-              },
+            facilities: {
+              '323': [
+                {
+                  resourceType: 'Location',
+                  id: '983',
+                  vistaId: '983',
+                  name: 'Cheyenne VA Medical Center',
+                  identifier: [
+                    {
+                      system: 'http://med.va.gov/fhir/urn',
+                      value: 'urn:va:division:983:983',
+                    },
+                    {
+                      system: 'urn:oid:2.16.840.1.113883.6.233',
+                      value: '983',
+                    },
+                  ],
+                  telecom: [
+                    {
+                      system: 'phone',
+                      value: '307-778-7550',
+                    },
+                  ],
+                  position: {
+                    longitude: -104.786159,
+                    latitude: 41.148179,
+                  },
+                  address: {
+                    line: ['2360 East Pershing Boulevard'],
+                    city: 'Cheyenne',
+                    state: 'WY',
+                    postalCode: '82001-5356',
+                  },
+                  legacyVAR: {
+                    settings: {
+                      '323': {
+                        id: '323',
+                        name: 'Primary Care',
+                        stopCodes: [
+                          {
+                            primary: '322',
+                          },
+                          {
+                            primary: '323',
+                          },
+                          {
+                            primary: '350',
+                          },
+                        ],
+                        direct: {
+                          patientHistoryRequired: false,
+                          canCancel: true,
+                          enabled: false,
+                        },
+                        request: {
+                          patientHistoryRequired: false,
+                          patientHistoryDuration: 0,
+                          submittedRequestLimit: 1,
+                          enterpriseSubmittedRequestLimit: 1,
+                          enabled: true,
+                        },
+                      },
+                    },
+                    distanceFromResidentialAddress: 950.7,
+                  },
+                },
+              ],
+            },
+            clinics: {
+              '983_323': [
+                {
+                  id: '983_308',
+                  stationId: '983',
+                  stationName: 'CHYSHR-Cheyenne VA Medical Center',
+                  serviceName: 'Green Team Clinic1',
+                },
+              ],
             },
           },
         };
-        const dispatch = sinon.spy();
 
+        const eligibility = {
+          facilityId: '983',
+          typeOfCareId: 'primaryCare',
+          pastClinics: true,
+          requestPastVisits: true,
+          directPastVisits: true,
+          limit: true,
+        };
+
+        mockEligibilityFetchesByVersion({
+          ...eligibility,
+          version: 2,
+        });
+        const getState = () => state;
+        const dispatch = action =>
+          typeof action === 'function' ? action(sinon.spy(), getState) : null;
         const nextState = await newAppointmentFlow.vaFacilityV2.next(
           state,
           dispatch,


### PR DESCRIPTION
## Description
Clinics are filtered correctly when selecting a facility that offers direct schedule. However if the veteran uses the back button to select another facility that only offers request appointment and again the user clicks the back button to select the original facility that offers direct schedule, the clinics are no longer filtered correctly.  

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37719


## Testing done
unit and manual test

## Screenshots
Filtered clinics after using the back button to select a different facility and back again to original
![image](https://user-images.githubusercontent.com/54327023/158413053-97aa64b9-aab3-473c-9ee4-3d62af798efd.png)

 

## Acceptance criteria
- [ ] Should show the same clinics

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
