### PR TITLE
Update to same Node/Chrome versions for E2E 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -261,7 +261,7 @@ jobs:
         run: echo ::set-output name=app_folders::$(node script/github-actions/get-changed-apps.js --output-type folder | tr ',' ' ')
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
-      
+
       - name: Get contract tests
         id: get-tests
         run: |
@@ -515,7 +515,7 @@ jobs:
       needs.cypress-tests-prep.result == 'success' &&
       needs.cypress-tests-prep.outputs.tests != '[]'
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
+      image: public.ecr.aws/cypress-io/cypress/browsers:node14.17.6-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           sed -i -e 's/\"istanbul\",//g' .babelrc
           sed -i -e 's/\"lodash\",/\"lodash\", \"istanbul\",/g' .babelrc
-          
+
       - name: Build
         run: yarn build --verbose --buildtype=${{ env.BUILDTYPE }}
         timeout-minutes: 30
@@ -149,7 +149,7 @@ jobs:
       needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success'
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
+      image: public.ecr.aws/cypress-io/cypress/browsers:node14.17.6-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:
@@ -295,14 +295,15 @@ jobs:
   testing-reports-cypress:
     name: Testing Reports - Cypress E2E Tests
     runs-on: ubuntu-latest
-    needs: [set-commit-sha, testing-reports-prep, cypress-tests-prep, cypress-tests]
+    needs:
+      [set-commit-sha, testing-reports-prep, cypress-tests-prep, cypress-tests]
     continue-on-error: true
     if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
-    
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}  
 
-    steps: 
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -401,14 +402,15 @@ jobs:
   e2e-code-coverage-cypress:
     name: E2E Code Coverage Reports
     runs-on: ubuntu-latest
-    needs: [set-commit-sha, testing-reports-prep, cypress-tests-prep, cypress-tests]
+    needs:
+      [set-commit-sha, testing-reports-prep, cypress-tests-prep, cypress-tests]
     continue-on-error: true
     if: ${{ always() && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
-    
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}  
 
-    steps: 
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -2,7 +2,7 @@ import 'cypress-real-events';
 
 // This is the timeout duration between each event. You can overwrite this in your test if you want it to move faster or slower.
 // eslint-disable-next-line prefer-const
-let timeoutDuration = 0;
+let timeoutDuration = 1;
 
 /**
  * This command is used by other commands to select form values. You can call this yourself if you want to move focus to a specific radio value while the radio field is focused. The value is the value of the input/option.

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -2,7 +2,7 @@ import 'cypress-real-events';
 
 // This is the timeout duration between each event. You can overwrite this in your test if you want it to move faster or slower.
 // eslint-disable-next-line prefer-const
-let timeoutDuration = 1;
+let timeoutDuration = 0;
 
 /**
  * This command is used by other commands to select form values. You can call this yourself if you want to move focus to a specific radio value while the radio field is focused. The value is the value of the input/option.


### PR DESCRIPTION
## Description

E2E tests were failing on Chrome 90 but not Chrome 100. Different versions were running for PRs vs. CI.

## Original issue(s)

https://dsva.slack.com/archives/CBU0KDSB1/p1652204073062629


## Testing done

- Ran the failing tests locally.
- Consistently passed with Chrome 100+.
- Consistently failed with Chrome 90.

## Screenshots

![image](https://user-images.githubusercontent.com/100248909/167716844-8663fa87-e608-417b-86d1-e2caa4891f02.png)


## Acceptance criteria
- [x] Both parts of the pipeline run the same Node and Chrome versions and produce the same result for E2E tests.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
