### PR TITLE
removed validation

### DIFF
--- a/src/applications/hca/config/chapters/householdInformation/spouseInformation.js
+++ b/src/applications/hca/config/chapters/householdInformation/spouseInformation.js
@@ -8,7 +8,7 @@ import {
   uiSchema as addressUI,
 } from 'platform/forms/definitions/address';
 
-import { validateMarriageDate } from '../../../validation';
+// import { validateMarriageDate } from '../../../validation';
 
 const {
   cohabitedLastYear,
@@ -54,7 +54,7 @@ export default {
     spouseDateOfBirth: currentOrPastDateUI('Spouse\u2019s date of birth'),
     dateOfMarriage: {
       ...currentOrPastDateUI('Date of marriage'),
-      'ui:validations': [validateMarriageDate],
+      // 'ui:validations': [validateMarriageDate],
     },
     cohabitedLastYear: {
       'ui:title': 'Did your spouse live with you last year?',


### PR DESCRIPTION
## Description
_Veterans are complaining that they receive an error when they are filling out the online 10-10EZ application form. When filling in spouses DOB and marriage date it kicks back the date saying it is invalid. The error code that comes up reads that the marriage date is before the date of birth. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44039

