### PR TITLE
Update Labs & Tests deep link with stakeholder-provided values

### DIFF
--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -162,7 +162,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.LAB_AND_TEST_RESULTS]: {
     id: CTA_WIDGET_TYPES.LAB_AND_TEST_RESULTS,
     deriveToolUrlDetails: authenticatedWithSSOe => ({
-      url: mhvUrl(authenticatedWithSSOe, 'web/myhealthevet/labs-tests'),
+      url: mhvUrl(authenticatedWithSSOe, 'labs-tests'),
       redirect: false,
     }),
     hasRequiredMhvAccount: accountLevel =>

--- a/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.js
+++ b/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.js
@@ -69,7 +69,7 @@ describe('CTA widgets', () => {
       ).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
-        }eauth.va.gov/mhv-portal-web/eauth?deeplinking=labs_tests`,
+        }eauth.va.gov/mhv-portal-web/web/myhealthevet/labs-tests`,
       );
     });
   });
@@ -120,9 +120,7 @@ describe('CTA widgets', () => {
         ctaWidgetsLookup?.[
           CTA_WIDGET_TYPES?.LAB_AND_TEST_RESULTS
         ]?.deriveToolUrlDetails()?.url,
-      ).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/labs-tests',
-      );
+      ).to.equal('https://mhv-syst.myhealth.va.gov/mhv-portal-web/labs-tests');
     });
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -20,10 +20,7 @@ export const AuthContent = ({
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="View lab and test results from:"
-      myHealtheVetLink={mhvUrl(
-        authenticatedWithSSOe,
-        'web/myhealthevet/labs-tests',
-      )}
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'labs-tests')}
       myVAHealthLink={getCernerURL('/pages/health_record/results/labs')}
     />
     <div>

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -11,7 +11,7 @@ const mhvToEauthRoutes = {
   'secure-messaging': 'eauth?deeplinking=secure_messaging',
   appointments: 'eauth?deeplinking=appointments',
   home: 'eauth',
-  'web/myhealthevet/labs-tests': 'eauth?deeplinking=labs_tests',
+  'labs-tests': 'web/myhealthevet/labs-tests',
 };
 
 // An MHV URL is a function of the following parameters:


### PR DESCRIPTION
## Description
This PR updates a missing deep link from the MHV Labs & Tests CTA. This link was not originally provided to the team during build, and the team tested assumed values. This PR corrects the assumed values.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38198

## Acceptance criteria
- [x] Widget redirects to deep link

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
