### PR TITLE
Fix Prop Type-releated ESlint errors in Caregivers Application

### DIFF
--- a/src/applications/caregivers/components/AdditionalInfo/index.jsx
+++ b/src/applications/caregivers/components/AdditionalInfo/index.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { focusElement } from 'platform/utilities/ui';
-
 import { links } from 'applications/caregivers/definitions/content';
 
 export const VeteranSSNInfo = () => (
@@ -28,6 +27,7 @@ export const VetInfo = ({ pageTitle, headerInfo }) => (
 );
 
 VetInfo.propTypes = {
+  headerInfo: PropTypes.bool,
   pageTitle: PropTypes.string,
 };
 
@@ -77,8 +77,8 @@ export const PrimaryCaregiverInfo = ({
 
 PrimaryCaregiverInfo.propTypes = {
   additionalInfo: PropTypes.bool,
-  pageTitle: PropTypes.string,
   headerInfo: PropTypes.bool,
+  pageTitle: PropTypes.string,
 };
 
 PrimaryCaregiverInfo.defaultProps = {
@@ -128,8 +128,8 @@ export const SecondaryCaregiverInfo = ({
 
 SecondaryCaregiverInfo.propTypes = {
   additionalInfo: PropTypes.bool,
-  pageTitle: PropTypes.string,
   headerInfo: PropTypes.string,
+  pageTitle: PropTypes.string,
 };
 
 export const FacilityInfo = () => (
@@ -164,6 +164,10 @@ export const CaregiverSupportInfo = () => (
 export const PrimaryHealthCoverage = ({ pageTitle }) => (
   <>{pageTitle && <h3 className="vads-u-font-size--h4">{pageTitle}</h3>}</>
 );
+
+PrimaryHealthCoverage.propTypes = {
+  pageTitle: PropTypes.string,
+};
 
 export const whyAskHealthCareCoverage = () => (
   <div className="vads-u-margin-y--2p5">

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 
-import SignatureInput from './SignatureInput';
 import recordEvent from 'platform/monitoring/record-event';
+import SignatureInput from './SignatureInput';
 
 const SignatureCheckbox = ({
   children,
@@ -89,8 +89,8 @@ SignatureCheckbox.propTypes = {
   setSignatures: PropTypes.func.isRequired,
   showError: PropTypes.bool.isRequired,
   submission: PropTypes.object.isRequired,
-  isRequired: PropTypes.bool,
   isRepresentative: PropTypes.bool,
+  isRequired: PropTypes.bool,
 };
 
 export default SignatureCheckbox;

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -130,13 +130,13 @@ const SignatureInput = ({
 
 SignatureInput.propTypes = {
   fullName: PropTypes.object.isRequired,
-  label: PropTypes.string.isRequired,
-  isChecked: PropTypes.bool.isRequired,
-  showError: PropTypes.bool.isRequired,
   hasSubmittedForm: PropTypes.bool.isRequired,
+  isChecked: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
   setSignatures: PropTypes.func.isRequired,
-  isRepresentative: PropTypes.bool,
+  showError: PropTypes.bool.isRequired,
   ariaDescribedBy: PropTypes.string,
+  isRepresentative: PropTypes.bool,
   required: PropTypes.bool,
 };
 

--- a/src/applications/caregivers/components/PreSubmitInfo/SubmitLoadingIndicator.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SubmitLoadingIndicator.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 const SubmitLoadingIndicator = ({ submission }) => {
   const [isLoading, setLoading] = useState(false);
 
-  const hasAttemptedSubmit = submission.hasAttemptedSubmit;
+  const { hasAttemptedSubmit } = submission;
   const isSubmitPending = submission.status === 'submitPending';
 
   // set loading to true if user has attempted to submit and submit is pending

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -270,10 +270,10 @@ const PreSubmitCheckboxGroup = ({
 };
 
 PreSubmitCheckboxGroup.propTypes = {
+  formData: PropTypes.object.isRequired,
+  setFormData: PropTypes.func.isRequired,
   showError: PropTypes.bool.isRequired,
   onSectionComplete: PropTypes.func.isRequired,
-  setFormData: PropTypes.func.isRequired,
-  formData: PropTypes.object.isRequired,
   submission: PropTypes.shape({
     hasAttemptedSubmit: PropTypes.bool,
     errorMessage: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
+++ b/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
@@ -16,7 +16,7 @@ const DownLoadLink = ({ form }) => {
   const [isLoading, setLoading] = useState(false);
   const [errors, setErrors] = useState([]);
   const getFormData = submitTransform(formConfig, form);
-  const veteranFullName = form.data.veteranFullName;
+  const { veteranFullName } = form.data;
   const pageList = createFormPageList(formConfig);
   const isFormValid = isValidForm(form, pageList);
 
@@ -99,6 +99,7 @@ const DownLoadLink = ({ form }) => {
       <div className="vads-u-margin-top--2 vads-u-color--secondary-dark pdf-download-link--error">
         <a
           aria-label="Error downloading 1010-CG PDF"
+          href={() => false}
           className="vads-u-color--gray-medium"
         >
           <i

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -57,6 +59,10 @@ const SubmitError = ({ form }) => {
       </div>
     </va-alert>
   );
+};
+
+SubmitError.propTypes = {
+  form: PropTypes.object,
 };
 
 export default SubmitError;

--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -7,8 +7,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import formConfig from '../config/form';
 import recordEvent from 'platform/monitoring/record-event';
+import formConfig from '../config/form';
 
 const App = ({ loading, location, children }) => {
   // find all yes/no check boxes and attach analytics events
@@ -30,11 +30,10 @@ const App = ({ loading, location, children }) => {
     },
     [loading, location],
   );
-  if (loading) {
-    return <LoadingIndicator />;
-  }
 
-  return (
+  return loading ? (
+    <LoadingIndicator />
+  ) : (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
@@ -47,6 +46,8 @@ const mapStateToProps = state => ({
 
 App.propTypes = {
   loading: PropTypes.bool.isRequired,
+  children: PropTypes.any,
+  location: PropTypes.string,
 };
 
 export default connect(mapStateToProps)(App);

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import moment from 'moment';
-import { links } from 'applications/caregivers/definitions/content';
+
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
-import { connect } from 'react-redux';
 
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { links } from 'applications/caregivers/definitions/content';
 
 const ConfirmationPage = props => {
   useEffect(() => {
@@ -95,7 +97,11 @@ const ConfirmationPage = props => {
           </ul>
         )}
 
-        <button className="usa-button button" onClick={() => window.print()}>
+        <button
+          type="button"
+          className="usa-button button"
+          onClick={() => window.print()}
+        >
           Print this page
         </button>
       </div>
@@ -150,6 +156,10 @@ const ConfirmationPage = props => {
       <PrintDetails />
     </section>
   );
+};
+
+ConfirmationPage.propTypes = {
+  form: PropTypes.object,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
## Description
There are ESlint warnings in multiple files within the Caregivers application that are related to prop types. Many of the warnings are due to prop types not being declared for components, while a few are due to the order in which props are declared. This PR addresses those warnings and ensures all prop types are declared as expected. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41021

## Testing
- [x] Unit Tests

## Acceptance criteria
- [ ] No Prop Type ESlint warnings are thrown

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
