### PR TITLE
Removes live requests to keepalive endpoint in E2E testing

### DIFF
--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -12,7 +12,7 @@ import mockCopays from '../../../medical-copays/tests/e2e/fixtures/mocks/copays.
 
 describe('Debt Letters', () => {
   beforeEach(() => {
-    cy.login(mockUser).as('login');
+    cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles).as(
       'features',
     );

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -10,10 +10,10 @@ import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 import mockCopays from '../../../medical-copays/tests/e2e/fixtures/mocks/copays.json';
 
-describe.skip('Debt Letters', () => {
+describe('Debt Letters', () => {
   beforeEach(() => {
-    cy.login(mockUser);
-    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
+    cy.login(mockUser).as('login');
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles).as(
       'features',
     );
     cy.intercept('GET', '/v0/debts', mockDebts).as('debts');

--- a/src/applications/debt-letters/tests/e2e/diary-codes-content.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/diary-codes-content.cypress.spec.js
@@ -2,7 +2,7 @@ import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 
-describe.skip('Diary Codes', () => {
+describe('Diary Codes', () => {
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);

--- a/src/applications/debt-letters/tests/e2e/diary-codes-next-step.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/diary-codes-next-step.cypress.spec.js
@@ -2,7 +2,7 @@ import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 
-describe.skip('Diary Codes - Next Steps', () => {
+describe('Diary Codes - Next Steps', () => {
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);

--- a/src/applications/medical-copays/tests/e2e/mcp.cypress.spec.js
+++ b/src/applications/medical-copays/tests/e2e/mcp.cypress.spec.js
@@ -52,7 +52,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays download statements - C12578', () => {
+  it('displays download statements - C12578', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');

--- a/src/applications/medical-copays/tests/e2e/statements.cypress.spec.js
+++ b/src/applications/medical-copays/tests/e2e/statements.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays other va debts', () => {
+  it('displays other va debts', () => {
     cy.findByTestId('other-va-debt-body').should('exist');
     cy.axeCheck();
   });
@@ -59,7 +59,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays view statements section - C12578', () => {
+  it('displays view statements section - C12578', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');
@@ -68,7 +68,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('navigates to view statements page - C12579', () => {
+  it('navigates to view statements page - C12579', () => {
     // get to page
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
@@ -83,7 +83,7 @@ describe('Medical Copays', () => {
     cy.axeCheck();
   });
 
-  it.skip('displays account summary - C12580', () => {
+  it('displays account summary - C12580', () => {
     // get to page
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();

--- a/src/platform/testing/e2e/cypress/support/commands/login.js
+++ b/src/platform/testing/e2e/cypress/support/commands/login.js
@@ -4,10 +4,17 @@ import { CSP_IDS } from 'platform/user/authentication/constants';
 /* eslint-disable camelcase */
 const mockUser = {
   data: {
+    id: '',
+    type: 'users_scaffolds',
     attributes: {
+      account: {
+        account_uuid: '777bfa-2cbb-98fc-zz-9231fbac',
+      },
       profile: {
         sign_in: {
-          service_name: CSP_IDS.ID_ME,
+          service_name: CSP_IDS.DS_LOGON,
+          account_type: '2',
+          ssoe: false,
         },
         email: 'fake@fake.com',
         loa: { current: 3 },
@@ -17,6 +24,10 @@ const mockUser = {
         gender: 'F',
         birth_date: '1985-01-01',
         verified: true,
+        authn_context: 'dslogon',
+        multifactor: true,
+        zip: '21076',
+        last_signed_in: '2022-05-18T22:02:02.188Z',
       },
       veteran_status: {
         status: 'OK',
@@ -43,10 +54,10 @@ const mockUser = {
       ],
       va_profile: {
         status: 'OK',
-        birth_date: '19511118',
-        family_name: 'Hunter',
-        gender: 'M',
-        given_names: ['Julio', 'E'],
+        birth_date: '19850101',
+        family_name: 'Doe',
+        gender: 'F',
+        given_names: ['Jane', 'E'],
         active_status: 'active',
         facilities: [
           {
@@ -58,6 +69,9 @@ const mockUser = {
             isCerner: false,
           },
         ],
+        is_cerner_patient: false,
+        va_patient: true,
+        mhv_account_state: 'OK',
       },
     },
   },

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -22,7 +22,9 @@ import localStorage from '../storage/localStorage';
 const keepAliveThreshold = 5 * 60 * 1000; // 5 minutes, in milliseconds
 
 function keepAlive() {
-  return environment.isLocalhost() ? mockKeepAlive() : liveKeepAlive();
+  return environment.isLocalhost() || window.Cypress
+    ? mockKeepAlive()
+    : liveKeepAlive();
 }
 
 export async function ssoKeepAliveSession() {


### PR DESCRIPTION
## Description
This PR updates the `keepAlive` method in E2E testing to use a mock call to the `/keepalive` endpoint rather than using the real call to eAuth.  Additionally, it reverts some of the `.skip` in some Cypress tests to any dealing with Debts.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#41626


## Testing done
Local Cypress, unit tests

## Screenshots
n/a

## Acceptance criteria
- [x] Cypress testing for Debts consistently passes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
