### PR TITLE
NOD: Remove unneccessary additional info

### DIFF
--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -68,19 +68,6 @@ export class IntroductionPage extends React.Component {
         >
           Follow these steps to request a Board Appeal
         </h2>
-        <va-additional-info trigger="Find out about opting in if you have an older claim">
-          <p>
-            If you’re requesting a Board Appeal on an issue in a claim we
-            decided before February 19, 2019, you’ll need to opt in to the new
-            decision review process. To do this, you’ll check a box at a certain
-            place in the form. This will move your issue from the old appeals
-            process to the new decision review process.
-          </p>
-          <p className="vads-u-margin-bottom--0">
-            Our new decision review process is part of the Appeals Modernization
-            Act. When you opt in, you’re likely to get a faster decision.
-          </p>
-        </va-additional-info>
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">


### PR DESCRIPTION
## Description

After the recent updates to the Notice of Disagreement introduction page, the included additional info block includes now incorrect content (the checkbox was removed).

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/38578

## Testing done

Unit tests passing

## Screenshots
![Expanded additional info with incorrect content](https://user-images.githubusercontent.com/136959/158812429-97232726-3ee4-45b8-b4d8-65112faf704b.png)
![Additional info block removed after the h2 of the subway map](https://user-images.githubusercontent.com/136959/158812433-3a8363dd-517e-4832-96cd-9c2639d86d84.png)

## Acceptance criteria
- [x] Additional info removed
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
