### PR TITLE
Fixed CT void caused by mobile fix

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -122,6 +122,7 @@ export function SearchPage({
                 </va-alert>
               </div>
             )}
+            {!error && !smallScreen && tabbedResults[tab]}
             {!error &&
               smallScreen && (
                 <div>


### PR DESCRIPTION
## Description
Comparison tool results don't show when in desktop mode only in mobile. A non-redundant was removed and interfered with other existing work to fix the mobile issue.

## Testing done
Local Testing

## Screenshots
<img width="1436" alt="Screen Shot 2022-03-15 at 2 23 58 PM" src="https://user-images.githubusercontent.com/86262790/158455591-34974513-dd9c-44b1-bc0a-4cc87c5402be.png">


## Acceptance criteria
- [x] This fixes the CT void issue on Desktop

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
