### PR TITLE
Removing cross app reference to see if it helps failing cypress tests

### DIFF
--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -4,10 +4,14 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { PATTERNS } from '@department-of-veterans-affairs/component-library/Telephone';
 import { apiRequest } from 'platform/utilities/api';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import DebtLetterCard from './DebtLetterCard';
 import { ErrorMessage, DowntimeMessage } from './Alerts';
 import OtherVADebts from './OtherVADebts';
-import { cdpAccessToggle } from '../../medical-copays/utils/helpers';
+
+const cdpAccessToggle = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.combinedDebtPortalAccess];
 
 const fetchCopaysResponseAsync = async () => {
   return apiRequest('/medical_copays')

--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -6,7 +6,7 @@ import { PATTERNS } from '@department-of-veterans-affairs/component-library/Tele
 import { apiRequest } from 'platform/utilities/api';
 import DebtLetterCard from './DebtLetterCard';
 import { ErrorMessage, DowntimeMessage } from './Alerts';
-import OtherVADebts from '../../medical-copays/components/OtherVADebts';
+import OtherVADebts from './OtherVADebts';
 import { cdpAccessToggle } from '../../medical-copays/utils/helpers';
 
 const fetchCopaysResponseAsync = async () => {

--- a/src/applications/debt-letters/components/OtherVADebts.jsx
+++ b/src/applications/debt-letters/components/OtherVADebts.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
+const OtherVADebts = ({ module }) => {
+  return (
+    <>
+      <h2 data-testid="other-va-debts-head" id="other-va-debts">
+        Your other VA {module === 'MCP' && <span>debt</span>}
+        {module === 'LTR' && <span>bills</span>}
+      </h2>
+      <p className="vads-u-font-family--sans">
+        Our records show you have
+        {module === 'MCP' && (
+          <span data-testid="other-va-debts-mcp-body">
+            &nbsp;VA benefit debt. You can&nbsp;
+            <a href="/manage-va-debt/your-debt">
+              check the details of your current debt
+            </a>
+            <span>
+              , find out how to pay your debt, and learn how to request
+              financial assistance.
+            </span>
+          </span>
+        )}{' '}
+        {module === 'LTR' && (
+          <span data-testid="other-va-debts-ltr-body">
+            a VA health care copay bill. You can&nbsp;
+            <a href="/health-care/pay-copay-bill/your-current-balances">
+              check the details of your copay balance
+            </a>
+            <span>
+              , find out how to pay your balance, and learn how to request
+              financial assistance.
+            </span>
+          </span>
+        )}
+      </p>
+      <Link
+        className="vads-u-font-size--sm vads-u-font-weight--bold"
+        aria-label="View all your VA debt and bills"
+        to="/debt-and-bills"
+        data-testid="other-va-debts-link"
+      >
+        <span>View all your VA debt and bills</span>
+        <i
+          className="fa fa-chevron-right vads-u-margin-left--1"
+          aria-hidden="true"
+        />
+      </Link>
+    </>
+  );
+};
+
+OtherVADebts.propTypes = {
+  module: PropTypes.string,
+};
+
+export default OtherVADebts;

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -8,7 +8,7 @@
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
-import mockCopays from '../../../medical-copays/tests/e2e/fixtures/mocks/copays.json';
+import mockCopays from './fixtures/mocks/copays.json';
 
 describe('Debt Letters', () => {
   beforeEach(() => {

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -22,7 +22,7 @@ describe('Debt Letters', () => {
     cy.wait(['@features', '@debts']);
   });
 
-  it.skip('displays the current debts section and navigates to debt details - C1226', () => {
+  it('displays the current debts section and navigates to debt details - C1226', () => {
     cy.findByTestId('debts-jumplink').click({ waitForAnimations: true });
     cy.get('[data-testclass="debt-details-button"]')
       .first()
@@ -39,7 +39,7 @@ describe('Debt Letters', () => {
   /* eslint-disable va/axe-check-required */
   // Same display-states below as test above which already had AXE-check.
 
-  it.skip('displays download debt letters - C1227', () => {
+  it('displays download debt letters - C1227', () => {
     cy.findByTestId('download-jumplink').click({ waitForAnimations: true });
     cy.findByTestId('download-letters-link').click();
     cy.get('#downloadDebtLetters').should('be.visible');

--- a/src/applications/debt-letters/tests/e2e/diary-codes-content.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/diary-codes-content.cypress.spec.js
@@ -2,7 +2,7 @@ import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 
-describe.skip('Diary Codes', () => {
+describe('Diary Codes', () => {
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);

--- a/src/applications/debt-letters/tests/e2e/fixtures/mocks/copays.json
+++ b/src/applications/debt-letters/tests/e2e/fixtures/mocks/copays.json
@@ -1,0 +1,817 @@
+{
+  "data": [
+    {
+      "id": "f4385298-08a6-42f8-a86f-50e97033fb85",
+      "pSSeqNum": 506,
+      "pSTotSeqNum": 588,
+      "pSFacilityNum": "534",
+      "pSFacPhoneNum": null,
+      "pSTotStatement": 27,
+      "pSStatementVal": "0000018255H",
+      "pSStatementDate": "11152019",
+      "pSStatementDateOutput": "11/15/2019",
+      "pSProcessDate": "11112019",
+      "pSProcessDateOutput": "11/11/2019",
+      "pHPatientLstNme": "JONES",
+      "pHPatientFstNme": "TRAVIS",
+      "pHPatientMidNme": "D",
+      "pHAddress1": "1885 SHORE DR S APT 327",
+      "pHAddress2": null,
+      "pHAddress3": null,
+      "pHCity": "SAVANNAH",
+      "pHState": "FL",
+      "pHZipCde": "314104413",
+      "pHZipCdeOutput": "31410-4413",
+      "pHCtryNme": null,
+      "pHAmtDue": 15,
+      "pHAmtDueOutput": "15.00&nbsp;&nbsp;",
+      "pHPrevBal": 135,
+      "pHPrevBalOutput": "135.00&nbsp;&nbsp;",
+      "pHTotCharges": 15,
+      "pHTotChargesOutput": "15.00&nbsp;&nbsp;",
+      "pHTotCredits": -135,
+      "pHTotCreditsOutput": "135.00-&nbsp;",
+      "pHNewBalance": 15,
+      "pHNewBalanceOutput": "15.00&nbsp;&nbsp;",
+      "pHSpecialNotes": "To pay your statement online, go to www.pay.gov or call 1-888-827-4817.",
+      "pHroParaCdes": "304050556065708085",
+      "pHNumOfLines": 10,
+      "pHDfnNumber": 346310,
+      "pHCernerStatementNumber": 1005154223,
+      "pHCernerPatientId": "1005154223",
+      "pHCernerAccountNumber": "1005154223",
+      "pHIcnNumber": "1012845638V677813",
+      "pHAccountNumber": 0,
+      "pHLargeFontIndcator": 0,
+      "details": [
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10072019",
+          "pDDatePostedOutput": "10/07/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "534-K90HEWN"
+        },
+        {
+          "pDDatePosted": "10152019",
+          "pDDatePostedOutput": "10/15/2019",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 09/07/2018",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 09/07/2018",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "534-K009FK8"
+        }
+      ],
+      "station": {
+        "facilitYNum": "534",
+        "visNNum": "07",
+        "facilitYDesc": "RALPH H. JOHNSON VA MEDICAL CENTER (534)",
+        "cyclENum": "012",
+        "remiTToFlag": "L",
+        "maiLInsertFlag": "0",
+        "staTAddress1": "ACCOUNTS RECEIVABLE (04AR)",
+        "staTAddress2": "109 BEE ST",
+        "staTAddress3": null,
+        "city": "CHARLESTON",
+        "state": "SC",
+        "ziPCde": "294015703",
+        "ziPCdeOutput": "29401-5703",
+        "baRCde": "*294015703090*",
+        "teLNumFlag": "P",
+        "teLNum": "1-866-258-2772",
+        "teLNum2": null,
+        "contacTInfo": null,
+        "dM2TelNum": null,
+        "contacTInfo2": null,
+        "toPTelNum": null,
+        "lbXFedexAddress1": null,
+        "lbXFedexAddress2": null,
+        "lbXFedexAddress3": null,
+        "lbXFedexCity": null,
+        "lbXFedexState": null,
+        "lbXFedexZipCde": null,
+        "lbXFedexBarCde": null,
+        "lbXFedexContact": null,
+        "lbXFedexContactTelNum": null
+      }
+    },
+    {
+      "id": "b381cc7b-ea3a-49dc-a982-7146416ed373",
+      "pSSeqNum": 1162,
+      "pSTotSeqNum": 1,
+      "pSFacilityNum": "757",
+      "pSFacPhoneNum": null,
+      "pSTotStatement": 11,
+      "pSStatementVal": "0000040520F",
+      "pSStatementDate": "06052021",
+      "pSStatementDateOutput": "06/05/2021",
+      "pSProcessDate": "06092021",
+      "pSProcessDateOutput": "06/09/2021",
+      "pHPatientLstNme": "JONES",
+      "pHPatientFstNme": "TRAVIS",
+      "pHPatientMidNme": "D",
+      "pHAddress1": "1885 SHORE DR S APT 327",
+      "pHAddress2": null,
+      "pHAddress3": null,
+      "pHCity": "SOUTH PASADENA",
+      "pHState": "FL",
+      "pHZipCde": "337074743",
+      "pHZipCdeOutput": "33707-4743",
+      "pHCtryNme": "US",
+      "pHAmtDue": 46,
+      "pHAmtDueOutput": "46.00&nbsp;&nbsp;",
+      "pHPrevBal": 30,
+      "pHPrevBalOutput": "30.00&nbsp;&nbsp;",
+      "pHTotCharges": 46,
+      "pHTotChargesOutput": "46.00&nbsp;&nbsp;",
+      "pHTotCredits": -30,
+      "pHTotCreditsOutput": "30.00-&nbsp;",
+      "pHNewBalance": 46,
+      "pHNewBalanceOutput": "46.00&nbsp;&nbsp;",
+      "pHSpecialNotes": null,
+      "pHroParaCdes": "254050556065708085",
+      "pHNumOfLines": 7,
+      "pHDfnNumber": 0,
+      "pHCernerStatementNumber": 1005154223,
+      "pHCernerPatientId": "1005154223",
+      "pHCernerAccountNumber": "1005154223",
+      "pHIcnNumber": "1012845638V677813",
+      "pHAccountNumber": 0,
+      "pHLargeFontIndcator": 0,
+      "details": [
+        {
+          "pDDatePosted": "03092020",
+          "pDDatePostedOutput": "03/09/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 01/14/2020",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 01/14/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00R4FL"
+        },
+        {
+          "pDDatePosted": "03092020",
+          "pDDatePostedOutput": "03/09/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K00R4FL"
+        },
+        {
+          "pDDatePosted": "03242020",
+          "pDDatePostedOutput": "03/24/2020",
+          "pDTransDesc": "COPAY RX:100020337B FD:01/23/2020",
+          "pDTransDescOutput": "COPAY RX#100020337B FILL DATE: 01/23/2020",
+          "pDTransAmt": 5,
+          "pDTransAmtOutput": "5.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00RSNZ"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:LISINOPRIL 5MG TAB  DAYS:30  QTY:30",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:LISINOPRIL 5MG TAB  DAYS:30  QTY:30",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "PHY:SANTOS,LOUISE  CHG:$5.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;PHY:SANTOS,LOUISE  CHG:$5.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "03242020",
+          "pDDatePostedOutput": "03/24/2020",
+          "pDTransDesc": "RX CO-PAYMENT/NSC VET",
+          "pDTransDescOutput": "PAYMENT POSTED ON 03/24/2020",
+          "pDTransAmt": -5,
+          "pDTransAmtOutput": "5.00-&nbsp;",
+          "pDRefNo": "516-K00RSNZ"
+        },
+        {
+          "pDDatePosted": "04032020",
+          "pDDatePostedOutput": "04/03/2020",
+          "pDTransDesc": "COPAY RX:100030241 FD:03/30/2020",
+          "pDTransDescOutput": "COPAY RX#100030241 FILL DATE: 03/30/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00S829"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "04272020",
+          "pDDatePostedOutput": "04/27/2020",
+          "pDTransDesc": "COPAY RX:100020336 FD:04/23/2020",
+          "pDTransDescOutput": "COPAY RX#100020336 FILL DATE: 04/23/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00SZBK"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:AMLODIPINE BESYLATE 10MG TAB  DAYS:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:AMLODIPINE BESYLATE 10MG TAB  DAYS:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:90  PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:90  PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "04282020",
+          "pDDatePostedOutput": "04/28/2020",
+          "pDTransDesc": "COPAY RX:100011847 FD:04/23/2020",
+          "pDTransDescOutput": "COPAY RX#100011847 FILL DATE: 04/23/2020",
+          "pDTransAmt": 8,
+          "pDTransAmtOutput": "8.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00SZBK"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:MICONAZOLE NITRATE 2% TOP TINCTURE  DAYS:30",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:MICONAZOLE NITRATE 2% TOP TINCTURE  DAYS:30",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:60  PHY:GUTHRIE,BROOKE L  CHG:$8.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:60  PHY:GUTHRIE,BROOKE L  CHG:$8.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "05262020",
+          "pDDatePostedOutput": "05/26/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 04/15/2020",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 04/15/2020",
+          "pDTransAmt": 50,
+          "pDTransAmtOutput": "50.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00TXGK"
+        },
+        {
+          "pDDatePosted": "05262020",
+          "pDDatePostedOutput": "05/26/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -50,
+          "pDTransAmtOutput": "50.00-&nbsp;",
+          "pDRefNo": "516-K00TXGK"
+        },
+        {
+          "pDDatePosted": "06302020",
+          "pDDatePostedOutput": "06/30/2020",
+          "pDTransDesc": "COPAY RX:100030241 FD:06/30/2020",
+          "pDTransDescOutput": "COPAY RX#100030241 FILL DATE: 06/30/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00UY3W"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "07092020",
+          "pDDatePostedOutput": "07/09/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 06/08/2020",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 06/08/2020",
+          "pDTransAmt": 50,
+          "pDTransAmtOutput": "50.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00V8T8"
+        },
+        {
+          "pDDatePosted": "07092020",
+          "pDDatePostedOutput": "07/09/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -50,
+          "pDTransAmtOutput": "50.00-&nbsp;",
+          "pDRefNo": "516-K00V8T8"
+        },
+        {
+          "pDDatePosted": "07092020",
+          "pDDatePostedOutput": "07/09/2020",
+          "pDTransDesc": "COMMENT: K00ULWR PD $50.00 DOS 060820",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;COMMENT: K00ULWR PD $50.00 DOS 060820",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00V8T8"
+        },
+        {
+          "pDDatePosted": "08132020",
+          "pDDatePostedOutput": "08/13/2020",
+          "pDTransDesc": "COPAY RX:100020336 FD:08/11/2020",
+          "pDTransDescOutput": "COPAY RX#100020336 FILL DATE: 08/11/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00WDZQ"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:AMLODIPINE BESYLATE 10MG TAB  DAYS:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:AMLODIPINE BESYLATE 10MG TAB  DAYS:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:90  PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:90  PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "09222020",
+          "pDDatePostedOutput": "09/22/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 08/20/2020",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 08/20/2020",
+          "pDTransAmt": 50,
+          "pDTransAmtOutput": "50.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00XUY2"
+        },
+        {
+          "pDDatePosted": "09222020",
+          "pDDatePostedOutput": "09/22/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -50,
+          "pDTransAmtOutput": "50.00-&nbsp;",
+          "pDRefNo": "516-K00XUY2"
+        },
+        {
+          "pDDatePosted": "09222020",
+          "pDDatePostedOutput": "09/22/2020",
+          "pDTransDesc": "COMMENT: K00X41A PD $50.00 DOS 082020",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;COMMENT: K00X41A PD $50.00 DOS 082020",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": "516-K00XUY2"
+        },
+        {
+          "pDDatePosted": "10072020",
+          "pDDatePostedOutput": "10/07/2020",
+          "pDTransDesc": "COPAY RX:100030241 FD:10/05/2020",
+          "pDTransDescOutput": "COPAY RX#100030241 FILL DATE: 10/05/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10J56V"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;PHY:GUTHRIE,BROOKE L  CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "10292020",
+          "pDDatePostedOutput": "10/29/2020",
+          "pDTransDesc": "COPAY RX:100045030 FD:10/27/2020",
+          "pDTransDescOutput": "COPAY RX#100045030 FILL DATE: 10/27/2020",
+          "pDTransAmt": 24,
+          "pDTransAmtOutput": "24.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10J56V"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:NIACIN (SLO-NIACIN) 250MG TAB,SA  DAYS:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:NIACIN (SLO-NIACIN) 250MG TAB,SA  DAYS:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:90  PHY:VELAZQUEZ SANCHEZ,VANESSA",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:90  PHY:VELAZQUEZ SANCHEZ,VANESSA",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "CHG:$24.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;CHG:$24.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "10292020",
+          "pDDatePostedOutput": "10/29/2020",
+          "pDTransDesc": "COPAY RX:100045028 FD:10/27/2020",
+          "pDTransDescOutput": "COPAY RX#100045028 FILL DATE: 10/27/2020",
+          "pDTransAmt": 8,
+          "pDTransAmtOutput": "8.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10J56V"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:CARBAMIDE PEROXIDE 6.5% OTIC SOLN  DAYS:14",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:CARBAMIDE PEROXIDE 6.5% OTIC SOLN  DAYS:14",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:45  PHY:VELAZQUEZ SANCHEZ,VANESSA  CHG:$8.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:45  PHY:VELAZQUEZ SANCHEZ,VANESSA  CHG:$8.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "10292020",
+          "pDDatePostedOutput": "10/29/2020",
+          "pDTransDesc": "COPAY RX:100045029 FD:10/27/2020",
+          "pDTransDescOutput": "COPAY RX#100045029 FILL DATE: 10/27/2020",
+          "pDTransAmt": 8,
+          "pDTransAmtOutput": "8.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10J56V"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:MICONAZOLE NITRATE 2% TOP TINCTURE  DAYS:30",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:MICONAZOLE NITRATE 2% TOP TINCTURE  DAYS:30",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:90  PHY:VELAZQUEZ SANCHEZ,VANESSA  CHG:$8.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:90  PHY:VELAZQUEZ SANCHEZ,VANESSA  CHG:$8.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT   (Int:0.12  Adm:1.64)",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -16.76,
+          "pDTransAmtOutput": "16.76-&nbsp;",
+          "pDRefNo": "516-K00JZPJ"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT   (Int:0.26  Adm:0.00)",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -15.26,
+          "pDTransAmtOutput": "15.26-&nbsp;",
+          "pDRefNo": "516-K00N8XA"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K00QKJJ"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K00S829"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -23,
+          "pDTransAmtOutput": "23.00-&nbsp;",
+          "pDRefNo": "516-K00SZBK"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K00UY3W"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K00WDZQ"
+        },
+        {
+          "pDDatePosted": "11192020",
+          "pDDatePostedOutput": "11/19/2020",
+          "pDTransDesc": "PAYMENT",
+          "pDTransDescOutput": "PAYMENT POSTED ON 11/19/2020",
+          "pDTransAmt": -55,
+          "pDTransAmtOutput": "55.00-&nbsp;",
+          "pDRefNo": "516-K10J56V"
+        },
+        {
+          "pDDatePosted": "11232020",
+          "pDDatePostedOutput": "11/23/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 10/27/2020",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 10/27/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10LD3I"
+        },
+        {
+          "pDDatePosted": "11232020",
+          "pDDatePostedOutput": "11/23/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K10LD3I"
+        },
+        {
+          "pDDatePosted": "11232020",
+          "pDDatePostedOutput": "11/23/2020",
+          "pDTransDesc": "COMMENT: K10KM1P PD $15.00 DOS:10/27/20",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;COMMENT: K10KM1P PD $15.00 DOS:10/27/20",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10LD3I"
+        },
+        {
+          "pDDatePosted": "12012020",
+          "pDDatePostedOutput": "12/01/2020",
+          "pDTransDesc": "COPAY RX:100046632 FD:11/18/2020",
+          "pDTransDescOutput": "COPAY RX#100046632 FILL DATE: 11/18/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10LT59"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:AMLODIPINE BESYLATE 10MG TAB  DAYS:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:AMLODIPINE BESYLATE 10MG TAB  DAYS:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "QTY:90  PHY:VELAZQUEZ SANCHEZ,VANESSA",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;QTY:90  PHY:VELAZQUEZ SANCHEZ,VANESSA",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "12162020",
+          "pDDatePostedOutput": "12/16/2020",
+          "pDTransDesc": "COPAY RX:100030241A FD:12/12/2020",
+          "pDTransDescOutput": "COPAY RX#100030241A FILL DATE: 12/12/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10MUDV"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;DRUG:ATENOLOL 25MG TAB  DAYS:90  QTY:90",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "PHY:VELAZQUEZ SANCHEZ,VANESSA  CHG:$15.00",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;PHY:VELAZQUEZ SANCHEZ,VANESSA  CHG:$15.00",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": "12212020",
+          "pDDatePostedOutput": "12/21/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC) VISIT DATE: 11/13/2020",
+          "pDTransDescOutput": "OUTPATIENT CARE VISIT DATE: 11/13/2020",
+          "pDTransAmt": 15,
+          "pDTransAmtOutput": "15.00&nbsp;&nbsp;",
+          "pDRefNo": "516-K10N4AR"
+        },
+        {
+          "pDDatePosted": "12212020",
+          "pDDatePostedOutput": "12/21/2020",
+          "pDTransDesc": "OUTPATIENT CARE(NSC)",
+          "pDTransDescOutput": "OUTPATIENT CARE",
+          "pDTransAmt": -15,
+          "pDTransAmtOutput": "15.00-&nbsp;",
+          "pDRefNo": "516-K10N4AR"
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.32 Adm:1.64 Other:0.00",
+          "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.32 Adm:1.64 Other:0.00",
+          "pDTransAmt": 1.96,
+          "pDTransAmtOutput": "1.96&nbsp;&nbsp;",
+          "pDRefNo": null
+        }
+      ],
+      "station": {
+        "facilitYNum": "649",
+        "visNNum": "22",
+        "facilitYDesc": "PRESCOTT VA MEDICAL CENTER (649)",
+        "cyclENum": "016",
+        "remiTToFlag": "L",
+        "maiLInsertFlag": "0",
+        "staTAddress1": "500 N US HIGHWAY 89",
+        "staTAddress2": "AGENT CASHIER (04C)",
+        "staTAddress3": null,
+        "city": "PRESCOTT",
+        "state": "AZ",
+        "ziPCde": "863135001",
+        "ziPCdeOutput": "86313-5001",
+        "baRCde": "*863135001003*",
+        "teLNumFlag": "S",
+        "teLNum": "1-866-802-6819",
+        "teLNum2": null,
+        "contacTInfo": null,
+        "dM2TelNum": null,
+        "contacTInfo2": null,
+        "toPTelNum": null,
+        "lbXFedexAddress1": null,
+        "lbXFedexAddress2": null,
+        "lbXFedexAddress3": null,
+        "lbXFedexCity": null,
+        "lbXFedexState": null,
+        "lbXFedexZipCde": null,
+        "lbXFedexBarCde": null,
+        "lbXFedexContact": null,
+        "lbXFedexContactTelNum": null
+      }
+    }
+  ]
+}

--- a/src/applications/medical-copays/tests/e2e/mcp.cypress.spec.js
+++ b/src/applications/medical-copays/tests/e2e/mcp.cypress.spec.js
@@ -52,7 +52,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays download statements - C12578', () => {
+  it('displays download statements - C12578', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');

--- a/src/applications/medical-copays/tests/e2e/statements.cypress.spec.js
+++ b/src/applications/medical-copays/tests/e2e/statements.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays other va debts', () => {
+  it('displays other va debts', () => {
     cy.findByTestId('other-va-debts-mcp-body').should('exist');
     cy.axeCheck();
   });
@@ -59,7 +59,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays view statements section - C12578', () => {
+  it('displays view statements section - C12578', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');
@@ -68,7 +68,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('navigates to view statements page - C12579', () => {
+  it('navigates to view statements page - C12579', () => {
     // get to page
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
@@ -83,7 +83,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays account summary - C12580', () => {
+  it('displays account summary - C12580', () => {
     // get to page
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();


### PR DESCRIPTION
## Description
Removing cross application component reference to see if it helps fix failing Cypress tests in CI, even though they've been passing locally. 

### Cypress skip fixes:
https://github.com/department-of-veterans-affairs/vets-website/pull/21009 

## Acceptance criteria
- [ ] No more Cypress failures!

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
