### PR TITLE
Covid vaccine trials - make zip code and facility selection not required

### DIFF
--- a/src/applications/coronavirus-research/update/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-research/update/config/va-location/DynamicRadioWidget.jsx
@@ -56,8 +56,8 @@ export function DynamicRadioWidget(props) {
   } else if (locations.length > 0 && loading === false) {
     upperContent = (
       <>
-        These are the VA medical centers closest to the zipcode you provided.
-        Select the medical center you primarly receive care at.
+        These are the VA medical centers closest to the Zip code you entered.
+        Select the medical center you mainly go to for care.
       </>
     );
     const optionsList = locations.map(location => ({

--- a/src/applications/coronavirus-research/update/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-research/update/config/va-location/DynamicRadioWidget.jsx
@@ -66,9 +66,9 @@ export function DynamicRadioWidget(props) {
           <p className="vads-u-padding-left--4 vads-u-margin-top--neg3">
             {location.attributes.name}
           </p>
-          <p className="vads-u-padding-left--4 vads-u-margin-top--neg2">{`${
-            location.attributes.city
-          } ${location.attributes.state}`}</p>
+          <p className="vads-u-padding-left--4 vads-u-margin-top--neg2">
+            {`${location.attributes.city} ${location.attributes.state}`}
+          </p>
         </>
       ),
       value: `${location.attributes.name}|${location.id}`,
@@ -78,7 +78,6 @@ export function DynamicRadioWidget(props) {
       <RadioButtons
         options={optionsList}
         label="Select your medical center"
-        required
         value={selected}
         onValueChange={value => {
           onChange(value.value);

--- a/src/applications/coronavirus-research/update/pages/covidResearchUISchema.js
+++ b/src/applications/coronavirus-research/update/pages/covidResearchUISchema.js
@@ -3,10 +3,10 @@ import React from 'react';
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import currentOrPastMonthYearUI from 'platform/forms-system/src/js/definitions/currentOrPastMonthYear';
 import MonthYearUI from 'platform/forms-system/src/js/definitions/monthYear';
+import get from 'platform/utilities/data/get';
 import CustomReviewField from '../containers/CustomReviewField';
 import CustomReviewRadio from '../containers/customReviewRadio';
 import CustomReviewYesNo from '../containers/customReviewYesNo';
-import get from 'platform/utilities/data/get';
 // import { facilityUiSchema } from '../config/va-location/va-location';
 import DynamicRadioWidget from '../config/va-location/DynamicRadioWidget.jsx';
 
@@ -611,14 +611,13 @@ export const uiSchema = {
   zipCode: {
     'ui:title': 'Zip code where you primarily receive VA care',
     'ui:errorMessages': {
-      required: 'Please enter a zip code',
-      pattern: 'Please enter a valid 5- or 9-digit zip code (dashes allowed)',
+      pattern:
+        'Please enter a valid 5- or 9-digit zip code if known (dashes allowed)',
     },
     'ui:options': {
       classNames: 'input-width',
       expandUnder: 'FACILITY',
     },
-    'ui:required': formData => formData.FACILITY,
   },
   vaLocation: {
     preferredFacility: {
@@ -633,9 +632,6 @@ export const uiSchema = {
           get('zipCode', formData).length < 5,
       },
       'ui:reviewWidget': vaLocationReviewWidget,
-      'ui:required': formData =>
-        get('zipCode', formData) !== undefined &&
-        get('zipCode', formData).length >= 5,
     },
   },
   'ui:validations': [conditionalValidateBooleanGroup],

--- a/src/applications/coronavirus-research/update/tests/config/coronavirus-research.unit.spec.js
+++ b/src/applications/coronavirus-research/update/tests/config/coronavirus-research.unit.spec.js
@@ -75,9 +75,9 @@ describe('Coronavirus Research Volunteer Form Update', () => {
       />,
     );
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(form.find('.usa-input-error').length).to.equal(0);
     expect(form.find('.input-error-date').length).to.equal(0);
-    expect(onSubmit.called).to.be.false;
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 
@@ -117,7 +117,7 @@ describe('Coronavirus Research Volunteer Form Update', () => {
       ).length,
     ).to.equal(1);
     // expect(form.find('.input-error-date').length).to.equal(0);
-    expect(onSubmit.called).to.be.false;
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 
@@ -157,7 +157,7 @@ describe('Coronavirus Research Volunteer Form Update', () => {
       ).length,
     ).to.equal(0);
     // expect(form.find('.input-error-date').length).to.equal(0);
-    expect(onSubmit.called).to.be.false;
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 
@@ -177,7 +177,7 @@ describe('Coronavirus Research Volunteer Form Update', () => {
 
     form.find('form').simulate('submit');
     expect(form.find('input[id="root_VACCINATED_PLAN_0"]').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 
@@ -197,7 +197,7 @@ describe('Coronavirus Research Volunteer Form Update', () => {
 
     form.find('form').simulate('submit');
     expect(form.find('input#root_zipCode').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 


### PR DESCRIPTION
## Description
This PR removes the `ui:required` from zip code and facility.  Per business partners, some participants do not know the zip code of the local VA facility or were not sure which facility to select and were not able to submit the form.  This information is nice to have but not vital to the business process. 

## Testing done
updated unit tests and CY tests all pass

## Screenshots
- zip-code not required
<img width="367" alt="image" src="https://user-images.githubusercontent.com/2481110/160929735-7d567ff4-c471-477b-80b3-a8362a0dcd2e.png">

- Facility not required
![image](https://user-images.githubusercontent.com/2481110/161280385-978f31c9-e306-4728-9f58-4708e4a1a9ac.png)


## Acceptance criteria
- [x] zip code is not required
- [x] facility selection is not required

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
