### PR TITLE
update text to be more general

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -162,7 +162,7 @@ const mapStateToProps = (state, ownProps) => {
   });
   const radioButtonDescription =
     ownProps.channelId === 'channel4-1' && !allFacilitiesSupportRxTracking
-      ? 'Only available at some Asheville and Denver VA health facilities. Check with your facility first.'
+      ? 'Only available at some VA health facilities. Check with your VA pharmacy first.'
       : null;
   return {
     apiStatus: uiState.updateStatus,

--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import CommunicationChannelModel from '@@profile/models/CommunicationChannel';
@@ -138,6 +139,19 @@ const NotificationChannel = ({
       />
     </>
   );
+};
+
+NotificationChannel.propTypes = {
+  saveSetting: PropTypes.func.isRequired,
+  apiStatus: PropTypes.string,
+  channelId: PropTypes.string,
+  channelType: PropTypes.number,
+  isMissingContactInfo: PropTypes.bool,
+  isOptedIn: PropTypes.bool,
+  itemId: PropTypes.string,
+  itemName: PropTypes.string,
+  permissionId: PropTypes.number,
+  radioButtonDescription: PropTypes.string,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -8,8 +8,8 @@
 
 import { PROFILE_PATHS } from '@@profile/constants';
 
-import { makeUserObject } from '~/applications/personalization/common/helpers';
 import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
+import { makeUserObject } from '~/applications/personalization/common/helpers';
 
 import {
   mockNotificationSettingsAPIs,
@@ -60,7 +60,7 @@ describe('Notification Settings', () => {
           .should('match', /prescription.*shipment/i)
           .should('match', /prescription.*tracking/i);
         cy.findAllByText(/^select an option/i).should('have.length', 1);
-        cy.findAllByText(/check with your facility first/i).should(
+        cy.findAllByText(/check with your VA pharmacy first/i).should(
           'have.length',
           1,
         );
@@ -101,7 +101,9 @@ describe('Notification Settings', () => {
           .should('match', /prescription.*shipment/i)
           .should('match', /prescription.*tracking/i);
         cy.findAllByText(/^select an option/i).should('have.length', 1);
-        cy.findAllByText(/check with your facility first/i).should('not.exist');
+        cy.findAllByText(/check with your VA pharmacy first/i).should(
+          'not.exist',
+        );
       });
     },
   );
@@ -138,7 +140,9 @@ describe('Notification Settings', () => {
           .should('not.match', /prescription.*shipment/i)
           .should('not.match', /prescription.*tracking/i);
         cy.findAllByText(/^select an option/i).should('have.length', 1);
-        cy.findAllByText(/check with your facility first/i).should('not.exist');
+        cy.findAllByText(/check with your VA pharmacy first/i).should(
+          'not.exist',
+        );
       });
     },
   );


### PR DESCRIPTION
## Description
Minor PR to adjust the text of the Shipping notification help text to be more general, since the list of supporting facilities has expanded.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/39459

## Testing done
Manual testing to verify message appears. Also updated E2E tests to verify


## Acceptance criteria
- [ ] Notice text shows up with general text

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
