### PR TITLE
Added check incase reasonCode coding element does not exist and is displaying undefined in appointment detail

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -133,9 +133,10 @@ export default function RequestedAppointmentDetailsPage() {
     appointment.vaos.appointmentType === APPOINTMENT_TYPES.ccRequest;
   const provider = appointment.preferredCommunityCareProviders?.[0];
   const comment = message || appointment.comment;
-  const apptDetails = comment
-    ? `${appointment.reason}: ${comment}`
-    : appointment.reason;
+  const apptDetails =
+    appointment.reason && comment
+      ? `${appointment.reason}: ${comment}`
+      : comment || (appointment.reason ? appointment.reason : null);
 
   return (
     <PageLayout>


### PR DESCRIPTION
## Description
Addressed the issue where the appointment information was not returning the reasonCode -> coding element. The details page will no longer display undefined when the reasonCode -> coding element is missing.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#37757


## Testing done
verified that undefined is not displayed when the reasonCode -> coding element is missing.

## Screenshots


## Acceptance criteria
- [x] undefined is not displayed in the appointment detail page when the reasonCode -> coding element is not returned by the VAOS Service

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
