### PR TITLE
Profile/38953/add and update preferred name

### DIFF
--- a/src/applications/personalization/profile/actions/index.js
+++ b/src/applications/personalization/profile/actions/index.js
@@ -1,6 +1,6 @@
 import { getData } from '../util';
 
-export * from './personalInfomation';
+export * from './personalInformation';
 
 export const FETCH_HERO = 'FETCH_HERO';
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';

--- a/src/applications/personalization/profile/actions/index.js
+++ b/src/applications/personalization/profile/actions/index.js
@@ -1,14 +1,10 @@
 import { getData } from '../util';
 
+export * from './personalInfomation';
+
 export const FETCH_HERO = 'FETCH_HERO';
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';
 export const FETCH_HERO_FAILED = 'FETCH_HERO_FAILED';
-
-export const FETCH_PERSONAL_INFORMATION = 'FETCH_PERSONAL_INFORMATION';
-export const FETCH_PERSONAL_INFORMATION_SUCCESS =
-  'FETCH_PERSONAL_INFORMATION_SUCCESS';
-export const FETCH_PERSONAL_INFORMATION_FAILED =
-  'FETCH_PERSONAL_INFORMATION_FAILED';
 
 export const FETCH_MILITARY_INFORMATION = 'FETCH_MILITARY_INFORMATION';
 export const FETCH_MILITARY_INFORMATION_SUCCESS =
@@ -30,26 +26,6 @@ export function fetchHero() {
     }
 
     dispatch({ type: FETCH_HERO_SUCCESS, hero: { userFullName: response } });
-  };
-}
-
-export function fetchPersonalInformation() {
-  return async dispatch => {
-    dispatch({ type: FETCH_PERSONAL_INFORMATION });
-
-    const response = await getData('/profile/personal_information');
-
-    if (response.errors || response.error) {
-      dispatch({
-        type: FETCH_PERSONAL_INFORMATION_FAILED,
-        personalInformation: { errors: response },
-      });
-      return;
-    }
-    dispatch({
-      type: FETCH_PERSONAL_INFORMATION_SUCCESS,
-      personalInformation: response,
-    });
   };
 }
 

--- a/src/applications/personalization/profile/actions/personalInfomation.js
+++ b/src/applications/personalization/profile/actions/personalInfomation.js
@@ -1,0 +1,146 @@
+import appendQuery from 'append-query';
+import set from 'lodash/set';
+import capitalize from 'lodash/capitalize';
+
+import { PERSONAL_INFO_FIELD_NAMES } from '@@vap-svc/constants';
+
+import {
+  VAP_SERVICE_TRANSACTION_REQUESTED,
+  VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED,
+  VAP_SERVICE_TRANSACTION_REQUEST_FAILED,
+  clearTransaction,
+} from '@@vap-svc/actions';
+
+import { getData } from '../util';
+
+import recordEvent from '~/platform/monitoring/record-event';
+import { apiRequest } from '~/platform/utilities/api';
+
+export const FETCH_PERSONAL_INFORMATION = 'FETCH_PERSONAL_INFORMATION';
+export const FETCH_PERSONAL_INFORMATION_SUCCESS =
+  'FETCH_PERSONAL_INFORMATION_SUCCESS';
+export const FETCH_PERSONAL_INFORMATION_FAILED =
+  'FETCH_PERSONAL_INFORMATION_FAILED';
+
+export function fetchPersonalInformation(forceCacheClear = false) {
+  return async dispatch => {
+    dispatch({ type: FETCH_PERSONAL_INFORMATION });
+
+    const baseUrl = '/profile/personal_information';
+
+    const url = forceCacheClear
+      ? appendQuery(baseUrl, { now: new Date().getTime() })
+      : baseUrl;
+
+    const response = await getData(url);
+
+    if (response.errors || response.error) {
+      dispatch({
+        type: FETCH_PERSONAL_INFORMATION_FAILED,
+        personalInformation: { errors: response },
+      });
+      return;
+    }
+
+    // preferred name returns as ALL CAPS, so it needs to be capitalized appropriately for display
+    // TODO: see if we could get case sensitive updates to downstream service / VAProfile
+    if (response?.[PERSONAL_INFO_FIELD_NAMES.PREFERRED_NAME]) {
+      set(
+        response,
+        PERSONAL_INFO_FIELD_NAMES.PREFERRED_NAME,
+        capitalize(response?.[PERSONAL_INFO_FIELD_NAMES.PREFERRED_NAME]),
+      );
+    }
+
+    dispatch({
+      type: FETCH_PERSONAL_INFORMATION_SUCCESS,
+      personalInformation: response,
+    });
+  };
+}
+
+// since the personal information api requests do no fall into a transactional life cylce
+// we need to treat them differently than contact information, but also still fall within
+// the state update paradigm so that the UI reacts correctly
+export function createPersonalInfoUpdate(
+  route,
+  method = 'PUT',
+  fieldName,
+  payload,
+  analyticsSectionName,
+) {
+  return async dispatch => {
+    const options = {
+      body: JSON.stringify(payload),
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+    try {
+      dispatch({
+        type: VAP_SERVICE_TRANSACTION_REQUESTED,
+        fieldName,
+        method,
+      });
+
+      const transaction = await apiRequest(route, options);
+
+      if (transaction?.errors) {
+        const error = new Error('There was a transaction error');
+        error.errors = transaction?.errors;
+        throw error;
+      }
+
+      // creating a unique id using field name and timestamp
+      // because a transactionId is needed by transaction flow logic
+      // clearTransaction uses the id in a lookup to remove it
+      set(
+        transaction,
+        'data.attributes.transactionId',
+        `${fieldName}_${transaction.source_date}`,
+      );
+
+      dispatch({
+        type: VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED,
+        fieldName,
+        transaction,
+      });
+
+      // We don't think these are needed within this sync style of api call, but they may be needed
+      // to make sure that the state is updated correctly, mostly for the sake of the UI
+      // dispatch({
+      //   type: VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED,
+      //   transaction,
+      // });
+
+      // dispatch({
+      //   type: VAP_SERVICE_TRANSACTION_UPDATED,
+      //   transaction,
+      // });
+
+      dispatch(clearTransaction(transaction));
+
+      // once the update has gone through, we should fetch fresh field data
+      dispatch(fetchPersonalInformation('now'));
+    } catch (error) {
+      const [firstError = {}] = error.errors ?? [];
+      const { code = 'code', title = 'title', detail = 'detail' } = firstError;
+      const profileSection = analyticsSectionName || 'unknown-profile-section';
+      recordEvent({
+        event: 'profile-edit-failure',
+        'profile-action': 'save-failure',
+        'profile-section': profileSection,
+        'error-key': `tx-creation-error-${profileSection}-${code}-${title}-${detail}`,
+      });
+      recordEvent({
+        'error-key': undefined,
+      });
+      dispatch({
+        type: VAP_SERVICE_TRANSACTION_REQUEST_FAILED,
+        error,
+        fieldName,
+      });
+    }
+  };
+}

--- a/src/applications/personalization/profile/actions/personalInformation.js
+++ b/src/applications/personalization/profile/actions/personalInformation.js
@@ -68,6 +68,7 @@ export function createPersonalInfoUpdate(
   fieldName,
   payload,
   analyticsSectionName,
+  recordAnalyticsEvent = recordEvent,
 ) {
   return async dispatch => {
     const options = {
@@ -127,13 +128,14 @@ export function createPersonalInfoUpdate(
       const [firstError = {}] = error.errors ?? [];
       const { code = 'code', title = 'title', detail = 'detail' } = firstError;
       const profileSection = analyticsSectionName || 'unknown-profile-section';
-      recordEvent({
+
+      recordAnalyticsEvent({
         event: 'profile-edit-failure',
         'profile-action': 'save-failure',
         'profile-section': profileSection,
         'error-key': `tx-creation-error-${profileSection}-${code}-${title}-${detail}`,
       });
-      recordEvent({
+      recordAnalyticsEvent({
         'error-key': undefined,
       });
       dispatch({

--- a/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 
-import { createPersonalInfoUpdate } from '@@profile/actions/personalInfomation';
+import { createPersonalInfoUpdate } from '@@profile/actions/personalInformation';
 
 import {
   createTransaction,

--- a/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 
+import { createPersonalInfoUpdate } from '@@profile/actions/personalInfomation';
+
 import {
   createTransaction,
   refreshTransaction,
@@ -15,7 +17,12 @@ import {
 } from '@@vap-svc/actions';
 
 import * as VAP_SERVICE from '@@vap-svc/constants';
-import { ACTIVE_EDIT_VIEWS, FIELD_NAMES, USA } from '@@vap-svc/constants';
+import {
+  ACTIVE_EDIT_VIEWS,
+  FIELD_NAMES,
+  USA,
+  PERSONAL_INFO_FIELD_NAMES,
+} from '@@vap-svc/constants';
 
 import {
   isFailedTransaction,
@@ -50,6 +57,7 @@ const propTypes = {
   apiRoute: PropTypes.oneOf(Object.values(VAP_SERVICE.API_ROUTES)).isRequired,
   clearTransactionRequest: PropTypes.func.isRequired,
   convertCleanDataToPayload: PropTypes.func.isRequired,
+  createPersonalInfoUpdate: PropTypes.func.isRequired,
   createTransaction: PropTypes.func.isRequired,
   doNotRequireInternationalPostalCode: PropTypes.bool.isRequired,
   fieldName: PropTypes.oneOf(Object.values(VAP_SERVICE.FIELD_NAMES)).isRequired,
@@ -178,7 +186,19 @@ export class ProfileInformationEditView extends Component {
       payload = convertCleanDataToPayload(payload, fieldName);
     }
 
-    const method = payload.id ? 'PUT' : 'POST';
+    // for personal info fields we are using a different request flow
+    if (Object.values(PERSONAL_INFO_FIELD_NAMES).includes(fieldName)) {
+      this.props.createPersonalInfoUpdate(
+        apiRoute,
+        'PUT',
+        fieldName,
+        payload,
+        analyticsSectionName,
+      );
+      return;
+    }
+
+    const method = payload?.id ? 'PUT' : 'POST';
 
     if (isAddressField) {
       this.props.validateAddress(
@@ -395,6 +415,7 @@ const mapDispatchToProps = {
   updateFormFieldWithSchema,
   validateAddress,
   refreshTransaction,
+  createPersonalInfoUpdate,
 };
 
 export default connect(

--- a/src/applications/personalization/profile/mocks/personalInfo.js
+++ b/src/applications/personalization/profile/mocks/personalInfo.js
@@ -30,6 +30,23 @@ const getBasicUserPersonalInfo = (req, res) => {
   return res.json(response);
 };
 
+const getUnsetUserPersonalInfo = {
+  data: {
+    id: '',
+    type: 'mvi_models_mvi_profiles',
+    attributes: {
+      gender: 'M',
+      birthDate: '1986-05-06',
+      preferredName: null,
+      pronouns: null,
+      pronounsNotListedText: null,
+      genderIdentity: { code: null, name: null },
+      sexualOrientation: null,
+      sexualOrientationNotListedText: null,
+    },
+  },
+};
+
 const putPreferredName = {
   'PUT /v0/profile/preferred_names': (req, res) => {
     // for testing if you submit a preferred name update with the text value of 'error' we can trigger the error response
@@ -57,5 +74,6 @@ const putPreferredName = {
 
 module.exports = {
   getBasicUserPersonalInfo,
+  getUnsetUserPersonalInfo,
   putPreferredName,
 };

--- a/src/applications/personalization/profile/mocks/personalInfo.js
+++ b/src/applications/personalization/profile/mocks/personalInfo.js
@@ -1,16 +1,61 @@
-module.exports = {
-  data: {
-    id: '',
-    type: 'mvi_models_mvi_profiles',
-    attributes: {
-      gender: 'M',
-      birthDate: '1986-05-06',
-      preferredName: 'Wes',
-      pronouns: ['heHimHis', 'theyThemTheirs'],
-      pronounsNotListedText: 'Other/pronouns/here',
-      genderIdentity: { code: 'M', name: 'Male' },
-      sexualOrientation: ['straightOrHeterosexual'],
-      sexualOrientationNotListedText: 'Some other orientation',
+const set = require('lodash/set');
+
+/* eslint-disable camelcase */
+const getBasicUserPersonalInfo = (req, res) => {
+  const response = {
+    data: {
+      id: '',
+      type: 'mvi_models_mvi_profiles',
+      attributes: {
+        gender: 'M',
+        birthDate: '1986-05-06',
+        preferredName: 'WES',
+        pronouns: ['heHimHis', 'theyThemTheirs'],
+        pronounsNotListedText: 'Other/pronouns/here',
+        genderIdentity: { code: 'M', name: 'Male' },
+        sexualOrientation: ['straightOrHeterosexual'],
+        sexualOrientationNotListedText: 'Some other orientation',
+      },
     },
+  };
+
+  // if the now query is added we want to test that the UI hydrates with new info
+  // primarily testing for if the preferred name hydrates correctly
+  // TODO: how to send dummy updated gender identity info for testing?
+  if (req?.query?.now) {
+    return res.json(
+      set(response, 'data.attributes.preferredName', 'nameupdated'),
+    );
+  }
+  return res.json(response);
+};
+
+const putPreferredName = {
+  'PUT /v0/profile/preferred_names': (req, res) => {
+    // for testing if you submit a preferred name update with the text value of 'error' we can trigger the error response
+    if (req?.body?.text === 'error') {
+      return res.json({
+        errors: [
+          {
+            title: 'Bad Request',
+            detail: 'Received a bad request response from the upstream server',
+            code: 'EVSS400',
+            source: 'EVSS::DisabilityCompensationForm::Service',
+            status: '400',
+            meta: {},
+          },
+        ],
+      });
+    }
+    return res.json({
+      text: req?.body?.text,
+      source_system_user: '123498767V234859',
+      source_date: '2022-04-08T15:09:23.000Z',
+    });
   },
+};
+
+module.exports = {
+  getBasicUserPersonalInfo,
+  putPreferredName,
 };

--- a/src/applications/personalization/profile/mocks/personalInfo.js
+++ b/src/applications/personalization/profile/mocks/personalInfo.js
@@ -1,36 +1,28 @@
+/* eslint-disable camelcase */
+// camelcase coming from mock api response for PUT request success
+
 const set = require('lodash/set');
 
-/* eslint-disable camelcase */
-const getBasicUserPersonalInfo = (req, res) => {
-  const response = {
-    data: {
-      id: '',
-      type: 'mvi_models_mvi_profiles',
-      attributes: {
-        gender: 'M',
-        birthDate: '1986-05-06',
-        preferredName: 'WES',
-        pronouns: ['heHimHis', 'theyThemTheirs'],
-        pronounsNotListedText: 'Other/pronouns/here',
-        genderIdentity: { code: 'M', name: 'Male' },
-        sexualOrientation: ['straightOrHeterosexual'],
-        sexualOrientationNotListedText: 'Some other orientation',
-      },
+// v0/personal_information route basic user response
+export const basicUserPersonalInfoResponse = {
+  data: {
+    id: '',
+    type: 'mvi_models_mvi_profiles',
+    attributes: {
+      gender: 'M',
+      birthDate: '1986-05-06',
+      preferredName: 'WES',
+      pronouns: ['heHimHis', 'theyThemTheirs'],
+      pronounsNotListedText: 'Other/pronouns/here',
+      genderIdentity: { code: 'M', name: 'Male' },
+      sexualOrientation: ['straightOrHeterosexual'],
+      sexualOrientationNotListedText: 'Some other orientation',
     },
-  };
-
-  // if the now query is added we want to test that the UI hydrates with new info
-  // primarily testing for if the preferred name hydrates correctly
-  // TODO: how to send dummy updated gender identity info for testing?
-  if (req?.query?.now) {
-    return res.json(
-      set(response, 'data.attributes.preferredName', 'nameupdated'),
-    );
-  }
-  return res.json(response);
+  },
 };
 
-const getUnsetUserPersonalInfo = {
+// v0/personal_information with none of the new demographics data set
+export const unsetUserPersonalInfoResponse = {
   data: {
     id: '',
     type: 'mvi_models_mvi_profiles',
@@ -47,33 +39,58 @@ const getUnsetUserPersonalInfo = {
   },
 };
 
+// example of api error from vets-api for PUT request
+export const putPreferredNameFailureResponse = {
+  errors: [
+    {
+      title: 'Bad Request',
+      detail: 'Received a bad request response from the upstream server',
+      code: 'EVSS400',
+      source: 'EVSS::DisabilityCompensationForm::Service',
+      status: '400',
+      meta: {},
+    },
+  ],
+};
+
+export const makePutPreferredNameSuccessResponse = name => {
+  return {
+    text: name,
+    source_system_user: '123498767V234859',
+    source_date: '2022-04-08T15:09:23.000Z',
+  };
+};
+
+// below are server responses specifically for Dev Mock API
+
+// if the now query is added we want to test that the UI hydrates with new info
+// primarily testing for if the preferred name hydrates correctly
+// TODO: how to send dummy updated gender identity info for testing?
+const getBasicUserPersonalInfo = (req, res) => {
+  if (req?.query?.now) {
+    return res.json(
+      set(
+        basicUserPersonalInfoResponse,
+        'data.attributes.preferredName',
+        'nameupdated',
+      ),
+    );
+  }
+  return res.json(basicUserPersonalInfoResponse);
+};
+
 const putPreferredName = {
   'PUT /v0/profile/preferred_names': (req, res) => {
+    // if the body doesnt include text then we should return an error
     // for testing if you submit a preferred name update with the text value of 'error' we can trigger the error response
-    if (req?.body?.text === 'error') {
-      return res.json({
-        errors: [
-          {
-            title: 'Bad Request',
-            detail: 'Received a bad request response from the upstream server',
-            code: 'EVSS400',
-            source: 'EVSS::DisabilityCompensationForm::Service',
-            status: '400',
-            meta: {},
-          },
-        ],
-      });
+    if (!req?.body?.text || req?.body?.text === 'error') {
+      return res.json(putPreferredNameFailureResponse);
     }
-    return res.json({
-      text: req?.body?.text,
-      source_system_user: '123498767V234859',
-      source_date: '2022-04-08T15:09:23.000Z',
-    });
+    return res.json(makePutPreferredNameSuccessResponse(req.body.tex));
   },
 };
 
 module.exports = {
   getBasicUserPersonalInfo,
-  getUnsetUserPersonalInfo,
   putPreferredName,
 };

--- a/src/applications/personalization/profile/mocks/personalInformation.js
+++ b/src/applications/personalization/profile/mocks/personalInformation.js
@@ -93,4 +93,8 @@ const putPreferredName = {
 module.exports = {
   getBasicUserPersonalInfo,
   putPreferredName,
+  basicUserPersonalInfoResponse,
+  unsetUserPersonalInfoResponse,
+  makePutPreferredNameSuccessResponse,
+  putPreferredNameFailureResponse,
 };

--- a/src/applications/personalization/profile/mocks/personalInformation.js
+++ b/src/applications/personalization/profile/mocks/personalInformation.js
@@ -4,7 +4,7 @@
 const set = require('lodash/set');
 
 // v0/personal_information route basic user response
-export const basicUserPersonalInfoResponse = {
+const basicUserPersonalInfoResponse = {
   data: {
     id: '',
     type: 'mvi_models_mvi_profiles',
@@ -22,7 +22,7 @@ export const basicUserPersonalInfoResponse = {
 };
 
 // v0/personal_information with none of the new demographics data set
-export const unsetUserPersonalInfoResponse = {
+const unsetUserPersonalInfoResponse = {
   data: {
     id: '',
     type: 'mvi_models_mvi_profiles',
@@ -40,7 +40,7 @@ export const unsetUserPersonalInfoResponse = {
 };
 
 // example of api error from vets-api for PUT request
-export const putPreferredNameFailureResponse = {
+const putPreferredNameFailureResponse = {
   errors: [
     {
       title: 'Bad Request',
@@ -53,7 +53,7 @@ export const putPreferredNameFailureResponse = {
   ],
 };
 
-export const makePutPreferredNameSuccessResponse = name => {
+const makePutPreferredNameSuccessResponse = name => {
   return {
     text: name,
     source_system_user: '123498767V234859',

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -4,7 +4,7 @@ const paymentHistory = require('./paymentHistory');
 const mhvAcccount = require('./mhvAccount');
 const address = require('./address');
 const status = require('./status');
-const personalInfo = require('./personalInfo');
+const personalInformation = require('./personalInformation');
 
 const { generateFeatureToggles } = require('./feature-toggles');
 
@@ -18,8 +18,9 @@ const responses = {
   'GET /v0/ppiu/payment_information': paymentHistory,
   'POST /v0/profile/address_validation': address.addressValidation,
   'GET /v0/mhv_account': mhvAcccount,
-  'GET /v0/profile/personal_information': personalInfo.getBasicUserPersonalInfo,
-  ...personalInfo.putPreferredName,
+  'GET /v0/profile/personal_information':
+    personalInformation.getBasicUserPersonalInfo,
+  ...personalInformation.putPreferredName,
   'GET /v0/profile/full_name': {
     id: '',
     type: 'hashes',

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -18,7 +18,8 @@ const responses = {
   'GET /v0/ppiu/payment_information': paymentHistory,
   'POST /v0/profile/address_validation': address.addressValidation,
   'GET /v0/mhv_account': mhvAcccount,
-  'GET /v0/profile/personal_information': personalInfo,
+  'GET /v0/profile/personal_information': personalInfo.getBasicUserPersonalInfo,
+  ...personalInfo.putPreferredName,
   'GET /v0/profile/full_name': {
     id: '',
     type: 'hashes',

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
@@ -10,19 +10,21 @@ describe('Content on the personal information page', () => {
     );
 
     cy.findByText('Preferred name').should('exist');
-    cy.findByText('Edit your profile to add a preferred name.').should('exist');
+    cy.findByTestId('preferredName').contains(
+      'Edit your profile to add a preferred name.',
+    );
 
     cy.findByText('Pronouns').should('exist');
-    cy.findByText('Edit your profile to add pronouns.').should('exist');
+    cy.findByTestId('pronouns').contains('Edit your profile to add pronouns.');
 
     cy.findByText('Gender identity').should('exist');
-    cy.findByText('Edit your profile to add a gender identity.').should(
-      'exist',
+    cy.findByTestId('genderIdentity').contains(
+      'Edit your profile to add a gender identity.',
     );
 
     cy.findByText('Sexual orientation').should('exist');
-    cy.findByText('Edit your profile to add a sexual orientation.').should(
-      'exist',
+    cy.findByTestId('sexualOrientation').contains(
+      'Edit your profile to add a sexual orientation.',
     );
 
     cy.injectAxeThenAxeCheck();

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
@@ -1,0 +1,149 @@
+import { setup } from '@@profile/tests/e2e/personal-information/setup';
+import {
+  basicUserPersonalInfoResponse,
+  putPreferredNameFailureResponse,
+  makePutPreferredNameSuccessResponse,
+} from '@@profile/mocks/personalInfo';
+import set from 'lodash/set';
+
+describe('Preferred name field tests on the personal information page', () => {
+  it('when api data is available, should render preferred name field and alert when cancel is attempted with unsaved edits', () => {
+    setup({ isEnhanced: true });
+
+    // preferred name field
+    const nameEditButtonLabel = 'Edit Preferred name';
+    const nameEditInputLabel =
+      'Provide your preferred name (25 characters maximum)';
+    const nameEditInputField = 'input[name="root_preferredName"]';
+
+    // check that 'WES' is formatted to 'Wes'
+    cy.findByTestId('preferredName').contains('Wes');
+
+    cy.findByLabelText(nameEditButtonLabel).click({ waitForAnimations: true });
+
+    cy.findByText(nameEditInputLabel).should('exist');
+
+    cy.get(nameEditInputField)
+      .clear()
+      .type('newname');
+
+    cy.findByTestId('cancel-edit-button').click();
+
+    // should show cancel editing alert
+    cy.findByRole('alertdialog').should('exist');
+
+    cy.findByRole('button', { name: 'Cancel' })
+      .should('exist')
+      .click();
+
+    cy.findByText(nameEditInputLabel).should('not.exist');
+
+    cy.get(nameEditInputField).should('not.exist');
+
+    cy.findByTestId('preferredName').contains('Wes');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('when updating preferred name is successful, should show success alert and the updated name', () => {
+    setup({ isEnhanced: true });
+
+    const updatedName = 'George';
+
+    cy.intercept(
+      'PUT',
+      'v0/profile/preferred_names',
+      makePutPreferredNameSuccessResponse(updatedName.toUpperCase()),
+    );
+
+    cy.intercept('GET', 'v0/profile/personal_information*', req => {
+      if (req?.query?.now) {
+        req.reply(
+          set(
+            { ...basicUserPersonalInfoResponse },
+            'data.attributes.preferredName',
+            updatedName.toUpperCase(),
+          ),
+        );
+      }
+    });
+
+    const nameEditButtonLabel = 'Edit Preferred name';
+    const nameEditInputField = 'input[name="root_preferredName"]';
+
+    cy.findByLabelText(nameEditButtonLabel).click({ waitForAnimations: true });
+
+    cy.get(nameEditInputField)
+      .clear()
+      .type(updatedName);
+
+    cy.findAllByTestId('save-edit-button').click({ waitForAnimations: true });
+
+    cy.findByTestId('preferredName')
+      .contains(updatedName)
+      .should('exist');
+
+    cy.findByTestId('update-success-alert').should('exist');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('when there is an API error, should show error alert', () => {
+    setup({ isEnhanced: true });
+
+    const updatedName = 'George';
+
+    cy.intercept(
+      'PUT',
+      'v0/profile/preferred_names',
+      putPreferredNameFailureResponse,
+    );
+
+    const nameEditButtonLabel = 'Edit Preferred name';
+    const nameEditInputField = 'input[name="root_preferredName"]';
+
+    cy.findByLabelText(nameEditButtonLabel).click({ waitForAnimations: true });
+
+    cy.get(nameEditInputField)
+      .clear()
+      .type(updatedName);
+
+    cy.findAllByTestId('save-edit-button').click({ waitForAnimations: true });
+
+    cy.findByTestId('edit-error-alert').should('exist');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('when there is an network error, should show error alert', () => {
+    setup({ isEnhanced: true });
+
+    const nameEditButtonLabel = 'Edit Preferred name';
+
+    cy.findByLabelText(nameEditButtonLabel).click({ waitForAnimations: true });
+
+    cy.findAllByTestId('save-edit-button')
+      .should('exist')
+      .click({ waitForAnimations: true });
+
+    cy.findByTestId('edit-error-alert').should('exist');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should show field validation errors', () => {
+    setup({ isEnhanced: true });
+
+    const nameEditButtonLabel = 'Edit Preferred name';
+
+    cy.findByLabelText(nameEditButtonLabel).click({ waitForAnimations: true });
+
+    cy.findAllByTestId('save-edit-button')
+      .should('exist')
+      .click({ waitForAnimations: true });
+
+    cy.findByTestId('edit-error-alert').should('exist');
+
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
@@ -3,7 +3,7 @@ import {
   basicUserPersonalInfoResponse,
   putPreferredNameFailureResponse,
   makePutPreferredNameSuccessResponse,
-} from '@@profile/mocks/personalInfo';
+} from '@@profile/mocks/personalInformation';
 import set from 'lodash/set';
 
 describe('Preferred name field tests on the personal information page', () => {

--- a/src/applications/personalization/profile/tests/e2e/personal-information/setup.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/setup.js
@@ -9,6 +9,7 @@ import mockProfileEnhancementsToggles from '@@profile/tests/fixtures/personal-in
 export const setup = (options = { personalInfo: null, isEnhanced: false }) => {
   cy.login(mockUser);
   cy.intercept(
+    'GET',
     'v0/profile/personal_information',
     options.personalInfo ||
       (options.isEnhanced

--- a/src/applications/personalization/profile/tests/fixtures/personal-information-success-enhanced.json
+++ b/src/applications/personalization/profile/tests/fixtures/personal-information-success-enhanced.json
@@ -5,7 +5,7 @@
     "attributes": {
       "gender": "M",
       "birthDate": "1986-05-06",
-      "preferredName": "Wes",
+      "preferredName": "WES",
       "pronouns": ["heHimHis", "theyThemTheirs"],
       "pronounsNotListedText": "Other/pronouns/here",
       "genderIdentity": {"code": "M", "name": "Male"},

--- a/src/applications/personalization/profile/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile/tests/selectors.unit.spec.js
@@ -527,7 +527,7 @@ describe('selectVAProfilePersonalInformation selector', () => {
     expect(
       selectors.selectVAProfilePersonalInformation(state, 'preferredName'),
     ).to.deep.equal({
-      preferredName: 'Wes',
+      preferredName: 'WES',
     });
   });
 

--- a/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
+++ b/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
@@ -110,15 +110,18 @@ export const getProfileInfoFieldAttributes = fieldName => {
           };
         };
         break;
+
       case FIELD_NAMES.GENDER_IDENTITY:
         apiRoute = API_ROUTES.GENDER_IDENTITY;
         title = FIELD_TITLES[FIELD_NAMES.GENDER_IDENTITY];
         break;
+
       case FIELD_NAMES.SEXUAL_ORIENTATION:
         // TODO: update when api route is avail
         apiRoute = '/';
         title = FIELD_TITLES[FIELD_NAMES.SEXUAL_ORIENTATION];
         break;
+
       case FIELD_NAMES.PRONOUNS:
         // TODO: update when api route is avail
         apiRoute = '/';

--- a/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
+++ b/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
@@ -117,7 +117,7 @@ export const getProfileInfoFieldAttributes = fieldName => {
       case FIELD_NAMES.SEXUAL_ORIENTATION:
         // TODO: update when api route is avail
         apiRoute = '/';
-        title = FIELD_TITLES[FIELD_NAMES.GENDER_IDENTITY];
+        title = FIELD_TITLES[FIELD_NAMES.SEXUAL_ORIENTATION];
         break;
       case FIELD_NAMES.PRONOUNS:
         // TODO: update when api route is avail

--- a/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
+++ b/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
@@ -94,12 +94,14 @@ export const getProfileInfoFieldAttributes = fieldName => {
   }
 
   if (personalInformation.includes(fieldName)) {
+    // dont manipulate the payload by default and rely on the
+    // conversion to happen within the switch statement below
+    // for each fields specific data transformation needs
     convertCleanDataToPayload = payload => {
-      // console.log(payload);
-      // TODO: this function will need to be changed so it can be used for the Data transformation for the API call. See https://github.com/department-of-veterans-affairs/vets-website/blob/Profile-31685-newpersonalinfosection/src/applications/personalization/profile/components/ProfileInformationEditView.jsx#L180
       return payload;
     };
 
+    // TODO: update convertCleanDataToPayload when other field api endpoints are ready
     switch (fieldName) {
       case FIELD_NAMES.PREFERRED_NAME:
         apiRoute = API_ROUTES.PREFERRED_NAME;

--- a/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
+++ b/src/applications/personalization/profile/util/getProfileInfoFieldAttributes.js
@@ -1,6 +1,10 @@
 import { API_ROUTES, FIELD_TITLES, FIELD_NAMES } from '@@vap-svc/constants';
 
 import {
+  getFormSchema as addressFormSchema,
+  getUiSchema as addressUiSchema,
+} from '@@vap-svc/components/AddressField/address-schemas';
+import {
   emailConvertCleanDataToPayload,
   emailUiSchema,
   emailFormSchema,
@@ -11,11 +15,6 @@ import {
   phoneFormSchema,
 } from './contact-information/phoneUtils';
 import { addressConvertCleanDataToPayload } from './contact-information/addressUtils';
-
-import {
-  getFormSchema as addressFormSchema,
-  getUiSchema as addressUiSchema,
-} from '@@vap-svc/components/AddressField/address-schemas';
 
 import {
   personalInformationFormSchemas,
@@ -95,29 +94,45 @@ export const getProfileInfoFieldAttributes = fieldName => {
   }
 
   if (personalInformation.includes(fieldName)) {
-    apiRoute = '/'; // TODO: DUMMY API ROUTE
     convertCleanDataToPayload = payload => {
       // console.log(payload);
       // TODO: this function will need to be changed so it can be used for the Data transformation for the API call. See https://github.com/department-of-veterans-affairs/vets-website/blob/Profile-31685-newpersonalinfosection/src/applications/personalization/profile/components/ProfileInformationEditView.jsx#L180
       return payload;
     };
+
+    switch (fieldName) {
+      case FIELD_NAMES.PREFERRED_NAME:
+        apiRoute = API_ROUTES.PREFERRED_NAME;
+        title = FIELD_TITLES[FIELD_NAMES.PREFERRED_NAME];
+        convertCleanDataToPayload = payload => {
+          return {
+            text: payload?.[FIELD_NAMES.PREFERRED_NAME],
+          };
+        };
+        break;
+      case FIELD_NAMES.GENDER_IDENTITY:
+        apiRoute = API_ROUTES.GENDER_IDENTITY;
+        title = FIELD_TITLES[FIELD_NAMES.GENDER_IDENTITY];
+        break;
+      case FIELD_NAMES.SEXUAL_ORIENTATION:
+        // TODO: update when api route is avail
+        apiRoute = '/';
+        title = FIELD_TITLES[FIELD_NAMES.GENDER_IDENTITY];
+        break;
+      case FIELD_NAMES.PRONOUNS:
+        // TODO: update when api route is avail
+        apiRoute = '/';
+        title = FIELD_TITLES[FIELD_NAMES.PRONOUNS];
+        break;
+
+      default:
+        apiRoute = '/';
+        title = 'Title Not Set';
+        break;
+    }
+
     uiSchema = personalInformationUiSchemas[fieldName];
     formSchema = personalInformationFormSchemas[fieldName];
-
-    // console.log(fieldName, ' uiSchema => ', uiSchema);
-    // console.log(fieldName, ' formSchema => ', formSchema);
-    if (fieldName === FIELD_NAMES.PREFERRED_NAME) {
-      title = FIELD_TITLES[FIELD_NAMES.PREFERRED_NAME];
-    }
-    if (fieldName === FIELD_NAMES.PRONOUNS) {
-      title = FIELD_TITLES[FIELD_NAMES.PRONOUNS];
-    }
-    if (fieldName === FIELD_NAMES.GENDER_IDENTITY) {
-      title = FIELD_TITLES[FIELD_NAMES.GENDER_IDENTITY];
-    }
-    if (fieldName === FIELD_NAMES.SEXUAL_ORIENTATION) {
-      title = FIELD_TITLES[FIELD_NAMES.SEXUAL_ORIENTATION];
-    }
   }
 
   return {

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -66,7 +66,7 @@ export const personalInformationFormSchemas = {
     properties: {
       preferredName: {
         type: 'string',
-        pattern: '^[A-Za-z\\s]+$',
+        pattern: '^[A-Za-z]+$',
         minLength: 1,
         maxLength: 25,
       },
@@ -113,7 +113,7 @@ export const personalInformationUiSchemas = {
       'ui:widget': TextWidget,
       'ui:title': `Provide your preferred name (25 characters maximum)`,
       'ui:errorMessages': {
-        pattern: 'Preferred name required',
+        pattern: 'This field accepts alphabetic characters only',
       },
     },
   },

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -174,6 +174,7 @@ export function createTransaction(
 
       // If the request does not hit the server, apiRequest which is using fetch - will throw an error
       // it will not return back a transaction with errors on it
+      // TODO: use mock server locally instead of isVAProfileServiceConfigured
       const transaction = isVAProfileServiceConfigured()
         ? await apiRequest(route, options)
         : await localVAProfileService.createTransaction();
@@ -200,7 +201,13 @@ export function createTransaction(
         fieldName,
         transaction,
       });
+
+      // TODO: if personal-information style request, then immediately fire off VAP_SERVICE_TRANSACTION_UPDATED with success metadata
+      // update transaction data to support transactions and immediate result style sync calls
     } catch (error) {
+      // TODO: handle unique errors for personal information requests
+      // dispatch VAP_SERVICE_TRANSACTION_UPDATE_FAILED with appropriate data
+
       const [firstError = {}] = error.errors ?? [];
       const { code = 'code', title = 'title', detail = 'detail' } = firstError;
       const profileSection = analyticsSectionName || 'unknown-profile-section';

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -179,8 +179,6 @@ export function createTransaction(
         ? await apiRequest(route, options)
         : await localVAProfileService.createTransaction();
 
-      // const transaction = await apiRequest(route, options);
-
       if (transaction?.errors) {
         const error = new Error('There was a transaction error');
         error.errors = transaction?.errors;
@@ -201,13 +199,7 @@ export function createTransaction(
         fieldName,
         transaction,
       });
-
-      // TODO: if personal-information style request, then immediately fire off VAP_SERVICE_TRANSACTION_UPDATED with success metadata
-      // update transaction data to support transactions and immediate result style sync calls
     } catch (error) {
-      // TODO: handle unique errors for personal information requests
-      // dispatch VAP_SERVICE_TRANSACTION_UPDATE_FAILED with appropriate data
-
       const [firstError = {}] = error.errors ?? [];
       const { code = 'code', title = 'title', detail = 'detail' } = firstError;
       const profileSection = analyticsSectionName || 'unknown-profile-section';

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -169,6 +169,8 @@ export const API_ROUTES = {
   TELEPHONES: '/profile/telephones',
   EMAILS: '/profile/email_addresses',
   ADDRESSES: '/profile/addresses',
+  PREFERRED_NAME: '/profile/preferred_names',
+  GENDER_IDENTITY: '/profile/gender_identity',
 };
 
 export const VAP_SERVICE_INITIALIZATION_STATUS = {


### PR DESCRIPTION
## Description
Adds the ability to update or add the Preferred Name in the VA Profile Personal Information page. This PR is already pushing 500 LOC, so I have a second PR that I will submit where I added moire unit tests and e2e tests.

- add action creator for doing PUT request to endpoint for updates
- move personal info actions to own file
- mock personal info api responses
- update getProfileFieldAttributes for inclusion of personal info data transformers where needed
- updated preferred name field validation and validation error message
- added constants for preferred name and gender identity api route pathnames

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38953

## Testing done
Added some E2E tests, but also have incoming PR with more tests to reduce PR size.

## Acceptance criteria
- [x] Allows preferred name to be added or updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
