### PR TITLE
Letters: Replace & remove eBenefits links

### DIFF
--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import PropTypes from 'prop-types';
 
 import { focusElement } from 'platform/utilities/ui';
 
@@ -12,7 +13,7 @@ import { AVAILABILITY_STATUSES, LETTER_TYPES } from '../utils/constants';
 
 export class LetterList extends React.Component {
   componentDidMount() {
-    focusElement('.nav-header');
+    focusElement('h2#nav-form-header');
   }
 
   render() {
@@ -124,9 +125,9 @@ export class LetterList extends React.Component {
               </strong>
             </a>
           </li>
-          <li>
+          {/* <li> // COE to be launched on VA.gov soon
             <a
-              href="https://eauth.va.gov/ebenefits/coe"
+              href="/housing-assistance/home-loans/request-coe-form-26-1880"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -135,16 +136,15 @@ export class LetterList extends React.Component {
                 (COE) for your home loan benefits.
               </strong>
             </a>
-          </li>
+          </li> */}
           <li>
             <a
-              href="https://eauth.va.gov/ebenefits/DPRIS"
+              href="/records/get-military-service-records/"
               rel="noopener noreferrer"
               target="_blank"
             >
               <strong>
-                Sign in to eBenefits to request a copy of your discharge or
-                separation papers (DD 214).
+                Request your military service records (including DD214).
               </strong>
             </a>
           </li>
@@ -172,5 +172,17 @@ function mapStateToProps(state) {
     optionsAvailable: letterState.optionsAvailable,
   };
 }
+
+LetterList.propTypes = {
+  letterDownloadStatus: PropTypes.shape({}),
+  letters: PropTypes.arrayOf(
+    PropTypes.shape({
+      letterType: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  ),
+  lettersAvailability: PropTypes.string,
+  optionsAvailable: PropTypes.bool,
+};
 
 export default connect(mapStateToProps)(LetterList);


### PR DESCRIPTION
## Description

At the bottom of the Letters app list, there is a list of links. Two of these links point to the eBenefits site

- The link to request a copy of a DD 214 now points to VA.gov with the text changed to "Request your military service records (including DD214)"
- The link to request a Certificate of Eligibility (COE) was removed. COE has been added to VA.gov, but it is not yet released into production

![sign in to e-Benefits to request a certificate of eligibility or DD 214](https://user-images.githubusercontent.com/136959/163044881-463daf76-ece7-4946-8635-4ee573890346.png)

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39899
Content & IA recommendations: https://github.com/department-of-veterans-affairs/va.gov-team/issues/39900

## Testing done

Unit tests

## Screenshots

See above

## Acceptance criteria
- [x] Replace DD 214 eBenefits link destination and text
- [x] Remove COE eBenefits link. It will be added once COE on VA.gov is in production
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
