### PR TITLE
Generate Cypress code coverage report only in dispatched E2E workflow

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -40,7 +40,6 @@
   ],
   "plugins": [
     "lodash",
-    "istanbul",
     // Stage 2
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",

--- a/.babelrc
+++ b/.babelrc
@@ -38,9 +38,8 @@
      */
     "./src/platform/polyfills/preESModulesPolyfills.js"
   ],
-  "plugins": [
+  "plugins": ["istanbul",
     "lodash",
-    "istanbul",
     // Stage 2
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",
@@ -83,7 +82,7 @@
   "env": {
     "test": {
       "presets": ["@babel/env", "@babel/preset-react"],
-      "plugins": [
+      "plugins": ["istanbul",
         "transform-class-properties",
         "dynamic-import-node",
         "transform-react-remove-prop-types",
@@ -100,7 +99,7 @@
       ]
     },
     "production": {
-      "plugins": [
+      "plugins": ["istanbul",
         [
           "transform-react-remove-prop-types",
           {

--- a/.babelrc
+++ b/.babelrc
@@ -38,8 +38,9 @@
      */
     "./src/platform/polyfills/preESModulesPolyfills.js"
   ],
-  "plugins": ["istanbul",
+  "plugins": [
     "lodash",
+    "istanbul",
     // Stage 2
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",
@@ -82,7 +83,7 @@
   "env": {
     "test": {
       "presets": ["@babel/env", "@babel/preset-react"],
-      "plugins": ["istanbul",
+      "plugins": [
         "transform-class-properties",
         "dynamic-import-node",
         "transform-react-remove-prop-types",
@@ -99,7 +100,7 @@
       ]
     },
     "production": {
-      "plugins": ["istanbul",
+      "plugins": [
         [
           "transform-react-remove-prop-types",
           {

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -486,9 +486,6 @@ jobs:
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
 
-      - name: Instrument code
-        run: npx nyc instrument --compact=false src .nyc_output
-
       - name: Run Cypress tests
         run: node script/github-actions/run-cypress-tests.js
         timeout-minutes: 30
@@ -497,16 +494,6 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
           APP_URLS: ${{ needs.cypress-tests-prep.outputs.app_urls }}
-
-      - name: View code coverage summary
-        run: npx nyc report --reporter=text-summary
-
-      - name: Create coverage artifact
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: code-coverage-artifacts
-          path: coverage/coverage-summary.json
 
       - name: Archive test videos
         uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Run the full E2E test suite on a specific commit
-        required: true
-  workflow_run:
-    workflows: [Continuous Integration]
-    types: [completed]
-    branches: [master]
+on: [push]
+  # workflow_dispatch:
+  #   inputs:
+  #     commit_sha:
+  #       description: Run the full E2E test suite on a specific commit
+  #       required: true
+  # workflow_run:
+  #   workflows: [Continuous Integration]
+  #   types: [completed]
+  #   branches: [master]
 
 env:
   NUM_CONTAINERS: '8'
@@ -88,6 +88,9 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+
+      - name: Add istanbul for Cypress code coverage reporting
+        run: sed -i -e 's/"plugins": \[/"plugins": \["istanbul",/g' .babelrc
           
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}
@@ -193,14 +196,28 @@ jobs:
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype=${{ env.BUILDTYPE }} --port=3001 &
 
+      - name: Instrument code
+        run: npx nyc instrument --compact=false src .nyc_output
+
       - name: Run Cypress tests
         run: node script/github-actions/run-cypress-tests.js
         timeout-minutes: 30
         env:
           CYPRESS_CI: true
+          CYPRESS_CODE_COVERAGE: true
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
           APP_URLS: ''
+
+      - name: View code coverage summary
+        run: npx nyc report --reporter=text-summary
+
+      - name: Create coverage artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: code-coverage-artifacts
+          path: coverage/coverage-summary.json
 
       - name: Archive test videos
         uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on: [push]
-  # workflow_dispatch:
-  #   inputs:
-  #     commit_sha:
-  #       description: Run the full E2E test suite on a specific commit
-  #       required: true
-  # workflow_run:
-  #   workflows: [Continuous Integration]
-  #   types: [completed]
-  #   branches: [master]
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Run the full E2E test suite on a specific commit
+        required: true
+  workflow_run:
+    workflows: [Continuous Integration]
+    types: [completed]
+    branches: [master]
 
 env:
   NUM_CONTAINERS: '8'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,7 +90,7 @@ jobs:
             node_modules
 
       - name: Add istanbul for Cypress code coverage reporting
-        run: sed -i -e 's/"plugins": \[/"plugins": \["istanbul",/g' .babelrc
+        run: sed -i -e 's/\"plugins\": \[/\"plugins\": \[\"istanbul\",/g' .babelrc
           
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Run the full E2E test suite on a specific commit
-        required: true
-  workflow_run:
-    workflows: [Continuous Integration]
-    types: [completed]
-    branches: [master]
+on: [push]
+  # workflow_dispatch:
+  #   inputs:
+  #     commit_sha:
+  #       description: Run the full E2E test suite on a specific commit
+  #       required: true
+  # workflow_run:
+  #   workflows: [Continuous Integration]
+  #   types: [completed]
+  #   branches: [master]
 
 env:
   NUM_CONTAINERS: '8'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -205,7 +205,7 @@ jobs:
         timeout-minutes: 30
         env:
           CYPRESS_CI: true
-          CYPRESS_CODE_COVERAGE: true
+          CODE_COVERAGE: true
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
           APP_URLS: ''

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,7 +90,8 @@ jobs:
             node_modules
 
       - name: Add istanbul for Cypress code coverage reporting
-        run: sed -i -e 's/\"plugins\": \[/\"plugins\": \[\"istanbul\",/g' .babelrc
+        run: | 
+          sed -i -e 's/\"plugins\": \[/\"plugins\": \[\"istanbul\",/g' .babelrc
           
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -12,8 +12,10 @@ const tableConfig = {
 };
 
 module.exports = async (on, config) => {
-  require('@cypress/code-coverage/task')(on, config);
-  on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
+  if (Cypress.env('CODE_COVERAGE') === true) {
+    require('@cypress/code-coverage/task')(on, config);
+    on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
+  }
 
   let appRegistry;
   if (fs.existsSync('../content-build/src/applications/registry.json')) {

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -12,7 +12,7 @@ const tableConfig = {
 };
 
 module.exports = async (on, config) => {
-  if (process.env.CODE_COVERAGE === true) {
+  if (process.env.CODE_COVERAGE === 'true') {
     require('@cypress/code-coverage/task')(on, config);
     on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
   }

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -12,7 +12,7 @@ const tableConfig = {
 };
 
 module.exports = async (on, config) => {
-  if (Cypress.env('CODE_COVERAGE') === true) {
+  if (process.env.CODE_COVERAGE === true) {
     require('@cypress/code-coverage/task')(on, config);
     on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
   }


### PR DESCRIPTION
## Description
This PR modifies the Cypress code coverage configuration so that code coverage reports are generated only in the `E2E Tests` workflow. Including code coverage in the CI workflow was slowing down CI by several minutes.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38674

## Testing done
* Ran E2E Tests worflow successfully with code coverage
* Ran CI successfully without code coverage

## Acceptance criteria
- [x] CI passes.