### PR TITLE
Display 'Not Applicable' for Active Duty Service Periods' Separation Reason and Character of Service

### DIFF
--- a/src/applications/my-education-benefits/components/ServicePeriodAccordionView.jsx
+++ b/src/applications/my-education-benefits/components/ServicePeriodAccordionView.jsx
@@ -48,10 +48,14 @@ export default function ServicePeriodAccordionView({ formData }) {
       </dd>
 
       <dt className="service-history-details_term">Character of service</dt>
-      <dd className="service-history-details_definition">{serviceCharacter}</dd>
+      <dd className="service-history-details_definition">
+        {servicePeriodTo ? serviceCharacter : 'Not Applicable'}
+      </dd>
 
       <dt className="service-history-details_term">Separation reason</dt>
-      <dd className="service-history-details_definition">{separationReason}</dd>
+      <dd className="service-history-details_definition">
+        {servicePeriodTo ? separationReason : 'Not Applicable'}
+      </dd>
 
       {!!formattedTrainingPeriods.length && (
         <>


### PR DESCRIPTION
## Description
We are sometimes receiving invalid data upstream for active duty service periods. Separation reason and character of service should always display 'Not Applicable' for active duty service periods.