### PR TITLE
38955 change gender indentity to single select field

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInformationView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationView.jsx
@@ -11,7 +11,10 @@ import {
   personalInformation,
 } from '@@profile/util/getProfileInfoFieldAttributes';
 
-import { formatMultiSelectAndText } from '@@profile/util/personal-information/personalInformationUtils';
+import {
+  formatMultiSelectAndText,
+  formatGenderIdentity,
+} from '@@profile/util/personal-information/personalInformationUtils';
 import { formatAddress } from '~/platform/forms/address/helpers';
 
 const ProfileInformationView = props => {
@@ -84,7 +87,11 @@ const ProfileInformationView = props => {
 
   // handle personal information field data and format accordingly for display
   if (fieldName in data && personalInformation.includes(fieldName)) {
-    if (fieldName === 'preferredName') return data[fieldName];
+    if (fieldName === FIELD_NAMES.PREFERRED_NAME) return data[fieldName];
+
+    if (fieldName === FIELD_NAMES.GENDER_IDENTITY) {
+      return formatGenderIdentity(data[fieldName]);
+    }
 
     return formatMultiSelectAndText(data, fieldName) || unsetFieldTitleSpan;
   }
@@ -93,8 +100,8 @@ const ProfileInformationView = props => {
 };
 
 ProfileInformationView.propTypes = {
-  data: PropTypes.object,
   fieldName: PropTypes.oneOf(Object.values(VAP_SERVICE.FIELD_NAMES)).isRequired,
+  data: PropTypes.object,
 };
 
 export default ProfileInformationView;

--- a/src/applications/personalization/profile/components/ProfileInformationView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationView.jsx
@@ -102,6 +102,7 @@ const ProfileInformationView = props => {
 ProfileInformationView.propTypes = {
   fieldName: PropTypes.oneOf(Object.values(VAP_SERVICE.FIELD_NAMES)).isRequired,
   data: PropTypes.object,
+  title: PropTypes.string,
 };
 
 export default ProfileInformationView;

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -102,9 +102,7 @@ const checkPersonalInfoFields = () => {
   cy.findByText('Transgender woman').should('exist');
   cy.findByText('Transgender man').should('exist');
   cy.findByText('Non-binary').should('exist');
-  cy.findByText('Prefer not to answer (un-checks other options)').should(
-    'exist',
-  );
+  cy.findByText('Prefer not to answer').should('exist');
   cy.findByText('A gender not listed here').should('exist');
 
   cy.findAllByTestId('cancel-edit-button')

--- a/src/applications/personalization/profile/tests/fixtures/personal-information-success-enhanced.json
+++ b/src/applications/personalization/profile/tests/fixtures/personal-information-success-enhanced.json
@@ -8,7 +8,7 @@
       "preferredName": "Wes",
       "pronouns": ["heHimHis", "theyThemTheirs"],
       "pronounsNotListedText": "Other/pronouns/here",
-      "genderIdentity": ["man"],
+      "genderIdentity": "man",
       "sexualOrientation": ["straightOrHeterosexual"],
       "sexualOrientationNotListedText": "Some other orientation"
     }

--- a/src/applications/personalization/profile/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile/tests/selectors.unit.spec.js
@@ -535,7 +535,7 @@ describe('selectVAProfilePersonalInformation selector', () => {
     expect(
       selectors.selectVAProfilePersonalInformation(state, 'genderIdentity'),
     ).to.deep.equal({
-      genderIdentity: ['man'],
+      genderIdentity: 'man',
     });
   });
 

--- a/src/applications/personalization/profile/util/contact-information/formValues.js
+++ b/src/applications/personalization/profile/util/contact-information/formValues.js
@@ -89,16 +89,17 @@ export const getInitialFormValues = options => {
   }
 
   if (personalInformation.includes(fieldName)) {
-    if (fieldName === 'preferredName') return transformInitialFormValues(data);
-
-    if (fieldName === 'genderIdentity') {
-      return transformInitialFormValues(
-        transformBooleanArrayToFormValues(data?.[fieldName]),
-      );
+    // handle a single string type of field value
+    if (
+      fieldName === FIELD_NAMES.PREFERRED_NAME ||
+      fieldName === FIELD_NAMES.GENDER_IDENTITY
+    ) {
+      return transformInitialFormValues(data);
     }
 
     const notListedTextKey = createNotListedTextKey(fieldName);
 
+    // handle multi-select values plus additional 'write in' value if present
     return transformInitialFormValues({
       ...transformBooleanArrayToFormValues(data?.[fieldName]),
       ...(data?.[notListedTextKey] &&

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -1,6 +1,7 @@
 import { mapValues } from 'lodash';
 import moment from 'moment';
 
+import RadioWidget from 'platform/forms-system/src/js/widgets/RadioWidget';
 import TextWidget from 'platform/forms-system/src/js/widgets/TextWidget';
 import OtherTextField from '@@profile/components/personal-information/OtherTextField';
 import { NOT_SET_TEXT } from '../../constants';
@@ -37,9 +38,12 @@ const genderLabels = {
   transgenderWoman: 'Transgender woman',
   transgenderMan: 'Transgender man',
   nonBinary: 'Non-binary',
-  preferNotToAnswer: 'Prefer not to answer (un-checks other options)',
+  preferNotToAnswer: 'Prefer not to answer',
   genderNotListed: 'A gender not listed here',
 };
+
+// use the keys from the genderLabels object as the option values
+const genderOptions = Object.keys(genderLabels);
 
 const sexualOrientationLabels = {
   lesbianGayHomosexual: 'Lesbian, gay, or homosexual',
@@ -84,7 +88,10 @@ export const personalInformationFormSchemas = {
   genderIdentity: {
     type: 'object',
     properties: {
-      ...createBooleanSchemaPropertiesFromOptions(genderLabels),
+      genderIndentity: {
+        type: 'string',
+        enum: genderOptions,
+      },
     },
     required: [],
   },
@@ -127,9 +134,13 @@ export const personalInformationUiSchemas = {
     },
   },
   genderIdentity: {
-    'ui:field': DeselectableObjectField,
-    'ui:description': `Select your gender identity`,
-    ...createUiTitlePropertiesFromOptions(genderLabels),
+    genderIdentity: {
+      'ui:field': RadioWidget,
+      'ui:description': `Select your gender identity`,
+      'ui:options': {
+        labels: genderLabels,
+      },
+    },
   },
   sexualOrientation: {
     'ui:field': DeselectableObjectField,

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -88,14 +88,13 @@ export const personalInformationFormSchemas = {
   genderIdentity: {
     type: 'object',
     properties: {
-      genderIndentity: {
+      genderIdentity: {
         type: 'string',
         enum: genderOptions,
       },
     },
     required: [],
   },
-
   sexualOrientation: {
     type: 'object',
     properties: {
@@ -135,10 +134,11 @@ export const personalInformationUiSchemas = {
   },
   genderIdentity: {
     genderIdentity: {
-      'ui:field': RadioWidget,
-      'ui:description': `Select your gender identity`,
+      'ui:widget': RadioWidget,
+      'ui:title': `Select your gender identity`,
       'ui:options': {
         labels: genderLabels,
+        enumOptions: genderOptions,
       },
     },
   },
@@ -160,6 +160,8 @@ export const formatIndividualLabel = (key, label) => {
   }
   return label;
 };
+
+export const formatGenderIdentity = genderKey => genderLabels?.[genderKey];
 
 export const formatMultiSelectAndText = (data, fieldName) => {
   const notListedTextKey = `${fieldName}NotListedText`;


### PR DESCRIPTION
## Description
We have once again been told that the Gender Identity field will be a radio button group instead of a multi select. This PR changes the input type, updates the value display, and updates the e2e tests for this field.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38955


## Testing done
E2E testing updated


## Acceptance criteria
- [ ] Gender identity changed to radio group instead of checkboxes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
