### PR TITLE
Update Cypress ESBuild configuration

### DIFF
--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -75,7 +75,6 @@ module.exports = async (on, config) => {
   };
 
   const bundler = createBundler({
-    entryPoints: ['src/**/*.cypress.spec.js*'],
     loader: { '.js': 'jsx' },
     format: 'cjs',
     external: [


### PR DESCRIPTION
## Description
The entry point for ESBuild is already pre-configured in `@bahmutov/cypress-esbuild-preprocessor`, so this line can be removed.

## Testing done
Cypress tests run locally

## Acceptance criteria
- [x] CI passes.