### PR TITLE
Burials: Add keyboard-only e2e test

### DIFF
--- a/src/applications/burials/tests/burials-keyboard-only.cypress.spec.js
+++ b/src/applications/burials/tests/burials-keyboard-only.cypress.spec.js
@@ -1,0 +1,68 @@
+import mockUser from './e2e/fixtures/mocks/mockUser';
+import burial1234 from './e2e/fixtures/mocks/burial-1234.json';
+import burialPost from './e2e/fixtures/mocks/burial-post.json';
+import testData from './schema/minimal-test.json';
+
+describe('Burials keyboard only navigation', () => {
+  it('navigates through a minimal form', () => {
+    const { data } = testData;
+    cy.intercept('PUT', 'v0/in_progress_forms/21P-530', {});
+    cy.intercept('GET', '/v0/burial_claims/1234', burial1234);
+    cy.intercept('POST', '/v0/burial_claims', { body: burialPost });
+
+    cy.login({
+      data: {
+        attributes: {
+          ...mockUser.data.attributes,
+          // eslint-disable-next-line camelcase
+          in_progress_forms: [],
+        },
+      },
+    });
+    cy.visit('/burials-and-memorials/application/530');
+    cy.injectAxeThenAxeCheck();
+
+    // Intro page
+    cy.tabToElement('button[id$="continueButton"]');
+    cy.realPress('Space');
+
+    // Claimant Info
+    cy.typeInFullName('root_claimantFullName_', data.claimantFullName);
+    cy.tabToElement('[name="root_relationship_type"]');
+    cy.chooseRadio(data.relationship.type);
+
+    // Fill in "Other" input which is revealed when the radio is selected
+    if (data.relationship.type === 'other') {
+      cy.typeInIfDataExists(
+        '#root_relationship_other',
+        data.relationship.other,
+      );
+      if (data.relationship['view:isEntity']) {
+        cy.tabToElement('#root_relationship_isEntity');
+        cy.realPress('Space');
+      }
+    }
+
+    cy.tabToElement('button[type="submit"]');
+    cy.realPress('Space');
+
+    // Deceased Veteran Info
+    cy.typeInFullName('root_veteranFullName_', data.veteranFullName);
+    cy.typeInIfDataExists(
+      '#root_veteranSocialSecurityNumber',
+      data.veteranSocialSecurityNumber,
+    );
+    cy.typeInIfDataExists(
+      '#root_vaFileNumber',
+      data.veteranSocialSecurityNumber,
+    );
+    cy.typeInDate('root_veteranDateOfBirth', data.veteranDateOfBirth);
+
+    // // Form submit button is a button type?
+    // cy.tabToElement('button[id$="continueButton"].usa-button-primary');
+    // cy.realPress('Space');
+
+    // // Confirmation page print button
+    // cy.get('button.screen-only').should('exist');
+  });
+});

--- a/src/applications/burials/tests/burials-keyboard-only.cypress.spec.js
+++ b/src/applications/burials/tests/burials-keyboard-only.cypress.spec.js
@@ -1,10 +1,11 @@
 import mockUser from './e2e/fixtures/mocks/mockUser';
 import burial1234 from './e2e/fixtures/mocks/burial-1234.json';
 import burialPost from './e2e/fixtures/mocks/burial-post.json';
+// This also works with maximal-test.json
 import testData from './schema/minimal-test.json';
 
 describe('Burials keyboard only navigation', () => {
-  it('navigates through a minimal form', () => {
+  it('navigates through a selected form', () => {
     const { data } = testData;
     cy.intercept('PUT', 'v0/in_progress_forms/21P-530', {});
     cy.intercept('GET', '/v0/burial_claims/1234', burial1234);
@@ -15,18 +16,18 @@ describe('Burials keyboard only navigation', () => {
         attributes: {
           ...mockUser.data.attributes,
           // eslint-disable-next-line camelcase
-          in_progress_forms: [],
+          in_progress_forms: [], // clear out in-progress state
         },
       },
     });
     cy.visit('/burials-and-memorials/application/530');
     cy.injectAxeThenAxeCheck();
 
-    // Intro page
+    // *** Intro page ***
     cy.tabToElement('button[id$="continueButton"]');
     cy.realPress('Space');
 
-    // Claimant Info
+    // *** Claimant Info ***
     cy.typeInFullName('root_claimantFullName_', data.claimantFullName);
     cy.tabToElement('[name="root_relationship_type"]');
     cy.chooseRadio(data.relationship.type);
@@ -37,16 +38,15 @@ describe('Burials keyboard only navigation', () => {
         '#root_relationship_other',
         data.relationship.other,
       );
-      if (data.relationship['view:isEntity']) {
-        cy.tabToElement('#root_relationship_isEntity');
-        cy.realPress('Space');
-      }
+      cy.setCheckboxFromData(
+        '#root_relationship_isEntity',
+        data.relationship['view:isEntity'],
+      );
     }
 
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
-    // Deceased Veteran Info
+    // *** Deceased Veteran Info, page 1 ***
     cy.typeInFullName('root_veteranFullName_', data.veteranFullName);
     cy.typeInIfDataExists(
       '#root_veteranSocialSecurityNumber',
@@ -56,13 +56,179 @@ describe('Burials keyboard only navigation', () => {
       '#root_vaFileNumber',
       data.veteranSocialSecurityNumber,
     );
+
     cy.typeInDate('root_veteranDateOfBirth', data.veteranDateOfBirth);
+    cy.typeInIfDataExists('#root_placeOfBirth', data.placeOfBirth);
 
-    // // Form submit button is a button type?
-    // cy.tabToElement('button[id$="continueButton"].usa-button-primary');
-    // cy.realPress('Space');
+    cy.tabToContinueForm();
 
-    // // Confirmation page print button
-    // cy.get('button.screen-only').should('exist');
+    // *** Deceased Veteran Info, page 2 ***
+    cy.typeInDate('root_deathDate', data.deathDate);
+    cy.typeInDate('root_burialDate', data.burialDate);
+
+    cy.tabToElement('input[name="root_locationOfDeath_location"]');
+    cy.chooseRadio(data.locationOfDeath.location);
+
+    cy.tabToContinueForm();
+
+    // *** Military History ***
+    /* Only adding one period, because tabbing takes a lot of time
+    const toursLength = data.toursOfDuty.length;
+    data.toursOfDuty.forEach((tour, index) => {
+      // Move toursOfDuty block below here if we're adding all
+
+      // Add more; save time, commenting this out
+      if (index + 1 < toursLength) {
+        cy.tabToElement('.va-growable-add-btn');
+        cy.realPress('Space');
+        // shift-tab up to edit button before new block
+        cy.tabToElement('.usa-button-secondary.edit', false);
+      }
+    }); */
+    if (data.toursOfDuty?.length) {
+      const tour = data.toursOfDuty?.[0];
+      const index = 0;
+      cy.typeInDate(
+        `root_toursOfDuty_${index}_dateRange_from`,
+        tour.dateRange.from,
+      );
+      cy.typeInDate(
+        `root_toursOfDuty_${index}_dateRange_to`,
+        tour.dateRange.to,
+      );
+      cy.typeInIfDataExists(
+        `#root_toursOfDuty_${index}_serviceBranch`,
+        tour.serviceBranch,
+      );
+      cy.typeInIfDataExists(`#root_toursOfDuty_${index}_rank`, tour.rank);
+      cy.typeInIfDataExists(
+        `#root_toursOfDuty_${index}_serviceNumber`,
+        tour.serviceNumber,
+      );
+      cy.typeInIfDataExists(
+        `#root_toursOfDuty_${index}_placeOfEntry`,
+        tour.placeOfEntry,
+      );
+      cy.typeInIfDataExists(
+        `#root_toursOfDuty_${index}_placeOfSeparation`,
+        tour.placeOfSeparation,
+      );
+    }
+
+    cy.tabToContinueForm();
+
+    // *** Serve under another name? ***
+    cy.tabToElement('[name="root_view:serveUnderOtherNames"]');
+    cy.chooseRadio('N'); // save time, chosing no
+
+    cy.tabToContinueForm();
+
+    // *** Benefits selection ***
+    const claimedBenefits = data['view:claimedBenefits'];
+    cy.setCheckboxFromData(
+      '#root_view\\:claimedBenefits_burialAllowance',
+      claimedBenefits.burialAllowance,
+    );
+    cy.setCheckboxFromData(
+      '#root_view\\:claimedBenefits_plotAllowance',
+      claimedBenefits.plotAllowance,
+    );
+    /*
+    // If transportation is checked, then a required upload is needed.
+    // TODO: Figure out how to test keyboard only uploads
+    if (claimedBenefits.transportation) {
+      cy.setCheckboxFromData(
+        '#root_view\\:claimedBenefits_transportation',
+        claimedBenefits.transportation,
+      );
+      // This input is visible if claimedBenefits.transportation is true
+      if (claimedBenefits.amountIncurred) {
+        cy.typeInIfDataExists(
+          '#root_view\\:claimedBenefits_amountIncurred',
+          claimedBenefits.amountIncurred,
+        );
+      }
+    }
+    */
+
+    cy.tabToContinueForm();
+
+    // *** Burial allowance ***
+    if (claimedBenefits.burialAllowance) {
+      cy.tabToElement('[name="root_burialAllowanceRequested"]');
+      // If set to "service", a file upload is required, see TODO above
+      cy.chooseRadio(
+        data.burialAllowanceRequested === 'service'
+          ? 'vaMC'
+          : data.burialAllowanceRequested,
+      );
+      if (data.burialAllowanceRequested === 'vaMC' && data.burialCost) {
+        cy.typeInIfDataExists('#root_burialCost', data.burialCost);
+      }
+      if (data.relationship.type === 'other') {
+        cy.tabToElement('[name="root_benefitsUnclaimedRemains');
+        cy.chooseRadio(data.benefitsUnclaimedRemains ? 'Y' : 'N');
+      }
+
+      cy.tabToContinueForm();
+    }
+
+    // *** Plot or interment allowance ***
+    if (claimedBenefits.plotAllowance) {
+      cy.typeInIfDataExists('#root_placeOfRemains', data.placeOfRemains);
+      cy.tabToElement('[name="root_federalCemetery"]');
+      cy.chooseRadio(data.federalCemetery ? 'Y' : 'N');
+      if (!data.federalCemetery) {
+        cy.tabToElement('[name="root_stateCemetery"]');
+        cy.chooseRadio(data.stateCemetery ? 'Y' : 'N');
+      }
+      cy.tabToElement('[name="root_govtContributions"]');
+      cy.chooseRadio(data.govtContributions ? 'Y' : 'N');
+
+      cy.tabToContinueForm();
+    }
+
+    // *** Claimant contact info ***
+    cy.typeInIfDataExists('#root_firmName', data.firmName);
+    cy.typeInIfDataExists('#root_officialPosition', data.officialPosition);
+
+    cy.tabToElement('#root_claimantAddress_country');
+    cy.chooseSelectOptionUsingValue(data.claimantAddress.country);
+    cy.typeInIfDataExists(
+      '#root_claimantAddress_street',
+      data.claimantAddress.street,
+    );
+    cy.typeInIfDataExists(
+      '#root_claimantAddress_street2',
+      data.claimantAddress.street2,
+    );
+    cy.typeInIfDataExists(
+      '#root_claimantAddress_city',
+      data.claimantAddress.city,
+    );
+    cy.tabToElement('#root_claimantAddress_state');
+    cy.chooseSelectOptionUsingValue(data.claimantAddress.state);
+    cy.typeInIfDataExists(
+      '#root_claimantAddress_postalCode',
+      data.claimantAddress.postalCode,
+    );
+    cy.typeInIfDataExists('#root_claimantEmail', data.claimantEmail);
+    cy.typeInIfDataExists('#root_claimantPhone', data.claimantPhone);
+
+    cy.tabToContinueForm();
+
+    // *** Upload ***
+    // Forcing uploads to not be required by setting the following:
+    // - claimedBenefits.transportation to `false`
+    // - data.burialAllowanceRequested to NOT be 'service'
+    cy.tabToSubmitForm();
+
+    // *** Review & Submit ***
+    cy.setCheckboxFromData('[name="privacyAgreementAccepted"]', true);
+    cy.tabToSubmitForm();
+
+    // *** Confirmation ***
+    // Look for print button
+    cy.get('button.screen-only').should('exist');
   });
 });

--- a/src/applications/burials/tests/schema/maximal-test.json
+++ b/src/applications/burials/tests/schema/maximal-test.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "firmName": "Home",
     "officialPosition": "Important",
     "claimantAddress": {
       "street": "123 Main St",


### PR DESCRIPTION
## Description

To improve accessibility, we need to add keyboard-only navigation of the Burials app end-to-end testing.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41143

## Testing done

Added keyboard-only e2e test using `minimal-test.json` data, but `maximal-test.json` works as well. Using the happy path because keyboard-only tests are slow

## Screenshots

N/A

## Acceptance criteria
- [x] Add keyboard-only e2e test on happy path
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
