### PR TITLE
[#437] adds logic to prompt user to login when an authenticated topic…

### DIFF
--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -1,6 +1,3 @@
-import piiReplace from './piiReplace';
-import * as _ from 'lodash';
-
 const GreetUser = {
   makeBotGreetUser: (
     csrfToken,
@@ -35,8 +32,17 @@ const GreetUser = {
       });
     }
 
-    if (action.type === 'WEB_CHAT/SEND_MESSAGE') {
-      _.assign(action.payload, { text: piiReplace(action.payload.text) });
+    if (action.type === 'DIRECT_LINE/INCOMING_ACTIVITY') {
+      const data = action.payload.activity;
+      if (
+        data.type === 'message' &&
+        data.text.includes('Please wait a moment. Sending you to sign in...') &&
+        data.from.role === 'bot'
+      ) {
+        const event = new Event('webchat-auth-activity');
+        event.data = action.payload.activity;
+        window.dispatchEvent(event);
+      }
     }
     return next(action);
   },


### PR DESCRIPTION
… is requested

Co-authored-by: Justin Trieu <justin.trieu@thoughtworks.com>

## Description
When a user tries to access information that requires authentication they are prompted to authenticate and presented the sign in modal if they chose to move forward. If not they are presented with a link to find more information

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#437

## Testing done
- Manual tests

## Acceptance criteria
- Sign in modal appears when user agrees to sign in

## Definition of done
- [ ] Events are logged appropriately
