### PR TITLE
updated reason code logic to correctly pass 'other' reason code detail

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import titleCase from 'platform/utilities/data/titleCase';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
-import { LANGUAGES, PURPOSE_TEXT } from '../../../utils/constants';
+import { LANGUAGES, PURPOSE_TEXT_V2 } from '../../../utils/constants';
 import {
   getTypeOfCare,
   getFormData,
@@ -99,7 +99,7 @@ export function transformFormToVAOSCCRequest(state) {
 export function transformFormToVAOSVARequest(state) {
   const data = getFormData(state);
   const typeOfCare = getTypeOfCare(data);
-  const code = PURPOSE_TEXT.find(
+  const code = PURPOSE_TEXT_V2.find(
     purpose => purpose.id === data.reasonForAppointment,
   )?.serviceName;
 
@@ -109,14 +109,20 @@ export function transformFormToVAOSVARequest(state) {
     locationId: data.vaFacility,
     // This may need to change when we get the new service type ids
     serviceType: typeOfCare.idV2,
-    reasonCode: {
-      coding: [
-        {
-          code,
-        },
-      ],
-      text: code,
-    },
+    reasonCode:
+      code === 'Other'
+        ? {
+            coding: [],
+            text: data.reasonAdditionalInfo,
+          }
+        : {
+            coding: [
+              {
+                code,
+              },
+            ],
+            text: code,
+          },
     comment: data.reasonAdditionalInfo,
     contact: {
       telecom: [

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -378,6 +378,72 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
     });
   });
 
+  it('should submit successfully - with Other reason code', async () => {
+    store = createTestStore({
+      ...defaultState,
+      newAppointment: {
+        ...defaultState.newAppointment,
+        data: {
+          ...defaultState.newAppointment.data,
+          reasonForAppointment: 'other',
+          reasonAdditionalInfo: 'I need an appt',
+        },
+      },
+    });
+    mockAppointmentSubmitV2({
+      id: 'fake_id',
+    });
+
+    const screen = renderWithStoreAndRouter(<ReviewPage />, {
+      store,
+    });
+
+    await screen.findByText(/requesting a primary care appointment/i);
+
+    userEvent.click(screen.getByText(/Request appointment/i));
+    await waitFor(() => {
+      expect(screen.history.push.lastCall.args[0]).to.equal(
+        '/requests/fake_id?confirmMsg=true',
+      );
+    });
+
+    const submitData = JSON.parse(global.fetch.getCall(0).args[1].body);
+    expect(submitData).to.deep.equal({
+      kind: 'telehealth',
+      status: 'proposed',
+      locationId: '983',
+      serviceType: 'primaryCare',
+      comment: 'I need an appt',
+      reasonCode: {
+        coding: [],
+        text: 'I need an appt',
+      },
+      contact: {
+        telecom: [
+          {
+            type: 'phone',
+            value: '1234567890',
+          },
+          {
+            type: 'email',
+            value: 'joeblow@gmail.com',
+          },
+        ],
+      },
+      requestedPeriods: [
+        {
+          start: '2020-05-25T00:00:00Z',
+          end: '2020-05-25T11:59:00Z',
+        },
+        {
+          start: '2020-05-26T12:00:00Z',
+          end: '2020-05-26T23:59:00Z',
+        },
+      ],
+      preferredTimesForPhoneCall: ['Morning', 'Afternoon', 'Evening'],
+    });
+  });
+
   it('should record GA tracking event', async () => {
     const tomorrow = moment().add(1, 'days');
     store = createTestStore({

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -57,6 +57,33 @@ export const PURPOSE_TEXT = [
   },
 ];
 
+export const PURPOSE_TEXT_V2 = [
+  {
+    id: 'routine-follow-up',
+    short: 'Follow-up/Routine',
+    label: 'This is a routine or follow-up visit.',
+    serviceName: 'Routine Follow-up',
+  },
+  {
+    id: 'new-issue',
+    short: 'New problem',
+    label: 'I have a new medical problem.',
+    serviceName: 'New Problem',
+  },
+  {
+    id: 'medication-concern',
+    short: 'Medication concern',
+    label: 'I have a concern or question about my medication.',
+    serviceName: 'Medication Concern',
+  },
+  {
+    id: 'other',
+    short: 'My reason isn’t listed',
+    label: 'My reason isn’t listed here.',
+    serviceName: 'Other',
+  },
+];
+
 export const PODIATRY_ID = 'tbd-podiatry';
 export const COVID_VACCINE_ID = 'covid';
 


### PR DESCRIPTION
## Description
This purpose of this ticket is to update the reasonCode logic to align with the recent enhancements made in the following VAOS-R ticket which changes how 'other' details are submitted to the back-end.

https://issues.mobilehealth.va.gov/browse/VAOSR-3158

Note: we are still displaying the reasonCode 'New Issue' in the front-end but mapping it to 'New Problem' in the back-end for the time-being to align with validation requirements specified in vaos-service.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37991


## Testing done
A unit test was added to reflect this change

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
