### PR TITLE
Add TransitionModal unit test

### DIFF
--- a/src/platform/user/tests/authentication/components/TransitionModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/TransitionModal.unit.spec.js
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 import TransitionModal from 'platform/user/authentication/components/account-transition/TransitionModal';
 
-describe('', () => {
+describe('TransitionModal', () => {
   const props = {
     visible: false,
     onClose: sinon.spy(),

--- a/src/platform/user/tests/authentication/components/TransitionModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/TransitionModal.unit.spec.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
+import TransitionModal from 'platform/user/authentication/components/account-transition/TransitionModal';
+
+describe('', () => {
+  const props = {
+    visible: false,
+    onClose: sinon.spy(),
+  };
+
+  it('should display when `visible` is set to true', () => {
+    const wrapper = mount(<TransitionModal {...props} />);
+    expect(wrapper.prop('visible')).to.be.false;
+    wrapper.props().visible = true;
+    expect(wrapper.prop('visible')).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should include `Prepare for sign in changes at VA` in the modal', () => {
+    const wrapper = mount(<TransitionModal {...props} />);
+    expect(wrapper.find('Modal').props().title).to.include(
+      'Prepare for sign in changes at VA',
+    );
+    wrapper.unmount();
+  });
+
+  it('should forward as a primary action', () => {
+    const wrapper = shallow(<TransitionModal {...props} />);
+    wrapper.prop('primaryButton').action();
+    expect(window.location).equal('/transfer-account');
+    wrapper.unmount();
+  });
+
+  it('should close as a secondary action', () => {
+    const wrapper = shallow(<TransitionModal {...props} />);
+    wrapper.prop('secondaryButton').action();
+    expect(wrapper.prop('onClose').calledOnce).to.be.true;
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This PR adds unit tests for the TransitionModal component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40922

## Testing done
Unit tests

## Screenshots
n/a

## Acceptance criteria
- [x] Unit tests for TransitionModal run and pass successfully

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

