### PR TITLE
Fix `istanbul` duplicate error

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on: [push]
-  # workflow_dispatch:
-  #   inputs:
-  #     commit_sha:
-  #       description: Run the full E2E test suite on a specific commit
-  #       required: true
-  # workflow_run:
-  #   workflows: [Continuous Integration]
-  #   types: [completed]
-  #   branches: [master]
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Run the full E2E test suite on a specific commit
+        required: true
+  workflow_run:
+    workflows: [Continuous Integration]
+    types: [completed]
+    branches: [master]
 
 env:
   NUM_CONTAINERS: '8'
@@ -93,9 +93,6 @@ jobs:
         run: |
           sed -i -e 's/\"istanbul\",//g' .babelrc
           sed -i -e 's/\"lodash\",/\"lodash\", \"istanbul\",/g' .babelrc
-      
-      - name: Print babelrc
-        run: cat .babelrc
           
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,7 +90,8 @@ jobs:
             node_modules
 
       - name: Add istanbul for Cypress code coverage reporting
-        run: | 
+        run: |
+          sed -i -e 's/\"istanbul\",//g' .babelrc
           sed -i -e 's/\"lodash\",/\"lodash\", \"istanbul\",/g' .babelrc
       
       - name: Print babelrc

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Run the full E2E test suite on a specific commit
-        required: true
-  workflow_run:
-    workflows: [Continuous Integration]
-    types: [completed]
-    branches: [master]
+on: [push]
+  # workflow_dispatch:
+  #   inputs:
+  #     commit_sha:
+  #       description: Run the full E2E test suite on a specific commit
+  #       required: true
+  # workflow_run:
+  #   workflows: [Continuous Integration]
+  #   types: [completed]
+  #   branches: [master]
 
 env:
   NUM_CONTAINERS: '8'
@@ -92,6 +92,9 @@ jobs:
       - name: Add istanbul for Cypress code coverage reporting
         run: | 
           sed -i -e 's/\"lodash\",/\"lodash\", \"istanbul\",/g' .babelrc
+      
+      - name: Print babelrc
+        run: cat .babelrc
           
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}


### PR DESCRIPTION
## Description
The E2E workflow is still occasionally showing errors for duplicates of `istanbul` even with the latest attempt at a fix. This PR removes all duplicate entries for `istanbul` in the `.babelrc` and ensures that `istanbul` appears only once in the entire file.

## Testing done
Ran E2E workflow without errors.

## Acceptance criteria
- [ ] CI passes.