### PR TITLE
Update service_account_key to use credentials_json

### DIFF
--- a/.github/workflows/configure-bigquery/action.yml
+++ b/.github/workflows/configure-bigquery/action.yml
@@ -10,9 +10,12 @@ runs:
         ssm_parameter: /dsva-vagov/testing-team/bigquery_service_credentials
         env_variable_name: BIGQUERY_SERVICE_CREDENTIALS
 
+    - name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v0
+      with:
+        credentials_json: '${{ env.BIGQUERY_SERVICE_CREDENTIALS }}'
+
     - name: Setup Cloud SDK
       uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: vsp-analytics-and-insights
-        service_account_key: ${{ env.BIGQUERY_SERVICE_CREDENTIALS }}
-        export_default_credentials: true

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 on:
-  workflow_dispatch:
+  ? workflow_dispatch
   schedule:
     - cron: '0 12 * * 1-5'
 
@@ -133,12 +133,15 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
         working-directory: testing-tools-team-dashboard-data
 
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: '${{ env.BIGQUERY_SERVICE_CREDENTIALS }}'
+
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: vsp-analytics-and-insights
-          service_account_key: ${{ env.BIGQUERY_SERVICE_CREDENTIALS }}
-          export_default_credentials: true
 
       - name: Copy results file to data dir
         run: |

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 on:
-  ? workflow_dispatch
+  workflow_dispatch:
   schedule:
     - cron: '0 12 * * 1-5'
 


### PR DESCRIPTION
## Description

Update to resolve the warning:
> Warning: "service_account_key" has been deprecated. Please switch to using google-github-actions/auth which supports both Workload Identity Federation and Service Account Key JSON authentication. For more details, see https://github.com/google-github-actions/setup-gcloud#authorization

- Update `service_account_key` to `credentials_json` (per [setup-gcloud GitHub Action - Authentication](https://github.com/google-github-actions/setup-gcloud#authorization)).
- Remove `export_default_credentials` (per [setup-gcloud GitHub Action - Authentication inputs](https://github.com/google-github-actions/setup-gcloud#authentication-inputs)).

## Original issue(s)
[Slack message](https://dsva.slack.com/archives/C01CHAY3ULR/p1651166474560119)


## Testing done

- [x] Ran GitHub Actions with CI step (on this PR) with the change, finished without the warnings
- [x] Ran [one-off lighthouse scan](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/2241273515) with the change, ran without the warnings 
  - Stopped it early, only needed to see that the warning didn't pop up. See screenshots.


## Screenshots

**Before & After CI**

![image](https://user-images.githubusercontent.com/100248909/165822719-13d0c28f-12e6-4278-9e02-2b0b5868a216.png)

**Before & After Lighthouse Scan**

![image](https://user-images.githubusercontent.com/100248909/165825200-0726e795-63f7-4604-9275-bc04c73cf811.png)


## Acceptance criteria
- [x] Warnings have been resolved, authentication to BigQuery works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
