### PR TITLE
Update 401 Error Handling on Validation Pages

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -106,7 +106,7 @@ class ApiInitializer {
         }
       });
     },
-    withFailure: (errorCode = 400) => {
+    withFailure: (errorCode = 401) => {
       cy.intercept('POST', '/check_in/v2/sessions', req => {
         req.reply(errorCode, session.post.createMockFailedResponse());
       });

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
@@ -35,8 +35,14 @@ const mocks = {
     },
     createMockValidateErrorResponse: () => {
       return {
-        error: true,
-        message: 'Invalid last4 or last name!',
+        errors: [
+          {
+            title: 'Authentication Error',
+            detail: 'Authentication Error',
+            code: 'LOROTA-MAPPED-API_401',
+            status: '401',
+          },
+        ],
       };
     },
     createMockFailedResponse,

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -122,7 +122,7 @@ const ValidateVeteran = props => {
         validateHandler={onClick}
         Footer={Footer}
         showValidateError={showValidateError}
-        validateErrorMessage="Sorry, we couldn't find an account that matches that last name or SSN. Please try again."
+        validateErrorMessage="We're sorry. We couldn't match your information to our records. Please try again."
       />
       <BackToHome />
     </>

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -77,10 +77,7 @@ const ValidateVeteran = props => {
           }
         } catch (e) {
           setIsLoading(false);
-          if (
-            e?.message !== 'Invalid last4 or last name!' ||
-            isMaxValidateAttempts
-          ) {
+          if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
             goToErrorPage();
           } else {
             if (!showValidateError) {

--- a/src/applications/check-in/day-of/tests/e2e/errors/post-session/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/post-session/non.200.status.code.cypress.spec.js
@@ -7,15 +7,9 @@ import Error from '../../pages/Error';
 describe('Check In Experience ', () => {
   describe('Error handling - POST /check_in/v2/session/ - Non 200 status code', () => {
     beforeEach(() => {
-      const {
-        initializeFeatureToggle,
-        initializeSessionGet,
-        initializeSessionPost,
-      } = ApiInitializer;
+      const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
       initializeFeatureToggle.withCurrentFeatures();
       initializeSessionGet.withSuccessfulNewSession();
-
-      initializeSessionPost.withFailure(400);
     });
     afterEach(() => {
       cy.window().then(window => {
@@ -23,6 +17,21 @@ describe('Check In Experience ', () => {
       });
     });
     it('bad status code (400)', () => {
+      const { initializeSessionPost } = ApiInitializer;
+      initializeSessionPost.withFailure(400);
+      cy.visitWithUUID();
+      // page: Validate
+      ValidateVeteran.validatePage.dayOf();
+      ValidateVeteran.validateVeteran();
+      cy.injectAxeThenAxeCheck();
+
+      ValidateVeteran.attemptToGoToNextPage();
+
+      Error.validatePageLoaded();
+    });
+    it('bad status code (401)', () => {
+      const { initializeSessionPost } = ApiInitializer;
+      initializeSessionPost.withFailure(401);
       cy.visitWithUUID();
       // page: Validate
       ValidateVeteran.validatePage.dayOf();

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -20,7 +20,7 @@ const Error = () => {
   const { appointments } = useSelector(selectVeteranData);
   // if date exists, then show date
   const defaultMessageText = isMaxValidateAttempts
-    ? "We're sorry. We couldn't match your information to our records. Call us at 800-698-2411 (TTY: 711) for help signing in."
+    ? "We're sorry. We couldn't match your information to our records. Please call us at 800-698-2411 (TTY:711) for help signing in."
     : 'We’re sorry. Something went wrong on our end. Please try again.';
   const messages = [
     {

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -78,10 +78,7 @@ const Index = ({ router }) => {
           }
         } catch (e) {
           setIsLoading(false);
-          if (
-            e?.message !== 'Invalid last4 or last name!' ||
-            isMaxValidateAttempts
-          ) {
+          if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
             goToErrorPage();
           } else {
             if (!showValidateError) {

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -125,7 +125,7 @@ const Index = ({ router }) => {
         }}
         Footer={Footer}
         showValidateError={showValidateError}
-        validateErrorMessage="Sorry, we couldn't find an account that matches that last name or SSN. Please try again."
+        validateErrorMessage="We're sorry. We couldn't match your information to our records. Please try again."
       />
       <BackToHome />
     </>

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/post-session/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/post-session/non.200.status.code.cypress.spec.js
@@ -11,12 +11,9 @@ describe('Pre-Check In Experience ', () => {
         const {
           initializeFeatureToggle,
           initializeSessionGet,
-          initializeSessionPost,
         } = ApiInitializer;
         initializeFeatureToggle.withCurrentFeatures();
         initializeSessionGet.withSuccessfulNewSession();
-
-        initializeSessionPost.withFailure(400);
       });
       afterEach(() => {
         cy.window().then(window => {
@@ -24,6 +21,21 @@ describe('Pre-Check In Experience ', () => {
         });
       });
       it('bad status code (400)', () => {
+        const { initializeSessionPost } = ApiInitializer;
+        initializeSessionPost.withFailure(400);
+        cy.visitPreCheckInWithUUID();
+        // page: Validate
+        ValidateVeteran.validatePage.preCheckIn();
+        ValidateVeteran.validateVeteran();
+        cy.injectAxeThenAxeCheck();
+
+        ValidateVeteran.attemptToGoToNextPage();
+
+        Error.validatePageLoaded();
+      });
+      it('bad status code (401)', () => {
+        const { initializeSessionPost } = ApiInitializer;
+        initializeSessionPost.withFailure(401);
         cy.visitPreCheckInWithUUID();
         // page: Validate
         ValidateVeteran.validatePage.preCheckIn();

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
@@ -3,7 +3,7 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 class Error {
   validatePageLoaded = (lastValidateAttempt = false) => {
     const messageText = lastValidateAttempt
-      ? "We're sorry. We couldn't match your information to our records. Call us at 800-698-2411 (TTY: 711) for help signing in."
+      ? "We're sorry. We couldn't match your information to our records. Please call us at 800-698-2411 (TTY:711) for help signing in."
       : 'We’re sorry. Something went wrong on our end. Please try again.';
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')

--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -108,7 +108,7 @@ class ValidateVeteran {
       .should('be.visible')
       .and(
         'have.text',
-        "Sorry, we couldn't find an account that matches that last name or SSN. Please try again.",
+        "We're sorry. We couldn't match your information to our records. Please try again.",
       );
   };
 }


### PR DESCRIPTION
## Description
Update 401 error handling in mock-api, day-of validate page, and pre-check-in validate page.
Update user facing error messages on validate pages and error page. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38018


## Testing done
Updated existing e2e tests

## Screenshots

**Check-in**
![check-in-validate](https://user-images.githubusercontent.com/4554388/158410046-efacad7f-f155-41e1-84fb-d5c6d51558c7.png)
![check-in-see-staff](https://user-images.githubusercontent.com/4554388/158410040-65be3d8a-2c19-465c-886c-e6dd832f5b26.png)

**Pre-check-in**
![Pre-check-in-validate](https://user-images.githubusercontent.com/4554388/158410049-3bac7efa-6dd3-47a1-af04-586a35f04ed5.png)
![pre-check-in-see-staff](https://user-images.githubusercontent.com/4554388/158410047-8716dd9b-46c1-4724-b9a3-0eb4644426eb.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
