### PR TITLE
Add event tracking to Outreach & Events Filters form submission

### DIFF
--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -109,13 +109,13 @@ export const Search = ({ onSearch }) => {
       }
     }
 
+    // Allow the event to be submitted and clear errors.
     recordEvent({
       event: 'events-apply-filter-click',
       'filter-by': selectedOption?.value,
       'filters-list': filterList,
     });
 
-    // Allow the event to be submitted and clear errors.
     onSearch(event);
     setStartDateMonthError(false);
     setStartDateDayError(false);

--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 // Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
 import {
   dayOptions,
   deriveDefaultSelectedOption,
@@ -64,27 +65,55 @@ export const Search = ({ onSearch }) => {
   const onSubmitHandler = event => {
     event.preventDefault();
 
+    let filterList;
+
     // Escape early with error if we are missing a required field.
-    if (
-      selectedOption?.value === 'specific-date' &&
-      (!startDateMonth || !startDateDay)
-    ) {
-      setStartDateMonthError(!startDateMonth);
-      setStartDateDayError(!startDateDay);
-      return;
+    if (selectedOption?.value === 'specific-date') {
+      filterList = {
+        startDateMonth,
+        startDateDay,
+      };
+
+      if (!startDateMonth || !startDateDay) {
+        recordEvent({
+          event: 'events-apply-filter-failed',
+          'filter-by': selectedOption?.value,
+          'filters-list': filterList,
+        });
+        setStartDateMonthError(!startDateMonth);
+        setStartDateDayError(!startDateDay);
+        return;
+      }
     }
 
     // Escape early with error if we are missing a required field.
-    if (
-      selectedOption?.value === 'custom-date-range' &&
-      (!startDateMonth || !startDateDay || !endDateMonth || !endDateDay)
-    ) {
-      setStartDateMonthError(!startDateMonth);
-      setStartDateDayError(!startDateDay);
-      setEndDateMonthError(!endDateMonth);
-      setEndDateDayError(!endDateDay);
-      return;
+    if (selectedOption?.value === 'custom-date-range') {
+      filterList = {
+        startDateMonth,
+        startDateDay,
+        endDateMonth,
+        endDateDay,
+      };
+
+      if (!startDateMonth || !startDateDay || !endDateMonth || !endDateDay) {
+        recordEvent({
+          event: 'events-apply-filter-failed',
+          'filter-by': selectedOption?.value,
+          'filters-list': filterList,
+        });
+        setStartDateMonthError(!startDateMonth);
+        setStartDateDayError(!startDateDay);
+        setEndDateMonthError(!endDateMonth);
+        setEndDateDayError(!endDateDay);
+        return;
+      }
     }
+
+    recordEvent({
+      event: 'events-apply-filter-click',
+      'filter-by': selectedOption?.value,
+      'filters-list': filterList,
+    });
 
     // Allow the event to be submitted and clear errors.
     onSearch(event);


### PR DESCRIPTION
## Description
The PR adds additional/missing analytics tracking to the Outreach & Events filter component. We have tracking on all other desired interactions on this page, but we were missing event tracking on the ""Apply Filters" button in the form. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34675

## Acceptance criteria
- [x] Adds requested event tracking

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
