### PR TITLE
39375 - [CDP] [debt] Add Your other VA bills section to Current VA debt page

### DIFF
--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSelector, connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { PATTERNS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { apiRequest } from 'platform/utilities/api';
 import DebtLetterCard from './DebtLetterCard';
 import { ErrorMessage, DowntimeMessage } from './Alerts';
+import OtherVADebts from '../../medical-copays/components/OtherVADebts';
+import { cdpAccessToggle } from '../../medical-copays/utils/helpers';
+
+const fetchCopaysResponseAsync = async () => {
+  return apiRequest('/medical_copays')
+    .then(({ response }) => {
+      return response.data.length > 0;
+    })
+    .catch(err => {
+      return !err;
+    });
+};
 
 const DebtCardsList = ({ debts, errors }) => {
+  const [hasCopays, setHasCopays] = useState(false);
+  const showCDPComponents = useSelector(state => cdpAccessToggle(state));
   const error = errors.length ? errors[0] : [];
 
   const renderError = () => {
@@ -15,6 +30,12 @@ const DebtCardsList = ({ debts, errors }) => {
     }
     return <ErrorMessage />;
   };
+
+  useEffect(() => {
+    fetchCopaysResponseAsync().then(hasCopaysResponse =>
+      setHasCopays(hasCopaysResponse),
+    );
+  }, []);
 
   return (
     <>
@@ -98,6 +119,9 @@ const DebtCardsList = ({ debts, errors }) => {
           </a>
           to learn about your payment options.
         </p>
+
+        {showCDPComponents && hasCopays && <OtherVADebts module="LTR" />}
+
         <h3
           id="downloadDebtLetters"
           className="vads-u-margin-top--4 vads-u-font-size--h2"

--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -11,7 +11,7 @@ import { cdpAccessToggle } from '../../medical-copays/utils/helpers';
 
 const fetchCopaysResponseAsync = async () => {
   return apiRequest('/medical_copays')
-    .then(({ response }) => {
+    .then(response => {
       return response.data.length > 0;
     })
     .catch(err => {

--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -50,7 +50,10 @@ const DebtCardsList = ({ debts, errors }) => {
 
       {!error?.status &&
         debts.length < 1 && (
-          <section className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3">
+          <section
+            className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3"
+            data-testid="debt-list-no-items"
+          >
             <h3 className="vads-u-font-family--serif vads-u-margin-top--0 vads-u-font-size--h4">
               Our records show that you don’t have any current debts
             </h3>
@@ -79,7 +82,7 @@ const DebtCardsList = ({ debts, errors }) => {
       {!error?.status &&
         debts.length > 0 && (
           <>
-            <div className="vads-u-margin-top--3">
+            <div className="vads-u-margin-top--3" data-testid="debt-list">
               {debts.map((debt, index) => (
                 <DebtLetterCard
                   key={`${index}-${debt.fileNumber}`}

--- a/src/applications/debt-letters/components/DebtLetterCard.jsx
+++ b/src/applications/debt-letters/components/DebtLetterCard.jsx
@@ -28,7 +28,10 @@ const DebtLetterCard = ({ debt, setActiveDebt }) => {
   };
 
   return (
-    <article className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--2">
+    <article
+      className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--2"
+      data-testid="debt-list-item"
+    >
       <h3 className="vads-u-margin--0">{debtCardHeading}</h3>
 
       {mostRecentHistory && (

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -70,7 +70,10 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
         <a href="/manage-va-debt/your-debt">Your VA debt</a>
       </Breadcrumbs>
 
-      <section className="vads-l-row vads-u-margin-x--neg2p5">
+      <section
+        className="vads-l-row vads-u-margin-x--neg2p5"
+        data-testid="current-va-debt"
+      >
         <h1 className="vads-u-padding-x--2p5 vads-u-margin-bottom--2">
           Current VA debt
         </h1>

--- a/src/applications/debt-letters/tests/DebtCardsList.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtCardsList.unit.spec.js
@@ -202,14 +202,6 @@ describe('DebtLettersSummary', () => {
       </Provider>,
     );
     expect(wrapper.getByTestId('debt-list-no-items')).to.exist;
-    // expect(
-    //   wrapper
-    //     .dive()
-    //     .dive()
-    //     .find('h3')
-    //     .at(0)
-    //     .text(),
-    // ).to.equal('Our records show that you don’t have any current debts');
     wrapper.unmount();
   });
 });

--- a/src/applications/debt-letters/tests/DebtCardsList.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtCardsList.unit.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 import DebtCardsList from '../components/DebtCardsList';
 
 describe('DebtLettersSummary', () => {
@@ -162,19 +164,15 @@ describe('DebtLettersSummary', () => {
     dispatch: () => {},
   };
 
-  it('mounts wrapper component', () => {
-    const wrapper = shallow(<DebtCardsList store={fakeStore} />);
-    expect(wrapper.length).to.equal(1);
-    wrapper.unmount();
-  });
   it('renders correct number of debt cards', () => {
-    const wrapper = shallow(<DebtCardsList store={fakeStore} />);
-    expect(
-      wrapper
-        .dive()
-        .dive()
-        .find(`Connect(DebtLetterCard)`).length,
-    ).to.equal(4);
+    const wrapper = render(
+      <Provider store={fakeStore}>
+        <BrowserRouter>
+          <DebtCardsList />
+        </BrowserRouter>
+      </Provider>,
+    );
+    expect(wrapper.getAllByTestId('debt-list-item')).to.have.lengthOf(4);
     wrapper.unmount();
   });
   it('renders correct empty state', () => {
@@ -196,16 +194,22 @@ describe('DebtLettersSummary', () => {
       subscribe: () => {},
       dispatch: () => {},
     };
-    const wrapper = shallow(<DebtCardsList store={fakeStoreEmptyState} />);
-    expect(wrapper.dive().find(`Connect(DebtLetterCard)`).length).to.equal(0);
-    expect(
-      wrapper
-        .dive()
-        .dive()
-        .find('h3')
-        .at(0)
-        .text(),
-    ).to.equal('Our records show that you don’t have any current debts');
+    const wrapper = render(
+      <Provider store={fakeStoreEmptyState}>
+        <BrowserRouter>
+          <DebtCardsList />
+        </BrowserRouter>
+      </Provider>,
+    );
+    expect(wrapper.getByTestId('debt-list-no-items')).to.exist;
+    // expect(
+    //   wrapper
+    //     .dive()
+    //     .dive()
+    //     .find('h3')
+    //     .at(0)
+    //     .text(),
+    // ).to.equal('Our records show that you don’t have any current debts');
     wrapper.unmount();
   });
 });

--- a/src/applications/debt-letters/tests/DebtLettersSummary.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtLettersSummary.unit.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+import { Provider } from 'react-redux';
 import DebtLettersSummary from '../components/DebtLettersSummary';
 
 describe('DebtLettersSummary', () => {
@@ -25,7 +26,11 @@ describe('DebtLettersSummary', () => {
       subscribe: () => {},
       dispatch: () => {},
     };
-    const wrapper = shallow(<DebtLettersSummary store={fakeStore} />);
+    const wrapper = shallow(
+      <Provider store={fakeStore}>
+        <DebtLettersSummary />
+      </Provider>,
+    );
     expect(wrapper.length).to.equal(1);
     wrapper.unmount();
   });

--- a/src/applications/debt-letters/tests/DebtLettersSummary.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtLettersSummary.unit.spec.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 import DebtLettersSummary from '../components/DebtLettersSummary';
 
 describe('DebtLettersSummary', () => {
@@ -26,12 +27,14 @@ describe('DebtLettersSummary', () => {
       subscribe: () => {},
       dispatch: () => {},
     };
-    const wrapper = shallow(
+    const wrapper = render(
       <Provider store={fakeStore}>
-        <DebtLettersSummary />
+        <BrowserRouter>
+          <DebtLettersSummary />
+        </BrowserRouter>
       </Provider>,
     );
-    expect(wrapper.length).to.equal(1);
+    expect(wrapper.getByTestId('current-va-debt')).to.exist;
     wrapper.unmount();
   });
 });

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -22,11 +22,6 @@ describe('Debt Letters', () => {
     cy.wait(['@features', '@debts']);
   });
 
-  it('displays other va debts', () => {
-    cy.findByTestId('other-va-debts-ltr-body').should('exist');
-    cy.axeCheck();
-  });
-
   it('displays the current debts section and navigates to debt details - C1226', () => {
     cy.findByTestId('debts-jumplink').click({ waitForAnimations: true });
     cy.get('[data-testclass="debt-details-button"]')
@@ -36,8 +31,14 @@ describe('Debt Letters', () => {
     cy.injectAxeThenAxeCheck();
   });
 
+  it('displays other va debts', () => {
+    cy.findByTestId('other-va-debts-ltr-body').should('exist');
+    cy.injectAxeThenAxeCheck();
+  });
+
   /* eslint-disable va/axe-check-required */
   // Same display-states below as test above which already had AXE-check.
+
   it('displays download debt letters - C1227', () => {
     cy.findByTestId('download-jumplink').click({ waitForAnimations: true });
     cy.findByTestId('download-letters-link').click();

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -8,6 +8,7 @@
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
+import mockCopays from '../../../medical-copays/tests/e2e/fixtures/mocks/copays.json';
 
 describe('Debt Letters', () => {
   beforeEach(() => {
@@ -16,8 +17,14 @@ describe('Debt Letters', () => {
       'features',
     );
     cy.intercept('GET', '/v0/debts', mockDebts).as('debts');
+    cy.intercept('GET', '/v0/medical_copays', mockCopays);
     cy.visit('/manage-va-debt/your-debt/');
     cy.wait(['@features', '@debts']);
+  });
+
+  it('displays other va debts', () => {
+    cy.findByTestId('other-va-debts-ltr-body').should('exist');
+    cy.axeCheck();
   });
 
   it('displays the current debts section and navigates to debt details - C1226', () => {

--- a/src/applications/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,6 +1,11 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{ "name": "debt_letters_show_letters", "value": true }]
+    "features": [
+      { "name": "debt_letters_show_letters", "value": true },
+      { 
+        "name": "combined_debt_portal_access", 
+        "value": true 
+      }]
   }
 }

--- a/src/applications/medical-copays/components/OtherVADebts.jsx
+++ b/src/applications/medical-copays/components/OtherVADebts.jsx
@@ -9,11 +9,11 @@ const OtherVADebts = ({ module }) => {
         Your other VA {module === 'MCP' && <span>debt</span>}
         {module === 'LTR' && <span>bills</span>}
       </h2>
-      <p>
-        Our records show you have&nbsp;
+      <p className="vads-u-font-family--sans">
+        Our records show you have
         {module === 'MCP' && (
           <span data-testid="other-va-debts-mcp-body">
-            VA benefit debt. You can&nbsp;
+            &nbsp;VA benefit debt. You can&nbsp;
             <a href="/manage-va-debt/your-debt">
               check the details of your current debt
             </a>

--- a/src/applications/medical-copays/tests/unit/otherdebts.unit.spec.js
+++ b/src/applications/medical-copays/tests/unit/otherdebts.unit.spec.js
@@ -15,6 +15,16 @@ describe('other va debts component', () => {
     );
     expect(otherDebts.getByTestId('other-va-debts-mcp-body')).to.exist;
   });
+  it('should exist', () => {
+    const moduleName = 'LTR';
+
+    const otherDebts = render(
+      <BrowserRouter>
+        <OtherVADebts module={moduleName} />
+      </BrowserRouter>,
+    );
+    expect(otherDebts.getByTestId('other-va-debts-ltr-body')).to.exist;
+  });
   it('should not exist', () => {
     const moduleName = 'NO-MATCH';
 


### PR DESCRIPTION
## Description
Add "Your other VA bills section" to Current VA debt page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39375 

## Screenshots
![image](https://user-images.githubusercontent.com/29178824/164073137-4ab55bc1-54fe-4de3-8ff6-ebea035a47e0.png)

![image](https://user-images.githubusercontent.com/29178824/164075417-69f9b122-20d1-490b-b3e8-d5628d7e0e6f.png)

![image](https://user-images.githubusercontent.com/29178824/164086968-7d2b5b75-2724-46d1-8851-aeb1d4c8e269.png)

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
