### PR TITLE
removed logging moment format

### DIFF
--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -62,12 +62,9 @@ function logMarriageError(
 ) {
   Sentry.withScope(scope => {
     const message = `hca_1010ez_error_${messageType}`;
-    const momentVetDOB = moment(veteranDateOfBirth, 'YYYY-MM-DD');
-    const momentSpouseDOB = moment(spouseDateOfBirth, 'YYYY-MM-DD');
-    const momentMarriage = moment(marriageDate, 'YYYY-MM-DD');
-    const momentNoFormatVetDOB = moment(veteranDateOfBirth);
-    const momentNoFormatSpouseDOB = moment(spouseDateOfBirth);
-    const momentNoFormatMarriage = moment(marriageDate);
+    const momentVetDOB = moment(veteranDateOfBirth);
+    const momentSpouseDOB = moment(spouseDateOfBirth);
+    const momentMarriage = moment(marriageDate);
     scope.setContext(message, {
       spouseDateOfBirth,
       veteranDateOfBirth,
@@ -75,9 +72,6 @@ function logMarriageError(
       momentSpouseDOB,
       momentVetDOB,
       momentMarriage,
-      momentNoFormatVetDOB,
-      momentNoFormatSpouseDOB,
-      momentNoFormatMarriage,
       errorMessage,
     });
     Sentry.captureMessage(message);


### PR DESCRIPTION
## Description
_Veterans are complaining that they receive an error when they are filling out the online 10-10EZ application form. When filling in spouses DOB and marriage date it kicks back the date saying it is invalid. The error code that comes up reads that the marriage date is before the date of birth.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40039
