### PR TITLE
Add Login Widget for Home Loans COE

### DIFF
--- a/src/applications/registry.scaffold.json
+++ b/src/applications/registry.scaffold.json
@@ -5,6 +5,11 @@
     "widgetType": "disability-rating-calculator"
   },
   {
+    "appName": "Check Home Loans COE Statsus",
+    "rootUrl": "/housing-assistance/home-loans/check-coe-status",
+    "widgetType": "home-loan-coe-login-widget"
+  },
+  {
     "appName": "Coronavirus Chatbot",
     "rootUrl": "/coronavirus-chatbot",
     "widgetType": "va-coronavirus-chatbot",

--- a/src/applications/static-pages/home-loan-coe-widget/components/App/index.js
+++ b/src/applications/static-pages/home-loan-coe-widget/components/App/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+// Relative imports.
+import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
+import ServiceProvidersText, {
+  ServiceProvidersTextCreateAcct,
+} from 'platform/user/authentication/components/ServiceProvidersText';
+
+export const App = ({ toggleLoginModal }) => {
+  return (
+    <va-alert status="continue" visible>
+      <h3 slot="headline">Please sign in to check the status of your COE</h3>
+      <p>
+        Sign in with your existing <ServiceProvidersText isBold /> account.{' '}
+        <ServiceProvidersTextCreateAcct />
+      </p>
+      <button
+        className="va-button-primary"
+        onClick={() => toggleLoginModal(true)}
+      >
+        Sign in or create an account
+      </button>
+    </va-alert>
+  );
+};
+
+App.propTypes = {
+  // From mapDispatchToProps.
+  toggleLoginModal: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = dispatch => ({
+  toggleLoginModal: open => dispatch(toggleLoginModalAction(open)),
+});
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(App);

--- a/src/applications/static-pages/home-loan-coe-widget/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/home-loan-coe-widget/components/App/index.unit.spec.js
@@ -12,9 +12,6 @@ describe('Home Loan COE Login Widget <App>', () => {
     expect(wrapper.text()).includes(
       'Please sign in to check the status of your COE',
     );
-    expect(wrapper.text()).includes(
-      'If you don’t have any of these accounts, you can create a free ID.me account now.',
-    );
     expect(wrapper.find('button.va-button-primary')).to.have.lengthOf(1);
     expect(wrapper.find(`button.va-button-primary`).text()).to.equal(
       'Sign in or create an account',

--- a/src/applications/static-pages/home-loan-coe-widget/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/home-loan-coe-widget/components/App/index.unit.spec.js
@@ -13,7 +13,7 @@ describe('Home Loan COE Login Widget <App>', () => {
       'Please sign in to check the status of your COE',
     );
     expect(wrapper.text()).includes(
-      'Sign in with your existing ID.me, DS Logon, or My HealtheVet account. If you don’t have any of these accounts, you can create a free ID.me account now.',
+      'If you don’t have any of these accounts, you can create a free ID.me account now.',
     );
     expect(wrapper.find('button.va-button-primary')).to.have.lengthOf(1);
     expect(wrapper.find(`button.va-button-primary`).text()).to.equal(

--- a/src/applications/static-pages/home-loan-coe-widget/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/home-loan-coe-widget/components/App/index.unit.spec.js
@@ -1,0 +1,24 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from '.';
+
+describe('Home Loan COE Login Widget <App>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<App />);
+    expect(wrapper.type()).to.not.equal(null);
+    expect(wrapper.text()).includes(
+      'Please sign in to check the status of your COE',
+    );
+    expect(wrapper.text()).includes(
+      'Sign in with your existing ID.me, DS Logon, or My HealtheVet account. If you don’t have any of these accounts, you can create a free ID.me account now.',
+    );
+    expect(wrapper.find('button.va-button-primary')).to.have.lengthOf(1);
+    expect(wrapper.find(`button.va-button-primary`).text()).to.equal(
+      'Sign in or create an account',
+    );
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/home-loan-coe-widget/index.js
+++ b/src/applications/static-pages/home-loan-coe-widget/index.js
@@ -1,0 +1,21 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+
+  if (root) {
+    import(/* webpackChunkName: "home-loan-coe-login-widget" */
+    './components/App').then(module => {
+      const { App } = module;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -52,6 +52,7 @@ import createFindVaForms, {
   findVaFormsWidgetReducer,
 } from '../find-forms/createFindVaForms';
 import createFindVaFormsPDFDownloadHelper from '../find-forms/widgets/createFindVaFormsPDFDownloadHelper';
+import createHomeLoanCOELoginWidget from './home-loan-coe-widget';
 import createLettersMobileCTA from './letters-mobile-cta';
 import createManageVADebtCTA from './manage-va-debt/createManageVADebtCTA';
 import createMedicalCopaysCTA from './medical-copays-cta';
@@ -191,6 +192,7 @@ createViewPaymentHistoryCTA(store, widgetTypes.VIEW_PAYMENT_HISTORY);
 createI18Select(store, widgetTypes.I_18_SELECT);
 createDependencyVerification(store, widgetTypes.DEPENDENCY_VERIFICATION);
 createCOEAccess(store, widgetTypes.COE_ACCESS);
+createHomeLoanCOELoginWidget(store, widgetTypes.HOME_LOAN_COE_LOGIN_WIDGET);
 createLettersMobileCTA(store, widgetTypes.LETTERS_MOBILE_CTA);
 createManageVADebtCTA(store, widgetTypes.MANAGE_VA_DEBT_CTA);
 

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -33,6 +33,7 @@ export default {
   GET_MEDICAL_RECORDS_PAGE: 'get-medical-records-page',
   HEALTH_CARE_APP_STATUS: 'health-care-app-status',
   HIGHER_LEVEL_REVIEW_APP_STATUS: 'higher-level-review-status',
+  HOME_LOAN_COE_LOGIN_WIDGET: 'home-loan-coe-login-widget',
   HOMEPAGE_BANNER: 'homepage-banner',
   I_18_SELECT: 'i18-select',
   LETTERS_MOBILE_CTA: 'letters-mobile-cta',


### PR DESCRIPTION
## Description
This PR adds the Home Loans COE Login Widget. The widget is designed as a CTA to get users to login to check their Home Loans eligibility. This widget is meant for use by content editors who drop react widgets into a page in Drupal.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37424

## Testing done
- [x] Unit Tests

## Screenshots
<img width="714" alt="Screen Shot 2022-03-14 at 2 38 48 PM" src="https://user-images.githubusercontent.com/6738544/158239074-c42fb55f-a835-410c-a392-bbe74a8d1afc.png">

## Acceptance criteria
- [x] Create Home Loans COE Login Widget

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
