### PR TITLE
Your military details should only allow Spouse and Child to apply to Ch. 35

### DIFF
--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -214,15 +214,6 @@ function CalculateYourBenefitsForm({
       }
     }
 
-    if (
-      field === 'militaryStatus' &&
-      (value === 'spouse' || value === 'child')
-    ) {
-      setIsDisabled(false);
-    } else {
-      setIsDisabled(true);
-    }
-
     if (!environment.isProduction()) recalculateBenefits();
   };
 


### PR DESCRIPTION
## Description
The Comparison Tool currently allows Veterans/users to select Veteran, Active Duty, National Guard / Reserves from What's your military status? drop down and allow them to select "Survivors' and Dependents' Educational Assistance (DEA) (Ch 35).

Spouse and Child are the only options eligible for CH 35.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#41316](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41316)


## Testing done
Local Environment

## Screenshots
<img width="559" alt="Screen Shot 2022-05-18 at 5 47 43 PM" src="https://user-images.githubusercontent.com/18352271/169169082-34de7186-3fb0-4902-b3ca-b6d1685a4eba.png">
<img width="570" alt="Screen Shot 2022-05-18 at 5 47 54 PM" src="https://user-images.githubusercontent.com/18352271/169169089-bcaa8401-edb0-44c7-90a5-39eba3316f29.png">

## Acceptance criteria
- [ ] disable/grey-out Ch 35 if their first choice is NOT Spouse or Child.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
