### PR TITLE
Add instanbul back into the test environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -83,6 +83,7 @@
     "test": {
       "presets": ["@babel/env", "@babel/preset-react"],
       "plugins": [
+        "istanbul",
         "transform-class-properties",
         "dynamic-import-node",
         "transform-react-remove-prop-types",


### PR DESCRIPTION
## Description
This PR fixes the Unit test coverage report not generating correctly. This can be added back here, since Instanbul is dynamically added when the Cypress coverage report is generated in the [E2E workflow](https://github.com/department-of-veterans-affairs/vets-website/pull/20582/files#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3R94).

## Acceptance criteria
- [x] Unit test coverage should be generated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
