### PR TITLE
Fix flaky Check-in Demographics E2E test

### DIFF
--- a/src/applications/check-in/day-of/tests/e2e/pages/Appointments.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Appointments.js
@@ -101,7 +101,7 @@ class Appointments {
   attemptCheckIn = (appointmentNumber = 1) => {
     cy.get(
       `:nth-child(${appointmentNumber}) > [data-testid=check-in-button]`,
-    ).click();
+    ).click({ waitForAnimations: true });
   };
 }
 


### PR DESCRIPTION
## Description
This PR fixes a small race condition in a page object that causes occasional flakiness in CI.

## Testing done
Ran test 30 times locally without failures.

## Acceptance criteria
- [ ] CI passes.