### PR TITLE
Sends user uuid to chatbot to confirm if a user is authenticated on va.gov

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,5 +103,4 @@ src/applications/education-letters @department-of-veterans-affairs/my-education-
 src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-admin
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe
 src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-health-platform
-
-
+src/applications/virtual-agent @department-of-veterans-affairs/orchid

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -14,6 +14,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
   const userFirstName = useSelector(state =>
     _.upperFirst(_.toLower(state.user.profile.userFullName.first)),
   );
+  const userUuid = useSelector(state => state.user.profile.accountUuid);
 
   const store = useMemo(
     () =>
@@ -25,6 +26,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
           environment.API_URL,
           environment.BASE_URL,
           userFirstName === '' ? 'noFirstNameFound' : userFirstName,
+          userUuid === null ? 'null' : userUuid, // Because PVA cannot support empty strings or null pass in 'null' if user is not logged in
         ),
       ),
     [createStore],

--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -8,6 +8,7 @@ const GreetUser = {
     apiURL,
     baseURL,
     userFirstName,
+    userUuid,
   ) => ({ dispatch }) => next => action => {
     if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
       dispatch({
@@ -28,6 +29,7 @@ const GreetUser = {
               apiURL,
               baseURL,
               userFirstName,
+              userUuid,
             },
           },
         },

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -89,6 +89,7 @@ describe('App', () => {
             userFullName: {
               first: 'MARK',
             },
+            accountUuid: 'fake_uuid',
           },
         },
       },
@@ -140,6 +141,7 @@ describe('App', () => {
           'https://dev-api.va.gov',
           'https://dev.va.gov',
           'Mark',
+          'fake_uuid',
         );
       });
 
@@ -165,6 +167,7 @@ describe('App', () => {
                   userFullName: {
                     first: null,
                   },
+                  accountUuid: 'fake_uuid',
                 },
               },
             },
@@ -181,6 +184,7 @@ describe('App', () => {
           'https://dev-api.va.gov',
           'https://dev.va.gov',
           'noFirstNameFound',
+          'fake_uuid',
         );
       });
 


### PR DESCRIPTION
## Description
In order for the chatbot to know if a user is authenticated the chatbot needs the user uuid which exists for users who are logged into va.gov

Also re-adds team orchid as code owners for the virtual agent repo

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#452


## Testing done
Added to tests which passes the variables to the chatbot via a direct line connection

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
