### PR TITLE
686: Improve a11y

### DIFF
--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import classNames from 'classnames';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
+
 import ManageDependents from '../../manage-dependents/containers/ManageDependentsApp';
+import { mask } from '../../util';
 
 function ViewDependentsListItem(props) {
   const [open, setOpen] = useState(false);
@@ -34,54 +35,48 @@ function ViewDependentsListItem(props) {
     }
   };
 
+  const fullName = `${firstName} ${lastName}`;
+
   return (
-    <div className="vads-l-row vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding-x--2">
+    <div className="mng-dependents-list-item vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding--2">
+      <h3 className="vads-u-font-family--serif vads-u-font-size--lg vads-u-margin-top--0 mng-dependents-name">
+        {fullName}
+      </h3>
       <dl
-        className={classNames({
-          'vads-l-row': true,
-          'vads-u-margin-bottom--0': manageDependentsToggle === true,
-          'vads-u-margin-bottom--2': manageDependentsToggle === false,
-        })}
+        className={`vads-u-margin-bottom--${
+          manageDependentsToggle ? '0p5' : '1'
+        }`}
       >
-        <dt
-          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-          tabIndex="-1"
-          className="vads-u-font-family--serif vads-l-col--12 vads-u-margin--0 vads-u-font-size--lg vads-u-font-weight--bold mng-dependents-name"
-        >
-          {firstName} {lastName}
-        </dt>
-        {manageDependentsToggle &&
-          submittedDependents.includes(stateKey) && (
-            <dd
-              aria-live="polite"
-              className="vads-l-col--12 vads-u-margin-y--1p5"
-            >
-              <dfn title="status">
-                <i
-                  aria-hidden="true"
-                  role="img"
-                  className="fas fa-exclamation-triangle"
-                />{' '}
-                Status:
-              </dfn>{' '}
-              Removal of dependent pending
-            </dd>
-          )}
-        <dd className="vads-l-col--12 vads-u-margin--0">
-          <dfn title="relationship">Relationship:</dfn> {relationship}
-        </dd>
+        {manageDependentsToggle && submittedDependents.includes(stateKey) ? (
+          <div aria-live="polite">
+            <dt>
+              <i
+                aria-hidden="true"
+                role="img"
+                className="fas fa-exclamation-triangle"
+              />{' '}
+              Status:&nbsp;
+            </dt>
+            <dd>Removal of dependent pending</dd>
+          </div>
+        ) : null}
+        <div>
+          <dt>Relationship:&nbsp;</dt>
+          <dd>{relationship}</dd>
+        </div>
 
         {ssn ? (
-          <dd className="vads-l-col--12 vads-u-margin--0">
-            <dfn title="ssn">SSN:</dfn> {ssn.replace(/[0-9](?=.{4,}$)/g, '*')}
-          </dd>
+          <div>
+            <dt>SSN:&nbsp;</dt>
+            <dd>{mask(ssn)}</dd>
+          </div>
         ) : null}
 
         {dateOfBirth ? (
-          <dd className="vads-l-col--12 vads-u-margin--0">
-            <dfn title="birthdate">Date of birth: </dfn>
-            {moment(dateOfBirth).format('MMMM D, YYYY')}
-          </dd>
+          <div>
+            <dt>Date of birth:&nbsp;</dt>
+            <dd>{moment(dateOfBirth).format('MMMM D, YYYY')}</dd>
+          </div>
         ) : null}
       </dl>
       {manageDependentsToggle && (
@@ -92,6 +87,7 @@ function ViewDependentsListItem(props) {
               onClick={handleClick}
               className="usa-button-secondary vads-u-background-color--white"
               disabled={openFormlett || submittedDependents.includes(stateKey)}
+              aria-label={`remove ${fullName} as a dependent`}
             >
               Remove this dependent
             </button>
@@ -134,10 +130,13 @@ export default connect(
 export { ViewDependentsListItem };
 
 ViewDependentsListItem.propTypes = {
+  dateOfBirth: PropTypes.string,
   firstName: PropTypes.string,
   lastName: PropTypes.string,
+  manageDependentsToggle: PropTypes.bool,
+  openFormlett: PropTypes.bool,
   relationship: PropTypes.string,
   ssn: PropTypes.string,
-  dateOfBirth: PropTypes.string,
   stateKey: PropTypes.number,
+  submittedDependents: PropTypes.array,
 };

--- a/src/applications/personalization/view-dependents/sass/view-dependents.scss
+++ b/src/applications/personalization/view-dependents/sass/view-dependents.scss
@@ -18,3 +18,9 @@
     display: none;
   }
 }
+
+.mng-dependents-list-item {
+  dt, dd {
+    display: inline-block;
+  }
+}

--- a/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
+++ b/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
@@ -14,7 +14,7 @@ const testHappyPath = () => {
   cy.visit(manifest.rootUrl);
   testAxe();
   cy.findByRole('heading', { name: /Your VA Dependents/i }).should('exist');
-  cy.findAllByRole('term', { name: /relationship/ }).should('have.length', 4);
+  cy.get('dt').should('have.length', 12);
   testAxe();
 };
 

--- a/src/applications/personalization/view-dependents/tests/util/index.unit.spec.jsx
+++ b/src/applications/personalization/view-dependents/tests/util/index.unit.spec.jsx
@@ -1,5 +1,13 @@
+import ReactTestUtils from 'react-dom/test-utils';
+import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
-import { splitPersons, isServerError, isClientError } from '../../util/index';
+
+import {
+  splitPersons,
+  isServerError,
+  isClientError,
+  mask,
+} from '../../util/index';
 
 describe('View Dependents splitPersons Utility', () => {
   const mockData = [
@@ -34,5 +42,14 @@ describe('View Dependents isClientError Utility', () => {
     const errorCheck = isClientError(400);
 
     expect(errorCheck).to.be.true;
+  });
+});
+
+describe('Mask utility', () => {
+  it('should mask all but the last 4 of the SSN', () => {
+    const tree = ReactTestUtils.renderIntoDocument(mask('1234-56-7890'));
+    const dom = findDOMNode(tree);
+    const result = `<span aria-hidden="true">●●●–●●–7890</span><span class="sr-only">ending with 7 8 9 0</span>`;
+    expect(dom.innerHTML).to.equal(result);
   });
 });

--- a/src/applications/personalization/view-dependents/util/index.js
+++ b/src/applications/personalization/view-dependents/util/index.js
@@ -1,4 +1,5 @@
 import { apiRequest } from 'platform/utilities/api';
+import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
 const SERVER_ERROR_REGEX = /^5\d{2}$/;
 const CLIENT_ERROR_REGEX = /^4\d{2}$/;
@@ -33,3 +34,13 @@ export function splitPersons(persons) {
 export const isServerError = errCode => SERVER_ERROR_REGEX.test(errCode);
 
 export const isClientError = errCode => CLIENT_ERROR_REGEX.test(errCode);
+
+// separate each number so the screenreader reads "number ending with 1 2 3 4"
+// instead of "number ending with 1,234"
+export const mask = value => {
+  const number = (value || '').toString().slice(-4);
+  return srSubstitute(
+    `●●●–●●–${number}`,
+    `ending with ${number.split('').join(' ')}`,
+  );
+};


### PR DESCRIPTION
## Description

- Updated dependents card HTML to improve accessibility for screen readers (per recommendations)
- Used string replacement on the masked SSN
- Added `aria-label` to the remove button (not in production) to read out "Remove {name} as a dependent"
- Fixed eslint warnings

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30017

## Testing done

Updated & checked unit tests

## Screenshots

<details><summary>View dependents card update</summary>

<!-- leave a blank line above -->
<img width="547" alt="view dependents page with updated dependent cards" src="https://user-images.githubusercontent.com/136959/166970547-c36f432e-3544-407d-8b94-501bb7d19f80.png"></details>

## Acceptance criteria
- [x] Dependent card HTML updated per recommedation
- [x] Improve SSN screenreader read out
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
