### PR TITLE
Revert to component-library version to 7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.17.7",
-    "@department-of-veterans-affairs/component-library": "^7.4.2",
+    "@department-of-veterans-affairs/component-library": "^7.4.1",
     "@department-of-veterans-affairs/formation": "7.0.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,7 +2671,7 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^7.4.2":
+"@department-of-veterans-affairs/component-library@^7.4.1":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-7.4.2.tgz#41d0e8f4372d5be7e8976e64648eca848b3ef617"
   integrity sha512-DxnsPOqXpzKQ7GNSXRJNn4PaBntoDD/7aTo2RjXwR4yCLzwaHKDpkbWSJ8uoMJzcbhNQ7HJjrF5zQFgoLoqyLA==


### PR DESCRIPTION
## Description
This PR reverts component-library dependency version to 7.4.1.

`va-accordion` is possibly being misused and it's affecting how it's displayed.

## Original issue(s)


## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/36863582/158814183-0958a4b2-2fe4-4bc4-b154-97fd893848d0.png)


## Acceptance criteria
- [x] Revert component-library dependency version to 7.4.1

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
