### PR TITLE
Add va-on-this-page analytics

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -175,6 +175,12 @@ const analyticsEvents = {
       prefix: 'segmented-progress-bar',
     },
   ],
+  'va-on-this-page': [
+    {
+      action: 'click',
+      event: 'nav-jumplink-click',
+    },
+  ],
 };
 
 export function subscribeComponentAnalyticsEvents(

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -204,7 +204,7 @@ export function subscribeComponentAnalyticsEvents(
       // If the event included additional details / context...
       if (e.detail.details) {
         for (const key of Object.keys(e.detail.details)) {
-          const newKey = `${action.prefix}-${key}`;
+          const newKey = action.prefix ? `${action.prefix}-${key}` : key;
 
           dataLayer[newKey] = e.detail.details[key];
         }


### PR DESCRIPTION
## Description


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38195


## Testing done


## Screenshots


## Acceptance criteria
- [x] Add `va-on-this-page` analytics tracking

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
