### PR TITLE
Add missing certs for self-hosted runner in unit test job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,6 +96,9 @@ jobs:
     outputs:
       app_folders: ${{ steps.get-changed-apps.outputs.app_folders }}
 
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Unit tests were failing with errors like this due to missing certs on the self-hosted runners:
```
An unexpected error occurred: "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz: self signed certificate in certificate chain"
```
Adding the certs should resolve the issue.

## Original issue(s)
N/A

## Testing done
Successful CI run

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
