### PR TITLE
Use latest Chrome Docker image in Cypress tests in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -508,7 +508,7 @@ jobs:
       needs.cypress-tests-prep.result == 'success' &&
       needs.cypress-tests-prep.outputs.tests != '[]'
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
+      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:
@@ -547,6 +547,16 @@ jobs:
         run: |
           mkdir -p build/vagovprod
           tar -C build/vagovprod -xjf vagovprod.tar.bz2
+
+      - name: Get Node version
+        id: get-node-version
+        shell: bash
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Install dependencies
         uses: ./.github/workflows/install


### PR DESCRIPTION
## Description
This PR updates CI to use the latest available `cypress/browsers` Docker image in Cypress tests.

## Acceptance criteria
- [ ] CI passes.