### PR TITLE
686 & view dependents: Fix document & H1 titles

### DIFF
--- a/src/applications/disability-benefits/686c-674/components/IntroductionPageHeader.jsx
+++ b/src/applications/disability-benefits/686c-674/components/IntroductionPageHeader.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import { PAGE_TITLE } from '../config/constants';
 
 export const IntroductionPageHeader = () => (
   <>
-    <FormTitle title="Add or remove a dependent on your VA disability benefits" />
+    <FormTitle title={PAGE_TITLE} />
     <p>
       Equal to VA Form 21-686c (Application Request to Add And/Or Remove
       Dependents) and/or Equal to VA Form 21-674 (Request for Approval of School

--- a/src/applications/disability-benefits/686c-674/config/constants.js
+++ b/src/applications/disability-benefits/686c-674/config/constants.js
@@ -1,3 +1,9 @@
+export const PAGE_TITLE = 'Add or remove dependents with VA Form 21-686C';
+// Tried to use platform/utilities/data/titleCase on the PAGE_TITLE, but it
+// makes "Or" lowercase
+export const DOC_TITLE =
+  'Add Or Remove Dependents With VA Form 21-686C | Veterans Affairs';
+
 export const TASK_KEYS = {
   addChild: 'addChild',
   addSpouse: 'addSpouse',

--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-
 import manifest from '../manifest.json';
 import formConfig from '../config/form';
+import { DOC_TITLE } from '../config/constants';
 
 function App({ location, children, isLoggedIn, isLoading, vaFileNumber }) {
+  // Must match the H1
+  document.title = DOC_TITLE;
   const content = (
     <article id="form-686c" data-location={`${location?.pathname?.slice(1)}`}>
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>

--- a/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
@@ -6,6 +6,7 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import { focusElement } from 'platform/utilities/ui';
 import { hasSession } from 'platform/user/profile/utilities';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+
 import { verifyVaFileNumber } from '../actions';
 import { IntroductionPageHeader } from '../components/IntroductionPageHeader';
 import { IntroductionPageFormProcess } from '../components/IntroductionPageFormProcess';
@@ -15,6 +16,7 @@ import {
   ServerErrorAlert,
 } from '../config/helpers';
 import { isServerError } from '../config/utilities';
+import { PAGE_TITLE } from '../config/constants';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -41,7 +43,7 @@ class IntroductionPage extends React.Component {
     } else if (!dependentsToggle) {
       content = (
         <>
-          <h1>Application to add or remove dependents</h1>
+          <h1>{PAGE_TITLE}</h1>
           <va-alert status="info">
             <h2 slot="headline" className="vads-u-font-size--h3">
               We’re still working on this feature

--- a/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -4,6 +4,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import { getAppUrl } from 'platform/utilities/registry-helpers';
 
 import { errorFragment } from '../../layouts/helpers';
+import { PAGE_TITLE } from '../../util';
 
 const form686Url = getAppUrl('686C-674');
 
@@ -73,7 +74,7 @@ function ViewDependentsHeader(props) {
   return (
     <div className="vads-l-row">
       <div className="vads-l-col--12">
-        <h1>Your VA dependents</h1>
+        <h1>{PAGE_TITLE}</h1>
         {alertProps && (
           <va-alert status={alertProps.status}>{alertProps.content}</va-alert>
         )}

--- a/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
+++ b/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
@@ -7,12 +7,16 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import titleCase from 'platform/utilities/data/titleCase';
+
 import { fetchAllDependents } from '../actions/index';
 import ViewDependentsLayout from '../layouts/ViewDependentsLayout';
+import { PAGE_TITLE, TITLE_SUFFIX } from '../util';
 
 class ViewDependentsApp extends Component {
   componentDidMount() {
     this.props.fetchAllDependents();
+    document.title = `${titleCase(PAGE_TITLE)}${TITLE_SUFFIX}`;
   }
 
   render() {

--- a/src/applications/personalization/view-dependents/tests/components/ViewDependentsHeader.unit.spec.jsx
+++ b/src/applications/personalization/view-dependents/tests/components/ViewDependentsHeader.unit.spec.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import ViewDependentsHeader from '../../components/ViewDependentsHeader/ViewDependentsHeader';
+import { PAGE_TITLE } from '../../util';
 
 describe('<ViewDependentsHeader />', () => {
   it('Should Render', () => {
     const wrapper = shallow(<ViewDependentsHeader />);
 
-    expect(wrapper.contains(<h1>Your VA dependents</h1>)).to.equal(true);
+    expect(wrapper.contains(<h1>{PAGE_TITLE}</h1>)).to.equal(true);
     wrapper.unmount();
   });
 });

--- a/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
+++ b/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
@@ -1,6 +1,7 @@
 import manifest from '../../manifest.json';
 import mockDependents from './fixtures/mock-dependents.json';
 import mockNoAwardDependents from './fixtures/mock-no-dependents-on-award.json';
+import { PAGE_TITLE } from '../../util';
 
 const DEPENDENTS_ENDPOINT = 'v0/dependents_applications/show';
 
@@ -13,7 +14,9 @@ const testHappyPath = () => {
   cy.intercept('GET', DEPENDENTS_ENDPOINT, mockDependents).as('mockDependents');
   cy.visit(manifest.rootUrl);
   testAxe();
-  cy.findByRole('heading', { name: /Your VA dependents/i }).should('exist');
+  cy.findByRole('heading', { name: new RegExp(PAGE_TITLE, 'i') }).should(
+    'exist',
+  );
   cy.get('dt').should('have.length', 12);
   testAxe();
 };

--- a/src/applications/personalization/view-dependents/util/index.js
+++ b/src/applications/personalization/view-dependents/util/index.js
@@ -4,6 +4,9 @@ import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-str
 const SERVER_ERROR_REGEX = /^5\d{2}$/;
 const CLIENT_ERROR_REGEX = /^4\d{2}$/;
 
+export const PAGE_TITLE = 'Your VA dependents';
+export const TITLE_SUFFIX = ' | Veteran Affairs';
+
 export async function getData(apiRoute, options) {
   try {
     const response = await apiRequest(apiRoute, options);


### PR DESCRIPTION
## Description

Updating the `document.title` and `H1` content for Forms 686C-674 and View dependents app.

Breadcrumbs have been updated in the `content-build` repo in this PR: https://github.com/department-of-veterans-affairs/content-build/pull/1130

## Original issue(s)

- Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/30014
- IA recommendations: https://github.com/department-of-veterans-affairs/va.gov-team/issues/41055#issuecomment-1122904618

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Update 686 & view-dependents apps with recommended `document.title` and `H1` content
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
