### PR TITLE
Remove broken link from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,5 +280,4 @@ for doing very specific things.
 ## Additional Resources
 
 1. [VA.gov Knowledge Hub](https://department-of-veterans-affairs.github.io/va.gov-team/)
-1. [Docs Directory](./docs)
 1. [Manual](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/testing/508-manual-testing.md) and [Automated](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/testing/508-automated-testing.md) 508 Testing


### PR DESCRIPTION
## Description
The `docs` directory no longer exists, so this link can be removed.