### PR TITLE
686: H1 to sentence-case

### DIFF
--- a/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -73,7 +73,7 @@ function ViewDependentsHeader(props) {
   return (
     <div className="vads-l-row">
       <div className="vads-l-col--12">
-        <h1>Your VA Dependents</h1>
+        <h1>Your VA dependents</h1>
         {alertProps && (
           <va-alert status={alertProps.status}>{alertProps.content}</va-alert>
         )}

--- a/src/applications/personalization/view-dependents/tests/components/ViewDependentsHeader.unit.spec.jsx
+++ b/src/applications/personalization/view-dependents/tests/components/ViewDependentsHeader.unit.spec.jsx
@@ -7,7 +7,7 @@ describe('<ViewDependentsHeader />', () => {
   it('Should Render', () => {
     const wrapper = shallow(<ViewDependentsHeader />);
 
-    expect(wrapper.contains(<h1>Your VA Dependents</h1>)).to.equal(true);
+    expect(wrapper.contains(<h1>Your VA dependents</h1>)).to.equal(true);
     wrapper.unmount();
   });
 });

--- a/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
+++ b/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
@@ -13,7 +13,7 @@ const testHappyPath = () => {
   cy.intercept('GET', DEPENDENTS_ENDPOINT, mockDependents).as('mockDependents');
   cy.visit(manifest.rootUrl);
   testAxe();
-  cy.findByRole('heading', { name: /Your VA Dependents/i }).should('exist');
+  cy.findByRole('heading', { name: /Your VA dependents/i }).should('exist');
   cy.get('dt').should('have.length', 12);
   testAxe();
 };


### PR DESCRIPTION
## Description

[View dependents page](https://staging.va.gov/view-change-dependents/view/) `H1` is now sentence-cased.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30020

## Testing done

All tests passing

## Screenshots

<img width="360" alt="Your VA dependents H1 in sentence-case" src="https://user-images.githubusercontent.com/136959/167172699-dcf35e5e-7a2c-4f5e-a61a-af871906d046.png">

## Acceptance criteria
- [x] H1 in sentence-case
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
