### PR TITLE
Adds information message for Safari users

### DIFF
--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -70,6 +70,11 @@ span.sidelines {
   }
 }
 
+#ios-bug ul {
+  list-style: square;
+  padding-left: 1.5em;
+}
+
 #login-root {
   .sitewide-search-drop-down-panel-button,
   .sign-in-drop-down-panel-button {

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -4,11 +4,10 @@ import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
 import DowntimeBanners from 'platform/user/authentication/components/DowntimeBanner';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
-export default function LoginHeader({ loggedOut }) {
-  const isIOS =
-    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-    navigator.userAgentData.platform.includes('macOS');
-
+const isIOSDevice = () =>
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  navigator.userAgentData.platform.includes('macOS');
+export default function LoginHeader({ loggedOut, isIOS = isIOSDevice }) {
   return (
     <>
       <div className="row">
@@ -69,5 +68,6 @@ export default function LoginHeader({ loggedOut }) {
 }
 
 LoginHeader.propTypes = {
+  isIOS: PropTypes.bool,
   loggedOut: PropTypes.bool,
 };

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -29,9 +29,9 @@ export default function LoginHeader({ loggedOut, isIOS = isIOSDevice }) {
                   You may have trouble signing in right now
                 </h2>
                 <p>
-                  We’re sorry. You may have trouble signing in with certain
-                  browsers or devices right now. We’re working to fix this
-                  problem as fast as we can.
+                  We’re sorry. If you're using the Safari browser or an Apple
+                  mobile device, you may have trouble signing in right now.
+                  We’re working to fix this problem as fast as we can.
                 </p>
                 <va-additional-info
                   id="ios-bug"

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -4,11 +4,28 @@ import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
 import DowntimeBanners from 'platform/user/authentication/components/DowntimeBanner';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
-const isIOSDevice = () =>
-  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-  (navigator.userAgent.indexOf('Safari') !== -1 &&
-    navigator.userAgent.indexOf('Chrome') === -1);
-export default function LoginHeader({ loggedOut, isIOS = isIOSDevice }) {
+function checkWebkit() {
+  const ua = navigator.userAgent.toLowerCase();
+
+  if (
+    ua.indexOf('chrome') === ua.indexOf('android') &&
+    ua.indexOf('safari') !== -1
+  ) {
+    // accessed via a WebKit-based browser
+    return true;
+  }
+
+  if (ua.includes('crios') || ua.includes('fxios')) {
+    return true;
+  }
+  // check if accessed via a WebKit-based webview
+  return (
+    ua.indexOf('ipad') !== -1 ||
+    ua.indexOf('iphone') !== -1 ||
+    ua.indexOf('ipod') !== -1
+  );
+}
+export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
   return (
     <>
       <div className="row">

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -2,8 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
 import DowntimeBanners from 'platform/user/authentication/components/DowntimeBanner';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 export default function LoginHeader({ loggedOut }) {
+  const isIOS =
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    navigator.userAgentData.platform.includes('macOS');
+
   return (
     <>
       <div className="row">
@@ -15,6 +20,50 @@ export default function LoginHeader({ loggedOut }) {
         </div>
       </div>
       <DowntimeBanners />
+      {isIOS && (
+        <div className="downtime-notification row">
+          <div className="columns small-12">
+            <div className="form-warning-banner">
+              <va-alert visible status="info">
+                <h2 slot="headline">
+                  You may have trouble signing in right now
+                </h2>
+                <p>
+                  We’re sorry. You may have trouble signing in with certain
+                  browsers or devices right now. We’re working to fix this
+                  problem as fast as we can.
+                </p>
+                <va-additional-info
+                  id="ios-bug"
+                  trigger="Here's what you can do now"
+                  disable-border
+                >
+                  <ul>
+                    <li>
+                      Try to sign in from a different browser or device. Use a
+                      browser other than Safari (like Edge, Chrome, or Firefox).
+                      If you're using an iPhone, iPad, or other Apple device,
+                      try a different device (like a laptop or desktop
+                      computer).
+                    </li>
+                    <li>
+                      If sign in fails, refresh the page in your browser.
+                      Refreshing the page may fix the problem.
+                    </li>
+                  </ul>
+                  <p>
+                    If you still have trouble signing in, try again later. Or
+                    call us at <va-telephone contact={CONTACTS.HELP_DESK} />{' '}
+                    (TTY: <va-telephone contact={CONTACTS['711']} />
+                    ). We’re here 24/7.
+                  </p>
+                </va-additional-info>
+              </va-alert>
+              <br />
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -6,7 +6,8 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/Tele
 
 const isIOSDevice = () =>
   /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-  navigator.userAgentData.platform.includes('macOS');
+  (navigator.userAgent.indexOf('Safari') !== -1 &&
+    navigator.userAgent.indexOf('Chrome') === -1);
 export default function LoginHeader({ loggedOut, isIOS = isIOSDevice }) {
   return (
     <>
@@ -19,7 +20,7 @@ export default function LoginHeader({ loggedOut, isIOS = isIOSDevice }) {
         </div>
       </div>
       <DowntimeBanners />
-      {isIOS && (
+      {isIOS() && (
         <div className="downtime-notification row">
           <div className="columns small-12">
             <div className="form-warning-banner">

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -5,7 +5,7 @@ import LoginHeader from 'platform/user/authentication/components/LoginHeader';
 
 describe('LoginHeader', () => {
   let wrapper;
-  const props = { loggedOut: false, isIOS: false };
+  const props = { loggedOut: false, isIOS: () => false };
 
   beforeEach(() => {
     wrapper = shallow(<LoginHeader {...props} />);
@@ -28,7 +28,7 @@ describe('LoginHeader', () => {
     expect(wrapper.find('DowntimeBanners').exists()).to.be.true;
   });
   it('should display an informational alert for iOS users', () => {
-    const mutatedProps = { loggedOut: false, isIOS: true };
+    const mutatedProps = { loggedOut: false, isIOS: () => true };
     wrapper = shallow(<LoginHeader {...mutatedProps} />);
     expect(wrapper.find('#ios-bug').exists()).to.be.true;
     wrapper.unmount();

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -5,7 +5,7 @@ import LoginHeader from 'platform/user/authentication/components/LoginHeader';
 
 describe('LoginHeader', () => {
   let wrapper;
-  const props = { loggedOut: false };
+  const props = { loggedOut: false, isIOS: false };
 
   beforeEach(() => {
     wrapper = shallow(<LoginHeader {...props} />);
@@ -26,5 +26,11 @@ describe('LoginHeader', () => {
   });
   it('should render `DowntimeBanners`', () => {
     expect(wrapper.find('DowntimeBanners').exists()).to.be.true;
+  });
+  it('should display an informational alert for iOS users', () => {
+    const mutatedProps = { loggedOut: false, isIOS: true };
+    wrapper = shallow(<LoginHeader {...mutatedProps} />);
+    expect(wrapper.find('#ios-bug').exists()).to.be.true;
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
This PR addresses the major regression impacting all WebKit browsers (iOS devices) and adds an informational message to users signing into VA.gov.  This effectively adds the notice to the Sign in Modal and the Unified Sign in Page and we only want to show this alert for iOS devices.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39841


## Testing done
Unit

## Screenshots
### Unified Sign in Page
<img width="1046" alt="Screen Shot 2022-04-12 at 11 26 40 AM" src="https://user-images.githubusercontent.com/67602137/162998115-ff0e0818-5401-4dc6-9542-70462647f249.png">

### Signin Modal
<img width="1046" alt="Screen Shot 2022-04-12 at 11 26 48 AM" src="https://user-images.githubusercontent.com/67602137/162998136-81beaf19-3f9c-40ef-82b4-404d2d32af3e.png">


## Acceptance criteria
- [x] Message shows exclusively for WebKit browsers
- [x] Message is shown in a blue `info` box
- [x] Message is shown on both the Sign In Modal and the Unified Sign In Page
- [x] Language has been reviewed by implementing team, to ensure it presents as human readable
- [x] Message has been tested on both desktop and mobile devices

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
