### PR TITLE
Remove extra text from `MissingId` component

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -1,23 +1,25 @@
 import React from 'react';
-
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
 
 const titleLowerCase = (title = '') =>
   `${title[0].toLowerCase() || ''}${title.slice(1)}`;
 
-const Alert = ({ title, content }) => (
+const Alert = ({ content, title }) => (
   <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
     <div className="usa-content">
       <h1>{title}</h1>
-
-      <va-alert visible status="error">
-        {content}
-      </va-alert>
+      <va-alert status="error">{content}</va-alert>
     </div>
   </div>
 );
+
+Alert.propTypes = {
+  content: PropTypes.node,
+  title: PropTypes.string,
+};
 
 export const MissingServices = ({ title }) => {
   const content = (
@@ -47,6 +49,10 @@ export const MissingServices = ({ title }) => {
   return <Alert title={title} content={content} />;
 };
 
+MissingServices.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
 export const MissingId = ({ title }) => {
   const content = (
     <>
@@ -57,9 +63,9 @@ export const MissingId = ({ title }) => {
         We don’t have all of your ID information for your account. We need this
         information before you can {titleLowerCase(title)}. To update your
         account, please call Veterans Benefits Assistance at{' '}
-        <va-telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:
+        <va-telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
         <va-telephone contact={CONTACTS['711']} />
-        )va-t We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+        ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p className="vads-u-font-size--base">
         Tell the representative that you may be missing your{' '}
@@ -84,6 +90,10 @@ export const MissingId = ({ title }) => {
     'alert-box-closeable': false,
   });
   return <Alert title={title} content={content} />;
+};
+
+MissingId.propTypes = {
+  title: PropTypes.string.isRequired,
 };
 
 export const MissingDob = ({ title }) => {
@@ -115,4 +125,8 @@ export const MissingDob = ({ title }) => {
     'alert-box-closeable': false,
   });
   return <Alert title={title} content={content} />;
+};
+
+MissingDob.propTypes = {
+  title: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## Description
* Removes extra text from `MissingId` component
* Adds space between `TTY:` and `711` text
* Fixes some linting errors

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41723

## Screenshots
|Before|After|
|-----|-----|
|![Screen Shot 2022-05-20 at 12 32 19 PM](https://user-images.githubusercontent.com/13838621/169581807-ecdd9458-6432-45e6-8367-e077d133950f.png)|![Screen Shot 2022-05-20 at 12 33 52 PM](https://user-images.githubusercontent.com/13838621/169581986-8ec85140-fa65-41b1-ae36-29e922ece4cf.png)|




## Acceptance criteria
- [x] `va-t` text is removed from `MissingId` component

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
