### PR TITLE
VAVSA-8869: Expand Benefits Search Radius for "All VA Benefits" searches

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -1,3 +1,4 @@
+import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import mapboxClient from '../components/MapboxClient';
 import {
   reverseGeocodeBox,
@@ -25,11 +26,11 @@ import LocatorApi from '../api';
 import {
   LocationType,
   BOUNDING_RADIUS,
+  EXPANDED_BOUNDING_RADIUS,
   MAPBOX_QUERY_TYPES,
   CountriesList,
 } from '../constants';
 
-import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import { distBetween, radiusFromBoundingBox } from '../utils/facilityDistance';
 
 const mbxClient = mbxGeo(mapboxClient);
@@ -322,7 +323,7 @@ export const searchWithBounds = ({
  * @param {Object<T>} query Current searchQuery state (`searchQuery.searchString` at a minimum)
  * @returns {Function<T>} A thunk for Redux to process OR a failure action object on bad input
  */
-export const genBBoxFromAddress = query => {
+export const genBBoxFromAddress = (query, expandedRadius = false) => {
   // Prevent empty search request to Mapbox, which would result in error, and
   // clear results list to respond with message of no facilities found.
   if (!query.searchString) {
@@ -371,19 +372,23 @@ export const genBBoxFromAddress = query => {
             : [],
         });
 
+        const searchBoundingRadius = expandedRadius
+          ? EXPANDED_BOUNDING_RADIUS
+          : BOUNDING_RADIUS;
+
         let minBounds = [
-          coordinates[0] - BOUNDING_RADIUS,
-          coordinates[1] - BOUNDING_RADIUS,
-          coordinates[0] + BOUNDING_RADIUS,
-          coordinates[1] + BOUNDING_RADIUS,
+          coordinates[0] - searchBoundingRadius,
+          coordinates[1] - searchBoundingRadius,
+          coordinates[0] + searchBoundingRadius,
+          coordinates[1] + searchBoundingRadius,
         ];
 
         if (featureBox) {
           minBounds = [
-            Math.min(featureBox[0], coordinates[0] - BOUNDING_RADIUS),
-            Math.min(featureBox[1], coordinates[1] - BOUNDING_RADIUS),
-            Math.max(featureBox[2], coordinates[0] + BOUNDING_RADIUS),
-            Math.max(featureBox[3], coordinates[1] + BOUNDING_RADIUS),
+            Math.min(featureBox[0], coordinates[0] - searchBoundingRadius),
+            Math.min(featureBox[1], coordinates[1] - searchBoundingRadius),
+            Math.max(featureBox[2], coordinates[0] + searchBoundingRadius),
+            Math.max(featureBox[3], coordinates[1] + searchBoundingRadius),
           ];
         }
 

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -59,6 +59,7 @@ export const LOCATION_OPTIONS = [
  * Defines the ± change in bounding box size for the map when changing zoom
  */
 export const BOUNDING_RADIUS = 0.75;
+export const EXPANDED_BOUNDING_RADIUS = 1.4;
 
 /**
  *Defines the marker letter list


### PR DESCRIPTION
## Description

Closes [department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8869)

## Original issue(s)

[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8869)

## Testing done

Visual

## Screenshots

<img width="1051" alt="Screen Shot 2022-04-29 at 11 28 03 AM" src="https://user-images.githubusercontent.com/10790736/165976366-09aa9446-d8cf-4d82-a2c7-0a0e87c74c57.png">

## Testing Setup Instructions

- [ ] In the local instance of `vets-website` repo, change `src/applications/facility-locator/config.js` replace lines 23-28 with:

```javascript
const railsEngineApi = {
 baseUrl: `https://api.va.gov/facilities_api/v1`,
 url: `https://api.va.gov/facilities_api/v1/va`,
 ccUrl: `https://api.va.gov/facilities_api/v1/ccp`,
 settings: apiSettings,
};
```

- [ ] Disable CORS in chrome - for reference: https://alfilatov.com/posts/run-chrome-without-cors/
- [ ] in `vets-website` repo, run `yarn watch`
- [ ] Once the above step has compiled, go to `http://localhost:3001/find-locations/`

## Acceptance criteria

- [ ] Enter "22903" for the zip code, select "VA benefits" for the facility type & "All VA benefit services" for the service type & press Search. Confirm that multiple facilities are listed due to an expanded bounding box, and that "Veteran Readiness and Employment Office at Veterans Affairs Acquisition Academy" is one of them.
- [ ] Change the service type to "vocational rehabilitation and employment help," and confirm that "Veteran Readiness and Employment Office at Veterans Affairs Acquisition Academy" is no longer listed. This will confirm that the bounding box has shrunk now that "All VA Benefits" is no longer being searched.
