### PR TITLE
Create LogoutAlert unit test

### DIFF
--- a/src/platform/user/authentication/components/LogoutAlert.jsx
+++ b/src/platform/user/authentication/components/LogoutAlert.jsx
@@ -8,6 +8,7 @@ export default function LogoutAlert() {
       <h2 slot="headline">You have successfully signed out.</h2>
       <strong>Looking for other VA benefits or services?</strong>
       <a
+        data-testid="vagov"
         href="/"
         className="vads-u-display--block vads-u-margin-y--1"
         target="_blank"
@@ -15,6 +16,7 @@ export default function LogoutAlert() {
         VA.gov
       </a>
       <a
+        data-testid="mhv"
         href="https://www.myhealth.va.gov"
         className="vads-u-display--block vads-u-margin-y--1"
         target="blank"

--- a/src/platform/user/tests/authentication/components/LogoutAlert.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LogoutAlert.unit.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
+
+describe('LogoutAlert', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<LogoutAlert />);
+  });
+  afterEach(() => wrapper.unmount());
+
+  it('should render', () => {
+    expect(wrapper.find('h2').text()).includes('signed out');
+    wrapper.unmount();
+  });
+
+  it('should verify URL links are correct', () => {
+    expect(wrapper.find('Connect(EbenefitsLink)').exists()).to.be.true;
+    expect(wrapper.find('[data-testid="mhv"]').prop('href')).to.eql(
+      'https://www.myhealth.va.gov',
+    );
+    expect(wrapper.find('[data-testid="mhv"]').prop('href')).includes('/');
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This PR adds unit tests for the LogoutAlert component to ensure link URLs display as intended and Signed out content is visible

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#37578


## Testing done
Unit

## Screenshots
n/a

## Acceptance criteria
- [x] Verify `You have successfully signed out` is visible
- [x] Verify link URLs were correctly generated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
