### PR TITLE
(feature) clear timeout if showUpdateSuccessAlert

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
@@ -1,28 +1,25 @@
-/* eslint-disable va/prefer-web-component-library */
-// having issues with the VaModal throwing errors
-// TODO: use VaModal web-component
-
 import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import set from 'lodash/set';
 
+// vap-svc deps
 import { updateCopyAddressModal, createTransaction } from '@@vap-svc/actions';
-
 import * as VAP_SERVICE from '@@vap-svc/constants';
-
 import { areAddressesEqual } from '@@vap-svc/util';
-
 import {
   selectCopyAddressModal,
   selectVAPContactInfoField,
   selectVAPServiceTransaction,
 } from '@@vap-svc/selectors';
+import { isPendingTransaction } from '@@vap-svc/util/transactions';
 
+// profile deps
 import { profileShowAddressChangeModal } from '@@profile/selectors';
 import { getProfileInfoFieldAttributes } from '@@profile/util/getProfileInfoFieldAttributes';
 
-import { isPendingTransaction } from '@@vap-svc/util/transactions';
+// platform deps
+import { focusElement } from '~/platform/utilities/ui';
 
 import CopyAddressModalPrompt from './CopyAddressModalPrompt';
 import CopyAddressModalSuccess from './CopyAddressModalSuccess';
@@ -100,6 +97,14 @@ const CopyAddressModal = props => {
     onCloseModal() {
       updateCopyAddressModalAction(null);
     },
+    onCloseSuccessModal() {
+      handlers.onCloseModal();
+      focusElement('#mailing-address [data-testid=update-success-alert]');
+    },
+    onCloseFailureModal() {
+      handlers.onCloseModal();
+      focusElement('#mailing-address .usa-input-error-message');
+    },
   };
 
   return (
@@ -120,13 +125,16 @@ const CopyAddressModal = props => {
         shouldProfileShowAddressChangeModal && (
           <CopyAddressModalSuccess
             address={homeAddress}
-            onClose={handlers.onCloseModal}
+            onClose={handlers.onCloseSuccessModal}
             visible
           />
         )}
       {copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.FAILURE &&
         shouldProfileShowAddressChangeModal && (
-          <CopyAddressModalFailure onClose={handlers.onCloseModal} visible />
+          <CopyAddressModalFailure
+            onClose={handlers.onCloseFailureModal}
+            visible
+          />
         )}
     </>
   );

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
@@ -75,8 +75,11 @@ describe('Home address update modal', () => {
 
     cy.findByTestId('residentialAddress')
       .findByTestId('update-success-alert')
-      .should('exist')
-      .should('be.focused');
+      .should('exist');
+
+    cy.focused()
+      .should('have.attr', 'data-testid')
+      .and('eq', 'update-success-alert');
 
     cy.injectAxeThenAxeCheck();
   });
@@ -127,6 +130,10 @@ describe('Home address update modal', () => {
       .get('.usa-input-error-message')
       .should('exist')
       .should('be.focused');
+
+    cy.focused()
+      .should('have.attr', 'class')
+      .and('eq', 'usa-input-error-message');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
@@ -75,7 +75,8 @@ describe('Home address update modal', () => {
 
     cy.findByTestId('residentialAddress')
       .findByTestId('update-success-alert')
-      .should('exist');
+      .should('exist')
+      .should('be.focused');
 
     cy.injectAxeThenAxeCheck();
   });
@@ -113,6 +114,18 @@ describe('Home address update modal', () => {
       .shadow()
       .findByText(`We can't update your mailing address`)
       .should('exist');
+
+    cy.findByTestId('copy-address-failure')
+      .shadow()
+      .findByText('Close')
+      .click({
+        force: true,
+      });
+
+    cy.findByTestId('mailingAddress')
+      .get('.usa-input-error-message')
+      .should('exist')
+      .should('be.focused');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
@@ -60,6 +60,23 @@ describe('Home address update modal', () => {
       .findByText(`We've updated your mailing address`)
       .should('exist');
 
+    cy.findByTestId('copy-address-success')
+      .shadow()
+      .findByText(`Close`)
+      .should('exist')
+      .click({
+        force: true,
+        waitForAnimations: true,
+      });
+
+    cy.findByTestId('mailingAddress')
+      .findByTestId('update-success-alert')
+      .should('exist');
+
+    cy.findByTestId('residentialAddress')
+      .findByTestId('update-success-alert')
+      .should('exist');
+
     cy.injectAxeThenAxeCheck();
   });
 

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/home-address-modal.cypress.spec.js
@@ -120,6 +120,7 @@ describe('Home address update modal', () => {
       .findByText('Close')
       .click({
         force: true,
+        waitForAnimations: true,
       });
 
     cy.findByTestId('mailingAddress')

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -155,7 +155,7 @@ class ProfileInformationFieldController extends React.Component {
       clearTimeout(this.closeModalTimeoutID);
       if (this.props.transaction) {
         focusElement(`div#${fieldName}-transaction-status`);
-      } else if (this.props.showUpdateSuccessAlert) {
+      } else if (showUpdateSuccessAlert) {
         focusElement('[data-testid=update-success-alert]');
         // Success check after confirming suggested address
         if (forceEditView && typeof successCallback === 'function') {

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -118,7 +118,12 @@ class ProfileInformationFieldController extends React.Component {
   closeModalTimeoutID = null;
 
   componentDidUpdate(prevProps) {
-    const { fieldName, forceEditView, successCallback } = this.props;
+    const {
+      fieldName,
+      forceEditView,
+      successCallback,
+      showUpdateSuccessAlert,
+    } = this.props;
     // Exit the edit view if it takes more than 5 seconds for the update/save
     // transaction to resolve. If the transaction has not resolved after 5
     // seconds we will show a "we're saving your new information..." message on
@@ -133,6 +138,13 @@ class ProfileInformationFieldController extends React.Component {
         // your..." message while Redux is processing everything.
         window.VetsGov.pollTimeout ? 50 : 5000,
       );
+    }
+
+    // component should clear timeout if the showUpdateSuccessAlert is set to true
+    // this is used to prevent the alerts from disappearing when a user directly updates
+    // their mailing address from the home address flow
+    if (showUpdateSuccessAlert) {
+      clearTimeout(this.closeModalTimeoutID);
     }
 
     // Do not auto-exit edit view if the transaction failed


### PR DESCRIPTION
## Description
This just adds logic to clear the timeout for hiding alerts if the showUpdateSuccessAlert is true. The edge case for this is when there are two alerts shown via the `CopyAddressModalController` component the timeout was firing and hiding them after 5 seconds.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35205


## Testing done
Local browser testing and updated e2e tests to check for double success alerts and also to make sure that focus is applied to the right elements during this update flow.


## Screenshots
![Screen Shot 2022-04-18 at 8 04 59 PM](https://user-images.githubusercontent.com/8332986/163905660-f6238003-bdf9-4d0a-b952-5eeffd2fabb6.png)


## Acceptance criteria
- [x] double success alerts shown upon updating both home and mailing address in one flow.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
