### PR TITLE
Adds ServiceProvidersText unit test

### DIFF
--- a/src/platform/user/authentication/components/ServiceProvidersText.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersText.jsx
@@ -17,22 +17,11 @@ const ServiceProviders = React.memo(({ isBold }) => {
     [!loginGovOff],
   );
 
-  return serviceProviders.map((csp, i) => {
-    const totalProviders = serviceProviders.length;
-    const last = i === totalProviders - 1;
-    const comma = !last && totalProviders > 2;
-    const or = totalProviders >= 2 && last;
-    const renderCSP = isBold ? <strong>{csp}</strong> : csp;
-
-    return (
-      <React.Fragment key={i}>
-        {or && 'or '}
-        {renderCSP}
-        {comma && ','}
-        {!last && ' '}
-      </React.Fragment>
-    );
-  });
+  return new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
+    .formatToParts(serviceProviders)
+    .map(({ type, value }) => {
+      return type === 'element' && isBold ? <strong>{value}</strong> : value;
+    });
 });
 
 export const ServiceProvidersTextCreateAcct = React.memo(

--- a/src/platform/user/tests/authentication/components/ServiceProvidersText.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/ServiceProvidersText.unit.spec.js
@@ -1,0 +1,147 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import ServiceProvidersText, {
+  ServiceProvidersTextCreateAcct,
+} from 'platform/user/authentication/components/ServiceProvidersText';
+
+const serviceProviders = ['Login.gov', 'ID.me', 'DS Logon', 'My HealtheVet'];
+const mockStore = configureMockStore();
+
+const getServiceProvidersTextData = ({
+  propsIsBold = false,
+  featureToggle = true,
+}) => {
+  const props = {
+    isBold: propsIsBold,
+  };
+  const store = mockStore({
+    featureToggles: {
+      login_gov_disabled: featureToggle,
+    },
+  });
+  const wrapper = mount(
+    <Provider store={store}>
+      <ServiceProvidersText {...props} />
+    </Provider>,
+  );
+  return {
+    props,
+    store,
+    wrapper,
+  };
+};
+
+describe('ServiceProvidersText', () => {
+  it('should display 3 CSPS if loginGovDisabled flag is enabled', () => {
+    const { wrapper } = getServiceProvidersTextData({});
+    expect(
+      serviceProviders
+        .filter(csp => csp !== 'Login.gov')
+        .includes(wrapper.text()),
+    );
+    wrapper.unmount();
+  });
+  it('should display 4 CSPS if loginGovDisabled flag is disabled', () => {
+    const { wrapper } = getServiceProvidersTextData({
+      featureToggle: false,
+    });
+    expect(serviceProviders.includes(wrapper.text()));
+    wrapper.unmount();
+  });
+  it('should display bold if `isBold` is truthy', () => {
+    const { wrapper } = getServiceProvidersTextData({
+      propsIsBold: true,
+      featureToggle: false,
+    });
+    expect(wrapper.find('strong').length).to.eql(4);
+    wrapper.unmount();
+  });
+  it('should display normal if `isBold` is falsy', () => {
+    const { wrapper } = getServiceProvidersTextData({
+      propsIsBold: false,
+    });
+    expect(wrapper.find('strong').exists()).to.be.false;
+    wrapper.unmount();
+  });
+});
+
+const getServiceProvidersTextCreateAcctData = ({
+  propsIsFormBased = false,
+  propsHasExtraTodo = false,
+  featureToggle = true,
+}) => {
+  const props = {
+    isFormBased: propsIsFormBased,
+    hasExtraTodo: propsHasExtraTodo,
+  };
+  const store = mockStore({
+    featureToggles: {
+      login_gov_disabled: featureToggle,
+    },
+  });
+  const wrapper = mount(
+    <Provider store={store}>
+      <ServiceProvidersTextCreateAcct {...props} />
+    </Provider>,
+  );
+  return {
+    wrapper,
+  };
+};
+
+describe('ServiceProvidersTextCreateAcct', () => {
+  it('should render string if `isFormBased` prop is truthy', () => {
+    const { wrapper } = getServiceProvidersTextCreateAcctData({
+      propsIsFormBased: true,
+    });
+    expect(wrapper.text()).to.include(
+      'completed this form without signing in, and you',
+    );
+    wrapper.unmount();
+  });
+  it('should NOT render string if `isFormBased` prop is falsy', () => {
+    const { wrapper } = getServiceProvidersTextCreateAcctData({
+      propsIsFormBased: false,
+    });
+    expect(wrapper.text()).to.not.include(
+      'completed this form without signing in, and you',
+    );
+    wrapper.unmount();
+  });
+  it('should NOT render Login.gov if feature flag is enabled', () => {
+    const { wrapper } = getServiceProvidersTextCreateAcctData({
+      featureToggle: true,
+    });
+    expect(wrapper.text()).to.not.include('Login.gov');
+    wrapper.unmount();
+  });
+  it('should render Login.gov if feature flag is disabled', () => {
+    const { wrapper } = getServiceProvidersTextCreateAcctData({
+      featureToggle: false,
+    });
+    expect(wrapper.text()).to.include('Login.gov');
+    wrapper.unmount();
+  });
+  it('should render string if `hasExtraTodo` prop is truthy', () => {
+    const { wrapper } = getServiceProvidersTextCreateAcctData({
+      propsHasExtraTodo: true,
+    });
+    expect(wrapper.text()).to.include(
+      'When you sign in or create an account, you’ll be able to:',
+    );
+    wrapper.unmount();
+  });
+  it('should NOT render string if `hasExtraTodo` prop is falsy', () => {
+    const { wrapper } = getServiceProvidersTextCreateAcctData({
+      propsHasExtraTodo: false,
+    });
+    expect(wrapper.text()).to.not.include(
+      'When you sign in or create an account, you’ll be able to:',
+    );
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This PR adds unit test to the ServiceProvidersText and ServiceProvidersTextCreateAcct components.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#37636


## Testing done
Unit

## Screenshots
n/a

## Acceptance criteria
- [x] Unit tests successfully pass for the ServiceProvidersText component

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
