### PR TITLE
32846 - [MCP] Create HTML statements page - Minor updates to components

### DIFF
--- a/src/applications/medical-copays/components/StatementAddresses.jsx
+++ b/src/applications/medical-copays/components/StatementAddresses.jsx
@@ -71,6 +71,12 @@ const StatementAddresses = ({ copay }) => {
           <span data-testid="recipient-city-state-zip">
             {copay.pHCity}, {copay.pHState} {copay.pHZipCde}
           </span>
+          <p>
+            If your address has changed, call &nbsp;
+            <span>
+              <va-telephone contact="8662602614" international="true" />.
+            </span>
+          </p>
         </dd>
       </dl>
     </>

--- a/src/applications/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/medical-copays/components/StatementCharges.jsx
@@ -19,7 +19,11 @@ const StatementCharges = ({ copay }) => {
   const tableData = copay.details.map(item => ({
     desc: item.pDTransDescOutput,
     billref: item.pDRefNo,
-    amount: <div>${item.pDTransAmtOutput.replace(/[^\d.-]/g, '')}</div>,
+    amount: (
+      <div>
+        ${item.pDTransAmtOutput.replace('-', '').replace(/[^\d.-]/g, '')}
+      </div>
+    ),
   }));
 
   return (


### PR DESCRIPTION

## Description
Fixed small bug in display of money in component and added missing address change phone num

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32846

`StatementCharges` Component had display issues with currency amounts per requirements. 
`StatementAddresses` was missing the phone number to call for information.

## Screenshots
![image](https://user-images.githubusercontent.com/29178824/161610631-e13539b7-9f51-44ab-97bf-9b768889532c.png)
