### PR TITLE
Press Enter for button & action links

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -125,7 +125,7 @@ Cypress.Commands.add('tabToStartForm', () => {
   cy.tabToElement(
     'button[id$="continueButton"].usa-button-primary, .vads-c-action-link--green',
   );
-  cy.realPress('Space');
+  cy.realPress('Enter');
 });
 
 // Target & use the "Continue" button on a form page


### PR DESCRIPTION
## Description

The `tabToStartForm` keyboard-only Cypress command should be using a real press of "Enter" to activate a primary action link. Using "Space" will only activate a button.

## Original issue(s)

department-of-veterans-affairs/va.gov-team#41733

## Testing done

Tested with action link

## Screenshots

N/A

## Acceptance criteria
- [x] `tabToStartForm` will properly work with either a button or action link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
