### PR TITLE
Fix flaky VAOS community care E2E test

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -34,7 +34,7 @@ describe('VAOS community care flow', () => {
       .and('contain', 'Your appointments');
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
 
     cy.injectAxe();
     // Select primary care
@@ -252,7 +252,7 @@ describe('VAOS community care flow', () => {
       .and('contain', 'Your appointments');
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
 
     cy.injectAxe();
     // Select primary care
@@ -478,7 +478,7 @@ describe('VAOS community care flow using VAOS service', () => {
     cy.injectAxe();
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
   });
 
   it('should submit request successfully', () => {


### PR DESCRIPTION
## Description
This PR fixes a small race condition in this test that causes occasional flakiness in CI.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/39053

## Testing done
Ran test locally 30 times without failures.

## Acceptance criteria
- [ ] CI passes.