### PR TITLE
Add letters app keyboard testing

### DIFF
--- a/src/applications/letters/tests/02-keyboard-only.cypress.spec.js
+++ b/src/applications/letters/tests/02-keyboard-only.cypress.spec.js
@@ -1,0 +1,48 @@
+import {
+  letters,
+  benefitSummaryOptions,
+  address,
+  newAddress,
+  countries,
+  states,
+  mockUserData,
+} from './e2e/fixtures/mocks/letters';
+
+describe('Authed Letter Test', () => {
+  it('confirms authed letter functionality', () => {
+    cy.intercept('GET', '/v0/letters/beneficiary', benefitSummaryOptions).as(
+      'benefitSummaryOptions',
+    );
+    cy.intercept('GET', '/v0/letters', letters);
+    cy.intercept('GET', '/v0/address', address);
+    cy.intercept('GET', '/v0/address/countries', countries);
+    cy.intercept('GET', '/v0/address/states', states);
+    cy.intercept('PUT', '/v0/address', newAddress);
+
+    cy.login(mockUserData);
+    cy.visit('/records/download-va-letters/letters');
+    cy.injectAxe();
+
+    // Update address
+    cy.tabToElement('#mailingAddress-edit-link');
+    cy.realPress('Space');
+    cy.tabToElement('.usa-button-secondary'); // just cancel
+    cy.realPress('Space');
+
+    // go to letters page
+    cy.tabToElement('.view-letters-button');
+    cy.realPress('Space');
+
+    cy.get('va-accordion-item').should('exist');
+    cy.get('va-accordion-item').should('have.length', 5);
+
+    // -- Go to letters list -- //
+    cy.tabToElement('va-accordion-item:nth-of-type(4)');
+    cy.realPress('Enter');
+    cy.axeCheck();
+
+    cy.tabToElement('#militaryService');
+    cy.realPress('Space');
+    cy.get('#militaryService').should('not.be.checked');
+  });
+});


### PR DESCRIPTION
## Description

Adding keyboard navigation e2e testing for the letters app

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41106

## Testing done

Added e2e keyboard only test

## Screenshots

N/A

## Acceptance criteria
- [x] Add keyboard e2e test for letters app
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
