### PR TITLE
Fix flaky personal info - edit state E2E test

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -44,7 +44,7 @@ const checkPersonalInfoFields = () => {
 
   cy.findByLabelText(nameEditButtonLabel)
     .should('exist')
-    .click();
+    .click({ waitForAnimations: true });
 
   cy.findByText(nameEditInputLabel).should('exist');
 


### PR DESCRIPTION
## Description
This PR fixes a small race condition in this test that causes occasional flakiness in CI.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/39053

## Testing done
Ran test locally 30 times without failures.

## Acceptance criteria
- [ ] CI passes.