### PR TITLE
Fix flaky VAOS appointment E2E test

### DIFF
--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -15,7 +15,7 @@ describe('VAOS direct schedule flow', () => {
     cy.injectAxe();
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
 
     // Choose Type of Care
     newApptTests.chooseTypeOfCareTest('Primary care');
@@ -81,7 +81,7 @@ describe('VAOS direct schedule flow', () => {
     cy.injectAxe();
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
 
     // Choose Type of Care
     newApptTests.chooseTypeOfCareTest('Eye care');
@@ -149,7 +149,7 @@ describe('VAOS direct schedule flow', () => {
     cy.injectAxe();
 
     // Start flow
-    cy.findByText('Start scheduling').click();
+    cy.findByText('Start scheduling').click({ waitForAnimations: true });
 
     // Choose Type of Care
     newApptTests.chooseTypeOfCareTest('Sleep medicine');


### PR DESCRIPTION
## Description
This PR fixes a small race condition in this test that causes occasional flakiness in CI.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/39053

## Testing done
Ran test locally 30 times without failures.

## Acceptance criteria
- [ ] CI passes.