### PR TITLE
Discrepancy with Requested queue sorting order for requests submitted on the same day

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -73,7 +73,6 @@ function handleClick({
   };
 }
 
-// do not merge this
 function handleKeyDown({
   history,
   dispatch,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -73,6 +73,7 @@ function handleClick({
   };
 }
 
+// do not merge this
 function handleKeyDown({
   history,
   dispatch,


### PR DESCRIPTION
## Description
The requested appointments are returned sorted in descending order by created date, but the time is not taken into consideration. Update sorting to also take into account the time the appointment date is created.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38467


## Testing done
Verified that the requested appointment is now taking into account the day and time the request was created.

## Screenshots


## Acceptance criteria
- [x] Verify the requested appointment list displayed is sorted by day and time descending.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
