### PR TITLE
Changed routing number title and fixed note formatting

### DIFF
--- a/src/applications/edu-benefits/0994/pages/bankInformation.js
+++ b/src/applications/edu-benefits/0994/pages/bankInformation.js
@@ -82,7 +82,7 @@ const bankAccountUI = {
     },
   },
   routingNumber: {
-    'ui:title': 'Bank’s 9 digit routing number',
+    'ui:title': 'Bank’s 9-digit routing number',
     'ui:validations': [validateRoutingNumber],
     'ui:errorMessages': {
       pattern: 'Please enter a valid 9 digit routing number',

--- a/src/applications/edu-benefits/10203/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/10203/content/directDeposit.jsx
@@ -97,17 +97,18 @@ export const bankInfoHelpText = (
       </div>
     ) : (
       <div>
-        The{' '}
-        <a href="https://veteransbenefitsbanking.org/">
-          Veterans Benefits Banking Program (VBBP)
-        </a>{' '}
-        provides a list of Veteran-friendly banks and credit unions. They’ll
-        work with you to set up an account, or help you qualify for an account,
-        so you can use direct deposit. To get started, call one of the
-        participating banks or credit unions listed on the VBBP website. Be sure
-        to mention the Veterans Benefits Banking Program.
-        <b />
-        <strong>
+        <p>
+          The{' '}
+          <a href="https://veteransbenefitsbanking.org/">
+            Veterans Benefits Banking Program (VBBP)
+          </a>{' '}
+          provides a list of Veteran-friendly banks and credit unions. They’ll
+          work with you to set up an account, or help you qualify for an
+          account, so you can use direct deposit. To get started, call one of
+          the participating banks or credit unions listed on the VBBP website.
+          Be sure to mention the Veterans Benefits Banking Program.
+        </p>
+        <p>
           Note: The Department of the Treasury requires us to make electronic
           payments. If you don’t want to use direct deposit, you’ll need to call
           the Department of the Treasury at{' '}
@@ -116,7 +117,7 @@ export const bankInfoHelpText = (
           </a>
           . Ask to talk with a representative who handles waiver requests. They
           can answer any questions or concerns you may have.
-        </strong>
+        </p>
       </div>
     )}
   </AdditionalInfo>

--- a/src/applications/edu-benefits/10203/pages/directDeposit.js
+++ b/src/applications/edu-benefits/10203/pages/directDeposit.js
@@ -22,7 +22,7 @@ export const uiSchema = {
     },
     routingNumber: {
       ...bankAccountUI.routingNumber,
-      'ui:title': 'Bank routing number',
+      'ui:title': 'Bank’s 9-digit routing number',
       'ui:required': useDirectDeposit,
     },
     accountNumber: {


### PR DESCRIPTION
## Description
Changed routing number title and fixed note formatting in accordion under direct deposit.
Also added dash to 0994 between 9 and digit after noticing it wasn't there.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24662


## Testing done
Local Testing

## Screenshots
10203 routing title
<img width="580" alt="Screen Shot 2022-03-14 at 10 05 19 AM" src="https://user-images.githubusercontent.com/86262790/158200775-6455cead-9229-4cca-8bf7-9499629d5461.png">
Accordion note
<img width="585" alt="Screen Shot 2022-03-14 at 10 05 08 AM" src="https://user-images.githubusercontent.com/86262790/158200777-1ddcac2e-36d9-42b5-8f52-7c590f3fb662.png">
0994's routing title
<img width="487" alt="Screen Shot 2022-03-14 at 10 11 31 AM" src="https://user-images.githubusercontent.com/86262790/158202014-a86ebff9-3a29-4ee5-9166-e766c7b2d694.png">



## Acceptance criteria
- [x] The note under "What if I don't have a bank account..." isn't in bold and starts a new paragraph
- [x] The routing number input title is "Bank’s 9-digit routing number"
- [x] 0994's routing number input titles is "Bank’s 9-digit routing number" ('-' included)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
