### PR TITLE
Add analytics tracking for 'va-alert-expandable' component

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -126,6 +126,16 @@ const analyticsEvents = {
       prefix: 'alert-box',
     },
   ],
+  'va-alert-expandable': [
+    {
+      action: 'expand',
+      event: 'int-alert-expandable-expand',
+    },
+    {
+      action: 'collapse',
+      event: 'int-alert-expandable-collapse',
+    },
+  ],
   'va-breadcrumbs': [
     {
       action: 'linkClick',

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -130,10 +130,12 @@ const analyticsEvents = {
     {
       action: 'expand',
       event: 'int-alert-expandable-expand',
+      prefix: 'alert-expandable',
     },
     {
       action: 'collapse',
       event: 'int-alert-expandable-collapse',
+      prefix: 'alert-expandable',
     },
   ],
   'va-breadcrumbs': [


### PR DESCRIPTION
## Description
We need to add analytics tracking for the newly-created `va-alert-expandable` component. This PR modifies the `analyticsEvents` object in [component-library-analytics-setup.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/component-library-analytics-setup.js) to include the necessary key/value pairs.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/833

## Acceptance criteria
- [ ] `va-alert-expandable` analytics tracking is set up in `vets-website`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
