### PR TITLE
[MCP] HTML Statement page download link

### DIFF
--- a/src/applications/medical-copays/components/DownloadStatement.jsx
+++ b/src/applications/medical-copays/components/DownloadStatement.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import recordEvent from 'platform/monitoring/record-event';
 import environment from 'platform/utilities/environment';
+import { mcpHTMLStatementToggle } from '../utils/helpers';
 
 const handleDownloadClick = date => {
   return recordEvent({
@@ -13,6 +15,9 @@ const handleDownloadClick = date => {
 };
 
 const DownloadStatement = ({ statementId, statementDate, fullName }) => {
+  const showHTMLStatements = useSelector(state =>
+    mcpHTMLStatementToggle(state),
+  );
   const formattedStatementDate = moment(statementDate, 'MM-DD-YYYY').format(
     'MMMM D, YYYY',
   );
@@ -41,7 +46,10 @@ const DownloadStatement = ({ statementId, statementDate, fullName }) => {
             role="img"
             className="fas fa-download vads-u-padding-right--1"
           />
-          <span aria-hidden="true">{formattedStatementDate} statement </span>
+          <span aria-hidden="true">
+            {showHTMLStatements ? 'Download your ' : ''}
+            {formattedStatementDate} statement{' '}
+          </span>
           <span className="sr-only">
             Download {formattedStatementDate} dated medical copay statement
           </span>

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -8,16 +8,21 @@ import Modals from '../components/Modals';
 import StatementAddresses from '../components/StatementAddresses';
 import AccountSummary from '../components/AccountSummary';
 import StatementCharges from '../components/StatementCharges';
+import DownloadStatement from '../components/DownloadStatement';
 
 const HTMLStatementPage = ({ match }) => {
   const selectedId = match.params.id;
   const statements = useSelector(({ mcp }) => mcp.statements) ?? [];
+  const userFullName = useSelector(({ user }) => user.profile.userFullName);
   const [selectedCopay] = statements.filter(({ id }) => id === selectedId);
   const statementDate = moment(selectedCopay.pSStatementDate, 'MM-DD').format(
     'MMMM D',
   );
   const title = `${statementDate} statement`;
   const prevPage = `Copay bill for ${selectedCopay.station.facilityName}`;
+  const fullName = userFullName.middle
+    ? `${userFullName.first} ${userFullName.middle} ${userFullName.last}`
+    : `${userFullName.first} ${userFullName.last}`;
 
   useEffect(() => {
     scrollToTop();
@@ -66,6 +71,14 @@ const HTMLStatementPage = ({ match }) => {
           data-testid="statement-charges"
           copay={selectedCopay}
         />
+        <div className="vads-u-margin-top--3">
+          <DownloadStatement
+            key={selectedId}
+            statementId={selectedId}
+            statementDate={selectedCopay.pSStatementDate}
+            fullName={fullName}
+          />
+        </div>
         <StatementAddresses
           data-testid="statement-addresses"
           copay={selectedCopay}


### PR DESCRIPTION
## Description
Added missing statement download link using existing DownloadStatement component which was modified to match text for new page. All hidden behind feature flag.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32846
- Missing element, so added to parent ticket

## Screenshots
<details><summary>Download Button (click to expand)</summary>

![image](https://user-images.githubusercontent.com/25368370/161795792-0eb674f1-e539-4f06-8a8e-3d8e18d70c04.png)

</details>

## Acceptance criteria
- [x] Statement download link has been added to statement page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
