### PR TITLE
bumps vets-json-schema to 20.20.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,7 +335,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#5ba819bc039e34ce6e1a1812cef7e0cee84c2982",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ecdb84139a36c0e698fe8e090361cf1fd08b3fa6",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20131,9 +20131,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#5ba819bc039e34ce6e1a1812cef7e0cee84c2982":
-  version "20.20.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#5ba819bc039e34ce6e1a1812cef7e0cee84c2982"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ecdb84139a36c0e698fe8e090361cf1fd08b3fa6":
+  version "20.20.2"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ecdb84139a36c0e698fe8e090361cf1fd08b3fa6"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description

This updates `package.json` to use `json-vets-schema` @ version `20.20.2`. This version corrects a typo, "Doctoral degre" to "Doctoral degree".


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29394

## Related Pull Request(s)
https://github.com/department-of-veterans-affairs/vets-api/pull/9878