### PR TITLE
Changed 'Routing Number' to '9-digit routing number'

### DIFF
--- a/src/applications/edu-benefits/1990e/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/1990e/content/directDeposit.jsx
@@ -145,7 +145,7 @@ export default function createDirectDepositPage() {
             },
           },
           routingNumber: {
-            'ui:title': 'Bank routing number',
+            'ui:title': 'Bank`s 9-digit routing number',
             'ui:validations': [validateRoutingNumber],
             'ui:errorMessages': {
               pattern: 'Please enter a valid 9 digit routing number',

--- a/src/applications/edu-benefits/1990e/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/1990e/content/directDeposit.jsx
@@ -145,7 +145,7 @@ export default function createDirectDepositPage() {
             },
           },
           routingNumber: {
-            'ui:title': 'Bank`s 9-digit routing number',
+            'ui:title': "Bank's 9-digit routing number",
             'ui:validations': [validateRoutingNumber],
             'ui:errorMessages': {
               pattern: 'Please enter a valid 9 digit routing number',


### PR DESCRIPTION
## Description
Text change to correct title

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24730

## Testing done
Local Testing

## Screenshots


## Acceptance criteria
- [ ] Routing number input title is "Bank's 9-digit routing number"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
