### PR TITLE
Replace custom event handlers with native ones in check-in

### DIFF
--- a/src/applications/check-in/components/pages/Edit/Address.jsx
+++ b/src/applications/check-in/components/pages/Edit/Address.jsx
@@ -216,7 +216,7 @@ export default function Address(props) {
                 name={addressField.name}
                 key={addressField.name}
                 value={addressValue[addressField.name]}
-                onVaBlur={
+                onBlur={
                   addressField.options?.extraValidation
                     ? event =>
                         onBlur(event, addressField.options.extraValidation)

--- a/src/applications/check-in/components/pages/Edit/Address.jsx
+++ b/src/applications/check-in/components/pages/Edit/Address.jsx
@@ -116,10 +116,10 @@ export default function Address(props) {
     },
     [setAddressValue, setAddressError, t],
   );
-  const onChange = useCallback(
+  const onInput = useCallback(
     (event, extraValidation = false) => {
       const fieldName = event.target.name;
-      const newValue = event.detail.value;
+      const newValue = event.target?.value;
       if (!isUpdatable) {
         if (extraValidation && newValue) {
           const validate = extraValidation(newValue);
@@ -222,11 +222,11 @@ export default function Address(props) {
                         onBlur(event, addressField.options.extraValidation)
                     : onBlur
                 }
-                onVaChange={
+                onInput={
                   addressField.options?.extraValidation
                     ? event =>
-                        onChange(event, addressField.options.extraValidation)
-                    : onChange
+                        onInput(event, addressField.options.extraValidation)
+                    : onInput
                 }
                 required={addressField.options?.required}
                 inputmode={addressField.options?.inputMode || 'text'}

--- a/src/applications/check-in/components/pages/Edit/Email.jsx
+++ b/src/applications/check-in/components/pages/Edit/Email.jsx
@@ -60,7 +60,7 @@ export default function Email(props) {
     scrollToTop('topScrollElement');
   }, []);
 
-  const onChange = useCallback(
+  const onInput = useCallback(
     event => {
       const { value: newEmail } = event.target;
       if (!newEmail) {
@@ -86,7 +86,7 @@ export default function Email(props) {
         name={key}
         value={email}
         required
-        onVaChange={onChange}
+        onInput={onInput}
         class="vads-u-padding-bottom--4"
       />
       <UpdateButton

--- a/src/applications/check-in/components/pages/Edit/Name.jsx
+++ b/src/applications/check-in/components/pages/Edit/Name.jsx
@@ -48,7 +48,7 @@ export default function Name(props) {
     scrollToTop('topScrollElement');
   }, []);
 
-  const onChange = useCallback(
+  const onInput = useCallback(
     event => {
       if (!event.target.value) {
         setError('Name is required');
@@ -80,7 +80,7 @@ export default function Name(props) {
         name={key}
         value={nameValue}
         required
-        onVaChange={onChange}
+        onInput={onInput}
         className="vads-u-margin-bottom--3"
       />
       <UpdateButton

--- a/src/applications/check-in/components/pages/Edit/PhoneNumber.jsx
+++ b/src/applications/check-in/components/pages/Edit/PhoneNumber.jsx
@@ -84,7 +84,7 @@ export default function PhoneNumber(props) {
     scrollToTop('topScrollElement');
   }, []);
 
-  const onPhoneNumberChange = useCallback(
+  const onPhoneNumberInput = useCallback(
     event => {
       const { value: newPhone } = event.target;
       if (newPhone === '') {
@@ -103,7 +103,7 @@ export default function PhoneNumber(props) {
     [setPhoneNumber, key, t],
   );
 
-  const onExtensionChange = useCallback(
+  const onExtensionInput = useCallback(
     event => {
       const { value: newExtension } = event.target;
       setExtension(newExtension);
@@ -124,7 +124,7 @@ export default function PhoneNumber(props) {
         maxlength={null}
         name={key}
         value={formatPhone(phoneNumber)}
-        onVaChange={onPhoneNumberChange}
+        onInput={onPhoneNumberInput}
         required
       />
       <VaTextInput
@@ -133,7 +133,7 @@ export default function PhoneNumber(props) {
         maxlength={null}
         name={`${key}-extension`}
         value={extension}
-        onVaChange={onExtensionChange}
+        onInput={onExtensionInput}
         class="vads-u-padding-bottom--6"
       />
       <UpdateButton

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -19,10 +19,10 @@ export default function ValidateDisplay({
     event => {
       switch (event.target.name) {
         case 'last-name':
-          setLastName(event.detail.value);
+          setLastName(event.target.value);
           break;
         case 'last-4-ssn':
-          setLast4Ssn(event.detail.value);
+          setLast4Ssn(event.target.value);
           break;
         default:
           break;
@@ -57,7 +57,7 @@ export default function ValidateDisplay({
           error={lastNameErrorMessage}
           label={t('your-last-name')}
           name="last-name"
-          onVaChange={updateField}
+          onInput={updateField}
           required
           spellCheck="false"
           value={lastName}
@@ -68,7 +68,7 @@ export default function ValidateDisplay({
           inputmode="numeric"
           label={t('last-4-digits-of-your-social-security-number')}
           maxlength="4"
-          onVaChange={updateField}
+          onInput={updateField}
           name="last-4-ssn"
           required
           value={last4Ssn}


### PR DESCRIPTION
## Description

These changes need to be merged before https://github.com/department-of-veterans-affairs/component-library/pull/363 in order to not break compatibility.

The reason we can rename `onVaChange` to `onInput` is because the `vaChange` event is [actually firing off of the `input` event](https://github.com/department-of-veterans-affairs/component-library/blob/ac16664ae6bab8b2ad1f14956ae29c98cfa94af3/packages/web-components/src/components/va-text-input/va-text-input.tsx#L170). Additionaly, since we're no longer putting the value into the custom event's `detail` property, there are a few places where `event.detail.value` is being changed to `event.target.value`.

This also means that the `VaTextInput` react bindings aren't necessary since we aren't using custom event handlers but I've left them alone in order to keep things consistent with components like `<VaSelect>`.

## Original issue(s)

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/38907

## Testing done

Local browser testing.

## Screenshots

Getting the value using a native `onBlur` handler:

```diff
diff --git a/src/applications/check-in/components/pages/Edit/Address.jsx b/src/applications/check-in/components/pages/Edit/Address.jsx
index fd9b7daab1..289b3c65cc 100644
--- a/src/applications/check-in/components/pages/Edit/Address.jsx
+++ b/src/applications/check-in/components/pages/Edit/Address.jsx
@@ -88,6 +88,8 @@ export default function Address(props) {
     (event, extraValidation = false) => {
       const fieldName = event.target.name;
       const newValue = event.detail?.value || event.target.value;
+      console.log('event', event);
+      console.log('newValue', newValue);
       if (event.target.required) {
         if (!newValue) {
           setAddressError(prevState => ({
```

![console log with onBlur event and target value highlighted](https://user-images.githubusercontent.com/2008881/163018814-24f15c14-299a-42e0-9a24-c7fae4b4f8dd.png)


When typing "123", `vaChange` fires for each character:

![Console logs highlighted for each character stroke](https://user-images.githubusercontent.com/2008881/163020471-bddf6be6-1256-4c49-9ae4-b356b5d141b8.png)

Having an `onInput` handler instead will have the same behavior:

![Console logs highlighted with the event being `input` instead of `vaChange`](https://user-images.githubusercontent.com/2008881/163021426-a74c9175-ac56-4ce9-a725-09406840a103.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
