### PR TITLE
526: Replace `CollapsiblePanel` with `va-accordion`

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/DownloadLink.jsx
+++ b/src/applications/disability-benefits/all-claims/components/DownloadLink.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Download link
+ * @param {string} url - URL to downloadable file
+ * @param {string|element} content - Link content
+ * @param {string|number} size - PDF size in MB
+ * @returns {element}
+ */
+const DownloadLink = ({ url = '', content, size }) => {
+  const fileName = url.split('/').slice(-1);
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      type="application/pdf"
+      download={fileName || null}
+    >
+      <i
+        aria-hidden="true"
+        className="fas fa-download vads-u-padding-right--1"
+        role="img"
+      />
+      {content}{' '}
+      <dfn>
+        <abbr title="Portable Document Format">PDF</abbr> ({size}
+        <abbr title="Megabytes">MB</abbr>)
+      </dfn>
+    </a>
+  );
+};
+
+DownloadLink.propTypes = {
+  content: PropTypes.oneOf(PropTypes.string, PropTypes.element),
+  size: PropTypes.string,
+  url: PropTypes.string,
+};
+
+export default DownloadLink;

--- a/src/applications/disability-benefits/all-claims/components/DownloadLink.jsx
+++ b/src/applications/disability-benefits/all-claims/components/DownloadLink.jsx
@@ -33,7 +33,7 @@ const DownloadLink = ({ url = '', content, size }) => {
 };
 
 DownloadLink.propTypes = {
-  content: PropTypes.oneOf(PropTypes.string, PropTypes.element),
+  content: PropTypes.oneOf([PropTypes.string, PropTypes.element]),
   size: PropTypes.string,
   url: PropTypes.string,
 };

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -1,82 +1,81 @@
 import React from 'react';
-import CollapsiblePanel from '@department-of-veterans-affairs/component-library/CollapsiblePanel';
+import DownloadLink from '../components/DownloadLink';
+
+export const SummaryTitle = () => <h3>Summary of additional benefits</h3>;
 
 const houseAssistanceContent = (
-  <CollapsiblePanel panelName="Adapted housing assistance">
+  <va-accordion-item>
+    <h4 slot="headline">Adapted housing assistance</h4>
     <p>
       To apply for an adapted housing grant, you’ll need to fill out an
       Application in Acquiring Specially Adapted Housing or Special Home
       Adaptation Grant (VA Form 26-4555).
     </p>
     <p>
-      <a
-        href="https://www.vba.va.gov/pubs/forms/vba-26-4555-are.pdf"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Download VA Form 26-4555
-      </a>
+      <DownloadLink
+        url="https://www.vba.va.gov/pubs/forms/vba-26-4555-are.pdf"
+        content="Download VA Form 26-4555"
+        size="0.8"
+      />
       .
     </p>
-  </CollapsiblePanel>
+  </va-accordion-item>
 );
 
 const carAssistanceContent = (
-  <CollapsiblePanel panelName="Automobile allowance">
+  <va-accordion-item>
+    <h4 slot="headline">Automobile allowance</h4>
     <p>
       To file a claim for a one-time payment to help you buy a specially
       equipped vehicle, you’ll need to fill out an Application for Automobile or
       Other Conveyance and Adaptive Equipment (VA Form 21-4502).
-      <div>
-        <a
-          href="https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Download VA Form 21-4502
-        </a>
-        .
-      </div>
+    </p>
+    <p>
+      <DownloadLink
+        url="https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf"
+        content="Download VA Form 21-4502"
+        size="2.7"
+      />
+      .
     </p>
     <p>
       To file a claim for adaptive equipment, you’ll need to fill out an
       Application for Adaptive Equipment—Motor Vehicle (VA Form 10-1394).
-      <div>
-        <a
-          href="https://www.va.gov/vaforms/medical/pdf/10-1394-fill.pdf"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Download VA Form 10-1394.
-        </a>
-      </div>
     </p>
-  </CollapsiblePanel>
+    <p>
+      <DownloadLink
+        url="https://www.va.gov/vaforms/medical/pdf/10-1394-fill.pdf"
+        content="Download VA Form 10-1394"
+        size="0.7"
+      />
+      .
+    </p>
+  </va-accordion-item>
 );
 
 const aidAndAttendanceContent = (
-  <CollapsiblePanel panelName="Aid and Attendance">
+  <va-accordion-item>
+    <h4 slot="headline">Aid and Attendance</h4>
     <p>
       To apply for Aid and Attendance benefits, your doctor needs to fill out an
       Examination for Housebound Status or Permanent Need for Regular Aid and
-      Attendance (VA Form 21-2680). You can submit this form once it's
+      Attendance (VA Form 21-2680). You can submit this form once it’s
       completed.
     </p>
-    <div>
-      <a
-        href="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Download VA Form 21-2680
-      </a>
+    <p>
+      <DownloadLink
+        url="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf"
+        content="Download VA Form 21-2680"
+        size="1.5"
+      />
       .
-    </div>
-  </CollapsiblePanel>
+    </p>
+  </va-accordion-item>
 );
 
 const individualUnemployabilityContent = (
-  <CollapsiblePanel panelName="Individual Unemployability">
+  <va-accordion-item>
+    <h4 slot="headline">Individual Unemployability</h4>
     <p>
       To file a claim for Individual Unemployability, you’ll need to fill out:
     </p>
@@ -84,36 +83,32 @@ const individualUnemployabilityContent = (
       <li>
         A Veteran’s Application for Increased Compensation Based on
         Unemployability (VA Form 21-8940)
-        <div>
-          <a
-            href="https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download VA Form 21-8940
-          </a>
+        <p>
+          <DownloadLink
+            url="https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf"
+            content="Download VA Form 21-8940"
+            size="1.6"
+          />
           , <strong>and</strong>
-        </div>
+        </p>
       </li>
       <li>
         A Request for Employment Information in Connection with Claim for
         Disability Benefits (VA Form 21-4192)
-        <div>
-          <a
-            href="https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download VA Form 21-4192
-          </a>
+        <p>
+          <DownloadLink
+            url="https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf"
+            content="Download VA Form 21-4192"
+            size="2"
+          />
           .
-        </div>
+        </p>
       </li>
     </ul>
-  </CollapsiblePanel>
+  </va-accordion-item>
 );
 
-export default function summaryDescription({ formData }) {
+export function summaryDescription({ formData }) {
   // In production, users should see the unemployable content if they indicate
   // that they're unemployable. In other environments, they should see the
   // unemployable content only when indicate unemployability and no selection
@@ -126,15 +121,17 @@ export default function summaryDescription({ formData }) {
     !formData['view:unemployabilityUploadChoice'];
 
   return (
-    <div>
+    <>
       <p>
         Based on what you told us, you may be eligible for these additional
         disability benefits.
       </p>
-      {formData['view:modifyingHome'] && houseAssistanceContent}
-      {formData['view:modifyingCar'] && carAssistanceContent}
-      {formData['view:aidAndAttendance'] && aidAndAttendanceContent}
-      {showUnemployableContent && individualUnemployabilityContent}
-    </div>
+      <va-accordion bordered>
+        {formData['view:modifyingHome'] && houseAssistanceContent}
+        {formData['view:modifyingCar'] && carAssistanceContent}
+        {formData['view:aidAndAttendance'] && aidAndAttendanceContent}
+        {showUnemployableContent && individualUnemployabilityContent}
+      </va-accordion>
+    </>
   );
 }

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -143,7 +143,7 @@ SummaryDescription.propTypes = {
     'view:aidAndAttendance': PropTypes.bool,
     'view:modifyingCar': PropTypes.bool,
     'view:modifyingHome': PropTypes.bool,
-    'view:unemployabilityUploadChoice': PropTypes.bool,
+    'view:unemployabilityUploadChoice': PropTypes.string,
     'view:unemployable': PropTypes.bool,
   }),
 };

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import DownloadLink from '../components/DownloadLink';
 
 export const SummaryTitle = () => <h3>Summary of additional benefits</h3>;
@@ -108,7 +110,7 @@ const individualUnemployabilityContent = (
   </va-accordion-item>
 );
 
-export function summaryDescription({ formData }) {
+export const SummaryDescription = ({ formData }) => {
   // In production, users should see the unemployable content if they indicate
   // that they're unemployable. In other environments, they should see the
   // unemployable content only when indicate unemployability and no selection
@@ -134,4 +136,14 @@ export function summaryDescription({ formData }) {
       </va-accordion>
     </>
   );
-}
+};
+
+SummaryDescription.propTypes = {
+  formData: PropTypes.shape({
+    'view:aidAndAttendance': PropTypes.bool,
+    'view:modifyingCar': PropTypes.bool,
+    'view:modifyingHome': PropTypes.bool,
+    'view:unemployabilityUploadChoice': PropTypes.bool,
+    'view:unemployable': PropTypes.bool,
+  }),
+};

--- a/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import CollapsiblePanel from '@department-of-veterans-affairs/component-library/CollapsiblePanel';
-
 export const claimExamsDescription = (
   <div>
     <p>
@@ -34,26 +32,30 @@ export const claimExamsDescription = (
 export const claimExamsFAQ = (
   <>
     <h3 className="vads-u-font-size--h4">More information about claim exams</h3>
-    <CollapsiblePanel panelName="What happens if I miss a phone call?">
-      <p>
-        If we can’t reach you by phone, we’ll schedule an appointment for you.
-        We’ll send you a letter with the date and time of your exam.
-      </p>
-      <p>
-        Please call the number on your appointment letter to confirm your exam
-        time and location.
-      </p>
-      <p>
-        If you can’t make your appointment, let us know right away. You can most
-        likely reschedule, but this may delay your claim.
-      </p>
-    </CollapsiblePanel>
-    <CollapsiblePanel panelName="Why do I need a claim exam?">
-      <p>
-        Not everyone who files a disability claim will need an exam. We’ll ask
-        you to have an exam only if we need more information to decide your
-        claim and to help us rate your disability.
-      </p>
-    </CollapsiblePanel>
+    <va-accordion bordered>
+      <va-accordion-item>
+        <h4 slot="headline">What happens if I miss a phone call?</h4>
+        <p>
+          If we can’t reach you by phone, we’ll schedule an appointment for you.
+          We’ll send you a letter with the date and time of your exam.
+        </p>
+        <p>
+          Please call the number on your appointment letter to confirm your exam
+          time and location.
+        </p>
+        <p>
+          If you can’t make your appointment, let us know right away. You can
+          most likely reschedule, but this may delay your claim.
+        </p>
+      </va-accordion-item>
+      <va-accordion-item>
+        <h4 slot="headline">Why do I need a claim exam?</h4>
+        <p>
+          Not everyone who files a disability claim will need an exam. We’ll ask
+          you to have an exam only if we need more information to decide your
+          claim and to help us rate your disability.
+        </p>
+      </va-accordion-item>
+    </va-accordion>
   </>
 );

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router';
-import environment from 'platform/utilities/environment';
 
 import {
   capitalizeEachWord,
@@ -34,9 +33,6 @@ const mapDisabilityName = (disabilityName, formData, index) => {
 };
 
 const getRedirectLink = formData => {
-  if (environment.isProduction()) {
-    return 'go back to the beginning of this step and add it';
-  }
   // Start from orientation page; assuming user has both existing & new
   // disabilities selected
   let destinationPath = DISABILITY_SHARED_CONFIG.orientation.path;
@@ -48,18 +44,15 @@ const getRedirectLink = formData => {
     destinationPath = DISABILITY_SHARED_CONFIG.addDisabilities.path;
   }
   return (
-    <>
-      <Link
-        aria-label="go back and add any missing disabilities"
-        to={{
-          pathname: destinationPath || '/',
-          search: '?redirect',
-        }}
-      >
-        go back and add
-      </Link>{' '}
-      it
-    </>
+    <Link
+      aria-label="go back and add any missing disabilities"
+      to={{
+        pathname: destinationPath || '/',
+        search: '?redirect',
+      }}
+    >
+      go back and add it
+    </Link>
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/ancillaryFormsWizardSummary.js
+++ b/src/applications/disability-benefits/all-claims/pages/ancillaryFormsWizardSummary.js
@@ -1,4 +1,7 @@
-import summaryDescription from '../content/ancillaryFormsWizardSummary';
+import {
+  SummaryTitle,
+  summaryDescription,
+} from '../content/ancillaryFormsWizardSummary';
 
 export const depends = formData =>
   !!(
@@ -9,8 +12,11 @@ export const depends = formData =>
   );
 
 export const uiSchema = {
-  'ui:title': 'Summary of additional benefits',
+  'ui:title': SummaryTitle,
   'ui:description': summaryDescription,
+  'ui:options': {
+    forceDivWrapper: true,
+  },
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/pages/ancillaryFormsWizardSummary.js
+++ b/src/applications/disability-benefits/all-claims/pages/ancillaryFormsWizardSummary.js
@@ -1,6 +1,6 @@
 import {
   SummaryTitle,
-  summaryDescription,
+  SummaryDescription,
 } from '../content/ancillaryFormsWizardSummary';
 
 export const depends = formData =>
@@ -13,7 +13,7 @@ export const depends = formData =>
 
 export const uiSchema = {
   'ui:title': SummaryTitle,
-  'ui:description': summaryDescription,
+  'ui:description': SummaryDescription,
   'ui:options': {
     forceDivWrapper: true,
   },

--- a/src/applications/disability-benefits/all-claims/tests/content/ancillaryFormsWizardSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/ancillaryFormsWizardSummary.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
-import SummaryDescription from '../../content/ancillaryFormsWizardSummary';
+import { SummaryDescription } from '../../content/ancillaryFormsWizardSummary';
 
 describe('526 All Claims -- Ancillary forms wizard summary content', () => {
   it('should render only the appropriate panels', () => {
@@ -11,6 +11,7 @@ describe('526 All Claims -- Ancillary forms wizard summary content', () => {
       'view:modifyingCar': true,
       'view:aidAndAttendance': true,
       'view:unemployable': true,
+      'view:unemployabilityUploadChoice': false,
     };
     const tree = shallow(<SummaryDescription formData={formData} />);
 
@@ -19,13 +20,13 @@ describe('526 All Claims -- Ancillary forms wizard summary content', () => {
     expect(
       accordion
         .first()
-        .find('h3')
+        .find('h4')
         .text(),
     ).to.equal('Adapted housing assistance');
     expect(
       accordion
         .last()
-        .find('h3')
+        .find('h4')
         .text(),
     ).to.equal('Individual Unemployability');
     tree.unmount();

--- a/src/applications/disability-benefits/all-claims/tests/content/ancillaryFormsWizardSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/ancillaryFormsWizardSummary.unit.spec.jsx
@@ -8,20 +8,26 @@ describe('526 All Claims -- Ancillary forms wizard summary content', () => {
   it('should render only the appropriate panels', () => {
     const formData = {
       'view:modifyingHome': true,
-      // view:modifyingCar omitted
+      'view:modifyingCar': true,
       'view:aidAndAttendance': true,
-      'view:unemployable': false,
+      'view:unemployable': true,
     };
     const tree = shallow(<SummaryDescription formData={formData} />);
 
-    const collapsiblePanels = tree.find('CollapsiblePanel');
-    expect(collapsiblePanels.length).to.equal(2);
-    expect(collapsiblePanels.first().props().panelName).to.equal(
-      'Adapted housing assistance',
-    );
-    expect(collapsiblePanels.last().props().panelName).to.equal(
-      'Aid and Attendance',
-    );
+    const accordion = tree.find('va-accordion-item');
+    expect(accordion.length).to.equal(4);
+    expect(
+      accordion
+        .first()
+        .find('h3')
+        .text(),
+    ).to.equal('Adapted housing assistance');
+    expect(
+      accordion
+        .last()
+        .find('h3')
+        .text(),
+    ).to.equal('Individual Unemployability');
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description

- Replace `CollapsiblePanel` with `va-accordion` per [migration guide](https://vfs.atlassian.net/wiki/spaces/DST/pages/2127527996/Manual+Component+Migration+Guide#Collapsible-Panel-to-va-accordion%3A)
- Fix form download links - created a `DownloadLink` component
- Adjusted heading levels (a11y) and removed unnecessary `fieldset/legend`
- Updated unit test

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/38882

## Testing done

Updated unit tests

## Screenshots

<details><summary>Claim exam FAQ</summary>

<!-- leave a blank line above -->
| Before | After |
|:------:| :----:|
| ![claim exam faq using collapsible panels](https://user-images.githubusercontent.com/136959/159782540-5088a6e5-7f9b-464b-9371-a1b2c0bd6223.png) | ![claim exam faq using va-accordion](https://user-images.githubusercontent.com/136959/159782536-e8404070-0533-45b0-9fce-ac5433552225.png) |
</details>

<details><summary>Benefit summary</summary>

<!-- leave a blank line above -->
| Before | After |
|:------:| :----:|
| ![benefit summary using va-accordion](https://user-images.githubusercontent.com/136959/159783237-a6949896-05a9-421c-9314-7fb77decedcf.png) | ![benefit summary using collapsible panels](https://user-images.githubusercontent.com/136959/159783224-41557897-65a8-4fba-9cc0-326e5a2940a7.png) |
</details>

## Acceptance criteria
- [x] Switch to web component
- [x] Updated tests
- [x] Fix a11y problems

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
