### PR TITLE
Fix linting warnings in view payments app

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -1,10 +1,18 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
-import Payments from './payments/Payments.jsx';
-import ViewPaymentsHeader from '../view-payments-header/ViewPaymentsHeader.jsx';
+
+import { getAllPayments } from '../../actions';
+import {
+  isClientError,
+  ServerErrorAlertContent,
+  NoPaymentsContent,
+} from '../../utils';
 import IdentityNotVerified from '../IdentityNotVerified';
+import ViewPaymentsHeader from '../view-payments-header/ViewPaymentsHeader';
 import {
   paymentsReturnedFields,
   paymentsReceivedFields,
@@ -14,12 +22,7 @@ import {
   reformatReturnPaymentDates,
   reformatPaymentDates,
 } from './helpers';
-import { getAllPayments } from '../../actions';
-import {
-  isClientError,
-  ServerErrorAlertContent,
-  NoPaymentsContent,
-} from '../../utils';
+import Payments from './payments/Payments';
 
 class ViewPaymentsLists extends Component {
   componentDidMount() {
@@ -220,6 +223,14 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   getAllPayments,
+};
+
+ViewPaymentsLists.propTypes = {
+  error: PropTypes.object,
+  getAllPayments: PropTypes.func,
+  isIdentityVerified: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  payments: PropTypes.object,
 };
 
 export default connect(

--- a/src/applications/disability-benefits/view-payments/containers/App.jsx
+++ b/src/applications/disability-benefits/view-payments/containers/App.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
-import backendServices from 'platform/user/profile/constants/backendServices';
 import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
-import ViewPaymentsLists from '../components/view-payments-lists/ViewPaymentsLists.jsx';
+import backendServices from 'platform/user/profile/constants/backendServices';
+
+import ViewPaymentsLists from '../components/view-payments-lists/ViewPaymentsLists';
 
 function ViewPaymentsApp(props) {
   return (
@@ -41,6 +44,10 @@ function ViewPaymentsApp(props) {
 const mapStateToProps = state => ({
   user: state.user,
 });
+
+ViewPaymentsApp.propTypes = {
+  user: PropTypes.object,
+};
 
 export default connect(mapStateToProps)(ViewPaymentsApp);
 export { ViewPaymentsApp };

--- a/src/applications/disability-benefits/view-payments/routes.jsx
+++ b/src/applications/disability-benefits/view-payments/routes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router';
-import ViewPaymentsApp from './containers/App.jsx';
+import ViewPaymentsApp from './containers/App';
 
 const routes = <Route path="/" component={ViewPaymentsApp} />;
 

--- a/src/applications/disability-benefits/view-payments/tests/actions/index.unit.spec.js
+++ b/src/applications/disability-benefits/view-payments/tests/actions/index.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+
 import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
@@ -7,7 +8,6 @@ import {
   PAYMENTS_RECEIVED_FAILED,
   getAllPayments,
 } from '../../actions';
-
 import { payments } from '../helpers';
 
 describe('View Payments actions: getAllPayments', () => {

--- a/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/view-payments-lists.unit.spec.jsx
+++ b/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/view-payments-lists.unit.spec.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { expect } from 'chai';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
-import { expect } from 'chai';
-import allPayments from '../../../reducers/index';
 import environment from 'platform/utilities/environment';
-import ViewPaymentsLists from '../../../components/view-payments-lists/ViewPaymentsLists.jsx';
+
+import allPayments from '../../../reducers/index';
+import ViewPaymentsLists from '../../../components/view-payments-lists/ViewPaymentsLists';
 import {
   payments,
   emptyPaymentsReturned,

--- a/src/applications/disability-benefits/view-payments/tests/reducers/index.unit.spec.js
+++ b/src/applications/disability-benefits/view-payments/tests/reducers/index.unit.spec.js
@@ -40,6 +40,6 @@ describe('allPayments reducer', () => {
     });
     expect(state.isLoading).to.be.false;
     expect(state.payments).to.equal(null);
-    expect(state.errorr).to.not.equal(null);
+    expect(state.error).to.not.equal(null);
   });
 });


### PR DESCRIPTION
## Description
Fixes linting warnings in the view payments application

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41061

## Acceptance criteria
- [x] Linting warning are fixed 

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
