### PR TITLE
[COE] Status app shows loading spinner indefinitely

### DIFF
--- a/src/applications/lgy/coe/shared/constants.js
+++ b/src/applications/lgy/coe/shared/constants.js
@@ -1,5 +1,3 @@
-export const COE_FORM_NUMBER = '26-1880';
-
 export const CALLSTATUS = {
   pending: 'pending',
   success: 'success',

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -8,11 +8,7 @@ import backendServices from 'platform/user/profile/constants/backendServices';
 import { isLoggedIn } from 'platform/user/selectors';
 
 import { generateCoe } from '../../shared/actions';
-import {
-  CALLSTATUS,
-  COE_FORM_NUMBER,
-  COE_ELIGIBILITY_STATUS,
-} from '../../shared/constants';
+import { CALLSTATUS, COE_ELIGIBILITY_STATUS } from '../../shared/constants';
 import {
   Available,
   Denied,
@@ -29,7 +25,6 @@ const App = ({
     profileIsUpdating,
   },
   getCoe,
-  hasSavedForm,
   loggedIn,
   user,
 }) => {
@@ -42,11 +37,11 @@ const App = ({
 
   useEffect(
     () => {
-      if (!profileIsUpdating && loggedIn && !hasSavedForm && !coe) {
+      if (!profileIsUpdating && loggedIn && !coe) {
         getCoe();
       }
     },
-    [coe, getCoe, hasSavedForm, loggedIn, profileIsUpdating],
+    [coe, getCoe, loggedIn, profileIsUpdating],
   );
 
   let content;
@@ -126,9 +121,6 @@ const mapStateToProps = state => ({
   certificateOfEligibility: state.certificateOfEligibility,
   user: state.user,
   loggedIn: isLoggedIn(state),
-  hasSavedForm: state?.user?.profile?.savedForms.some(
-    form => form.form === COE_FORM_NUMBER,
-  ),
 });
 
 const mapDispatchToProps = {
@@ -138,7 +130,6 @@ const mapDispatchToProps = {
 App.propTypes = {
   certificateOfEligibility: PropTypes.object,
   getCoe: PropTypes.func,
-  hasSavedForm: PropTypes.bool,
   loggedIn: PropTypes.bool,
   user: PropTypes.object,
 };


### PR DESCRIPTION
## Description
Currently the status app for COE displays a loading spinner indefinitely if the veteran has a COE form in progress. This PR removes that behavior.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38298

## Acceptance criteria
- [x] Loading spinner no longer shows indefinitely when veteran has in progress COE form

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
