### PR TITLE
Dependents: Remove <header> in modal

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationHeader.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const DependencyVerificationHeader = () => {
   return (
-    <header>
+    <>
       <h3 className="vads-u-padding-top--3 small-screen:vads-u-padding-top--0">
         Please make sure your dependents are correct
       </h3>
@@ -11,7 +11,7 @@ const DependencyVerificationHeader = () => {
         our records are right so your benefits pay is correct. If you skip this
         for now, we’ll ask you again later.
       </p>
-    </header>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

Remove `<header>` from the dependency verification modal. Including it would cause screen readers to announce the paragraph as a "banner" region.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/30015

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] `<header>` removed from modal
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
