### PR TITLE
rearrange which fields are shown, correct prop naming

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -20,7 +20,7 @@ const PersonalInformationSection = ({
   gender,
   dob,
   shouldProfileShowGender,
-  shouldShowProfileAndSexualOrientation,
+  shouldShowPronounsAndSexualOrientation,
 }) => {
   const tableFields = [
     { title: 'Date of birth', value: renderDOB(dob) },
@@ -34,31 +34,35 @@ const PersonalInformationSection = ({
         />
       ),
     },
-    {
-      title: 'Pronouns',
-      id: FIELD_IDS[FIELD_NAMES.PRONOUNS],
-      value: (
-        <ProfileInformationFieldController
-          fieldName={FIELD_NAMES.PRONOUNS}
-          isDeleteDisabled
-        />
-      ),
-    },
-    ...(shouldProfileShowGender
-      ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
-      : []),
-    ...(shouldShowProfileAndSexualOrientation
+    ...(shouldShowPronounsAndSexualOrientation
       ? [
           {
-            title: 'Gender identity',
-            id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
+            title: 'Pronouns',
+            id: FIELD_IDS[FIELD_NAMES.PRONOUNS],
             value: (
               <ProfileInformationFieldController
-                fieldName={FIELD_NAMES.GENDER_IDENTITY}
+                fieldName={FIELD_NAMES.PRONOUNS}
                 isDeleteDisabled
               />
             ),
           },
+        ]
+      : []),
+    ...(shouldProfileShowGender
+      ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
+      : []),
+    {
+      title: 'Gender identity',
+      id: FIELD_IDS[FIELD_NAMES.GENDER_IDENTITY],
+      value: (
+        <ProfileInformationFieldController
+          fieldName={FIELD_NAMES.GENDER_IDENTITY}
+          isDeleteDisabled
+        />
+      ),
+    },
+    ...(shouldShowPronounsAndSexualOrientation
+      ? [
           {
             title: 'Sexual orientation',
             id: FIELD_IDS[FIELD_NAMES.SEXUAL_ORIENTATION],
@@ -129,7 +133,7 @@ const PersonalInformationSection = ({
 PersonalInformationSection.propTypes = {
   dob: PropTypes.string.isRequired,
   shouldProfileShowGender: PropTypes.bool.isRequired,
-  shouldShowProfileAndSexualOrientation: PropTypes.bool.isRequired,
+  shouldShowPronounsAndSexualOrientation: PropTypes.bool.isRequired,
   gender: PropTypes.string,
 };
 
@@ -141,7 +145,7 @@ const mapStateToProps = state => ({
   genderIdentity: state.vaProfile?.personalInformation?.genderIdentity,
   sexualOrientation: state.vaProfile?.personalInformation?.sexualOrientation,
   shouldProfileShowGender: profileShowGender(state),
-  shouldShowProfileAndSexualOrientation: profileShowPronounsAndSexualOrientation(
+  shouldShowPronounsAndSexualOrientation: profileShowPronounsAndSexualOrientation(
     state,
   ),
 });


### PR DESCRIPTION
## Description
Minor hotfix PR. Was hiding the wrong fields from my previous PR and this PR hides the correct fields of Pronouns and Sexual orientation. I had accidentally hid the Gender identity and Sexual orientation previously.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38639

## Testing done
manual testing since this is temporary anyways until the other fields are approved

## Acceptance criteria
- [x] Correct fields are now hidden

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
