### PR TITLE
39352 - [MCP] - HTML Statements - On This Page Component Does Not Navigate to Section

### DIFF
--- a/src/applications/medical-copays/components/AccountSummary.jsx
+++ b/src/applications/medical-copays/components/AccountSummary.jsx
@@ -11,7 +11,9 @@ const AccountSummary = ({
 }) => {
   return (
     <div className="vads-u-padding--0">
-      <h2 data-testid="account-summary-head">Account summary</h2>
+      <h2 data-testid="account-summary-head" id="account-summary">
+        Account summary
+      </h2>
       <h3
         className="vads-u-margin-bottom--0"
         data-testid="account-summary-date"

--- a/src/applications/medical-copays/components/StatementAddresses.jsx
+++ b/src/applications/medical-copays/components/StatementAddresses.jsx
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 const StatementAddresses = ({ copay }) => {
   return (
     <>
-      <h2 data-testid="statement-address-head">Statement Addresses</h2>
+      <h2 data-testid="statement-address-head" id="statement-addresses">
+        Statement Addresses
+      </h2>
       <dl>
         <dt
           className="vads-u-font-weight--bold"

--- a/src/applications/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/medical-copays/components/StatementCharges.jsx
@@ -24,7 +24,9 @@ const StatementCharges = ({ copay }) => {
 
   return (
     <>
-      <h2 data-testid="statement-charges-head">Statement Charges</h2>
+      <h2 data-testid="statement-charges-head" id="statement-charges">
+        Statement Charges
+      </h2>
       <p>
         This statement shows charges you received between{' '}
         {previousCopaysStartDate} and {today}

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -70,7 +70,9 @@ const HTMLStatementPage = ({ match }) => {
           data-testid="statement-addresses"
           copay={selectedCopay}
         />
-        <h2>What if I have questions about my statement?</h2>
+        <h2 id="if-i-have-questions">
+          What if I have questions about my statement?
+        </h2>
         <p>
           Contact the VA Health Resource Center at{' '}
           <va-telephone contact="8664001238" /> (TTY:{' '}


### PR DESCRIPTION
## Description
Clicking links in on this page now takes you to the appropriate section of the page. Id's were missing on fields for component to locate to.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#39352

## Acceptance criteria
- [X ] Links in component now navigate properly

## Definition of done
- [ X] Events are logged appropriately
- [X ] Documentation has been updated, if applicable
- [X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
