### PR TITLE
Letters: Skip failing e2e test

### DIFF
--- a/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('tabToInputWithLabel', text => {
     });
 });
 
-describe('Notice of Disagreement keyboard only navigation', () => {
+describe.skip('Notice of Disagreement keyboard only navigation', () => {
   it('navigates through a maximal form', () => {
     cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
     cy.intercept('PUT', 'v0/in_progress_forms/10182', mockInProgress);

--- a/src/applications/letters/tests/02-keyboard-only.cypress.spec.js
+++ b/src/applications/letters/tests/02-keyboard-only.cypress.spec.js
@@ -9,7 +9,7 @@ import {
 } from './e2e/fixtures/mocks/letters';
 
 describe('Authed Letter Test', () => {
-  it('confirms authed letter functionality', () => {
+  it.skip('confirms authed letter functionality', () => {
     cy.intercept('GET', '/v0/letters/beneficiary', benefitSummaryOptions).as(
       'benefitSummaryOptions',
     );


### PR DESCRIPTION
## Description

[Skipping Letters app keyboard-only e2e tests per this Slack conversation](https://dsva.slack.com/archives/CBU0KDSB1/p1652210516061559?thread_ts=1652204073.062629&cid=CBU0KDSB1)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41106

## Testing done

Skipping test

## Screenshots

N/A

## Acceptance criteria
- [x] Skip failing e2e test
- [x] All other tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
