### PR TITLE
Replace 'LoadingIndicator' component with 'va-loading-indicator' in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SubmitLoadingIndicator.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SubmitLoadingIndicator.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 const SubmitLoadingIndicator = ({ submission }) => {
   const [isLoading, setLoading] = useState(false);
@@ -27,11 +26,7 @@ const SubmitLoadingIndicator = ({ submission }) => {
       {isLoading && (
         <div className="loading-container">
           <div className="vads-u-margin-y--4">
-            <LoadingIndicator />
-            <p>
-              We’re processing your application. This may take up to 1 minute.
-              Please don’t refresh your browser.
-            </p>
+            <va-loading-indicator message="We’re processing your application. This may take up to 1 minute. Please don’t refresh your browser." />
           </div>
         </div>
       )}

--- a/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
+++ b/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import * as Sentry from '@sentry/browser';
 import moment from 'moment';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import formConfig from 'applications/caregivers/config/form';
 import environment from 'platform/utilities/environment';
@@ -129,7 +128,7 @@ const DownLoadLink = ({ form }) => {
   const renderLoadingIndicator = () => {
     return (
       <div className="pdf-download-link--loading">
-        <LoadingIndicator message="Downloading PDF..." />
+        <va-loading-indicator message="Downloading PDF..." />
       </div>
     );
   };

--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -2,8 +2,6 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import recordEvent from 'platform/monitoring/record-event';
@@ -31,7 +29,7 @@ const App = ({ loading, location, children }) => {
   );
 
   return loading ? (
-    <LoadingIndicator />
+    <va-loading-indicator />
   ) : (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}


### PR DESCRIPTION
## Description
The `<LoadingIndicator>` component is utilized multiple times throughout the Caregivers application markup. This component has been deprecated by the Design team in favor of the `<va-loading-indicator>` component. We need to upgrade the Caregivers app to remove this deprecated component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41014

## Testing done
- [x] Unit Tests

## Acceptance criteria
- [ ] Application utilizes the most up-to-date Design System loading component.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
