### PR TITLE
update filter now conditionally active

### DIFF
--- a/src/applications/gi/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi/containers/search/LocationSearchResults.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/prop-types */
+import environment from 'platform/utilities/environment';
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import 'mapbox-gl/dist/mapbox-gl.css';
@@ -456,9 +457,15 @@ function LocationSearchResults({
               <FilterYourResults />
             </>
           )}
-          {(smallScreen || landscape) && (
-            <MobileFilterControls className="vads-u-margin-top--2" />
-          )}
+          {environment.isProduction()
+            ? (smallScreen || landscape) && (
+                <MobileFilterControls className="vads-u-margin-top--2" />
+              )
+            : smallScreen &&
+              !landscape &&
+              results.length > 0 && (
+                <MobileFilterControls className="vads-u-margin-top--2" />
+              )}
         </>
       );
     }


### PR DESCRIPTION
## Description
On mobile in both mode portrait and landscape, I noticed that in "Search by location" tab, the update tuition and filter you results buttons/accordions are displayed in the landing page before search has been executed.

[Portrait mode: Screen Shot 2022-03-16 at 10 51 36 AM](https://user-images.githubusercontent.com/86266024/158626419-6662483c-2ac5-4ff8-9a71-9264fee3414a.png)
[Landscape mode: Screen Shot 2022-03-16 at 10 52 52 AM](https://user-images.githubusercontent.com/86266024/158632328-7cad5a26-851b-4848-bbe7-10d53a0c71d0.png)

Steps to Reproduce

On a mobile in portrait mode, navigate to: https://staging.va.gov/education/gi-bill-comparison-tool/
Click to expand the "Search by location" tab.
Verify if update tuition & filter your results buttons are displayed.
Switch the view to landscape mode
Verify if update tuition & filter your results accordions and buttons are displayed

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38631


## Testing done
Locally

## Screenshots
Landscape Mobile
<img width="1109" alt="Screen Shot 2022-03-21 at 11 29 15 AM" src="https://user-images.githubusercontent.com/86262790/159307201-7d61cd1e-e6de-4125-ba6b-12806b33b969.png">
Pre-Search Mobile Portrait
<img width="536" alt="Screen Shot 2022-03-21 at 11 28 35 AM" src="https://user-images.githubusercontent.com/86262790/159307217-fdc2b388-3aeb-4c14-88ad-f33cbbddc9d5.png">
Post Search Mobile Portrait
<img width="531" alt="Screen Shot 2022-03-21 at 11 28 51 AM" src="https://user-images.githubusercontent.com/86262790/159307209-567bfdea-3a24-4c80-aa70-1ca10f5227af.png">

## Acceptance criteria
- [x] On Portrait mode, the Update tuitions & filter your results buttons should be displayed only after the search has been executed.
- [x] On Landscape mode, only the update tuition & filter your results accordions should be displayed after the search has been executed. Remove the extra buttons.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
