### PR TITLE
[COE] connect DocumentList to live data

### DIFF
--- a/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
@@ -8,14 +8,14 @@ const DocumentList = ({ notOnUploadPage }) => {
   const [documents, setDocuments] = useState([]);
 
   useEffect(() => {
-    async function getData() {
+    const getData = async () => {
       const data = await getCoeDocuments();
       if (data.errors) {
         // Will add error handling in the future
       } else {
         setDocuments(data);
       }
-    }
+    };
 
     getData();
   }, []);

--- a/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
@@ -1,24 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+import { getCoeDocuments } from './api';
 import List from './List';
 
-const documents = [
-  {
-    id: 0,
-    title: 'a document',
-    type: 'PDF',
-    timestamp: 1645565285000,
-  },
-  {
-    id: 1,
-    title: 'another document',
-    type: 'PDF',
-    timestamp: 1645565285000,
-  },
-];
-
 const DocumentList = ({ notOnUploadPage }) => {
+  const [documents, setDocuments] = useState([]);
+
+  const getDocuments = async () => setDocuments(await getCoeDocuments());
+
+  useEffect(() => {
+    getDocuments();
+  }, []);
+
   if (documents.length > 0) {
     return (
       <>
@@ -34,6 +28,7 @@ const DocumentList = ({ notOnUploadPage }) => {
       </>
     );
   }
+
   if (notOnUploadPage) {
     return (
       <>

--- a/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
@@ -7,9 +7,9 @@ import List from './List';
 const DocumentList = ({ notOnUploadPage }) => {
   const [documents, setDocuments] = useState([]);
 
-  const getDocuments = async () => setDocuments(await getCoeDocuments());
-
   useEffect(() => {
+    const getDocuments = async () => setDocuments(await getCoeDocuments());
+
     getDocuments();
   }, []);
 
@@ -19,7 +19,7 @@ const DocumentList = ({ notOnUploadPage }) => {
         <h2 className="vads-u-margin-bottom--0">
           You have letters about your COE request
         </h2>
-        <p className="vads-u-border-color--gray-lighter vads-u-border-bottom--1px vads-u-margin--0 vads-u-padding-y--4">
+        <p className="vads-u-border-color--gray-lighter vads-u-border-bottom--1px vads-u-margin--0 vads-u-padding-y--3">
           We’ve emailed you notification letters about your COE request. Please
           read these and follow the steps they outline. You may need to take
           action before we can make a final decision.
@@ -34,14 +34,14 @@ const DocumentList = ({ notOnUploadPage }) => {
       <>
         <h2>How will I know if VA needs more information from me?</h2>
         <p className="vads-u-margin-bottom--0">
-          If we need more information, we’ll notify you by email or mail. You
-          can also check the status of your request for a COE by returning to
-          this page.
+          If we need more information, we’ll notify you by email. You can also
+          check the status of your request for a COE by returning to this page.
         </p>
       </>
     );
   }
-  return '';
+
+  return null;
 };
 
 DocumentList.propTypes = {

--- a/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
@@ -8,9 +8,16 @@ const DocumentList = ({ notOnUploadPage }) => {
   const [documents, setDocuments] = useState([]);
 
   useEffect(() => {
-    const getDocuments = async () => setDocuments(await getCoeDocuments());
+    async function getData() {
+      const data = await getCoeDocuments();
+      if (data.errors) {
+        // Will add error handling in the future
+      } else {
+        setDocuments(data);
+      }
+    }
 
-    getDocuments();
+    getData();
   }, []);
 
   if (documents.length > 0) {

--- a/src/applications/lgy/coe/status/components/DocumentList/List.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/List.jsx
@@ -4,21 +4,34 @@ import PropTypes from 'prop-types';
 
 import ListItem from './ListItem';
 
-const formatDate = date => moment(date).format('MMMM DD, YYYY');
+const formatDate = timestamp => moment(timestamp).format('MMMM DD, YYYY');
+const formatLabelDate = timestamp => moment(timestamp).format('MMDDYYYY');
+
+// ex docType: '.pdf'
+const getDocumentType = docType => docType.slice(1).toUpperCase();
+
+const getDownloadLinkLabel = (timestamp, documentType) =>
+  `Download Notification Letter ${formatLabelDate(
+    timestamp,
+  )} (${getDocumentType(documentType)})`;
 
 const List = ({ documents }) => {
   return documents.map((document, i) => {
+    const { description, documentType, timestamp } = document;
+
+    const downloadLinkLabel = getDownloadLinkLabel(timestamp, documentType);
     // This will come from the document payload in the future
     const downloadUrl = '∂';
-    const sentDate = formatDate(document.timestamp);
+    const sentDate = formatDate(timestamp);
+    const title = description;
 
     return (
       <ListItem
         key={i}
+        downloadLinkLabel={downloadLinkLabel}
         downloadUrl={downloadUrl}
         sentDate={sentDate}
-        title={document.title}
-        type={document.type}
+        title={title}
       />
     );
   });

--- a/src/applications/lgy/coe/status/components/DocumentList/List.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/List.jsx
@@ -21,7 +21,6 @@ const List = ({ documents }) => {
     // This will come from the document payload in the future
     const downloadUrl = '∂';
     const sentDate = formatDate(timestamp);
-    const title = description;
 
     return (
       <ListItem
@@ -29,7 +28,7 @@ const List = ({ documents }) => {
         downloadLinkLabel={downloadLinkLabel}
         downloadUrl={downloadUrl}
         sentDate={sentDate}
-        title={title}
+        title={description}
       />
     );
   });

--- a/src/applications/lgy/coe/status/components/DocumentList/List.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/List.jsx
@@ -16,11 +16,11 @@ const getDownloadLinkLabel = (timestamp, documentType) =>
   )} (${getDocumentType(documentType)})`;
 
 const List = ({ documents }) => {
-  return documents.map(({ description, documentType, timestamp }, i) => {
-    const downloadLinkLabel = getDownloadLinkLabel(timestamp, documentType);
+  return documents.map(({ createDate, description, documentType }, i) => {
+    const downloadLinkLabel = getDownloadLinkLabel(createDate, documentType);
     // This will come from the document payload in the future
     const downloadUrl = '∂';
-    const sentDate = formatDate(timestamp);
+    const sentDate = formatDate(createDate);
 
     return (
       <ListItem

--- a/src/applications/lgy/coe/status/components/DocumentList/List.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/List.jsx
@@ -16,9 +16,7 @@ const getDownloadLinkLabel = (timestamp, documentType) =>
   )} (${getDocumentType(documentType)})`;
 
 const List = ({ documents }) => {
-  return documents.map((document, i) => {
-    const { description, documentType, timestamp } = document;
-
+  return documents.map(({ description, documentType, timestamp }, i) => {
     const downloadLinkLabel = getDownloadLinkLabel(timestamp, documentType);
     // This will come from the document payload in the future
     const downloadUrl = '∂';

--- a/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import DownloadLink from '../../../shared/components/DownloadLink';
 
 const ListItem = ({ downloadUrl, downloadLinkLabel, sentDate, title }) => (
-  <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-margin-top--4 vads-u-padding-bottom--4">
+  <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-margin-top--2p5 vads-u-padding-bottom--4">
     <h3 className="vads-u-font-family--serif vads-u-margin--0">{title}</h3>
     <p className="vads-u-margin-y--1p5">Date Sent: {sentDate}</p>
     <DownloadLink href={downloadUrl} label={downloadLinkLabel} />

--- a/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import DownloadLink from '../../../shared/components/DownloadLink';
 
-const ListItem = ({ downloadUrl, sentDate, title, type }) => (
+const ListItem = ({ downloadUrl, downloadLinkLabel, sentDate, title }) => (
   <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-margin-top--4 vads-u-padding-bottom--4">
     <h3 className="vads-u-font-family--serif vads-u-margin--0">{title}</h3>
     <p className="vads-u-margin-y--1p5">Date Sent: {sentDate}</p>
-    <DownloadLink href={downloadUrl} label={`${title} ${type}`} />
+    <DownloadLink href={downloadUrl} label={downloadLinkLabel} />
   </div>
 );
 
 ListItem.propTypes = {
+  downloadLinkLabel: PropTypes.string,
   downloadUrl: PropTypes.string,
   sentDate: PropTypes.string,
   title: PropTypes.string,
-  type: PropTypes.string,
 };
 
 export default ListItem;

--- a/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
@@ -1,19 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import DownloadLink from '../../../shared/components/DownloadLink';
+// NOTE: The DownloadLink is being hidden for the moment because vets-api doesn't currently
+// return a url as part of the payload, which means the link currently doesn't point to anything.
+// Adding a url to the payload is planned as future work.
+// import DownloadLink from '../../../shared/components/DownloadLink';
 
-const ListItem = ({ downloadUrl, downloadLinkLabel, sentDate, title }) => (
+const ListItem = ({
+  /* downloadUrl, downloadLinkLabel, */ sentDate,
+  title,
+}) => (
   <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-margin-top--2p5 vads-u-padding-bottom--4">
     <h3 className="vads-u-font-family--serif vads-u-margin--0">{title}</h3>
     <p className="vads-u-margin-y--1p5">Date Sent: {sentDate}</p>
-    <DownloadLink href={downloadUrl} label={downloadLinkLabel} />
+    {/* <DownloadLink href={downloadUrl} label={downloadLinkLabel} /> */}
   </div>
 );
 
 ListItem.propTypes = {
-  downloadLinkLabel: PropTypes.string,
-  downloadUrl: PropTypes.string,
+  // downloadLinkLabel: PropTypes.string,
+  // downloadUrl: PropTypes.string,
   sentDate: PropTypes.string,
   title: PropTypes.string,
 };

--- a/src/applications/lgy/coe/status/components/DocumentList/api.js
+++ b/src/applications/lgy/coe/status/components/DocumentList/api.js
@@ -1,0 +1,12 @@
+import { apiRequest } from 'platform/utilities/api';
+
+const COE_DOCUMENTS_URI = '/coe/documents';
+
+export const getCoeDocuments = async () => {
+  try {
+    const response = await apiRequest(COE_DOCUMENTS_URI);
+    return response.data.attributes;
+  } catch (error) {
+    return error;
+  }
+};


### PR DESCRIPTION
## Description
The document list has been using static data while we waited for `vets-api` to have an endpoint that we could retrieve the data from. Now that the `coe/documents` endpoint is ready, we need to connect to it.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38293

## Acceptance criteria
- [x] The `DocumentList` component uses data from `vets-api` to populate the list of documents

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
