### PR TITLE
38103: AuthApp redirects handled in event callback

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -58,6 +58,7 @@ export class AuthApp extends React.Component {
     recordEvent({
       event: AUTH_EVENTS.ERROR_FORCE_NEEDED,
       eventCallback: this.redirect,
+      eventTimeout: 2000,
     });
   };
 
@@ -113,6 +114,7 @@ export class AuthApp extends React.Component {
       recordEvent({
         event: `login-inbound-redirect-to-${app}`,
         eventCallback: handleRedirect,
+        eventTimeout: 2000,
       });
       return;
     }

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -12,7 +12,6 @@ import {
   EXTERNAL_APPS,
   EXTERNAL_REDIRECTS,
   CSP_IDS,
-  POLICY_TYPES,
   AUTH_EVENTS,
 } from 'platform/user/authentication/constants';
 import {
@@ -20,81 +19,20 @@ import {
   setupProfileSession,
 } from 'platform/user/profile/utilities';
 import { apiRequest } from 'platform/utilities/api';
-import get from 'platform/utilities/data/get';
 import RenderErrorUI from '../components/RenderErrorContainer';
+import AuthMetrics from './AuthMetrics';
 
 const REDIRECT_IGNORE_PATTERN = new RegExp(
   ['/auth/login/callback', '/session-expired'].join('|'),
 );
 
-class AuthMetrics {
-  constructor(type, payload) {
-    this.type = type;
-    this.payload = payload;
-    this.userProfile = get('data.attributes.profile', payload, {});
-    this.loaCurrent = get('loa.current', this.userProfile, null);
-    this.serviceName = get('signIn.serviceName', this.userProfile, null);
-  }
-
-  compareLoginPolicy = () => {
-    // This is experimental code related to GA that will let us determine
-    // if the backend is returning an accurate service_name
-
-    const attemptedLoginPolicy =
-      this.type === CSP_IDS.MHV ? CSP_IDS.MHV_VERBOSE : this.type;
-
-    if (this.serviceName !== attemptedLoginPolicy) {
-      recordEvent({
-        event: `login-mismatch-${attemptedLoginPolicy}-${this.serviceName}`,
-      });
-    }
-  };
-
-  recordGAAuthEvents = () => {
-    switch (this.type) {
-      case POLICY_TYPES.SIGNUP:
-        recordEvent({ event: `register-success-${this.serviceName}` });
-        break;
-      case POLICY_TYPES.CUSTOM: /* type=custom is used for SSOe auto login */
-      case CSP_IDS.MHV:
-      case CSP_IDS.DS_LOGON:
-      case CSP_IDS.ID_ME:
-      case CSP_IDS.LOGIN_GOV:
-        recordEvent({ event: `login-success-${this.serviceName}` });
-        this.compareLoginPolicy();
-        break;
-      default:
-        recordEvent({ event: `login-or-register-success-${this.serviceName}` });
-        Sentry.withScope(scope => {
-          scope.setExtra('type', this.type || 'N/A');
-          Sentry.captureMessage('Unrecognized auth event type');
-        });
-    }
-
-    // Report out the current level of assurance for the user.
-    if (this.loaCurrent) {
-      recordEvent({ event: `login-loa-current-${this.loaCurrent}` });
-    }
-  };
-
-  reportSentryErrors = () => {
-    if (!Object.keys(this.userProfile).length) {
-      Sentry.captureMessage('Unexpected response for user object');
-    } else if (!this.serviceName) {
-      Sentry.captureMessage('Missing serviceName in user object');
-    }
-  };
-
-  run = () => {
-    this.reportSentryErrors();
-    if (!hasSession()) this.recordGAAuthEvents();
-  };
-}
-
 export class AuthApp extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { error: props.location.query.auth === 'fail' };
+    this.state = {
+      error: props.location.query.auth === 'fail',
+      returnUrl: sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL) || '',
+    };
   }
 
   componentDidMount() {
@@ -116,8 +54,11 @@ export class AuthApp extends React.Component {
   };
 
   handleAuthForceNeeded = () => {
-    recordEvent({ event: AUTH_EVENTS.ERROR_FORCE_NEEDED });
-    this.redirect();
+    // Handle redirect in the callback of the event data to ensure we process the even before navigation occurs
+    recordEvent({
+      event: AUTH_EVENTS.ERROR_FORCE_NEEDED,
+      eventCallback: this.redirect,
+    });
   };
 
   handleAuthSuccess = payload => {
@@ -131,6 +72,19 @@ export class AuthApp extends React.Component {
 
   redirect = (userProfile = {}) => {
     const returnUrl = sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL) || '';
+
+    const handleRedirect = () => {
+      sessionStorage.removeItem(AUTHN_SETTINGS.RETURN_URL);
+
+      const postAuthUrl = returnUrl
+        ? appendQuery(returnUrl, 'postLogin=true')
+        : returnUrl;
+
+      const redirectUrl =
+        (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && postAuthUrl) || '/';
+
+      window.location.replace(redirectUrl);
+    };
 
     // Enforce LOA3 for external redirects to My VA Health
     if (
@@ -155,19 +109,15 @@ export class AuthApp extends React.Component {
           app: CSP_IDS.MHV,
         }),
       };
-      recordEvent({ event: `login-inbound-redirect-to-${app}` });
+
+      recordEvent({
+        event: `login-inbound-redirect-to-${app}`,
+        eventCallback: handleRedirect,
+      });
+      return;
     }
 
-    sessionStorage.removeItem(AUTHN_SETTINGS.RETURN_URL);
-
-    const postAuthUrl = returnUrl
-      ? appendQuery(returnUrl, 'postLogin=true')
-      : returnUrl;
-
-    const redirectUrl =
-      (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && postAuthUrl) || '/';
-
-    window.location.replace(redirectUrl);
+    handleRedirect();
   };
 
   // Fetch the user to get the login policy and validate the session.

--- a/src/applications/auth/containers/AuthMetrics.jsx
+++ b/src/applications/auth/containers/AuthMetrics.jsx
@@ -1,0 +1,70 @@
+import * as Sentry from '@sentry/browser';
+
+import recordEvent from 'platform/monitoring/record-event';
+import { CSP_IDS, POLICY_TYPES } from 'platform/user/authentication/constants';
+import { hasSession } from 'platform/user/profile/utilities';
+import get from 'platform/utilities/data/get';
+
+export default class AuthMetrics {
+  constructor(type, payload) {
+    this.type = type;
+    this.payload = payload;
+    this.userProfile = get('data.attributes.profile', payload, {});
+    this.loaCurrent = get('loa.current', this.userProfile, null);
+    this.serviceName = get('signIn.serviceName', this.userProfile, null);
+  }
+
+  compareLoginPolicy = () => {
+    // This is experimental code related to GA that will let us determine
+    // if the backend is returning an accurate service_name
+
+    const attemptedLoginPolicy =
+      this.type === CSP_IDS.MHV ? CSP_IDS.MHV_VERBOSE : this.type;
+
+    if (this.serviceName !== attemptedLoginPolicy) {
+      recordEvent({
+        event: `login-mismatch-${attemptedLoginPolicy}-${this.serviceName}`,
+      });
+    }
+  };
+
+  recordGAAuthEvents = () => {
+    switch (this.type) {
+      case POLICY_TYPES.SIGNUP:
+        recordEvent({ event: `register-success-${this.serviceName}` });
+        break;
+      case POLICY_TYPES.CUSTOM: /* type=custom is used for SSOe auto login */
+      case CSP_IDS.MHV:
+      case CSP_IDS.DS_LOGON:
+      case CSP_IDS.ID_ME:
+      case CSP_IDS.LOGIN_GOV:
+        recordEvent({ event: `login-success-${this.serviceName}` });
+        this.compareLoginPolicy();
+        break;
+      default:
+        recordEvent({ event: `login-or-register-success-${this.serviceName}` });
+        Sentry.withScope(scope => {
+          scope.setExtra('type', this.type || 'N/A');
+          Sentry.captureMessage('Unrecognized auth event type');
+        });
+    }
+
+    // Report out the current level of assurance for the user.
+    if (this.loaCurrent) {
+      recordEvent({ event: `login-loa-current-${this.loaCurrent}` });
+    }
+  };
+
+  reportSentryErrors = () => {
+    if (!Object.keys(this.userProfile).length) {
+      Sentry.captureMessage('Unexpected response for user object');
+    } else if (!this.serviceName) {
+      Sentry.captureMessage('Missing serviceName in user object');
+    }
+  };
+
+  run = () => {
+    this.reportSentryErrors();
+    if (!hasSession()) this.recordGAAuthEvents();
+  };
+}

--- a/src/platform/monitoring/record-event.js
+++ b/src/platform/monitoring/record-event.js
@@ -8,7 +8,6 @@
 
 export default function recordEvent(data) {
   const { eventCallback } = data;
-  const eventTimeout = eventCallback ? { eventTimeout: 2000 } : {};
 
   // Handle eventCallback when window.google_tag_manager is undefined
   // This ensures that the callback is called when GTM is not loaded
@@ -21,12 +20,7 @@ export default function recordEvent(data) {
   // accompanying eventTimeout, this ensures the eventCallback is fired
   // even if the event stalls
   return (
-    window.google_tag_manager &&
-    window.dataLayer &&
-    window.dataLayer.push({
-      ...data,
-      ...eventTimeout,
-    })
+    window.google_tag_manager && window.dataLayer && window.dataLayer.push(data)
   );
 }
 

--- a/src/platform/monitoring/record-event.js
+++ b/src/platform/monitoring/record-event.js
@@ -13,14 +13,15 @@ export default function recordEvent(data) {
   // Handle eventCallback when window.google_tag_manager is undefined
   // This ensures that the callback is called when GTM is not loaded
   // This is needed for localhost, and for users utilizng an adblocker
-  if (typeof eventCallback === 'function' && window.google_tag_manager) {
-    eventCallback();
+  if (typeof eventCallback === 'function' && !window.google_tag_manager) {
+    return eventCallback();
   }
 
   // If the data includes an eventCallback, ensure we always add an
   // accompanying eventTimeout, this ensures the eventCallback is fired
   // even if the event stalls
   return (
+    window.google_tag_manager &&
     window.dataLayer &&
     window.dataLayer.push({
       ...data,

--- a/src/platform/monitoring/record-event.js
+++ b/src/platform/monitoring/record-event.js
@@ -1,12 +1,26 @@
+import env from '~/platform/utilities/environment';
+
 /**
  * Helper function for reporting events to Google Analytics. An alias for window.dataLayer.push.
  * @module platform/monitoring/record-event
  * @see https://developers.google.com/tag-manager/devguide
  * @param {object} data - The event data that will be sent to GA.
+ * @param {function} data.eventCallback - The function that will trigger on event completion
  */
 
 export default function recordEvent(data) {
-  return window.dataLayer && window.dataLayer.push(data);
+  const { eventCallback } = data;
+  const pushEvent = () => window.dataLayer && window.dataLayer.push(data);
+
+  // Handle eventCallback on localhost
+  // Since we do not send the data off locally, any reliance on an `eventCallback`
+  // will not work on localhost without this force call
+  if (typeof eventCallback === 'function' && env.isLocalhost()) {
+    pushEvent();
+    eventCallback();
+  }
+
+  return pushEvent();
 }
 
 /**

--- a/src/platform/monitoring/record-event.js
+++ b/src/platform/monitoring/record-event.js
@@ -8,20 +8,22 @@
 
 export default function recordEvent(data) {
   const { eventCallback } = data;
+  const pushEvent = () => {
+    return window.dataLayer && window.dataLayer.push(data);
+  };
 
   // Handle eventCallback when window.google_tag_manager is undefined
   // This ensures that the callback is called when GTM is not loaded
   // This is needed for localhost, and for users utilizng an adblocker
   if (typeof eventCallback === 'function' && !window.google_tag_manager) {
+    pushEvent();
     return eventCallback();
   }
 
   // If the data includes an eventCallback, ensure we always add an
   // accompanying eventTimeout, this ensures the eventCallback is fired
   // even if the event stalls
-  return (
-    window.google_tag_manager && window.dataLayer && window.dataLayer.push(data)
-  );
+  return pushEvent();
 }
 
 /**

--- a/src/platform/monitoring/tests/record-event.unit.spec.js
+++ b/src/platform/monitoring/tests/record-event.unit.spec.js
@@ -35,21 +35,6 @@ describe('recordEvent', () => {
     expect(global.window.dataLayer).to.eql([]);
   });
 
-  it('should add eventTimeout if eventCallback exists', () => {
-    const e = {
-      event: 'foo-bar',
-      contextualData: 'text',
-      eventCallback: () => {},
-    };
-    recordEvent(e);
-    expect(global.window.dataLayer).to.eql([
-      {
-        ...e,
-        eventTimeout: 2000,
-      },
-    ]);
-  });
-
   it('should return the eventCallback in the event that google_tag_manager is undefiend', () => {
     // eslint-disable-next-line camelcase
     global.window.google_tag_manager = undefined;

--- a/src/platform/monitoring/tests/record-event.unit.spec.js
+++ b/src/platform/monitoring/tests/record-event.unit.spec.js
@@ -11,6 +11,9 @@ describe('recordEvent', () => {
     global.window = Object.create(global.window);
     Object.assign(global.window, {
       dataLayer: [],
+      // eslint-disable-next-line camelcase
+      google_tag_manager: true,
+      test: 'test',
     });
   });
 
@@ -21,7 +24,43 @@ describe('recordEvent', () => {
   it('should record events to the data layer', () => {
     const e = { event: 'foo-bar', contextualData: 'text' };
     recordEvent(e);
-    expect(global.window.dataLayer.includes(e)).to.be.true;
+    expect(global.window.dataLayer).to.eql([e]);
+  });
+
+  it('should not record events to the data layer if google_tag_manager is undefined', () => {
+    // eslint-disable-next-line camelcase
+    global.window.google_tag_manager = undefined;
+    const e = { event: 'foo-bar', contextualData: 'text' };
+    recordEvent(e);
+    expect(global.window.dataLayer).to.eql([]);
+  });
+
+  it('should add eventTimeout if eventCallback exists', () => {
+    const e = {
+      event: 'foo-bar',
+      contextualData: 'text',
+      eventCallback: () => {},
+    };
+    recordEvent(e);
+    expect(global.window.dataLayer).to.eql([
+      {
+        ...e,
+        eventTimeout: 2000,
+      },
+    ]);
+  });
+
+  it('should return the eventCallback in the event that google_tag_manager is undefiend', () => {
+    // eslint-disable-next-line camelcase
+    global.window.google_tag_manager = undefined;
+    const testString = 'callbackfired';
+    const e = {
+      event: 'foo-bar',
+      contextualData: 'text',
+      eventCallback: () => testString,
+    };
+    const response = recordEvent(e);
+    expect(response).to.equal(testString);
   });
 });
 

--- a/src/platform/monitoring/tests/record-event.unit.spec.js
+++ b/src/platform/monitoring/tests/record-event.unit.spec.js
@@ -27,14 +27,6 @@ describe('recordEvent', () => {
     expect(global.window.dataLayer).to.eql([e]);
   });
 
-  it('should not record events to the data layer if google_tag_manager is undefined', () => {
-    // eslint-disable-next-line camelcase
-    global.window.google_tag_manager = undefined;
-    const e = { event: 'foo-bar', contextualData: 'text' };
-    recordEvent(e);
-    expect(global.window.dataLayer).to.eql([]);
-  });
-
   it('should return the eventCallback in the event that google_tag_manager is undefiend', () => {
     // eslint-disable-next-line camelcase
     global.window.google_tag_manager = undefined;


### PR DESCRIPTION
## Description
We are seeing lower than expected success rates on authentication success events in Google analytics. I believe the issue may be related to a race condition caused by navigating away from va.gov before the event is finished processing.

This change implements the usage of the `eventCallback` provided by the event `dataLayer` which will allow us to ensure the event is resolved before navigation occurs.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38103


## Testing done
- Unit tests still pass

## Screenshots


## Acceptance criteria
- [x] No auth regressions were introduced
- [x] Auth redirects still occur as expected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
