### PR TITLE
CST: Replace `CollapsiblePanel` with `va-accordion`

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/Issues.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Issues.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CollapsiblePanel from '@department-of-veterans-affairs/component-library/CollapsiblePanel';
 
 const Issues = ({ issues, isAppeal }) => {
   const open = issues.filter(i => i.status === 'open');
@@ -65,13 +64,13 @@ const Issues = ({ issues, isAppeal }) => {
   if (openListItems.length || remandListItems.length) {
     // Active panel should always render as expanded by default (when items present)
     activeItems = (
-      <CollapsiblePanel
-        panelName={`Currently on ${isAppeal ? 'appeal' : 'review'}`}
-        startOpen
-      >
+      <va-accordion-item open>
+        <h2 slot="headline">
+          {`Currently on ${isAppeal ? 'appeal' : 'review'}`}
+        </h2>
         {openSection}
         {remandSection}
-      </CollapsiblePanel>
+      </va-accordion-item>
     );
   }
 
@@ -83,19 +82,22 @@ const Issues = ({ issues, isAppeal }) => {
   ) {
     // Closed panel should render as expanded by default only if no active panel present
     closedItems = (
-      <CollapsiblePanel panelName={'Closed'} startOpen={!activeItems}>
+      <va-accordion-item open={!activeItems}>
+        <h2 slot="headline">Closed</h2>
         {grantedSection}
         {deniedSection}
         {withdrawnSection}
-      </CollapsiblePanel>
+      </va-accordion-item>
     );
   }
 
   return (
     <div className="issues-container">
       <h2>Issues</h2>
-      {activeItems}
-      {closedItems}
+      <va-accordion bordered open-single>
+        {activeItems}
+        {closedItems}
+      </va-accordion>
     </div>
   );
 };

--- a/src/applications/claims-status/components/appeals-v2/Issues.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Issues.jsx
@@ -23,8 +23,8 @@ const Issues = ({ issues, isAppeal }) => {
   let remandSection = null;
   if (remandListItems.length) {
     remandSection = (
-      <div>
-        <h5>Remand</h5>
+      <div className="remand-section">
+        <h4 className="vads-u-font-size--h5">Remand</h4>
         <ul>{remandListItems}</ul>
       </div>
     );
@@ -34,7 +34,7 @@ const Issues = ({ issues, isAppeal }) => {
   if (grantedListItems.length) {
     grantedSection = (
       <div className="granted-section">
-        <h5>Granted</h5>
+        <h4 className="vads-u-font-size--h5">Granted</h4>
         <ul>{grantedListItems}</ul>
       </div>
     );
@@ -44,7 +44,7 @@ const Issues = ({ issues, isAppeal }) => {
   if (deniedListItems.length) {
     deniedSection = (
       <div className="denied-section">
-        <h5>Denied</h5>
+        <h4 className="vads-u-font-size--h5">Denied</h4>
         <ul>{deniedListItems}</ul>
       </div>
     );
@@ -53,8 +53,8 @@ const Issues = ({ issues, isAppeal }) => {
   let withdrawnSection = null;
   if (withdrawnListItems.length) {
     withdrawnSection = (
-      <div>
-        <h5 className="withdrawn-section">Withdrawn</h5>
+      <div className="withdrawn-section">
+        <h4 className="vads-u-font-size--h5">Withdrawn</h4>
         <ul>{withdrawnListItems}</ul>
       </div>
     );
@@ -65,9 +65,9 @@ const Issues = ({ issues, isAppeal }) => {
     // Active panel should always render as expanded by default (when items present)
     activeItems = (
       <va-accordion-item open>
-        <h2 slot="headline">
+        <h3 slot="headline">
           {`Currently on ${isAppeal ? 'appeal' : 'review'}`}
-        </h2>
+        </h3>
         {openSection}
         {remandSection}
       </va-accordion-item>
@@ -83,7 +83,7 @@ const Issues = ({ issues, isAppeal }) => {
     // Closed panel should render as expanded by default only if no active panel present
     closedItems = (
       <va-accordion-item open={!activeItems}>
-        <h2 slot="headline">Closed</h2>
+        <h3 slot="headline">Closed</h3>
         {grantedSection}
         {deniedSection}
         {withdrawnSection}
@@ -103,6 +103,7 @@ const Issues = ({ issues, isAppeal }) => {
 };
 
 Issues.propTypes = {
+  isAppeal: PropTypes.bool.isRequired,
   issues: PropTypes.arrayOf(
     PropTypes.shape({
       status: PropTypes.oneOf([
@@ -115,7 +116,6 @@ Issues.propTypes = {
       description: PropTypes.string.isRequired,
     }),
   ).isRequired,
-  isAppeal: PropTypes.bool.isRequired,
 };
 
 export default Issues;

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -4,7 +4,7 @@ import {
   mockFetch,
   setFetchJSONFailure,
   setFetchJSONResponse,
-} from 'platform/testing/unit/helpers.js';
+} from 'platform/testing/unit/helpers';
 
 import {
   ADD_FILE,

--- a/src/applications/claims-status/tests/components/appeals-v2/Issues.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/Issues.unit.spec.jsx
@@ -37,7 +37,7 @@ describe('<Issues/>', () => {
 
   it('should render one panel when only an open issue is passed in', () => {
     const wrapper = shallow(<Issues {...oneOpenIssue} />);
-    const openPanel = wrapper.find('va-accordion-item').find('h2');
+    const openPanel = wrapper.find('va-accordion-item').find('h3');
     const panelName = openPanel.text();
     expect(panelName).to.equal('Currently on appeal');
     wrapper.unmount();
@@ -45,7 +45,7 @@ describe('<Issues/>', () => {
 
   it('should render one panel when only a closed issue is passed in', () => {
     const wrapper = shallow(<Issues {...oneClosedIssue} />);
-    const closedPanel = wrapper.find('va-accordion-item').find('h2');
+    const closedPanel = wrapper.find('va-accordion-item').find('h3');
     const panelName = closedPanel.text();
     expect(panelName).to.equal('Closed');
     wrapper.unmount();
@@ -64,7 +64,7 @@ describe('<Issues/>', () => {
     };
     const wrapper = mount(<Issues {...props} />);
     const panel = wrapper.find('va-accordion-item');
-    expect(panel.find('h2').text()).to.contain('Currently on appeal');
+    expect(panel.find('h3').text()).to.contain('Currently on appeal');
     // no need to click, panel should be auto-expanded
     // open items are in the first ul within the first accordion's content
     const openContentList = panel.find('ul');
@@ -78,7 +78,7 @@ describe('<Issues/>', () => {
     };
     const wrapper = mount(<Issues {...props} />);
     const panel = wrapper.find('va-accordion-item');
-    expect(panel.find('h2').text()).to.contain('Closed');
+    expect(panel.find('h3').text()).to.contain('Closed');
     // no need to click, panel should be auto-expanded
     // closed items are in accordion > div > ul > li
     const remandDiv = wrapper.find('va-accordion-item > div');
@@ -89,7 +89,7 @@ describe('<Issues/>', () => {
   it('should pass auto-expand prop to active panel when both active and closed panels present', () => {
     const wrapper = shallow(<Issues {...manyIssues} />);
     const activePanel = wrapper.find('va-accordion-item').first();
-    expect(activePanel.find('h2').text()).to.equal('Currently on appeal');
+    expect(activePanel.find('h3').text()).to.equal('Currently on appeal');
     expect(activePanel.props().open).to.be.true;
     wrapper.unmount();
   });
@@ -97,7 +97,7 @@ describe('<Issues/>', () => {
   it('should pass auto-expand prop to active panel when only active panel present', () => {
     const wrapper = shallow(<Issues {...oneOpenIssue} />);
     const activePanel = wrapper.find('va-accordion-item');
-    expect(activePanel.find('h2').text()).to.equal('Currently on appeal');
+    expect(activePanel.find('h3').text()).to.equal('Currently on appeal');
     expect(activePanel.props().open).to.be.true;
     wrapper.unmount();
   });
@@ -105,7 +105,7 @@ describe('<Issues/>', () => {
   it('should pass auto-expand prop to closed panel when no active panel present', () => {
     const wrapper = shallow(<Issues {...oneClosedIssue} />);
     const closedPanel = wrapper.find('va-accordion-item').first();
-    expect(closedPanel.find('h2').text()).to.equal('Closed');
+    expect(closedPanel.find('h3').text()).to.equal('Closed');
     expect(closedPanel.props().open).to.be.true;
     wrapper.unmount();
   });
@@ -113,7 +113,7 @@ describe('<Issues/>', () => {
   it('should not pass auto-expand prop to closed panel when active panel present', () => {
     const wrapper = shallow(<Issues {...manyIssues} />);
     const closedPanel = wrapper.find('va-accordion-item').at(1);
-    expect(closedPanel.find('h2').text()).to.equal('Closed');
+    expect(closedPanel.find('h3').text()).to.equal('Closed');
     expect(closedPanel.props().open).to.be.false;
     wrapper.unmount();
   });
@@ -122,7 +122,7 @@ describe('<Issues/>', () => {
     const props = set('isAppeal', false, oneOpenIssue);
     const wrapper = shallow(<Issues {...props} />);
     const activePanel = wrapper.find('va-accordion-item');
-    expect(activePanel.find('h2').text()).to.equal('Currently on review');
+    expect(activePanel.find('h3').text()).to.equal('Currently on review');
     wrapper.unmount();
   });
 });

--- a/src/applications/claims-status/tests/components/appeals-v2/Issues.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/Issues.unit.spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+import set from 'platform/utilities/data/set';
+
 import Issues from '../../../components/appeals-v2/Issues';
 import { addStatusToIssues } from '../../../utils/appeals-v2-helpers';
 import { mockData } from '../../../utils/helpers';
-import set from 'platform/utilities/data/set';
 
 describe('<Issues/>', () => {
   const emptyIssues = { issues: addStatusToIssues([]), isAppeal: true };
@@ -30,35 +31,29 @@ describe('<Issues/>', () => {
   it('should render no panels when no issues passed in', () => {
     // Note: this probably isn't possible in real-world usage
     const wrapper = shallow(<Issues {...emptyIssues} />);
-    expect(wrapper.find('CollapsiblePanel').length).to.equal(0);
+    expect(wrapper.find('va-accordion-item').length).to.equal(0);
     wrapper.unmount();
   });
 
   it('should render one panel when only an open issue is passed in', () => {
     const wrapper = shallow(<Issues {...oneOpenIssue} />);
-    const openPanelButton = wrapper
-      .find('CollapsiblePanel')
-      .dive()
-      .find('button');
-    const panelName = openPanelButton.render().text();
+    const openPanel = wrapper.find('va-accordion-item').find('h2');
+    const panelName = openPanel.text();
     expect(panelName).to.equal('Currently on appeal');
     wrapper.unmount();
   });
 
   it('should render one panel when only a closed issue is passed in', () => {
     const wrapper = shallow(<Issues {...oneClosedIssue} />);
-    const closedPanelButton = wrapper
-      .find('CollapsiblePanel')
-      .dive()
-      .find('button');
-    const panelName = closedPanelButton.render().text();
+    const closedPanel = wrapper.find('va-accordion-item').find('h2');
+    const panelName = closedPanel.text();
     expect(panelName).to.equal('Closed');
     wrapper.unmount();
   });
 
   it('should render two panels when both open *AND* closed issues are passed in', () => {
     const wrapper = shallow(<Issues {...manyIssues} />);
-    expect(wrapper.find('CollapsiblePanel').length).to.equal(2);
+    expect(wrapper.find('va-accordion-item').length).to.equal(2);
     wrapper.unmount();
   });
 
@@ -68,11 +63,11 @@ describe('<Issues/>', () => {
       isAppeal: true,
     };
     const wrapper = mount(<Issues {...props} />);
-    const panelButton = wrapper.find('.usa-accordion-button');
-    expect(panelButton.html()).to.contain('Currently on appeal');
+    const panel = wrapper.find('va-accordion-item');
+    expect(panel.find('h2').text()).to.contain('Currently on appeal');
     // no need to click, panel should be auto-expanded
     // open items are in the first ul within the first accordion's content
-    const openContentList = wrapper.find('.usa-accordion-content > ul');
+    const openContentList = panel.find('ul');
     expect(openContentList.find('li').length).to.equal(props.issues.length);
     wrapper.unmount();
   });
@@ -82,61 +77,52 @@ describe('<Issues/>', () => {
       issues: [{ status: 'granted', description: 'test closed issue' }],
     };
     const wrapper = mount(<Issues {...props} />);
-    const panelButton = wrapper.find('.usa-accordion-button');
-    expect(panelButton.html()).to.contain('Closed');
+    const panel = wrapper.find('va-accordion-item');
+    expect(panel.find('h2').text()).to.contain('Closed');
     // no need to click, panel should be auto-expanded
     // closed items are in accordion > div > ul > li
-    const remandDiv = wrapper.find('.usa-accordion-content > div');
+    const remandDiv = wrapper.find('va-accordion-item > div');
     expect(remandDiv.find('ul > li').length).to.equal(props.issues.length);
     wrapper.unmount();
   });
 
   it('should pass auto-expand prop to active panel when both active and closed panels present', () => {
     const wrapper = shallow(<Issues {...manyIssues} />);
-    const activePanelProps = wrapper
-      .find('CollapsiblePanel')
-      .first()
-      .props();
-    expect(activePanelProps.panelName).to.equal('Currently on appeal');
-    expect(activePanelProps.startOpen).to.be.true;
+    const activePanel = wrapper.find('va-accordion-item').first();
+    expect(activePanel.find('h2').text()).to.equal('Currently on appeal');
+    expect(activePanel.props().open).to.be.true;
     wrapper.unmount();
   });
 
   it('should pass auto-expand prop to active panel when only active panel present', () => {
     const wrapper = shallow(<Issues {...oneOpenIssue} />);
-    const activePanelProps = wrapper.find('CollapsiblePanel').props();
-    expect(activePanelProps.panelName).to.equal('Currently on appeal');
-    expect(activePanelProps.startOpen).to.be.true;
+    const activePanel = wrapper.find('va-accordion-item');
+    expect(activePanel.find('h2').text()).to.equal('Currently on appeal');
+    expect(activePanel.props().open).to.be.true;
     wrapper.unmount();
   });
 
   it('should pass auto-expand prop to closed panel when no active panel present', () => {
     const wrapper = shallow(<Issues {...oneClosedIssue} />);
-    const closedPanelProps = wrapper
-      .find('CollapsiblePanel')
-      .first()
-      .props();
-    expect(closedPanelProps.panelName).to.equal('Closed');
-    expect(closedPanelProps.startOpen).to.be.true;
+    const closedPanel = wrapper.find('va-accordion-item').first();
+    expect(closedPanel.find('h2').text()).to.equal('Closed');
+    expect(closedPanel.props().open).to.be.true;
     wrapper.unmount();
   });
 
   it('should not pass auto-expand prop to closed panel when active panel present', () => {
     const wrapper = shallow(<Issues {...manyIssues} />);
-    const closedPanelProps = wrapper
-      .find('CollapsiblePanel')
-      .at(1)
-      .props();
-    expect(closedPanelProps.panelName).to.equal('Closed');
-    expect(closedPanelProps.startOpen).to.be.false;
+    const closedPanel = wrapper.find('va-accordion-item').at(1);
+    expect(closedPanel.find('h2').text()).to.equal('Closed');
+    expect(closedPanel.props().open).to.be.false;
     wrapper.unmount();
   });
 
   it('should use the word "review" if a Supplemental Claim or Higher-Level Review', () => {
     const props = set('isAppeal', false, oneOpenIssue);
     const wrapper = shallow(<Issues {...props} />);
-    const activePanelProps = wrapper.find('CollapsiblePanel').props();
-    expect(activePanelProps.panelName).to.equal('Currently on review');
+    const activePanel = wrapper.find('va-accordion-item');
+    expect(activePanel.find('h2').text()).to.equal('Currently on review');
     wrapper.unmount();
   });
 });

--- a/src/applications/claims-status/tests/e2e/07.appeal-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/07.appeal-status.cypress.spec.js
@@ -1,0 +1,60 @@
+import legacyAppeal from './fixtures/mocks/legacy-appeal.json';
+import backendStatuses from './fixtures/mocks/backend-statuses.json';
+
+beforeEach(() => {
+  cy.intercept('GET', '/v0/feature_toggles*', { data: { features: [] } });
+  cy.intercept('GET', '/v0/backend_statuses*', backendStatuses);
+  cy.intercept('GET', '/v0/appeals', legacyAppeal);
+  cy.login();
+});
+
+describe('Appeals page test', () => {
+  it('should show issue not found', () => {
+    cy.visit('/track-claims/appeals/10/status');
+
+    cy.title().should('eq', 'Track Claims | Veterans Affairs');
+    cy.get('h1').should('contain', 'Sorry, we couldn’t find that appeal.');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should show appropriate status information', () => {
+    cy.visit('/track-claims/appeals/12/status');
+
+    cy.get('h1').should('contain', 'Appeal received August 2017');
+    cy.get('h2:first-of-type').should('contain', 'Reveal past events');
+    cy.get('#tabv2status[aria-selected="true"]').should('be.visible');
+
+    //  expand past events
+    cy.get('.past-events-expander button').click();
+    cy.get('#appeal-timeline li:nth-of-type(4)').should(
+      'contain',
+      'sent you a Statement of the Case',
+    );
+
+    cy.get('.alerts-list li').should('contain', 'Return VA Form 9 by');
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should show issue statuses', () => {
+    cy.visit('/track-claims/appeals/12/detail');
+
+    cy.get('h1').should('contain', 'Appeal received August 2017');
+    cy.get('h2').should('contain', 'Issues');
+
+    // first accordion auto-expanded
+    cy.get('va-accordion-item[open="true"]').should('be.visible');
+    cy.get('va-accordion-item[open="true"] li').should('have.length', 3);
+    cy.injectAxeThenAxeCheck();
+
+    // expand second accordion
+    cy.get('va-accordion-item[open="false"]')
+      .shadow()
+      .then(accordion => {
+        cy.wrap(accordion.find('button')).click({ force: true });
+      });
+    cy.get('va-accordion-item[open="true"]').should('be.visible');
+    cy.get('va-accordion-item[open="true"] li').should('have.length', 4);
+    cy.axeCheck();
+  });
+});

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/backend-statuses.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/backend-statuses.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "attributes": {
+      "reported_at": "2019-03-21T16:54:34.000Z",
+      "statuses": [
+        {
+          "service": "Appeals",
+          "service_id": "appeals",
+          "status": "active",
+          "last_incident_timestamp": "2019-03-21T16:54:34.000Z"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/legacy-appeal.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/legacy-appeal.json
@@ -1,0 +1,87 @@
+{
+  "data": [{
+    "id": "12",
+    "type": "legacyAppeal",
+    "attributes": {
+      "appealIds": ["12"],
+      "updated": "2018-05-29T19:38:40-04:00",
+      "incompleteHistory": false,
+      "type": "original",
+      "active": true,
+      "description": "Service connection, sleep apnea",
+      "aod": false,
+      "location": "aoj",
+      "aoj": "vba",
+      "programArea": "compensation",
+      "status": {
+        "type": "pending_form9",
+        "details": {
+          "lastSocDate": "2018-05-15",
+          "certificationTimeliness": [2, 12],
+          "ssocTimeliness": [7, 20]
+        }
+      },
+      "alerts": [{
+        "type": "form9_needed",
+        "details": {
+          "dueDate": "2018-07-31"
+        }
+      }],
+      "docket": null,
+      "issues": [{
+        "description": "Service connection, sleep apnea0",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": null,
+        "date": null
+      },{
+        "description": "Service connection, tinnitus",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": "field_grant",
+        "date": null
+      },{
+        "description": "Service connection, sore foot",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": "withdrawn",
+        "date": null
+      },{
+        "description": "Service connection, shoulder ache",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": "allowed",
+        "date": null
+      },{
+        "description": "Service connection, knee ankylosis",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": "denied",
+        "date": null
+      },{
+        "description": "Service connection, arthritis",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": "remand",
+        "date": null
+      },{
+        "description": "Service connection, wrist issue",
+        "diagnosticCode": "6847",
+        "active": true,
+        "lastAction": "cavc_remand",
+        "date": null
+      }],
+      "events": [{
+        "type": "claim_decision",
+        "date": "2017-07-31"
+      }, {
+        "type": "nod",
+        "date": "2017-08-10"
+      }, {
+        "type": "soc",
+        "date": "2018-05-15"
+      }],
+      "evidence": []
+    }
+  }]
+}


### PR DESCRIPTION
## Description

- Replace `CollapsiblePanel` with `va-accordion` per [migration guide](https://vfs.atlassian.net/wiki/spaces/DST/pages/2127527996/Manual+Component+Migration+Guide#Collapsible-Panel-to-va-accordion%3A)
- Adjusted heading levels (a11y)
- Updated unit tests
- Added e2e test for appeals page view

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38879

## Testing done

Updated unit tests & added e2e test

## Screenshots

![appeal page accordions only allowing one open at a time](https://user-images.githubusercontent.com/136959/159722765-ef3ddd4c-d572-4bf7-b51b-4e8a5c58f203.gif)

## Acceptance criteria
- [x] Switch to web component
- [x] Updated tests
- [x] Fix a11y problems

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
