### PR TITLE
create more specific 409 error message

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Redirect, useHistory } from 'react-router-dom';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import { selectReviewPage } from '../../redux/selectors';
 import { FLOW_TYPES, FETCH_STATUS } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import ReviewDirectScheduleInfo from './ReviewDirectScheduleInfo';
 import ReviewRequestInfo from './ReviewRequestInfo';
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import { submitAppointmentOrRequest } from '../../redux/actions';
 import FacilityAddress from '../../../components/FacilityAddress';
 import InfoAlert from '../../../components/InfoAlert';
@@ -23,6 +23,7 @@ export default function ReviewPage() {
     parentFacility,
     submitStatus,
     submitStatusVaos400,
+    submitStatusVaos409,
     systemId,
     vaCityState,
   } = useSelector(selectReviewPage, shallowEqual);
@@ -89,13 +90,21 @@ export default function ReviewPage() {
             headline="We couldn’t schedule this appointment"
           >
             <>
-              {submitStatusVaos400 ? (
+              {submitStatusVaos409 && (
                 <p>
-                  We’re sorry. Something went wrong when we tried to submit your{' '}
-                  {submissionType}. Call your VA medical center to schedule this{' '}
-                  {submissionType}.
+                  We’re sorry. You already have an overlapping booked{' '}
+                  {submissionType}. Please schedule for a different day.
                 </p>
-              ) : (
+              )}
+              {submitStatusVaos400 &&
+                !submitStatusVaos409 && (
+                  <p>
+                    We’re sorry. Something went wrong when we tried to submit
+                    your {submissionType}. Call your VA medical center to
+                    schedule this {submissionType}.
+                  </p>
+                )}
+              {!submitStatusVaos400 && (
                 <p>
                   We’re sorry. Something went wrong when we tried to submit your{' '}
                   {submissionType}. You can try again later, or call your VA

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -68,6 +68,7 @@ import {
   captureError,
   getErrorCodes,
   has400LevelError,
+  has409LevelError,
 } from '../../utils/error';
 import {
   STARTED_NEW_APPOINTMENT_FLOW,
@@ -317,7 +318,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
       const featureFacilitiesServiceV2 = selectFeatureFacilitiesServiceV2(
         initialState,
       );
-      const newAppointment = initialState.newAppointment;
+      const { newAppointment } = initialState;
       const typeOfCare = getTypeOfCare(newAppointment.data);
       const typeOfCareId = typeOfCare?.id;
       if (typeOfCareId) {
@@ -784,6 +785,7 @@ export function submitAppointmentOrRequest(history) {
         dispatch({
           type: FORM_SUBMIT_FAILED,
           isVaos400Error: has400LevelError(error),
+          isVaos409Error: has409LevelError(error),
         });
 
         dispatch(fetchFacilityDetails(newAppointment.data.vaFacility));
@@ -933,10 +935,10 @@ export function requestProvidersList(address) {
         getState(),
       );
       let location = address;
-      const newAppointment = getState().newAppointment;
-      const communityCareProviders = newAppointment.communityCareProviders;
+      const { newAppointment } = getState();
+      const { communityCareProviders } = newAppointment;
       const sortMethod = newAppointment.ccProviderPageSortMethod;
-      let selectedCCFacility = newAppointment.selectedCCFacility;
+      let { selectedCCFacility } = newAppointment;
       const typeOfCare = getTypeOfCare(newAppointment.data);
       let ccProviderCacheKey = `${sortMethod}_${typeOfCare.ccId}`;
       if (sortMethod === FACILITY_SORT_METHODS.distanceFromFacility) {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -791,6 +791,7 @@ export default function formReducer(state = initialState, action) {
         ...state,
         submitStatus: FETCH_STATUS.failed,
         submitStatusVaos400: action.isVaos400Error,
+        submitStatusVaos409: action.isVaos409Error,
       };
     case FORM_UPDATE_CC_ELIGIBILITY: {
       return {

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -373,6 +373,7 @@ export function selectReviewPage(state) {
     parentFacility: getChosenCCSystemById(state),
     submitStatus: state.newAppointment.submitStatus,
     submitStatusVaos400: state.newAppointment.submitStatusVaos400,
+    submitStatusVaos409: state.newAppointment.submitStatusVaos409,
     systemId: getSiteIdForChosenFacility(state),
     hasResidentialAddress: selectHasVAPResidentialAddress(state),
     vaCityState: getChosenVACityState(state),

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
-import { recordVaosError } from './events';
 import environment from 'platform/utilities/environment';
+import { recordVaosError } from './events';
 
 export function captureError(
   err,
@@ -74,4 +74,8 @@ export function getErrorCodes(error) {
 
 export function has400LevelError(error) {
   return getErrorCodes(error).some(code => code.startsWith('VAOS_4'));
+}
+
+export function has409LevelError(error) {
+  return getErrorCodes(error).some(code => code.startsWith('VAOS_409'));
 }


### PR DESCRIPTION
## Description
Show a specific error message to user when they have overbooked an appoitment

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38693


## Testing done
Manual and unit


## Screenshots
Cannot display mocked screenshot due to error comes from VAOS service as a 409

## Acceptance criteria
- [ ] Much more useful to let the user know what the problem is, based on the information passed in by the back end, instead of the current vague message. The user could just pick another time, if they knew that was the problem.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
