### PR TITLE
[COE] Updating option in list of upload document types

### DIFF
--- a/src/applications/lgy/coe/status/constants.js
+++ b/src/applications/lgy/coe/status/constants.js
@@ -1,7 +1,7 @@
 export const DOCUMENT_TYPES = [
   'Discharge or separation papers (DD214)',
   'Statement of service',
-  'Report of separation and Record of Service',
+  'Report of Separation and Record of Service (NGB Form 22)',
   'Retirement Points Statement (NGB Form 23)',
   'Proof of honorable service',
   'Annual retirement points',


### PR DESCRIPTION
## Description
Updating one of the options in the list of document types for the standalone uploader:
`Report of separation and Record of Service` -> `Report of Separation and Record of Service (NGB Form 22)`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38986


## Acceptance criteria
- [x] Document types dropdown list matches prototype

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
