### PR TITLE
DHP 154 View my devices

### DIFF
--- a/src/applications/dhp-connected-devices/actions/api.js
+++ b/src/applications/dhp-connected-devices/actions/api.js
@@ -1,0 +1,7 @@
+import environment from 'platform/utilities/environment';
+
+const CONNECTED_DEVICES_BASE_URL = `${
+  environment.API_URL
+}/dhp_connected_devices`;
+
+export const FETCH_CONNECTED_DEVICES = `${CONNECTED_DEVICES_BASE_URL}/veteran-device-records`;

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -58,8 +58,7 @@ export const ConnectedDevicesContainer = () => {
       try {
         const headers = { 'Content-Type': 'application/json' };
         const response = await apiRequest(FETCH_CONNECTED_DEVICES, { headers });
-        // console.log('getConnectedDevices', response);
-        setConnectedDevices(response?.data);
+        setConnectedDevices(response?.data?.devices);
       } catch (err) {
         // console.error('getConnectedDevices error:', err);
       }

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -4,23 +4,6 @@ import { DevicesToConnectSection } from './DevicesToConnectSection';
 import { ConnectedDevicesSection } from './ConnectedDevicesSection';
 import { FETCH_CONNECTED_DEVICES } from '../actions/api';
 
-// const devices = [
-//   {
-//     vendor: 'vendor-1',
-//     key: 'vendor1',
-//     authUrl: 'path/to/vetsapi/vendor-1/connect/method',
-//     disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
-//     connected: true,
-//   },
-//   {
-//     vendor: 'vendor-2',
-//     key: 'vendor2',
-//     authUrl: 'path/to/vetsapi/vendor-2/connect/method',
-//     disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
-//     connected: false,
-//   },
-// ];
-
 export const ConnectedDevicesContainer = () => {
   const [connectedDevices, setConnectedDevices] = useState([]);
   const [successAlert, setSuccessAlert] = useState(false);

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -1,35 +1,30 @@
 import React, { useEffect, useState } from 'react';
+import { apiRequest } from 'platform/utilities/api';
 import { DevicesToConnectSection } from './DevicesToConnectSection';
 import { ConnectedDevicesSection } from './ConnectedDevicesSection';
+import { FETCH_CONNECTED_DEVICES } from '../actions/api';
 
-const devices = [
-  {
-    vendor: 'vendor-1',
-    key: 'vendor1',
-    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
-    connected: true,
-  },
-  {
-    vendor: 'vendor-2',
-    key: 'vendor2',
-    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
-    connected: false,
-  },
-];
+// const devices = [
+//   {
+//     vendor: 'vendor-1',
+//     key: 'vendor1',
+//     authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+//     disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+//     connected: true,
+//   },
+//   {
+//     vendor: 'vendor-2',
+//     key: 'vendor2',
+//     authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+//     disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+//     connected: false,
+//   },
+// ];
 
 export const ConnectedDevicesContainer = () => {
   const [connectedDevices, setConnectedDevices] = useState([]);
   const [successAlert, setSuccessAlert] = useState(false);
   const [failureAlert, setFailureAlert] = useState(false);
-
-  const getConnectedDevices = () => {
-    // fetch
-    // await apiRequest(`DHP_API_DEVICES_ENDPOINT`)
-    // update connectedDevices
-    setConnectedDevices(devices);
-  };
 
   const updateConnectedDevices = vendor => {
     const connectedDevicesCopy = [...connectedDevices];
@@ -57,7 +52,21 @@ export const ConnectedDevicesContainer = () => {
   };
 
   // run after initial render
-  useEffect(getConnectedDevices, []);
+  useEffect(() => {
+    const getConnectedDevices = async () => {
+      // fetch from endpoint that returns json
+      try {
+        const headers = { 'Content-Type': 'application/json' };
+        const response = await apiRequest(FETCH_CONNECTED_DEVICES, { headers });
+        // console.log('getConnectedDevices', response);
+        setConnectedDevices(response?.data);
+      } catch (err) {
+        // console.error('getConnectedDevices error:', err);
+      }
+      // setConnectedDevices(devices);
+    };
+    getConnectedDevices();
+  }, []);
   // run if updates to successAlert, failureAlert states
   useEffect(
     () => {

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -9,14 +9,6 @@ export const ConnectedDevicesContainer = () => {
   const [successAlert, setSuccessAlert] = useState(false);
   const [failureAlert, setFailureAlert] = useState(false);
 
-  const updateConnectedDevices = vendor => {
-    const connectedDevicesCopy = [...connectedDevices];
-    const device =
-      connectedDevicesCopy[connectedDevices.findIndex(d => d.key === vendor)];
-    device.connected = true;
-    setConnectedDevices(connectedDevicesCopy);
-  };
-
   const showSuccessAlert = () => {
     setSuccessAlert(true);
   };
@@ -27,7 +19,6 @@ export const ConnectedDevicesContainer = () => {
 
   const showConnectionAlert = (vendor, status) => {
     if (status === 'success') {
-      updateConnectedDevices(vendor);
       showSuccessAlert();
     } else if (status === 'error') {
       showFailureAlert();

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -2,18 +2,34 @@ import React, { useEffect, useState } from 'react';
 import { DevicesToConnectSection } from './DevicesToConnectSection';
 import { ConnectedDevicesSection } from './ConnectedDevicesSection';
 
+const devices = [
+  {
+    vendor: 'vendor-1',
+    key: 'vendor1',
+    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+    connected: true,
+  },
+  {
+    vendor: 'vendor-2',
+    key: 'vendor2',
+    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+    connected: false,
+  },
+];
+
 export const ConnectedDevicesContainer = () => {
-  const [connectedDevices, setConnectedDevices] = useState([
-    {
-      vendor: 'Fitbit',
-      key: 'fitbit',
-      authUrl: `/fitbit`,
-      disconnectUrl: 'placeholder',
-      connected: false,
-    },
-  ]);
+  const [connectedDevices, setConnectedDevices] = useState([]);
   const [successAlert, setSuccessAlert] = useState(false);
   const [failureAlert, setFailureAlert] = useState(false);
+
+  const getConnectedDevices = () => {
+    // fetch
+    // await apiRequest(`DHP_API_DEVICES_ENDPOINT`)
+    // update connectedDevices
+    setConnectedDevices(devices);
+  };
 
   const updateConnectedDevices = vendor => {
     const connectedDevicesCopy = [...connectedDevices];
@@ -40,6 +56,9 @@ export const ConnectedDevicesContainer = () => {
     }
   };
 
+  // run after initial render
+  useEffect(getConnectedDevices, []);
+  // run if updates to successAlert, failureAlert states
   useEffect(
     () => {
       const handleRedirectQueryParams = () => {

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -58,11 +58,10 @@ export const ConnectedDevicesContainer = () => {
       try {
         const headers = { 'Content-Type': 'application/json' };
         const response = await apiRequest(FETCH_CONNECTED_DEVICES, { headers });
-        setConnectedDevices(response?.data?.devices);
+        setConnectedDevices(response?.devices);
       } catch (err) {
         // console.error('getConnectedDevices error:', err);
       }
-      // setConnectedDevices(devices);
     };
     getConnectedDevices();
   }, []);

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
@@ -26,6 +26,7 @@ export const ConnectedDevicesSection = ({
           return (
             <DeviceDisconnectionCard
               device={device}
+              key={device.key}
               onClickHandler={() => {
                 // console.log('Disconnect');
               }}

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
@@ -50,7 +50,7 @@ export const ConnectedDevicesSection = ({
       {failureAlert && <DeviceConnectionFailedAlert />}
       {!areDevicesConnected() && (
         <p data-testid="no-devices-connected-alert">
-          You do not have any devices connected
+          You do not have any devices connected.
         </p>
       )}
       {areDevicesConnected() && connectedDevicesMapped()}
@@ -59,7 +59,7 @@ export const ConnectedDevicesSection = ({
 };
 
 ConnectedDevicesSection.propTypes = {
+  connectedDevices: PropTypes.array.isRequired,
   failureAlert: PropTypes.bool.isRequired,
   successAlert: PropTypes.bool.isRequired,
-  connectedDevices: PropTypes.array,
 };

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
@@ -12,23 +12,36 @@ export const ConnectedDevicesSection = ({
   failureAlert,
 }) => {
   const areDevicesConnected = () => {
-    return connectedDevices.some(device => device.connected);
+    try {
+      return connectedDevices.some(device => device.connected);
+    } catch (err) {
+      return false;
+    }
   };
 
   const connectedDevicesMapped = () => {
-    return connectedDevices.map(device => {
-      if (device.connected) {
-        return (
-          <DeviceDisconnectionCard
-            device={device}
-            onClickHandler={() => {
-              // console.log('Disconnect');
-            }}
-          />
-        );
-      }
-      return <></>;
-    });
+    try {
+      return connectedDevices.map(device => {
+        if (device.connected) {
+          return (
+            <DeviceDisconnectionCard
+              device={device}
+              key={device.key}
+              onClickHandler={() => {
+                // console.log('Disconnect');
+              }}
+            />
+          );
+        }
+        return <></>;
+      });
+    } catch (err) {
+      return (
+        <p data-testid="no-devices-connected-alert">
+          You do not have any devices connected
+        </p>
+      );
+    }
   };
 
   return (
@@ -46,7 +59,7 @@ export const ConnectedDevicesSection = ({
 };
 
 ConnectedDevicesSection.propTypes = {
-  connectedDevices: PropTypes.array.isRequired,
   failureAlert: PropTypes.bool.isRequired,
   successAlert: PropTypes.bool.isRequired,
+  connectedDevices: PropTypes.array,
 };

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
@@ -26,7 +26,6 @@ export const ConnectedDevicesSection = ({
           return (
             <DeviceDisconnectionCard
               device={device}
-              key={device.key}
               onClickHandler={() => {
                 // console.log('Disconnect');
               }}

--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesSection.jsx
@@ -38,7 +38,7 @@ export const ConnectedDevicesSection = ({
     } catch (err) {
       return (
         <p data-testid="no-devices-connected-alert">
-          You do not have any devices connected
+          You do not have any devices connected.
         </p>
       );
     }

--- a/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
@@ -5,7 +5,7 @@ import environment from 'platform/utilities/environment';
 export const DeviceConnectionCard = ({ device }) => {
   return (
     <div className="connect-device">
-      <h3 className="vads-u-margin-y--0">{device.vendor}</h3>
+      <h3 className="vads-u-margin-y--0">{device.name}</h3>
       <p className="vads-u-margin-y--0">
         <a
           data-testid={`${device.key}-connect-link`}

--- a/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
@@ -5,7 +5,7 @@ export const DeviceDisconnectionCard = ({ device, onClickHandler }) => {
   return (
     <div className="connect-device">
       <h3 className="vads-u-margin-y--0">
-        {device.vendor}{' '}
+        {device.name}{' '}
         <span className="connected-header-text"> - Connected</span>{' '}
       </h3>
       <p className="vads-u-margin-y--0">

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -20,7 +20,7 @@ export const DevicesToConnectSection = ({ connectedDevices }) => {
     } catch (err) {
       return (
         <p data-testid="all-devices-connected-alert">
-          There are no devices available to connect. ghvjbkn
+          There are no devices available to connect.
         </p>
       );
     }

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -4,15 +4,27 @@ import { DeviceConnectionCard } from './DeviceConnectionCard';
 
 export const DevicesToConnectSection = ({ connectedDevices }) => {
   const areAllDevicesConnected = () => {
-    return connectedDevices.every(device => device.connected);
+    try {
+      return connectedDevices.every(device => device.connected);
+    } catch (err) {
+      return false;
+    }
   };
   const devicesToConnectMapped = () => {
-    return connectedDevices.map(device => {
-      if (!device.connected) {
-        return <DeviceConnectionCard key={device.vendor} device={device} />;
-      }
-      return <></>;
-    });
+    try {
+      return connectedDevices.map(device => {
+        if (!device.connected) {
+          return <DeviceConnectionCard key={device.vendor} device={device} />;
+        }
+        return <></>;
+      });
+    } catch (err) {
+      return (
+        <p data-testid="all-devices-connected-alert">
+          There are no devices available to connect.
+        </p>
+      );
+    }
   };
 
   return (
@@ -28,5 +40,5 @@ export const DevicesToConnectSection = ({ connectedDevices }) => {
 };
 
 DevicesToConnectSection.propTypes = {
-  connectedDevices: PropTypes.array.isRequired,
+  connectedDevices: PropTypes.array,
 };

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -39,5 +39,5 @@ export const DevicesToConnectSection = ({ connectedDevices }) => {
 };
 
 DevicesToConnectSection.propTypes = {
-  connectedDevices: PropTypes.array,
+  connectedDevices: PropTypes.array.isRequired,
 };

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -12,16 +12,15 @@ export const DevicesToConnectSection = ({ connectedDevices }) => {
   };
   const devicesToConnectMapped = () => {
     try {
-      return connectedDevices.map(device => {
-        if (!device.connected) {
-          return <DeviceConnectionCard key={device.vendor} device={device} />;
-        }
-        return <></>;
-      });
+      return connectedDevices
+        .filter(device => !device.connected)
+        .map(device => {
+          return <DeviceConnectionCard key={device.key} device={device} />;
+        });
     } catch (err) {
       return (
         <p data-testid="all-devices-connected-alert">
-          There are no devices available to connect.
+          There are no devices available to connect. ghvjbkn
         </p>
       );
     }

--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -6,6 +6,7 @@ import { FrequentlyAskedQuestions } from '../components/FrequentlyAskedQuestions
 
 export default function App() {
   const isLoggedIn = useSelector(state => state.user.login.currentlyLoggedIn);
+
   return (
     <div className="usa-grid-full margin landing-page">
       <div className="usa-width-three-fourths">

--- a/src/applications/dhp-connected-devices/tests/components/AuthenticatedPageContent.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/AuthenticatedPageContent.spec.js
@@ -24,7 +24,7 @@ describe('as an authenticated user, landing page', () => {
     ],
   };
 
-  before(() => {
+  beforeEach(() => {
     mockApiRequest(connectedDevicesList);
   });
 

--- a/src/applications/dhp-connected-devices/tests/components/AuthenticatedPageContent.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/AuthenticatedPageContent.spec.js
@@ -1,9 +1,33 @@
 import React from 'react';
 import { expect } from 'chai';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import { AuthenticatedPageContent } from '../../components/AuthenticatedPageContent';
 
 describe('as an authenticated user, landing page', () => {
+  const connectedDevicesList = {
+    devices: [
+      {
+        name: 'Fitbit-1',
+        key: 'fitbit',
+        authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+        disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+        connected: true,
+      },
+      {
+        name: 'vendor-2',
+        key: 'vendor 2',
+        authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+        disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+        connected: false,
+      },
+    ],
+  };
+
+  before(() => {
+    mockApiRequest(connectedDevicesList);
+  });
+
   it('renders with "Devices" sections', () => {
     const loggedInState = {
       user: {
@@ -17,18 +41,5 @@ describe('as an authenticated user, landing page', () => {
     });
     expect(screen.getByText(/Your connected devices/)).to.exist;
     expect(screen.getByText(/Devices you can connect/)).to.exist;
-  });
-  it("renders 'Fitbit'", () => {
-    const loggedInState = {
-      user: {
-        login: {
-          currentlyLoggedIn: true,
-        },
-      },
-    };
-    const screen = renderInReduxProvider(<AuthenticatedPageContent />, {
-      initialState: loggedInState,
-    });
-    expect(screen.getByText(/Fitbit/)).to.exist;
   });
 });

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -157,10 +157,10 @@ describe('Connect Devices Container', () => {
 describe('Device connection url parameters', () => {
   const successUrl = `${
     environment.BASE_URL
-  }/health-care/connected-devices/?vendor1=success#_=_`;
+  }/health-care/connected-devices/?vendor-1=success#_=_`;
   const failureUrl = `${
     environment.BASE_URL
-  }/health-care/connected-devices/?vendor1=error#_=_`;
+  }/health-care/connected-devices/?vendor-1=error#_=_`;
   const savedLocation = window.location;
 
   beforeEach(() => {
@@ -171,6 +171,7 @@ describe('Device connection url parameters', () => {
   });
 
   it('should render success alert when url params contain a success message', async () => {
+    mockApiRequest(oneDeviceConnectedState);
     window.location = Object.assign(new URL(successUrl), {
       ancestorOrigins: '',
       assign: sinon.spy(),

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -6,55 +6,62 @@ import environment from 'platform/utilities/environment';
 import { mockApiRequest } from 'platform/testing/unit/helpers';
 import { ConnectedDevicesContainer } from '../../components/ConnectedDevicesContainer';
 
-const noDevicesConnectedState = [
-  {
-    vendor: 'vendor-1',
-    key: 'vendor1',
-    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
-    connected: false,
-  },
-  {
-    vendor: 'vendor-2',
-    key: 'vendor2',
-    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
-    connected: false,
-  },
-];
-const oneDeviceConnectedState = [
-  {
-    vendor: 'vendor-1',
-    key: 'vendor1',
-    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
-    connected: true,
-  },
-  {
-    vendor: 'vendor-2',
-    key: 'vendor2',
-    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
-    connected: false,
-  },
-];
+const noDevicesConnectedState = {
+  devices: [
+    {
+      name: 'Vendor 1',
+      key: 'vendor-1',
+      authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+      disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+      connected: false,
+    },
+    {
+      name: 'Vendor 2',
+      key: 'vendor-2',
+      authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+      disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+      connected: false,
+    },
+  ],
+};
 
-const twoDevicesConnectedState = [
-  {
-    vendor: 'vendor 1',
-    key: 'vendor-1',
-    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
-    connected: true,
-  },
-  {
-    vendor: 'vendor 2',
-    key: 'vendor-2',
-    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
-    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
-    connected: true,
-  },
-];
+const oneDeviceConnectedState = {
+  devices: [
+    {
+      name: 'Vendor 1',
+      key: 'vendor-1',
+      authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+      disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+      connected: true,
+    },
+    {
+      name: 'Vendor 2',
+      key: 'vendor-2',
+      authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+      disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+      connected: false,
+    },
+  ],
+};
+
+const twoDevicesConnectedState = {
+  devices: [
+    {
+      name: 'Vendor 1',
+      key: 'vendor-1',
+      authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+      disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+      connected: true,
+    },
+    {
+      name: 'Vendor 2',
+      key: 'vendor-2',
+      authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+      disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+      connected: true,
+    },
+  ],
+};
 
 describe('Connect Devices Container', () => {
   it('should render DeviceConnectionSection and DeviceConnectionCards when devices are not connected', async () => {
@@ -82,8 +89,13 @@ describe('Connect Devices Container', () => {
     const connectedDevicesContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
     );
+
+    const vendorKey = oneDeviceConnectedState.devices[0].key;
+
     expect(
-      await connectedDevicesContainer.findByTestId('vendor-1-connect-link'),
+      await connectedDevicesContainer.findByTestId(
+        `${vendorKey}-disconnect-link`,
+      ),
     ).to.exist;
   });
 
@@ -96,7 +108,7 @@ describe('Connect Devices Container', () => {
 
     expect(
       noConnectedDevicesContainer.findByText(
-        'You do not have any devices connected',
+        'You do not have any devices connected.',
       ),
     ).to.exist;
   });
@@ -109,7 +121,7 @@ describe('Connect Devices Container', () => {
 
     expect(
       twoDevicesConnectedContainer.findByTestId('all-devices-connected-alert'),
-    ).to.be.empty;
+    ).to.exist;
   });
 
   it('should render success alert when successAlert is set to true', () => {

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -6,7 +6,6 @@ import environment from 'platform/utilities/environment';
 import { mockApiRequest } from 'platform/testing/unit/helpers';
 import { ConnectedDevicesContainer } from '../../components/ConnectedDevicesContainer';
 
-// mockApiRequest(mockData);
 const noDevicesConnectedState = [
   {
     vendor: 'vendor-1',
@@ -77,7 +76,7 @@ describe('Connect Devices Container', () => {
     ).to.exist;
   });
 
-  it('should render apple watch in connected devices section when connected', async () => {
+  it('should render Vendor 1 in connected devices section when connected', async () => {
     mockApiRequest(oneDeviceConnectedState);
 
     const connectedDevicesContainer = renderInReduxProvider(

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -42,15 +42,15 @@ const oneDeviceConnectedState = [
 
 const twoDevicesConnectedState = [
   {
-    vendor: 'vendor-1',
-    key: 'vendor1',
+    vendor: 'vendor 1',
+    key: 'vendor-1',
     authUrl: 'path/to/vetsapi/vendor-1/connect/method',
     disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
     connected: true,
   },
   {
-    vendor: 'vendor-2',
-    key: 'vendor2',
+    vendor: 'vendor 2',
+    key: 'vendor-2',
     authUrl: 'path/to/vetsapi/vendor-2/connect/method',
     disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
     connected: true,
@@ -72,8 +72,9 @@ describe('Connect Devices Container', () => {
         'devices-to-connect-section',
       ),
     ).to.exist;
-    expect(await connectedDevicesContainer.findByTestId('fitbit-connect-link'))
-      .to.exist;
+    expect(
+      await connectedDevicesContainer.findByTestId('vendor-1-connect-link'),
+    ).to.exist;
   });
 
   it('should render apple watch in connected devices section when connected', async () => {
@@ -82,8 +83,9 @@ describe('Connect Devices Container', () => {
     const connectedDevicesContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
     );
-    expect(await connectedDevicesContainer.findByTestId('vendor1-connect-link'))
-      .to.exist;
+    expect(
+      await connectedDevicesContainer.findByTestId('vendor-1-connect-link'),
+    ).to.exist;
   });
 
   it('should render "You do not have any devices connected" when no devices are connected', () => {
@@ -102,22 +104,12 @@ describe('Connect Devices Container', () => {
 
   it('should render "You have connected all supported devices" when all supported devices are connected', () => {
     mockApiRequest(twoDevicesConnectedState);
-
-    const twoConnectedDevicesContainer = renderInReduxProvider(
+    const twoDevicesConnectedContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
     );
 
     expect(
-      twoConnectedDevicesContainer.findByTestId('no-devices-connected-alert'),
-    ).to.exist;
-
-    mockApiRequest(oneDeviceConnectedState);
-    const oneConnectedDeviceContainer = renderInReduxProvider(
-      <ConnectedDevicesContainer />,
-    );
-
-    expect(
-      oneConnectedDeviceContainer.findByTestId('all-devices-connected-alert'),
+      twoDevicesConnectedContainer.findByTestId('all-devices-connected-alert'),
     ).to.be.empty;
   });
 

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -3,10 +3,64 @@ import { expect } from 'chai';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import sinon from 'sinon';
 import environment from 'platform/utilities/environment';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import { ConnectedDevicesContainer } from '../../components/ConnectedDevicesContainer';
+
+// mockApiRequest(mockData);
+const noDevicesConnectedState = [
+  {
+    vendor: 'vendor-1',
+    key: 'vendor1',
+    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+    connected: false,
+  },
+  {
+    vendor: 'vendor-2',
+    key: 'vendor2',
+    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+    connected: false,
+  },
+];
+const oneDeviceConnectedState = [
+  {
+    vendor: 'vendor-1',
+    key: 'vendor1',
+    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+    connected: true,
+  },
+  {
+    vendor: 'vendor-2',
+    key: 'vendor2',
+    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+    connected: false,
+  },
+];
+
+const twoDevicesConnectedState = [
+  {
+    vendor: 'vendor-1',
+    key: 'vendor1',
+    authUrl: 'path/to/vetsapi/vendor-1/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-1/disconnect/method',
+    connected: true,
+  },
+  {
+    vendor: 'vendor-2',
+    key: 'vendor2',
+    authUrl: 'path/to/vetsapi/vendor-2/connect/method',
+    disconnectUrl: 'path/to/vetsapi/vendor-2/disconnect/method',
+    connected: true,
+  },
+];
 
 describe('Connect Devices Container', () => {
   it('should render DeviceConnectionSection and DeviceConnectionCards when devices are not connected', async () => {
+    mockApiRequest(noDevicesConnectedState);
+
     const connectedDevicesContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
     );
@@ -23,28 +77,20 @@ describe('Connect Devices Container', () => {
   });
 
   it('should render apple watch in connected devices section when connected', async () => {
+    mockApiRequest(oneDeviceConnectedState);
+
     const connectedDevicesContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
     );
-    expect(await connectedDevicesContainer.findByTestId('fitbit-connect-link'))
+    expect(await connectedDevicesContainer.findByTestId('vendor1-connect-link'))
       .to.exist;
   });
 
   it('should render "You do not have any devices connected" when no devices are connected', () => {
-    const noDevicesConnectedState = {
-      connectedDevices: [
-        {
-          vendor: 'Fitbit',
-          authUrl: 'path/to/vetsapi/fitbit/connect/method',
-          disconnectUrl: 'placeholder',
-          connected: false,
-        },
-      ],
-    };
+    mockApiRequest(noDevicesConnectedState);
 
     const noConnectedDevicesContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
-      { noDevicesConnectedState },
     );
 
     expect(
@@ -55,46 +101,19 @@ describe('Connect Devices Container', () => {
   });
 
   it('should render "You have connected all supported devices" when all supported devices are connected', () => {
-    const allDevicesConnectedState = {
-      connectedDevices: [
-        {
-          vendor: 'Fitbit',
-          authUrl: 'path/to/vetsapi/fitbit/connect/method',
-          disconnectUrl: 'placeholder',
-          connected: true,
-        },
-      ],
-    };
+    mockApiRequest(twoDevicesConnectedState);
 
-    const allConnectedDevicesContainer = renderInReduxProvider(
+    const twoConnectedDevicesContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
-      { allDevicesConnectedState },
     );
 
     expect(
-      allConnectedDevicesContainer.findByTestId('no-devices-connected-alert'),
+      twoConnectedDevicesContainer.findByTestId('no-devices-connected-alert'),
     ).to.exist;
 
-    const oneDeviceConnectedState = {
-      connectedDevices: [
-        {
-          vendor: 'Fitbit',
-          authUrl: 'path/to/vetsapi/fitbit/connect/method',
-          disconnectUrl: 'placeholder',
-          connected: true,
-        },
-        {
-          vendor: 'Fitbit2',
-          authUrl: 'path/to/vetsapi/fitbit/connect/method',
-          disconnectUrl: 'placeholder',
-          connected: false,
-        },
-      ],
-    };
-
+    mockApiRequest(oneDeviceConnectedState);
     const oneConnectedDeviceContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,
-      { oneDeviceConnectedState },
     );
 
     expect(
@@ -103,15 +122,8 @@ describe('Connect Devices Container', () => {
   });
 
   it('should render success alert when successAlert is set to true', () => {
+    mockApiRequest(twoDevicesConnectedState);
     const initialState = {
-      connectedDevices: [
-        {
-          vendor: 'Fitbit',
-          authUrl: 'path/to/vetsapi/fitbit/connect/method',
-          disconnectUrl: 'placeholder',
-          connected: true,
-        },
-      ],
       successAlert: true,
     };
     const connectedDevicesContainer = renderInReduxProvider(
@@ -124,15 +136,9 @@ describe('Connect Devices Container', () => {
   });
 
   it('should render failure alert when failureAlert is set to true', () => {
+    mockApiRequest(twoDevicesConnectedState);
+
     const initialState = {
-      connectedDevices: [
-        {
-          vendor: 'Fitbit',
-          authUrl: 'path/to/vetsapi/fitbit/connect/method',
-          disconnectUrl: 'placeholder',
-          connected: false,
-        },
-      ],
       failureAlert: true,
     };
     const connectedDevicesContainer = renderInReduxProvider(
@@ -148,10 +154,10 @@ describe('Connect Devices Container', () => {
 describe('Device connection url parameters', () => {
   const successUrl = `${
     environment.BASE_URL
-  }/health-care/connected-devices/?fitbit=success#_=_`;
+  }/health-care/connected-devices/?vendor1=success#_=_`;
   const failureUrl = `${
     environment.BASE_URL
-  }/health-care/connected-devices/?fitbit=error#_=_`;
+  }/health-care/connected-devices/?vendor1=error#_=_`;
   const savedLocation = window.location;
 
   beforeEach(() => {

--- a/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
@@ -7,7 +7,7 @@ describe('Device connection card', () => {
   it('Renders vendors name', () => {
     const card = renderInReduxProvider(
       <DeviceConnectionCard
-        device={{ vendor: 'Test Vendor' }}
+        device={{ name: 'Test Vendor' }}
         authUrl="www.google.com"
       />,
     );

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { DeviceDisconnectionCard } from '../../components/DeviceDisconnectionCard';
+
+describe('Device to connect card', () => {
+  it('Renders vendors name', () => {
+    const card = renderInReduxProvider(
+      <DeviceDisconnectionCard
+        device={{ name: 'Test Vendor' }}
+        onClickHandler="www.google.com"
+      />,
+    );
+
+    expect(card.getByText(/Test Vendor/)).to.exist;
+  });
+});


### PR DESCRIPTION
## Description
Fetches a list of devices from vets api endpoint `/dhp_connected_devices/veteran-device-records` to render devices sections on the connected devices page.

## Original issue(s)


## Testing done
Existing component tests were modified to use data returned from a mock api request. 

## Screenshots
If no devices are returned from the fetch:
![Screen Shot 2022-05-04 at 4 54 01 PM](https://user-images.githubusercontent.com/29789422/166848483-6f7cba13-983c-4e79-939b-7ef535cab817.png)

If the list returned by the fetch contains devices, creates a card in the appropriate sections based on whether the device is connected for user. 
 ![Screen Shot 2022-05-04 at 5 28 18 PM](https://user-images.githubusercontent.com/29789422/166848480-5223e0e4-57ec-4ab7-94ad-4ceda68de5df.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs



