### PR TITLE
38691: Initial Sign-In Service Logic

### DIFF
--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -9,6 +9,9 @@ export const API_VERSION = 'v1';
 export const API_SESSION_URL = ({ version = API_VERSION, type = null }) =>
   `${environment.API_URL}/${version}/sessions/${type}/new`;
 
+export const API_SIGN_IN_SERVICE_URL = ({ type = null }) =>
+  `${environment.API_URL}/sign_in/${type}/authorize`;
+
 export const AUTH_EVENTS = {
   MODAL_LOGIN: 'login-link-clicked-modal',
   LOGIN: 'login-link-clicked',
@@ -53,6 +56,23 @@ export const EXTERNAL_APPS = {
   VA_FLAGSHIP_MOBILE: 'vamobile',
   VA_OCC_MOBILE: 'vaoccmobile',
 };
+
+export const MOBILE_APPS = [
+  EXTERNAL_APPS.VA_OCC_MOBILE,
+  EXTERNAL_APPS.VA_FLAGSHIP_MOBILE,
+];
+
+export const OAUTH_ENABLED_APPS = [
+  EXTERNAL_APPS.VA_OCC_MOBILE,
+  EXTERNAL_APPS.VA_FLAGSHIP_MOBILE,
+];
+
+export const OAUTH_ENABLED_POLICIES = [
+  CSP_IDS.MHV,
+  CSP_IDS.DS_LOGON,
+  CSP_IDS.LOGIN_GOV,
+  CSP_IDS.ID_ME,
+];
 
 export const EBenefitsDefaultPath = '/profilepostauth';
 
@@ -130,4 +150,13 @@ export const ACCOUNT_TRANSITION_DISMISSED = 'accountTransitionDismissed';
 export const LINK_TYPES = {
   CREATE: 'create',
   SIGNIN: 'signin',
+};
+
+// Keep these KEYS camel case for ease of destructuring
+export const AUTH_PARAMS = {
+  application: 'application',
+  OAuth: 'oauth',
+  codeChallenge: 'code_challenge',
+  codeChallengeMethod: 'code_challenge_method',
+  to: 'to',
 };

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -35,7 +35,8 @@ export const getQueryParams = () => {
   const paramsObj = {};
 
   Object.keys(AUTH_PARAMS).forEach(paramKey => {
-    paramsObj[paramKey] = searchParams.get(AUTH_PARAMS[paramKey]);
+    const paramValue = searchParams.get(AUTH_PARAMS[paramKey]);
+    if (paramValue) paramsObj[paramKey] = paramValue;
   });
 
   return paramsObj;

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -17,6 +17,11 @@ import {
   API_SESSION_URL,
   GA_CLIENT_ID_KEY,
   EBenefitsDefaultPath,
+  API_SIGN_IN_SERVICE_URL,
+  AUTH_PARAMS,
+  MOBILE_APPS,
+  OAUTH_ENABLED_APPS,
+  OAUTH_ENABLED_POLICIES,
 } from './constants';
 import recordEvent from '../../monitoring/record-event';
 
@@ -27,10 +32,13 @@ export const loginAppUrlRE = new RegExp('^/sign-in(/.*)?$');
 
 export const getQueryParams = () => {
   const searchParams = new URLSearchParams(window.location.search);
-  const application = searchParams.get('application');
-  const to = searchParams.get('to');
+  const paramsObj = {};
 
-  return { application, to };
+  Object.keys(AUTH_PARAMS).forEach(paramKey => {
+    paramsObj[paramKey] = searchParams.get(AUTH_PARAMS[paramKey]);
+  });
+
+  return paramsObj;
 };
 
 export const isExternalRedirect = () => {
@@ -106,26 +114,36 @@ export function sessionTypeUrl({
   if (!type) {
     return null;
   }
+
+  // application is fetched from location, not the passed through queryParams arg
+  const {
+    application,
+    OAuth,
+    codeChallenge,
+    codeChallengeMethod,
+  } = getQueryParams();
+
   const externalRedirect = isExternalRedirect();
-  const verifiedOnlyApps = [
-    EXTERNAL_APPS.VA_OCC_MOBILE,
-    EXTERNAL_APPS.VA_FLAGSHIP_MOBILE,
-  ];
+  const isMobileApplication = MOBILE_APPS.includes(application);
   const isSignup = Object.values(SIGNUP_TYPES).includes(type);
   const isLogin = Object.values(CSP_IDS).includes(type);
   const appendParams = {};
 
-  // application is fetched from location, not the passed through queryParams arg
-  const { application } = getQueryParams();
+  // We should use OAuth when the following are true:
+  // OAuth param is true
+  // Application has OAuth enabled
+  // The policy type has OAuth enabled
+  const useOAuth =
+    OAuth === 'true' &&
+    OAUTH_ENABLED_APPS.includes(application) &&
+    OAUTH_ENABLED_POLICIES.includes(type);
 
   // Only require verification when all of the following are true:
   // 1. On the USiP (Unified Sign In Page)
   // 2. The outbound application is one of the mobile apps
   // 3. The generated link type is for signup, and login only
   const requireVerification =
-    externalRedirect &&
-    (isLogin || isSignup) &&
-    verifiedOnlyApps.includes(application)
+    externalRedirect && (isLogin || isSignup) && isMobileApplication
       ? '_verified'
       : '';
 
@@ -137,8 +155,16 @@ export function sessionTypeUrl({
     appendParams.postLogin = true;
   }
 
+  // Append extra params for mobile sign in service authentication
+  if (useOAuth) {
+    appendParams[AUTH_PARAMS.codeChallenge] = codeChallenge;
+    appendParams[AUTH_PARAMS.codeChallengeMethod] = codeChallengeMethod;
+  }
+
   return appendQuery(
-    API_SESSION_URL({ version, type: `${type}${requireVerification}` }),
+    useOAuth
+      ? API_SIGN_IN_SERVICE_URL({ type })
+      : API_SESSION_URL({ version, type: `${type}${requireVerification}` }),
     { ...queryParams, ...appendParams },
   );
 }

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -90,7 +90,7 @@ describe('Authentication Utilities', () => {
     const application = 'application';
     const to = 'to';
 
-    it('should return application and to params when present', () => {
+    it('should return any AUTH_PARAMS params when present', () => {
       setup({ path: usipPathWithParams(mhvUsipParams) });
       const searchParams = new URLSearchParams(global.window.location.search);
       expect(authUtilities.getQueryParams()).to.deep.equal({
@@ -99,7 +99,7 @@ describe('Authentication Utilities', () => {
       });
     });
 
-    it('should not return params other than application and to', () => {
+    it('should not return params other than defined AUTH_PARAMS', () => {
       setup({ path: usipPathWithParams(`${mhvUsipParams}&useless=useless`) });
       const searchParams = new URLSearchParams(global.window.location.search);
       expect(authUtilities.getQueryParams()).to.deep.equal({
@@ -108,12 +108,9 @@ describe('Authentication Utilities', () => {
       });
     });
 
-    it('should return null for application and to params when not present', () => {
+    it('should return empty object when no valid AUTH_PARAMS are found', () => {
       setup({ path: usipPath });
-      expect(authUtilities.getQueryParams()).to.deep.equal({
-        [application]: null,
-        [to]: null,
-      });
+      expect(authUtilities.getQueryParams()).to.deep.equal({});
     });
   });
 


### PR DESCRIPTION
## Description
Adds the initial sign-in service logic that will send authentication attempts to a new endpoint when the following conditions are true:
- `?oauth=true`
- `?application=value` is included in the list of OAuth enabled applications
- Auth action is included in the list of OAuth enabled actions (currently on login)

Currently, as this is only being enabled for mobile app authentication, there is an additional requirement that we pass through the `code_challenge and code_challenge_method` params to the sign-in service endpoint.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38691


## Testing done
## Screenshots

https://user-images.githubusercontent.com/13320944/158838814-f8f5af6d-4d98-4ee0-9a2b-83f362797644.mov



## Acceptance criteria
- [x] Login attempts are directed to the new sign-in service endpoint when necessary
- [x] For mobile app authentication, we must pass through the following params: `code_challenge, code_challenge_method`
- [x] All other conditions result in original logic and send users to the v1 sessions endpoint

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
