### PR TITLE
Sync source maps for changed app deploys

### DIFF
--- a/script/github-actions/partial-deploy.sh
+++ b/script/github-actions/partial-deploy.sh
@@ -135,16 +135,16 @@ aws s3 sync --only-show-errors \
     --acl public-read \
     --cache-control "public, no-cache" \
     --exclude '*' \
-    --include '*.js' \
-    --include '*.css' \
+    --include '*.js*' \
+    --include '*.css*' \
     . "$DEST"
 
 # Compress assets
 say "INFO: Compressing assets"
 find . \
     \( \
-    -name '*.js' -o \
-    -name '*.css' -o \
+    -name '*.js*' -o \
+    -name '*.css*' -o \
     -name '*.txt' \
     \) \
     -exec gzip -n {} \; -exec mv {}.gz {} \;
@@ -156,8 +156,8 @@ aws s3 sync --only-show-errors \
     --content-encoding gzip \
     --cache-control "public, no-cache" \
     --exclude '*' \
-    --include '*.js' \
-    --include '*.css' \
+    --include '*.js*' \
+    --include '*.css*' \
     --include '*.txt' \
     . "$ASSET_DEST"
 


### PR DESCRIPTION
## Description
Source maps aren't being synced to the deployment buckets for changed app deploys. This PR updates the glob pattern for the S3 sync so that source maps are included in deployments.

## Acceptance criteria
- [x] Source maps are synced to the deployment buckets for changed app deployments.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
