### PR TITLE
[MCP] 34174 - Alert message heading fixes

### DIFF
--- a/src/applications/medical-copays/components/Alerts.jsx
+++ b/src/applications/medical-copays/components/Alerts.jsx
@@ -22,7 +22,7 @@ Alert.Error = () => (
       We’re sorry. Something went wrong on our end. You won’t be able to access
       information about your copay balances at this time.
     </p>
-    <h4>What you can do</h4>
+    <h2 className="vads-u-font-size--h4">What you can do</h2>
     <p>
       <strong className="vads-u-margin-right--0p5">
         For questions about your payment or relief options,

--- a/src/applications/medical-copays/components/Alerts.jsx
+++ b/src/applications/medical-copays/components/Alerts.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import PropTypes from 'prop-types';
 import { currency, calcDueDate, formatDate } from '../utils/helpers';
 
@@ -27,14 +24,11 @@ Alert.Error = () => (
       <strong className="vads-u-margin-right--0p5">
         For questions about your payment or relief options,
       </strong>
-      contact us at
-      <Telephone contact="866-400-1238" className="vads-u-margin-x--0p5" />
-      (TTY:
-      <Telephone
-        contact={CONTACTS[711]}
-        pattern={PATTERNS['3_DIGIT']}
-        className="vads-u-margin-left--0p5"
-      />
+      contact us at{' '}
+      <span className="no-wrap">
+        <va-telephone contact="866-400-1238" />
+      </span>{' '}
+      (TTY: <va-telephone contact={CONTACTS[711]} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
     <p>
@@ -74,14 +68,11 @@ Alert.PastDue = ({ copay }) => {
           If you haven’t either paid your full balance or requested financial
           help,
         </strong>
-        contact us at
-        <Telephone contact="866-400-1238" className="vads-u-margin-x--0p5" />
-        (TTY:
-        <Telephone
-          contact={CONTACTS[711]}
-          pattern={PATTERNS['3_DIGIT']}
-          className="vads-u-margin-left--0p5"
-        />
+        contact us at{' '}
+        <span className="no-wrap">
+          <va-telephone contact="866-400-1238" />
+        </span>{' '}
+        (TTY: <va-telephone contact={CONTACTS[711]} />
         ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
       </p>
     </va-alert>
@@ -157,9 +148,11 @@ Alert.NoHealthcare = () => (
       .
     </p>
     <p>
-      If you think this is incorrect, call our toll-free hotline at
-      <Telephone contact="877-222-8387" className="vads-u-margin-left--0p5" />,
-      Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+      If you think this is incorrect, call our toll-free hotline at{' '}
+      <span className="no-wrap">
+        <va-telephone contact="877-222-8387" />
+      </span>
+      , Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </va-alert>
 );
@@ -178,14 +171,11 @@ Alert.NoHistory = () => (
       you haven’t received a copay bill in the past 6 months.
     </p>
     <p>
-      If you think this is incorrect, contact the VA Health Resource Center at
-      <Telephone contact="866-400-1238" className="vads-u-margin-left--0p5" />.
-      (TTY:
-      <Telephone
-        contact={CONTACTS[711]}
-        pattern={PATTERNS['3_DIGIT']}
-        className="vads-u-margin-left--0p5"
-      />
+      If you think this is incorrect, contact the VA Health Resource Center at{' '}
+      <span className="no-wrap">
+        <va-telephone contact="866-400-1238" />
+      </span>
+      . (TTY: <va-telephone contact={CONTACTS[711]} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </va-alert>
@@ -224,9 +214,11 @@ Alert.Status = ({ copay }) => (
     </h3>
     <p>
       You may need to continue making payments while we review your request.
-      Call us at
-      <Telephone contact="866-400-1238" className="vads-u-margin-left--0p5" />,
-      Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+      Call us at{' '}
+      <span className="no-wrap">
+        <va-telephone contact="866-400-1238" />
+      </span>
+      , Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </va-alert>
 );

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -17,11 +17,11 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
   return (
     <va-alert status={loggedIn ? 'info' : 'continue'}>
       {/* Title */}
-      <h2 slot="headline" className="vads-u-font-size--h3">
+      <h3 slot="headline">
         {loggedIn
           ? 'Review your VA copay balances'
           : 'Please sign in to review your VA copay balances'}
-      </h2>
+      </h3>
 
       {/* Explanation */}
       {loggedIn ? (
@@ -50,6 +50,7 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
         <button
           className="va-button-primary"
           onClick={() => toggleLoginModal(true)}
+          type="button"
         >
           Sign in or create an account
         </button>
@@ -59,11 +60,11 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
 };
 
 App.propTypes = {
+  // From mapDispatchToProps.
+  toggleLoginModal: PropTypes.func.isRequired,
   // From mapStateToProps.
   loggedIn: PropTypes.bool,
   show: PropTypes.bool,
-  // From mapDispatchToProps.
-  toggleLoginModal: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
## Description
A few alerts were not following the proper heading hierarchy. "What you can do" in alert has changed to an h2 from an h4 to meet heading standards. 

While investigating the issue with the "what you can do" heading size defined in the original ticket, "Review your VA copay balances"/"Please sign in to review your VA copay balances" header was changed to an h3 to better fit the heading structure following talks with accessibility SME.


### Additional fixes
- Deprecated `<Telephone />` components also update to new `<va-telephone />`
- Fixed a few linting errors on same page as "Review your VA copay balances"

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34174

## Screenshots
![image](https://user-images.githubusercontent.com/25368370/164311651-3ba5f839-0e07-4f1f-bb7c-664825789644.png)

![image](https://user-images.githubusercontent.com/25368370/164481443-cff09dec-e619-4240-9d84-62838cf824d3.png)

<details><summary>Unauthenticated card: (click to expand)</summary>

![image](https://user-images.githubusercontent.com/25368370/164481016-b5f72dd8-d1bb-42af-9218-a21d2dcd73dc.png)

</details>


## Acceptance criteria
- [x] Heading tags now meet standards
- [x] Outstanding warnings/errors resolved

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
