### PR TITLE
Remove QA Standards from manifest CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,4 +104,3 @@ src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-adm
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe
 src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-health-platform
 src/applications/virtual-agent @department-of-veterans-affairs/orchid
-src/applications/**/manifest.json @department-of-veterans-affairs/qa-standards


### PR DESCRIPTION
## Description
Removes QA Standards from `manifest.json` files approval in CODEOWNERS now that Product IDs have been modified in [this ticket](https://github.com/department-of-veterans-affairs/vets-website/pull/21049).

## Original issue(s)
Final piece of https://app.zenhub.com/workspaces/sprint-board-qa-standards-613a3f47e06ba00013d05eed/issues/department-of-veterans-affairs/va.gov-team/41040

