### PR TITLE
Your military details should only allow Spouse and Child to apply to Ch. 35

### DIFF
--- a/src/applications/gi/components/Dropdown.jsx
+++ b/src/applications/gi/components/Dropdown.jsx
@@ -44,11 +44,12 @@ const Dropdown = ({
         onFocus={() => onFocus(dropdownId)}
       >
         {options.map(
-          ({ optionValue, optionLabel }, index) =>
+          ({ optionValue, optionLabel, optionDisabled }, index) =>
             optionLabel && (
               <option
                 key={index}
                 value={optionValue}
+                disabled={optionDisabled}
                 className={
                   optionValue === value
                     ? 'vads-u-font-weight--bold'

--- a/src/applications/gi/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi/components/profile/BenefitsForm.jsx
@@ -1,34 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
-
+import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import { ariaLabels } from '../../constants';
 import Dropdown from '../Dropdown';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import LearnMoreLabel from '../LearnMoreLabel';
 
-export class BenefitsForm extends React.Component {
-  state = { showYourMilitaryDetails: false };
-
-  static propTypes = {
-    showModal: PropTypes.func,
-    hideModal: PropTypes.func,
-    eligibilityChange: PropTypes.func,
-    showHeader: PropTypes.bool,
-    handleInputFocus: PropTypes.func,
-    giBillChapterOpen: PropTypes.arrayOf(PropTypes.bool),
-    yourMilitaryDetails: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    showGbBenefit: false,
-    showHeader: false,
-    giBillChapterOpen: [],
-    yourMilitaryDetails: true,
-  };
-
-  cumulativeServiceOptions = () => [
+const BenefitsForm = ({
+  children,
+  cumulativeService,
+  eligForPostGiBill,
+  eligibilityChange,
+  enlistmentService,
+  giBillChapter,
+  giBillChapterOpen,
+  handleInputFocus,
+  militaryStatus,
+  numberOfDependents,
+  optionDisabled,
+  showHeader,
+  showModal,
+  spouseActiveDuty,
+}) => {
+  // eslint-disable-next-line no-console
+  console.log(`benefitsForm ${optionDisabled}`);
+  const cumulativeServiceOptions = () => [
     { optionValue: '1.0', optionLabel: '36+ months: 100%' }, // notice not 1.00
     { optionValue: '0.9', optionLabel: '30 months: 90%' },
     { optionValue: '0.8', optionLabel: '24 months: 80%' },
@@ -43,11 +39,17 @@ export class BenefitsForm extends React.Component {
     { optionValue: 'purple heart', optionLabel: 'Purple Heart Service: 100%' },
   ];
 
-  renderLearnMoreLabel = ({ text, modal, ariaLabel, labelFor, buttonId }) => (
+  const renderLearnMoreLabel = ({
+    text,
+    modal,
+    ariaLabel,
+    labelFor,
+    buttonId,
+  }) => (
     <LearnMoreLabel
       text={text}
       onClick={() => {
-        this.props.showModal(modal);
+        showModal(modal);
       }}
       ariaLabel={ariaLabel}
       labelFor={labelFor || modal}
@@ -55,18 +57,11 @@ export class BenefitsForm extends React.Component {
     />
   );
 
-  handleMilitaryDetailsClick = () => {
-    this.setState({
-      showYourMilitaryDetails: !this.state.showYourMilitaryDetails,
-    });
-  };
-
-  renderYourMilitaryDetails() {
-    const chapter33Check =
-      this.props.giBillChapter === '33a' || this.props.giBillChapter === '33b';
+  const renderYourMilitaryDetails = () => {
+    const chapter33Check = giBillChapter === '33a' || giBillChapter === '33b';
     return (
       <div>
-        <ExpandingGroup open={this.props.militaryStatus === 'spouse'}>
+        <ExpandingGroup open={militaryStatus === 'spouse'}>
           <Dropdown
             label="What's your military status?"
             name="militaryStatus"
@@ -80,11 +75,11 @@ export class BenefitsForm extends React.Component {
               { optionValue: 'spouse', optionLabel: 'Spouse' },
               { optionValue: 'child', optionLabel: 'Child' },
             ]}
-            value={this.props.militaryStatus}
+            value={militaryStatus}
             alt="What's your military status?"
             visible
-            onChange={this.props.eligibilityChange}
-            onFocus={this.props.handleInputFocus}
+            onChange={eligibilityChange}
+            onFocus={handleInputFocus}
           />
           <Dropdown
             label="Is your spouse currently on active duty?"
@@ -93,21 +88,21 @@ export class BenefitsForm extends React.Component {
               { optionValue: 'yes', optionLabel: 'Yes' },
               { optionValue: 'no', optionLabel: 'No' },
             ]}
-            value={this.props.spouseActiveDuty}
+            value={spouseActiveDuty}
             alt="Is your spouse on active duty?"
             visible
-            onChange={this.props.eligibilityChange}
-            onFocus={this.props.handleInputFocus}
+            onChange={eligibilityChange}
+            onFocus={handleInputFocus}
           />
         </ExpandingGroup>
         <ExpandingGroup
           open={
-            ['30', '31', '33a', '33b'].includes(this.props.giBillChapter) ||
-            this.props.giBillChapterOpen.includes(true)
+            ['30', '31', '33a', '33b'].includes(giBillChapter) ||
+            giBillChapterOpen.includes(true)
           }
         >
           <Dropdown
-            label={this.renderLearnMoreLabel({
+            label={renderLearnMoreLabel({
               text: 'Which GI Bill benefit do you want to use?',
               modal: 'giBillChapter',
               ariaLabel: ariaLabels.learnMore.giBillBenefits,
@@ -130,16 +125,17 @@ export class BenefitsForm extends React.Component {
                 optionValue: '35',
                 optionLabel:
                   "Survivors' and Dependents' Educational Assistance (DEA) (Ch 35)",
+                optionDisabled,
               },
             ]}
-            value={this.props.giBillChapter}
+            value={giBillChapter}
             alt="Which GI Bill benefit do you want to use?"
             visible
-            onChange={this.props.eligibilityChange}
-            onFocus={this.props.handleInputFocus}
+            onChange={eligibilityChange}
+            onFocus={handleInputFocus}
           />
           <div>
-            {this.props.militaryStatus === 'active duty' &&
+            {militaryStatus === 'active duty' &&
               chapter33Check && (
                 <div className="military-status-info warning form-group">
                   <i className="fa fa-warning" />
@@ -157,7 +153,7 @@ export class BenefitsForm extends React.Component {
                   monthly housing allowance.
                 </div>
               )}
-            {this.props.giBillChapter === '31' && (
+            {giBillChapter === '31' && (
               <div className="military-status-info info form-group">
                 <i className="fa fa-info-circle" />
                 To apply for VR&E benefits, please{' '}
@@ -168,22 +164,22 @@ export class BenefitsForm extends React.Component {
               </div>
             )}
             <Dropdown
-              label={this.renderLearnMoreLabel({
+              label={renderLearnMoreLabel({
                 text: 'Cumulative Post-9/11 active-duty service',
                 modal: 'cumulativeService',
                 ariaLabel: ariaLabels.learnMore.post911Chapter33,
                 buttonId: 'cumulative-service-learn-more',
               })}
               name="cumulativeService"
-              options={this.cumulativeServiceOptions()}
-              value={this.props.cumulativeService}
+              options={cumulativeServiceOptions()}
+              value={cumulativeService}
               alt="Cumulative Post-9/11 active-duty service"
               visible={chapter33Check}
-              onChange={this.props.eligibilityChange}
-              onFocus={this.props.handleInputFocus}
+              onChange={eligibilityChange}
+              onFocus={handleInputFocus}
             />
             <Dropdown
-              label={this.renderLearnMoreLabel({
+              label={renderLearnMoreLabel({
                 text: 'Completed an enlistment of:',
                 modal: 'enlistmentService',
                 ariaLabel: ariaLabels.learnMore.montgomeryGIBill,
@@ -194,11 +190,11 @@ export class BenefitsForm extends React.Component {
                 { optionValue: '3', optionLabel: '3 or more years' },
                 { optionValue: '2', optionLabel: '2 or more years' },
               ]}
-              value={this.props.enlistmentService}
+              value={enlistmentService}
               alt="Completed an enlistment of:"
-              visible={this.props.giBillChapter === '30'}
-              onChange={this.props.eligibilityChange}
-              onFocus={this.props.handleInputFocus}
+              visible={giBillChapter === '30'}
+              onChange={eligibilityChange}
+              onFocus={handleInputFocus}
             />
             <Dropdown
               label="Are you eligible for the Post-9/11 GI Bill?"
@@ -207,11 +203,11 @@ export class BenefitsForm extends React.Component {
                 { optionValue: 'yes', optionLabel: 'Yes' },
                 { optionValue: 'no', optionLabel: 'No' },
               ]}
-              value={this.props.eligForPostGiBill}
+              value={eligForPostGiBill}
               alt="Are you eligible for the Post-9/11 GI Bill?"
-              visible={this.props.giBillChapter === '31'}
-              onChange={this.props.eligibilityChange}
-              onFocus={this.props.handleInputFocus}
+              visible={giBillChapter === '31'}
+              onChange={eligibilityChange}
+              onFocus={handleInputFocus}
             />
             <Dropdown
               label="How many dependents do you have?"
@@ -224,30 +220,44 @@ export class BenefitsForm extends React.Component {
                 { optionValue: '4', optionLabel: '4 Dependents' },
                 { optionValue: '5', optionLabel: '5 Dependents' },
               ]}
-              value={this.props.numberOfDependents}
+              value={numberOfDependents}
               alt="How many dependents do you have?"
-              visible={
-                this.props.giBillChapter === '31' &&
-                this.props.eligForPostGiBill === 'no'
-              }
-              onChange={this.props.eligibilityChange}
-              onFocus={this.props.handleInputFocus}
+              visible={giBillChapter === '31' && eligForPostGiBill === 'no'}
+              onChange={eligibilityChange}
+              onFocus={handleInputFocus}
             />
-            {this.props.children}
+            {children}
           </div>
         </ExpandingGroup>
       </div>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div className="eligibility-form">
-        {this.props.showHeader && <h2>Your benefits</h2>}
-        {this.renderYourMilitaryDetails()}
-      </div>
-    );
-  }
-}
+  return (
+    <div className="eligibility-form">
+      {showHeader && <h2>Your benefits</h2>}
+      {renderYourMilitaryDetails()}
+    </div>
+  );
+};
 
 export default BenefitsForm;
+
+BenefitsForm.propTypes = {
+  children: PropTypes.node,
+  cumulativeService: PropTypes.string,
+  eligForPostGiBill: PropTypes.string,
+  eligibilityChange: PropTypes.func,
+  enlistmentService: PropTypes.string,
+  giBillChapter: PropTypes.string,
+  giBillChapterOpen: PropTypes.arrayOf(PropTypes.bool),
+  handleInputFocus: PropTypes.func,
+  hideModal: PropTypes.func,
+  militaryStatus: PropTypes.string,
+  numberOfDependents: PropTypes.string,
+  optionDisabled: PropTypes.bool,
+  showHeader: PropTypes.bool,
+  showModal: PropTypes.func,
+  spouseActiveDuty: PropTypes.string,
+  yourMilitaryDetails: PropTypes.bool,
+};

--- a/src/applications/gi/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi/components/profile/BenefitsForm.jsx
@@ -22,8 +22,6 @@ const BenefitsForm = ({
   showModal,
   spouseActiveDuty,
 }) => {
-  // eslint-disable-next-line no-console
-  console.log(`benefitsForm ${optionDisabled}`);
   const cumulativeServiceOptions = () => [
     { optionValue: '1.0', optionLabel: '36+ months: 100%' }, // notice not 1.00
     { optionValue: '0.9', optionLabel: '30 months: 90%' },

--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -209,13 +209,11 @@ function CalculateYourBenefitsForm({
     });
     eligibilityChange({ [field]: value });
     setInputUpdated(true);
-    if (
-      field === 'militaryStatus' &&
-      (value === 'spouse' || value === 'child')
-    ) {
-      setIsDisabled(false);
-    } else {
+    if (field === 'militaryStatus') {
       setIsDisabled(true);
+      if (value === 'spouse' || value === 'child') {
+        setIsDisabled(false);
+      }
     }
 
     if (!environment.isProduction()) recalculateBenefits();

--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -202,10 +202,6 @@ function CalculateYourBenefitsForm({
   const updateEligibility = e => {
     const field = e.target.name;
     const { value } = e.target;
-    // eslint-disable-next-line no-console
-    console.log(`value: ${value}`);
-    // eslint-disable-next-line no-console
-    console.log(`isDisabled: ${isDisabled}`);
     recordEvent({
       event: 'gibct-form-change',
       'gibct-form-field': field,
@@ -1219,17 +1215,19 @@ function CalculateYourBenefitsForm({
 }
 
 CalculateYourBenefitsForm.propTypes = {
-  profile: PropTypes.object,
+  updateEstimatedBenefits: PropTypes.func.isRequired,
+  calculatorInputChange: PropTypes.func,
+  displayedInputs: PropTypes.object,
   eligibility: PropTypes.object,
   eligibilityChange: PropTypes.func,
-  inputs: PropTypes.object,
-  displayedInputs: PropTypes.object,
-  showModal: PropTypes.func,
-  calculatorInputChange: PropTypes.func,
-  onBeneficiaryZIPCodeChanged: PropTypes.func,
   estimatedBenefits: PropTypes.object,
-  updateEstimatedBenefits: PropTypes.func.isRequired,
+  focusHandler: PropTypes.func,
+  hideModal: PropTypes.func,
+  inputs: PropTypes.object,
+  profile: PropTypes.object,
+  showModal: PropTypes.func,
   updateBenefitsButtonEnabled: PropTypes.bool,
+  onBeneficiaryZIPCodeChanged: PropTypes.func,
 };
 
 export default CalculateYourBenefitsForm;

--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -48,7 +48,7 @@ function CalculateYourBenefitsForm({
     learningFormatAndSchedule: false,
     scholarshipsAndOtherFunding: false,
   });
-
+  const [isDisabled, setIsDisabled] = useState(true);
   const displayExtensionBeneficiaryZipcode = !inputs.classesoutsideus;
 
   const getExtensions = () => {
@@ -202,6 +202,10 @@ function CalculateYourBenefitsForm({
   const updateEligibility = e => {
     const field = e.target.name;
     const { value } = e.target;
+    // eslint-disable-next-line no-console
+    console.log(`value: ${value}`);
+    // eslint-disable-next-line no-console
+    console.log(`isDisabled: ${isDisabled}`);
     recordEvent({
       event: 'gibct-form-change',
       'gibct-form-field': field,
@@ -209,6 +213,14 @@ function CalculateYourBenefitsForm({
     });
     eligibilityChange({ [field]: value });
     setInputUpdated(true);
+    if (
+      field === 'militaryStatus' &&
+      (value === 'spouse' || value === 'child')
+    ) {
+      setIsDisabled(false);
+    } else {
+      setIsDisabled(true);
+    }
 
     if (!environment.isProduction()) recalculateBenefits();
   };
@@ -1054,6 +1066,7 @@ function CalculateYourBenefitsForm({
             hideModal={hideModal}
             showModal={showModal}
             inputs={inputs}
+            optionDisabled={environment.isProduction() ? false : isDisabled}
             displayedInputs={displayedInputs}
             handleInputFocus={handleEYBInputFocus}
             giBillChapterOpen={[displayedInputs?.giBillBenefit]}

--- a/src/applications/gi/tests/components/profile/BenefitsForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/profile/BenefitsForm.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 
 import createCommonStore from 'platform/startup/store';
-import { BenefitsForm } from '../../../components/profile/BenefitsForm';
-import reducer from '../../../reducers';
 import { Provider } from 'react-redux';
+import BenefitsForm from '../../../components/profile/BenefitsForm';
+import reducer from '../../../reducers';
 
 const commonStore = createCommonStore(reducer);
 const defaultProps = {

--- a/src/applications/gi/tests/components/profile/BenefitsForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/profile/BenefitsForm.unit.spec.jsx
@@ -49,17 +49,6 @@ describe('<BenefitsForm>', () => {
     tree.unmount();
   });
 
-  it('should render fields for Post-9/11 GI Bill (Ch 33)', () => {
-    const props = { ...defaultProps, giBillChapter: '33' };
-    const tree = mount(<BenefitsForm {...props} />);
-    checkExpectedDropdowns(tree, [
-      'militaryStatus',
-      'giBillChapter',
-      'cumulativeService',
-    ]);
-    tree.unmount();
-  });
-
   it('should render fields for Montgomery GI Bill (Ch 30)', () => {
     const props = { ...defaultProps, giBillChapter: '30' };
     const tree = mount(<BenefitsForm {...props} />);


### PR DESCRIPTION
## Description
The Comparison Tool currently allows Veterans/users to select Veteran, Active Duty, National Guard / Reserves from What's your military status? drop down and allow them to select "Survivors' and Dependents' Educational Assistance (DEA) (Ch 35).

Spouse and Child are the only options eligible for CH 35.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#41316](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41316)


## Testing done
Local Environment

## Screenshots
<img width="559" alt="Screen Shot 2022-05-18 at 5 47 43 PM" src="https://user-images.githubusercontent.com/18352271/169169082-34de7186-3fb0-4902-b3ca-b6d1685a4eba.png">
<img width="570" alt="Screen Shot 2022-05-18 at 5 47 54 PM" src="https://user-images.githubusercontent.com/18352271/169169089-bcaa8401-edb0-44c7-90a5-39eba3316f29.png">

## Acceptance criteria
- [ ] disable/grey-out Ch 35 if their first choice is NOT Spouse or Child.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
