### PR TITLE
[COE] Fix issue with 'Print this page' button on Confirmation page

### DIFF
--- a/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
@@ -9,7 +9,7 @@ import { focusElement } from 'platform/utilities/ui';
 
 import { MoreQuestions } from '../../status/components/MoreQuestions';
 
-const printPage = () => window.print;
+const printPage = () => window.print();
 
 const statusUrl = getAppUrl('coe-status');
 


### PR DESCRIPTION
## Description
The `Print this page` button on the Confirmation page doesn't do anything currently. This PR fixes this issue so that clicking `Print this page` brings up the browsers print dialogue

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38706

## Acceptance criteria
- [x] Clicking `Print this page` brings up the browsers print dialogue

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
