### PR TITLE
[COE] Update instances of 'application' to 'request' in SIP components

### DIFF
--- a/src/applications/lgy/coe/form/config/form.js
+++ b/src/applications/lgy/coe/form/config/form.js
@@ -38,9 +38,12 @@ const formConfig = {
   transformForSubmit: customCOEsubmit,
   trackingPrefix: '26-1880-',
   customText: {
+    appAction: 'your COE request',
     appSavedSuccessfullyMessage: 'Your request has been saved.',
     appType: 'request',
+    continueAppButtonText: 'Continue your request',
     finishAppLaterMessage: 'Finish this request later',
+    startNewAppButtonText: 'Start a new request',
     reviewPageTitle: 'Review your request',
   },
   introduction: IntroductionPage,


### PR DESCRIPTION
## Description
Updates the instances of 'application'/'apply' to 'request' in the SIP alert

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38986

## Screenshots
|Before|After|
|:-----:|:-----:|
|![Screen Shot 2022-04-01 at 2 41 20 PM](https://user-images.githubusercontent.com/13838621/161331100-b54dcd8f-149d-4884-a517-63e17b596608.png)|![Screen Shot 2022-04-01 at 2 40 50 PM](https://user-images.githubusercontent.com/13838621/161331128-b673b07f-826a-4e1a-a515-d672e636509f.png)|

## Acceptance criteria
- [x] Instances of 'application'/'apply' should be replaced with 'request' in SIP components

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
