### PR TITLE
Dhp 255 button style change

### DIFF
--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -17,7 +17,7 @@ export const UnauthenticatedPageContent = () => {
           account now.
         </div>
         <div className="button">
-          <UserNav isHeaderV2 customText="Sign in or create an account" />
+          <UserNav isHeaderV2 />
         </div>
       </va-alert>
     </>

--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -16,7 +16,7 @@ export const UnauthenticatedPageContent = () => {
           If you don’t have any of these accounts, you can create a free ID.me
           account now.
         </div>
-        <div className="button">
+        <div className="dhp-button">
           <UserNav isHeaderV2 />
         </div>
       </va-alert>

--- a/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
+++ b/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
@@ -28,3 +28,7 @@
   font-size: 1.5rem;
   font-weight: 400;
 }
+
+.dhp-button .sign-in-nav {
+  margin-left: -10px;
+}

--- a/src/applications/dhp-connected-devices/tests/components/UnauthenticatedPageContent.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/UnauthenticatedPageContent.spec.js
@@ -10,18 +10,4 @@ describe('connect health devices landing page, user not logged in', () => {
 
     expect(dhpContainer.getByText(title)).to.exist;
   });
-
-  it("App renders 'Sign in or create account' button", () => {
-    const loggedInState = {
-      user: {
-        login: {
-          currentlyLoggedIn: false,
-        },
-      },
-    };
-    const screen = renderInReduxProvider(<DhpApp />, {
-      initialState: loggedInState,
-    });
-    expect(screen.getByText(/Sign in or create an account/)).to.exist;
-  });
 });

--- a/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
+++ b/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
@@ -11,8 +11,9 @@ describe(manifest.appName, () => {
     );
   });
 
-  it("displays login modal after clicking 'Sign in or create an account' for veteran NOT logged in", () => {
-    cy.findByText('Sign in or create an account').click({
+  it("displays login modal after clicking 'Sign in' for veteran NOT logged in", () => {
+    cy.findAllByText('Sign in').click({
+      multiple: true,
       force: true,
       waitForAnimations: true,
     });

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -17,7 +17,6 @@ class SearchHelpSignIn extends Component {
     isProfileLoading: PropTypes.bool.isRequired,
     onSignInSignUp: PropTypes.func.isRequired,
     toggleMenu: PropTypes.func.isRequired,
-    customText: PropTypes.string,
     userGreeting: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.arrayOf(PropTypes.node),
@@ -65,7 +64,7 @@ class SearchHelpSignIn extends Component {
       <div className="sign-in-links">
         {!isSubdomain && (
           <button className="sign-in-link" onClick={this.handleSignInSignUp}>
-            {this.props.customText ? this.props.customText : 'Sign in'}
+            Sign in
           </button>
         )}
         {isSubdomain && (
@@ -74,7 +73,7 @@ class SearchHelpSignIn extends Component {
             href="https://www.va.gov/my-va"
             onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
           >
-            {this.props.customText ? this.props.customText : 'Sign in'}
+            Sign in
           </a>
         )}
       </div>

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -226,7 +226,6 @@ export class Main extends Component {
           onSignInSignUp={this.signInSignUp}
           toggleMenu={this.props.toggleSearchHelpUserMenu}
           userGreeting={this.props.userGreeting}
-          customText={this.props.customText}
         />
         <FormSignInModal
           onClose={this.closeFormSignInModal}
@@ -332,5 +331,4 @@ Main.propTypes = {
   showLoginModal: PropTypes.bool,
   userGreeting: PropTypes.array,
   utilitiesMenuIsOpen: PropTypes.object,
-  customText: PropTypes.string,
 };


### PR DESCRIPTION
## Description
The DHP team reused a modal that the VA had previously, `UserNav`, to allow veterans to authenticate with the VA. Where the DHP team would like that button, and how it's styled, it slightly off from how the button is by default. This PR will align _only_ the button `Sign in`, found on our page and within our page content, to the text found above. This PR _does not_ change the styling of the `Sign in` button found in the header, or anywhere else on the VA.gov website.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
No testing needed, this PR is for styling changes only.

## Screenshots
**Button before custom styling applied:**

![Screen Shot 2022-04-18 at 1 56 01 PM](https://user-images.githubusercontent.com/92477481/163869960-f107e43f-c1a6-4d17-b795-76294e2ff2fb.png)

**Button after custom styling applied:**
![Screen Shot 2022-04-15 at 1 11 01 PM](https://user-images.githubusercontent.com/92477481/163870108-72820bb5-a866-4bfc-9467-581a14445ee6.png)


## Acceptance criteria
No acceptance criteria

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
