### PR TITLE
CST: Remove PDF size feature flag

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
@@ -11,7 +10,6 @@ import TextInput from '@department-of-veterans-affairs/component-library/TextInp
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   readAndCheckFile,
   checkTypeAndExtensionMatches,
@@ -38,7 +36,6 @@ import {
   MAX_PDF_SIZE_MB,
 } from '../utils/validations';
 import { setFocus } from '../utils/page';
-import { uploadPdfLimitFeature } from '../utils/appeals-v2-helpers';
 
 const displayTypes = FILE_TYPES.join(', ');
 
@@ -75,16 +72,11 @@ class AddFilesForm extends React.Component {
 
   add = async files => {
     const file = files[0];
-    const {
-      requestLockedPdfPassword,
-      onAddFile,
-      pdfSizeFeature,
-      mockReadAndCheckFile,
-    } = this.props;
+    const { onAddFile, mockReadAndCheckFile } = this.props;
     const extraData = {};
-    const hasPdfSizeLimit = isPdf(file) && pdfSizeFeature;
+    const hasPdfSizeLimit = isPdf(file);
 
-    if (isValidFile(file, pdfSizeFeature)) {
+    if (isValidFile(file)) {
       // Check if the file is an encrypted PDF
       const checks = { checkTypeAndExtensionMatches, checkIsEncryptedPdf };
       const checkResults = mockReadAndCheckFile
@@ -98,10 +90,7 @@ class AddFilesForm extends React.Component {
         return;
       }
 
-      if (
-        requestLockedPdfPassword && // feature flag
-        file.name?.toLowerCase().endsWith('pdf')
-      ) {
+      if (file.name?.toLowerCase().endsWith('pdf')) {
         extraData.isEncrypted = checkResults.checkIsEncryptedPdf;
       }
 
@@ -119,7 +108,7 @@ class AddFilesForm extends React.Component {
       this.setState({
         errorMessage: 'Please choose a file from one of the accepted types.',
       });
-    } else if (!isValidFileSize(file, pdfSizeFeature)) {
+    } else if (!isValidFileSize(file)) {
       const maxSize = hasPdfSizeLimit ? MAX_PDF_SIZE_MB : MAX_FILE_SIZE_MB;
       this.setState({
         errorMessage: `The file you selected is larger than the ${maxSize}MB maximum file size and could not be added.`,
@@ -188,15 +177,11 @@ class AddFilesForm extends React.Component {
           <p className="file-requirement-text">{displayTypes}</p>
           <p className="file-requirement-header">Maximum file size:</p>
           <p className="file-requirement-text">
-            {`${MAX_FILE_SIZE_MB}MB${
-              this.props.pdfSizeFeature ? ' (non-PDF)' : ''
-            }`}
+            {`${MAX_FILE_SIZE_MB}MB (non-PDF)`}
           </p>
-          {this.props.pdfSizeFeature && (
-            <p className="file-requirement-text">
-              {`${MAX_PDF_SIZE_MB}MB (PDF only)`}
-            </p>
-          )}
+          <p className="file-requirement-text">
+            {`${MAX_PDF_SIZE_MB}MB (PDF only)`}
+          </p>
         </div>
         {this.props.files.map(
           ({ file, docType, isEncrypted, password }, index) => (
@@ -212,6 +197,7 @@ class AddFilesForm extends React.Component {
                   </div>
                   <div className="remove-document-button">
                     <button
+                      type="button"
                       className="usa-button-secondary"
                       onClick={() => this.props.onRemoveFile(index)}
                     >
@@ -288,7 +274,7 @@ class AddFilesForm extends React.Component {
           }
         />
         <div>
-          <button className="usa-button" onClick={this.submit}>
+          <button type="submit" className="usa-button" onClick={this.submit}>
             Submit Files for Review
           </button>
           <Link to={this.props.backUrl} className="claims-files-cancel">
@@ -315,23 +301,17 @@ class AddFilesForm extends React.Component {
 }
 
 AddFilesForm.propTypes = {
-  files: PropTypes.array.isRequired,
   field: PropTypes.object.isRequired,
-  uploading: PropTypes.bool,
-  backUrl: PropTypes.string,
-  onSubmit: PropTypes.func.isRequired,
+  files: PropTypes.array.isRequired,
   onAddFile: PropTypes.func.isRequired,
-  onRemoveFile: PropTypes.func.isRequired,
-  onFieldChange: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   onDirtyFields: PropTypes.func.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
+  onRemoveFile: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  backUrl: PropTypes.string,
+  mockReadAndCheckFile: PropTypes.bool,
+  uploading: PropTypes.bool,
 };
 
-const mapStateToProps = state => ({
-  requestLockedPdfPassword: toggleValues(state).request_locked_pdf_password,
-  pdfSizeFeature: uploadPdfLimitFeature(state),
-});
-
-export { AddFilesForm };
-
-export default connect(mapStateToProps)(AddFilesForm);
+export default AddFilesForm;

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   FILE_TYPE_MISMATCH_ERROR,
 } from 'platform/forms-system/src/js/utilities/file';
 
-import { AddFilesForm } from '../../components/AddFilesForm';
+import AddFilesForm from '../../components/AddFilesForm';
 import {
   MAX_FILE_SIZE_BYTES,
   MAX_FILE_SIZE_MB,
@@ -276,7 +276,6 @@ describe('<AddFilesForm>', () => {
         onFieldChange={onFieldChange}
         onCancel={onCancel}
         onDirtyFields={onDirtyFields}
-        pdfSizeFeature
       />,
     );
     tree.getMountedInstance().add([
@@ -396,7 +395,6 @@ describe('<AddFilesForm>', () => {
         onCancel={onCancel}
         onDirtyFields={onDirtyFields}
         mockReadAndCheckFile={mockReadAndCheckFile}
-        pdfSizeFeature
       />,
     );
     tree.getMountedInstance().add([
@@ -439,7 +437,6 @@ describe('<AddFilesForm>', () => {
         onCancel={onCancel}
         onDirtyFields={onDirtyFields}
         mockReadAndCheckFile={mockReadAndCheckFile}
-        pdfSizeFeature
       />,
     );
     tree.getMountedInstance().add([
@@ -520,7 +517,6 @@ describe('<AddFilesForm>', () => {
         onFieldChange={onFieldChange}
         onCancel={onCancel}
         onDirtyFields={onDirtyFields}
-        requestLockedPdfPassword
       />,
     );
     expect(tree.getMountedInstance().state.errorMessage).to.be.null;

--- a/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('<AdditionalEvidencePage>', () => {
         submitFiles={onSubmit}
       />,
     );
-    tree.subTree('Connect(AddFilesForm)').props.onSubmit();
+    tree.subTree('AddFilesForm').props.onSubmit();
     expect(onSubmit.calledWith(1, null, files)).to.be.true;
   });
   it('should reset uploads and set title on mount', () => {

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -152,7 +152,7 @@ describe('<DocumentRequestPage>', () => {
         submitFiles={onSubmit}
       />,
     );
-    tree.subTree('Connect(AddFilesForm)').props.onSubmit();
+    tree.subTree('AddFilesForm').props.onSubmit();
     expect(onSubmit.called).to.be.true;
   });
   it('should reset uploads and set title on mount', () => {

--- a/src/applications/claims-status/tests/utils/validations.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/validations.unit.spec.js
@@ -9,7 +9,6 @@ import {
   MAX_PDF_SIZE_BYTES,
 } from '../../utils/validations';
 
-const pdfSizeFeature = true;
 const validPdfSize =
   MAX_FILE_SIZE_BYTES + (MAX_PDF_SIZE_BYTES - MAX_FILE_SIZE_BYTES) / 2;
 
@@ -26,19 +25,13 @@ describe('Claims status validation:', () => {
     });
 
     it('should validate PDF size is less than max', () => {
-      const result = isValidFileSize(
-        { name: 'test.pdf', size: validPdfSize },
-        pdfSizeFeature,
-      );
+      const result = isValidFileSize({ name: 'test.pdf', size: validPdfSize });
       expect(result).to.be.true;
     });
 
     it('should invalidate PDF size is greater than max', () => {
       const invalidSize = MAX_PDF_SIZE_BYTES;
-      const result = isValidFileSize(
-        { name: 'test.pdf', size: invalidSize },
-        pdfSizeFeature,
-      );
+      const result = isValidFileSize({ name: 'test.pdf', size: invalidSize });
       expect(result).to.be.false;
     });
   });
@@ -80,10 +73,7 @@ describe('Claims status validation:', () => {
       expect(result).to.be.false;
     });
     it('should validate file for size and type', () => {
-      const result = isValidFile(
-        { name: 'testing.pdf', size: validPdfSize },
-        pdfSizeFeature,
-      );
+      const result = isValidFile({ name: 'testing.pdf', size: validPdfSize });
 
       expect(result).to.be.true;
     });

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -2168,7 +2168,8 @@ export function sortByLastUpdated(item1, item2) {
 
   if (moment(lastUpdatedDate1).isAfter(lastUpdatedDate2)) {
     return -1;
-  } else if (moment(lastUpdatedDate1).isBefore(lastUpdatedDate2)) {
+  }
+  if (moment(lastUpdatedDate1).isBefore(lastUpdatedDate2)) {
     return 1;
   }
   return 0;
@@ -2181,6 +2182,3 @@ export function getVisibleRows(list, currentPage) {
   }
   return list.slice(currentIndex, currentIndex + ROWS_PER_PAGE);
 }
-
-export const uploadPdfLimitFeature = state =>
-  state.featureToggles?.['evss_upload_limit_150mb'];

--- a/src/applications/claims-status/utils/validations.js
+++ b/src/applications/claims-status/utils/validations.js
@@ -20,9 +20,8 @@ export function validateIfDirty(field, validator) {
 
 export const isPdf = file => file.name?.toLowerCase().endsWith('pdf') || false;
 
-export function isValidFileSize(file, pdfSizeFeature) {
-  const maxSize =
-    isPdf(file) && pdfSizeFeature ? MAX_PDF_SIZE_BYTES : MAX_FILE_SIZE_BYTES;
+export function isValidFileSize(file) {
+  const maxSize = isPdf(file) ? MAX_PDF_SIZE_BYTES : MAX_FILE_SIZE_BYTES;
   return file.size < maxSize;
 }
 
@@ -34,10 +33,10 @@ export function isValidFileType(file) {
   return FILE_TYPES.some(type => file.name.toLowerCase().endsWith(type));
 }
 
-export function isValidFile(file, pdfSizeFeature) {
+export function isValidFile(file) {
   return (
     !!file &&
-    isValidFileSize(file, pdfSizeFeature) &&
+    isValidFileSize(file) &&
     !isEmptyFileSize(file) &&
     isValidFileType(file)
   );


### PR DESCRIPTION
## Description

Remove PDF size feature flag. It was added when EVSS added support for splitting a 150MB file into smaller chunks. This feature has been stable

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38829

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Remove locked PDF password feature flag
- [x] Remove PDF 150MB limit feature flag
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
