### PR TITLE
Migrate view-payments app from `Telephone` to `va-telephone` web-component

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
 import Payments from './payments/Payments.jsx';
-import ViewPaymentsHeader from '../../components/view-payments-header/ViewPaymentsHeader.jsx';
+import ViewPaymentsHeader from '../view-payments-header/ViewPaymentsHeader.jsx';
 import IdentityNotVerified from '../IdentityNotVerified';
 import {
   paymentsReturnedFields,
@@ -54,7 +52,7 @@ class ViewPaymentsLists extends Component {
           <p className="vads-u-font-size--base">
             We can’t find any returned VA payments. If you think this is an
             error, or if you have questions about your payment history, please
-            call <Telephone contact={CONTACTS.VA_BENEFITS} />.
+            call <va-telephone contact={CONTACTS.VA_BENEFITS} />.
           </p>
         </va-alert>
       );
@@ -87,7 +85,7 @@ class ViewPaymentsLists extends Component {
           <p className="vads-u-font-size--base">
             We can’t find any VA payments made to you. If you think this is an
             error, or if you have questions about your payment history, please
-            call <Telephone contact={CONTACTS.VA_BENEFITS} />.
+            call <va-telephone contact={CONTACTS.VA_BENEFITS} />.
           </p>
         </va-alert>
       );
@@ -143,7 +141,7 @@ class ViewPaymentsLists extends Component {
             </p>
             <p>
               If you have questions about payments made by VA, please call the
-              VA Help Desk at <Telephone contact={CONTACTS.VA_BENEFITS} />
+              VA Help Desk at <va-telephone contact={CONTACTS.VA_BENEFITS} />
             </p>
             {paymentsReturnedTable}
             <h3>What if I find a check that I reported missing?</h3>
@@ -179,7 +177,7 @@ class ViewPaymentsLists extends Component {
             <p className="vads-u-margin-bottom--3">
               {' '}
               To report a missing payment, contact us at{' '}
-              <Telephone contact={CONTACTS.VA_BENEFITS} />. Please have the
+              <va-telephone contact={CONTACTS.VA_BENEFITS} />. Please have the
               following information ready for the call: your address, Social
               Security number or VA claim number. If you receive payments
               through direct deposit, you’ll need your bank account information
@@ -193,10 +191,10 @@ class ViewPaymentsLists extends Component {
               eligibility? Call our toll free number:
             </p>
             <p className="vads-u-font-weight--bold vads-u-margin-y--0">
-              <Telephone contact={CONTACTS.VA_BENEFITS} />
+              <va-telephone contact={CONTACTS.VA_BENEFITS} />
             </p>
             <p className="vads-u-font-weight--bold vads-u-margin-y--0">
-              TTY <Telephone contact={CONTACTS.FEDERAL_RELAY_SERVICE} />
+              TTY <va-telephone contact={CONTACTS.FEDERAL_RELAY_SERVICE} />
             </p>
             <p className="vads-u-margin-bottom--4">
               Monday through Friday, 8:00 a.m. to 9:00 p.m. E.T.

--- a/src/applications/disability-benefits/view-payments/utils.js
+++ b/src/applications/disability-benefits/view-payments/utils.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 const SERVER_ERROR_REGEX = /^5\d{2}$/;
 const CLIENT_ERROR_REGEX = /^4\d{2}$/;
@@ -21,8 +18,8 @@ export const ServerErrorAlertContent = (
     </p>
     <p className="vads-u-font-size--base">
       If you get this error again, please call the VA.gov help desk at{' '}
-      <Telephone contact={CONTACTS.VA_311} />
-      (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+      <va-telephone contact={CONTACTS.VA_311} />
+      (TTY: <va-telephone contact={CONTACTS['711']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET
     </p>
   </>
@@ -39,7 +36,7 @@ export const NoPaymentsContent = (
       less than $1 for direct deposit, or $5 for mailed checks, will not show in
       your online payment history. If you think this is an error, or if you have
       questions about your payment history, please call{' '}
-      <Telephone contact={CONTACTS.VA_BENEFITS} />
+      <va-telephone contact={CONTACTS.VA_BENEFITS} />
     </p>
     <p className="vads-u-font-size--base">
       VA pays benefits on the first day of the month for the previous month.


### PR DESCRIPTION
## Description
Migrating the view-payments app from the `Telephone` react component to the new `va-telephone` web-component

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41054

## Testing done
Test still pass

## Acceptance criteria
- [x] Instances of `Telephone` component are replaced with `va-telephone` in view-payments application

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
