### PR TITLE
Added moment as a resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,6 +372,7 @@
     "**/yargs-parser": "13.1.2",
     "@babel/runtime": "^7.15.4",
     "punycode": "1.4.1",
-    "**/cached-path-relative": "1.1.0"
+    "**/cached-path-relative": "1.1.0",
+    "moment": "^2.29.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "markdown-it": "^12.3.2",
     "markdown-it-link-attributes": "^4.0.0",
     "moment": "^2.19.3",
-    "moment-timezone": "^0.5.33",
+    "moment-timezone": "^0.5.34",
     "prop-types": "^15.6.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -373,6 +373,6 @@
     "@babel/runtime": "^7.15.4",
     "punycode": "1.4.1",
     "**/cached-path-relative": "1.1.0",
-    "moment": "^2.29.2"
+    "**/moment": "^2.29.2"
   }
 }

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -12,6 +12,7 @@ const exceptionSet = new Set([
   'https://npmjs.com/advisories/996',
   'https://npmjs.com/advisories/1488',
   'https://github.com/advisories/GHSA-r683-j2x4-v87g',
+  'https://github.com/advisories/GHSA-8hfj-j24r-96c4',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13997,22 +13997,22 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
-moment-timezone@^0.5.33:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+moment-timezone@^0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.19.3:
+"moment@>= 2.9.0", moment@^2.22.1, moment@^2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+
+moment@^2.19.3:
   version "2.24.0"
   resolved "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-moment@^2.22.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
## Description
Tried to upgrade moment due to severity high vulnerability. This resulted in multiple unit and cypress tests failures. 

Tests are having the correct data but it still fails

![image](https://user-images.githubusercontent.com/55560129/162795491-8ae00f8e-b5e3-4081-a96d-eb6beb940276.png)

Therefore, moment was added as a resolution

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
