### PR TITLE
39619/39126 -  Inherited proofing API Call, Flipper gates for modal and transition kickoff

### DIFF
--- a/src/applications/login/components/TransitionAccountCTA.js
+++ b/src/applications/login/components/TransitionAccountCTA.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ACCOUNT_TRANSITION } from '../constants';
 
-function dismiss() {
-  // TODO: trackEvent for dismissing
-  window.location = '/';
-}
-
 export default function TransitionAccountCTA({ canTransition }) {
-  const { headline, signUpIDme, signUpLoginGov } = ACCOUNT_TRANSITION;
+  const {
+    headline,
+    signUpIDme,
+    signUpLoginGov,
+    startTransition,
+    dismiss,
+  } = ACCOUNT_TRANSITION;
 
   return (
     <va-featured-content>
@@ -41,7 +42,10 @@ export default function TransitionAccountCTA({ canTransition }) {
           )}
         </ul>
         <div>
-          <button type="button" onClick={signUpLoginGov}>
+          <button
+            type="button"
+            onClick={canTransition ? startTransition : signUpLoginGov}
+          >
             {canTransition ? `Start transition now` : `Login.gov`}
           </button>
           {!canTransition && (

--- a/src/applications/login/components/TransitionAccountPage.jsx
+++ b/src/applications/login/components/TransitionAccountPage.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { transitionMHVAccount } from 'platform/user/authentication/selectors';
+import { mhvTransitionEnabled } from 'platform/user/selectors';
 import TransitionAccountCTA from './TransitionAccountCTA';
 import IdentityWizard from './IdentityWizard';
 
 export default function TransitionAccount() {
   // TODO: wait for BE team to add to User model
   const canTransition = useSelector(transitionMHVAccount);
+  const transitionEnabled = useSelector(mhvTransitionEnabled);
 
   return (
     <main className="usa-grid usa-grid-full">
@@ -22,7 +24,7 @@ export default function TransitionAccount() {
         </div>
         <TransitionAccountCTA
           data-testid="can-transition"
-          canTransition={canTransition}
+          canTransition={Boolean(canTransition && transitionEnabled)}
         />
         {!canTransition && (
           <div data-testid="cant-transition">

--- a/src/applications/login/constants.js
+++ b/src/applications/login/constants.js
@@ -1,5 +1,16 @@
 import { signup } from 'platform/user/authentication/utilities';
 import { CSP_IDS } from 'platform/user/authentication/constants';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
+
+export const TRANSITION_ENDPOINT = `${
+  environment.API_URL
+}/inherited_proofing/auth`;
+
+export const EVENTS = {
+  TRANSITION_STARTED: 'login-transition-started-mhv-to-logingov',
+  TRANSITION_PAGE_DISMISSED: 'login-transition-page-dismissed',
+};
 
 export const IDENTITY_WIZARD_QUESTIONS = [
   {
@@ -63,5 +74,26 @@ export const ACCOUNT_TRANSITION = {
   },
   signUpIDme() {
     signup({ csp: CSP_IDS.ID_ME });
+  },
+  startTransition() {
+    const redirect = () => {
+      window.location = TRANSITION_ENDPOINT;
+    };
+    recordEvent({
+      event: EVENTS.TRANSITION_STARTED,
+      eventCallback: redirect,
+      eventTimeout: 2000,
+    });
+  },
+  dismiss() {
+    const redirect = () => {
+      // TODO: Implement logic to return users to previous page
+      window.location = '/';
+    };
+    recordEvent({
+      event: EVENTS.TRANSITION_PAGE_DISMISSED,
+      eventCallback: redirect,
+      eventTimeout: 2000,
+    });
   },
 };

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -22,6 +22,8 @@ import {
   isProfileLoading,
   isLOA3,
   selectUser,
+  mhvTransitionEnabled,
+  mhvTransitionModalEnabled,
 } from 'platform/user/selectors';
 import {
   toggleFormSignInModal,
@@ -200,6 +202,7 @@ export class Main extends Component {
   };
 
   render() {
+    const { mhvTransition, mhvTransitionModal } = this.props;
     // checks if on Unified Sign in Page
     if (loginAppUrlRE.test(window.location.pathname)) {
       return null;
@@ -226,11 +229,14 @@ export class Main extends Component {
           onClose={this.closeLoginModal}
           visible={this.props.showLoginModal}
         />
-        <AccountTransitionModal
-          onClose={this.closeAccountTransitionModal}
-          visible={this.props.showAccountTransitionModal}
-          history={history}
-        />
+        {mhvTransition &&
+          mhvTransitionModal && (
+            <AccountTransitionModal
+              onClose={this.closeAccountTransitionModal}
+              visible={this.props.showAccountTransitionModal}
+              history={history}
+            />
+          )}
         <AccountTransitionSuccessModal
           onClose={this.closeAccountTransitionSuccessModal}
           visible={this.props.showAccountTransitionSuccessModal}
@@ -265,9 +271,11 @@ export const mapStateToProps = state => {
     currentlyLoggedIn: isLoggedIn(state),
     isLOA3: isLOA3(state),
     isProfileLoading: isProfileLoading(state),
-    user: selectUser(state),
+    mhvTransition: mhvTransitionEnabled(state),
+    mhvTransitionModal: mhvTransitionModalEnabled(state),
     signInServiceName: signInServiceNameSelector(state),
     shouldConfirmLeavingForm,
+    user: selectUser(state),
     userGreeting: selectUserGreeting(state),
     ...state.navigation,
   };
@@ -304,6 +312,8 @@ Main.propTypes = {
   isHeaderV2: PropTypes.bool,
   isLOA3: PropTypes.bool,
   isProfileLoading: PropTypes.bool,
+  mhvTransition: PropTypes.bool,
+  mhvTransitionModal: PropTypes.bool,
   shouldConfirmLeavingForm: PropTypes.bool,
   showAccountTransitionModal: PropTypes.bool,
   showAccountTransitionSuccessModal: PropTypes.bool,

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -1,3 +1,5 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import {
   CERNER_APPOINTMENTS_BLOCKLIST,
   CERNER_FACILITY_IDS,
@@ -126,3 +128,9 @@ export const selectCernerTestResultsFacilities = state =>
   selectPatientFacilities(state)?.filter(
     f => f.isCerner && f.usesCernerTestResults,
   );
+
+export const mhvTransitionEnabled = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.mhvToLogingovAccountTransition];
+
+export const mhvTransitionModalEnabled = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.mhvToLogingovAccountTransitionModal];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -72,6 +72,8 @@ export default Object.freeze({
   manageDependents: 'dependents_management',
   megaMenuMobileV2: 'mega_menu_mobile_v2',
   medicalCopaysHtmlMedicalStatementsViewEnabled:'medical_copays_html_medical_statements_view_enabled',
+  mhvToLogingovAccountTransition: 'mhv_to_logingov_account_transition',
+  mhvToLogingovAccountTransitionModal: 'mhv_to_logingov_account_transition_modal',
   omniChannelLink: 'omni_channel_link',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',
   profileNotificationSettings: 'profile_notification_settings',


### PR DESCRIPTION
## Description
Adds the API call logic to the "Start Transition" button.
The Button only appears when eligible property exists on the user model and the flipper feature is enabled.

It also adds a flipper feature gate to the transition modal.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39619
department-of-veterans-affairs/va.gov-team#39126


## Testing done


## Screenshots


## Acceptance criteria
- [ ] Tranistion button leads to `<API>/inherited_proofing/auth` 
- [ ] Button only shows when eligible and flipper is enabled
- [ ] modal only shows when eligible and flipper is enabled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
