### PR TITLE
Add cross-domain redirect for request #38579

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1221,5 +1221,10 @@
     "domain": "www.beckley.va.gov",
     "src": "/locations/princeton_vet_center.asp",
     "dest": "/princeton-vet-center/"
+  },
+  {
+    "domain": "www.fayettevillenc.va.gov",
+    "src": "/locations/FayettevilleVetCenter.asp",
+    "dest": "/fayetteville-nc-vet-center/"
   }
 ]


### PR DESCRIPTION
## Description
The PR add a cross domain redirect for the Fayetteville vet center. The redirect is as follows:

Current URL  |  Redirect to
---  |  ---
www.fayettevillenc.va.gov/locations/FayettevilleVetCenter.asp | www.va.gov/fayetteville-nc-vet-center/

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38579

## Acceptance criteria
- [x] Adds successful redirect

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
