### PR TITLE
[COE] Adjustments to prior VA home loan page

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -52,6 +52,7 @@ export const uiSchema = {
     },
     items: {
       'ui:options': {
+        classNames: 'column',
         itemName: 'VA-backed loan',
       },
       dateRange: {
@@ -123,7 +124,9 @@ export const uiSchema = {
           },
         },
       },
-      vaLoanNumber: {},
+      vaLoanNumber: {
+        'ui:options': { widgetClassNames: 'usa-input-medium' },
+      },
       propertyOwned: {
         'ui:title': 'Do you still own this property?',
         'ui:widget': 'yesNo',


### PR DESCRIPTION
## Description
Updates to the prior VA home loan page
* VA Loan Number input has been shortened
* Inputs are now left aligned to match rest of page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38986

## Screenshots
|Before|After|
|:------:|:-----:|
|![Screen Shot 2022-03-31 at 2 30 53 PM](https://user-images.githubusercontent.com/13838621/161136910-ed131b0a-411b-4508-956f-551d4b7157ee.png)|![Screen Shot 2022-03-31 at 2 29 26 PM](https://user-images.githubusercontent.com/13838621/161137033-0e0b3346-c339-4cde-91b4-9afc9b51788f.png)|


## Acceptance criteria
- [x] VA home loan page matches mockups

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
