### PR TITLE
Fix single app deploy inconsistencies

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -374,7 +374,10 @@ module.exports = async (env = {}) => {
       symlinks: false,
     },
     optimization: {
+      // 'chunkIds' and 'moduleIds' are set to 'named' for preserving
+      // consistency between full and single app builds
       chunkIds: 'named',
+      moduleIds: 'named',
       minimizer: [
         new TerserPlugin({
           terserOptions: {


### PR DESCRIPTION
## Description
Single app builds are having issues after being deployed to staging because of inconsistent references being made between full and single app builds, e.g.
```
Uncaught (in promise) TypeError: can't access property "call", n[e] is undefined
```

This PR resolves the inconsistencies between builds by setting `moduleIds` to `named` in the Webpack config. This should allow moduleIds to be consistent between full and single app builds.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29142

## Testing done
Tested locally by running single app builds after full builds and syncing the changed app bundles.

## Acceptance criteria
- [x] Application assets built in single app builds should be able to work with a full build after being synced in partial deploys.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
