### PR TITLE
Hotfix remove facilities ccp call

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -19,7 +19,6 @@ import {
 import { getRequestMessages } from '../../services/var';
 
 import {
-  getCommunityProvider,
   getLocation,
   getLocations,
   getLocationSettings,
@@ -514,13 +513,14 @@ export function fetchRequestDetails(id) {
           captureError(e);
         }
       }
-      if (featureVAOSServiceRequests && request.practitioners?.length) {
-        request.preferredCommunityCareProviders = [
-          await getCommunityProvider(
-            request.practitioners[0].identifier[0].value,
-          ),
-        ];
-      }
+      // No longer need this facilities call, deprecated endpoint
+      // if (featureVAOSServiceRequests && request.practitioners?.length) {
+      //   request.preferredCommunityCareProviders = [
+      //     await getCommunityProvider(
+      //       request.practitioners[0].identifier[0].value,
+      //     ),
+      //   ];
+      // }
 
       dispatch({
         type: FETCH_REQUEST_DETAILS_SUCCEEDED,

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -513,14 +513,6 @@ export function fetchRequestDetails(id) {
           captureError(e);
         }
       }
-      // No longer need this facilities call, deprecated endpoint
-      // if (featureVAOSServiceRequests && request.practitioners?.length) {
-      //   request.preferredCommunityCareProviders = [
-      //     await getCommunityProvider(
-      //       request.practitioners[0].identifier[0].value,
-      //     ),
-      //   ];
-      // }
 
       dispatch({
         type: FETCH_REQUEST_DETAILS_SUCCEEDED,

--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -361,6 +361,7 @@ export async function getCommunityProvidersByTypeOfCare({
  * @returns {Object<Location>} A FHIR Location resources
  */
 
+// Possibly no longer needed - the facilities call isn't needed in cc appointments flow
 export async function getCommunityProvider(id) {
   try {
     const facility = await getCommunityCareFacility(id);

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -854,7 +854,6 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
         name: 'Preferred community care provider',
       }),
     ).to.be.ok;
-    // expect(screen.getByText('Atlantic Medical Care')).to.be.ok;
 
     expect(
       screen.getByRole('heading', {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -854,7 +854,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
         name: 'Preferred community care provider',
       }),
     ).to.be.ok;
-    expect(screen.getByText('Atlantic Medical Care')).to.be.ok;
+    // expect(screen.getByText('Atlantic Medical Care')).to.be.ok;
 
     expect(
       screen.getByRole('heading', {


### PR DESCRIPTION
## Description
This change is to remove a call to a deprecated endpoint in our cc appointments flow.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38607