### PR TITLE
Update content on expired error page headers

### DIFF
--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -155,5 +155,11 @@
   "youre-also-responsible-for-protecting-your-personal-health-information-if-you-print-or-download-your-information-or-share-it-electronically-with-others-youll-need-to-take-steps-to-protect-it": "You’re also responsible for protecting your personal health information. If you print or download your information—or share it electronically with others—you’ll need to take steps to protect it.",
   "youre-checked-in-for-your-appointment": "You're checked in for your {{date, time}} appointment",
   "youve-completed-pre-check-in": "You’ve completed pre-check-in",
-  "zip-code-is-required": "Zip code is required"
+  "zip-code-is-required": "Zip code is required",
+  "what-is-pre-check-in": "What is pre-check-in?",
+  "why-cant-i-pre-check-in": "Why can't I pre-check-in?",
+  "you-can-pre-check-in-online-before-midnight-of-the-day-of-your-appointment": "You can pre-check-in online before midnight of the day of your appointment.",
+  "during-pre-check-in-you-can-review-your-personal-emergency-contact-and-next-of-kin-information-and-confirm-its-up-to-date-this-helps-us-better-prepare-for-your-appointment": "During pre-check-in, you can review your personal, emergency contact, and next of kin information and confirm it's up to date. This helps us better prepare for your appointment.",
+  "you-can-also-sign-in-to-your-va-account-to-review-your-information": "You can also <0>{{link}}</0> to your VA account to review your information.",
+  "sign-in": "sign in"
 }

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -104,6 +104,7 @@
   "saving-your-responses": "Saving your responses...",
   "sister": "Sister",
   "son": "Son",
+  "sorry-pre-check-in-is-no-longer-available": "Sorry, pre-check-in is no longer available",
   "sorry-we-cant-complete-pre-check-in": "Sorry, we can’t complete pre-check-in",
   "start-again": "Start again",
   "start-here": "Start here",
@@ -154,11 +155,5 @@
   "youre-also-responsible-for-protecting-your-personal-health-information-if-you-print-or-download-your-information-or-share-it-electronically-with-others-youll-need-to-take-steps-to-protect-it": "You’re also responsible for protecting your personal health information. If you print or download your information—or share it electronically with others—you’ll need to take steps to protect it.",
   "youre-checked-in-for-your-appointment": "You're checked in for your {{date, time}} appointment",
   "youve-completed-pre-check-in": "You’ve completed pre-check-in",
-  "zip-code-is-required": "Zip code is required",
-  "what-is-pre-check-in": "What is pre-check-in?",
-  "why-cant-i-pre-check-in": "Why can't I pre-check-in?",
-  "you-can-pre-check-in-online-before-midnight-of-the-day-of-your-appointment": "You can pre-check-in online before midnight of the day of your appointment.",
-  "during-pre-check-in-you-can-review-your-personal-emergency-contact-and-next-of-kin-information-and-confirm-its-up-to-date-this-helps-us-better-prepare-for-your-appointment": "During pre-check-in, you can review your personal, emergency contact, and next of kin information and confirm it's up to date. This helps us better prepare for your appointment.",
-  "you-can-also-sign-in-to-your-va-account-to-review-your-information": "You can also <0>{{link}}</0> to your VA account to review your information.",
-  "sign-in": "sign in"
+  "zip-code-is-required": "Zip code is required"
 }

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -61,14 +61,18 @@ const Error = () => {
     const accordions = <PreCheckInAccordionBlock key="accordion" errorPage />;
     if (appointments && appointments.length) {
       // don't show sub message if we are 15 minutes past appointment start time
-      if (appointmentStartTimePast15(appointments)) return ['', accordions];
+      if (appointmentStartTimePast15(appointments))
+        return [t('sorry-pre-check-in-is-no-longer-available'), '', accordions];
       if (preCheckinExpired(appointments))
-        return [t('you-can-still-check-in-once-you-arrive'), accordions];
+        return [
+          t('sorry-pre-check-in-is-no-longer-available'),
+          t('you-can-still-check-in-once-you-arrive'),
+          accordions,
+        ];
     }
-    return [combinedMessage, null];
+    return [t('sorry-we-cant-complete-pre-check-in'), combinedMessage, null];
   };
-  const header = t('sorry-we-cant-complete-pre-check-in');
-  const [message, additionalDetails] = getErrorMessages();
+  const [header, message, additionalDetails] = getErrorMessages();
 
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
@@ -16,7 +16,7 @@ class Error {
   validateExpiredPageLoaded = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
-      .and('have.text', 'Sorry, we can’t complete pre-check-in');
+      .and('have.text', 'Sorry, pre-check-in is no longer available');
     cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .contains(


### PR DESCRIPTION
## Description
I did not have the correct content in the header for an expired error page (midnight to appt, and 15+ min after appt).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41139

## Screenshots
<img width="349" alt="Screen Shot 2022-05-17 at 12 42 19 PM" src="https://user-images.githubusercontent.com/5032149/168888243-9bf97cc6-e3d2-4327-9ded-147c9a92c59f.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
