### PR TITLE
[BUG] Fix double escaping in interpolated i18n values

### DIFF
--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -4,6 +4,7 @@ import configureStore from 'redux-mock-store';
 
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { within } from '@testing-library/dom';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import Error from '../index';
 
@@ -42,7 +43,13 @@ describe('check-in', () => {
             <Error />
           </Provider>,
         );
-        expect(component.getByTestId('date-message')).to.exist;
+        const dateMessage = component.getByTestId('date-message');
+        expect(dateMessage).to.exist;
+        expect(
+          within(dateMessage).getByText(
+            'You can pre-check in online until 01/02/2022.',
+          ),
+        ).to.exist;
       });
     });
     describe('empty redux store', () => {
@@ -59,6 +66,14 @@ describe('check-in', () => {
         store = mockStore(initState);
       });
       it('renders error page', () => {
+        const component = render(
+          <Provider store={store}>
+            <Error />
+          </Provider>,
+        );
+        expect(component.getByTestId('error-message')).to.exist;
+      });
+      it('correctly renders pre-check-in expiration date', () => {
         const component = render(
           <Provider store={store}>
             <Error />

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -28,6 +28,7 @@ i18n
     fallbackLng: 'en',
     debug: true,
     interpolation: {
+      escapeValue: false,
       format: (value, format, lng) => {
         if (isDate(value)) {
           const locale = locales[lng];


### PR DESCRIPTION
## Description

When testing the app, I ran across this on the pre-check-in error page:

![Screen Shot 2022-03-31 at 5 06 59 PM](https://user-images.githubusercontent.com/101649/161163841-a4b2084c-dbed-4c86-ae45-8b47cd31bca0.png)

I missed that i18next's [XSS escaping should be disabled when using it with React](https://react.i18next.com/latest/using-with-hooks#configure-i18next), as React already escapes values by default.

This PR adds a test that fails with the previous configuration, and adds the necessary config for i18next.

## Testing done

Manual testing, added unit test case.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
