### PR TITLE
686: Address label update

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -155,7 +155,7 @@ export const addressUISchema = (
       },
       addressLine1: {
         'ui:required': callback,
-        'ui:title': 'Street',
+        'ui:title': 'Street address',
         'ui:errorMessages': {
           required: 'Street address is required',
           pattern: 'Street address must be under 100 characters',


### PR DESCRIPTION
## Description

Updating form 686c Veteran address page "Street" label. It should be "Street address"

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30023

## Testing done

Visual testing

## Screenshots

<details><summary>Before & After</summary>

<!-- leave a blank line above -->
Before
<img width="439" alt="Before, 'street' label for input" src="https://user-images.githubusercontent.com/136959/166810311-d39bddc4-cec5-4709-8a0c-d349fcfe9e71.png">

After
<img width="446" alt="After, 'street address' label for input" src="https://user-images.githubusercontent.com/136959/166810308-aa6df633-89ce-42e6-81d2-df4d70f72446.png"></details>

## Acceptance criteria
- [x] Street address label updated
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
