### PR TITLE
workflow protection for manual runs

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -29,7 +29,7 @@ jobs:
         id: check-environment
         run: |
           if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
-            echo ::set-output name=env_name::'dev-test'
+            echo ::set-output name=env_name::'production'
           else
             echo ::set-output name=env_name::''
           fi

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -20,6 +20,19 @@ env:
   BUILD_ENV: vagovprod
 
 jobs:
+  get-workflow-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      environment_name: ${{ steps.check-environment.outputs.env_name }}
+    steps:
+      - name: Check environment
+        id: check-environment
+        run: |
+          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            echo ::set-output name=env_name::'dev-test'
+          else
+            echo ::set-output name=env_name::''
+          fi
   set-env:
     name: Set Env Variables
     runs-on: ubuntu-latest
@@ -238,7 +251,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: [set-env, create-release]
+    needs: [set-env, create-release, get-workflow-environment]
+    environment: ${{ needs.get-workflow-environment.outputs.environment_name }}
 
     env:
       DEPLOY_BUCKET: www.va.gov


### PR DESCRIPTION
## Description
The environment within github for now is named as "dev-test" and this can be changed based on:
> successful execution of this
> and the cleanup of environment task doesnt delete anything that is other than master

Manual trigger of the workflow at deploy step will trigger an approval to the vsp-frontend-team members
This was also tested here to make sure the scheduled jobs are not required to go through an approval.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37940


## Testing done
yes

## Screenshots


## Acceptance criteria
- [X]

## Definition of done
- [X] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
