### PR TITLE
Revert "temporary disable check of latest github run number blocking deploy j…"

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1136,7 +1136,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ always() && github.ref == 'refs/heads/master' && needs.get-latest-run-number.result == 'success' }}
+    if: ${{ always() && github.ref == 'refs/heads/master' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_run_number == github.run_number}}
     needs: [build, get-latest-run-number]
 
     strategy:


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#20803 - GH api now delivering current info on runs, so okay to revert this PR