### PR TITLE
Add va custom plugin rules back

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,18 @@ module.exports = {
       },
     ], // 40
     'jsx-a11y/no-static-element-interactions': 1, // 20
+
+    /* || va custom plugin || */
+    'va/proptypes-camel-cased': 2,
+    'va/enzyme-unmount': 2,
+    'va/use-resolved-path': [
+      2,
+      {
+        aliases: ['applications', 'platform', 'site', '@@vap-svc', '@@profile'],
+      },
+    ],
+    'va/correct-apostrophe': 1,
+    'va/prefer-web-component-library': 1,
   },
   overrides: [
     {


### PR DESCRIPTION
## Description
This PR adds back the rules from the VA custom ESLint plugin that were removed.

## Testing done
Tested locally.

## Acceptance criteria
- [x] VA custom ESLint plugin rules should be used

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
