### PR TITLE
686: fix headers

### DIFF
--- a/src/applications/personalization/view-dependents/components/ViewDependentsSidebar/ViewDependentsSidebarBlock.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsSidebar/ViewDependentsSidebarBlock.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 const ViewDependentsSidebarBlock = props => (
   <div className="vads-u-margin-bottom--5">
-    <h3 className="vads-u-margin-top--0 vads-u-padding-bottom--1p5 vads-u-border-bottom--3px vads-u-border-color--primary">
+    <h2 className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-padding-bottom--1p5 vads-u-border-bottom--3px vads-u-border-color--primary">
       {props.heading}
-    </h3>
+    </h2>
     {props.content}
   </div>
 );


### PR DESCRIPTION
## Description

The view dependents page does not follow proper heading hierarchy. The side bar headers should be the same level as the main content (see screenshots)

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30025

## Testing done

Testing using "Headings map" extension

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
Side bar headers are `H3` and therefore nested under the "Dependents not on your VA benefits" header

<img width="1058" alt="Headings map showing sidebar blocks using h3" src="https://user-images.githubusercontent.com/136959/166815322-6ef8dccc-3796-4d12-a096-1bb4265782d7.png"></details>

<details><summary>After</summary>

<!-- leave a blank line above -->
Sidebar headers are now `H2`, and are at the same level as the central content
<img width="1056" alt="Headings map showing sidebar blocks using H2" src="https://user-images.githubusercontent.com/136959/166815305-60e8e355-2d96-411d-9f16-4cbc229b8da7.png"></details>

## Acceptance criteria
- [x] Fix sidebar headings to be `H2` instead of `H3`
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
