### PR TITLE
logging additional data

### DIFF
--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -53,13 +53,24 @@ export function validateServiceDates(
   }
 }
 
-function logMarriageError(errorMessage, spouseDOB, vetDOB, marriage) {
+function logMarriageError(
+  errorMessage,
+  spouseDateOfBirth,
+  veteranDateOfBirth,
+  marriageDate,
+  momentSpouseDOB,
+  momentVetDOB,
+  momentMarriage,
+) {
   Sentry.withScope(scope => {
     const message = `hca_1010ez_dob_marrige_error`;
     scope.setContext(message, {
-      spouseDOB,
-      vetDOB,
-      marriage,
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      marriageDate,
+      momentSpouseDOB,
+      momentVetDOB,
+      momentMarriage,
       errorMessage,
     });
     Sentry.captureMessage(message);
@@ -71,9 +82,9 @@ export function validateMarriageDate(
   marriageDate,
   { spouseDateOfBirth, veteranDateOfBirth, discloseFinancialInformation },
 ) {
-  const vetDOB = moment(veteranDateOfBirth);
-  const spouseDOB = moment(spouseDateOfBirth);
-  const marriage = moment(marriageDate);
+  const vetDOB = moment(veteranDateOfBirth, 'YYYY-MM-DD');
+  const spouseDOB = moment(spouseDateOfBirth, 'YYYY-MM-DD');
+  const marriage = moment(marriageDate, 'YYYY-MM-DD');
   if (
     discloseFinancialInformation &&
     spouseDOB.isAfter(marriage) &&
@@ -84,6 +95,9 @@ export function validateMarriageDate(
     );
     logMarriageError(
       'Date of marriage cannot be before the Veteran’s or the spouse’s date of birth',
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      marriageDate,
       spouseDOB,
       vetDOB,
       marriage,
@@ -94,6 +108,9 @@ export function validateMarriageDate(
     );
     logMarriageError(
       'Date of marriage cannot be before the spouse’s date of birth',
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      marriageDate,
       spouseDOB,
       vetDOB,
       marriage,
@@ -104,6 +121,9 @@ export function validateMarriageDate(
     );
     logMarriageError(
       'Date of marriage cannot be before the Veteran’s date of birth',
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      marriageDate,
       spouseDOB,
       vetDOB,
       marriage,


### PR DESCRIPTION
## Description
_Veterans are complaining that they receive an error when they are filling out the online 10-10EZ application form. When filling in spouses DOB and marriage date it kicks back the date saying it is invalid. The error code that comes up reads that the marriage date is before the date of birth. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40039

