### PR TITLE
Corrects Change Dependents button text

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationFooter.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationFooter.jsx
@@ -19,7 +19,7 @@ const DependencyVerificationFooter = ({ handleCloseAndUpdateDiaries }) => {
         }}
         type="button"
       >
-        Change dependents
+        Add or remove dependents
       </button>
     </div>
   );


### PR DESCRIPTION
## Description

This updates the "Change dependents" button text in **Static Pages > Dependency Verification** to be "Add or remove dependents" to match the other buttons.

## Original issue(s)
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/30019