### PR TITLE
Handle no mailing address in copy address prompt modal, update tests, use WC modal

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/addresses/AddressesTable.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/AddressesTable.jsx
@@ -9,13 +9,13 @@ import {
 } from '@@vap-svc/constants';
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 
-import CopyAddressModal from './CopyAddressModal';
+import CopyAddressModalController from './CopyAddressModalController';
 
 import ProfileInfoTable from '../../ProfileInfoTable';
 
 const AddressesTable = ({ className }) => (
   <>
-    <CopyAddressModal />
+    <CopyAddressModalController />
     <ProfileInfoTable
       title="Addresses"
       level={2}

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
@@ -7,9 +7,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import set from 'lodash/set';
 
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
-import AddressView from '@@vap-svc/components/AddressField/AddressView';
-
 import { updateCopyAddressModal, createTransaction } from '@@vap-svc/actions';
 
 import * as VAP_SERVICE from '@@vap-svc/constants';
@@ -27,7 +24,9 @@ import { getProfileInfoFieldAttributes } from '@@profile/util/getProfileInfoFiel
 
 import { isPendingTransaction } from '@@vap-svc/util/transactions';
 
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import CopyAddressModalPrompt from './CopyAddressModalPrompt';
+import CopyAddressModalSuccess from './CopyAddressModalSuccess';
+import CopyAddressModalFailure from './CopyAddressModalFailure';
 
 const CopyAddressModal = props => {
   const {
@@ -46,8 +45,7 @@ const CopyAddressModal = props => {
 
   const checkAddressAndPrompt = useCallback(
     () => {
-      // TODO: handle home address update with no mailing address and show custom modal content
-      if (!mailingAddress || !homeAddress) {
+      if (!homeAddress) {
         updateCopyAddressModalAction(null);
         return;
       }
@@ -73,16 +71,12 @@ const CopyAddressModal = props => {
   const isLoading =
     transactionRequest?.isPending || isPendingTransaction(transaction);
 
-  // const error =
-  //   transactionRequest?.error || (isFailedTransaction(transaction) ? {} : null);
-
   const handlers = {
     onYes() {
       const payload = convertCleanDataToPayload(homeAddress, mailingFieldName);
 
-      const payloadWithUpdatedId = mailingAddress?.id
-        ? set(payload, 'id', mailingAddress.id)
-        : payload;
+      // make sure we are sending correct id in payload, or empty string if no mailing address for user
+      const payloadWithUpdatedId = set(payload, 'id', mailingAddress?.id || '');
 
       const method = payloadWithUpdatedId.id ? 'PUT' : 'POST';
 
@@ -108,119 +102,32 @@ const CopyAddressModal = props => {
     },
   };
 
-  const CopyAddressMainModal = () => (
-    <Modal
-      title="We've updated your home address"
-      visible={
-        copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.PROMPT ||
-        copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.PENDING
-      }
-      onClose={handlers.onCloseModal}
-      id="copy-address-modal"
-    >
-      <>
-        <p data-testid="modal-content">
-          Your updated home address:
-          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
-            <AddressView data={homeAddress} />
-          </span>
-        </p>
-        <va-featured-content>
-          We have this mailing address on file for you:
-          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
-            <AddressView data={mailingAddress} />
-          </span>
-          Do you want to update your mailing address to match this home address?
-          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
-            <AddressView data={homeAddress} />
-          </span>
-        </va-featured-content>
-
-        <div className="vads-u-display--flex vads-u-flex-wrap--wrap">
-          <LoadingButton
-            data-action="save-edit"
-            data-testid="save-edit-button"
-            isLoading={isLoading}
-            loadingText="Saving changes"
-            className="vads-u-margin-top--0"
-            onClick={handlers.onYes}
-          >
-            Yes
-          </LoadingButton>
-
-          {!isLoading && (
-            <button
-              data-testid="cancel-edit-button"
-              type="button"
-              className="usa-button-secondary small-screen:vads-u-margin-top--0"
-              onClick={handlers.onCloseModal}
-            >
-              No
-            </button>
-          )}
-        </div>
-      </>
-    </Modal>
-  );
-
-  const UpdateErrorModal = () => (
-    <Modal
-      title="We can't update your mailing address"
-      visible={
-        copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.FAILURE
-      }
-      onClose={handlers.onCloseModal}
-      status="error"
-      primaryButton={{
-        action: () => {
-          handlers.onCloseModal();
-        },
-        text: 'Close',
-      }}
-    >
-      <>
-        <p data-testid="modal-content">
-          We’re sorry. We can’t update your information right now. We’re working
-          to fix this problem. Please check back later.
-        </p>
-      </>
-    </Modal>
-  );
-
-  const UpdateSuccessModal = () => (
-    <Modal
-      title="We've updated your mailing address"
-      visible={
-        copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.SUCCESS
-      }
-      onClose={handlers.onCloseModal}
-      primaryButton={{
-        action: () => {
-          handlers.onCloseModal();
-        },
-        text: 'Close',
-      }}
-    >
-      <>
-        <p data-testid="modal-content">
-          We’ve updated your mailing address to match your home address.
-          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
-            <AddressView data={homeAddress} />
-          </span>
-        </p>
-      </>
-    </Modal>
-  );
-
   return (
     <>
       {(copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.PROMPT ||
         copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.PENDING) &&
-        shouldProfileShowAddressChangeModal && <CopyAddressMainModal />}
+        shouldProfileShowAddressChangeModal && (
+          <CopyAddressModalPrompt
+            isLoading={isLoading}
+            homeAddress={homeAddress}
+            mailingAddress={mailingAddress}
+            onClose={handlers.onCloseModal}
+            onYes={handlers.onYes}
+            visible
+          />
+        )}
       {copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.SUCCESS &&
-        shouldProfileShowAddressChangeModal && <UpdateSuccessModal />}
+        shouldProfileShowAddressChangeModal && (
+          <CopyAddressModalSuccess
+            address={homeAddress}
+            onClose={handlers.onCloseModal}
+            visible
+          />
+        )}
       {copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.FAILURE &&
-        shouldProfileShowAddressChangeModal && <UpdateErrorModal />}
+        shouldProfileShowAddressChangeModal && (
+          <CopyAddressModalFailure onClose={handlers.onCloseModal} visible />
+        )}
     </>
   );
 };

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalFailure.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalFailure.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const CopyAddressModalFailure = ({ visible, onClose }) => (
+  <VaModal
+    modalTitle="We can't update your mailing address"
+    visible={visible}
+    onClose={onClose}
+    status="error"
+    primaryButtonText="Close"
+    onPrimaryButtonClick={onClose}
+    data-testid="copy-address-failure"
+  >
+    <>
+      <div data-testid="modal-content">
+        <p>
+          We’re sorry. We can’t update your information right now. We’re working
+          to fix this problem. Please check back later.
+        </p>
+      </div>
+    </>
+  </VaModal>
+);
+
+CopyAddressModalFailure.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default CopyAddressModalFailure;

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalPrompt.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalPrompt.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import AddressView from '@@vap-svc/components/AddressField/AddressView';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+
+const CopyAddressModalPrompt = ({
+  visible,
+  onClose,
+  homeAddress,
+  mailingAddress,
+  isLoading,
+  onYes,
+}) => {
+  // content to show based on whether a mailAddress is present or not
+  // this edge base may never present itself, but figured it is better to handle the 'what if'
+  const MailingAddressInfo = mailingAddress ? (
+    <>
+      <p>We have this mailing address on file for you:</p>
+      <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
+        <AddressView data={mailingAddress} />
+      </span>{' '}
+    </>
+  ) : (
+    <p>We don’t have a mailing address on file for you.</p>
+  );
+
+  return (
+    <VaModal
+      modalTitle="We've updated your home address"
+      visible={visible}
+      onClose={onClose}
+      onCloseEvent={onClose}
+      data-testid="copy-address-prompt"
+    >
+      <div data-testid="modal-content">
+        <p>
+          Your updated home address:
+          <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
+            <AddressView data={homeAddress} />
+          </span>
+        </p>
+      </div>
+      <va-featured-content>
+        {MailingAddressInfo}
+        Do you want to update your mailing address to match this home address?
+        <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
+          <AddressView data={homeAddress} />
+        </span>
+      </va-featured-content>
+
+      <div className="vads-u-display--flex vads-u-flex-wrap--wrap">
+        <LoadingButton
+          data-action="save-edit"
+          data-testid="save-edit-button"
+          isLoading={isLoading}
+          loadingText="Saving changes"
+          className="vads-u-margin-top--0"
+          onClick={onYes}
+        >
+          Yes
+        </LoadingButton>
+
+        {!isLoading && (
+          <button
+            data-testid="cancel-edit-button"
+            type="button"
+            className="usa-button-secondary small-screen:vads-u-margin-top--0"
+            onClick={onClose}
+          >
+            No
+          </button>
+        )}
+      </div>
+    </VaModal>
+  );
+};
+
+CopyAddressModalPrompt.propTypes = {
+  homeAddress: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onYes: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+  mailingAddress: PropTypes.object,
+  visible: PropTypes.bool,
+};
+
+export default CopyAddressModalPrompt;

--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalSuccess.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalSuccess.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import AddressView from '@@vap-svc/components/AddressField/AddressView';
+
+const CopyAddressModalSuccess = ({ address, visible = false, onClose }) => (
+  <VaModal
+    modalTitle="We've updated your mailing address"
+    visible={visible}
+    onCloseEvent={onClose}
+    onPrimaryButtonClick={onClose}
+    primaryButtonText="Close"
+    data-testid="copy-address-success"
+  >
+    <div data-testid="modal-content">
+      <p>We’ve updated your mailing address to match your home address.</p>
+      <span className="vads-u-font-weight--bold vads-u-display--block vads-u-margin-y--1p5">
+        <AddressView data={address} />
+      </span>
+    </div>
+  </VaModal>
+);
+
+CopyAddressModalSuccess.propTypes = {
+  address: PropTypes.object,
+  visible: PropTypes.bool,
+  onClose: PropTypes.func,
+};
+
+export default CopyAddressModalSuccess;

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
@@ -45,15 +45,20 @@ describe('Home address update modal', () => {
     addressPage.fillAddressForm(formFields);
     addressPage.saveForm();
 
-    cy.findByTestId('modal-content').should('exist');
+    cy.findByTestId('copy-address-prompt')
+      .shadow()
+      .findByText(`We've updated your home address`)
+      .should('exist');
 
     cy.findByTestId('save-edit-button').click({
       force: true,
+      waitForAnimations: true,
     });
 
-    cy.findByTestId('modal-content').should('exist');
-
-    cy.findByText(`We've updated your mailing address`).should('exist');
+    cy.findByTestId('copy-address-success')
+      .shadow()
+      .findByText(`We've updated your mailing address`)
+      .should('exist');
 
     cy.injectAxeThenAxeCheck();
   });
@@ -78,15 +83,19 @@ describe('Home address update modal', () => {
     addressPage.fillAddressForm(formFields);
     addressPage.saveForm();
 
-    cy.findByTestId('modal-content').should('exist');
+    cy.findByTestId('copy-address-prompt')
+      .shadow()
+      .findByText(`We've updated your home address`)
+      .should('exist');
 
     cy.findByTestId('save-edit-button').click({
       force: true,
     });
 
-    cy.findByTestId('modal-content').should('exist');
-
-    cy.findByText(`We can't update your mailing address`).should('exist');
+    cy.findByTestId('copy-address-failure')
+      .shadow()
+      .findByText(`We can't update your mailing address`)
+      .should('exist');
 
     cy.injectAxeThenAxeCheck();
   });


### PR DESCRIPTION
## Description
We have encountered the potential edge case that a user updates their home address, but does not currently have a mailing address listed. In this case, the modal was showing up to ask if the user would like to update their mailing address to match the home address, but would show a blank space for the original mailing address data.

This PR updates the prompt modal to display specific messaging if a mailing address is not present.

Additional changes in this PR include:

- Updating the usage of modals to now use the web component va-modal instead of the old react component.
- Updating E2E and unit tests to work for web component usage.
- Splitting up the various modals into 3 unique react components, and rendering them within the `CopyAddressModalController` component conditionally.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/37842


## Testing done
E2E tests and unit tests updated

## Screenshots
New content for when mailing address is not present
![Screen Shot 2022-04-08 at 10 31 09 AM](https://user-images.githubusercontent.com/8332986/162484301-039a13bc-2ee6-4a06-ba7c-4b58580a38de.png)


## Acceptance criteria
- [x] Specific language appears in modal prompt when mailing address is not present.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
