### PR TITLE
[MCP] 35878 Statement Balance Questions 

### DIFF
--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -65,8 +65,8 @@ const HTMLStatementPage = ({ match }) => {
         <h2>What if I have questions about my statement?</h2>
         <p>
           Contact the VA Health Resource Center at{' '}
-          <va-telephone contact="8664001238" />
-          (TTY: <va-telephone contact="711" />
+          <va-telephone contact="8664001238" /> (TTY:{' '}
+          <va-telephone contact="711" />
           ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </p>
         <Modals title="Notice of rights and responsibilities">

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -63,6 +63,12 @@ const HTMLStatementPage = ({ match }) => {
         />
         <StatementAddresses id="statement-addresses" copay={selectedCopay} />
         <h2>What if I have questions about my statement?</h2>
+        <p>
+          Contact the VA Health Resource Center at{' '}
+          <va-telephone contact="8664001238" />
+          (TTY: <va-telephone contact="711" />
+          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+        </p>
         <Modals title="Notice of rights and responsibilities">
           <Modals.Rights />
         </Modals>


### PR DESCRIPTION
## Description
Updating Statement Balance questions section. Mockup shows "Notice of rights and responsibilities" styled as link, but with feedback from design, moving forward with secondary button style. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35878

## Screenshots
<details><summary>Statement Questions Section</summary>

<img width="673" alt="image" src="https://user-images.githubusercontent.com/25368370/159934011-023c533b-fe0d-435c-8d35-71ebdf890cd0.png">

</details>

## Acceptance criteria
- [x] Balance Questions section matches mockup

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
