### PR TITLE
Fix duplicate istanbul error in E2E workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on: [push]
-  # workflow_dispatch:
-  #   inputs:
-  #     commit_sha:
-  #       description: Run the full E2E test suite on a specific commit
-  #       required: true
-  # workflow_run:
-  #   workflows: [Continuous Integration]
-  #   types: [completed]
-  #   branches: [master]
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Run the full E2E test suite on a specific commit
+        required: true
+  workflow_run:
+    workflows: [Continuous Integration]
+    types: [completed]
+    branches: [master]
 
 env:
   NUM_CONTAINERS: '8'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Run the full E2E test suite on a specific commit
-        required: true
-  workflow_run:
-    workflows: [Continuous Integration]
-    types: [completed]
-    branches: [master]
+on: [push]
+  # workflow_dispatch:
+  #   inputs:
+  #     commit_sha:
+  #       description: Run the full E2E test suite on a specific commit
+  #       required: true
+  # workflow_run:
+  #   workflows: [Continuous Integration]
+  #   types: [completed]
+  #   branches: [master]
 
 env:
   NUM_CONTAINERS: '8'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Add istanbul for Cypress code coverage reporting
         run: | 
-          sed -i -e 's/\"plugins\": \[/\"plugins\": \[\"istanbul\",/g' .babelrc
+          sed -i -e 's/\"lodash\",/\"lodash\", \"istanbul\",/g' .babelrc
           
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}


### PR DESCRIPTION
## Description
This PR modifies the E2E GitHub Actions workflow so that `istanbul` is not duplicated in any `plugins` array.

## Acceptance criteria
- [ ] CI passes.