### PR TITLE
Update Webpack to generate sourcemaps for Sentry

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -11,8 +11,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const HtmlPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin;
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const WebpackBar = require('webpackbar');
 const StylelintPlugin = require('stylelint-webpack-plugin');
@@ -257,10 +256,12 @@ module.exports = async (env = {}) => {
   };
 
   const apps = getEntryPoints(buildOptions.entry);
-  const entryFiles = Object.assign({}, apps, globalEntryFiles);
+  const entryFiles = { ...apps, ...globalEntryFiles };
   const isOptimizedBuild = [VAGOVSTAGING, VAGOVPROD].includes(buildtype);
   const scaffoldAssets = await getScaffoldAssets();
   const appRegistry = JSON.parse(scaffoldAssets['registry.json']);
+  const envBucketUrl = BUCKETS[buildtype];
+  const sourceMapSlug = envBucketUrl || '';
 
   // enable css sourcemaps for all non-localhost builds
   // or if build options include local-css-sourcemaps or entry
@@ -277,7 +278,8 @@ module.exports = async (env = {}) => {
   );
 
   const baseConfig = {
-    mode: 'development',
+    mode: isOptimizedBuild ? 'production' : 'development',
+    devtool: false,
     entry: entryFiles,
     output: {
       path: path.resolve(buildPath, 'generated'),
@@ -410,6 +412,11 @@ module.exports = async (env = {}) => {
         __REGISTRY__: JSON.stringify(appRegistry),
       }),
 
+      new webpack.SourceMapDevToolPlugin({
+        append: `\n//# sourceMappingURL=${sourceMapSlug}/generated/[url]`,
+        filename: '[file].map',
+      }),
+
       new StylelintPlugin({
         configFile: '.stylelintrc.json',
         exclude: ['node_modules', 'build', 'coverage', '.cache'],
@@ -463,30 +470,6 @@ module.exports = async (env = {}) => {
           getEntryManifests(buildOptions.entry)[0].rootUrl
         : '';
     baseConfig.devServer.open = { target };
-  }
-
-  if (isOptimizedBuild) {
-    const bucket = BUCKETS[buildtype];
-
-    baseConfig.plugins.push(
-      new webpack.SourceMapDevToolPlugin({
-        append: `\n//# sourceMappingURL=${bucket}/generated/[url]`,
-        filename: '[file].map',
-      }),
-    );
-
-    // baseConfig.plugins.optimization.moduleIds = 'deterministic';
-    baseConfig.mode = 'production';
-  } else {
-    baseConfig.devtool = 'eval-source-map';
-
-    // The eval-source-map devtool doesn't seem to work for CSS, so we
-    // add a separate plugin for CSS source maps.
-    baseConfig.plugins.push(
-      new webpack.SourceMapDevToolPlugin({
-        test: /\.css$/,
-      }),
-    );
   }
 
   if (buildOptions.analyzer) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -263,13 +263,6 @@ module.exports = async (env = {}) => {
   const envBucketUrl = BUCKETS[buildtype];
   const sourceMapSlug = envBucketUrl || '';
 
-  // enable css sourcemaps for all non-localhost builds
-  // or if build options include local-css-sourcemaps or entry
-  const enableCSSSourcemaps =
-    buildtype !== LOCALHOST ||
-    buildOptions['local-css-sourcemaps'] ||
-    !!buildOptions.entry;
-
   const buildPath = path.resolve(
     __dirname,
     '../',
@@ -310,7 +303,7 @@ module.exports = async (env = {}) => {
             {
               loader: 'css-loader',
               options: {
-                sourceMap: enableCSSSourcemaps,
+                sourceMap: true,
               },
             },
             {
@@ -430,6 +423,15 @@ module.exports = async (env = {}) => {
         contextRegExp: /moment$/,
       }),
 
+      new CopyPlugin({
+        patterns: [
+          {
+            from: 'src/site/assets',
+            to: buildPath,
+          },
+        ],
+      }),
+
       new WebpackBar(),
     ],
     devServer: generateWebpackDevConfig(buildOptions),
@@ -443,18 +445,6 @@ module.exports = async (env = {}) => {
       }),
     );
   }
-
-  // Copy over image assets for when metalsmith is removed
-  baseConfig.plugins.push(
-    new CopyPlugin({
-      patterns: [
-        {
-          from: 'src/site/assets',
-          to: buildPath,
-        },
-      ],
-    }),
-  );
 
   // Optionally generate mocked HTML pages for apps without running content build.
   if (buildOptions.scaffold) {


### PR DESCRIPTION
## Description

Sourcemaps are not reporting correctly in Sentry for javascript files. The theory is that this is related to the order in which the maps are being generated. This PR is a attempt to shuffle that order to see if we can get it working.

I also simplified some of the webpack config

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39488


## Testing done

Testing sourcemap functionality locally for: 
localhost, vagovdev, vagovstaging, and vagovprod

Also testing in review instances, and will followup test in staging through Chrome and Sentry.

Testing here is a more minor deal since the maps don't appear to be working with sentry right now anyway.