### PR TITLE
Fix flaky VAOS VA request E2E test

### DIFF
--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -131,6 +131,7 @@ describe('VAOS VA request flow', () => {
         .click();
     });
   });
+
   it('should display Cerner how to schedule page if a Cerner facility is chosen', () => {
     initAppointmentListMock();
     initVARequestMock({ cernerFacility: '983' });
@@ -152,7 +153,7 @@ describe('VAOS VA request flow', () => {
     cy.injectAxe();
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
 
     // Choose Type of Care
     newApptTests.chooseTypeOfCareTest('Social work');


### PR DESCRIPTION
## Description
This PR fixes a small race condition in this test that causes occasional flakiness in CI.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/39053

## Testing done
Ran test locally 30 times without failures.

## Acceptance criteria
- [ ] CI passes.