### PR TITLE
HLR: Update wizard content

### DIFF
--- a/src/applications/appeals/996/wizard/WizardContainer.jsx
+++ b/src/applications/appeals/996/wizard/WizardContainer.jsx
@@ -43,10 +43,9 @@ export const WizardContainer = ({ setWizardStatus, hlrV2 }) => {
       <div className="wizard-container">
         <h2>Is this the form I need?</h2>
         <p>
-          Use this form if you disagree with VA’s decision on your claim and
-          want to request that a senior reviewer take a new look at your case
-          and the evidence you provided. You can’t submit any new evidence with
-          a Higher-Level Review.
+          Use this form if you disagree with our decision on your claim and want
+          a senior reviewer to review your case again. You can’t submit any new
+          evidence with a Higher-Level Review.
         </p>
         <p>{getStarted}</p>
         <Wizard


### PR DESCRIPTION
## Description

The first paragraph of the [Higher-Level Review wizard](https://staging.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start) content needs to be updated to be [more direct & task-focused per a content review](https://github.com/department-of-veterans-affairs/va.gov-team/issues/34879#issuecomment-1129110225)

Recommendation:

> revise the first sentence ("Use this form...") like this:
>
> Is this the form I need?
>
> Use this form if you disagree with our decision on your claim and want a senior reviewer to review your case again. You can’t submit any new evidence with a Higher-Level Review.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41605

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Update HLR wizard content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
