### PR TITLE
add feature toggle, hide show fields, update fixture

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
-import { profileShowGender } from '@@profile/selectors';
+import {
+  profileShowGender,
+  profileShowPronounsAndSexualOrientation,
+} from '@@profile/selectors';
 
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
@@ -17,6 +20,7 @@ const PersonalInformationSection = ({
   gender,
   dob,
   shouldProfileShowGender,
+  shouldShowProfileAndSexualOrientation,
 }) => {
   const tableFields = [
     { title: 'Date of birth', value: renderDOB(dob) },
@@ -43,26 +47,30 @@ const PersonalInformationSection = ({
     ...(shouldProfileShowGender
       ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
       : []),
-    {
-      title: 'Gender identity',
-      id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
-      value: (
-        <ProfileInformationFieldController
-          fieldName={FIELD_NAMES.GENDER_IDENTITY}
-          isDeleteDisabled
-        />
-      ),
-    },
-    {
-      title: 'Sexual orientation',
-      id: FIELD_IDS[FIELD_NAMES.SEXUAL_ORIENTATION],
-      value: (
-        <ProfileInformationFieldController
-          fieldName={FIELD_NAMES.SEXUAL_ORIENTATION}
-          isDeleteDisabled
-        />
-      ),
-    },
+    ...(shouldShowProfileAndSexualOrientation
+      ? [
+          {
+            title: 'Gender identity',
+            id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
+            value: (
+              <ProfileInformationFieldController
+                fieldName={FIELD_NAMES.GENDER_IDENTITY}
+                isDeleteDisabled
+              />
+            ),
+          },
+          {
+            title: 'Sexual orientation',
+            id: FIELD_IDS[FIELD_NAMES.SEXUAL_ORIENTATION],
+            value: (
+              <ProfileInformationFieldController
+                fieldName={FIELD_NAMES.SEXUAL_ORIENTATION}
+                isDeleteDisabled
+              />
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -121,6 +129,7 @@ const PersonalInformationSection = ({
 PersonalInformationSection.propTypes = {
   dob: PropTypes.string.isRequired,
   shouldProfileShowGender: PropTypes.bool.isRequired,
+  shouldShowProfileAndSexualOrientation: PropTypes.bool.isRequired,
   gender: PropTypes.string,
 };
 
@@ -132,6 +141,9 @@ const mapStateToProps = state => ({
   genderIdentity: state.vaProfile?.personalInformation?.genderIdentity,
   sexualOrientation: state.vaProfile?.personalInformation?.sexualOrientation,
   shouldProfileShowGender: profileShowGender(state),
+  shouldShowProfileAndSexualOrientation: profileShowPronounsAndSexualOrientation(
+    state,
+  ),
 });
 
 export default connect(mapStateToProps)(PersonalInformationSection);

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -94,6 +94,11 @@ export const profileShowFaxNumber = state =>
 export const profileShowGender = state =>
   toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowGender];
 
+export const profileShowPronounsAndSexualOrientation = state =>
+  toggleValues(state)?.[
+    FEATURE_FLAG_NAMES.profileShowPronounsAndSexualOrientation
+  ];
+
 export function selectVAProfilePersonalInformation(state, fieldName) {
   const fieldValue = state?.vaProfile?.personalInformation?.[fieldName];
 

--- a/src/applications/personalization/profile/tests/fixtures/personal-information-feature-toggles.json
+++ b/src/applications/personalization/profile/tests/fixtures/personal-information-feature-toggles.json
@@ -8,6 +8,14 @@
       {
         "name": "profile_enhancements",
         "value": true
+      },
+      {
+        "name": "profile_show_pronouns_and_sexual_orientation",
+        "value": true
+      },
+      {
+        "name": "profileShowPronounsAndSexualOrientation",
+        "value": true
       }
     ]
   }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -76,6 +76,7 @@ export default Object.freeze({
   profileShowAddressChangeModal: 'profile_show_address_change_modal',
   profileShowFaxNumber: 'profile_show_fax_number',
   profileShowGender: 'profile_show_gender',
+  profileShowPronounsAndSexualOrientation: 'profile_show_pronouns_and_sexual_orientation',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',
   searchDropdownComponentEnabled: 'search_dropdown_component_enabled',


### PR DESCRIPTION
## Description
Updates the profile's personal information page (currently only on staging) to hide the Pronouns and Sexual Orientation fields for now. These fields have yet to be approved fully, and we are looking to launch the functionality to update the other two fields for now while these two fields are reviewed by the powers at be.

There is a PR already submitted for the vets-api side: https://github.com/department-of-veterans-affairs/vets-api/pull/9485

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38639


## Testing done
Update e2e / fixture, and manual testing


## Acceptance criteria
- [x] Shows / hides Pronouns and Sexual Orientation fields based on feature toggle

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
