### PR TITLE
24730 - Revert incorrectly updated 1990e content

### DIFF
--- a/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import environment from 'platform/utilities/environment';
 import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
@@ -70,68 +69,26 @@ export class IntroductionPage extends React.Component {
                     <li>Bank account direct deposit information</li>
                     <li>Education history</li>
                   </ul>
-                  {environment.isProduction() ? (
-                    <div>
-                      <p>
-                        <strong>
-                          What if I need help filling out my application?
-                        </strong>{' '}
-                        An accredited representative with a Veterans Service
-                        Organization (VSO) can help you fill out your claim.{' '}
-                        <a href="/disability-benefits/apply/help/index.html">
-                          Find an accredited representative
-                        </a>
-                        .
-                      </p>
-                      <h6>Learn about educational programs</h6>
-                      <p>
-                        See what benefits you’ll get at the school you want to
-                        attend.{' '}
-                        <a href="/education/gi-bill-comparison-tool/">
-                          Use the GI Bill Comparison Tool
-                        </a>
-                        .
-                      </p>
-                    </div>
-                  ) : (
-                    <div>
-                      <p>
-                        <strong>
-                          What if I need help filling out my application?
-                        </strong>{' '}
-                      </p>
-                      <p>
-                        The{' '}
-                        <a href="https://veteransbenefitsbanking.org/">
-                          Veterans Benefits Banking Program (VBBP)
-                        </a>{' '}
-                        provides a list of Veteran-friendly banks and credit
-                        unions. They’ll work with you to set up an account, or
-                        help you qualify for an account, so you can use direct
-                        deposit. To get started, call one of the participating
-                        banks or credit unions listed on the VBBP website. Be
-                        sure to mention the Veterans Benefits Banking Program.
-                      </p>
-                      <p>
-                        Note: The Department of the Treasury requires us to make
-                        electronic payments. If you don’t want to use direct
-                        deposit, you’ll need to call the Department of the
-                        Treasury at <a href="tel:8882242950">888-224-2950</a>.
-                        Ask to talk with a representative who handles waiver
-                        requests. They can answer any questions or concerns you
-                        may have.{' '}
-                      </p>
-                      <h6>Learn about educational programs</h6>
-                      <p>
-                        See what benefits you’ll get at the school you want to
-                        attend.{' '}
-                        <a href="/education/gi-bill-comparison-tool/">
-                          Use the GI Bill Comparison Tool
-                        </a>
-                        .
-                      </p>
-                    </div>
-                  )}
+                  <p>
+                    <strong>
+                      What if I need help filling out my application?
+                    </strong>{' '}
+                    An accredited representative with a Veterans Service
+                    Organization (VSO) can help you fill out your claim.{' '}
+                    <a href="/disability-benefits/apply/help/index.html">
+                      Find an accredited representative
+                    </a>
+                    .
+                  </p>
+                  <h6>Learn about educational programs</h6>
+                  <p>
+                    See what benefits you’ll get at the school you want to
+                    attend.{' '}
+                    <a href="/education/gi-bill-comparison-tool/">
+                      Use the GI Bill Comparison Tool
+                    </a>
+                    .
+                  </p>
                 </li>
                 <li className="process-step list-two">
                   <div>


### PR DESCRIPTION
## Revert incorrectly updated 1990e content

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/24730

This reverts the following PR which updated content on the wrong chapter page: https://github.com/department-of-veterans-affairs/vets-website/pull/20587/files

## Testing done


## Screenshots
<img width="496" alt="Screen Shot 2022-03-22 at 1 52 39 PM" src="https://user-images.githubusercontent.com/3818397/159574386-86e89be8-8a5f-4974-9974-c819b372d8a9.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
