### PR TITLE
Update CODEOWNERS for QA Standards to update manifests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,3 +104,4 @@ src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-adm
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe
 src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-health-platform
 src/applications/virtual-agent @department-of-veterans-affairs/orchid
+src/applications/**/manifest.json @department-of-veterans-affairs/qa-standards


### PR DESCRIPTION
## Description
Adds line to `CODEOWNERS` to allow for QA Standards to update `manifest.json` files of various products to reflect the UUID detailed in the [product directory](https://docs.google.com/spreadsheets/d/1VaXAZIYj2LdG4H9ZQUbdCGjMk5qQ8Ari2mMySF1oah0/edit#gid=0).

## Original issue(s)
[Zenhub - Update Manifests to add UUID#41040](https://app.zenhub.com/workspaces/sprint-board-qa-standards-613a3f47e06ba00013d05eed/issues/department-of-veterans-affairs/va.gov-team/41040)


## Testing done
Ticket is in review for QA Standards and Release Tools to examine.


## Acceptance criteria
- [x] `CODEOWNERS` is modified to allow update to `manifest.json` files without each team's individual approval.
