### PR TITLE
Direct Scheduling Choose Date Time: Select Previous Or Next Month Displays Error to User

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
@@ -71,7 +71,7 @@ export const WaitTimeAlert = ({
   const today = moment();
   const momentPreferredDate = moment(preferredDate);
   let momentNextAvailableDate;
-  if (nextAvailableApptDate?.includes('Z')) {
+  if (nextAvailableApptDate?._i?.includes('Z')) {
     momentNextAvailableDate = moment(nextAvailableApptDate).tz(
       getTimezoneByFacilityId(facilityId),
     );
@@ -119,7 +119,8 @@ export const WaitTimeAlert = ({
           </>
         </InfoAlert>
       );
-    } else if (!hasNextAvailableApptDate) {
+    }
+    if (!hasNextAvailableApptDate) {
       return (
         <InfoAlert
           headline="We couldn’t find an appointment for your selected date"

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
@@ -71,7 +71,7 @@ export const WaitTimeAlert = ({
   const today = moment();
   const momentPreferredDate = moment(preferredDate);
   let momentNextAvailableDate;
-  if (nextAvailableApptDate?._i?.includes('Z')) {
+  if (nextAvailableApptDate?.includes('Z')) {
     momentNextAvailableDate = moment(nextAvailableApptDate).tz(
       getTimezoneByFacilityId(facilityId),
     );

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -625,7 +625,7 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
             }
             return slot;
           })
-          .sort((a, b) => a.start.localeCompare(b.start));
+          .sort((a, b) => a.start.valueOf() - b.start.valueOf());
         dispatch({
           type: FORM_CALENDAR_FETCH_SLOTS_SUCCEEDED,
           availableSlots: sortedSlots,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -625,7 +625,7 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
             }
             return slot;
           })
-          .sort((a, b) => a.start.valueOf() - b.start.valueOf());
+          .sort((a, b) => a.start.localeCompare(b.start));
         dispatch({
           type: FORM_CALENDAR_FETCH_SLOTS_SUCCEEDED,
           availableSlots: sortedSlots,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -610,7 +610,7 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
           // for the correct day.
           .map(slot => {
             if (featureVAOSServiceVAAppointments) {
-              let time = moment(slot.start);
+              let time = moment(slot.start).format('YYYY-MM-DDTHH:mm:ss');
               if (slot.start.endsWith('Z') && timezone) {
                 // The moment.tz() function will parse a given time with offset
                 // and convert it to the time zone provided.


### PR DESCRIPTION
## Description
When choosing a date for a direct scheduled appointment and scrolling in the calendar widget for future months the application would error out when the calendar would fetch the next page of months. Updated the getAppointmentSlots function in vaos new-appointment redux actions.js to handle paging in the calendar widget.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39675


## Testing done
scrolled in the calendar widget and verified that paging was handled properly.

## Screenshots


## Acceptance criteria
- [x] the calendar widget can be scrolled and when paging occurs does not error.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
