### PR TITLE
Reduce to 100 char for VA request Other option

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -113,7 +113,7 @@ export function transformFormToVAOSVARequest(state) {
       code === 'Other'
         ? {
             coding: [],
-            text: data.reasonAdditionalInfo,
+            text: data.reasonAdditionalInfo.slice(0, 100),
           }
         : {
             coding: [

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -133,12 +133,16 @@ export function transformVAOSAppointment(appt) {
         'YYYY-MM-DDTHH:mm:ss',
       )}.999`,
     }));
+    const hasReasonCode = appt.reasonCode?.coding?.length > 0;
+    const reason = hasReasonCode
+      ? PURPOSE_TEXT.find(
+          purpose => purpose.serviceName === appt.reasonCode?.coding?.[0].code,
+        )?.short
+      : null;
     requestFields = {
       requestedPeriod: reqPeriods,
       created,
-      reason: PURPOSE_TEXT.find(
-        purpose => purpose.serviceName === appt.reasonCode?.coding?.[0].code,
-      )?.short,
+      reason,
       preferredTimesForPhoneCall: appt.preferredTimesForPhoneCall,
       requestVisitType: getTypeOfVisit(appt.kind),
       type: {

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.v2.unit.spec.js
@@ -198,5 +198,90 @@ describe('VAOS V2 data transformation', () => {
         preferredTimesForPhoneCall: ['Morning'],
       });
     });
+
+    it('reasonCode text is 100 characters and less when My reason isn/`t listed is chosen', () => {
+      // Given a user has entered 250 max characters for additional information
+      const reasonAdditionalInfo =
+        'The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog.';
+      // When the VA request is submitted
+      const state = {
+        newAppointment: {
+          data: {
+            phoneNumber: '5035551234',
+            bestTimeToCall: {
+              morning: true,
+            },
+            email: 'test@va.gov',
+            visitType: 'clinic',
+            reasonForAppointment: 'other',
+            reasonAdditionalInfo,
+            selectedDates: ['2019-11-20T12:00:00.000'],
+            vaParent: '983',
+            vaFacility: '983GB',
+            facilityType: 'vamc',
+            typeOfCareId: 'SLEEP',
+            typeOfSleepCareId: '349',
+          },
+          parentFacilities: [
+            {
+              id: '983',
+              identifier: [
+                {
+                  system: VHA_FHIR_ID,
+                  value: '983',
+                },
+              ],
+            },
+          ],
+          facilities: {
+            '349': [
+              {
+                id: '983GB',
+                identifier: [
+                  {
+                    system: VHA_FHIR_ID,
+                    value: '983GB',
+                  },
+                ],
+                name: 'Cheyenne VA Medical Center',
+                address: {
+                  city: 'Cheyenne',
+                  state: 'WY',
+                },
+                legacyVAR: {
+                  institutionTimezone: 'America/Denver',
+                },
+              },
+            ],
+          },
+          flowType: FLOW_TYPES.REQUEST,
+        },
+        featureToggles: {},
+      };
+
+      const data = transformFormToVAOSVARequest(state);
+      // Then the reasonCode text will submit the first 100 characters
+      expect(data).to.deep.equal({
+        kind: 'clinic',
+        status: 'proposed',
+        locationId: '983GB',
+        serviceType: 'cpap',
+        reasonCode: {
+          coding: [],
+          text: reasonAdditionalInfo.slice(0, 100),
+        },
+        comment: reasonAdditionalInfo,
+        contact: {
+          telecom: [
+            { type: 'phone', value: '5035551234' },
+            { type: 'email', value: 'test@va.gov' },
+          ],
+        },
+        requestedPeriods: [
+          { start: '2019-11-20T12:00:00Z', end: '2019-11-20T23:59:00Z' },
+        ],
+        preferredTimesForPhoneCall: ['Morning'],
+      });
+    });
   });
 });

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -838,6 +838,7 @@ describe('VAOS Appointment service', () => {
           { op: 'remove', path: ['description'] },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
+          { op: 'replace', path: ['reason'], value: undefined },
         ],
         'Transformers for v0 and v2 appointment request data are out of sync',
       );
@@ -934,6 +935,8 @@ describe('VAOS Appointment service', () => {
         [
           { op: 'remove', path: ['description'] },
           { op: 'remove', path: ['practitioners'] },
+          { op: 'replace', path: ['reason'], value: undefined },
+
           {
             op: 'replace',
             path: ['type', 'coding', 0, 'code'],
@@ -1039,6 +1042,7 @@ describe('VAOS Appointment service', () => {
           { op: 'remove', path: ['description'] },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },
+          { op: 'replace', path: ['reason'], value: undefined },
         ],
         'Transformers for v0 and v2 appointment request data are out of sync',
       );


### PR DESCRIPTION
## Description
When user selects "My reason isn't listed" and enters 250 characters for the required additional reason, the transformer takes the value and assigns it to the reasonCode.text which allows a max character of 100. Trim the value of text property to 100 characters.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39864


## Testing done
Unit and local test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/165359414-a404d22a-98a8-4b6c-96d1-2f1a5201920c.png)

{
  "id": "97054",
  "identifier": [
    {
      "system": "http://med.va.gov/fhir/urn/vaos/ars/id",
      "value": "e5fe1f1b80241f60018066daa81a0016"
    }
  ],
  "kind": "clinic",
  "status": "proposed",
  "serviceType": "outpatientMentalHealth",
  "reasonCode": {
    **"text": "This is just a test to see the number of characters allowed for this entry. It is currently at limit"**
  },
  "patientIcn": "1012845943V900681",
  "locationId": "983",
  "created": "2022-04-26T11:10:47Z",
  "requestedPeriods": [
    {
      "start": "2022-05-06T12:00:00Z",
      "end": "2022-05-06T23:59:59.999Z"
    }
  ],
  "contact": {
    "telecom": [
      {
        "type": "email",
        "value": "veteran@gmail.com"
      },
      {
        "type": "phone",
        "value": "5035551234"
      }
    ]
  },
  "preferredTimesForPhoneCall": [
    "Evening"
  ],
  **"comment": "This is just a test to see the number of characters allowed for this entry. It is currently at limited to 100 for submission.",**
  "cancellable": true,
  "extension": {
    "ccLocation": {
      "address": {}
    }
  }
}


## Acceptance criteria
- [ ] comment will retain the max of 250 characters
- [ ] reasonCode.text will reduce to 100 characters
- [ ] VA request is valid when Other option is selected and more than 100 characters entered under additional reason

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
