### PR TITLE
removed type button from accordion item

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -54,7 +54,6 @@ export default function AccordionItem({
             className="usa-accordion-button"
             aria-expanded={displayExpanded}
             aria-controls={id}
-            type="button"
           >
             <span className="vads-u-font-family--sans vads-u-color--gray-dark">
               {button}


### PR DESCRIPTION
## Description
Search by location and name had a blue background instead of gray. 

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#40161](https://github.com/department-of-veterans-affairs/va.gov-team/issues/40161)


## Testing done
Local Env

## Screenshots
<img width="440" alt="Screen Shot 2022-04-19 at 12 01 49 PM" src="https://user-images.githubusercontent.com/18352271/164056980-3147c6d8-d20a-4ad9-b984-7f9a8756df50.png">


## Acceptance criteria
- [ ] tab background is gray on mobile and desktop.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
