### PR TITLE
[FE] Display Message to User when Attempting to Pre-Check-In on the Day of Appointment

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -190,6 +190,15 @@ class ApiInitializer {
         emergencyContactConfirmedAt,
       );
     },
+    withExpired: () => {
+      const data = preCheckInData.get.createMockSuccessResponse(
+        preCheckInData.get.expiredUUID,
+      );
+      cy.intercept('GET', '/check_in/v2/pre_check_ins/*', req => {
+        req.reply(data);
+      });
+      return data;
+    },
     withBadData: ({
       extraValidation = null,
       demographicsNeedsUpdate = true,

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
@@ -1,3 +1,5 @@
+const addDays = require('date-fns/addDays');
+
 const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
 
 const createMockSuccessResponse = (
@@ -64,8 +66,9 @@ const createAppointment = (
   facilityId = 'some-facility',
   appointmentIen = 'some-ien',
   clinicFriendlyName = 'TEST CLINIC',
+  preCheckInValid = false,
 ) => {
-  const startTime = new Date();
+  const startTime = preCheckInValid ? addDays(new Date(), 1) : new Date();
   const checkInWindowStart = new Date();
   const checkInWindowEnd = new Date();
 

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -82,10 +82,8 @@ const createMockSuccessResponse = (
           startTime: mockTime,
           eligibility: 'ELIGIBLE',
           facilityId: 'some-facility',
-          checkInWindowStart: new Date().setDate(
-            new Date(mockTime).getDate() - 30,
-          ),
-          checkInWindowEnd: new Date(mockTime).setHours(0, 0, 0, 0),
+          checkInWindowStart: mockTime,
+          checkInWindowEnd: mockTime,
           checkedInTime: '',
         },
         {
@@ -97,10 +95,8 @@ const createMockSuccessResponse = (
           startTime: mockTime,
           eligibility: 'ELIGIBLE',
           facilityId: 'some-facility',
-          checkInWindowStart: new Date().setDate(
-            new Date(mockTime).getDate() - 30,
-          ),
-          checkInWindowEnd: new Date(mockTime).setHours(0, 0, 0, 0),
+          checkInWindowStart: mockTime,
+          checkInWindowEnd: mockTime,
           checkedInTime: '',
         },
       ],

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -1,5 +1,5 @@
 const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
-const errorUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
+const expiredUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
 
 const createMockSuccessResponse = (
   token,
@@ -11,7 +11,7 @@ const createMockSuccessResponse = (
   emergencyContactConfirmedAt = null,
 ) => {
   const mockTime =
-    token === errorUUID
+    token === expiredUUID
       ? new Date()
       : new Date().setDate(new Date().getDate() + 1);
   return {
@@ -122,4 +122,5 @@ module.exports = {
   createMockSuccessResponse,
   createMockFailedResponse,
   defaultUUID,
+  expiredUUID,
 };

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -1,4 +1,5 @@
 const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
+const errorUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
 
 const createMockSuccessResponse = (
   token,
@@ -9,7 +10,10 @@ const createMockSuccessResponse = (
   emergencyContactNeedsUpdate = false,
   emergencyContactConfirmedAt = null,
 ) => {
-  const mockTime = new Date();
+  const mockTime =
+    token === errorUUID
+      ? new Date()
+      : new Date().setDate(new Date().getDate() + 1);
   return {
     id: token || defaultUUID,
     payload: {
@@ -78,8 +82,10 @@ const createMockSuccessResponse = (
           startTime: mockTime,
           eligibility: 'ELIGIBLE',
           facilityId: 'some-facility',
-          checkInWindowStart: mockTime,
-          checkInWindowEnd: mockTime,
+          checkInWindowStart: new Date().setDate(
+            new Date(mockTime).getDate() - 30,
+          ),
+          checkInWindowEnd: new Date(mockTime).setHours(0, 0, 0, 0),
           checkedInTime: '',
         },
         {
@@ -91,8 +97,10 @@ const createMockSuccessResponse = (
           startTime: mockTime,
           eligibility: 'ELIGIBLE',
           facilityId: 'some-facility',
-          checkInWindowStart: mockTime,
-          checkInWindowEnd: mockTime,
+          checkInWindowStart: new Date().setDate(
+            new Date(mockTime).getDate() - 30,
+          ),
+          checkInWindowEnd: new Date(mockTime).setHours(0, 0, 0, 0),
           checkedInTime: '',
         },
       ],

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -1,3 +1,5 @@
+const addDays = require('date-fns/addDays');
+
 const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
 const expiredUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
 
@@ -10,10 +12,7 @@ const createMockSuccessResponse = (
   emergencyContactNeedsUpdate = false,
   emergencyContactConfirmedAt = null,
 ) => {
-  const mockTime =
-    token === expiredUUID
-      ? new Date()
-      : new Date().setDate(new Date().getDate() + 1);
+  const mockTime = token === expiredUUID ? new Date() : addDays(new Date(), 1);
   return {
     id: token || defaultUUID,
     payload: {

--- a/src/applications/check-in/components/ErrorMessage.jsx
+++ b/src/applications/check-in/components/ErrorMessage.jsx
@@ -25,10 +25,8 @@ const ErrorMessage = ({ header, message, showAlert = true }) => {
       <div data-testid="error-message">{errorMessage}</div>
     </>
   );
-  if (showAlert) {
-    return <va-alert status="error">{body}</va-alert>;
-  }
-  return { body };
+
+  return showAlert ? <va-alert status="error">{body}</va-alert> : body;
 };
 
 ErrorMessage.propTypes = {

--- a/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
@@ -14,6 +14,12 @@ export default function TestComponent({ router }) {
   } = useFormRouting(router);
   const currentPage = getCurrentPageFromRouter();
   const previousPage = getPreviousPageFromRouter();
+
+  const errorTest = () => {
+    // strip out button click event stuff from being sent as a param to the function
+    goToErrorPage();
+  };
+
   return (
     <div>
       <h1>Test component for the useFormRouting hook</h1>
@@ -34,7 +40,7 @@ export default function TestComponent({ router }) {
       <button type="button" onClick={goToNextPage} data-testid="next-button">
         Next
       </button>
-      <button type="button" onClick={goToErrorPage} data-testid="error-button">
+      <button type="button" onClick={errorTest} data-testid="error-button">
         Error
       </button>
       <button

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -11,8 +11,8 @@ const useFormRouting = (router = {}) => {
   const { pages } = useSelector(selectForm);
 
   const goToErrorPage = useCallback(
-    () => {
-      router.push(URLS.ERROR);
+    (params = '') => {
+      router.push(URLS.ERROR + params);
     },
     [router],
   );

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -134,6 +134,8 @@
   "you-can-pre-check-in-online-until-date": "You can pre-check in online until {{date, mdY}}.",
   "were-sorry-something-went-wrong-on-our-end-please-try-again": "We’re sorry. Something went wrong on our end. Please try again.",
   "were-sorry-we-couldnt-match-your-information-to-our-records-please-call-us-at-800-698-2411-tty-711-for-help-signing-in": "We're sorry. We couldn't match your information to our records. Please call us at 800-698-2411 (TTY:711) for help signing in.",
+  "sorry-we-cant-complete-pre-check-in": "Sorry, we can't complete pre-check-in",
+  "you-can-still-check-in-once-you-arrive": "You can still check-in with your phone once you arrive at your appointment.",
   "relationship-to-you": "relationship to you",
   "ward": "Ward",
   "unrelated-friend": "Unrelated Friend",

--- a/src/applications/check-in/locales/es/translation.json
+++ b/src/applications/check-in/locales/es/translation.json
@@ -97,6 +97,8 @@
   "we-need-to-verify-your-identity-so-you-can-start-pre-check-in": "Necesitamos verificar su identidad para que pueda iniciar el registro previo.",
   "were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member": "Lo lamentamos. Algo salió mal de nuestra parte. Regístrese con un miembro del personal.",
   "were-sorry-we-couldnt-match-your-information-to-our-records-please-ask-a-staff-member-for-help": "Lo lamentamos. No pudimos hacer coincidir su información con nuestros registros. Pida ayuda a un miembro del personal.",
+  "sorry-we-cant-complete-pre-check-in": "Lo sentimos, no podemos completar el registro previo",
+  "you-can-still-check-in-once-you-arrive": "Todavía puede registrarse con su teléfono una vez que llegue a su cita.",
   "what-if-i-have-questions-about-my-appointment": "¿Qué pasa si tengo preguntas sobre mi cita?",
   "will-va-protect-my-personal-health-information": "¿VA protegerá mi información médica personal?",
   "work-phone": "Teléfono del trabajo",

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -14,7 +14,7 @@ import { makeSelectVeteranData } from '../../../selectors';
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
 
 const Error = ({ location }) => {
-  const { expired } = location.query;
+  const { type } = location.query;
   const { getValidateAttempts } = useSessionStorage(true);
   const { isMaxValidateAttempts } = getValidateAttempts(window);
   // try get date of appointment
@@ -53,21 +53,22 @@ const Error = ({ location }) => {
     </>
   );
 
+  // use type param to set unique error messages
+  const getErrorMessagePropsByType = () => {
+    if (type && type === 'expired')
+      return [
+        t('sorry-we-cant-complete-pre-check-in'),
+        t('you-can-still-check-in-once-you-arrive'),
+        false,
+      ];
+    return [t('we-couldnt-complete-pre-check-in'), combinedMessage, true];
+  };
+
+  const [header, message, showAlert] = getErrorMessagePropsByType();
+
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">
-      <ErrorMessage
-        header={
-          expired
-            ? t('sorry-we-cant-complete-pre-check-in')
-            : t('we-couldnt-complete-pre-check-in')
-        }
-        message={
-          expired
-            ? t('you-can-still-check-in-once-you-arrive')
-            : combinedMessage
-        }
-        showAlert={!expired}
-      />
+      <ErrorMessage header={header} message={message} showAlert={showAlert} />
       <Footer />
       <BackToHome />
     </div>
@@ -77,7 +78,7 @@ const Error = ({ location }) => {
 Error.propTypes = {
   location: PropTypes.shape({
     query: PropTypes.shape({
-      expired: PropTypes.string,
+      type: PropTypes.string,
     }),
   }),
 };

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -14,7 +14,10 @@ import { makeSelectVeteranData } from '../../../selectors';
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
 
 const Error = ({ location }) => {
-  const { type } = location.query;
+  const type =
+    location && location.query && location.query.type
+      ? location.query.type
+      : undefined;
   const { getValidateAttempts } = useSessionStorage(true);
   const { isMaxValidateAttempts } = getValidateAttempts(window);
   // try get date of appointment

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -12,7 +12,8 @@ import { makeSelectVeteranData } from '../../../selectors';
 
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
 
-const Error = () => {
+const Error = props => {
+  const { expired } = props.location.query;
   const { getValidateAttempts } = useSessionStorage(true);
   const { isMaxValidateAttempts } = getValidateAttempts(window);
   // try get date of appointment
@@ -54,8 +55,17 @@ const Error = () => {
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">
       <ErrorMessage
-        header={t('we-couldnt-complete-pre-check-in')}
-        message={combinedMessage}
+        header={
+          expired
+            ? t('sorry-we-cant-complete-pre-check-in')
+            : t('we-couldnt-complete-pre-check-in')
+        }
+        message={
+          expired
+            ? t('you-can-still-check-in-once-you-arrive')
+            : combinedMessage
+        }
+        showAlert={!expired}
       />
       <Footer />
       <BackToHome />

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
 
 import { subDays } from 'date-fns';
 
@@ -12,8 +13,8 @@ import { makeSelectVeteranData } from '../../../selectors';
 
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
 
-const Error = props => {
-  const { expired } = props.location.query;
+const Error = ({ location }) => {
+  const { expired } = location.query;
   const { getValidateAttempts } = useSessionStorage(true);
   const { isMaxValidateAttempts } = getValidateAttempts(window);
   // try get date of appointment
@@ -71,6 +72,14 @@ const Error = props => {
       <BackToHome />
     </div>
   );
+};
+
+Error.propTypes = {
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      expired: PropTypes.string,
+    }),
+  }),
 };
 
 export default Error;

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -51,6 +51,20 @@ describe('check-in', () => {
           ),
         ).to.exist;
       });
+      it('renders correct error message when pre-checkin is expired', () => {
+        const component = render(
+          <Provider store={store}>
+            <Error location={{ query: { type: 'expired' } }} />
+          </Provider>,
+        );
+        const expiredMessage = component.getByTestId('error-message');
+        expect(expiredMessage).to.exist;
+        expect(
+          within(expiredMessage).getByText(
+            'You can still check-in with your phone once you arrive at your appointment.',
+          ),
+        ).to.exist;
+      });
     });
     describe('empty redux store', () => {
       let store;

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -15,6 +15,7 @@ import {
 import { useFormRouting } from '../../../hooks/useFormRouting';
 
 import { makeSelectCurrentContext } from '../../../selectors';
+import { preCheckinExpired } from '../../../utils/appointment';
 
 const Introduction = props => {
   const { router } = props;
@@ -50,21 +51,14 @@ const Introduction = props => {
             return; // stops the rest of the code from executing and causing a state update on an unmounted component
           }
           const { payload } = json;
-          if (payload.appointments && payload.appointments.length > 0) {
-            const today = new Date();
-            // if any appointments are tomorrow or later, the link is not expired
-            let pceExpired = !Object.values(payload.appointments).some(appt => {
-              const checkInExpiry = new Date(appt.checkInWindowEnd);
-              if (today.getTime() < checkInExpiry.getTime()) {
-                pceExpired = false;
-                return true; // break the loop as soon as we have a valid appointment
-              }
-              return false;
-            });
-            if (pceExpired) {
-              goToErrorPage('?expired=true');
-              return;
-            }
+          // if any appointments are tomorrow or later, the link is not expired
+          if (
+            payload.appointments &&
+            payload.appointments.length > 0 &&
+            preCheckinExpired(payload.appointments)
+          ) {
+            goToErrorPage('?expired=true');
+            return;
           }
 
           //  set data to state

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -47,8 +47,26 @@ const Introduction = props => {
         .then(json => {
           if (json.error) {
             goToErrorPage();
+            return; // stops the rest of the code from executing and causing a state update on an unmounted component
           }
           const { payload } = json;
+          if (payload.appointments && payload.appointments.length > 0) {
+            const today = new Date();
+            // if any appointments are tomorrow or later, the link is not expired
+            let pceExpired = !Object.values(payload.appointments).some(appt => {
+              const checkInExpiry = new Date(appt.checkInWindowEnd);
+              if (today.getTime() < checkInExpiry.getTime()) {
+                pceExpired = false;
+                return true; // break the loop as soon as we have a valid appointment
+              }
+              return false;
+            });
+            if (pceExpired) {
+              goToErrorPage('?expired=true');
+              return;
+            }
+          }
+
           //  set data to state
           dispatchSetVeteranData(payload);
           // hide loading screen

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -40,6 +40,9 @@ const Introduction = props => {
 
   useEffect(
     () => {
+      const setDataToState = async data => {
+        await dispatchSetVeteranData(data);
+      };
       // show loading screen
       setIsLoading(true);
       //  call get data from API
@@ -48,21 +51,19 @@ const Introduction = props => {
         .then(json => {
           if (json.error) {
             goToErrorPage();
-            return; // stops the rest of the code from executing and causing a state update on an unmounted component
+            return; // prevent a react no-op on an unmounted component
           }
           const { payload } = json;
+          //  set data to state
+          setDataToState(payload);
           // if any appointments are tomorrow or later, the link is not expired
           if (
             payload.appointments &&
             payload.appointments.length > 0 &&
             preCheckinExpired(payload.appointments)
           ) {
-            goToErrorPage('?expired=true');
-            return;
+            goToErrorPage('?type=expired');
           }
-
-          //  set data to state
-          dispatchSetVeteranData(payload);
           // hide loading screen
           setIsLoading(false);
         })

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
@@ -1,0 +1,39 @@
+import '../../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../../tests/e2e/pages/ValidateVeteran';
+import Error from '../../pages/Error';
+
+describe('Pre-Check In Experience ', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializePreCheckInDataGet,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+
+    initializeSessionPost.withSuccess();
+
+    initializePreCheckInDataGet.withExpired();
+  });
+  afterEach(() => {
+    cy.window().then(window => {
+      window.sessionStorage.clear();
+    });
+  });
+  it('Render Error is caught', () => {
+    cy.visitPreCheckInWithUUID();
+    // page: Validate
+    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validateVeteran();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    // Expired UUID should navigate to an error
+    Error.validateExpiredPageLoaded();
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
@@ -13,6 +13,17 @@ class Error {
       .contains(messageText);
   };
 
+  validateExpiredPageLoaded = () => {
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('have.text', "Sorry, we can't complete pre-check-in");
+    cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .contains(
+        'You can still check-in with your phone once you arrive at your appointment.',
+      );
+  };
+
   validateDatePreCheckInDateShows = () => {
     cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
       .should('be.visible')

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
@@ -8,7 +8,9 @@ class Introduction {
       .and('have.text', 'Answer pre-check-in questions');
   };
 
-  validateMultipleAppointmentIntroText = (appointmentDate = new Date()) => {
+  validateMultipleAppointmentIntroText = (
+    appointmentDate = new Date().setDate(new Date().getDate() + 1),
+  ) => {
     cy.get('p[data-testid="appointment-day-location"]').contains(
       `Your appointments are on ${format(
         appointmentDate,

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -3,6 +3,7 @@ import {
   hasMoreAppointmentsToCheckInto,
   sortAppointmentsByStartTime,
   removeTimeZone,
+  preCheckinExpired,
 } from './index';
 
 import { get } from '../../api/local-mock-api/mocks/v2/check-in-data';
@@ -184,6 +185,22 @@ describe('check in', () => {
         expect(updatedPayloadWithoutTZ.appointments[0].startTime).to.equal(
           '2018-01-01T00:00:00',
         );
+      });
+    });
+    describe('preCheckinExpired', () => {
+      it('identifies an expired pre-check-in appointment list', () => {
+        const appointments = [
+          createAppointment(null, null, null, null, false),
+          createAppointment(null, null, null, null, false),
+        ];
+        expect(preCheckinExpired(appointments)).to.be.true;
+      });
+      it('identifies a valid pre-check-in appointment list', () => {
+        const appointments = [
+          createAppointment(null, null, null, null, true),
+          createAppointment(null, null, null, null, true),
+        ];
+        expect(preCheckinExpired(appointments)).to.be.false;
       });
     });
   });

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -1,3 +1,4 @@
+import { startOfDay } from 'date-fns';
 import { ELIGIBILITY } from './eligibility';
 
 /**
@@ -76,8 +77,8 @@ const removeTimeZone = payload => {
 const preCheckinExpired = appointments => {
   return !Object.values(appointments).some(appt => {
     const today = new Date();
-    const checkInExpiry = new Date(appt.startTime).setHours(0, 0, 0, 0);
-    return today.getTime() < checkInExpiry;
+    const checkInExpiry = startOfDay(new Date(appt.startTime));
+    return today.getTime() < checkInExpiry.getTime();
   });
 };
 

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -72,8 +72,18 @@ const removeTimeZone = payload => {
 
   return updatedPayload;
 };
+
+const preCheckinExpired = appointments => {
+  return !Object.values(appointments).some(appt => {
+    const today = new Date();
+    const checkInExpiry = new Date(appt.startTime).setHours(0, 0, 0, 0);
+    return today.getTime() < checkInExpiry;
+  });
+};
+
 export {
   hasMoreAppointmentsToCheckInto,
   sortAppointmentsByStartTime,
   removeTimeZone,
+  preCheckinExpired,
 };


### PR DESCRIPTION
## Description
In progress PR to show the user a unique error page / message when attempting to use a pre-check-in link on the same day as their appointment(s).

This PR:
- Checks whether appointments associated to a user are tomorrow or later (with a new helper function). If no valid appointments are found that are tomorrow or later, the user is forwarded to an error page with a new header and message.
- Refactors the Error page to add capability to change the message / header based on a query param in the URL. The props that are sent to ErrorMessage are dependent on what value the `type` param has. currently `expired` shows the new error messages.
- Adds PLACEHOLDER translations for spanish - i'm not sure if we have official translations for this page? If not, should I leave the placeholder translations or put english for both?

How to test:
The existing (and default) UUID '0429dda5-4165-46be-9ed1-1e652a8dfd83', should work exactly the same as before. The appointments using this UUID are now set to tomorrow instead of the current date, so that they remain valid.
A new test UUID has been added: '354d5b3a-b7b7-4e5c-99e4-8d563f15c521'
The appointments for this UUID are all set to the current day. Using this UUID in the link will therefore direct to the new error page.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#37983


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
