### PR TITLE
(fix) add check for code null, e2e tests to cover edge case

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInformationView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationView.jsx
@@ -20,7 +20,8 @@ import { formatAddress } from '~/platform/forms/address/helpers';
 const shouldShowUnsetFieldTitleSpan = (data, fieldName) => {
   // show if there is no data or a gender identity code is not present in data object
   return (
-    !data || (fieldName === FIELD_NAMES.GENDER_IDENTITY && !data?.[fieldName])
+    !data ||
+    (fieldName === FIELD_NAMES.GENDER_IDENTITY && !data?.[fieldName]?.code)
   );
 };
 

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-gender-identity.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-gender-identity.cypress.spec.js
@@ -2,13 +2,13 @@ import { setup } from '@@profile/tests/e2e/personal-information/setup';
 import {
   putBadRequestFailure,
   createPutGenderIdentitySuccess,
+  unsetUserPersonalInfo,
 } from '@@profile/mocks/personal-information';
 
 describe('Gender identity field tests on the personal information page', () => {
   it('when api data is available, should render gender identity field and alert when cancel is attempted with unsaved edits', () => {
     setup({ isEnhanced: true });
 
-    // preferred name field
     const genderEditButtonLabel = 'Edit Gender identity';
     const genderEditInputLabel = 'Select your gender identity';
     const nameEditInputField = 'input[name="root_genderIdentity"]';
@@ -41,6 +41,16 @@ describe('Gender identity field tests on the personal information page', () => {
     cy.get(nameEditInputField).should('not.exist');
 
     cy.findByTestId('genderIdentity').contains('Man');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('when api data is empty, should render gender identity field and placeholder content', () => {
+    setup({ isEnhanced: true, personalInfo: unsetUserPersonalInfo });
+
+    cy.findByTestId('genderIdentity')
+      .contains('Edit your profile to add a gender identity.')
+      .should('exist');
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
@@ -3,6 +3,7 @@ import {
   basicUserPersonalInfo,
   putBadRequestFailure,
   createPutPreferredNameSuccess,
+  unsetUserPersonalInfo,
 } from '@@profile/mocks/personal-information';
 import set from 'lodash/set';
 
@@ -41,6 +42,16 @@ describe('Preferred name field tests on the personal information page', () => {
     cy.get(nameEditInputField).should('not.exist');
 
     cy.findByTestId('preferredName').contains('Wes');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('when api data is empty, should render preferred name field and placeholder content', () => {
+    setup({ isEnhanced: true, personalInfo: unsetUserPersonalInfo });
+
+    cy.findByTestId('preferredName')
+      .contains('Edit your profile to add a preferred name.')
+      .should('exist');
 
     cy.injectAxeThenAxeCheck();
   });


### PR DESCRIPTION
## Description
A small hotfix with accompanying tests for when the api returns gender identity but the code property is null. This fix addresses the issue that no placeholder text was appearing when gender identity had not been set.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38952

## Testing done
E2E tests added for gender identity and also to cover preferred name although it is not an object and is just a string returned from api.

## Screenshots
Before with no placeholder content
![image](https://user-images.githubusercontent.com/8332986/166502729-c83608aa-3d32-4292-8529-8ef34f4345ac.png)

After with the placeholder content showing
![Screen Shot 2022-05-03 at 12 07 28 PM](https://user-images.githubusercontent.com/8332986/166515499-03a7bda9-3d1c-461c-90be-5bb9c591b245.png)


## Acceptance criteria
- [x] Shows placeholder content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
