### PR TITLE
Changes default value of userUuid

### DIFF
--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -26,7 +26,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
           environment.API_URL,
           environment.BASE_URL,
           userFirstName === '' ? 'noFirstNameFound' : userFirstName,
-          userUuid === null ? 'null' : userUuid, // Because PVA cannot support empty strings or null pass in 'null' if user is not logged in
+          userUuid === null ? 'noUserUuid' : userUuid, // Because PVA cannot support empty strings or null pass in 'null' if user is not logged in
         ),
       ),
     [createStore],


### PR DESCRIPTION
## Description
PVA does not support 'null' and interprets it as an empty string in power flows therefore we need to change what we send up as the default value

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#452


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
