### PR TITLE
fix redirect loop

### DIFF
--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -25,7 +25,10 @@ function AppointmentListSection() {
   });
 
   if (shouldRedirectToStart) {
-    const path = window.location.pathname.replace('/appointments/', '/');
+    const path = window.location.pathname.replace(
+      /(\/appointments\/|\/appointments)/,
+      '/',
+    );
     window.location.replace(path);
   }
 


### PR DESCRIPTION
## Description
This PR fixes error when redirecting to the VAOS homepage. The problem occurs when the browser address is changed to 'http://localhost:3001/health-care/schedule-view-va-appointments/appointment' (no trailing slash '/'). This causes a loop.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38606


## Testing done
Unit and e2e testing

## Screenshots
N/A

## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
