### PR TITLE
NOD & Letters: un-skip keyboard e2e tests

### DIFF
--- a/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('tabToInputWithLabel', text => {
     });
 });
 
-describe.skip('Notice of Disagreement keyboard only navigation', () => {
+describe('Notice of Disagreement keyboard only navigation', () => {
   it('navigates through a maximal form', () => {
     cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
     cy.intercept('PUT', 'v0/in_progress_forms/10182', mockInProgress);
@@ -30,66 +30,53 @@ describe.skip('Notice of Disagreement keyboard only navigation', () => {
     cy.injectAxeThenAxeCheck();
 
     // Intro page
-    cy.tabToElement('button[id$="continueButton"]');
-    cy.realPress('Space');
+    cy.tabToStartForm();
 
     // Veteran details
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Homelessness radios
     cy.tabToElement('[name="root_homeless"]');
     cy.chooseRadio('N');
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Contact info
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Filing deadlines
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Issues for review (sorted by random decision date) - only selecting one,
     // or more complex code is needed to find if the next checkbox is before or
     // after the first
     cy.tabToInputWithLabel('tinnitus');
     cy.realPress('Space');
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // area of disagreement for tinnitus
     cy.tabToInputWithLabel('service connection');
     cy.realPress('Space');
     cy.tabToElement('#root_otherEntry');
     cy.typeInFocused('Few words');
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Issue summary
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Board review option
     cy.tabToElement('[name="root_boardReviewOption"]');
     cy.chooseRadio('hearing');
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Hearing type
     cy.tabToElement('[name="root_hearingTypePreference"]');
     cy.chooseRadio('video_conference');
-    cy.tabToElement('button[type="submit"]');
-    cy.realPress('Space');
+    cy.tabToContinueForm();
 
     // Review & submit page
     cy.tabToElement('[name="privacyAgreementAccepted"]');
     cy.realPress('Space');
-
-    // Form submit button is a button type?
-    cy.tabToElement('button[id$="continueButton"].usa-button-primary');
-    cy.realPress('Space');
+    cy.tabToSubmitForm();
 
     // Confirmation page print button
     cy.get('button.screen-only').should('exist');

--- a/src/applications/burials/tests/burials-keyboard-only.cypress.spec.js
+++ b/src/applications/burials/tests/burials-keyboard-only.cypress.spec.js
@@ -24,8 +24,7 @@ describe('Burials keyboard only navigation', () => {
     cy.injectAxeThenAxeCheck();
 
     // *** Intro page ***
-    cy.tabToElement('button[id$="continueButton"]');
-    cy.realPress('Space');
+    cy.tabToStartForm();
 
     // *** Claimant Info ***
     cy.typeInFullName('root_claimantFullName_', data.claimantFullName);

--- a/src/applications/letters/tests/02-keyboard-only.cypress.spec.js
+++ b/src/applications/letters/tests/02-keyboard-only.cypress.spec.js
@@ -9,7 +9,7 @@ import {
 } from './e2e/fixtures/mocks/letters';
 
 describe('Authed Letter Test', () => {
-  it.skip('confirms authed letter functionality', () => {
+  it('confirms authed letter functionality', () => {
     cy.intercept('GET', '/v0/letters/beneficiary', benefitSummaryOptions).as(
       'benefitSummaryOptions',
     );

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -121,8 +121,10 @@ Cypress.Commands.add(
 
 // Target & use the "Start" form button on the Introduction page
 Cypress.Commands.add('tabToStartForm', () => {
-  // Same selector as tabToSubmitForm
-  cy.tabToElement('button[id$="continueButton"].usa-button-primary');
+  // Same button selector as tabToSubmitForm, or action link
+  cy.tabToElement(
+    'button[id$="continueButton"].usa-button-primary, .vads-c-action-link--green',
+  );
   cy.realPress('Space');
 });
 

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -119,6 +119,13 @@ Cypress.Commands.add(
   },
 );
 
+// Target & use the "Start" form button on the Introduction page
+Cypress.Commands.add('tabToStartForm', () => {
+  // Same selector as tabToSubmitForm
+  cy.tabToElement('button[id$="continueButton"].usa-button-primary');
+  cy.realPress('Space');
+});
+
 // Target & use the "Continue" button on a form page
 Cypress.Commands.add('tabToContinueForm', () => {
   cy.tabToElement('button[type="submit"]');


### PR DESCRIPTION
## Description

The keyboard-only e2e tests for the Notice of Disagreement (NOD) form and letters app were skipped recently due to the tests failing in CI. That problem has since been fixed, so we can now re-enable these tests

Additionally, a `tabToStartForm` command was added. The selector is the same as the review & submit page submit button, but a better-named command was included instead.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41733

## Testing done

Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Enable NOD keyboard-only e2e tests
- [x] Enable Letters keyboard-only e2e tests
- [x] Add a form start Cypress command

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
