### PR TITLE
Replace TextInput component in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -127,7 +127,7 @@ const SignatureInput = ({
   return (
     <VaTextInput
       aria-describedby={ariaDescribedBy}
-      data-testid="signature-input"
+      class="signature-input"
       label={createInputLabel(label)}
       required={required}
       value={signature.value}

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { VaTextInput } from 'web-components/react-bindings';
 
 const SignatureInput = ({
   fullName,
@@ -13,7 +13,7 @@ const SignatureInput = ({
   isChecked,
   ariaDescribedBy,
 }) => {
-  const [hasError, setError] = useState(false);
+  const [error, setError] = useState();
   const firstName = fullName.first || '';
   const lastName = fullName.last || '';
   const middleName = fullName.middle || '';
@@ -63,6 +63,13 @@ const SignatureInput = ({
 
   const isSignatureComplete = signatureMatches && isChecked;
 
+  const onBlur = useCallback(
+    event => {
+      setSignature({ value: event.target.value, dirty: true });
+    },
+    [setSignature],
+  );
+
   useEffect(
     () => {
       if (!isSignatureComplete) return;
@@ -85,7 +92,7 @@ const SignatureInput = ({
         setSignatures(prevState => {
           return { ...prevState, [label]: '' };
         });
-        setError(true);
+        setError(errorMessage);
       }
 
       /* if input has been touched and signature matches allow submission
@@ -100,7 +107,7 @@ const SignatureInput = ({
         setSignatures(prevState => {
           return { ...prevState, [label]: signature.value };
         });
-        setError(false);
+        setError();
       }
     },
     [
@@ -112,18 +119,19 @@ const SignatureInput = ({
       signature,
       setSignatures,
       label,
+      errorMessage,
     ],
   );
 
   return (
-    <TextInput
-      ariaDescribedBy={ariaDescribedBy}
-      additionalClass="signature-input"
+    <VaTextInput
+      aria-describedby={ariaDescribedBy}
+      class="signature-input"
       label={createInputLabel(label)}
       required={required}
-      onValueChange={signatureValue => setSignature(signatureValue)}
-      field={{ value: signature.value, dirty: signature.dirty }}
-      errorMessage={hasError && errorMessage}
+      value={signature.value}
+      error={error}
+      onBlur={onBlur}
     />
   );
 };

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { VaTextInput } from 'web-components/react-bindings';
+
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const SignatureInput = ({
   fullName,
@@ -126,7 +127,7 @@ const SignatureInput = ({
   return (
     <VaTextInput
       aria-describedby={ariaDescribedBy}
-      class="signature-input"
+      data-testid="signature-input"
       label={createInputLabel(label)}
       required={required}
       value={signature.value}

--- a/src/applications/caregivers/definitions/UIDefinitions/veteranUI.js
+++ b/src/applications/caregivers/definitions/UIDefinitions/veteranUI.js
@@ -7,12 +7,12 @@ import {
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 import { states } from 'platform/forms/address';
 import get from 'platform/utilities/data/get';
-import { veteranFields } from '../constants';
 import {
   medicalCenterLabels,
   medicalCentersByState,
   facilityNameMaxLength,
 } from 'applications/caregivers/helpers';
+import { veteranFields } from '../constants';
 
 const emptyFacilityList = [];
 const stateLabels = createUSAStateLabels(states);

--- a/src/applications/caregivers/definitions/content.js
+++ b/src/applications/caregivers/definitions/content.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export const links = {
   findLocations: {
@@ -95,4 +96,8 @@ export const SecondaryCaregiverCopy = ({ label }) => {
       <PrivacyPolicy />
     </div>
   );
+};
+
+SecondaryCaregiverCopy.propTypes = {
+  label: PropTypes.string,
 };

--- a/src/applications/caregivers/reducers/index.js
+++ b/src/applications/caregivers/reducers/index.js
@@ -1,5 +1,5 @@
-import formConfig from '../config/form';
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import formConfig from '../config/form';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/caregivers/tests/00.caregivers.cypress.spec.js
+++ b/src/applications/caregivers/tests/00.caregivers.cypress.spec.js
@@ -1,5 +1,5 @@
-import manifest from '../manifest.json';
 import environments from 'site/constants/environments';
+import manifest from '../manifest.json';
 
 describe('Caregivers test', () => {
   it('Loads the page body', () => {

--- a/src/applications/caregivers/tests/components/SignatureCheckbox.unit.spec.js
+++ b/src/applications/caregivers/tests/components/SignatureCheckbox.unit.spec.js
@@ -21,29 +21,29 @@ describe('10-10CG', () => {
     it('should render aria-describedby attribute when "isRepresentative" is true', () => {
       const label = 'test-label';
       const labelId = `${label}-signature-label`;
+      const inputId = 'signature-input';
       const { mockProps } = getData({
         isRepresentative: true,
         label,
       });
       const view = render(<SignatureCheckbox {...mockProps} />);
 
-      expect(
-        view.getByLabelText(
-          'Enter your name to sign as the Veteran’s representative',
-        ),
-      ).to.have.attribute('aria-describedby', labelId);
+      expect(view.getByTestId(inputId)).to.have.attribute(
+        'aria-describedby',
+        labelId,
+      );
     });
 
     it('should not render aria-describedby attribute when "isRepresentative" is false', () => {
       const label = 'test-label';
-      const inputLabel = `${label} full name`;
+      const inputId = 'signature-input';
       const { mockProps } = getData({
         isRepresentative: false,
         label,
       });
       const view = render(<SignatureCheckbox {...mockProps} />);
 
-      expect(view.getByLabelText(inputLabel)).to.not.have.attribute(
+      expect(view.getByTestId(inputId)).to.not.have.attribute(
         'aria-describedby',
       );
     });

--- a/src/applications/caregivers/tests/components/SignatureCheckbox.unit.spec.js
+++ b/src/applications/caregivers/tests/components/SignatureCheckbox.unit.spec.js
@@ -21,31 +21,26 @@ describe('10-10CG', () => {
     it('should render aria-describedby attribute when "isRepresentative" is true', () => {
       const label = 'test-label';
       const labelId = `${label}-signature-label`;
-      const inputId = 'signature-input';
       const { mockProps } = getData({
         isRepresentative: true,
         label,
       });
       const view = render(<SignatureCheckbox {...mockProps} />);
+      const inputComponent = view.container.querySelector('.signature-input');
 
-      expect(view.getByTestId(inputId)).to.have.attribute(
-        'aria-describedby',
-        labelId,
-      );
+      expect(inputComponent).to.have.attribute('aria-describedby', labelId);
     });
 
     it('should not render aria-describedby attribute when "isRepresentative" is false', () => {
       const label = 'test-label';
-      const inputId = 'signature-input';
       const { mockProps } = getData({
         isRepresentative: false,
         label,
       });
       const view = render(<SignatureCheckbox {...mockProps} />);
+      const inputComponent = view.container.querySelector('.signature-input');
 
-      expect(view.getByTestId(inputId)).to.not.have.attribute(
-        'aria-describedby',
-      );
+      expect(inputComponent).to.not.have.attribute('aria-describedby');
     });
   });
 });

--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -52,6 +52,8 @@ const checkContent = (partyLabel, content, mockContent) => {
 
 const signAsParty = (partyLabel, signature) => {
   cy.findByTestId(partyLabel)
+    .find('.signature-input')
+    .shadow()
     .find('input')
     .first()
     .type(signature);
@@ -79,7 +81,6 @@ const testSecondaryTwo = createTestConfig(
     },
 
     setupPerTest: () => {
-      cy.server();
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
       cy.intercept('POST', 'v0/form1010cg/attachments', mockUpload);
     },
@@ -209,19 +210,15 @@ const testSecondaryTwo = createTestConfig(
         });
         // sign signature as veteran
 
-        cy.route({
-          method: 'POST',
-          url: '/v0/caregivers_assistance_claims',
-          status: 200,
-          response: {
-            body: {
-              data: {
-                id: '',
-                type: 'form1010cg_submissions',
-                attributes: {
-                  confirmationNumber: 'aB935000000F3VnCAK',
-                  submittedAt: '2020-08-06T19:18:11+00:00',
-                },
+        cy.intercept('POST', '/v0/caregivers_assistance_claims', {
+          statusCode: 200,
+          body: {
+            data: {
+              id: '',
+              type: 'form1010cg_submissions',
+              attributes: {
+                confirmationNumber: 'aB935000000F3VnCAK',
+                submittedAt: '2020-08-06T19:18:11+00:00',
               },
             },
           },

--- a/src/applications/caregivers/tests/helpers.unit.spec.js
+++ b/src/applications/caregivers/tests/helpers.unit.spec.js
@@ -1,8 +1,3 @@
-import {
-  submitTransform,
-  isSSNUnique,
-  arrayToSentenceString,
-} from '../helpers';
 import { expect } from 'chai';
 import formConfig from 'applications/caregivers/config/form';
 import {
@@ -11,6 +6,11 @@ import {
   secondaryOneFields,
   secondaryTwoFields,
 } from 'applications/caregivers/definitions/constants';
+import {
+  submitTransform,
+  isSSNUnique,
+  arrayToSentenceString,
+} from '../helpers';
 
 // data
 import requiredOnly from './e2e/fixtures/data/requiredOnly.json';


### PR DESCRIPTION
## Description
The `<TextInput>` component is utilized in the Caregivers application markup. This component has been deprecated by the Design team in favor of the `<va-text-input>` component. This PR upgrades the app to remove this deprecated component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41081

## Testing done
- [x] Unit tests

## Acceptance criteria
- [ ] Application utilizes the most up-to-date Design System text input component.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
