### PR TITLE
Aligns 'Sign in' with text directly above it

### DIFF
--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -16,7 +16,7 @@ export const UnauthenticatedPageContent = () => {
           If you don’t have any of these accounts, you can create a free ID.me
           account now.
         </div>
-        <div className="dhp-button">
+        <div className="dhp-login-button">
           <UserNav isHeaderV2 />
         </div>
       </va-alert>

--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -16,7 +16,7 @@ export const UnauthenticatedPageContent = () => {
           If you don’t have any of these accounts, you can create a free ID.me
           account now.
         </div>
-        <div className="button">
+        <div className="dhp-button">
           <UserNav isHeaderV2 />
         </div>
       </va-alert>

--- a/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
+++ b/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
@@ -28,3 +28,7 @@
   font-size: 1.5rem;
   font-weight: 400;
 }
+
+.dhp-button .sign-in-nav {
+  margin-left: -10px;
+}

--- a/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
+++ b/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
@@ -29,6 +29,6 @@
   font-weight: 400;
 }
 
-.dhp-button .sign-in-nav {
+.dhp-login-button .sign-in-nav {
   margin-left: -10px;
 }


### PR DESCRIPTION
## Description
The DHP team reused a modal that the VA had previously, `UserNav`, to allow veterans to authenticate with the VA. Where the DHP team would like that button, and how it's styled, it slightly off from how the button is by default. This PR will align _only_ the button `Sign in`, found on our page and within our page content, to the text found above. This PR _does not_ change the styling of the `Sign in` button found in the header, or anywhere else on the VA.gov website.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
No testing needed, this PR is for styling changes only.

## Screenshots
**Button before custom styling applied:**

![Screen Shot 2022-04-15 at 1 11 01 PM](https://user-images.githubusercontent.com/92477481/163870108-72820bb5-a866-4bfc-9467-581a14445ee6.png)


**Button after custom styling applied:**
![Screen Shot 2022-04-18 at 1 56 01 PM](https://user-images.githubusercontent.com/92477481/163869960-f107e43f-c1a6-4d17-b795-76294e2ff2fb.png)


## Acceptance criteria
No acceptance criteria

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
