### PR TITLE
38995 - [MCP] - Create Statement Addresses Unit Tests

### DIFF
--- a/src/applications/medical-copays/components/StatementAddresses.jsx
+++ b/src/applications/medical-copays/components/StatementAddresses.jsx
@@ -61,7 +61,7 @@ const StatementAddresses = ({ copay }) => {
           {copay.pHAddress3 && (
             <>
               <span data-testid="recipient-address-three">
-                {copay.pHAddress3 ? copay.pHAddress3 : ''}
+                {copay.pHAddress3}
               </span>
               <br />
             </>

--- a/src/applications/medical-copays/components/StatementAddresses.jsx
+++ b/src/applications/medical-copays/components/StatementAddresses.jsx
@@ -4,49 +4,69 @@ import PropTypes from 'prop-types';
 const StatementAddresses = ({ copay }) => {
   return (
     <>
-      <h2>Statement Addresses</h2>
+      <h2 data-testid="statement-address-head">Statement Addresses</h2>
       <dl>
-        <dt className="vads-u-font-weight--bold">Sender Address</dt>
+        <dt
+          className="vads-u-font-weight--bold"
+          data-testid="sender-address-head"
+        >
+          Sender Address
+        </dt>
         <dd>
-          <span>{copay.station.facilityName}</span>
+          <span data-testid="sender-facility-name">
+            {copay.station.facilityName}
+          </span>
           <br />
-          <span>{copay.station.staTAddress1}</span>
+          <span data-testid="sender-address-one">
+            {copay.station.staTAddress1}
+          </span>
           <br />
           {copay.station.staTAddress2 && (
             <>
-              <span>{copay.station.staTAddress2}</span>
+              <span data-testid="sender-address-two">
+                {copay.station.staTAddress2}
+              </span>
               <br />
             </>
           )}
           {copay.station.staTAddress3 && (
             <>
-              <span>
+              <span data-testid="sender-address-three">
                 {copay.station.staTAddress3 ? copay.station.staTAddress3 : ''}
               </span>
               <br />
             </>
           )}
-          <span>
+          <span data-testid="sender-city-state-zip">
             {copay.station.city}, {copay.station.state} {copay.station.ziPCde}
           </span>
         </dd>
-        <dt className="vads-u-font-weight--bold">Sender Address</dt>
+        <dt
+          className="vads-u-font-weight--bold"
+          data-testid="recipient-address-head"
+        >
+          Recipient Address
+        </dt>
         <dd>
-          <span>{copay.pHAddress1}</span>
+          <span data-testid="recipient-address-one">{copay.pHAddress1}</span>
           <br />
           {copay.pHAddress2 && (
             <>
-              <span>{copay.pHAddress2}</span>
+              <span data-testid="recipient-address-two">
+                {copay.pHAddress2}
+              </span>
               <br />
             </>
           )}
           {copay.pHAddress3 && (
             <>
-              <span>{copay.pHAddress3 ? copay.pHAddress3 : ''}</span>
+              <span data-testid="recipient-address-three">
+                {copay.pHAddress3 ? copay.pHAddress3 : ''}
+              </span>
               <br />
             </>
           )}
-          <span>
+          <span data-testid="recipient-city-state-zip">
             {copay.pHCity}, {copay.pHState} {copay.pHZipCde}
           </span>
         </dd>

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -61,7 +61,10 @@ const HTMLStatementPage = ({ match }) => {
           previousBalance={selectedCopay.pHPrevBal}
           statementDate={statementDate}
         />
-        <StatementAddresses id="statement-addresses" copay={selectedCopay} />
+        <StatementAddresses
+          data-testid="statement-addresses"
+          copay={selectedCopay}
+        />
         <h2>What if I have questions about my statement?</h2>
         <Modals title="Notice of rights and responsibilities">
           <Modals.Rights />

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import Modals from '../components/Modals';
 import StatementAddresses from '../components/StatementAddresses';
+import AccountSummary from '../components/AccountSummary';
 
 const HTMLStatementPage = ({ match }) => {
   const selectedId = match.params.id;
@@ -53,10 +54,14 @@ const HTMLStatementPage = ({ match }) => {
           <strong>Return to facility details</strong>
         </Link>
         <va-on-this-page className="vads-u-margin-top--0" />
-        <StatementAddresses
-          data-testid="statement-addresses"
-          copay={selectedCopay}
+        <AccountSummary
+          currentBalance={selectedCopay.pHNewBalance}
+          newCharges={selectedCopay.pHTotCharges}
+          paymentsReceived={selectedCopay.pHTotCredits}
+          previousBalance={selectedCopay.pHPrevBal}
+          statementDate={statementDate}
         />
+        <StatementAddresses id="statement-addresses" copay={selectedCopay} />
         <h2>What if I have questions about my statement?</h2>
         <Modals title="Notice of rights and responsibilities">
           <Modals.Rights />

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import Modals from '../components/Modals';
 import StatementAddresses from '../components/StatementAddresses';
-import AccountSummary from '../components/AccountSummary';
 
 const HTMLStatementPage = ({ match }) => {
   const selectedId = match.params.id;
@@ -54,14 +53,10 @@ const HTMLStatementPage = ({ match }) => {
           <strong>Return to facility details</strong>
         </Link>
         <va-on-this-page className="vads-u-margin-top--0" />
-        <AccountSummary
-          currentBalance={selectedCopay.pHNewBalance}
-          newCharges={selectedCopay.pHTotCharges}
-          paymentsReceived={selectedCopay.pHTotCredits}
-          previousBalance={selectedCopay.pHPrevBal}
-          statementDate={statementDate}
+        <StatementAddresses
+          data-testid="statement-addresses"
+          copay={selectedCopay}
         />
-        <StatementAddresses id="statement-addresses" copay={selectedCopay} />
         <h2>What if I have questions about my statement?</h2>
         <Modals title="Notice of rights and responsibilities">
           <Modals.Rights />

--- a/src/applications/medical-copays/tests/unit/statement.unit.spec.js
+++ b/src/applications/medical-copays/tests/unit/statement.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import { render } from '@testing-library/react';
 import AccountSummary from '../../components/AccountSummary';
+import StatementAddresses from '../../components/StatementAddresses';
 
 describe('mcp statement view', () => {
   describe('statement account summary component', () => {
@@ -43,6 +44,70 @@ describe('mcp statement view', () => {
       expect(summary.getByTestId('account-summary-new-charges')).to.exist;
       expect(summary.getByTestId('account-summary-new-charges')).to.have.text(
         'New charges: $10.00',
+      );
+    });
+  });
+
+  describe('statement addresses component', () => {
+    it('should render statement addresses', () => {
+      const selectedCopay = {
+        station: {
+          facilityName: 'Test Facility',
+          staTAddress1: '123 Main St',
+          staTAddress2: 'Apt 1',
+          staTAddress3: 'Address 3',
+          city: 'New York',
+          state: 'NY',
+          ziPCde: '10001',
+          pHAddress1: '456 Alternate St',
+          pHAddress2: 'Apt 2',
+          phAddress3: 'Suite 3',
+          pHCity: 'Tampa',
+          pHState: 'FL',
+          pHZipCde: '33333',
+        },
+      };
+
+      const addresses = render(<StatementAddresses copay={selectedCopay} />);
+      expect(addresses.getByTestId('statement-addresses')).to.exist;
+      expect(addresses.getByTestId('statement-address-head')).to.exist;
+      expect(addresses.getByTestId('sender-address-head')).to.exist;
+
+      expect(addresses.getByTestId('sender-facility-name')).to.exist;
+      expect(addresses.getByTestId('sender-facility-name')).to.have.text(
+        'Test Facility',
+      );
+
+      expect(addresses.getByTestId('sender-address-one')).to.exist;
+      expect(addresses.getByTestId('sender-address-one')).to.have.text(
+        '123 Main St',
+      );
+      expect(addresses.getByTestId('sender-address-two')).to.exist;
+      expect(addresses.getByTestId('sender-address-two')).to.have.text('Apt 1');
+      expect(addresses.getByTestId('sender-address-three')).to.exist;
+      expect(addresses.getByTestId('sender-address-three')).to.have.text(
+        'Address 3',
+      );
+      expect(addresses.getByTestId('sender-city-state-zip')).to.exist;
+      expect(addresses.getByTestId('sender-city-state-zip')).to.have.text(
+        'New York, NY 10001',
+      );
+      expect(addresses.getByTestId('recipient-address-head')).to.exist;
+      expect(addresses.getByTestId('recipient-address-one')).to.exist;
+      expect(addresses.getByTestId('recipient-address-one')).to.have.text(
+        '456 Alternate St',
+      );
+      expect(addresses.getByTestId('recipient-address-two')).to.exist;
+      expect(addresses.getByTestId('recipient-address-two')).to.have.text(
+        'Apt 2',
+      );
+      expect(addresses.getByTestId('recipient-address-three')).to.exist;
+      expect(addresses.getByTestId('recipient-address-three')).to.have.text(
+        'Suite 3',
+      );
+      expect(addresses.getByTestId('recipient-city-state-zip')).to.exist;
+      expect(addresses.getByTestId('recipient-city-state-zip')).to.have.text(
+        'Tampa, FL 33333',
       );
     });
   });

--- a/src/applications/medical-copays/tests/unit/statement.unit.spec.js
+++ b/src/applications/medical-copays/tests/unit/statement.unit.spec.js
@@ -59,17 +59,16 @@ describe('mcp statement view', () => {
           city: 'New York',
           state: 'NY',
           ziPCde: '10001',
-          pHAddress1: '456 Alternate St',
-          pHAddress2: 'Apt 2',
-          phAddress3: 'Suite 3',
-          pHCity: 'Tampa',
-          pHState: 'FL',
-          pHZipCde: '33333',
         },
+        pHAddress1: '456 Alternate St',
+        pHAddress2: 'Apt 2',
+        phAddress3: 'Test Patient Address 3',
+        pHCity: 'Tampa',
+        pHState: 'FL',
+        pHZipCde: '33333',
       };
 
       const addresses = render(<StatementAddresses copay={selectedCopay} />);
-      expect(addresses.getByTestId('statement-addresses')).to.exist;
       expect(addresses.getByTestId('statement-address-head')).to.exist;
       expect(addresses.getByTestId('sender-address-head')).to.exist;
 
@@ -82,29 +81,36 @@ describe('mcp statement view', () => {
       expect(addresses.getByTestId('sender-address-one')).to.have.text(
         '123 Main St',
       );
+
       expect(addresses.getByTestId('sender-address-two')).to.exist;
       expect(addresses.getByTestId('sender-address-two')).to.have.text('Apt 1');
+
       expect(addresses.getByTestId('sender-address-three')).to.exist;
       expect(addresses.getByTestId('sender-address-three')).to.have.text(
         'Address 3',
       );
+
       expect(addresses.getByTestId('sender-city-state-zip')).to.exist;
       expect(addresses.getByTestId('sender-city-state-zip')).to.have.text(
         'New York, NY 10001',
       );
+
       expect(addresses.getByTestId('recipient-address-head')).to.exist;
       expect(addresses.getByTestId('recipient-address-one')).to.exist;
       expect(addresses.getByTestId('recipient-address-one')).to.have.text(
         '456 Alternate St',
       );
+
       expect(addresses.getByTestId('recipient-address-two')).to.exist;
       expect(addresses.getByTestId('recipient-address-two')).to.have.text(
         'Apt 2',
       );
+
       expect(addresses.getByTestId('recipient-address-three')).to.exist;
       expect(addresses.getByTestId('recipient-address-three')).to.have.text(
-        'Suite 3',
+        'Test Patient Address 3',
       );
+
       expect(addresses.getByTestId('recipient-city-state-zip')).to.exist;
       expect(addresses.getByTestId('recipient-city-state-zip')).to.have.text(
         'Tampa, FL 33333',

--- a/src/applications/medical-copays/tests/unit/statement.unit.spec.js
+++ b/src/applications/medical-copays/tests/unit/statement.unit.spec.js
@@ -62,7 +62,7 @@ describe('mcp statement view', () => {
         },
         pHAddress1: '456 Alternate St',
         pHAddress2: 'Apt 2',
-        phAddress3: 'Test Patient Address 3',
+        pHAddress3: 'Test Patient Address 3',
         pHCity: 'Tampa',
         pHState: 'FL',
         pHZipCde: '33333',


### PR DESCRIPTION
## Description
Added unit tests for `StatementAddresses` Component

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38995

# Screenshots
![image](https://user-images.githubusercontent.com/29178824/159970651-a657c7de-fd18-4b7d-8ea2-9ae11f73ac88.png)

## Acceptance criteria
- [ X ] Tests written and passing

## Definition of done
- [X ] Events are logged appropriately
- [X ] Documentation has been updated, if applicable
- [X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
