### PR TITLE
37906 Preferred Provider information missing for CC request

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -171,6 +171,11 @@ export default function RequestedAppointmentDetailsPage() {
             <span>
               {provider.name ||
                 (provider.providerName || provider.practiceName)}
+              <br />
+              {provider.address?.line[0]}
+              <br />
+              {provider.address?.city}, {provider.address?.state}{' '}
+              {provider.address?.postalCode}
             </span>
           )}
           {!provider && <span>No provider selected</span>}

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -289,7 +289,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         name: 'Preferred community care provider',
       }),
     ).to.be.ok;
-    expect(screen.getByText('Atlantic Medical Care')).to.be.ok;
+    expect(screen.getByText(/Atlantic Medical Care/)).to.be.ok;
 
     expect(
       screen.getByRole('heading', {
@@ -809,7 +809,12 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
       id: '123',
       type: 'provider',
       attributes: {
-        address: {},
+        address: {
+          street: '123 Main Street',
+          city: 'Orlando',
+          state: 'FL',
+          zipCode: '32826',
+        },
         caresitePhone: null,
         name: 'Atlantic Medical Care',
         lat: null,
@@ -854,7 +859,9 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
         name: 'Preferred community care provider',
       }),
     ).to.be.ok;
-    expect(screen.getByText('Atlantic Medical Care')).to.be.ok;
+    expect(screen.getByText(/Atlantic Medical Care/)).to.be.ok;
+    expect(screen.getByText(/123 Main Street/)).to.be.ok;
+    expect(screen.getByText(/Orlando, FL 32826/)).to.be.ok;
 
     expect(
       screen.getByRole('heading', {


### PR DESCRIPTION
## Description
This PR adds the provider address information the CC request details page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37906


## Testing done
Unit testing

## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_appointments_requests_25958 (1)](https://user-images.githubusercontent.com/3587066/158446144-60ce9108-ada8-401e-b556-a2b5b0d7db97.png)

## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
