### PR TITLE
Add UUID to Product ID of Manifests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,3 +104,4 @@ src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-adm
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe
 src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-health-platform
 src/applications/virtual-agent @department-of-veterans-affairs/orchid
+src/applications/**/manifest.json @department-of-veterans-affairs/qa-standards

--- a/src/applications/_mock-form/manifest.json
+++ b/src/applications/_mock-form/manifest.json
@@ -3,5 +3,6 @@
   "entryFile": "./app-entry.jsx",
   "entryName": "mock-form",
   "rootUrl": "/mock-form",
-  "production": false
+  "production": false,
+  "productId": "b00f9ad9-f81a-402b-957f-eeb9b2554f2d"
 }

--- a/src/applications/appeals/10182/manifest.json
+++ b/src/applications/appeals/10182/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./form-entry.jsx",
   "entryName": "10182-board-appeal",
   "rootUrl": "/decision-reviews/board-appeal/request-board-appeal-form-10182",
-  "productId": 9
+  "productId": "efe70873-bf4e-491d-8191-e55558fb5368"
 }

--- a/src/applications/auth/manifest.json
+++ b/src/applications/auth/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Authentication callback",
   "entryFile": "./auth-entry.jsx",
   "entryName": "auth",
-  "rootUrl": "/auth/login/callback"
+  "rootUrl": "/auth/login/callback",
+  "productId": "ca6d20e7-6a64-4008-ad39-2735cc5c04bd"
 }

--- a/src/applications/burials/manifest.json
+++ b/src/applications/burials/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./burials-entry.jsx",
   "entryName": "burials",
   "rootUrl": "/burials-and-memorials/application/530",
-  "productId": 18
+  "productId": "02990746-9fc6-425b-9fdd-b33bf32ee580"
 }

--- a/src/applications/caregivers/manifest.json
+++ b/src/applications/caregivers/manifest.json
@@ -4,5 +4,5 @@
   "entryName": "1010cg-application-caregiver-assistance",
   "rootUrl": "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg",
   "e2eTestsDisabled": true,
-  "productId": 11
+  "productId": "4d22afe4-3f1b-4b02-bebf-18840df27cbc"
 }

--- a/src/applications/claims-status/manifest.json
+++ b/src/applications/claims-status/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./claims-status-entry.jsx",
   "entryName": "claims-status",
   "rootUrl": "/track-claims",
-  "productId": 2
+  "productId": "268792c2-367e-4fc9-bb20-3abafbb4e3d6"
 }

--- a/src/applications/coronavirus-research/sign-up/manifest.json
+++ b/src/applications/coronavirus-research/sign-up/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Coronavirus Research - Volunteer",
   "entryFile": "./app-entry.jsx",
   "entryName": "coronavirus-research",
-  "rootUrl": "/coronavirus-research/volunteer"
+  "rootUrl": "/coronavirus-research/volunteer",
+  "productId": "39af3c31-26cc-4b69-8cb4-131881f90f9b"
 }

--- a/src/applications/coronavirus-research/update/manifest.json
+++ b/src/applications/coronavirus-research/update/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Coronavirus Research - Update",
   "entryFile": "./app-entry.jsx",
   "entryName": "coronavirus-research-update",
-  "rootUrl": "/coronavirus-research/volunteer/update"
+  "rootUrl": "/coronavirus-research/volunteer/update",
+  "productId": "36a4b95a-af8e-4fe7-8aa4-e8c430124fcf"
 }

--- a/src/applications/coronavirus-screener/manifest.json
+++ b/src/applications/coronavirus-screener/manifest.json
@@ -2,5 +2,6 @@
   "appName": "COVID-19 Screener",
   "entryFile": "./app-entry.jsx",
   "entryName": "covid19screen",
-  "rootUrl": "/covid19screen"
+  "rootUrl": "/covid19screen",
+  "productId": "a59d2f4f-469a-4ef8-9558-419442896df1"
 }

--- a/src/applications/coronavirus-vaccination-expansion/manifest.json
+++ b/src/applications/coronavirus-vaccination-expansion/manifest.json
@@ -2,5 +2,6 @@
   "appName": "covid-vaccine-expansion",
   "entryFile": "./app-entry.jsx",
   "entryName": "covid-vaccine",
-  "rootUrl": "/health-care/covid-19-vaccine/sign-up"
+  "rootUrl": "/health-care/covid-19-vaccine/sign-up",
+  "productId": "fedb57b6-fc46-44fb-86e5-0393cead77c0"
 }

--- a/src/applications/coronavirus-vaccination/manifest.json
+++ b/src/applications/coronavirus-vaccination/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./coronavirus-vaccination-entry.jsx",
   "entryName": "coronavirus-vaccination",
   "rootUrl": "/health-care/covid-19-vaccine/stay-informed",
-  "productId": 180
+  "productId": "dc4c86de-6747-4aea-9be1-b5aa3fcb6240"
 }

--- a/src/applications/debt-letters/manifest.json
+++ b/src/applications/debt-letters/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Debt Letters",
   "entryFile": "./app-entry.jsx",
   "entryName": "your-debt",
-  "rootUrl": "/manage-va-debt/your-debt"
+  "rootUrl": "/manage-va-debt/your-debt",
+  "productId": "01c70d93-d02b-47c1-a8a2-eb3d32b1b6f2"
 }

--- a/src/applications/dhp-connected-devices/manifest.json
+++ b/src/applications/dhp-connected-devices/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Connect Your Device",
   "entryFile": "./app-entry.jsx",
   "entryName": "dhp-consent-flow",
-  "rootUrl": "/health-care/connected-devices"
+  "rootUrl": "/health-care/connected-devices",
+  "productId": "96ef6002-5e4c-43c1-892c-a3f1bbc59ea0"
 }

--- a/src/applications/disability-benefits/2346/manifest.json
+++ b/src/applications/disability-benefits/2346/manifest.json
@@ -3,5 +3,6 @@
   "entryFile": "./app-entry.jsx",
   "entryName": "order-form-2346",
   "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",
-  "e2eTestsDisabled": false
+  "e2eTestsDisabled": false,
+  "productId": "57a9ee68-ed2f-42ef-a194-f803d3fbca9d"
 }

--- a/src/applications/disability-benefits/686c-674/manifest.json
+++ b/src/applications/disability-benefits/686c-674/manifest.json
@@ -4,5 +4,5 @@
   "entryName": "686C-674",
   "rootUrl": "/view-change-dependents/add-remove-form-21-686c",
   "e2eTestsDisabled": false,
-  "productId": 34
+  "productId": "500cfb4d-0f70-4663-bfe2-28d295d3301a"
 }

--- a/src/applications/disability-benefits/996/manifest.json
+++ b/src/applications/disability-benefits/996/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Request for Higher-Level Review",
   "entryFile": "./form-entry.jsx",
   "entryName": "0996-higher-level-review",
-  "rootUrl": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996"
+  "rootUrl": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996",
+  "productId": "b50c24e3-acd1-4f67-9ac8-2763715367b2"
 }

--- a/src/applications/disability-benefits/all-claims/manifest.json
+++ b/src/applications/disability-benefits/all-claims/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./form-entry.jsx",
   "entryName": "526EZ-all-claims",
   "rootUrl": "/disability/file-disability-claim-form-21-526ez",
-  "productId": 14
+  "productId": "ebcf7274-ee64-4bc7-8365-d9ab2ec0323a"
 }

--- a/src/applications/disability-benefits/view-payments/manifest.json
+++ b/src/applications/disability-benefits/view-payments/manifest.json
@@ -4,5 +4,5 @@
   "entryName": "view-payments",
   "rootUrl": "/va-payment-history/payments",
   "production": false,
-  "productId": 112
+  "productId": "def80a4c-2174-40cd-b241-892faa4d52d4"
 }

--- a/src/applications/discharge-wizard/manifest.json
+++ b/src/applications/discharge-wizard/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./discharge-wizard-entry.jsx",
   "entryName": "discharge-upgrade-instructions",
   "rootUrl": "/discharge-upgrade-instructions",
-  "productId": 46
+  "productId": "cfe16aad-e92e-4fd9-a194-3938f2e1b0d4"
 }

--- a/src/applications/edu-benefits/0993/manifest.json
+++ b/src/applications/edu-benefits/0993/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "0993-edu-benefits",
   "rootUrl": "/education/opt-out-information-sharing/opt-out-form-0993",
-  "productId": 68
+  "productId": "3dbf9046-e929-4c62-b5fe-7789633487aa"
 }

--- a/src/applications/edu-benefits/0994/manifest.json
+++ b/src/applications/edu-benefits/0994/manifest.json
@@ -2,5 +2,6 @@
   "appName": "22-0994 Education benefits form",
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "0994-edu-benefits",
-  "rootUrl": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994"
+  "rootUrl": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994",
+  "productId": "b9e84f9b-2f1d-42bf-a6c2-b34a1d2c1b0c"
 }

--- a/src/applications/edu-benefits/10203/manifest.json
+++ b/src/applications/edu-benefits/10203/manifest.json
@@ -2,5 +2,6 @@
   "appName": "22-10203 Education benefits form",
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "10203-edu-benefits",
-  "rootUrl": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203"
+  "rootUrl": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203",
+  "productId": "56aac481-bcbb-4933-9a4d-7774fed355b9"
 }

--- a/src/applications/edu-benefits/1990/manifest.json
+++ b/src/applications/edu-benefits/1990/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "1990-edu-benefits",
   "rootUrl": "/education/apply-for-education-benefits/application/1990",
-  "productId": 54
+  "productId": "74dba175-91a7-4986-86cb-7070773e1abe"
 }

--- a/src/applications/edu-benefits/1990e/manifest.json
+++ b/src/applications/edu-benefits/1990e/manifest.json
@@ -4,5 +4,5 @@
   "entryName": "1990e-edu-benefits",
   "rootUrl": "/education/apply-for-education-benefits/application/1990E",
   "e2eTestsDisabled": "true",
-  "productId": 60
+  "productId": "a48ec05a-819c-46d5-bba2-8d8c1fc005dc"
 }

--- a/src/applications/edu-benefits/1990n/manifest.json
+++ b/src/applications/edu-benefits/1990n/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "1990n-edu-benefits",
   "rootUrl": "/education/apply-for-education-benefits/application/1990N",
-  "productId": 58
+  "productId": "94791da3-0da1-4c70-8239-54ea2e944fab"
 }

--- a/src/applications/edu-benefits/1990s/manifest.json
+++ b/src/applications/edu-benefits/1990s/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Veteran Rapid Retraining Assistance Program",
   "entryFile": "./app-entry.jsx",
   "entryName": "1990s-edu-benefits",
-  "rootUrl": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s"
+  "rootUrl": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s",
+  "productId": "b2080fb8-aab8-47e2-92d2-e77e663bf4c9"
 }

--- a/src/applications/edu-benefits/1995/manifest.json
+++ b/src/applications/edu-benefits/1995/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "1995-edu-benefits",
   "rootUrl": "/education/apply-for-education-benefits/application/1995",
-  "productId": 62
+  "productId": "2430e3ec-3b99-4086-81b9-9afb2609e75c"
 }

--- a/src/applications/edu-benefits/5490/manifest.json
+++ b/src/applications/edu-benefits/5490/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "5490-edu-benefits",
   "rootUrl": "/education/apply-for-education-benefits/application/5490",
-  "productId": 56
+  "productId": "c730214c-071e-41ba-8ecd-832295e5d7b0"
 }

--- a/src/applications/edu-benefits/5495/manifest.json
+++ b/src/applications/edu-benefits/5495/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "5495-edu-benefits",
   "rootUrl": "/education/apply-for-education-benefits/application/5495",
-  "productId": 64
+  "productId": "bb16ba23-c4aa-478f-b7c4-0cf8e74fdbdb"
 }

--- a/src/applications/edu-benefits/feedback-tool/manifest.json
+++ b/src/applications/edu-benefits/feedback-tool/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./feedback-tool-entry.jsx",
   "entryName": "feedback-tool",
   "rootUrl": "/education/submit-school-feedback",
-  "productId": 82
+  "productId": "9d7ff36b-1fa7-41fd-9208-b43f4c0a254b"
 }

--- a/src/applications/education-letters/manifest.json
+++ b/src/applications/education-letters/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Education Letters",
   "entryFile": "./app-entry.jsx",
   "entryName": "education-letters",
-  "rootUrl": "/education/education-letters"
+  "rootUrl": "/education/education-letters",
+  "productId": "34de0e14-4104-4181-a8bd-131498684823"
 }

--- a/src/applications/enrollment-verification/manifest.json
+++ b/src/applications/enrollment-verification/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Enrollment Verification",
   "entryFile": "./app-entry.jsx",
   "entryName": "enrollment-verification",
-  "rootUrl": "/enrollment-history"
+  "rootUrl": "/enrollment-history",
+  "productId": "ab97e09b-5a10-4433-a123-b404bf15e60b"
 }

--- a/src/applications/facility-locator/manifest.json
+++ b/src/applications/facility-locator/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./facility-locator-entry.jsx",
   "entryName": "facilities",
   "rootUrl": "/find-locations",
-  "productId": 48
+  "productId": "0f27f045-978f-4139-b7b9-e48f94f1d70e"
 }

--- a/src/applications/financial-status-report/manifest.json
+++ b/src/applications/financial-status-report/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Financial Status Report",
   "entryFile": "./app-entry.jsx",
   "entryName": "request-debt-help-form-5655",
-  "rootUrl": "/manage-va-debt/request-debt-help-form-5655"
+  "rootUrl": "/manage-va-debt/request-debt-help-form-5655",
+  "productId": "09445726-e7a5-4461-ada6-25e45f3699d8"
 }

--- a/src/applications/gi/manifest.json
+++ b/src/applications/gi/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./gi-entry.jsx",
   "entryName": "gi",
   "rootUrl": "/education/gi-bill-comparison-tool",
-  "productId": 80
+  "productId": "44b6c66d-6a19-4d27-8b02-910e4cc2a55f"
 }

--- a/src/applications/hca/manifest.json
+++ b/src/applications/hca/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./hca-entry.jsx",
   "entryName": "hca",
   "rootUrl": "/health-care/apply/application",
-  "productId": 86
+  "productId": "49610634-597e-49c1-b11a-db67f35f437b"
 }

--- a/src/applications/health-care-questionnaire/list/manifest.json
+++ b/src/applications/health-care-questionnaire/list/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Questionnaire List",
   "entryFile": "./app-entry.jsx",
   "entryName": "questionnaire-list",
-  "rootUrl": "/health-care/health-questionnaires/questionnaires"
+  "rootUrl": "/health-care/health-questionnaires/questionnaires",
+  "productId": "028188dc-1b83-4d1b-a663-e2206430e823"
 }

--- a/src/applications/health-care-questionnaire/questionnaire/manifest.json
+++ b/src/applications/health-care-questionnaire/questionnaire/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Health care Questionnaire",
   "entryFile": "./app-entry.jsx",
   "entryName": "questionnaire",
-  "rootUrl": "/health-care/health-questionnaires/questionnaires/answer-questions"
+  "rootUrl": "/health-care/health-questionnaires/questionnaires/answer-questions",
+  "productId": "4e3529ee-66e7-4fa6-bc4e-63601dda6aad"
 }

--- a/src/applications/letters/manifest.json
+++ b/src/applications/letters/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./letters-entry.jsx",
   "entryName": "letters",
   "rootUrl": "/records/download-va-letters/letters",
-  "productId": 52
+  "productId": "194b4d19-60fd-433e-812a-0c711b844903"
 }

--- a/src/applications/lgy/coe/form/manifest.json
+++ b/src/applications/lgy/coe/form/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Apply for Certificate of Eligibility",
   "entryFile": "./app-entry.jsx",
   "entryName": "coe",
-  "rootUrl": "/housing-assistance/home-loans/request-coe-form-26-1880"
+  "rootUrl": "/housing-assistance/home-loans/request-coe-form-26-1880",
+  "productId": "56491e7e-ed71-42c1-9678-f8e0b4cacb07"
 }

--- a/src/applications/login/manifest.json
+++ b/src/applications/login/manifest.json
@@ -4,5 +4,5 @@
   "entryName": "login-page",
   "rootUrl": "/sign-in",
   "e2eTestsDisabled": true,
-  "productId": 12
+  "productId": "40839364-43fa-454a-b29a-bc333ad63e1f"
 }

--- a/src/applications/medical-copays/manifest.json
+++ b/src/applications/medical-copays/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Medical Copays",
   "entryFile": "./app-entry.jsx",
   "entryName": "medical-copays",
-  "rootUrl": "/health-care/pay-copay-bill/your-current-balances"
+  "rootUrl": "/health-care/pay-copay-bill/your-current-balances",
+  "productId": "71bc2422-2e0c-4d3f-80f9-e7af4ec03372"
 }

--- a/src/applications/mhv-inherited-proofing/manifest.json
+++ b/src/applications/mhv-inherited-proofing/manifest.json
@@ -4,5 +4,5 @@
   "entryName": "mhv-inherited-proofing",
   "rootUrl": "/transfer-account",
   "e2eTestsDisabled": true,
-  "productId": 999
+  "productId": "e0d8b571-c134-433b-a66a-83b101db1429"
 }

--- a/src/applications/my-education-benefits/manifest.json
+++ b/src/applications/my-education-benefits/manifest.json
@@ -2,5 +2,6 @@
   "appName": "My Education Benefits",
   "entryFile": "./app-entry.jsx",
   "entryName": "1990ez-edu-benefits",
-  "rootUrl": "/education/apply-for-benefits-form-22-1990"
+  "rootUrl": "/education/apply-for-benefits-form-22-1990",
+  "productId": "43852fd7-9ba4-4dc0-901a-8f111102b5fe"
 }

--- a/src/applications/office-directory/manifest.json
+++ b/src/applications/office-directory/manifest.json
@@ -2,5 +2,6 @@
   "appName": "All VA offices",
   "entryFile": "./app-entry.jsx",
   "entryName": "office-directory",
-  "rootUrl": "/office-directory"
+  "rootUrl": "/office-directory",
+  "productId": "9bde0ae6-8d58-4b08-a971-97408bf65e08"
 }

--- a/src/applications/pensions/manifest.json
+++ b/src/applications/pensions/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./pensions-entry.jsx",
   "entryName": "pensions",
   "rootUrl": "/pension/application/527EZ",
-  "productId": 114
+  "productId": "fb68f9f1-c8f0-4e81-9181-57c35dc84910"
 }

--- a/src/applications/personalization/dashboard/manifest.json
+++ b/src/applications/personalization/dashboard/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./dashboard-entry.jsx",
   "entryName": "dashboard",
   "rootUrl": "/my-va",
-  "productId": 38
+  "productId": "e72a828d-94a2-4e39-b668-526940b85253"
 }

--- a/src/applications/personalization/profile/manifest.json
+++ b/src/applications/personalization/profile/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./profile-entry.jsx",
   "entryName": "profile",
   "rootUrl": "/profile",
-  "productId": 1
+  "productId": "f9278bea-a113-4cb6-aed7-54dbaea258b0"
 }

--- a/src/applications/personalization/rated-disabilities/manifest.json
+++ b/src/applications/personalization/rated-disabilities/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Rated Disabilities",
   "entryFile": "./rated-disabilities-entry.jsx",
   "entryName": "disability-my-rated-disabilities",
-  "rootUrl": "/disability/view-disability-rating/rating"
+  "rootUrl": "/disability/view-disability-rating/rating",
+  "productId": "def3bac9-c967-4fdb-a877-1b6e58945ea9"
 }

--- a/src/applications/personalization/search-representative/manifest.json
+++ b/src/applications/personalization/search-representative/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Search Representative",
   "entryFile": "./app-entry.jsx",
   "entryName": "search-representative",
-  "rootUrl": "/view-change-representative/search"
+  "rootUrl": "/view-change-representative/search",
+  "productId": "a638f89a-9710-49ad-b389-0aadbef1e447"
 }

--- a/src/applications/personalization/view-representative/manifest.json
+++ b/src/applications/personalization/view-representative/manifest.json
@@ -2,5 +2,6 @@
   "appName": "View your representative",
   "entryFile": "./app-entry.jsx",
   "entryName": "view-representative",
-  "rootUrl": "/view-change-representative/view"
+  "rootUrl": "/view-change-representative/view",
+  "productId": "669f9818-10f5-4fa9-ac9d-c984c810a329"
 }

--- a/src/applications/post-911-gib-status/manifest.json
+++ b/src/applications/post-911-gib-status/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./post-911-gib-status-entry.jsx",
   "entryName": "post-911-gib-status",
   "rootUrl": "/education/gi-bill/post-9-11/ch-33-benefit/status",
-  "productId": 122
+  "productId": "35ed0a9b-e426-4afa-83d7-51f1a9d9e773"
 }

--- a/src/applications/pre-need/manifest.json
+++ b/src/applications/pre-need/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./pre-need-entry.jsx",
   "entryName": "pre-need",
   "rootUrl": "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility",
-  "productId": 124
+  "productId": "07069333-cb9c-4757-8518-1c4d373efb88"
 }

--- a/src/applications/resources-and-support/manifest.json
+++ b/src/applications/resources-and-support/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./resources-and-support-entry.jsx",
   "entryName": "resources-and-support",
   "rootUrl": "/resources/search",
-  "productId": 136
+  "productId": "344b3137-b604-493e-8322-087ba938cda3"
 }

--- a/src/applications/sah/sahg/manifest.json
+++ b/src/applications/sah/sahg/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Apply for Specially Adapted Housing Grant",
   "entryFile": "./app-entry.jsx",
   "entryName": "sahg",
-  "rootUrl": "/specially-adapted-housing-grant"
+  "rootUrl": "/specially-adapted-housing-grant",
+  "productId": "d15ac5c5-deaf-475a-b175-760768d45f91"
 }

--- a/src/applications/search/manifest.json
+++ b/src/applications/search/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./search-entry.jsx",
   "entryName": "search",
   "rootUrl": "/search",
-  "productId": 140
+  "productId": "2408a96e-8045-4d92-a744-31cd78818c83"
 }

--- a/src/applications/terms-and-conditions/manifest.json
+++ b/src/applications/terms-and-conditions/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./terms-and-conditions-entry.js",
   "entryName": "terms-and-conditions",
   "rootUrl": "/health-care/medical-information-terms-conditions",
-  "productId": 182
+  "productId": "932728f7-2800-4b19-834a-409f900be7da"
 }

--- a/src/applications/vaos/manifest.json
+++ b/src/applications/vaos/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./vaos-entry",
   "entryName": "vaos",
   "rootUrl": "/health-care/schedule-view-va-appointments/appointments",
-  "productId": 162
+  "productId": "ad7d320a-a77b-4bea-ab87-5f9a8a5b47ef"
 }

--- a/src/applications/verify/manifest.json
+++ b/src/applications/verify/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Verify identity",
   "entryFile": "./verify-entry.jsx",
   "entryName": "verify",
-  "rootUrl": "/verify"
+  "rootUrl": "/verify",
+  "productId": "ef9b62a6-633d-4b55-ad9c-3e22ab9fb8dd"
 }

--- a/src/applications/veteran-id-card/manifest.json
+++ b/src/applications/veteran-id-card/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./veteran-id-card-entry.jsx",
   "entryName": "veteran-id-card",
   "rootUrl": "/records/get-veteran-id-cards/apply",
-  "productId": 170
+  "productId": "8fbbb1cb-3ac9-4f47-a9e3-0ffbd9c03fed"
 }

--- a/src/applications/virtual-agent/manifest.json
+++ b/src/applications/virtual-agent/manifest.json
@@ -2,5 +2,6 @@
   "appName": "Virtual Agent",
   "entryFile": "./app-entry.jsx",
   "entryName": "virtual-agent",
-  "rootUrl": "/contact-us/virtual-agent"
+  "rootUrl": "/contact-us/virtual-agent",
+  "productId": "7059158c-2c5e-4ddb-9ba7-391ba7f5e54e"
 }

--- a/src/applications/vre/28-1900/manifest.json
+++ b/src/applications/vre/28-1900/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./app-entry.jsx",
   "entryName": "28-1900-chapter-31",
   "rootUrl": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900",
-  "productId": 172
+  "productId": "e51e0c18-8b17-4295-beaf-a6fd345e719c"
 }

--- a/src/applications/vre/28-8832/manifest.json
+++ b/src/applications/vre/28-8832/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./app-entry.jsx",
   "entryName": "28-8832-planning-and-career-guidance",
   "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832",
-  "productId": 120
+  "productId": "b5ef01e5-7227-4542-a2df-167eb7e23cb6"
 }

--- a/src/applications/yellow-ribbon/manifest.json
+++ b/src/applications/yellow-ribbon/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./yellow-ribbon-entry",
   "entryName": "yellow-ribbon",
   "rootUrl": "/education/yellow-ribbon-participating-schools",
-  "productId": 178
+  "productId": "8962c707-5e39-41f1-8ae4-e4f6b9b74fa6"
 }


### PR DESCRIPTION
## Description
Modifies the `productId` value of the `manifest.json` files of various products to reflect the UUID detailed in the [product directory](https://docs.google.com/spreadsheets/d/1VaXAZIYj2LdG4H9ZQUbdCGjMk5qQ8Ari2mMySF1oah0/edit#gid=0).

Note: Before merging please advise on appropriate ProductID for the following products which contain lines to the same path:
```Secure Inbox and Resource & Support
Original Claims and Benefits Delivery at Discharge
```


## Original issue(s)
[Zenhub - Update Manifests to add UUID#41040](https://app.zenhub.com/workspaces/sprint-board-qa-standards-613a3f47e06ba00013d05eed/issues/department-of-veterans-affairs/va.gov-team/41040)


## Testing done
Ticket is in review for QA Standards and Release Tools to examine.


## Acceptance criteria
- [x] All productIds in vets-website are using the UUIDs defined in the product list
