### PR TITLE
Remove i18n missing key log lines from tests and app

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -44,7 +44,7 @@ const AppointmentBlock = props => {
                   className="pre-check-in--value"
                   data-testid="appointment-time"
                 >
-                  {t('{{date, time}}', { date: appointmentDateTime })}
+                  {t('date-time', { date: appointmentDateTime })}
                 </dd>
                 <dt className="pre-check-in--label vads-u-margin-right--1">
                   {t('clinic')}:

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -16,7 +16,7 @@ const AppointmentListItem = props => {
           className="appointment-time vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin-bottom--1 "
           data-testid="appointment-time"
         >
-          {t('{{date, time}}', { date: appointmentDateTime })}
+          {t('date-time', { date: appointmentDateTime })}
         </dd>
         <dt className="facility-label vads-u-margin--0 vads-u-margin-right--1 vads-u-font-family--serif vads-u-font-weight--bold ">
           {t('facility')}:{' '}

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -153,5 +153,6 @@
   "your-date-of-birth-can-not-be-in-the-future": "Your date of birth can not be in the future",
   "please-provide-a-response": "Please provide a response",
   "in-en": "in english",
-  "sorry-we-cant-complete-pre-check-in": "Sorry, we can’t complete pre-check-in"
+  "sorry-we-cant-complete-pre-check-in": "Sorry, we can’t complete pre-check-in",
+  "date-time": "{{date, time}}"
 }


### PR DESCRIPTION
## Description
When running tests there are several dozen lines of log output about a missing i18n key, making it difficult to parse the log results. These logs also occasionally appear in the app console on the pages where the missing key is found.

This PR moves the '{{date, time}}' used on a couple pages into its own key to remove these warning lines.

Can we also set i18n debug to false by default, to further clean up logs when running tests? Or do we want the extra verbosity?

## Original issue(s)
N/A
