### PR TITLE
HLR: Require LOA 3 status to start form

### DIFF
--- a/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
+++ b/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const NeedsToVerify = ({ pathname }) => (
+  <va-alert status="warning">
+    We want to keep your information safe with the highest level of security.
+    Please{' '}
+    <a href={`/verify?next=${pathname}`} className="verify-link">
+      verify your identity
+    </a>{' '}
+    to access this form.
+  </va-alert>
+);
+
+NeedsToVerify.propTypes = {
+  pathname: PropTypes.string,
+};
+
+export default NeedsToVerify;

--- a/src/applications/disability-benefits/996/components/VeteranInformation.jsx
+++ b/src/applications/disability-benefits/996/components/VeteranInformation.jsx
@@ -12,7 +12,7 @@ import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-str
 // separate each number so the screenreader reads "number ending with 1 2 3 4"
 // instead of "number ending with 1,234"
 const mask = value => {
-  const number = value.slice(-4).toString();
+  const number = (value || '').toString().slice(-4);
   return srSubstitute(
     `●●●–●●–${number}`,
     `ending with ${number.split('').join(' ')}`,
@@ -24,6 +24,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
   const { dob, gender, userFullName = {} } = profile;
 
   const { first, middle, last, suffix } = userFullName;
+  const momentDob = moment(dob || null); // called with undefined = today's date
 
   return (
     <>
@@ -32,27 +33,22 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
       <div className="blue-bar-block">
         <strong className="name">
           {`${first || ''} ${middle || ''} ${last || ''}`}
-          {suffix && `, ${suffix}`}
+          {suffix ? `, ${suffix}` : null}
         </strong>
-        {ssnLastFour && (
-          <p className="ssn">
-            Social Security number: {mask(ssnLastFour.slice(-4))}
-          </p>
-        )}
-        {vaFileLastFour && (
-          <p className="vafn">
-            VA file number: {mask(vaFileLastFour.slice(-4))}
-          </p>
-        )}
+        {ssnLastFour ? (
+          <p className="ssn">Social Security number: {mask(ssnLastFour)}</p>
+        ) : null}
+        {vaFileLastFour ? (
+          <p className="vafn">VA file number: {mask(vaFileLastFour)}</p>
+        ) : null}
         <p>
           Date of birth:{' '}
-          <span className="dob">{dob ? moment(dob).format('LL') : ''}</span>
+          {momentDob.isValid() ? (
+            <span className="dob">{momentDob.format('LL')}</span>
+          ) : null}
         </p>
         <p>
-          Gender:{' '}
-          <span className="gender">
-            {(gender && genderLabels[gender]) || ''}
-          </span>
+          Gender: <span className="gender">{genderLabels?.[gender] || ''}</span>
         </p>
       </div>
       <br />

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -30,6 +30,7 @@ import {
   showContestableIssueError,
   showHasEmptyAddress,
 } from '../content/contestableIssueAlerts';
+import NeedsToVerify from '../components/NeedsToVerify';
 
 export class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -40,11 +41,17 @@ export class IntroductionPage extends React.Component {
   getCallToActionContent = ({ last } = {}) => {
     const {
       loggedIn,
+      isVerified,
       route,
       contestableIssues,
       delay = 250,
       hlrV2,
+      location,
     } = this.props;
+
+    if (loggedIn && !isVerified) {
+      return <NeedsToVerify pathname={location.basename} />;
+    }
 
     if (contestableIssues?.error) {
       return showContestableIssueError(contestableIssues, delay);
@@ -238,6 +245,10 @@ IntroductionPage.propTypes = {
   delay: PropTypes.number,
   hasEmptyAddress: PropTypes.bool,
   hlrV2: PropTypes.bool,
+  isVerified: PropTypes.bool,
+  location: PropTypes.shape({
+    basename: PropTypes.string,
+  }),
   loggedIn: PropTypes.bool,
   route: PropTypes.shape({
     formConfig: PropTypes.shape({
@@ -252,10 +263,12 @@ IntroductionPage.propTypes = {
 
 function mapStateToProps(state) {
   const { form, contestableIssues } = state;
+  const profile = selectProfile(state);
   return {
     form,
     loggedIn: isLoggedIn(state),
-    savedForms: selectProfile(state).savedForms,
+    savedForms: profile.savedForms,
+    isVerified: profile.verified,
     contestableIssues,
     hasEmptyAddress: isEmptyAddress(
       selectVAPContactInfoField(state, FIELD_NAMES.MAILING_ADDRESS),

--- a/src/applications/disability-benefits/996/tests/components/veteranInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/veteranInformation.unit.spec.jsx
@@ -5,6 +5,11 @@ import { shallow } from 'enzyme';
 import { VeteranInformation } from '../../components/VeteranInformation';
 
 describe('<VeteranInformation>', () => {
+  it('should render with empty data', () => {
+    const wrapper = shallow(<VeteranInformation />);
+    expect(wrapper.find('.blue-bar-block').length).to.eq(1);
+    wrapper.unmount();
+  });
   it('should render', () => {
     const wrapper = shallow(<VeteranInformation />);
     expect(wrapper.find('.blue-bar-block').length).to.eq(1);

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -14,6 +14,7 @@ import { setHlrWizardStatus, removeHlrWizardStatus } from '../../wizard/utils';
 const defaultProps = {
   getContestableIssues: () => {},
   allowHlr: true,
+  isVerified: true,
   user: {
     profile: {
       // need to have a saved form or else form will redirect to v2
@@ -135,6 +136,22 @@ describe('IntroductionPage', () => {
     expect(recordedEvent['alert-box-heading']).to.include(errorMessage);
     tree.unmount();
   });
+  it('should show verify your account alert', () => {
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
+    const props = {
+      ...defaultProps,
+      isVerified: false,
+      loggedIn: true,
+    };
+    const tree = shallow(<IntroductionPage {...props} />);
+    const verifyAlert = tree
+      .find('NeedsToVerify')
+      .first()
+      .html();
+    expect(verifyAlert).to.contain('/verify?');
+    tree.unmount();
+  });
+
   it('should render start button', () => {
     setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const props = {


### PR DESCRIPTION
## Description

When a Veteran starts the Higher-Level Review form and isn't verified (LOA 3), the prefill and contestable issues do not properly load and won't be displayed. To prevent this problem, we're preventing all non-LOA 3 Veterans from starting the form.

Also modified code to prevent JS error when the Veteran information page passes a SSN or VA file number that isn't a string.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38668

## Testing done

Added & updated unit tests

## Screenshots

![HLR intro page with verify your identity alert](https://user-images.githubusercontent.com/136959/158694991-04115942-0e7b-4598-b4df-692fced954a2.png)

## Acceptance criteria
- [x] Require LOA 3 to start HLR form, show verify link
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
