### PR TITLE
remove feature flag evss_upload_limit_150mb

### DIFF
--- a/src/applications/coronavirus-chatbot/tests/config/data/chatbotResponse.json
+++ b/src/applications/coronavirus-chatbot/tests/config/data/chatbotResponse.json
@@ -59,8 +59,6 @@
       { "name": "direct_deposit_vanotify", "value": true },
       { "name": "educationReportsCleanup", "value": false },
       { "name": "education_reports_cleanup", "value": false },
-      { "name": "evssUploadLimit150mb", "value": true },
-      { "name": "evss_upload_limit_150mb", "value": true },
       { "name": "facilitiesPPMSSuppressCommunityCare", "value": false },
       { "name": "facilities_ppms_suppress_community_care", "value": false },
       { "name": "facilitiesPPMSSuppressPharmacies", "value": false },

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -25,7 +25,6 @@ import {
 import { MVI_ADD_SUCCEEDED } from './actions';
 import {
   WIZARD_STATUS,
-  PDF_SIZE_FEATURE,
   SHOW_8940_4192,
   PAGE_TITLE_SUFFIX,
   DOCUMENT_TITLE_SUFFIX,
@@ -69,7 +68,6 @@ export const Form526Entry = ({
   location,
   loggedIn,
   mvi,
-  pdfLimit,
   router,
   savedForms,
   showSubforms,
@@ -187,11 +185,6 @@ export const Form526Entry = ({
       return wrapWithBreadcrumb(title, <MissingServices title={title} />);
     }
   }
-
-  // No easy method to pass a feature flag setting to a uiSchema, so we'll use
-  // sessionStorage for now. Done here because continuing an application may
-  // bypass the intro page.
-  sessionStorage.setItem(PDF_SIZE_FEATURE, pdfLimit);
 
   return wrapWithBreadcrumb(
     title,

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -11,6 +11,8 @@ import {
 } from 'platform/site-wide/wizard';
 import { isLoggedIn } from 'platform/user/selectors';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from 'platform/utilities/ui';
 import formConfig from './config/form';
 import AddPerson from './containers/AddPerson';
 import ITFWrapper from './containers/ITFWrapper';
@@ -36,10 +38,6 @@ import {
   wrapWithBreadcrumb,
   isExpired,
 } from './utils';
-import { uploadPdfLimitFeature } from './config/selectors';
-
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { focusElement } from 'platform/utilities/ui';
 
 export const serviceRequired = [
   backendServices.FORM526,
@@ -214,7 +212,6 @@ const mapStateToProps = state => ({
   isStartingOver: state.form?.isStartingOver,
   loggedIn: isLoggedIn(state),
   mvi: state.mvi,
-  pdfLimit: uploadPdfLimitFeature(state),
   savedForms: state?.user?.profile?.savedForms || [],
   showSubforms: showSubform8940And4192(state),
   showWizard: show526Wizard(state),

--- a/src/applications/disability-benefits/all-claims/config/selectors.js
+++ b/src/applications/disability-benefits/all-claims/config/selectors.js
@@ -1,5 +1,0 @@
-// import the toggleValues helper
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-
-export const uploadPdfLimitFeature = state =>
-  toggleValues(state).evss_upload_limit_150mb;

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -310,9 +310,6 @@ export const EBEN_526_PATH =
 export const BDD_INFO_URL =
   '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/';
 
-// PDF upload limit feature
-export const PDF_SIZE_FEATURE = 'pdfSizeFeature';
-
 // maxLength from schema
 export const CHAR_LIMITS = [
   'primaryDescription',

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-
 import { MAX_FILE_SIZE_MB, MAX_PDF_FILE_SIZE_MB } from '../constants';
-import { getPdfSizeFeature } from '../utils/schemas';
 
 /**
  * Generic description added to file upload pages
  * @param {String|ReactComponent} uploadTitle - page title
  */
-export const UploadDescription = ({
-  uploadTitle,
-  showPdfSize = getPdfSizeFeature(),
-}) => (
+export const UploadDescription = ({ uploadTitle }) => (
   <div>
     {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
@@ -24,14 +19,8 @@ export const UploadDescription = ({
       <li>
         File types you can upload: .pdf, .jpg, .jpeg, .png, .gif, .bmp, or .txt
       </li>
-      <li>
-        {`Maximum ${
-          showPdfSize ? 'non-PDF ' : ''
-        }file size: ${MAX_FILE_SIZE_MB}MB`}
-      </li>
-      {showPdfSize && (
-        <li>{`Maximum PDF file size: ${MAX_PDF_FILE_SIZE_MB}MB`}</li>
-      )}
+      <li>{`Maximum non-PDF file size: ${MAX_FILE_SIZE_MB}MB`}</li>
+      <li>{`Maximum PDF file size: ${MAX_PDF_FILE_SIZE_MB}MB`}</li>
     </ul>
     <p>
       <em>

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -6,7 +6,6 @@ import { getPdfSizeFeature } from '../utils/schemas';
 /**
  * Generic description added to file upload pages
  * @param {String|ReactComponent} uploadTitle - page title
- *   feature flag
  */
 export const UploadDescription = ({
   uploadTitle,

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -6,7 +6,6 @@ import { getPdfSizeFeature } from '../utils/schemas';
 /**
  * Generic description added to file upload pages
  * @param {String|ReactComponent} uploadTitle - page title
- * @param {Boolean} uploadPdfLimit - state of the evss_upload_limit_150mb
  *   feature flag
  */
 export const UploadDescription = ({

--- a/src/applications/disability-benefits/all-claims/tests/content/fileUploadDescription.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/fileUploadDescription.unit.spec.jsx
@@ -7,27 +7,15 @@ import { MAX_FILE_SIZE_MB, MAX_PDF_FILE_SIZE_MB } from '../../constants';
 
 describe('526 All Claims -- File upload descriptions', () => {
   it('should render', () => {
-    const tree = shallow(
-      <UploadDescription uploadTitle={'test'} showPdfSize={false} />,
-    );
+    const tree = shallow(<UploadDescription uploadTitle="test" />);
     expect(tree.find('UploadDescription')).to.exist;
     tree.unmount();
   });
-  it('should render only the max global file size', () => {
-    const tree = shallow(
-      <UploadDescription uploadTitle={'test'} showPdfSize={false} />,
-    );
+  it('should render the max file sizes', () => {
+    const tree = shallow(<UploadDescription uploadTitle="test" />);
     const text = tree.text();
-    expect(text).to.contain(`Maximum file size: ${MAX_FILE_SIZE_MB}`);
-    expect(text).to.not.contain(MAX_PDF_FILE_SIZE_MB);
-    tree.unmount();
-  });
-  it('should render only the appropriate panels', () => {
-    const tree = shallow(
-      <UploadDescription uploadTitle={'test'} showPdfSize />,
-    );
-    const text = tree.text();
-    expect(text).to.contain(MAX_PDF_FILE_SIZE_MB);
+    expect(text).to.contain(`Maximum non-PDF file size: ${MAX_FILE_SIZE_MB}MB`);
+    expect(text).to.contain(`Maximum PDF file size: ${MAX_PDF_FILE_SIZE_MB}MB`);
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -25,7 +25,6 @@ import {
   MAX_PDF_FILE_SIZE_BYTES,
   USA,
   NULL_CONDITION_STRING,
-  PDF_SIZE_FEATURE,
 } from '../constants';
 
 import {
@@ -253,9 +252,6 @@ export function incidentLocationUISchema(addressPath) {
   };
 }
 
-export const getPdfSizeFeature = () =>
-  sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
-
 export const ancillaryFormUploadUi = (
   label,
   itemDescription,
@@ -267,7 +263,6 @@ export const ancillaryFormUploadUi = (
     addAnotherLabel = 'Add Another',
   } = {},
 ) => {
-  const pdfSizeFeature = getPdfSizeFeature();
   // a11y focus management. Move focus to select after upload
   // see va.gov-team/issues/19688
   const findAndFocusLastSelect = () => {
@@ -286,7 +281,7 @@ export const ancillaryFormUploadUi = (
     // not sure what to do here... we need to differentiate pdf vs everything
     // else; the check is in the actions.js > uploadFile function
     maxSize: MAX_FILE_SIZE_BYTES,
-    maxPdfSize: pdfSizeFeature ? MAX_PDF_FILE_SIZE_BYTES : MAX_FILE_SIZE_BYTES,
+    maxPdfSize: MAX_PDF_FILE_SIZE_BYTES,
     minSize: 1,
     createPayload: (file, _formId, password) => {
       const payload = new FormData();

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -39,7 +39,6 @@ export default Object.freeze({
   dependencyVerification: 'dependency_verification',
   dischargeWizardFeatures: 'discharge_wizard_features',
   enrollmentVerification: 'enrollment_verification',
-  evssUploadLimit150Mb: 'evss_upload_limit_150mb',
   facilitiesPpmsSuppressAll: 'facilities_ppms_suppress_all',
   facilitiesPpmsSuppressCommunityCare:
     'facilities_ppms_suppress_community_care',


### PR DESCRIPTION
## Description
Removes old `evss_upload_limit_150mb` feature flag

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38842


## Testing done
Tests still pass

## Acceptance criteria
- [x]  Remove feature flag `evss_upload_limit_150mb` feature code in 526
- [x]  Update tests

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
