### PR TITLE
HLR/NOD update verify identity content

### DIFF
--- a/src/applications/appeals/10182/components/NeedsToVerify.jsx
+++ b/src/applications/appeals/10182/components/NeedsToVerify.jsx
@@ -3,14 +3,15 @@ import PropTypes from 'prop-types';
 
 const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
-    <h2 slot="headline">We need you to verify your identity</h2>
+    <h2 slot="headline">Verify your identity to start your request</h2>
     <p>
-      You’ll be able to complete this form after we confirm your identify. This
-      helps us keep your information safe.
+      Before we give you access to your personal information, we need to make
+      sure that you’re you—and not someone pretending to be you. This helps us
+      keep your information safe.
     </p>
     <p>
       <a href={`/verify?next=${pathname}`} className="verify-link">
-        Verify your identity
+        Verify your identity to start your request
       </a>
     </p>
   </va-alert>

--- a/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
+++ b/src/applications/disability-benefits/996/components/NeedsToVerify.jsx
@@ -3,14 +3,15 @@ import PropTypes from 'prop-types';
 
 const NeedsToVerify = ({ pathname }) => (
   <va-alert status="warning">
-    <h2 slot="headline">We need you to verify your identity</h2>
+    <h2 slot="headline">Verify your identity to start your request</h2>
     <p>
-      You’ll be able to complete this form after we confirm your identify. This
-      helps us keep your information safe.
+      Before we give you access to your personal information, we need to make
+      sure that you’re you—and not someone pretending to be you. This helps us
+      keep your information safe.
     </p>
     <p>
       <a href={`/verify?next=${pathname}`} className="verify-link">
-        Verify your identity
+        Verify your identity to start your request
       </a>
     </p>
   </va-alert>


### PR DESCRIPTION
## Description

Applying content recommendations to an alert that is shown when a Veteran has not verified their identity, the Higher-Level Review and Notice of Disagreement forms both show an alert on the introduction page and are prevented from continuing the form.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39109
Latest content recommendation: https://github.com/department-of-veterans-affairs/va.gov-team/issues/38849#issuecomment-1092082519

## Testing done

All tests passing

## Screenshots

<img width="545" alt="Screen Shot 2022-04-11 at 11 14 16 AM" src="https://user-images.githubusercontent.com/136959/162786213-d563726b-1717-4fc3-a3ea-0552ed8c05d3.png">

## Acceptance criteria
- [x] Verify identity alert content updated
- [x] All tests passing (include accessibility checks)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
