### PR TITLE
[department-of-veterans-affairs/va-virtual-agent] hot fix for Prod CSAT error

### DIFF
--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -36,6 +36,7 @@ const GreetUser = {
       const data = action.payload.activity;
       if (
         data.type === 'message' &&
+        data.text &&
         data.text.includes('Please wait a moment. Sending you to sign in...') &&
         data.from.role === 'bot'
       ) {


### PR DESCRIPTION
Checks for property on JavaScript object before using it.

Co-authored-by: Justin Trieu <justin.trieu@thoughtworks.com>

## Description

The customer satisfaction survey started erroring out yesterday evening. Determined the cause. Added a check for the existence of a property before actually referencing it.

## Testing done

Tested on localhost. Testing on Dev/Staging. Automated integration tests identified this problem on Prod. We have a ticket to replicate these tests in the lower environments so that we can catch issues like this earlier.

## Acceptance criteria

- [ ] At end of conversation, customer sees satisfaction rating stars, per usual, and flow continues.
 
## Definition of done

- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
