### PR TITLE
Avoid Calling Demographics API if all confirmation pages skipped

### DIFF
--- a/src/applications/check-in/day-of/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/index.jsx
@@ -27,6 +27,7 @@ const Confirmation = props => {
     demographicsData,
     demographicsFlagsSent,
     setDemographicsFlagsSent,
+    demographicsFlagsEmpty,
   } = useDemographicsFlags();
   const refreshAppointments = useCallback(
     () => {
@@ -45,6 +46,7 @@ const Confirmation = props => {
       if (
         !isDayOfDemographicsFlagsEnabled ||
         demographicsFlagsSent ||
+        demographicsFlagsEmpty ||
         getDemographicsConfirmed(window)
       )
         return;
@@ -62,6 +64,7 @@ const Confirmation = props => {
     },
     [
       demographicsData,
+      demographicsFlagsEmpty,
       demographicsFlagsSent,
       getDemographicsConfirmed,
       goToErrorPage,

--- a/src/applications/check-in/day-of/pages/SeeStaff.jsx
+++ b/src/applications/check-in/day-of/pages/SeeStaff.jsx
@@ -25,6 +25,7 @@ const SeeStaff = props => {
     demographicsData,
     demographicsFlagsSent,
     setDemographicsFlagsSent,
+    demographicsFlagsEmpty,
   } = useDemographicsFlags();
   const { goBack } = router;
   const selectSeeStaffMessage = useMemo(makeSelectSeeStaffMessage, []);
@@ -39,6 +40,7 @@ const SeeStaff = props => {
       if (
         !isDayOfDemographicsFlagsEnabled ||
         demographicsFlagsSent ||
+        demographicsFlagsEmpty ||
         getDemographicsConfirmed(window)
       )
         return;
@@ -55,6 +57,7 @@ const SeeStaff = props => {
     },
     [
       demographicsData,
+      demographicsFlagsEmpty,
       demographicsFlagsSent,
       getDemographicsConfirmed,
       goToErrorPage,

--- a/src/applications/check-in/hooks/tests/useDemographicsFlags/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useDemographicsFlags/TestComponent.jsx
@@ -7,6 +7,7 @@ export default function TestComponent() {
     demographicsData,
     demographicsFlagsSent,
     setDemographicsFlagsSent,
+    demographicsFlagsEmpty,
   } = useDemographicsFlags();
   return (
     <div>
@@ -21,6 +22,9 @@ export default function TestComponent() {
       </div>
       <div data-testid="demographicsFlagsSent">
         {demographicsFlagsSent ? 'yes' : 'no'}
+      </div>
+      <div data-testid="demographicsFlagsEmpty">
+        {demographicsFlagsEmpty ? 'yes' : 'no'}
       </div>
       <button
         type="button"

--- a/src/applications/check-in/hooks/tests/useDemographicsFlags/useDemographicsFlags.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useDemographicsFlags/useDemographicsFlags.unit.spec.jsx
@@ -98,7 +98,7 @@ describe('check-in', () => {
         );
         expect(component.getByTestId('nextOfKinUpToDate')).to.have.text('yes');
         expect(component.getByTestId('demographicsFlagsEmpty')).to.have.text(
-          'yes',
+          'no',
         );
       });
     });

--- a/src/applications/check-in/hooks/tests/useDemographicsFlags/useDemographicsFlags.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useDemographicsFlags/useDemographicsFlags.unit.spec.jsx
@@ -50,6 +50,9 @@ describe('check-in', () => {
         expect(component.getByTestId('demographicsFlagsSent')).to.have.text(
           'no',
         );
+        expect(component.getByTestId('demographicsFlagsEmpty')).to.have.text(
+          'yes',
+        );
         fireEvent.click(sentTrueButton);
         expect(component.getByTestId('demographicsFlagsSent')).to.have.text(
           'yes',
@@ -94,6 +97,9 @@ describe('check-in', () => {
           'no',
         );
         expect(component.getByTestId('nextOfKinUpToDate')).to.have.text('yes');
+        expect(component.getByTestId('demographicsFlagsEmpty')).to.have.text(
+          'yes',
+        );
       });
     });
   });

--- a/src/applications/check-in/hooks/useDemographicsFlags.jsx
+++ b/src/applications/check-in/hooks/useDemographicsFlags.jsx
@@ -39,7 +39,17 @@ const useDemographicsFlags = () => {
       nextOfKinUpToDate: nextOfKinUpToDate === 'yes',
     };
 
-  return { demographicsData, demographicsFlagsSent, setDemographicsFlagsSent };
+  const demographicsFlagsEmpty =
+    demographicsUpToDate === undefined &&
+    emergencyContactUpToDate === undefined &&
+    nextOfKinUpToDate === undefined;
+
+  return {
+    demographicsData,
+    demographicsFlagsSent,
+    setDemographicsFlagsSent,
+    demographicsFlagsEmpty,
+  };
 };
 
 export { useDemographicsFlags };


### PR DESCRIPTION
## Description
Bug fix to handle edge case with demographics flags in day-of check in. Demographics endpoint should not be called from the confirmation page if all demographics pages were skipped in the app.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38856


## Testing done
update unit and e2e tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
