### PR TITLE
updated content that shows outside of feature flag

### DIFF
--- a/src/applications/static-pages/nod-cta/components/App/index.js
+++ b/src/applications/static-pages/nod-cta/components/App/index.js
@@ -5,7 +5,94 @@ import { connect } from 'react-redux';
 
 export const App = ({ show }) => {
   if (!show) {
-    return null;
+    return (
+      <div
+        itemScope=""
+        itemProp="mainEntity"
+        itemType="https://schema.org/Question"
+        id="8925"
+      >
+        <div className="vads-u-display--flex">
+          <h2 itemProp="name" id="how-do-i-request-a-board-appea">
+            How do I request a Board Appeal?
+          </h2>
+        </div>
+
+        <div
+          itemProp="acceptedAnswer"
+          itemScope=""
+          itemType="http://schema.org/Answer"
+          data-entity-id="8925"
+        >
+          <div
+            data-template="paragraphs/wysiwyg"
+            data-entity-id="8924"
+            className="processed-content"
+          >
+            <div itemProp="text">
+              <p>You can request a Board Appeal in any of these ways:</p>
+
+              <h3 id="by-mail">By mail</h3>
+
+              <p>
+                Fill out a Decision Review Request: Board Appeal (Notice of
+                Disagreement) (VA Form 10182).&nbsp;
+                <br />
+                <a
+                  data-entity-substitution="canonical"
+                  data-entity-type="node"
+                  data-entity-uuid="6145c61f-7bcf-4650-bd7a-508e7c51f240"
+                  href="/find-forms/about-form-10182"
+                  title="About VA Form VA10182"
+                  hrefLang="en"
+                >
+                  Get VA Form 10182 to download
+                </a>
+              </p>
+
+              <p>
+                <strong>Note:</strong>
+                &nbsp;You can also get this form from a VA regional office. Or,
+                you can call us at&nbsp;
+                <a href="tel:+18008271000">800-827-1000</a>
+                 to request a form. We’re here Monday through Friday, 8:00 a.m.
+                to 9:00 p.m. ET.
+              </p>
+
+              <p>Send the completed form to this address:</p>
+
+              <p className="va-address-block">
+                Board of Veterans’ Appeals
+                <br />
+                PO Box 27063&nbsp;
+                <br />
+                Washington, D.C. 20038
+              </p>
+
+              <h3 id="in-person">In person</h3>
+
+              <p>
+                Bring your completed form to a VA regional office.&nbsp;
+                <br />
+                <a href="https://www.va.gov/find-locations/" hrefLang="en">
+                  Find a VA regional office near you
+                </a>
+              </p>
+
+              <h3 id="by-fax">By fax</h3>
+
+              <p>
+                Fax your completed form to&nbsp;
+                <a href="tel:844-678-8979" target="_blank" rel="noreferrer">
+                  844-678-8979
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Description
While testing the React widget for the static Drupal page about NOD we found that the content that is rendered when the user is outside of the feature flag needs to actually be the original content, not simply null. This PR updates that content.

## Testing done
tested locally

## Screenshots


## Acceptance criteria
- [x] the content rendered by the React widget for those users outside the feature flag is the original content from the page
