### PR TITLE
HLR/NOD: Replace Modal with va-modal

### DIFF
--- a/src/applications/appeals/10182/content/contestableIssues.jsx
+++ b/src/applications/appeals/10182/content/contestableIssues.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from 'web-components/react-bindings';
 
 import { scrollAndFocus } from 'platform/utilities/ui';
 
@@ -60,17 +60,17 @@ export const maxSelectedErrorMessage =
 // Not setting "visible" as a variable since we're controlling rendering at a
 // higher level
 export const MaxSelectionsAlert = ({ closeModal }) => (
-  <Modal
-    title={maxSelectedErrorMessage}
+  <VaModal
+    modalTitle={maxSelectedErrorMessage}
     status="warning"
-    onClose={closeModal}
+    onCloseEvent={closeModal}
     visible
   >
     You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each Notice
     of Disagreement request. If you would like to select more than{' '}
     {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
     for the remaining issues.
-  </Modal>
+  </VaModal>
 );
 
 export const noneSelected = 'Please select at least one issue';

--- a/src/applications/appeals/10182/validations/date.js
+++ b/src/applications/appeals/10182/validations/date.js
@@ -4,7 +4,6 @@ import { parseISODate } from 'platform/forms-system/src/js/helpers';
 import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
 
 import { FORMAT_YMD } from '../constants';
-import { $ } from '../utils/ui';
 
 import { issueErrorMessages } from '../content/addIssue';
 
@@ -30,13 +29,6 @@ export const validateDate = (errors, dateString) => {
     errors.addError(issueErrorMessages.pastDate);
   } else if (date.isBefore(minDate)) {
     errors.addError(issueErrorMessages.newerDate);
-  }
-  if ($('body.modal-open')) {
-    // prevent contact page modal "update" button from acting like the
-    // page "continue" button
-    errors.addError(
-      'Please finish editing your contact info before continuing',
-    );
   }
 };
 

--- a/src/applications/disability-benefits/996/content/contestableIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssues.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from 'web-components/react-bindings';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { scrollAndFocus } from 'platform/utilities/ui';
@@ -126,17 +126,17 @@ export const maxSelectedErrorMessage =
 // Not setting "visible" as a variable since we're controlling rendering at a
 // higher level
 export const MaxSelectionsAlert = ({ closeModal }) => (
-  <Modal
-    title={maxSelectedErrorMessage}
+  <VaModal
+    modalTitle={maxSelectedErrorMessage}
     status="warning"
-    onClose={closeModal}
+    onCloseEvent={closeModal}
     visible
   >
     You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each
     Higher-Level Review request. If you would like to select more than{' '}
     {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
     for the remaining issues.
-  </Modal>
+  </VaModal>
 );
 
 export const noneSelected = 'Please select at least one issue';

--- a/src/applications/disability-benefits/996/validations/date.js
+++ b/src/applications/disability-benefits/996/validations/date.js
@@ -4,7 +4,6 @@ import { parseISODate } from 'platform/forms-system/src/js/helpers';
 import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
 
 import { FORMAT_YMD } from '../constants';
-import { $ } from '../utils/ui';
 
 import { issueErrorMessages } from '../content/addIssue';
 
@@ -30,13 +29,6 @@ export const validateDate = (errors, dateString) => {
     errors.addError(issueErrorMessages.pastDate);
   } else if (date.isBefore(minDate)) {
     errors.addError(issueErrorMessages.newerDate);
-  }
-  if ($('body.modal-open')) {
-    // prevent contact page modal "update" button from acting like the
-    // page "continue" button
-    errors.addError(
-      'Please finish editing your contact info before continuing',
-    );
   }
 };
 


### PR DESCRIPTION
## Description

Higher-Level Review & Notice of Disagreement forms are still using the React `Modal` component. These need to be replaced by. the `va-modal` web component.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38843

## Testing done

Verified unit tests passing

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] Switch to `va-modal`
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
