### PR TITLE
[CDP] Removing productId to pass failing unit tests

### DIFF
--- a/src/applications/combined-debt-portal/combined/manifest.json
+++ b/src/applications/combined-debt-portal/combined/manifest.json
@@ -2,6 +2,5 @@
   "appName": "Debt and bills",
   "entryFile": "./app-entry.jsx",
   "entryName": "combined-debt-portal",
-  "rootUrl": "/debt-and-bills",
-  "productId": "1a3f7e62-027f-414b-80a5-fa033431faa7"
+  "rootUrl": "/debt-and-bills"
 }


### PR DESCRIPTION
## Description
Removed productId from combined-debt-portal manifest.json to prevent unit tests from failing

### Failing Test
https://github.com/department-of-veterans-affairs/vets-website/runs/6376509865?check_suite_focus=true

## Acceptance criteria
- [ ] unit tests no longer failing
