### PR TITLE
Updated skip time from 3 days to 7 days.

### DIFF
--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -49,7 +49,7 @@ const updateFormPages = (
       : null;
     if (
       pageLastUpdated &&
-      isWithInDays(3, pageLastUpdated) &&
+      isWithInDays(7, pageLastUpdated) &&
       page.needsUpdate === false
     ) {
       skippedPages.push(page.url);

--- a/src/applications/check-in/utils/navigation/navigation.unit.spec.js
+++ b/src/applications/check-in/utils/navigation/navigation.unit.spec.js
@@ -108,8 +108,8 @@ describe('Global check in', () => {
         );
         expect(form.find(page => page === URLS.DEMOGRAPHICS)).to.exist;
       });
-      it('should skip a page that has been updated more than 72 hours ago but within three calendar days', () => {
-        MockDate.set('2022-01-04T14:00:00.000-05:00');
+      it('should skip a page that has been updated more than 168 hours ago but within seven calendar days', () => {
+        MockDate.set('2022-01-08T14:00:00.000-05:00');
         const patientDemographicsStatus = {
           demographicsNeedsUpdate: true,
           demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
@@ -127,8 +127,8 @@ describe('Global check in', () => {
         expect(form.find(page => page === URLS.EMERGENCY_CONTACT)).to.be
           .undefined;
       });
-      it('should skip a page that has been updated less than 72 hours ago', () => {
-        MockDate.set('2022-01-04T06:00:00.000-05:00');
+      it('should skip a page that has been updated less than 168 hours ago', () => {
+        MockDate.set('2022-01-08T06:00:00.000-05:00');
         const patientDemographicsStatus = {
           demographicsNeedsUpdate: true,
           demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',


### PR DESCRIPTION
## Description
Updates days to skip demographics confirmation screens from 3 days to 7 days.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38721


## Testing done
Updated unit tests

