### PR TITLE
VACMS-8740: Fixes link in test-and-lab-results widget

### DIFF
--- a/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.js
+++ b/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.js
@@ -69,7 +69,7 @@ describe('CTA widgets', () => {
       ).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
-        }eauth.va.gov/mhv-portal-web/web/myhealthevet/labs-tests`,
+        }eauth.va.gov/mhv-portal-web/eauth?deeplinking=labs-tests`,
       );
     });
   });

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -11,7 +11,7 @@ const mhvToEauthRoutes = {
   'secure-messaging': 'eauth?deeplinking=secure_messaging',
   appointments: 'eauth?deeplinking=appointments',
   home: 'eauth',
-  'labs-tests': 'web/myhealthevet/labs-tests',
+  'labs-tests': 'eauth?deeplinking=labs-tests',
 };
 
 // An MHV URL is a function of the following parameters:


### PR DESCRIPTION
## Description
Changes link to point to eauth servlet. 

New link is this one:
https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=labs-tests

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8740


## Testing done


## Screenshots


## Acceptance criteria
- [ ] Clicking button should navigate to new link as described above.
