### PR TITLE
VAVSA-39384: Prevent Impossible Event Search Filters

### DIFF
--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -1,5 +1,5 @@
 // Node modules.
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 // Relative imports.
 import recordEvent from 'platform/monitoring/record-event';
@@ -8,6 +8,7 @@ import {
   deriveDefaultSelectedOption,
   filterByOptions,
   monthOptions,
+  getDisabledEndDateOptions,
 } from '../../helpers';
 
 export const Search = ({ onSearch }) => {
@@ -32,11 +33,88 @@ export const Search = ({ onSearch }) => {
     queryParams.get('endDateDay') || '',
   );
 
+  const [endDateMonthOptions, setEndDateMonthOptions] = useState(
+    getDisabledEndDateOptions(monthOptions, startDateMonth),
+  );
+  const [endDateDayOptions, setEndDateDayOptions] = useState(
+    startDateMonth === endDateMonth
+      ? getDisabledEndDateOptions(dayOptions, startDateDay)
+      : dayOptions,
+  );
+
   // Derive errors state.
   const [startDateMonthError, setStartDateMonthError] = useState(false);
   const [startDateDayError, setStartDateDayError] = useState(false);
   const [endDateMonthError, setEndDateMonthError] = useState(false);
   const [endDateDayError, setEndDateDayError] = useState(false);
+
+  useEffect(() => {
+    if (startDateMonth > endDateMonth) {
+      setEndDateMonth(startDateMonth);
+    }
+
+    if (startDateMonth === endDateMonth && startDateDay > endDateDay) {
+      setEndDateDay(startDateDay);
+    }
+  }, []);
+
+  useEffect(
+    () => {
+      // If the end month is too early
+      if (startDateMonth > endDateMonth) {
+        setEndDateMonth(startDateMonth);
+        setEndDateDay(startDateDay > endDateDay ? startDateDay : endDateDay);
+      } else if (startDateMonth === endDateMonth) {
+        // If the start and end months are the same
+        setEndDateDay(startDateDay > endDateDay ? startDateDay : endDateDay);
+        setEndDateDayOptions(
+          getDisabledEndDateOptions(dayOptions, startDateDay),
+        );
+      } else {
+        // If the end month is after the start month
+        setEndDateDayOptions(dayOptions);
+      }
+
+      setEndDateMonthOptions(
+        getDisabledEndDateOptions(monthOptions, startDateMonth),
+      );
+    },
+    [startDateMonth],
+  );
+
+  useEffect(
+    () => {
+      if (startDateMonth === endDateMonth) {
+        if (startDateDay > endDateDay) {
+          setEndDateDay(startDateDay);
+        }
+
+        setEndDateDayOptions(
+          getDisabledEndDateOptions(dayOptions, startDateDay),
+        );
+      } else {
+        setEndDateDayOptions(dayOptions);
+      }
+    },
+    [startDateDay],
+  );
+
+  useEffect(
+    () => {
+      if (startDateMonth === endDateMonth) {
+        if (startDateDay > endDateDay) {
+          setEndDateDay(startDateDay);
+        }
+
+        setEndDateDayOptions(
+          getDisabledEndDateOptions(dayOptions, startDateDay),
+        );
+      } else {
+        setEndDateDayOptions(dayOptions);
+      }
+    },
+    [endDateMonth],
+  );
 
   const onFilterByChange = event => {
     const filterByOption = filterByOptions?.find(
@@ -374,8 +452,12 @@ export const Search = ({ onSearch }) => {
                   onChange={event => setEndDateMonth(event.target.value)}
                   value={endDateMonth}
                 >
-                  {monthOptions?.map(option => (
-                    <option key={option?.value} value={option?.value}>
+                  {endDateMonthOptions?.map(option => (
+                    <option
+                      disabled={option?.disabled}
+                      key={option?.value}
+                      value={option?.value}
+                    >
                       {option?.label}
                     </option>
                   ))}
@@ -403,8 +485,12 @@ export const Search = ({ onSearch }) => {
                   onChange={event => setEndDateDay(event.target.value)}
                   value={endDateDay}
                 >
-                  {dayOptions?.map(option => (
-                    <option key={option?.value} value={option?.value}>
+                  {endDateDayOptions?.map(option => (
+                    <option
+                      disabled={option?.disabled}
+                      key={option?.value}
+                      value={option?.value}
+                    >
                       {option?.label}
                     </option>
                   ))}

--- a/src/applications/static-pages/events/helpers/index.js
+++ b/src/applications/static-pages/events/helpers/index.js
@@ -408,3 +408,12 @@ export const deriveFilteredEvents = ({
     endsAtUnix,
   });
 };
+
+export const getDisabledEndDateOptions = (options, limit) => {
+  return options.map(option => {
+    return {
+      ...option,
+      disabled: parseInt(option.value, 10) < limit,
+    };
+  });
+};


### PR DESCRIPTION
## Description

Closes [department-of-veterans-affairs/va.gov-team#39384](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/39384)

## Original issue(s)

[department-of-veterans-affairs/va.gov-team#39384](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/39384)

## Testing done

Visual

## Screenshots

The below screenshots show how options are disabled to prevent impossible date ranges. This pull request also automatically updates the end dates as needed to prevent any impossible date ranges caused by changing earlier dates (for example, changing the start month to a date after the current end month).

<img width="1026" alt="Screen Shot 2022-05-04 at 4 37 09 PM" src="https://user-images.githubusercontent.com/10790736/166821682-c22edd42-3c71-48b0-ae59-c6a41f7ad015.png">

<img width="1048" alt="Screen Shot 2022-05-04 at 4 37 17 PM" src="https://user-images.githubusercontent.com/10790736/166821686-53600303-7a30-4f32-a2e7-610a58c1bf3a.png">

## Testing Setup

- [ ] Run `yarn preview` on `content-build` and `yarn-watch` on `vets-website`
- [ ] Navigate to [this local link.](http://localhost:3002/preview?nodeId=32932)

## Acceptance Criteria

There's a lot of cases to test here...

- [ ] Set the start month and day to a random date. Confirm that the end date and month cannot be set to an earlier month or day than the start dates by checking the disabled options.
- [ ] Change the start month and day to dates that are not later than the current end month and day. Confirm that the disabled options for the end month and day have been updated appropriately.
- [ ] Change the start month and day to dates that are later than the current end month and day. Confirm that the selected end month and day update to the same month and day (to prevent impossible time ranges) and the disabled options for both still update appropriately.
- [ ] Confirm that the end day options are only limited when the start and end months are the same. This prevents impossible ranges within the same months, but still lets users choose from all available days on later months.
- [ ] Set the start month and day to a random date. Set the end month to a month *after* the start month, and the end day to a day *before* the start day. Change the end month to the *same* month as the start month. Confirm that the end day updates to be the same as the start day.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
