### PR TITLE
NOD: Fix header level

### DIFF
--- a/src/applications/appeals/10182/content/WorkInProgressMessage.jsx
+++ b/src/applications/appeals/10182/content/WorkInProgressMessage.jsx
@@ -9,7 +9,7 @@ export const showWorkInProgress = ({ title, subTitle }) => (
     <div className="usa-width-two-thirds medium-8 columns">
       <FormTitle title={title} subTitle={subTitle} />
       <va-alert status="info">
-        <h3 slot="headline">We’re still working on this feature</h3>
+        <h2 slot="headline">We’re still working on this feature</h2>
         <p className="vads-u-font-size--base">
           We’re rolling out the Board Appeals (Notice of Disagreement) form in
           stages. It’s not quite ready yet. Please check back again soon.


### PR DESCRIPTION
## Description

Work in progress alert shown for Notice of Disagreement users should be an `h2`.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/40373

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Header levels meet a11y standard
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
