### PR TITLE
[COE] File upload is no longer required

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
+++ b/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
@@ -53,7 +53,6 @@ export const uiSchema = {
     },
   },
   files: {
-    'ui:required': () => true,
     ...fileUploadUI('Your uploaded documents', {
       buttonText: 'Upload this document',
       hideLabelText: true,


### PR DESCRIPTION
## Description
The COE form no longer requires you to upload files on the supporting documents step

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38992

## Acceptance criteria
- [x] COE form no longer requires file to be uploaded

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
