### PR TITLE
Create React widget for shifted veteran banner feature rollout

### DIFF
--- a/src/applications/static-pages/shifted-vets-banner/components/App/index.js
+++ b/src/applications/static-pages/shifted-vets-banner/components/App/index.js
@@ -19,7 +19,7 @@ export const App = ({ show }) => {
   // Render the shifted location banner image.
   return (
     <div id="vets-banner-2" className="veteran-banner">
-      <div className="veteran-banner-container">
+      <div className="veteran-banner-container vads-u-margin-y--0 vads-u-margin-x--auto">
         <picture>
           <source
             srcSet="/img/homepage/veterans-banner-mobile-1.png 640w, /img/homepage/veterans-banner-mobile-2.png 920w, /img/homepage/veterans-banner-mobile-3.png 1316w"

--- a/src/applications/static-pages/shifted-vets-banner/components/App/index.js
+++ b/src/applications/static-pages/shifted-vets-banner/components/App/index.js
@@ -1,0 +1,56 @@
+// Node modules.
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+// Relative imports.
+import { hideDefaultBanner, showDefaultBanner } from '../../helpers';
+
+export const App = ({ show }) => {
+  // If the feature toggle is disabled, do not render.
+  if (!show) {
+    // Ensure the default banner is rendered & escape early.
+    showDefaultBanner();
+    return null;
+  }
+
+  // Hide the default location banner image.
+  hideDefaultBanner();
+
+  // Render the shifted location banner image.
+  return (
+    <div id="vets-banner-2" className="veteran-banner">
+      <div className="veteran-banner-container">
+        <picture>
+          <source
+            srcSet="/img/homepage/veterans-banner-mobile-1.png 640w, /img/homepage/veterans-banner-mobile-2.png 920w, /img/homepage/veterans-banner-mobile-3.png 1316w"
+            media="(max-width: 767px)"
+          />
+          <source
+            srcSet="/img/homepage/veterans-banner-tablet-1.png 1008w, /img/homepage/veterans-banner-tablet-2.png 1887w"
+            media="(max-width: 1008px)"
+          />
+          <img
+            className="veteran-banner-image"
+            src="/img/homepage/veterans-banner-desktop-1.png"
+            srcSet="/img/homepage/veterans-banner-desktop-1.png 1280w, /img/homepage/veterans-banner-desktop-2.png 2494w"
+            alt="Veteran portraits"
+          />
+        </picture>
+      </div>
+    </div>
+  );
+};
+
+App.propTypes = {
+  // From mapStateToProps.
+  show: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  show: state?.featureToggles?.shiftVetsBanner,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(App);

--- a/src/applications/static-pages/shifted-vets-banner/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/shifted-vets-banner/components/App/index.unit.spec.js
@@ -1,0 +1,30 @@
+// Node modules.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from '.';
+
+describe('Shifted Veteran Banner <App>', () => {
+  it('does not render when feature toggle disabled', () => {
+    // Set up.
+    const wrapper = shallow(<App />);
+
+    // Assertions.
+    expect(wrapper.type()).to.equal(null);
+
+    // Clean up.
+    wrapper.unmount();
+  });
+
+  it('renders what we expect with feature toggle enabled', () => {
+    // Set up.
+    const wrapper = shallow(<App show />);
+
+    // Assertions.
+    expect(wrapper.find('#vets-banner-2')).to.have.length(1);
+
+    // Clean up.
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/shifted-vets-banner/helpers/index.js
+++ b/src/applications/static-pages/shifted-vets-banner/helpers/index.js
@@ -1,0 +1,29 @@
+export const hideDefaultBanner = () => {
+  // Derive the default banner on the page.
+  const defaultBanner = document.querySelector('div[id="vets-banner-1"]');
+
+  // Escape early if the default banner doesn't exist.
+  if (!defaultBanner) {
+    return;
+  }
+
+  // Add `vads-u-display--none` class to the default banner if it doesn't already exist.
+  if (!defaultBanner.classList.contains('vads-u-display--none')) {
+    defaultBanner.classList.add('vads-u-display--none');
+  }
+};
+
+export const showDefaultBanner = () => {
+  // Derive the default banner on the page.
+  const defaultBanner = document.querySelector('div[id="vets-banner-1"]');
+
+  // Escape early if the default banner doesn't exist.
+  if (!defaultBanner) {
+    return;
+  }
+
+  // Add `vads-u-display--none` class to the default banner if it doesn't already exist.
+  if (defaultBanner.classList.contains('vads-u-display--none')) {
+    defaultBanner.classList.remove('vads-u-display--none');
+  }
+};

--- a/src/applications/static-pages/shifted-vets-banner/helpers/index.unit.spec.js
+++ b/src/applications/static-pages/shifted-vets-banner/helpers/index.unit.spec.js
@@ -1,0 +1,16 @@
+// Node modules.
+import { expect } from 'chai';
+// Relative imports.
+import { hideDefaultBanner, showDefaultBanner } from '.';
+
+describe('hideDefaultBanner', () => {
+  it('returns what we expect with no arguments', () => {
+    expect(hideDefaultBanner()).to.equal(undefined);
+  });
+});
+
+describe('showDefaultBanner', () => {
+  it('returns what we expect with no arguments', () => {
+    expect(showDefaultBanner()).to.equal(undefined);
+  });
+});

--- a/src/applications/static-pages/shifted-vets-banner/index.js
+++ b/src/applications/static-pages/shifted-vets-banner/index.js
@@ -1,0 +1,21 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+
+  if (root) {
+    import(/* webpackChunkName: "shifted-vets-banner" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -62,6 +62,7 @@ import createPost911GiBillStatusWidget, {
   post911GIBillStatusReducer,
 } from '../post-911-gib-status/createPost911GiBillStatusWidget';
 import createResourcesAndSupportSearchWidget from './widget-creators/resources-and-support-search';
+import createShiftedVetsBanner from './shifted-vets-banner';
 import createThirdPartyApps, {
   thirdPartyAppsReducer,
 } from '../third-party-app-directory/createThirdPartyApps';
@@ -193,6 +194,7 @@ createDependencyVerification(store, widgetTypes.DEPENDENCY_VERIFICATION);
 createCOEAccess(store, widgetTypes.COE_ACCESS);
 createLettersMobileCTA(store, widgetTypes.LETTERS_MOBILE_CTA);
 createManageVADebtCTA(store, widgetTypes.MANAGE_VA_DEBT_CTA);
+createShiftedVetsBanner(store, widgetTypes.SHIFTED_VETS_BANNER);
 
 // Create the My VA Login widget only on the homepage.
 if (location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -49,6 +49,7 @@ export default {
   SCO_ANNOUNCEMENTS: 'sco-announcements',
   SCO_EVENTS: 'sco-events',
   SECURE_MESSAGING_PAGE: 'secure-messaging-page',
+  SHIFTED_VETS_BANNER: 'shifted-vets-banner',
   SIDE_NAV: 'side-nav',
   THIRD_PARTY_APP_DIRECTORY: 'third-party-app-directory',
   VET_CENTER_HOURS: 'vet-center-hours',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -79,6 +79,7 @@ export default Object.freeze({
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',
   searchDropdownComponentEnabled: 'search_dropdown_component_enabled',
+  shiftVetsBanner: 'shift_vets_banner',
   show526Wizard: 'show526_wizard',
   showPaymentAndDebtSection: 'show_payment_and_debt_section',
   showContactChatbot: 'show_contact_chatbot',


### PR DESCRIPTION
## Description
This PR creates a react widget that controls the placement of the veteran banner image on the home page. The PR addresses an ask for a way to test if there is a better place to house this image on the homepage to encourage more engagement with the page content. The current feeling is that users may see that image in its current location and stop scrolling on the page by assuming that is the end of the most relevant content. The widget is controlled by a feature flag that, if engaged, will hide the banner in its current location and render the banner at the bottom of the main content, just above the footer.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37435

## Crosslinked PR(s)
- https://github.com/department-of-veterans-affairs/content-build/pull/1042
- https://github.com/department-of-veterans-affairs/vets-api/pull/9422

## Testing done
[x] Unit tests

## Screenshots
<img width="496" alt="Screen Shot 2022-03-21 at 3 32 54 PM" src="https://user-images.githubusercontent.com/6738544/159350006-1b8fb987-0267-42cb-aa87-4252134dcb0e.png">

## Acceptance criteria
- [x] Adds react widget for feature rollout

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
