### PR TITLE
32740 - [FSR] Add content to FSR's confirmation page indicating that Veterans will receive an email confirmation

### DIFF
--- a/src/applications/combined-debt-portal/combined/actions/debts.js
+++ b/src/applications/combined-debt-portal/combined/actions/debts.js
@@ -140,5 +140,3 @@ export const fetchDebtLetters = async dispatch => {
     return dispatch(fetchDebtLettersFailure(error.errors));
   }
 };
-
-export const getStatements = () => {};

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -86,7 +86,6 @@ RequestDetailsCard.propTypes = {
 const ConfirmationPage = ({ form, download }) => {
   const { response } = form.submission;
   const { data } = form;
-  data.personalData.emailAddress = 'test@test.com';
 
   useEffect(() => {
     focusElement('.schemaform-title > h1');

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -86,6 +86,7 @@ RequestDetailsCard.propTypes = {
 const ConfirmationPage = ({ form, download }) => {
   const { response } = form.submission;
   const { data } = form;
+  data.personalData.emailAddress = 'test@test.com';
 
   useEffect(() => {
     focusElement('.schemaform-title > h1');
@@ -98,7 +99,14 @@ const ConfirmationPage = ({ form, download }) => {
         <strong>Please print this page for your records.</strong>
       </p>
 
-      <h3 className="confirmation-page-title">We’ve received your request</h3>
+      <va-alert status="success">
+        <h3 className="confirmation-page-title">We’ve received your request</h3>
+        <p>
+          We’ll send you an email confirming your request to{' '}
+          <strong>{data.personalData.emailAddress}.</strong>
+        </p>
+      </va-alert>
+
       <p>
         We’ll send you a letter with our decision and any next steps. If you
         experience changes that may affect our decision (like a job loss or a


### PR DESCRIPTION
## Description

Requirements in ticket requested the paragraph be converted to using the `va-alert` component to make it more apparent they'd be receiving an email upon successful submission.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32740

## Screenshots
![image](https://user-images.githubusercontent.com/29178824/165372370-e06274c0-1567-4395-8f6b-ac7782c65806.png)


## Acceptance criteria
- [ X ] Paragraph converted to `va-alert` component
