### PR TITLE
Go to error page when any appointment has been canceled

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -199,6 +199,15 @@ class ApiInitializer {
       });
       return data;
     },
+    withCanceledAppointment: () => {
+      const data = preCheckInData.get.createMockSuccessResponse(
+        preCheckInData.get.canceledAppointmentUUID,
+      );
+      cy.intercept('GET', '/check_in/v2/pre_check_ins/*', req => {
+        req.reply(data);
+      });
+      return data;
+    },
     withExpired: () => {
       const data = preCheckInData.get.createMockSuccessResponse(
         preCheckInData.get.expiredUUID,

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -3,6 +3,7 @@ const format = require('date-fns/format');
 
 const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
 const alreadyPreCheckedInUUID = '4d523464-c450-49dc-9a18-c04b3f1642ee';
+const canceledAppointmentUUID = '9d7b7c15-d539-4624-8d15-b740b84e8548';
 const expiredUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
 
 const createMockSuccessResponse = (
@@ -17,6 +18,8 @@ const createMockSuccessResponse = (
   const mockTime = token === expiredUUID ? new Date() : addDays(new Date(), 1);
 
   let checkInSteps = [];
+  let status = '';
+
   if (token === alreadyPreCheckedInUUID) {
     const dateFormat = "yyyy-LL-dd'T'HH:mm:ss";
     // 35 minutes ago.
@@ -42,6 +45,8 @@ const createMockSuccessResponse = (
         ien: 2,
       },
     ];
+  } else if (token === canceledAppointmentUUID) {
+    status = 'CANCELLED BY CLINIC';
   }
 
   return {
@@ -116,6 +121,7 @@ const createMockSuccessResponse = (
           checkInWindowStart: mockTime,
           checkInWindowEnd: mockTime,
           checkedInTime: '',
+          status,
         },
         {
           facility: 'LOMA LINDA VA CLINIC',
@@ -130,6 +136,7 @@ const createMockSuccessResponse = (
           checkInWindowStart: mockTime,
           checkInWindowEnd: mockTime,
           checkedInTime: '',
+          status,
         },
       ],
       patientDemographicsStatus: {
@@ -152,6 +159,7 @@ const createMockFailedResponse = _data => {
 
 module.exports = {
   alreadyPreCheckedInUUID,
+  canceledAppointmentUUID,
   createMockSuccessResponse,
   createMockFailedResponse,
   defaultUUID,

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -14,6 +14,7 @@ import {
 
 import { makeSelectCurrentContext } from '../../../selectors';
 import {
+  appointmentWasCanceled,
   preCheckinAlreadyCompleted,
   preCheckinExpired,
 } from '../../../utils/appointment';
@@ -73,6 +74,10 @@ const Introduction = props => {
             preCheckinExpired(payload.appointments)
           ) {
             goToErrorPage('?type=expired');
+          }
+
+          if (appointmentWasCanceled(payload.appointments)) {
+            goToErrorPage();
           }
 
           if (preCheckinAlreadyCompleted(payload.appointments)) {

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
@@ -1,0 +1,39 @@
+import '../../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../../tests/e2e/pages/ValidateVeteran';
+import Error from '../../pages/Error';
+
+describe('Pre-Check In Experience ', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializePreCheckInDataGet,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+
+    initializeSessionPost.withSuccess();
+
+    initializePreCheckInDataGet.withCanceledAppointment();
+  });
+  afterEach(() => {
+    cy.window().then(window => {
+      window.sessionStorage.clear();
+    });
+  });
+  it('Canceled Appointments are taken to Error Page', () => {
+    cy.visitPreCheckInWithUUID();
+    // page: Validate
+    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validateVeteran();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    // UUID with canceled appointments should navigate to the error page.
+    Error.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import {
+  appointmentWasCanceled,
   hasMoreAppointmentsToCheckInto,
   preCheckinAlreadyCompleted,
   sortAppointmentsByStartTime,
@@ -114,6 +115,48 @@ describe('check in', () => {
         expect(
           hasMoreAppointmentsToCheckInto(appointments, selectedAppointment),
         ).to.equal(false);
+      });
+    });
+    describe('appointmentWasCanceled', () => {
+      const generateAppointments = () => {
+        const earliest = createAppointment();
+        earliest.startTime = '2018-01-01T00:00:00.000Z';
+        const midday = createAppointment();
+        midday.startTime = '2018-01-01T12:00:00.000Z';
+        const latest = createAppointment();
+        latest.startTime = '2018-01-01T23:59:59.000Z';
+
+        return [latest, earliest, midday];
+      };
+
+      it('returns false when no appointment was canceled', () => {
+        const appointments = generateAppointments();
+        expect(appointmentWasCanceled(appointments)).to.deep.equal(false);
+      });
+      it('returns false when appointments are not set', () => {
+        expect(appointmentWasCanceled(null)).to.deep.equal(false);
+      });
+      it('returns false when there are no appointments', () => {
+        expect(appointmentWasCanceled([])).to.deep.equal(false);
+      });
+      it('returns true when any appointment has been canceled', () => {
+        const appointments = generateAppointments();
+        appointments[0].status = 'CANCELLED BY CLINIC';
+        expect(appointmentWasCanceled(appointments)).to.deep.equal(true);
+      });
+      it('returns false when status is undefined', () => {
+        const appointments = generateAppointments();
+        appointments.forEach((appt, idx) => {
+          delete appointments[idx].status;
+        });
+        expect(appointmentWasCanceled(appointments)).to.deep.equal(false);
+      });
+      it('returns true when all appointments have been canceled', () => {
+        const appointments = generateAppointments();
+        appointments[0].status = 'CANCELLED BY CLINIC';
+        appointments[1].status = 'CANCELLED BY PATIENT';
+        appointments[0].status = 'CANCELLED BY CLINIC';
+        expect(appointmentWasCanceled(appointments)).to.deep.equal(true);
       });
     });
     describe('preCheckinAlreadyCompleted', () => {

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -30,6 +30,18 @@ const hasMoreAppointmentsToCheckInto = (appointments, currentAppointment) => {
 };
 
 /**
+ * Check if any appointment was canceled.
+ *
+ * @param {Array<Appointment>} appointments
+ */
+const appointmentWasCanceled = appointments => {
+  const statusIsCanceled = appointment =>
+    appointment.status?.startsWith('CANCELLED');
+
+  return Array.isArray(appointments) && appointments.some(statusIsCanceled);
+};
+
+/**
  * Check if all appointments have completed pre-check-in.
  *
  * @param {Array<Appointment>} appointments
@@ -104,6 +116,7 @@ const preCheckinExpired = appointments => {
 };
 
 export {
+  appointmentWasCanceled,
   hasMoreAppointmentsToCheckInto,
   sortAppointmentsByStartTime,
   preCheckinAlreadyCompleted,


### PR DESCRIPTION
## Description

We are showing the generic error page when a veteran visits pre-check-in with a canceled appointment as a temporary workaround.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#41105](https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/department-of-veterans-affairs/va.gov-team/41105)


## Testing done

Local testing, added unit & e2e tests.

## QA

- [ ] visiting with canceled appt uuid `9d7b7c15-d539-4624-8d15-b740b84e8548` directs user to generic pre-checkin error page
- [ ] other UUIDs function as spec'd
