### PR TITLE
aria-labelledby ID not accessible

### DIFF
--- a/src/applications/gi/components/CompareGrid.jsx
+++ b/src/applications/gi/components/CompareGrid.jsx
@@ -68,7 +68,7 @@ export function CompareGrid({
         >
           {displayDiff && (
             <div className="label-diff">
-              <i className="fas fa-asterisk" />
+              <i className="fas fa-asterisk" aria-hidden="true" />
             </div>
           )}
           {field.label}

--- a/src/applications/gi/components/CompareGrid.jsx
+++ b/src/applications/gi/components/CompareGrid.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import environment from 'platform/utilities/environment';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 export function CompareGrid({
@@ -11,7 +13,13 @@ export function CompareGrid({
   smallScreen,
   subSectionLabel,
 }) {
-  const sectionLabelId = `sectionLabel${sectionLabel}`;
+  // const sectionLabelArr = ;
+  const sectionLabelId = `sectionLabel-${sectionLabel
+    ?.split(' ')
+    .map(word => `${word}-`)
+    ?.join('')
+    .slice(0, -1)}`;
+  const sectionLabelIdOld = `sectionLabel${sectionLabel}`;
   const empties = [];
 
   for (let i = 0; i < 3 - institutions.length; i++) {
@@ -60,7 +68,7 @@ export function CompareGrid({
         >
           {displayDiff && (
             <div className="label-diff">
-              <i className={`fas fa-asterisk`} />
+              <i className="fas fa-asterisk" />
             </div>
           )}
           {field.label}
@@ -111,7 +119,10 @@ export function CompareGrid({
     <div className={classNames('compare-grid', className)}>
       {sectionLabel && (
         <div className="compare-header-section non-scroll-parent">
-          <div className="non-scroll-label" id={sectionLabelId}>
+          <div
+            className="non-scroll-label"
+            id={environment.isProduction() ? sectionLabelIdOld : sectionLabelId}
+          >
             <h2>{sectionLabel}</h2>
           </div>{' '}
         </div>
@@ -199,5 +210,15 @@ export function CompareGrid({
     </div>
   );
 }
+
+CompareGrid.propTypes = {
+  className: PropTypes.string || undefined,
+  fieldData: PropTypes.array,
+  institutions: PropTypes.array,
+  sectionLabel: PropTypes.string,
+  showDifferences: PropTypes.bool,
+  smallScreen: PropTypes.bool,
+  subSectionLabel: PropTypes.string || undefined,
+};
 
 export default CompareGrid;


### PR DESCRIPTION
## Description
Compare page table titles have the incorrect ids. Instead of being a correctly formatted hyphenated string it's adding each word of the title as a separate id so the table titles have multiple ids. The aria-labelledby on the table that points to the table title is also using the incorrect table id. For comparison the single page has tables and table titles with the correct id formatting

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#33880](https://github.com/department-of-veterans-affairs/va.gov-team/issues/33882)

## Testing done
local environment

## Screenshots
<img width="632" alt="Screen Shot 2022-04-20 at 1 15 53 PM" src="https://user-images.githubusercontent.com/18352271/164296222-4d13d196-c009-41ea-88eb-34a61596be9f.png">

## Acceptance criteria
- [ ] aria-labelledby ids are hyphenated 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
