### PR TITLE
Replace 'Telephone' component with 'VA-Telephone' in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { links } from 'applications/caregivers/definitions/content';
 
 const NeedHelpFooter = () => {

--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+
 import { links } from 'applications/caregivers/definitions/content';
 
 const NeedHelpFooter = () => {
@@ -10,8 +7,8 @@ const NeedHelpFooter = () => {
     <>
       <p>
         You can call the VA Caregiver Support Line at
-        <Telephone
-          contact={CONTACTS.CAREGIVER}
+        <va-telephone
+          contact="8552603274"
           className="vads-u-margin-left--0p5"
         />
         . We’re here Monday through Friday, 8:00 a.m. to 10:00 p.m. ET, and
@@ -20,10 +17,7 @@ const NeedHelpFooter = () => {
 
       <p>
         You can also call
-        <Telephone
-          contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
-          className="vads-u-margin-x--0p5"
-        />
+        <va-telephone contact="8554888440" className="vads-u-margin-x--0p5" />
         if you have questions about completing your application, or contact your
         local Caregiver Support Coordinator.
       </p>
@@ -40,20 +34,15 @@ const NeedHelpFooter = () => {
       </span>
 
       <p>
-        If this form isn't working right for you, please call us at
-        <Telephone
-          contact={CONTACTS.HELP_DESK}
+        If this form isn’t working right for you, please call us at
+        <va-telephone
+          contact="8006982411"
           className="vads-u-margin-left--0p5"
         />
         .<br />
         <span>
           If you have hearing loss, call TTY:
-          <Telephone
-            className="vads-u-margin-left--0p5"
-            contact={CONTACTS['711']}
-            pattern={PATTERNS['911']}
-          />
-          .
+          <va-telephone contact="711" className="vads-u-margin-left--0p5" />.
         </span>
       </p>
     </>

--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 import { links } from 'applications/caregivers/definitions/content';
 
 const NeedHelpFooter = () => {

--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { links } from 'applications/caregivers/definitions/content';
 
 const NeedHelpFooter = () => {
@@ -8,7 +9,7 @@ const NeedHelpFooter = () => {
       <p>
         You can call the VA Caregiver Support Line at
         <va-telephone
-          contact="8552603274"
+          contact={CONTACTS.CAREGIVER}
           className="vads-u-margin-left--0p5"
         />
         . We’re here Monday through Friday, 8:00 a.m. to 10:00 p.m. ET, and
@@ -17,7 +18,10 @@ const NeedHelpFooter = () => {
 
       <p>
         You can also call
-        <va-telephone contact="8554888440" className="vads-u-margin-x--0p5" />
+        <va-telephone
+          contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
+          className="vads-u-margin-x--0p5"
+        />
         if you have questions about completing your application, or contact your
         local Caregiver Support Coordinator.
       </p>
@@ -36,13 +40,17 @@ const NeedHelpFooter = () => {
       <p>
         If this form isn’t working right for you, please call us at
         <va-telephone
-          contact="8006982411"
+          contact={CONTACTS.HELP_DESK}
           className="vads-u-margin-left--0p5"
         />
         .<br />
         <span>
           If you have hearing loss, call TTY:
-          <va-telephone contact="711" className="vads-u-margin-left--0p5" />.
+          <va-telephone
+            contact={CONTACTS['711']}
+            className="vads-u-margin-left--0p5"
+          />
+          .
         </span>
       </p>
     </>

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { focusElement } from 'platform/utilities/ui';
 import DownLoadLink from './DownloadLink';
 

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { focusElement } from 'platform/utilities/ui';
 import DownLoadLink from './DownloadLink';
 
@@ -47,8 +48,8 @@ const SubmitError = ({ form }) => {
           <a className="vads-u-margin-x--0p5" href="https://www.va.gov/">
             VA.gov
           </a>
-          help desk at <va-telephone contact="8006982411" /> (TTY: 711). We’re
-          here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          help desk at <va-telephone contact={CONTACTS.HELP_DESK} /> (TTY: 711).{' '}
+          We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </div>
 
         <DownLoadLink form={form} />

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -1,11 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
 import { focusElement } from 'platform/utilities/ui';
-
 import DownLoadLink from './DownloadLink';
 
 const SubmitError = ({ form }) => {
@@ -51,8 +47,8 @@ const SubmitError = ({ form }) => {
           <a className="vads-u-margin-x--0p5" href="https://www.va.gov/">
             VA.gov
           </a>
-          help desk at <Telephone contact={CONTACTS.HELP_DESK} /> (TTY: 711).
-          We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          help desk at <va-telephone contact="8006982411" /> (TTY: 711). We’re
+          here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </div>
 
         <DownLoadLink form={form} />

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 import { focusElement } from 'platform/utilities/ui';
 import DownLoadLink from './DownloadLink';
 

--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import recordEvent from 'platform/monitoring/record-event';
 import formConfig from '../config/form';

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { links } from 'applications/caregivers/definitions/content';

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -3,10 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
-
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { links } from 'applications/caregivers/definitions/content';
@@ -128,8 +124,8 @@ const ConfirmationPage = props => {
             or if you are interested in learning more about the supports and
             services available to support Veterans and caregivers, you may
             contact the VA Caregiver Support Line at
-            <Telephone
-              contact={CONTACTS.CAREGIVER}
+            <va-telephone
+              contact="8552603274"
               className="vads-u-margin-x--0p5"
             />
             or visit

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { links } from 'applications/caregivers/definitions/content';

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { links } from 'applications/caregivers/definitions/content';
@@ -125,7 +126,7 @@ const ConfirmationPage = props => {
             services available to support Veterans and caregivers, you may
             contact the VA Caregiver Support Line at
             <va-telephone
-              contact="8552603274"
+              contact={CONTACTS.CAREGIVER}
               className="vads-u-margin-x--0p5"
             />
             or visit

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
+import {
+  CONTACTS,
+  OMBInfo,
+} from '@department-of-veterans-affairs/component-library';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from 'platform/utilities/ui';
@@ -133,11 +135,10 @@ export const IntroductionPage = ({
               <ul className="process-lists">
                 <li>
                   Call us at
-                  <span className="vads-u-margin-x--0p5">
-                    <va-telephone
-                      contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
-                    />
-                  </span>
+                  <va-telephone
+                    contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
+                    className="vads-u-margin-x--0p5"
+                  />
                   and ask for help filling out the form
                 </li>
                 <li>
@@ -154,9 +155,10 @@ export const IntroductionPage = ({
                 </li>
                 <li>
                   Contact the VA National Caregiver Support Line by calling
-                  <span className="vads-u-margin-left--0p5">
-                    <va-telephone contact={CONTACTS.CAREGIVER} />
-                  </span>
+                  <va-telephone
+                    contact={CONTACTS.CAREGIVER}
+                    className="vads-u-margin-left--0p5"
+                  />
                 </li>
               </ul>
 
@@ -217,9 +219,10 @@ export const IntroductionPage = ({
               You may also be eligible for the Program of General Caregiver
               Support Services (PGCSS). To find out more, call the VA Caregiver
               Support Line at
-              <span className="vads-u-margin-left--0p5">
-                <va-telephone contact={CONTACTS.CAREGIVER} />
-              </span>
+              <va-telephone
+                contact={CONTACTS.CAREGIVER}
+                className="vads-u-margin-left--0p5"
+              />
               , visit
               <a
                 target="_blank"

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -2,10 +2,8 @@ import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import {
-  CONTACTS,
-  OMBInfo,
-} from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from 'platform/utilities/ui';


### PR DESCRIPTION
## Description
The `<Telephone>` component is utilized multiple times throughout the Caregivers application markup. While this component has not yet been deprecated by the Design team, the preferred/recommended component to use is `<va-telephone>`. This PR upgrades the Caregivers app to utilize the preferred component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41017

## Testing done
- [x] Unit tests

## Acceptance criteria
- [ ] Application utilizes the most up-to-date Design System telephone component.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
