### PR TITLE
Integrate My VA Benefits E2E-spec with TestRail

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
@@ -1,3 +1,10 @@
+/**
+ * [TestRail-integrated] Spec for My VA - Benefits Payments & Debt
+ * @testrailinfo projectId 4
+ * @testrailinfo suiteId 5
+ * @testrailinfo groupId 4072
+ * @testrailinfo runName MyVA-e2e-Benefits
+ */
 import { makeMockUser } from '@@profile/tests/fixtures/users/user';
 import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
 import notInESR from '@@profile/tests/fixtures/enrollment-system/not-in-esr.json';
@@ -28,7 +35,7 @@ describe('The My VA Dashboard', () => {
       cy.login(user);
       cy.visit(manifest.rootUrl);
     });
-    it('should show info about disability benefits, health care, and education benefits', () => {
+    it('should show info about disability benefits, health care, and education benefits - C15782', () => {
       sectionHeadingsExist();
 
       cy.findAllByTestId('benefit-of-interest').should('have.length', 3);
@@ -37,8 +44,7 @@ describe('The My VA Dashboard', () => {
       disabilityCompensationExists(true);
       educationBenefitExists(true);
 
-      cy.injectAxe();
-      cy.axeCheck();
+      cy.injectAxeThenAxeCheck();
     });
   });
 });


### PR DESCRIPTION
## Description

Integrate My VA (Dashboard) Benefits-of-Interest Cypress E2E-spec with TestRail test case management system:

- Add TestRail comment-block and case-IDs to spec.
- [Misc.] Replace `injectAxe()` and `axeCheck()` calls with combined `injectAxeThenAxeCheck()`.

## Original issue(s)

[n/a: Part of QA continuous-improvement]


## Testing done

Ran updated specs locally, and successfully posted results to TestRail [see screenshot below].

## Screenshots

![2022-03-11_14-03-51](https://user-images.githubusercontent.com/587583/157966681-c5e70290-6a54-4a46-bb44-79a51e23ed83.png)


## Acceptance criteria
- [ ] Code-reviewer(s) approved changes

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
