### PR TITLE
Change UserNav component back

### DIFF
--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -17,7 +17,7 @@ export const UnauthenticatedPageContent = () => {
           account now.
         </div>
         <div className="button">
-          <UserNav isHeaderV2 customText="Sign in or create an account" />
+          <UserNav isHeaderV2 />
         </div>
       </va-alert>
     </>

--- a/src/applications/dhp-connected-devices/tests/components/UnauthenticatedPageContent.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/UnauthenticatedPageContent.spec.js
@@ -10,18 +10,4 @@ describe('connect health devices landing page, user not logged in', () => {
 
     expect(dhpContainer.getByText(title)).to.exist;
   });
-
-  it("App renders 'Sign in or create account' button", () => {
-    const loggedInState = {
-      user: {
-        login: {
-          currentlyLoggedIn: false,
-        },
-      },
-    };
-    const screen = renderInReduxProvider(<DhpApp />, {
-      initialState: loggedInState,
-    });
-    expect(screen.getByText(/Sign in or create an account/)).to.exist;
-  });
 });

--- a/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
+++ b/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
@@ -11,8 +11,9 @@ describe(manifest.appName, () => {
     );
   });
 
-  it("displays login modal after clicking 'Sign in or create an account' for veteran NOT logged in", () => {
-    cy.findByText('Sign in or create an account').click({
+  it("displays login modal after clicking 'Sign in' for veteran NOT logged in", () => {
+    cy.findAllByText('Sign in').click({
+      multiple: true,
       force: true,
       waitForAnimations: true,
     });

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -17,7 +17,6 @@ class SearchHelpSignIn extends Component {
     isProfileLoading: PropTypes.bool.isRequired,
     onSignInSignUp: PropTypes.func.isRequired,
     toggleMenu: PropTypes.func.isRequired,
-    customText: PropTypes.string,
     userGreeting: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.arrayOf(PropTypes.node),
@@ -65,7 +64,7 @@ class SearchHelpSignIn extends Component {
       <div className="sign-in-links">
         {!isSubdomain && (
           <button className="sign-in-link" onClick={this.handleSignInSignUp}>
-            {this.props.customText ? this.props.customText : 'Sign in'}
+            Sign in
           </button>
         )}
         {isSubdomain && (
@@ -74,7 +73,7 @@ class SearchHelpSignIn extends Component {
             href="https://www.va.gov/my-va"
             onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
           >
-            {this.props.customText ? this.props.customText : 'Sign in'}
+            Sign in
           </a>
         )}
       </div>

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -226,7 +226,6 @@ export class Main extends Component {
           onSignInSignUp={this.signInSignUp}
           toggleMenu={this.props.toggleSearchHelpUserMenu}
           userGreeting={this.props.userGreeting}
-          customText={this.props.customText}
         />
         <FormSignInModal
           onClose={this.closeFormSignInModal}
@@ -332,5 +331,4 @@ Main.propTypes = {
   showLoginModal: PropTypes.bool,
   userGreeting: PropTypes.array,
   utilitiesMenuIsOpen: PropTypes.object,
-  customText: PropTypes.string,
 };


### PR DESCRIPTION
## Description
The DHP team changed the `UserNav` component to accept custom text. After receiving feedback from the VSP team, we changed it _back_ to what was originally there: the component does not accept custom text.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Testing specific for the DHP application was done. This include unit testing the DHP `Unauthenticated` component, as well as a Cypress test.


## Screenshots
**Previous button**
![Screen Shot 2022-04-15 at 1 13 02 PM](https://user-images.githubusercontent.com/92477481/163622564-d76332cf-6e21-4055-8605-1f1ab444b96a.png)



**Current button (after changes)**

![Screen Shot 2022-04-15 at 1 11 01 PM](https://user-images.githubusercontent.com/92477481/163622439-a778ca2d-1f24-46fa-9b25-df4759f63c5f.png)




## Acceptance criteria

-Remove `customText` prop and associated logic from `UserNav` component so that it used the standardized text 'Sign in' only.

-Update the [Unauthenticated Page Content component](https://github.com/department-of-veterans-affairs/vets-website/blob/0318e668308fa78a2b091a3370d90f8aabd47269/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx#L20) to remove `customText`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
