### PR TITLE
Letters: a11y & design fixes

### DIFF
--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -28,8 +28,8 @@ function ClaimsDecision({ completedDate }) {
       <p>If you agree with your rating, you don’t need to do anything else.</p>
       <p>
         If we decided that an issue you claimed wasn’t service connected, and
-        you have new evidence that you haven’t submitted yet, you can ask VA
-        to reopen your claim.{' '}
+        you have new evidence that you haven’t submitted yet, you can ask VA to
+        reopen your claim.{' '}
         <a href="/disability/how-to-file-claim/when-to-file/" target="_blank">
           Find out how to reopen your claim
         </a>

--- a/src/applications/letters/components/NoAddressBanner.jsx
+++ b/src/applications/letters/components/NoAddressBanner.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
 const noAddressBanner = (
-  <va-alert status="warning" className="vads-u-margin-bottom--4">
-    <h3 slot="headline">We don’t have a valid address on file for you</h3>
-    <div>
-      You’ll need to <a href="/profile">update your address</a> before you can
-      view and download your VA letters or documents.
-    </div>
-  </va-alert>
+  <>
+    <va-alert status="warning" className="vads-u-margin-bottom--4">
+      <h3 slot="headline">We don’t have a valid address on file for you</h3>
+      <div>
+        You’ll need to <a href="/profile">update your address</a> before you can
+        view and download your VA letters or documents.
+      </div>
+    </va-alert>
+    <p />
+  </>
 );
 
 export default noAddressBanner;

--- a/src/applications/letters/components/systemDownMessage.jsx
+++ b/src/applications/letters/components/systemDownMessage.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const systemDownMessage = (
+  <va-alert status="warning">
+    <h3 slot="headline">
+      We’re sorry. Our system is temporarily down while we fix a few things.
+    </h3>
+    <p>Please try again later.</p>
+    <p>
+      <a href="/">Go back to VA.gov</a>
+    </p>
+  </va-alert>
+);
+
+export default systemDownMessage;

--- a/src/applications/letters/components/systemDownMessage.jsx
+++ b/src/applications/letters/components/systemDownMessage.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 
 const systemDownMessage = (
-  <va-alert status="warning">
-    <h3 slot="headline">
-      We’re sorry. Our system is temporarily down while we fix a few things.
-    </h3>
-    <p>Please try again later.</p>
-    <p>
-      <a href="/">Go back to VA.gov</a>
-    </p>
-  </va-alert>
+  <>
+    <va-alert status="warning">
+      <h3 slot="headline">
+        We’re sorry. Our system is temporarily down while we fix a few things.
+      </h3>
+      <p>Please try again later.</p>
+      <p>
+        <a href="/">Go back to VA.gov</a>
+      </p>
+    </va-alert>
+    <p />
+  </>
 );
 
 export default systemDownMessage;

--- a/src/applications/letters/components/systemDownMessage.jsx
+++ b/src/applications/letters/components/systemDownMessage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const systemDownMessage = (
   <>
-    <va-alert status="warning">
+    <va-alert id="systemDownMessage" status="warning">
       <h3 slot="headline">
         We’re sorry. Our system is temporarily down while we fix a few things.
       </h3>

--- a/src/applications/letters/containers/DownloadLetters.jsx
+++ b/src/applications/letters/containers/DownloadLetters.jsx
@@ -4,7 +4,7 @@ import findIndex from 'lodash/findIndex';
 
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 
-import { chapters } from '../routes';
+import { chapters } from '../utils/chapters';
 
 export function DownloadLetters({ children, location }) {
   const currentPageIndex = findIndex(chapters, ['path', location.pathname]);

--- a/src/applications/letters/containers/LettersApp.jsx
+++ b/src/applications/letters/containers/LettersApp.jsx
@@ -22,6 +22,7 @@ export class AppContent extends React.Component {
       this.state = { errorLogged: false };
     }
   }
+
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     // only log isDataAvailable error if one isn't already logged
@@ -37,11 +38,15 @@ export class AppContent extends React.Component {
 
     if (unregistered) {
       view = (
-        <h4>
-          We weren’t able to find information about your VA letters. If you
-          think you should be able to access this information, please{' '}
-          <CallVBACenter />
-        </h4>
+        <>
+          <h1>VA letters and documents</h1>
+          <va-alert status="error">
+            We weren’t able to find information about your VA letters. If you
+            think you should be able to access this information, please{' '}
+            <CallVBACenter />
+          </va-alert>
+          <p className="vads-u-margin-bottom--4" />
+        </>
       );
     } else {
       view = this.props.children;

--- a/src/applications/letters/containers/LettersApp.jsx
+++ b/src/applications/letters/containers/LettersApp.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as Sentry from '@sentry/browser';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
@@ -33,12 +34,9 @@ export class AppContent extends React.Component {
   }
 
   render() {
-    const unregistered = this.props.isDataAvailable === false;
-    let view;
-
-    if (unregistered) {
-      view = (
-        <>
+    if (this.props.isDataAvailable === false) {
+      return (
+        <div className="usa-grid">
           <h1>VA letters and documents</h1>
           <va-alert status="error">
             We weren’t able to find information about your VA letters. If you
@@ -46,13 +44,11 @@ export class AppContent extends React.Component {
             <CallVBACenter />
           </va-alert>
           <p className="vads-u-margin-bottom--4" />
-        </>
+        </div>
       );
-    } else {
-      view = this.props.children;
     }
 
-    return <div className="usa-grid">{view}</div>;
+    return <div className="usa-grid">{this.props.children}</div>;
   }
 }
 
@@ -73,6 +69,16 @@ export function LettersApp({ user, children }) {
     </RequiredLoginView>
   );
 }
+
+AppContent.propTypes = {
+  children: PropTypes.element,
+  isDataAvailable: PropTypes.bool,
+};
+
+LettersApp.propTypes = {
+  children: PropTypes.element,
+  user: PropTypes.shape({}),
+};
 
 function mapStateToProps(state) {
   return { user: state.user };

--- a/src/applications/letters/containers/Main.jsx
+++ b/src/applications/letters/containers/Main.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
-import { systemDownMessage } from 'platform/static-data/error-messages';
 import { selectVAPContactInfo } from 'platform/user/selectors';
 import { AVAILABILITY_STATUSES } from '../utils/constants';
 import { recordsNotFound, isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
+import systemDownMessage from '../components/systemDownMessage';
 
 import {
   getLetterListAndBSLOptions,
@@ -30,43 +31,38 @@ export class Main extends React.Component {
     return this.props.profileHasEmptyAddress();
   }
 
-  appAvailability(lettersAvailability) {
-    if (lettersAvailability === awaitingResponse) {
-      return awaitingResponse;
-    }
-
-    return lettersAvailability;
-  }
-
   render() {
-    let appContent;
-
-    switch (this.appAvailability(this.props.lettersAvailability)) {
+    const { lettersAvailability } = this.props;
+    const status =
+      lettersAvailability === awaitingResponse
+        ? awaitingResponse
+        : lettersAvailability;
+    switch (status) {
       case available:
-        appContent = this.props.children;
-        break;
+        return this.props.children;
       case awaitingResponse:
-        appContent = <va-loading-indicator message="Loading your letters..." />;
-        break;
+        return <va-loading-indicator message="Loading your letters..." />;
       case backendAuthenticationError:
-        appContent = recordsNotFound;
-        break;
+        return recordsNotFound;
       case letterEligibilityError:
-        appContent = this.props.children;
-        break;
+        return this.props.children;
       case hasEmptyAddress:
-        appContent = noAddressBanner;
-        break;
+        return noAddressBanner;
       case unavailable: // fall-through to default
       case backendServiceError: // fall-through to default
       default:
-        appContent = systemDownMessage;
-        break;
+        return systemDownMessage;
     }
-
-    return <main>{appContent}</main>;
   }
 }
+
+Main.propTypes = {
+  children: PropTypes.any,
+  emptyAddress: PropTypes.bool,
+  getLetterListAndBSLOptions: PropTypes.func,
+  lettersAvailability: PropTypes.string,
+  profileHasEmptyAddress: PropTypes.func,
+};
 
 function mapStateToProps(state) {
   const letterState = state.letters;

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -128,39 +128,43 @@ export class VeteranBenefitSummaryLetter extends React.Component {
           <h3 className="vads-u-font-size--h4">
             Choose the information you want to include.
           </h3>
-          <h3 className="vads-u-font-size--h2">Military service information</h3>
-          <p>
-            Our records show the 3 most recent service periods. There may be
-            additional service periods not shown here.
-          </p>
-          <div className="form-checkbox">
-            <input
-              checked={militaryService}
-              id="militaryService"
-              name="militaryService"
-              type="checkbox"
-              onChange={this.handleChange}
-            />
-            <label name="militaryService-label" htmlFor="militaryService">
-              Include military service information
-            </label>
-          </div>
-          {militaryServiceRows.length && (
-            <table id="militaryServiceTable">
-              <thead>
-                <tr>
-                  <th scope="col">Branch of service</th>
-                  <th scope="col">Discharge type</th>
-                  <th scope="col">Active duty start</th>
-                  <th scope="col">Separation date</th>
-                </tr>
-              </thead>
-              <tbody>{militaryServiceRows}</tbody>
-            </table>
-          )}
-          <h3 className="vads-u-font-size--h2">
+          {militaryServiceRows.length ? (
+            <>
+              <h4 className="vads-u-font-size--h2">
+                Military service information
+              </h4>
+              <p>
+                Our records show the 3 most recent service periods. There may be
+                additional service periods not shown here.
+              </p>
+              <div className="form-checkbox">
+                <input
+                  checked={militaryService}
+                  id="militaryService"
+                  name="militaryService"
+                  type="checkbox"
+                  onChange={this.handleChange}
+                />
+                <label name="militaryService-label" htmlFor="militaryService">
+                  Include military service information
+                </label>
+              </div>
+              <table id="militaryServiceTable">
+                <thead>
+                  <tr>
+                    <th scope="col">Branch of service</th>
+                    <th scope="col">Discharge type</th>
+                    <th scope="col">Active duty start</th>
+                    <th scope="col">Separation date</th>
+                  </tr>
+                </thead>
+                <tbody>{militaryServiceRows}</tbody>
+              </table>
+            </>
+          ) : null}
+          <h4 className="vads-u-font-size--h2">
             VA benefit and disability information
-          </h3>
+          </h4>
           <p>
             Please choose what information you want to include in your letter.
           </p>

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -199,11 +199,11 @@ export class VeteranBenefitSummaryLetter extends React.Component {
 
 VeteranBenefitSummaryLetter.propTypes = {
   benefitSummaryOptions: PropTypes.shape({
-    benefitInfo: PropTypes.array,
+    benefitInfo: PropTypes.shape({}),
     serviceInfo: PropTypes.array,
   }),
   isVeteran: PropTypes.bool,
-  optionsAvailable: PropTypes.shape({}),
+  optionsAvailable: PropTypes.bool,
   requestOptions: PropTypes.shape({
     militaryService: PropTypes.bool,
   }),

--- a/src/applications/letters/routes.jsx
+++ b/src/applications/letters/routes.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route, IndexRedirect } from 'react-router';
 
-import DownloadLetters from './containers/DownloadLetters.jsx';
-import AddressSection from './containers/AddressSection.jsx';
-import LetterList from './containers/LetterList.jsx';
-import Main from './containers/Main.jsx';
-import LettersApp from './containers/LettersApp.jsx';
+import DownloadLetters from './containers/DownloadLetters';
+import AddressSection from './containers/AddressSection';
+import LetterList from './containers/LetterList';
+import Main from './containers/Main';
+import LettersApp from './containers/LettersApp';
 
 const routes = (
   <Route path="/" component={LettersApp}>
@@ -35,8 +35,3 @@ const routes = (
 );
 
 export default routes;
-
-export const chapters = [
-  { name: 'Review your address', path: '/confirm-address' },
-  { name: 'Select and download', path: '/letter-list' },
-];

--- a/src/applications/letters/tests/01-authed.cypress.spec.js
+++ b/src/applications/letters/tests/01-authed.cypress.spec.js
@@ -40,6 +40,11 @@ describe('Authed Letter Test', () => {
         cy.get('va-accordion-item').should('have.length', 5);
       });
 
+    /* Remove `cy.wait(100)` once expandAccordions uses the expand all button
+     * https://github.com/department-of-veterans-affairs/vets-website/pull/20605
+     */
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
     cy.expandAccordions();
     cy.axeCheck();
 

--- a/src/applications/letters/tests/containers/LettersApp.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/LettersApp.unit.spec.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
+import createCommonStore from 'platform/startup/store';
 import { LettersApp, AppContent } from '../../containers/LettersApp';
 
 import reducer from '../../reducers';
-import createCommonStore from 'platform/startup/store';
 
 const store = createCommonStore(reducer);
 
@@ -50,6 +50,8 @@ describe('<LettersApp>', () => {
           <span>Rendered!</span>
         </AppContent>,
       );
+      expect(tree.subTree('h1')).to.exist;
+      expect(tree.subTree('va-alert')).to.exist;
       const text = tree.text();
       expect(text).to.contain(
         'We weren’t able to find information about your VA letters.',

--- a/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -71,6 +71,17 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     expect(tree.subTree('#benefitInfoTable')).to.be.false;
   });
 
+  it('should not render military service information section if no service history', () => {
+    const props = set('benefitSummaryOptions.serviceInfo', [], defaultProps);
+    const tree = SkinDeep.shallowRender(
+      <VeteranBenefitSummaryLetter {...props} />,
+    );
+    const subHeader = tree.subTree('h4');
+
+    expect(tree.subTree('#militaryServiceTable')).to.be.false;
+    expect(subHeader.length).to.eq(1);
+  });
+
   it('maps each service entry to its own table row', () => {
     const navyService = [
       {

--- a/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -76,10 +76,11 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     const tree = SkinDeep.shallowRender(
       <VeteranBenefitSummaryLetter {...props} />,
     );
-    const subHeader = tree.subTree('h4');
 
     expect(tree.subTree('#militaryServiceTable')).to.be.false;
-    expect(subHeader.length).to.eq(1);
+    expect(tree.subTree('h4').text()).to.contain(
+      'VA benefit and disability information',
+    );
   });
 
   it('maps each service entry to its own table row', () => {

--- a/src/applications/letters/utils/chapters.js
+++ b/src/applications/letters/utils/chapters.js
@@ -1,0 +1,4 @@
+export const chapters = [
+  { name: 'Review your address', path: '/confirm-address' },
+  { name: 'Select and download', path: '/letter-list' },
+];

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -20,10 +20,9 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
 export const recordsNotFound = (
   <div id="records-not-found">
-    <header>
-      <h1>We couldn’t find your VA letters or documents</h1>
-    </header>
+    <p />
     <va-alert status="warning">
+      <h2 slot="headline">We couldn’t find your VA letters or documents</h2>
       <p>
         <EbenefitsLink path="ebenefits/download-letters">
           If you’re a dependent, please go to eBenefits to look for your


### PR DESCRIPTION
## Description

- Added missing `h1` & bottom padding on alert-only pages
- Fixed empty military service showing a zero
- Move some content into alerts
- Added PropTypes to some pages
- Lint fixes, including fixing a circular dependency
- Code cleanup

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38699

## Testing done

- Updated unit test
- Temporarily added a `cy.wait(100)` to allow accordions to expand ([Slack conversation](https://dsva.slack.com/archives/CBU0KDSB1/p1647609046050589))

## Screenshots

<details><summary>"We couldn't find..." alert</summary>

<!-- leave a blank line above -->
The header was an `h1` outside the alert. Changed to an `h2` and moved inside the alert

![we couldn't find your VA letters or documents alert now an h2](https://user-images.githubusercontent.com/136959/159045885-464d4ddd-032b-46e6-b2fb-04795d20fa37.png)</details>

<details><summary>Letters not found</summary>

<!-- leave a blank line above -->
Before (`h4` text)

<img width="929" alt="h4 stating we weren't able to find information, and the call center number" src="https://user-images.githubusercontent.com/136959/159045792-c1c987e9-f9a5-4bb2-b1ef-7654c2d57ae5.png">

After, added `h1` and an alert
![Change to include `h1` with VA letters and documents and the `h4` text moved inside an alert](https://user-images.githubusercontent.com/136959/159045750-fd68edf4-6482-4f1a-a57f-e431a365e2ad.png)</details>

<details><summary>Military service section empty</summary>

<!-- leave a blank line above -->
Hide military service information header, description and checkbox when no military history is available
<img width="714" alt="Empty military service history shows a zero" src="https://user-images.githubusercontent.com/136959/159045849-ff223e4c-4c68-42f9-b2ce-8651a1874270.png"></details>

<details><summary>Service (system down) not available changes</summary>

<!-- leave a blank line above -->
Copied content into an alert

![System not available inside an alert](https://user-images.githubusercontent.com/136959/159045937-f5f2fb53-e942-412d-811b-461c272e0dcf.png)</details>

## Acceptance criteria
- [x] A11y improvements to letters app
- [x] Linting fixes in place
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
