### PR TITLE
Replace AlertBox component with VA-Alert in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -12,12 +11,13 @@ const SubmitError = ({ form }) => {
     focusElement('.caregivers-error-message');
   }, []);
 
-  const ErrorBody = () => {
-    return (
-      <section>
+  return (
+    <va-alert status="error" className="caregivers-error-message">
+      <h3 slot="headline">We didn’t receive your online application</h3>
+      <div>
         <p>
           We’re sorry. Something went wrong when you tried to submit your
-          application. You won't be able to resubmit the form online.
+          application. You won’t be able to resubmit the form online.
         </p>
 
         <div>
@@ -54,17 +54,8 @@ const SubmitError = ({ form }) => {
         </div>
 
         <DownLoadLink form={form} />
-      </section>
-    );
-  };
-
-  return (
-    <AlertBox
-      className="caregivers-error-message"
-      headline="We didn't receive your online application"
-      content={ErrorBody()}
-      status="error"
-    />
+      </div>
+    </va-alert>
   );
 };
 

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import moment from 'moment';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { links } from 'applications/caregivers/definitions/content';
 import Telephone, {
   CONTACTS,
@@ -69,12 +68,13 @@ const ConfirmationPage = props => {
 
   return (
     <section className="caregiver-confirmation vads-u-margin-bottom--2p5">
-      <AlertBox
-        level={2}
-        headline="You’ve successfully submitted your application."
-        content="Once we’ve reviewed your application, a Caregiver Support Coordinator will contact you to discuss next steps."
-        status="success"
-      />
+      <va-alert status="success">
+        <h2 slot="headline">You’ve successfully submitted your application.</h2>
+        <div>
+          Once we’ve reviewed your application, a Caregiver Support Coordinator
+          will contact you to discuss next steps.
+        </div>
+      </va-alert>
       <div className="inset vads-u-margin-top--4">
         <h3 className="insert-title vads-u-font-size--h4">
           Application for the Program of Comprehensive Assistance for Family


### PR DESCRIPTION
## Description
The `<AlertBox>` component is utilized multiple times throughout the caregivers application markup. This component has been deprecated by the Design System team in favor of the `<va-alert>` component. This PR upgrades the application to remove this deprecated component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41019

## Testing done
- [x] Unit Tests

## Acceptance criteria
- [ ] Application utilizes the most up-to-date Design System alert component.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
