### PR TITLE
Fix Veterans Crisis Line modal on legacy pages

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -117,10 +117,8 @@ function mountReactComponents(headerFooterData, commonStore) {
   startHeader(commonStore, headerFooterData.megaMenuData);
 
   // Start Veteran Crisis Line modal functionality.
-  document.addEventListener('DOMContentLoaded', () => {
-    addFocusBehaviorToCrisisLineModal();
-    addOverlayTriggers();
-  });
+  addFocusBehaviorToCrisisLineModal();
+  addOverlayTriggers();
 }
 
 function getContentHostName() {


### PR DESCRIPTION
## Description
The crisis line modal has not been opening in the desktop view on legacy pages such as https://www.va.gov/opa/. This PR fixes it.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8782

## Testing done
Local testing

## Acceptance criteria
- [x] CI passes.