### PR TITLE
(feature) New content messaging for direct deposit 

### DIFF
--- a/src/applications/static-pages/cta-widget/TODO.content.changes.md
+++ b/src/applications/static-pages/cta-widget/TODO.content.changes.md
@@ -1,8 +1,0 @@
-# TODO
-
-- Create mock server endpoitns for
-  - feature toggles,
-  - user profile
-  - mvh data
-- Create Feature Toggle for this
-- tests for sign in and need verify

--- a/src/applications/static-pages/cta-widget/TODO.content.changes.md
+++ b/src/applications/static-pages/cta-widget/TODO.content.changes.md
@@ -1,0 +1,8 @@
+# TODO
+
+- Create mock server endpoitns for
+  - feature toggles,
+  - user profile
+  - mvh data
+- Create Feature Toggle for this
+- tests for sign in and need verify

--- a/src/applications/static-pages/cta-widget/components/messages/DirectDeposit/MFA.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/DirectDeposit/MFA.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CallToActionAlert from '../../CallToActionAlert';
+
+const MFA = ({ primaryButtonHandler }) => {
+  const content = {
+    heading: `Verify your identity with Login.gov or ID.me to change your direct deposit information online`,
+    alertText: (
+      <>
+        <p>
+          Before we give you access to change your direct deposit information,
+          we need to make sure you’re you—and not someone pretending to be you.
+          This helps us protect your bank account and prevent fraud.
+        </p>
+        <p>
+          <strong>If you have a verified Login.gov or ID.me account</strong>,
+          sign out now. Then sign back in with that account to continue.
+        </p>
+        <p>
+          <strong>If you don’t have one of these accounts</strong>, you can
+          create one and verify your identity now.
+        </p>
+        <p>Create a Login.gov account</p>
+        <p>Create an ID.me account</p>
+        <p>
+          <strong>Note:</strong> If you need help updating your direct deposit
+          information, call us at <va-telephone contact="800-827-1000" />
+          <va-telephone contact="711">TTY : 711</va-telephone>. We’re here
+          Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+        </p>
+      </>
+    ),
+    primaryButtonText: 'Set up 2-factor authentication',
+    primaryButtonHandler,
+    status: 'continue',
+  };
+
+  return <CallToActionAlert {...content} />;
+};
+
+MFA.propTypes = {
+  primaryButtonHandler: PropTypes.func.isRequired,
+};
+
+export default MFA;

--- a/src/applications/static-pages/cta-widget/components/messages/DirectDeposit/MFA.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/DirectDeposit/MFA.jsx
@@ -7,7 +7,7 @@ const MFA = ({ primaryButtonHandler }) => {
     heading: `Verify your identity with Login.gov or ID.me to change your direct deposit information online`,
     alertText: (
       <>
-        <p>
+        <p data-testid="direct-deposit-mfa-message">
           Before we give you access to change your direct deposit information,
           we need to make sure you’re you—and not someone pretending to be you.
           This helps us protect your bank account and prevent fraud.

--- a/src/applications/static-pages/cta-widget/components/messages/DirectDeposit/Unauthed.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/DirectDeposit/Unauthed.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CallToActionAlert from '../../CallToActionAlert';
+
+const Unauthed = ({
+  primaryButtonHandler,
+  headerLevel,
+  ariaLabel = null,
+  ariaDescribedby = null,
+}) => {
+  const content = {
+    heading: `Sign in to change your direct deposit information online`,
+    headerLevel,
+    alertText: (
+      <div>
+        <p>
+          Sign in with your existing Login.gov or ID.me account. Or create one
+          of these accounts now.
+        </p>
+        <p>
+          <strong>Note:</strong> If you sign in with a DS Logon or My HealtheVet
+          account, you won’t be able to change your direct deposit information.
+        </p>
+      </div>
+    ),
+    primaryButtonText: 'Sign in or create an account',
+    primaryButtonHandler,
+    status: 'continue',
+    ariaLabel,
+    ariaDescribedby,
+  };
+
+  return <CallToActionAlert {...content} />;
+};
+
+Unauthed.propTypes = {
+  primaryButtonHandler: PropTypes.func.isRequired,
+  ariaDescribedby: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  headerLevel: PropTypes.number,
+};
+
+export default Unauthed;

--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -6,12 +6,25 @@ import appendQuery from 'append-query';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 // Relative imports.
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import recordEvent from 'platform/monitoring/record-event';
+import {
+  createAndUpgradeMHVAccount,
+  fetchMHVAccount,
+  upgradeMHVAccount,
+} from 'platform/user/profile/actions';
+
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
+import { isLoggedIn, selectProfile } from 'platform/user/selectors';
+import { logout, verify, mfa } from 'platform/user/authentication/utilities';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import { AUTH_EVENTS } from 'platform/user/authentication/constants';
+import MFA from './components/messages/DirectDeposit/MFA';
 import ChangeAddress from './components/messages/ChangeAddress';
 import DeactivatedMHVIds from './components/messages/DeactivatedMHVIds';
 import DirectDeposit from './components/messages/DirectDeposit';
+import DirectDepositUnAuthed from './components/messages/DirectDeposit/Unauthed';
 import HealthToolsDown from './components/messages/HealthToolsDown';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-import MFA from './components/messages/MFA';
 import MultipleIds from './components/messages/MultipleIds';
 import NeedsSSNResolution from './components/messages/NeedsSSNResolution';
 import NoMHVAccount from './components/messages/NoMHVAccount';
@@ -24,19 +37,8 @@ import UpgradeAccount from './components/messages/UpgradeAccount';
 import UpgradeFailed from './components/messages/UpgradeFailed';
 import VAOnlineScheduling from './components/messages/VAOnlineScheduling';
 import Verify from './components/messages/Verify';
-import recordEvent from 'platform/monitoring/record-event';
 import { ACCOUNT_STATES, ACCOUNT_STATES_SET } from './constants';
-import {
-  createAndUpgradeMHVAccount,
-  fetchMHVAccount,
-  upgradeMHVAccount,
-} from 'platform/user/profile/actions';
 import { ctaWidgetsLookup, CTA_WIDGET_TYPES } from './ctaWidgets';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
-import { isLoggedIn, selectProfile } from 'platform/user/selectors';
-import { logout, verify, mfa } from 'platform/user/authentication/utilities';
-import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
-import { AUTH_EVENTS } from 'platform/user/authentication/constants';
 
 export class CallToActionWidget extends Component {
   static propTypes = {
@@ -134,6 +136,16 @@ export class CallToActionWidget extends Component {
 
   getContent = () => {
     if (!this.props.isLoggedIn) {
+      if (this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT) {
+        return (
+          <DirectDepositUnAuthed
+            primaryButtonHandler={this.openLoginModal}
+            headerLevel={this.props.headerLevel}
+            ariaLabel={this.props.ariaLabel}
+            ariaDescribedby={this.props.ariaDescribedby}
+          />
+        );
+      }
       return (
         <SignIn
           serviceDescription={this._serviceDescription}
@@ -175,14 +187,8 @@ export class CallToActionWidget extends Component {
 
     if (this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT) {
       if (!this.props.profile.multifactor) {
-        return (
-          <MFA
-            serviceDescription={this._serviceDescription}
-            primaryButtonHandler={this.mfaHandler}
-          />
-        );
+        return <MFA primaryButtonHandler={this.mfaHandler} />;
       }
-
       return (
         <DirectDeposit
           serviceDescription={this._serviceDescription}
@@ -273,7 +279,8 @@ export class CallToActionWidget extends Component {
           primaryButtonHandler={this.verifyHandler}
         />
       );
-    } else if (mhvAccountIdState === 'DEACTIVATED') {
+    }
+    if (mhvAccountIdState === 'DEACTIVATED') {
       recordEvent({ event: `${this._gaPrefix}-error-has-deactivated-mhv-ids` });
       return <DeactivatedMHVIds />;
     }
@@ -414,7 +421,8 @@ export class CallToActionWidget extends Component {
       const ctaWidget = ctaWidgetsLookup?.[appId];
 
       return ctaWidget?.hasRequiredMhvAccount(mhvAccount.accountLevel);
-    } else if (this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT) {
+    }
+    if (this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT) {
       // Direct Deposit requires multifactor
       return this.props.profile.verified && this.props.profile.multifactor;
     }

--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -19,7 +19,8 @@ import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import { logout, verify, mfa } from 'platform/user/authentication/utilities';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { AUTH_EVENTS } from 'platform/user/authentication/constants';
-import MFA from './components/messages/DirectDeposit/MFA';
+import MFAV2 from './components/messages/DirectDeposit/MFA';
+import MFA from './components/messages/MFA';
 import ChangeAddress from './components/messages/ChangeAddress';
 import DeactivatedMHVIds from './components/messages/DeactivatedMHVIds';
 import DirectDeposit from './components/messages/DirectDeposit';
@@ -136,7 +137,10 @@ export class CallToActionWidget extends Component {
 
   getContent = () => {
     if (!this.props.isLoggedIn) {
-      if (this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT) {
+      if (
+        this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT &&
+        this.props.featureToggles.profileShowNewDirectDepositCtaMessage
+      ) {
         return (
           <DirectDepositUnAuthed
             primaryButtonHandler={this.openLoginModal}
@@ -187,6 +191,9 @@ export class CallToActionWidget extends Component {
 
     if (this.props.appId === CTA_WIDGET_TYPES.DIRECT_DEPOSIT) {
       if (!this.props.profile.multifactor) {
+        if (this.props.featureToggles.profileShowNewDirectDepositCtaMessage) {
+          return <MFAV2 primaryButtonHandler={this.mfaHandler} />;
+        }
         return <MFA primaryButtonHandler={this.mfaHandler} />;
       }
       return (

--- a/src/applications/static-pages/cta-widget/tests/index.unit.spec.js
+++ b/src/applications/static-pages/cta-widget/tests/index.unit.spec.js
@@ -20,7 +20,12 @@ const defaultOptions = {
   mviStatus: {},
 };
 
-const getData = ({ profile = {}, mhvAccount = {}, mviStatus = {} } = {}) => ({
+const getData = ({
+  profile = {},
+  mhvAccount = {},
+  mviStatus = {},
+  featureToggles = {},
+} = {}) => ({
   props: {
     profile: {
       ...defaultOptions.profile,
@@ -40,6 +45,7 @@ const getData = ({ profile = {}, mhvAccount = {}, mviStatus = {} } = {}) => ({
     getState: () => ({
       featureToggles: {
         loading: false,
+        ...featureToggles,
       },
       user: {
         profile: {
@@ -125,6 +131,51 @@ describe('<CallToActionWidget>', () => {
     expect(signIn.prop('ariaDescribedby')).to.eq('test-id');
     tree.unmount();
   });
+  it('should show general sign in state when the direct deposit toggle if false', () => {
+    const { props, mockStore } = getData();
+    const tree = mount(
+      <Provider store={mockStore}>
+        <CallToActionWidget
+          {...props}
+          featureToggles={{
+            loading: false,
+            profileShowNewDirectDepositCtaMessage: false,
+          }}
+          appId={CTA_WIDGET_TYPES.DIRECT_DEPOSIT}
+          ariaLabel="test aria-label"
+          ariaDescribedby="test-id"
+        />
+      </Provider>,
+    );
+
+    const signIn = tree.find('SignIn');
+    expect(tree.find('LoadingIndicator').exists()).to.be.false;
+    expect(signIn.exists()).to.be.true;
+    expect(signIn.prop('ariaLabel')).to.eq('test aria-label');
+    expect(signIn.prop('ariaDescribedby')).to.eq('test-id');
+    tree.unmount();
+  });
+  it('should show direct deposit sign in state when the direct deposit toggle if true', () => {
+    const { props, mockStore } = getData();
+    const tree = mount(
+      <Provider store={mockStore}>
+        <CallToActionWidget
+          {...props}
+          featureToggles={{
+            loading: false,
+            profileShowNewDirectDepositCtaMessage: true,
+          }}
+          appId={CTA_WIDGET_TYPES.DIRECT_DEPOSIT}
+          ariaLabel="test aria-label"
+          ariaDescribedby="test-id"
+        />
+      </Provider>,
+    );
+    expect(tree.find('Unauthed').exists()).to.be.true;
+
+    tree.unmount();
+  });
+
   it('should show verify link', () => {
     const tree = mount(
       <CallToActionWidget
@@ -455,7 +506,7 @@ describe('<CallToActionWidget>', () => {
       tree.unmount();
     });
 
-    it('should show multifactor message for direct deposit', () => {
+    it('should show multifactor message for direct deposit and toggle is disabled', () => {
       const tree = mount(
         <CallToActionWidget
           fetchMHVAccount={d => d}
@@ -474,11 +525,42 @@ describe('<CallToActionWidget>', () => {
           mviStatus="GOOD"
           featureToggles={{
             loading: false,
+            profileShowNewDirectDepositCtaMessage: false,
           }}
         />,
       );
 
       expect(tree.find('MFA').exists()).to.be.true;
+      expect(tree.find('[data-testid="direct-deposit-mfa-message"]').exists())
+        .to.be.false;
+      tree.unmount();
+    });
+
+    it('should show revised multifactor message for direct deposit and toggle is disabled', () => {
+      const tree = mount(
+        <CallToActionWidget
+          fetchMHVAccount={d => d}
+          isLoggedIn
+          appId={CTA_WIDGET_TYPES.DIRECT_DEPOSIT}
+          profile={{
+            loading: false,
+            verified: true,
+            multifactor: false,
+          }}
+          mhvAccount={{
+            loading: false,
+            accountState: 'good',
+            accountLevel: 'Premium',
+          }}
+          mviStatus="GOOD"
+          featureToggles={{
+            loading: false,
+            profileShowNewDirectDepositCtaMessage: true,
+          }}
+        />,
+      );
+      expect(tree.find('[data-testid="direct-deposit-mfa-message"]').exists())
+        .to.be.true;
       tree.unmount();
     });
 
@@ -501,6 +583,7 @@ describe('<CallToActionWidget>', () => {
           mviStatus="GOOD"
           featureToggles={{
             loading: false,
+            profileShowNewDirectDepositCtaMessage: false,
           }}
         />,
       );
@@ -508,6 +591,7 @@ describe('<CallToActionWidget>', () => {
       expect(tree.find('DirectDeposit').exists()).to.be.true;
       tree.unmount();
     });
+
     describe('account state errors', () => {
       const defaultProps = {
         fetchMHVAccount: d => d,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -84,6 +84,7 @@ export default Object.freeze({
   profileShowFaxNumber: 'profile_show_fax_number',
   profileShowGender: 'profile_show_gender',
   profileShowPronounsAndSexualOrientation: 'profile_show_pronouns_and_sexual_orientation',
+  profileShowNewDirectDepositCTAMessage: 'profile_show_new_direct_deposit_cta_message',
   profileUseVaosV2Api:'profile_use_vaos_v2_api',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',


### PR DESCRIPTION
## Description
The app I am working only allows users to use `ID.me` and `Login.gov` to access a feature, therefore, we want to only show those as options. This PR hides the only options from the list, just for our app. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/40723

## Testing done
- added unit tests

## Screenshots
![Screen Shot 2022-05-05 at 11 09 22 AM](https://user-images.githubusercontent.com/1793923/166954466-b4cc7d93-8355-4267-a1b4-f9a3004e2dfd.png)

