### PR TITLE
NOD: Use correct feature flag

### DIFF
--- a/src/applications/static-pages/nod-cta/components/App/index.js
+++ b/src/applications/static-pages/nod-cta/components/App/index.js
@@ -155,7 +155,7 @@ App.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  show: state?.featureToggles?.form1018Nod,
+  show: state?.featureToggles?.form10182Nod,
 });
 
 export default connect(mapStateToProps)(App);


### PR DESCRIPTION
## Description

A typo on the NOD feature flag is preventing the react widget from rendering the correct content. This PR fixes that.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/40568

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] The correct feature flag name is used

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
