### PR TITLE
(fix) change to TF and F for transgender woman and woman

### DIFF
--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -36,8 +36,8 @@ const genderLabels = {
   M: 'Man',
   B: 'Non-binary',
   TM: 'Transgender man',
-  TW: 'Transgender woman',
-  W: 'Woman',
+  TF: 'Transgender woman',
+  F: 'Woman',
   N: 'Prefer not to answer',
   O: 'A gender not listed here',
 };


### PR DESCRIPTION
## Description
Small hotfix for the codes that are being sent to API for updating Gender Identity. Should be TF and F even though the UI is referring as Transgender Woman and Woman respectively.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38952

## Testing done
Manually tested

## Acceptance criteria
- [ ] Codes changed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
