### PR TITLE
[department-of-veterans-affairs/va-virtual-agent#442] Adds pii filter…

### DIFF
--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -1,4 +1,5 @@
 import piiReplace from './piiReplace';
+import * as _ from 'lodash';
 
 const GreetUser = {
   makeBotGreetUser: (
@@ -35,8 +36,7 @@ const GreetUser = {
     }
 
     if (action.type === 'WEB_CHAT/SEND_MESSAGE') {
-      // eslint-disable-next-line no-param-reassign
-      action.payload.text = piiReplace(action.payload.text);
+      _.assign(action.payload, { text: piiReplace(action.payload.text) });
     }
     return next(action);
   },

--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -1,3 +1,5 @@
+import piiReplace from './piiReplace';
+
 const GreetUser = {
   makeBotGreetUser: (
     csrfToken,
@@ -30,6 +32,11 @@ const GreetUser = {
         },
         type: 'DIRECT_LINE/POST_ACTIVITY',
       });
+    }
+
+    if (action.type === 'WEB_CHAT/SEND_MESSAGE') {
+      // eslint-disable-next-line no-param-reassign
+      action.payload.text = piiReplace(action.payload.text);
     }
     return next(action);
   },

--- a/src/applications/virtual-agent/components/webchat/piiReplace.js
+++ b/src/applications/virtual-agent/components/webchat/piiReplace.js
@@ -1,0 +1,11 @@
+// Regex Breakdown
+// SSN: \b(?!666|000|9\d{2})\d{3}-(?!00)\d{2}-(?!0{4})\d{4}\b
+// EMAIL: [A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}
+// PHONE: (\+\d{1,2}\s)?\(?\b\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}\b
+const regExp = /(\b(?!666|000|9\d{2})\d{3}-(?!00)\d{2}-(?!0{4})\d{4}\b)|([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})|(\(?\b\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}\b)/gim;
+export default function piiReplace(message) {
+  if (message.match(regExp)) {
+    return message.replace(regExp, '****');
+  }
+  return message;
+}

--- a/src/applications/virtual-agent/tests/piiReplace.unit.spec.js
+++ b/src/applications/virtual-agent/tests/piiReplace.unit.spec.js
@@ -1,0 +1,69 @@
+import piiReplace from '../components/webchat/piiReplace';
+import { expect } from 'chai';
+
+describe('replacing a message that includes pii with ****', () => {
+  it("should replace ssn's with ****", () => {
+    const ssns = ['123-45-6789', '856-45-6789'];
+    const replacedMessage = '****';
+
+    for (let j = 0; j < ssns.length; j++) {
+      expect(piiReplace(ssns[j])).to.equal(replacedMessage);
+    }
+  });
+
+  it('should replace multiple phone numbers with ****', () => {
+    const phoneNumbers = [
+      '123-456-7890',
+      '(123) 456-7890',
+      '123 456 7890',
+      '123.456.7890',
+    ];
+    const replacedMessage = '****';
+
+    for (let j = 0; j < phoneNumbers.length; j++) {
+      expect(piiReplace(phoneNumbers[j])).to.equal(replacedMessage);
+    }
+  });
+
+  it('should replace multiple emails with ****', () => {
+    const emails = [
+      'firstName@google.com',
+      'first.name@va.gov',
+      'fun-email@blahblah.tv',
+      'fadsfasdfasd@df.sasd',
+    ];
+    const replacedMessage = '****';
+
+    for (let j = 0; j < emails.length; j++) {
+      expect(piiReplace(emails[j])).to.equal(replacedMessage);
+    }
+  });
+
+  it("should replace multiple pii's in a single message", () => {
+    const message =
+      'My email is firstName@google.com, my ssn is 123-45-6789, and my phone number is (123) 456-7890';
+    const replacedMessage =
+      'My email is ****, my ssn is ****, and my phone number is ****';
+    expect(piiReplace(message)).to.equal(replacedMessage);
+  });
+});
+
+describe('does not replace invalid pii', () => {
+  it('should not replace an invalid ssn', () => {
+    const invalidSsns = ['000-45-6789', '8561-45-6789', '856-45-0000'];
+    for (let i = 0; i < invalidSsns.length; i++) {
+      expect(piiReplace(invalidSsns[i])).to.equal(invalidSsns[i]);
+    }
+  });
+
+  it('should not replace an invalid phone', () => {
+    const invalidPhones = [
+      '1123-456-78901',
+      '1123 456 78901',
+      '1123.456.78901',
+    ];
+    for (let i = 0; i < invalidPhones.length; i++) {
+      expect(piiReplace(invalidPhones[i])).to.equal(invalidPhones[i]);
+    }
+  });
+});


### PR DESCRIPTION
…ing and tests for pii filtering

Co-authored-by: Jacob Gacek <jacob.gacek@thoughtworks.com>

## Description
Filters out PII entered to the virtual agent chatbot by the user. This includes ssns, phone numbers, and email addresses.

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#442

## Testing done
- Wrote and passed unit tests

## Acceptance criteria
- Any ssn, phone number, or email addresses get replaced with '****'

## Definition of done
- PII gets censored in the bot
