### PR TITLE
Upload: Get extension from last part of filename

### DIFF
--- a/src/platform/forms-system/src/js/utilities/file/checkTypeAndExtensionMatches.js
+++ b/src/platform/forms-system/src/js/utilities/file/checkTypeAndExtensionMatches.js
@@ -85,14 +85,18 @@ export const fileTypeSignatures = {
 export default function checkTypeAndExtensionMatches({ file, result }) {
   // file.name and file.type may be undefined in some browsers, see
   // https://developer.mozilla.org/en-US/docs/Web/API/File#browser_compatibility
-  const [, extension] = (file.name || '').toLowerCase().split('.');
+  const extension = (file.name || '')
+    .toLowerCase()
+    .split('.')
+    .pop();
   const match = extension && fileTypeSignatures[extension];
   const signature = match?.sig;
 
   if (match?.mime === file.type) {
     if (extension === 'txt') {
       return true;
-    } else if (signature) {
+    }
+    if (signature) {
       return arrayIncludesArray(
         result,
         Array.isArray(signature)

--- a/src/platform/forms-system/test/js/utilities/file.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/file.unit.spec.js
@@ -85,6 +85,20 @@ describe('readAndCheckFile', () => {
         done();
       });
     });
+    it('should return true for name with extra periods (pdf)', done => {
+      const file = { name: 'some.file.test.pdf', ...setup('pdf') };
+      readAndCheckFile(file, checks).then(result => {
+        expect(result.checkTypeAndExtensionMatches).to.be.true;
+        done();
+      });
+    });
+    it('should return true for string with only an extension (pdf)', done => {
+      const file = { name: '.pdf', ...setup('pdf') };
+      readAndCheckFile(file, checks).then(result => {
+        expect(result.checkTypeAndExtensionMatches).to.be.true;
+        done();
+      });
+    });
     it('should return true for array signature checks (doc)', done => {
       const file = setup('doc');
       readAndCheckFile(file, checks).then(result => {


### PR DESCRIPTION
## Description

Previously, the extension checking code was not accounting for file names with multiple periods. This change fixes that.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41059

## Testing done

Added unit tests

## Screenshots

Before

![upload issue error message](https://user-images.githubusercontent.com/136959/167216664-135a0c9a-e57d-42db-bc37-afb0890210d1.PNG)

After
<img width="540" alt="File name with multiple periods is not blocked" src="https://user-images.githubusercontent.com/136959/167216689-e05e1705-2a36-4170-9197-f1f8dfd141c7.png">

## Acceptance criteria
- [x] File names with multiple periods are not immediately rejected based on their file name
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
