### PR TITLE
Refactor pre-check-in error page and remove sub message when 15 minutes past appointment start time

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -1,4 +1,5 @@
 const addDays = require('date-fns/addDays');
+const addMinutes = require('date-fns/addDays');
 const format = require('date-fns/format');
 
 const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
@@ -119,7 +120,7 @@ const createMockSuccessResponse = (
           eligibility: 'ELIGIBLE',
           facilityId: 'some-facility',
           checkInWindowStart: mockTime,
-          checkInWindowEnd: mockTime,
+          checkInWindowEnd: addMinutes(new Date(mockTime), 15),
           checkedInTime: '',
           status,
         },
@@ -134,7 +135,7 @@ const createMockSuccessResponse = (
           eligibility: 'ELIGIBLE',
           facilityId: 'some-facility',
           checkInWindowStart: mockTime,
-          checkInWindowEnd: mockTime,
+          checkInWindowEnd: addMinutes(new Date(mockTime), 15),
           checkedInTime: '',
           status,
         },

--- a/src/applications/check-in/components/ErrorMessage.jsx
+++ b/src/applications/check-in/components/ErrorMessage.jsx
@@ -15,14 +15,21 @@ const ErrorMessage = ({ header, message }) => {
     focusElement('h1');
   }, []);
 
+  const subMessage =
+    errorMessage.length === 0 ? (
+      ''
+    ) : (
+      <va-alert background-only show-icon data-testid="error-message">
+        <div>{errorMessage}</div>
+      </va-alert>
+    );
+
   return (
     <>
       <h1 tabIndex="-1" slot="headline">
         {errorHeader}
       </h1>
-      <va-alert background-only show-icon data-testid="error-message">
-        <div>{errorMessage}</div>
-      </va-alert>
+      {subMessage}
     </>
   );
 };

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -10,14 +10,14 @@ import BackToHome from '../../../components/BackToHome';
 import Footer from '../../../components/Footer';
 
 import { makeSelectVeteranData } from '../../../selectors';
+import {
+  preCheckinExpired,
+  appointmentStartTimePast15,
+} from '../../../utils/appointment';
 
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
 
-const Error = ({ location }) => {
-  const type =
-    location && location.query && location.query.type
-      ? location.query.type
-      : undefined;
+const Error = () => {
   const { getValidateAttempts } = useSessionStorage(true);
   const { isMaxValidateAttempts } = getValidateAttempts(window);
   // try get date of appointment
@@ -56,17 +56,17 @@ const Error = ({ location }) => {
     </>
   );
 
-  // use type param to set unique error messages
-  const getErrorMessagePropsByType = () => {
-    if (type && type === 'expired')
-      return [
-        t('sorry-we-cant-complete-pre-check-in'),
-        t('you-can-still-check-in-once-you-arrive'),
-      ];
-    return [t('sorry-we-cant-complete-pre-check-in'), combinedMessage];
+  const getErrorMessage = () => {
+    if (appointments && appointments.length) {
+      // don't show sub message if we are 15 minutes past appointment start time
+      if (appointmentStartTimePast15(appointments)) return '';
+      if (preCheckinExpired(appointments))
+        return t('you-can-still-check-in-once-you-arrive');
+    }
+    return combinedMessage;
   };
-
-  const [header, message] = getErrorMessagePropsByType();
+  const header = t('sorry-we-cant-complete-pre-check-in');
+  const message = getErrorMessage();
 
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -6,6 +6,7 @@ import { add, sub } from 'date-fns';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { within } from '@testing-library/dom';
+import MockDate from 'mockdate';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import Error from '../index';
 
@@ -25,20 +26,24 @@ describe('check-in', () => {
                 clinicFriendlyName: 'TEST CLINIC',
                 clinicName: 'LOM ACC CLINIC TEST',
                 appointmentIen: 'some-ien',
-                startTime: add(new Date(), { days: 6 }),
+                startTime: '2022-01-03T14:56:04.788Z',
                 eligibility: 'ELIGIBLE',
                 facilityId: 'some-facility',
-                checkInWindowStart: add(new Date(), { days: 6 }),
-                checkInWindowEnd: add(new Date(), { days: 6 }),
+                checkInWindowStart: '2022-01-03T14:56:04.788Z',
+                checkInWindowEnd: '2022-01-03T14:56:04.788Z',
                 checkedInTime: '',
               },
             ],
             veteranData: {},
           },
         };
+        afterEach(() => {
+          MockDate.reset();
+        });
         store = mockStore(initState);
       });
       it('renders appointments date', () => {
+        MockDate.set('2022-01-01T14:00:00.000-05:00');
         const component = render(
           <Provider store={store}>
             <Error />
@@ -47,7 +52,7 @@ describe('check-in', () => {
         const dateMessage = component.getByTestId('date-message');
         expect(dateMessage).to.exist;
         expect(dateMessage).to.contain.text(
-          'You can pre-check in online until',
+          'You can pre-check in online until 01/02/2022.',
         );
       });
     });

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('check-in', () => {
         );
       });
     });
-    describe('store with expired appointment', () => {
+    describe('store with expired appointment (between midnight and 15 min after appt start time)', () => {
       let store;
       beforeEach(() => {
         const middleware = [];
@@ -69,7 +69,7 @@ describe('check-in', () => {
                 eligibility: 'ELIGIBLE',
                 facilityId: 'some-facility',
                 checkInWindowStart: new Date(),
-                checkInWindowEnd: new Date(),
+                checkInWindowEnd: add(new Date(), { minutes: 16 }),
                 checkedInTime: '',
               },
             ],

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { add } from 'date-fns';
+import { add, sub } from 'date-fns';
 
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
@@ -91,6 +91,42 @@ describe('check-in', () => {
             'You can still check-in with your phone once you arrive at your appointment.',
           ),
         ).to.exist;
+      });
+    });
+    describe('store with appointment more than 15 minutes past its start time', () => {
+      let store;
+      beforeEach(() => {
+        const middleware = [];
+        const mockStore = configureStore(middleware);
+        const initState = {
+          checkInData: {
+            appointments: [
+              {
+                facility: 'LOMA LINDA VA CLINIC',
+                clinicPhoneNumber: '5551234567',
+                clinicFriendlyName: 'TEST CLINIC',
+                clinicName: 'LOM ACC CLINIC TEST',
+                appointmentIen: 'some-ien',
+                startTime: sub(new Date(), { minutes: 16 }),
+                eligibility: 'INELIGIBLE_TOO_LATE',
+                facilityId: 'some-facility',
+                checkInWindowStart: sub(new Date(), { minutes: 16 }),
+                checkInWindowEnd: sub(new Date(), { minutes: 16 }),
+                checkedInTime: '',
+              },
+            ],
+            veteranData: {},
+          },
+        };
+        store = mockStore(initState);
+      });
+      it('renders no sub message when appointment started more than 15 minutes ago', () => {
+        const component = render(
+          <Provider store={store}>
+            <Error />
+          </Provider>,
+        );
+        expect(component.queryByTestId('error-message')).to.be.null;
       });
     });
     describe('empty redux store', () => {

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { add } from 'date-fns';
 
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
@@ -24,11 +25,11 @@ describe('check-in', () => {
                 clinicFriendlyName: 'TEST CLINIC',
                 clinicName: 'LOM ACC CLINIC TEST',
                 appointmentIen: 'some-ien',
-                startTime: '2022-01-03T14:56:04.788Z',
+                startTime: add(new Date(), { days: 6 }),
                 eligibility: 'ELIGIBLE',
                 facilityId: 'some-facility',
-                checkInWindowStart: '2022-01-03T14:56:04.788Z',
-                checkInWindowEnd: '2022-01-03T14:56:04.788Z',
+                checkInWindowStart: add(new Date(), { days: 6 }),
+                checkInWindowEnd: add(new Date(), { days: 6 }),
                 checkedInTime: '',
               },
             ],
@@ -45,16 +46,42 @@ describe('check-in', () => {
         );
         const dateMessage = component.getByTestId('date-message');
         expect(dateMessage).to.exist;
-        expect(
-          within(dateMessage).getByText(
-            'You can pre-check in online until 01/02/2022.',
-          ),
-        ).to.exist;
+        expect(dateMessage).to.contain.text(
+          'You can pre-check in online until',
+        );
+      });
+    });
+    describe('store with expired appointment', () => {
+      let store;
+      beforeEach(() => {
+        const middleware = [];
+        const mockStore = configureStore(middleware);
+        const initState = {
+          checkInData: {
+            appointments: [
+              {
+                facility: 'LOMA LINDA VA CLINIC',
+                clinicPhoneNumber: '5551234567',
+                clinicFriendlyName: 'TEST CLINIC',
+                clinicName: 'LOM ACC CLINIC TEST',
+                appointmentIen: 'some-ien',
+                startTime: new Date(),
+                eligibility: 'ELIGIBLE',
+                facilityId: 'some-facility',
+                checkInWindowStart: new Date(),
+                checkInWindowEnd: new Date(),
+                checkedInTime: '',
+              },
+            ],
+            veteranData: {},
+          },
+        };
+        store = mockStore(initState);
       });
       it('renders correct error message when pre-checkin is expired', () => {
         const component = render(
           <Provider store={store}>
-            <Error location={{ query: { type: 'expired' } }} />
+            <Error />
           </Provider>,
         );
         const expiredMessage = component.getByTestId('error-message');

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -73,7 +73,7 @@ const Introduction = props => {
             payload.appointments.length > 0 &&
             preCheckinExpired(payload.appointments)
           ) {
-            goToErrorPage('?type=expired');
+            goToErrorPage();
           }
 
           if (appointmentWasCanceled(payload.appointments)) {

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -1,4 +1,4 @@
-import { startOfDay, add } from 'date-fns';
+import { startOfDay } from 'date-fns';
 import { ELIGIBILITY } from './eligibility';
 import { VISTA_CHECK_IN_STATUS_IENS } from '../appConstants';
 
@@ -118,8 +118,8 @@ const preCheckinExpired = appointments => {
 const appointmentStartTimePast15 = appointments => {
   return !Object.values(appointments).some(appt => {
     const today = new Date();
-    const deadline = add(new Date(appt.startTime), { minutes: 15 });
-    return today.getTime() < deadline.getTime();
+    const deadline = appt.checkInWindowEnd;
+    return today.getTime() < new Date(deadline).getTime();
   });
 };
 

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -1,4 +1,4 @@
-import { startOfDay } from 'date-fns';
+import { startOfDay, add } from 'date-fns';
 import { ELIGIBILITY } from './eligibility';
 import { VISTA_CHECK_IN_STATUS_IENS } from '../appConstants';
 
@@ -110,12 +110,21 @@ const removeTimeZone = payload => {
 const preCheckinExpired = appointments => {
   return !Object.values(appointments).some(appt => {
     const today = new Date();
-    const checkInExpiry = startOfDay(new Date(appt.startTime));
-    return today.getTime() < checkInExpiry.getTime();
+    const preCheckInExpiry = startOfDay(new Date(appt.startTime));
+    return today.getTime() < preCheckInExpiry.getTime();
+  });
+};
+
+const appointmentStartTimePast15 = appointments => {
+  return !Object.values(appointments).some(appt => {
+    const today = new Date();
+    const deadline = add(new Date(appt.startTime), { minutes: 15 });
+    return today.getTime() < deadline.getTime();
   });
 };
 
 export {
+  appointmentStartTimePast15,
   appointmentWasCanceled,
   hasMoreAppointmentsToCheckInto,
   sortAppointmentsByStartTime,


### PR DESCRIPTION
## Description
Now that I have a better understanding of how the codebase works, I was able to refactor the error page to no longer need the 'type=expired' param to accomplish the expired link functionality.

This PR adds to that functionality to remove the submessage (blue box) if any appointments are 15 or more minutes past their start time.

You can test by removing 15 minutes from the mock start time for the expired uuid

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41139


## Testing done
- Refactored unit tests and added new ones
- Should there be a new e2e test?

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
