### PR TITLE
Creates DowntimeBanner unit test

### DIFF
--- a/src/platform/user/tests/authentication/components/DowntimeBanner.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/DowntimeBanner.unit.spec.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import DowntimeBanners, {
+  downtimeBannersConfig,
+  DowntimeBanner,
+} from 'platform/user/authentication/components/DowntimeBanner';
+
+const mockStore = configureMockStore();
+const generateState = ({
+  ssoeDown = false,
+  idmeDown = false,
+  dslogonDown = false,
+  mhvDown = false,
+  mviDown = false,
+  logingovDown = false,
+}) => ({
+  externalServiceStatuses: {
+    statuses: [
+      {
+        service: 'DS Logon',
+        serviceId: 'dslogon',
+        status: dslogonDown ? 'inactive' : 'active',
+      },
+      {
+        service: 'ID.me',
+        serviceId: 'idme',
+        status: idmeDown ? 'inactive' : 'active',
+      },
+      {
+        service: 'SSOe',
+        serviceId: 'ssoe',
+        status: ssoeDown ? 'inactive' : 'active',
+      },
+      {
+        service: 'Login.gov',
+        serviceId: 'logingov',
+        status: logingovDown ? 'inactive' : 'active',
+      },
+      {
+        service: 'MVI',
+        serviceId: 'mvi',
+        status: mviDown ? 'inactive' : 'active',
+      },
+      {
+        service: 'MHV',
+        serviceId: 'mhv',
+        status: mhvDown ? 'inactive' : 'active',
+      },
+    ],
+  },
+});
+const filteredDowntimeConfig = deps => {
+  return downtimeBannersConfig.reduce((dependency, current) => {
+    return current.dependencies.includes(deps) ? current : dependency;
+  }, {});
+};
+
+describe('DowntimeBanners', () => {
+  it('should render a collection of `DowntimeBanner`', () => {
+    const initialState = generateState({});
+    const store = mockStore(initialState);
+    const wrapper = shallow(<DowntimeBanners store={store} />);
+
+    expect(wrapper.find('DowntimeBanner').length).to.eql(5);
+    wrapper.unmount();
+  });
+});
+
+describe('DowntimeBanner', () => {
+  const downtimeDeps = ['ssoe', 'mhv', 'idme', 'logingov', 'dslogon', 'mhv'];
+  let initialState;
+  let downtimeBannerProps;
+  let store;
+
+  beforeEach(() => {
+    initialState = generateState({});
+    store = mockStore(initialState);
+    downtimeBannerProps = filteredDowntimeConfig();
+  });
+
+  downtimeDeps.forEach(dependency => {
+    it(`should render if ${dependency} is down`, () => {
+      initialState = generateState({ [`${dependency}Down`]: true });
+      store = mockStore(initialState);
+      downtimeBannerProps = filteredDowntimeConfig(dependency);
+
+      const wrapper = shallow(
+        <DowntimeBanner store={store} {...downtimeBannerProps} />,
+      );
+
+      expect(wrapper.find('h2').text()).to.eql(downtimeBannerProps.headline);
+      expect(wrapper.find('va-alert').prop('visible')).to.be.true;
+      expect(wrapper.find('va-alert').prop('status')).to.eql(
+        downtimeBannerProps.status,
+      );
+      wrapper.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Description
This PR creates a unit test for the DowntimeBanner component
- Mock downtime banners to see which ones are visible

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#37579


## Testing done
unit

## Screenshots
n/a

## Acceptance criteria
- [x] The DowntimeBanner component has an associated unit test

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
