### PR TITLE
[COE] Adding customText fields to form config

### DIFF
--- a/src/applications/lgy/coe/form/config/form.js
+++ b/src/applications/lgy/coe/form/config/form.js
@@ -35,6 +35,12 @@ const formConfig = {
   submitUrl: `${environment.API_URL}/v0/coe/submit_coe_claim`,
   transformForSubmit: customCOEsubmit,
   trackingPrefix: '26-1880-',
+  customText: {
+    appSavedSuccessfullyMessage: 'Your request has been saved.',
+    appType: 'request',
+    finishAppLaterMessage: 'Finish this request later',
+    reviewPageTitle: 'Review your request',
+  },
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '26-1880',


### PR DESCRIPTION
## Description
For the COE application, we have are using the word 'request' instead of 'application'. This PR adds the customText field to the form config so that we can replace the default text that includes the word 'application' in various places in the form.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37513

## Acceptance criteria
- [x] `customText` field has been added to the form config

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
