### PR TITLE
Updates Contacts Source in CST, NOD & HLR

### DIFF
--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';

--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import { selectProfile } from 'platform/user/selectors';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { FORMAT_READABLE } from '../constants';
 import { getSelected, getIssueName } from '../utils/helpers';

--- a/src/applications/appeals/10182/content/GetFormHelp.jsx
+++ b/src/applications/appeals/10182/content/GetFormHelp.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 

--- a/src/applications/claims-status/components/AskVAQuestions.jsx
+++ b/src/applications/claims-status/components/AskVAQuestions.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';

--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import recordEvent from 'platform/monitoring/record-event';
 

--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -234,6 +235,12 @@ const StemDeniedDetails = ({
       </div>
     </>
   );
+};
+
+StemDeniedDetails.propTypes = {
+  deniedAt: PropTypes.string,
+  isEnrolledStem: PropTypes.bool,
+  isPursuingTeachingCert: PropTypes.bool,
 };
 
 export default StemDeniedDetails;

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import recordEvent from 'platform/monitoring/record-event';
 

--- a/src/applications/disability-benefits/all-claims/content/common.jsx
+++ b/src/applications/disability-benefits/all-claims/content/common.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export const editNote = name => (
   <p>

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import DownloadPDF from '../components/DownloadPDF';
 import { capitalizeEachWord, formatDate } from '../utils';

--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export const FDCDescription = (
   <div>

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { VaAdditionalInfo } from 'web-components/react-bindings';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { recordEventOnce } from 'platform/monitoring/record-event';
 

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { VA_FORM4192_URL } from '../constants';
 import { claimsIntakeAddress } from './itfWrapper';

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { VaAdditionalInfo } from 'web-components/react-bindings';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { recordEventOnce } from 'platform/monitoring/record-event';
 

--- a/src/applications/financial-status-report/components/AvailableDebts.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebts.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import Telephone from '@department-of-veterans-affairs/component-library';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
 import PropTypes from 'prop-types';
 import { ErrorAlert } from './Alerts';
 import { fetchDebts } from '../actions';

--- a/src/applications/financial-status-report/components/AvailableDebts.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebts.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import Telephone from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import PropTypes from 'prop-types';
 import { ErrorAlert } from './Alerts';
 import { fetchDebts } from '../actions';


### PR DESCRIPTION
## Description

This updates the `va-telephone` contacts that are being imported from the old React Telephone component and confirms that any existing tests continue to pass.

Additionally, this adds PropTypes to the `StemDeniedDetails` component and resolves those _eslint_ warnings.

## Original issue(s)
Resolves department-of-veterans-affairs/va.gov-team#41083
Resolves department-of-veterans-affairs/va.gov-team#41084
Resolves department-of-veterans-affairs/va.gov-team#41085