### PR TITLE
HLR/NOD: Update verify identity alert content

### DIFF
--- a/src/applications/appeals/10182/components/NeedsToVerify.jsx
+++ b/src/applications/appeals/10182/components/NeedsToVerify.jsx
@@ -5,8 +5,8 @@ const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
     <h2 slot="headline">We need you to verify your identity</h2>
     <p>
-      You’ll be able to complete this form after your identity is confirmed.
-      This helps us keep your information safe during the application process.
+      You’ll be able to complete this form after we confirm your identify. This
+      helps us keep your information safe.
     </p>
     <p>
       <a href={`/verify?next=${pathname}`} className="verify-link">

--- a/src/applications/appeals/10182/components/NeedsToVerify.jsx
+++ b/src/applications/appeals/10182/components/NeedsToVerify.jsx
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
     <h2 slot="headline">We need you to verify your identity</h2>
-    You’ll be able to complete this form after your identity is confirmed. This
-    helps us keep your information safe during the application process.
+    <p>
+      You’ll be able to complete this form after your identity is confirmed.
+      This helps us keep your information safe during the application process.
+    </p>
     <p>
       <a href={`/verify?next=${pathname}`} className="verify-link">
         Verify your identity

--- a/src/applications/appeals/10182/components/NeedsToVerify.jsx
+++ b/src/applications/appeals/10182/components/NeedsToVerify.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 
 const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
-    We want to keep your information safe with the highest level of security.
-    Please{' '}
-    <a href={`/verify?next=${pathname}`} className="verify-link">
-      verify your identity
-    </a>{' '}
-    to access this form.
+    <h2 slot="headline">We need you to verify your identity</h2>
+    You’ll be able to complete this form after your identity is confirmed. This
+    helps us keep your information safe during the application process.
+    <p>
+      <a href={`/verify?next=${pathname}`} className="verify-link">
+        Verify your identity
+      </a>
+    </p>
   </va-alert>
 );
 

--- a/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
+++ b/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
@@ -5,8 +5,8 @@ const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
     <h2 slot="headline">We need you to verify your identity</h2>
     <p>
-      You’ll be able to complete this form after your identity is confirmed.
-      This helps us keep your information safe during the application process.
+      You’ll be able to complete this form after we confirm your identify. This
+      helps us keep your information safe.
     </p>
     <p>
       <a href={`/verify?next=${pathname}`} className="verify-link">

--- a/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
+++ b/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
     <h2 slot="headline">We need you to verify your identity</h2>
-    You’ll be able to complete this form after your identity is confirmed. This
-    helps us keep your information safe during the application process.
+    <p>
+      You’ll be able to complete this form after your identity is confirmed.
+      This helps us keep your information safe during the application process.
+    </p>
     <p>
       <a href={`/verify?next=${pathname}`} className="verify-link">
         Verify your identity

--- a/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
+++ b/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 
 const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
-    We want to keep your information safe with the highest level of security.
-    Please{' '}
-    <a href={`/verify?next=${pathname}`} className="verify-link">
-      verify your identity
-    </a>{' '}
-    to access this form.
+    <h2 slot="headline">We need you to verify your identity</h2>
+    You’ll be able to complete this form after your identity is confirmed. This
+    helps us keep your information safe during the application process.
+    <p>
+      <a href={`/verify?next=${pathname}`} className="verify-link">
+        Verify your identity
+      </a>
+    </p>
   </va-alert>
 );
 


### PR DESCRIPTION
## Description

Applying content recommendations to an alert that is shown when a Veteran has not verified their identity, the Higher-Level Review and Notice of Disagreement forms both show an alert on the introduction page and are prevented from continuing the form.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39109

## Testing done

Visual and a11y check of heading levels

## Screenshots

<img width="540" alt="verify identity alert" src="https://user-images.githubusercontent.com/136959/160135082-df6456a9-a710-4b8f-b395-871d785d62f2.png">

## Acceptance criteria
- [x] Verify identity alert content updated
- [x] All tests passing (include accessibility checks)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
