### PR TITLE
Profile/41001/handle personal edge cases

### DIFF
--- a/src/applications/personalization/profile/actions/personalInformation.js
+++ b/src/applications/personalization/profile/actions/personalInformation.js
@@ -46,13 +46,18 @@ export function fetchPersonalInformation(forceCacheClear = false) {
     }
 
     // preferred name returns as ALL CAPS, so it needs to be capitalized appropriately for display
-    // TODO: see if we could get case sensitive updates to downstream service / VAProfile
     if (response?.[PERSONAL_INFO_FIELD_NAMES.PREFERRED_NAME]) {
       set(
         response,
         PERSONAL_INFO_FIELD_NAMES.PREFERRED_NAME,
         capitalize(response?.[PERSONAL_INFO_FIELD_NAMES.PREFERRED_NAME]),
       );
+    }
+
+    // a null code for gender identity needs to instead be set to an empty string or else
+    // validation message will be incorrectly set to 'is not of a type(s) string'
+    if (!response?.[PERSONAL_INFO_FIELD_NAMES.GENDER_IDENTITY]?.code) {
+      set(response, `${PERSONAL_INFO_FIELD_NAMES.GENDER_IDENTITY}.code`, '');
     }
 
     dispatch({

--- a/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
@@ -235,6 +235,16 @@ export class ProfileInformationEditView extends Component {
     if (newFieldValue['view:livesOnMilitaryBase']) {
       newFieldValue.countryCodeIso3 = USA.COUNTRY_ISO3_CODE;
     }
+
+    // doing this to trigger a blur when the field is cleared so that validation runs
+    // otherwise there didn't seem to be a way to show validation appropriately
+    if (
+      this.props.fieldName === FIELD_NAMES.PREFERRED_NAME &&
+      !newFieldValue[FIELD_NAMES.PREFERRED_NAME]
+    ) {
+      document.getElementById('root_preferredName').blur();
+    }
+
     this.onChangeFormDataAndSchemas(newFieldValue, schema, uiSchema);
   };
 

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -27,13 +27,15 @@ const responses = {
   'PUT /v0/profile/preferred_names': handlePutPreferredNameRoute,
   'PUT /v0/profile/gender_identities': handlePutGenderIdentitiesRoute,
   'GET /v0/profile/full_name': {
-    id: '',
-    type: 'hashes',
-    attributes: {
-      first: 'Mitchell',
-      middle: 'G',
-      last: 'Jenkins',
-      suffix: null,
+    data: {
+      id: '',
+      type: 'hashes',
+      attributes: {
+        first: 'Mitchell',
+        middle: 'G',
+        last: 'Jenkins',
+        suffix: null,
+      },
     },
   },
   'GET /v0/profile/ch33_bank_accounts': {

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -13,7 +13,9 @@ const checkPersonalInfoFields = () => {
 
   cy.findByText(nameEditInputLabel).should('exist');
 
-  cy.get(nameEditInputField).should('exist');
+  cy.get(nameEditInputField)
+    .should('exist')
+    .blur();
 
   cy.findAllByTestId('cancel-edit-button')
     .should('exist')

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info.dont-require-field-when-no-initial-data.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info.dont-require-field-when-no-initial-data.cypress.spec.js
@@ -9,35 +9,28 @@ describe('Personal information', () => {
         isEnhanced: true,
         personalData: set(
           mockPersonalInformationEnhanced,
-          'data.attributes.preferredName',
-          '',
+          'data.attributes.genderIdentity',
+          { code: null, name: null },
         ),
       });
     });
 
-    it('should show the preferred name field as not required and allow cancel', () => {
-      cy.findByLabelText('Edit Preferred name')
+    it('should show the Gender Identity field as not required and allow cancel', () => {
+      cy.findByLabelText('Edit Gender identity')
         .should('exist')
         .click({ waitForAnimations: true });
 
-      cy.findByText(
-        'Provide your preferred name (25 characters maximum)',
-      ).should('exist');
+      cy.findByText('Select your gender identity').should('exist');
 
       cy.findByText(`(*Required)`).should('not.exist');
-
-      // if we clear the field and attempt to update the error should appear
-      cy.get('input[name="root_preferredName"]')
-        .should('exist')
-        .clear();
 
       cy.findByTestId('cancel-edit-button')
         .should('exist')
         .click({ waitForAnimations: true });
 
-      cy.get('#root_preferredName-error-message').should('not.exist');
+      cy.get('#root_genderIdentity-error-message').should('not.exist');
 
-      cy.get('input[name="root_preferredName"]').should('not.exist');
+      cy.get('#root_genderIdentity-label').should('not.exist');
 
       cy.injectAxeThenAxeCheck();
     });

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info.require-field-with-intial-data.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info.require-field-with-intial-data.cypress.spec.js
@@ -1,4 +1,6 @@
 import { setup } from '@@profile/tests/e2e/personal-information/setup';
+import mockPersonalInformationEnhanced from '@@profile/tests/fixtures/personal-information-success-enhanced.json';
+import set from 'lodash/set';
 
 describe('Personal information', () => {
   describe('require field when initial data is present from api call', () => {
@@ -41,6 +43,37 @@ describe('Personal information', () => {
       cy.findByText('Select your gender identity').should('exist');
 
       cy.findByText(`(*Required)`).should('exist');
+
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  describe('require a Gender Identity selection when initial data is not present from api call and update is attempted on empty selection', () => {
+    it('should show and error and not allow update without selecting option or cancelling out of edit mode', () => {
+      setup({
+        isEnhanced: true,
+        personalData: set(
+          mockPersonalInformationEnhanced,
+          'data.attributes.genderIdentity',
+          { code: null, name: null },
+        ),
+      });
+
+      cy.findByLabelText('Edit Gender identity')
+        .should('exist')
+        .click({ waitForAnimations: true });
+
+      cy.findByText('Select your gender identity').should('exist');
+
+      cy.findByText(`(*Required)`).should('not.exist');
+
+      cy.findByTestId('save-edit-button')
+        .should('exist')
+        .click({ waitForAnimations: true });
+
+      cy.get('#root_genderIdentity-error-message')
+        .contains('Please select a valid option')
+        .should('exist');
 
       cy.injectAxeThenAxeCheck();
     });

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -71,6 +71,7 @@ export const personalInformationFormSchemas = {
         maxLength: 25,
       },
     },
+    required: ['preferredName'],
   },
   pronouns: {
     type: 'object',


### PR DESCRIPTION
## Description
Addresses 2 edge cases for Personal Information profile page

1. When no preferred name is present from the API's initial response, and attempt could be made to update the preferred name with an empty field value. This is fixed and will show a 'required' validation error or allow cancelling of the edit state to return to the view state.
2. When no gender identity was provided from the initial API response, the gender identity field validation would show an unfriendly error message. This is fixed to make sure that a null value is set to an empty string and will result in a correct validation error message displaying.

Note: this is work that was split from this previous PR: https://github.com/department-of-veterans-affairs/vets-website/pull/21022

The accessibility issue that was also addressed in this previous PR is still pending some discussion, so the edge cases fixes were moved to this PR so that it could be merged first.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/41001


## Testing done
E2E testing added for these edge cases

## Acceptance criteria
- [x] Edge cases addressed and validate in the forms correctly.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
