### PR TITLE
NOD: Board & various updates

### DIFF
--- a/src/applications/appeals/10182/components/NeedsToVerify.jsx
+++ b/src/applications/appeals/10182/components/NeedsToVerify.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const NeedsToVerify = ({ pathname }) => (
+  <va-alert status="warning">
+    We want to keep your information safe with the highest level of security.
+    Please{' '}
+    <a href={`/verify?next=${pathname}`} className="verify-link">
+      verify your identity
+    </a>{' '}
+    to access this form.
+  </va-alert>
+);
+
+NeedsToVerify.propTypes = {
+  pathname: PropTypes.string,
+};
+
+export default NeedsToVerify;

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -20,7 +20,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
   // separate each number so the screenreader reads "number ending with 1 2 3 4"
   // instead of "number ending with 1,234"
   const mask = value => {
-    const number = value.slice(-4).toString();
+    const number = (value || '').toString().slice(-4);
     return srSubstitute(
       `●●●–●●–${number}`,
       `ending with ${number.split('').join(' ')}`,

--- a/src/applications/appeals/10182/content/FilingDeadlines.jsx
+++ b/src/applications/appeals/10182/content/FilingDeadlines.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export const FilingDeadlinesDescription = (
+// Needed for Introduction page
+export const filingDeadlineContent = (
   <>
-    <h3>Filing deadlines</h3>
     <p>
       You can submit this online form (VA Form 10182) to appeal a VA decision
       dated on or after February 19, 2019. The Board must receive your completed
@@ -15,7 +15,7 @@ export const FilingDeadlinesDescription = (
       your decision notice. A contested claim is when a favorable claim decision
       for one person results in denial or reduced benefits for another person.
     </p>
-    <p className="vads-u-margin-left--4">
+    <div className="vads-u-margin-left--4">
       <strong>If you have a Statement of the Case (SOC)</strong> or a{' '}
       <strong>
         Supplemental Statement of the Case (SSOC) from the old appeals system
@@ -32,7 +32,14 @@ export const FilingDeadlinesDescription = (
           jurisdiction
         </li>
       </ul>
-    </p>
+    </div>
+  </>
+);
+
+export const FilingDeadlinesDescription = (
+  <>
+    <h3>Filing deadlines</h3>
+    {filingDeadlineContent}
     <p>
       Please understand that by listing any issues currently pending in the old
       system, you are specifically opting those issues into the new decision

--- a/src/applications/appeals/10182/content/hearingType.js
+++ b/src/applications/appeals/10182/content/hearingType.js
@@ -9,7 +9,7 @@ export const hearingTypeContent = {
         You can attend your hearing on a computer, mobile phone, or tablet from
         a location you choose. You just need to be somewhere that has a Wi-Fi
         connection. Your accredited representative can be with you or in a
-        separate location. The Veterans Law Judge will be located in a separate
+        separate location. The Veterans Law Judge will be located in a separate
         location.
       </p>
     </>
@@ -17,15 +17,13 @@ export const hearingTypeContent = {
 
   video_conference: (
     <>
-      <strong>A video hearing at a VA regional office near you</strong>
+      <strong>
+        A Regional Office hearing at a VA Regional Office near you
+      </strong>
       <p className="hide-on-review">
         You and your accredited representative can attend your hearing by video
         at a VA regional office near you. The Veterans Law Judge will be located
         in a separate location.
-      </p>
-      <p className="hide-on-review">
-        <strong>Note:</strong> Fewer Veterans will be able to use this option
-        right now due to COVID-19 and social distancing.
       </p>
     </>
   ),
@@ -35,10 +33,6 @@ export const hearingTypeContent = {
       <strong>An in-person hearing at the Board in Washington, D.C.</strong>
       <p className="hide-on-review">
         You can attend an in-person hearing with a Veterans Law Judge.
-      </p>
-      <p className="hide-on-review">
-        <strong>Note:</strong> Fewer Veterans will be able to use this option
-        right now due to COVID-19 and social distancing.
       </p>
     </>
   ),

--- a/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
@@ -5,6 +5,11 @@ import { shallow } from 'enzyme';
 import { VeteranInformation } from '../../components/VeteranInformation';
 
 describe('<VeteranInformation>', () => {
+  it('should render with empty data', () => {
+    const wrapper = shallow(<VeteranInformation />);
+    expect(wrapper.find('.blue-bar-block').length).to.eq(1);
+    wrapper.unmount();
+  });
   it('should render', () => {
     const wrapper = shallow(<VeteranInformation />);
     expect(wrapper.find('.blue-bar-block').length).to.eq(1);

--- a/src/applications/appeals/10182/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/IntroductionPage.unit.spec.jsx
@@ -1,49 +1,39 @@
 import React from 'react';
-import moment from 'moment';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { VA_FORM_IDS } from 'platform/forms/constants';
 
-import IntroductionPage from '../../containers/IntroductionPage';
+import { IntroductionPage } from '../../containers/IntroductionPage';
+import manifest from '../../manifest.json';
 
-const defaultProps = {
-  user: {
-    profile: {
-      savedForms: [
-        {
-          form: VA_FORM_IDS.FORM_10182,
-          metadata: { lastUpdated: 3000, expiresAt: moment().unix() + 2000 },
-        },
-      ],
-    },
-  },
-  saveInProgress: {
-    user: {},
-  },
+const defaultProps = ({ isVerified = true } = {}) => ({
+  loggedIn: true,
+  isVerified,
   location: {
     pathname: '/introduction',
+    basename: manifest.rootUrl,
   },
-  saveInProgressActions: {},
   route: {
     formConfig: {
+      title: 'NOD',
       verifyRequiredPrefill: true,
       savedFormMessages: [],
     },
     pageList: [],
   },
-};
+});
 
 describe('IntroductionPage', () => {
   it('should render', () => {
-    const tree = shallow(<IntroductionPage {...defaultProps} />);
+    const tree = shallow(<IntroductionPage {...defaultProps()} />);
     const intro = tree.find('Connect(SaveInProgressIntro)');
     expect(intro).to.exist;
+    expect(tree.find('FormTitle').props().title).to.eq('NOD');
 
     tree.unmount();
   });
 
   it('should render SaveInProgressIntro', () => {
-    const tree = shallow(<IntroductionPage {...defaultProps} />);
+    const tree = shallow(<IntroductionPage {...defaultProps()} />);
     const saveInProgressIntro = tree.find(
       'withRouter(Connect(SaveInProgressIntro))',
     );
@@ -52,9 +42,25 @@ describe('IntroductionPage', () => {
     tree.unmount();
   });
 
+  it('should show verify your account alert', () => {
+    const props = defaultProps({ isVerified: false });
+    const tree = shallow(<IntroductionPage {...props} />);
+    const saveInProgressIntro = tree.find(
+      'withRouter(Connect(SaveInProgressIntro))',
+    );
+
+    const alertText = tree
+      .find('NeedsToVerify')
+      .first()
+      .html();
+    expect(saveInProgressIntro.length).to.eq(0);
+    expect(alertText).to.contain('/verify?');
+    tree.unmount();
+  });
+
   it('should render start button', () => {
     const props = {
-      ...defaultProps,
+      ...defaultProps(),
       contestableIssues: {
         issues: [{}],
         status: 'done',

--- a/src/applications/appeals/10182/utils/selectors.js
+++ b/src/applications/appeals/10182/utils/selectors.js
@@ -1,0 +1,3 @@
+import { selectProfile } from 'platform/user/selectors';
+
+export const makeSelectProfile = () => selectProfile;

--- a/src/applications/appeals/10182/utils/selectors.js
+++ b/src/applications/appeals/10182/utils/selectors.js
@@ -1,3 +1,0 @@
-import { selectProfile } from 'platform/user/selectors';
-
-export const makeSelectProfile = () => selectProfile;


### PR DESCRIPTION
## Description

- Applied a few Board recommendations:
  - Intro page, replace step 1 description with content from the filing deadlines page
  - Update hearing type name from "video hearing" to "Regional Office hearing"
- Prevent starting the form if the user isn't verified. If they are allowed to start the form, none of the prefills nor the contestable issues will load and display properly.
- Fixed a bug on the Veterans Information page causing a JS error if a SSN or VA file number isn't a string

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38578

## Testing done

Added & updated unit tests

## Screenshots

<details><summary>NOD Intro page changes</summary>

<!-- leave a blank line above -->

- User is not verified (LOA 1) so the alert includes a verify link
- Content under step 1 of the subway map is updated with new content

![NOD intro page](https://user-images.githubusercontent.com/136959/158681960-ad23d947-536f-4d32-8ee9-5e438f409cc2.png)</details>

<details><summary>Hearing type content updates</summary>

<!-- leave a blank line above -->
![video hearing renamed to regional office hearing](https://user-images.githubusercontent.com/136959/158681956-58f8c092-4225-4dd3-9ce8-33fe60e39f13.png)</details>

## Acceptance criteria
- [x] Board content updates have been applied
- [x] Prevent starting NOD if the Veteran is not verified
- [x] No JS error if the SSN or VA file number is not a string

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
