### PR TITLE
Skip flaky chatbox unit test

### DIFF
--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -880,7 +880,7 @@ describe('App', () => {
       },
     };
 
-    it('when message activity is fired, then utterances should be stored in sessionStorage', () => {
+    it.skip('when message activity is fired, then utterances should be stored in sessionStorage', () => {
       loadWebChat();
       mockApiRequest({ token: 'FAKETOKEN', apiSession: 'FAKEAPISESSION' });
 


### PR DESCRIPTION
## Description
Skip flaky Chatbox unit test that failed twice today.
https://github.com/department-of-veterans-affairs/vets-website/runs/6474740863?check_suite_focus=true

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
