### PR TITLE
1010/bug/40039/ez added validation logging to va facility page

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility.js
@@ -2,6 +2,7 @@ import get from 'platform/utilities/data/get';
 import { states } from 'platform/forms/address';
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
+import { logValidateMarriageDateVaFacilityPage } from '../../../validation';
 
 import {
   facilityHelp,
@@ -37,6 +38,7 @@ export default {
         'ui:options': {
           labels: stateLabels,
         },
+        'ui:validations': [logValidateMarriageDateVaFacilityPage],
       },
       vaMedicalFacility: {
         'ui:title': 'Center or clinic',

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -122,6 +122,52 @@ export function logValidateMarriageDate(
   }
 }
 
+export function logValidateMarriageDateVaFacilityPage(
+  errors,
+  marriageDate,
+  {
+    dateOfMarriage,
+    spouseDateOfBirth,
+    veteranDateOfBirth,
+    discloseFinancialInformation,
+  },
+) {
+  if (!dateOfMarriage) return;
+
+  const vetDOB = moment(veteranDateOfBirth);
+  const spouseDOB = moment(spouseDateOfBirth);
+  const marriage = moment(dateOfMarriage);
+  if (
+    discloseFinancialInformation &&
+    spouseDOB.isAfter(marriage) &&
+    vetDOB.isAfter(marriage)
+  ) {
+    logMarriageError(
+      'marriage_date_VaFacilityPage',
+      'Date of marriage cannot be before the Veteran’s or the spouse’s date of birth',
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      dateOfMarriage,
+    );
+  } else if (discloseFinancialInformation && spouseDOB.isAfter(marriage)) {
+    logMarriageError(
+      'spouse_dob_VaFacilityPage',
+      'Date of marriage cannot be before the spouse’s date of birth',
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      dateOfMarriage,
+    );
+  } else if (discloseFinancialInformation && vetDOB.isAfter(marriage)) {
+    logMarriageError(
+      'veteran_dob_VaFacilityPage',
+      'Date of marriage cannot be before the Veteran’s date of birth',
+      spouseDateOfBirth,
+      veteranDateOfBirth,
+      dateOfMarriage,
+    );
+  }
+}
+
 // export function validateMarriageDate(
 //   errors,
 //   marriageDate,

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -80,7 +80,7 @@ function logMarriageError(
 
 export function logValidateMarriageDate(
   errors,
-  marriageDate,
+  formfield,
   {
     dateOfMarriage,
     spouseDateOfBirth,
@@ -124,7 +124,7 @@ export function logValidateMarriageDate(
 
 export function logValidateMarriageDateVaFacilityPage(
   errors,
-  marriageDate,
+  formField,
   {
     dateOfMarriage,
     spouseDateOfBirth,


### PR DESCRIPTION
## Description
_Veterans are complaining that they receive an error when they are filling out the online 10-10EZ application form. When filling in spouses DOB and marriage date it kicks back the date saying it is invalid. The error code that comes up reads that the marriage date is before the date of birth. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40039