### PR TITLE
686: confirmation page updates

### DIFF
--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -7,9 +7,11 @@ import formConfig from '../config/form';
 
 function App({ location, children, isLoggedIn, isLoading, vaFileNumber }) {
   const content = (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
-    </RoutedSavableApp>
+    <article id="form-686c" data-location={`${location?.pathname?.slice(1)}`}>
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        {children}
+      </RoutedSavableApp>
+    </article>
   );
 
   // If on intro page, just return

--- a/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import PropTypes from 'prop-types';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
@@ -25,46 +26,62 @@ export class ConfirmationPage extends React.Component {
     const { response } = submission;
     const veteranFirstName = data?.veteranInformation?.fullName?.first || '';
     const veteranLastName = data?.veteranInformation?.fullName?.last || '';
+    const dateSubmitted = moment(response?.timestamp);
 
     return (
       <>
-        <div>
-          <button onClick={this.handlePrintClick} className="usa-button">
+        <div className="print-only">
+          <img
+            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+            alt="VA logo"
+            width="300"
+          />
+          <h2 className="vads-u-margin-top--2">
+            Add or remove a dependent on your VA disability benefits
+          </h2>
+          <div className="vads-u-margin-bottom--2">
+            VA Form 21-686c (with 21P-527EZ and 21-674)
+          </div>
+        </div>
+        <div className="inset">
+          <h2
+            id="thank-you-message"
+            className="vads-u-font-size--h3 vads-u-font-family--serif vads-u-margin-top--1"
+          >
+            Thank you for submitting your application
+          </h2>
+          <dl>
+            <dt>
+              <strong>
+                Application for Declaration of Status of Dependents (Form
+                21-686c), and/or
+                <br />
+                Request for Approval of School Attendance (Form 21-674), and/or
+                <br />
+                Application for Veterans Pension (Form 21P-527EZ)
+              </strong>
+            </dt>
+            <dd>
+              {veteranFirstName || veteranLastName
+                ? `for ${veteranFirstName} ${veteranLastName}`
+                : ''}
+            </dd>
+            <dt>
+              <strong>Date submitted</strong>
+            </dt>
+            <dd>
+              {dateSubmitted.isValid()
+                ? dateSubmitted.format('MMMM D, YYYY')
+                : ''}
+            </dd>
+          </dl>
+          <button
+            type="button"
+            className="usa-button screen-only"
+            onClick={this.handlePrintClick}
+          >
             Print this page for your records
           </button>
-          <div className="inset">
-            <h2
-              id="thank-you-message"
-              className="vads-u-font-size--h3 vads-u-font-family--serif"
-            >
-              Thank you for submitting your application
-            </h2>
-            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">
-              Application for Declaration of Status of Dependents (Form 21-686c)
-            </p>
-            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">
-              and/or Request for Approval of School Attendance (Form 21-674)
-            </p>
-            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">
-              and/or Application for Veterans Pension (Form 21P-527EZ)
-            </p>
-            {response && (
-              <div>
-                <p>
-                  for {veteranFirstName} {veteranLastName}
-                </p>
-                <ul className="claim-list">
-                  <li>
-                    <strong>Date submitted</strong>
-                    <br />
-                    <span>
-                      {moment(response.timestamp).format('MMM D, YYYY')}
-                    </span>
-                  </li>
-                </ul>
-              </div>
-            )}
-          </div>
         </div>
         <div>
           <h2 className="vads-u-font-size--h3 vads-u-font-family--serif">
@@ -80,8 +97,8 @@ export class ConfirmationPage extends React.Component {
             If we haven’t contacted you within a week after you submitted your
             application, <strong>please don’t apply again</strong>. Instead,
             please call our toll-free hotline at{' '}
-            <a href="tel:877-222-8387">877-222-VETS</a> (877-222-8387). We’re
-            here Monday through Friday, 8:00 am to 8:00 pm ET
+            <va-telephone contact="8772228387" vanity="VETS" />. We’re here
+            Monday through Friday, 8:00 am to 8:00 pm ET
           </p>
 
           <h2 className="vads-u-font-size--h3 vads-u-font-family--serif">
@@ -123,7 +140,7 @@ export class ConfirmationPage extends React.Component {
               </p>
             </li>
           </ol>
-          <h2 className="vads-u-font-size--h3 vads-u-font-family--serif">
+          <h2 className="vads-u-font-size--h3 vads-u-font-family--serif vads-u-margin-top--0">
             How will I know if my application to add or remove dependents is
             approved?
           </h2>
@@ -148,9 +165,9 @@ export class ConfirmationPage extends React.Component {
             What if I have more questions?
           </h2>
           <p className="vads-u-margin-bottom--6">
-            Please call <a href="tel:877-222-8387">877-222-VETS</a>{' '}
-            (877-222-8387) and select 2. We’re here Monday through Friday, 8:00
-            a.m. to 8:00 p.m. ET.
+            Please call <va-telephone contact="8772228387" vanity="VETS" /> and
+            select 2. We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.
+            ET.
           </p>
         </div>
       </>
@@ -163,5 +180,24 @@ function mapStateToProps(state) {
     form: state.form,
   };
 }
+
+ConfirmationPage.propTypes = {
+  form: PropTypes.shape({
+    data: PropTypes.shape({
+      veteranInformation: PropTypes.shape({
+        fullName: PropTypes.shape({
+          first: PropTypes.string,
+          last: PropTypes.string,
+        }),
+      }),
+    }),
+    formId: PropTypes.string,
+    submission: PropTypes.shape({
+      response: {
+        timestamp: PropTypes.string,
+      },
+    }),
+  }),
+};
 
 export default connect(mapStateToProps)(ConfirmationPage);

--- a/src/applications/disability-benefits/686c-674/sass/new-686.scss
+++ b/src/applications/disability-benefits/686c-674/sass/new-686.scss
@@ -41,3 +41,16 @@ div.review {
 div.form-review-panel-page-header-row {
   margin-bottom: 1rem;
 }
+
+article[data-location="confirmation"] {
+  @media print {
+    .usa-width-two-thirds {
+      width: 100%;
+    }
+
+    /* hide page title above VA logo */
+    .schemaform-title {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Updated form 686's confirmation page to fix the markup:
- Wrapped app in an `<article>` with a `data-location` attribute to allow targeting specific pages with CSS
- Added prop-types to fix eslint warnings
- Added a VA Logo to the print header
- Replaced paragraphs (`<p>`) with a description list (`<dl>`)
- Moved the print this page button inside the inset (per designs on other forms)
- Replaced telephone link with `<va-telephone>` component with vanity phone number
- Fixed margins around headers

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/30016

## Testing done

Verified passing unit & e2e tests

## Screenshots

<details><summary>Confirmation page with the inset block HTML shown along the side to display the description list markup</summary>

<!-- leave a blank line above -->
<img width="1204" alt="Screen Shot 2022-05-04 at 9 42 01 AM" src="https://user-images.githubusercontent.com/136959/166720469-19e775ac-ea1f-4c9b-9a8b-a92d873c3de4.png"></details>

<details><summary>Print preview</summary>

<!-- leave a blank line above -->
<img width="508" alt="print preview showing a VA logo at the top and using 100% width" src="https://user-images.githubusercontent.com/136959/166720461-2bd90f97-47c6-4369-9775-8586caa4aa83.png"></details>

## Acceptance criteria
- [x] Fix HTML markup for screenreaders
- [x] Bring page up-to-date with design standards
- [x] Use `va-telephone` component 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
