### PR TITLE
Turn on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,12 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     # Allow up to 10 open pull requests for npm dependencies
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 3
+    ignore:
+      # Ignore updates to packages that start with 'cypress'
+      # Wildcards match zero or more arbitrary characters
+      - dependency-name: "cypress*"
+      - dependency-name: "@testing-library/*"
+      # For all packages, ignore all patch updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description
Testing `dependabot` again. This time it will ignore all majors and testing related dependencies. Dependabot will only create up to 3 outstanding PRs at the time.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
