### PR TITLE
Removed redundant code block

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -122,7 +122,6 @@ export function SearchPage({
                 </va-alert>
               </div>
             )}
-            {!error && !smallScreen && tabbedResults[tab]}
             {!error &&
               smallScreen && (
                 <div>


### PR DESCRIPTION
## Description
When I execute a search on a mobile in portrait mode, the search results page has duplicate content (accordions and institutions cards): the results are displayed twice; above and below the tabs. This is happening with both tabs; search by name and search by location.
For search by location, I noticed that the map is only displayed on the results above the tab and it's blank on the results displayed below the tab.

Seems to be a part of other work but other references to new tab implementation is utilized in the correct place under the redundant block.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38359


## Testing done
Local testing

## Screenshots
https://user-images.githubusercontent.com/86262790/158406874-0594d030-05a1-4f7f-b306-6ad18badfeee.mov

## Acceptance criteria
- [ ] Search bar and results don't double when the screen is in portrait mode/is smaller.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
