### PR TITLE
Catalog file for Vets Website for the Console UI.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: vets-website
+  description: This is the front end for VA.gov.
+  annotations:
+    github.com/project-slug: department-of-veterans-affairs/vets-website
+  tags:
+    - javascript
+    - sass
+spec:
+  type: website
+  owner: platform-release-tools
+  lifecycle: production


### PR DESCRIPTION
## Description

The addition of this configuration file will allow the Console UI to give the vets-website a catalog entry and profile page in the Console UI. Additionally it will allow the Console UI to monitor and update all of the tools connected to the vets-website project.

## Original issue(s)

Related to:

department-of-veterans-affairs/platform-console-ui#338

and

department-of-veterans-affairs/platform-console-ui#275

Right now the Console UI has the platform-console-ui component and its dependencies recorded. Given that vets-website is a key dependency for the majority of VFS apps, we want to set it up in the Console UI as soon as practicable. It will also help test our auto-discovery of projects in the organization which should be referenced from the Console UI (338) and test our ability to identify projects which should be a part of the Console UI, but have not been onboarded yet.

## Testing done

We have onboarded vets-api with a similar configuration file:

https://github.com/department-of-veterans-affairs/vets-api/pull/9679

## Screenshots

![Screen Shot 2022-04-20 at 5 32 53 PM](https://user-images.githubusercontent.com/116142/164326562-1e43ccc1-33fe-468d-bfcf-be5ed68c9a36.png)

## Acceptance Criteria

This is simply a configuration file consumed by another system.

We have a similar, but more complex file in our own repository:

https://github.com/department-of-veterans-affairs/platform-console-ui/blob/main/catalog-info.yaml

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
