### PR TITLE
Update class attributes on va-telephone components in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -10,7 +10,7 @@ const NeedHelpFooter = () => {
         You can call the VA Caregiver Support Line at
         <va-telephone
           contact={CONTACTS.CAREGIVER}
-          className="vads-u-margin-left--0p5"
+          class="vads-u-margin-left--0p5"
         />
         . We’re here Monday through Friday, 8:00 a.m. to 10:00 p.m. ET, and
         Saturday, 8:00 a.m. to 5:00 p.m. ET.
@@ -20,7 +20,7 @@ const NeedHelpFooter = () => {
         You can also call
         <va-telephone
           contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
-          className="vads-u-margin-x--0p5"
+          class="vads-u-margin-x--0p5"
         />
         if you have questions about completing your application, or contact your
         local Caregiver Support Coordinator.
@@ -41,14 +41,14 @@ const NeedHelpFooter = () => {
         If this form isn’t working right for you, please call us at
         <va-telephone
           contact={CONTACTS.HELP_DESK}
-          className="vads-u-margin-left--0p5"
+          class="vads-u-margin-left--0p5"
         />
         .<br />
         <span>
           If you have hearing loss, call TTY:
           <va-telephone
             contact={CONTACTS['711']}
-            className="vads-u-margin-left--0p5"
+            class="vads-u-margin-left--0p5"
           />
           .
         </span>

--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -7,21 +7,15 @@ const NeedHelpFooter = () => {
   return (
     <>
       <p>
-        You can call the VA Caregiver Support Line at
-        <va-telephone
-          contact={CONTACTS.CAREGIVER}
-          class="vads-u-margin-left--0p5"
-        />
-        . We’re here Monday through Friday, 8:00 a.m. to 10:00 p.m. ET, and
-        Saturday, 8:00 a.m. to 5:00 p.m. ET.
+        You can call the VA Caregiver Support Line at{' '}
+        <va-telephone contact={CONTACTS.CAREGIVER} />. We’re here Monday through
+        Friday, 8:00 a.m. to 10:00 p.m. ET, and Saturday, 8:00 a.m. to 5:00 p.m.
+        ET.
       </p>
 
       <p>
-        You can also call
-        <va-telephone
-          contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
-          class="vads-u-margin-x--0p5"
-        />
+        You can also call{' '}
+        <va-telephone contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER} /> if you
         if you have questions about completing your application, or contact your
         local Caregiver Support Coordinator.
       </p>
@@ -38,19 +32,11 @@ const NeedHelpFooter = () => {
       </span>
 
       <p>
-        If this form isn’t working right for you, please call us at
-        <va-telephone
-          contact={CONTACTS.HELP_DESK}
-          class="vads-u-margin-left--0p5"
-        />
-        .<br />
+        If this form isn’t working right for you, please call us at{' '}
+        <va-telephone contact={CONTACTS.HELP_DESK} />.<br />
         <span>
-          If you have hearing loss, call TTY:
-          <va-telephone
-            contact={CONTACTS['711']}
-            class="vads-u-margin-left--0p5"
-          />
-          .
+          If you have hearing loss, call TTY:{' '}
+          <va-telephone contact={CONTACTS['711']} />.
         </span>
       </p>
     </>

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -48,13 +48,8 @@ const SubmitError = ({ form }) => {
           <a className="vads-u-margin-x--0p5" href="https://www.va.gov/">
             VA.gov
           </a>
-          help desk at{' '}
-          <va-telephone
-            contact={CONTACTS.HELP_DESK}
-            class="vads-u-margin-x--0p5"
-          />{' '}
-          (TTY: 711). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.
-          ET.
+          help desk at <va-telephone contact={CONTACTS.HELP_DESK} /> (TTY: 711).
+          We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </div>
 
         <DownLoadLink form={form} />

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -48,8 +48,13 @@ const SubmitError = ({ form }) => {
           <a className="vads-u-margin-x--0p5" href="https://www.va.gov/">
             VA.gov
           </a>
-          help desk at <va-telephone contact={CONTACTS.HELP_DESK} /> (TTY: 711).{' '}
-          We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          help desk at{' '}
+          <va-telephone
+            contact={CONTACTS.HELP_DESK}
+            class="vads-u-margin-x--0p5"
+          />{' '}
+          (TTY: 711). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.
+          ET.
         </div>
 
         <DownLoadLink form={form} />

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -124,12 +124,8 @@ const ConfirmationPage = props => {
             If you have questions about your application, what to expect next,
             or if you are interested in learning more about the supports and
             services available to support Veterans and caregivers, you may
-            contact the VA Caregiver Support Line at
-            <va-telephone
-              contact={CONTACTS.CAREGIVER}
-              class="vads-u-margin-x--0p5"
-            />
-            or visit
+            contact the VA Caregiver Support Line at{' '}
+            <va-telephone contact={CONTACTS.CAREGIVER} /> or visit
             <a
               className="vads-u-margin-left--0p5"
               href={links.caregiverHelpPage.link}

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -127,7 +127,7 @@ const ConfirmationPage = props => {
             contact the VA Caregiver Support Line at
             <va-telephone
               contact={CONTACTS.CAREGIVER}
-              className="vads-u-margin-x--0p5"
+              class="vads-u-margin-x--0p5"
             />
             or visit
             <a

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -132,11 +132,10 @@ export const IntroductionPage = ({
 
               <ul className="process-lists">
                 <li>
-                  Call us at
+                  Call us at{' '}
                   <va-telephone
                     contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
-                    class="vads-u-margin-x--0p5"
-                  />
+                  />{' '}
                   and ask for help filling out the form
                 </li>
                 <li>
@@ -152,11 +151,8 @@ export const IntroductionPage = ({
                   to find a coordinator at your nearest VA health care facility
                 </li>
                 <li>
-                  Contact the VA National Caregiver Support Line by calling
-                  <va-telephone
-                    contact={CONTACTS.CAREGIVER}
-                    class="vads-u-margin-left--0p5"
-                  />
+                  Contact the VA National Caregiver Support Line by calling{' '}
+                  <va-telephone contact={CONTACTS.CAREGIVER} />
                 </li>
               </ul>
 
@@ -216,12 +212,8 @@ export const IntroductionPage = ({
             <p>
               You may also be eligible for the Program of General Caregiver
               Support Services (PGCSS). To find out more, call the VA Caregiver
-              Support Line at
-              <va-telephone
-                contact={CONTACTS.CAREGIVER}
-                class="vads-u-margin-left--0p5"
-              />
-              , visit
+              Support Line at <va-telephone contact={CONTACTS.CAREGIVER} />,
+              visit
               <a
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -135,7 +135,7 @@ export const IntroductionPage = ({
                   Call us at
                   <va-telephone
                     contact={CONTACTS.HEALTHCARE_ELIGIBILITY_CENTER}
-                    className="vads-u-margin-x--0p5"
+                    class="vads-u-margin-x--0p5"
                   />
                   and ask for help filling out the form
                 </li>
@@ -155,7 +155,7 @@ export const IntroductionPage = ({
                   Contact the VA National Caregiver Support Line by calling
                   <va-telephone
                     contact={CONTACTS.CAREGIVER}
-                    className="vads-u-margin-left--0p5"
+                    class="vads-u-margin-left--0p5"
                   />
                 </li>
               </ul>
@@ -219,7 +219,7 @@ export const IntroductionPage = ({
               Support Line at
               <va-telephone
                 contact={CONTACTS.CAREGIVER}
-                className="vads-u-margin-left--0p5"
+                class="vads-u-margin-left--0p5"
               />
               , visit
               <a


### PR DESCRIPTION
## Description
`va-telephone` components don't take the `className` attribute to assign classes to the object. They need to use the standard `class` attribute. This PR fixes the use of the attribute to assign classes to the component. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41017

## Testing done
- [x] Unit tests

## Acceptance criteria
- [ ] Classes are assigned to the component in runtime and applied correctly.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
