### PR TITLE
HLR: Add keyboard-only e2e test

### DIFF
--- a/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
@@ -1,84 +1,117 @@
+import path from 'path';
+
 import formConfig from '../config/form';
 import { fixDecisionDates } from './nod.cypress.helpers';
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUser from './fixtures/mocks/user.json';
-import mockData from './fixtures/data/maximal-test.json';
-
-// Modified from Cypress docs
-// https://glebbahmutov.com/cypress-examples/6.5.0/recipes/form-input-by-label.html#reusable-function
-Cypress.Commands.add('tabToInputWithLabel', text => {
-  cy.contains('label', text)
-    .invoke('attr', 'for')
-    .then(id => {
-      cy.tabToElement(`#${id}`);
-    });
-});
 
 describe.skip('Notice of Disagreement keyboard only navigation', () => {
-  it('navigates through a maximal form', () => {
+  before(() => {
+    cy.fixture(path.join(__dirname, 'fixtures/data/minimal-test.json')).as(
+      'testData',
+    );
     cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
     cy.intercept('PUT', 'v0/in_progress_forms/10182', mockInProgress);
     cy.intercept('POST', formConfig.submitUrl, mockSubmit);
-    cy.intercept('GET', 'v0/notice_of_disagreements/contestable_issues', {
-      data: fixDecisionDates(mockData.data.contestableIssues),
-    });
-
     cy.login(mockUser);
-    cy.visit('/decision-reviews/board-appeal/request-board-appeal-form-10182');
-    cy.injectAxeThenAxeCheck();
+  });
 
-    // Intro page
-    cy.tabToStartForm();
+  it('navigates through a maximal form', () => {
+    cy.get('@testData').then(({ data }) => {
+      const { chapters } = formConfig;
+      cy.intercept('GET', 'v0/notice_of_disagreements/contestable_issues', {
+        data: fixDecisionDates(data.contestableIssues),
+      });
+      cy.visit(
+        '/decision-reviews/board-appeal/request-board-appeal-form-10182',
+      );
+      cy.injectAxeThenAxeCheck();
 
-    // Veteran details
-    cy.tabToContinueForm();
+      // Intro page
+      cy.tabToStartForm();
 
-    // Homelessness radios
-    cy.tabToElement('[name="root_homeless"]');
-    cy.chooseRadio('N');
-    cy.tabToContinueForm();
+      // Veteran details
+      cy.url().should(
+        'include',
+        chapters.infoPages.pages.veteranInformation.path,
+      );
+      cy.tabToContinueForm();
 
-    // Contact info
-    cy.tabToContinueForm();
+      // Homelessness radios
+      cy.url().should('include', chapters.infoPages.pages.homeless.path);
+      cy.tabToElement('[name="root_homeless"]');
+      cy.chooseRadio('N');
+      cy.tabToContinueForm();
 
-    // Filing deadlines
-    cy.tabToContinueForm();
+      // Contact info
+      cy.url().should(
+        'include',
+        chapters.infoPages.pages.confirmContactInformation.path,
+      );
+      cy.tabToContinueForm();
 
-    // Issues for review (sorted by random decision date) - only selecting one,
-    // or more complex code is needed to find if the next checkbox is before or
-    // after the first
-    cy.tabToInputWithLabel('tinnitus');
-    cy.realPress('Space');
-    cy.tabToContinueForm();
+      // Filing deadlines
+      cy.url().should(
+        'include',
+        chapters.conditions.pages.filingDeadlines.path,
+      );
+      cy.tabToContinueForm();
 
-    // area of disagreement for tinnitus
-    cy.tabToInputWithLabel('service connection');
-    cy.realPress('Space');
-    cy.tabToElement('#root_otherEntry');
-    cy.typeInFocused('Few words');
-    cy.tabToContinueForm();
+      // Issues for review (sorted by random decision date) - only selecting one,
+      // or more complex code is needed to find if the next checkbox is before or
+      // after the first
+      cy.url().should(
+        'include',
+        chapters.conditions.pages.contestableIssues.path,
+      );
+      cy.tabToInputWithLabel('tinnitus');
+      cy.realPress('Space');
+      cy.tabToContinueForm();
 
-    // Issue summary
-    cy.tabToContinueForm();
+      // area of disagreement for tinnitus
+      cy.url().should(
+        'include',
+        chapters.conditions.pages.areaOfDisagreementFollowUp.path.replace(
+          ':index',
+          '',
+        ),
+      );
+      cy.tabToInputWithLabel('service connection');
+      cy.realPress('Space');
+      cy.tabToElement('#root_otherEntry');
+      cy.typeInFocused('Few words');
+      cy.tabToContinueForm();
 
-    // Board review option
-    cy.tabToElement('[name="root_boardReviewOption"]');
-    cy.chooseRadio('hearing');
-    cy.tabToContinueForm();
+      // Issue summary
+      cy.url().should('include', chapters.conditions.pages.issueSummary.path);
+      cy.tabToContinueForm();
 
-    // Hearing type
-    cy.tabToElement('[name="root_hearingTypePreference"]');
-    cy.chooseRadio('video_conference');
-    cy.tabToContinueForm();
+      // Board review option
+      cy.url().should(
+        'include',
+        chapters.boardReview.pages.boardReviewOption.path,
+      );
+      cy.tabToElement('[name="root_boardReviewOption"]');
+      cy.chooseRadio('hearing');
+      cy.tabToContinueForm();
 
-    // Review & submit page
-    cy.tabToElement('[name="privacyAgreementAccepted"]');
-    cy.realPress('Space');
-    cy.tabToSubmitForm();
+      // Hearing type
+      cy.url().should('include', chapters.boardReview.pages.hearingType.path);
+      cy.tabToElement('[name="root_hearingTypePreference"]');
+      cy.chooseRadio('video_conference');
+      cy.tabToContinueForm();
 
-    // Confirmation page print button
-    cy.get('button.screen-only').should('exist');
+      // Review & submit page
+      cy.url().should('include', 'review-and-submit');
+      cy.tabToElement('[name="privacyAgreementAccepted"]');
+      cy.realPress('Space');
+      cy.tabToSubmitForm();
+
+      // Check confirmation page print button
+      cy.url().should('include', 'confirmation');
+      cy.get('button.screen-only').should('exist');
+    });
   });
 });

--- a/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
@@ -1,0 +1,156 @@
+import path from 'path';
+
+import formConfig from '../config/form';
+import { CONTESTABLE_ISSUES_API, WIZARD_STATUS } from '../constants';
+
+import {
+  mockContestableIssues,
+  // getRandomDate,
+  fixDecisionDates,
+} from './hlr.cypress.helpers';
+import mockInProgress from './fixtures/mocks/in-progress-forms.json';
+import mockStatus from './fixtures/mocks/profile-status.json';
+import mockSubmit from './fixtures/mocks/application-submit.json';
+import mockUser from './fixtures/mocks/user.json';
+
+describe('Notice of Disagreement keyboard only navigation', () => {
+  before(() => {
+    window.sessionStorage.removeItem(WIZARD_STATUS);
+
+    cy.fixture(path.join(__dirname, 'fixtures/data/maximal-test-v2.json')).as(
+      'testData',
+    );
+    cy.intercept('GET', '/v0/feature_toggles?*', {
+      data: {
+        type: 'feature_toggles',
+        features: [{ name: 'hlrV2', value: true }],
+      },
+    });
+    cy.intercept('PUT', 'v0/in_progress_forms/10182', mockInProgress);
+    cy.intercept('GET', '/v0/profile/status', mockStatus);
+    cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+
+    cy.intercept(
+      'GET',
+      `/v1${CONTESTABLE_ISSUES_API}compensation`,
+      mockContestableIssues,
+    );
+
+    cy.login(mockUser);
+  });
+  after(() => {
+    window.sessionStorage.removeItem(WIZARD_STATUS);
+  });
+
+  it('navigates through a maximal form', () => {
+    cy.get('@testData').then(({ data }) => {
+      const { chapters } = formConfig;
+      cy.intercept('GET', 'v1/notice_of_disagreements/contestable_issues', {
+        data: fixDecisionDates(data.contestableIssues),
+      });
+      cy.visit(
+        '/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996',
+      );
+      cy.injectAxeThenAxeCheck();
+
+      // Wizard
+      cy.tabToElement('input[name="higher-level-review-option"]');
+      cy.chooseRadio('compensation');
+      cy.tabToStartForm();
+
+      // Intro page
+      cy.tabToStartForm();
+
+      // Veteran details
+      cy.url().should(
+        'include',
+        chapters.infoPages.pages.veteranInformation.path,
+      );
+      cy.tabToContinueForm();
+
+      // Homelessness radios
+      cy.url().should('include', chapters.infoPages.pages.homeless.path);
+      cy.tabToElement('[name="root_homeless"]');
+      cy.chooseRadio(data.homeless ? 'Y' : 'N');
+      cy.tabToContinueForm();
+
+      // Contact info
+      cy.url().should(
+        'include',
+        chapters.infoPages.pages.confirmContactInformation.path,
+      );
+      cy.tabToContinueForm();
+
+      // Issues for review (sorted by random decision date) - only selecting one,
+      // or more complex code is needed to find if the next checkbox is before or
+      // after the first
+      cy.url().should(
+        'include',
+        chapters.conditions.pages.contestableIssues.path,
+      );
+      cy.tabToInputWithLabel('Tinnitus');
+      cy.realPress('Space');
+      cy.tabToContinueForm();
+
+      // Area of disagreement for tinnitus
+      cy.url().should(
+        'include',
+        chapters.conditions.pages.areaOfDisagreementFollowUp.path.replace(
+          ':index',
+          '',
+        ),
+      );
+      cy.tabToInputWithLabel('service connection');
+      cy.realPress('Space');
+      cy.tabToElement('#root_otherEntry');
+      cy.typeInFocused('Few words');
+      cy.tabToContinueForm();
+
+      // Issue summary
+      cy.url().should('include', chapters.conditions.pages.issueSummary.path);
+      cy.tabToContinueForm();
+
+      // Informal conference option
+      cy.url().should(
+        'include',
+        chapters.informalConference.pages.requestConference.path,
+      );
+      cy.tabToElement('[name="root_informalConference"]');
+      cy.chooseRadio(data.informalConference);
+      cy.tabToContinueForm();
+
+      // Rep name & contact info
+      cy.url().should(
+        'include',
+        chapters.informalConference.pages.representativeInfoV2.path,
+      );
+      const rep = data.informalConferenceRep;
+      const repPrefix = '#root_informalConferenceRep_';
+      cy.typeInIfDataExists(`${repPrefix}firstName`, rep.firstName);
+      cy.typeInIfDataExists(`${repPrefix}lastName`, rep.lastName);
+      cy.typeInIfDataExists(`${repPrefix}phone`, rep.phone);
+      cy.typeInIfDataExists(`${repPrefix}extension`, rep.extension);
+      cy.typeInIfDataExists(`${repPrefix}email`, rep.email);
+      cy.tabToContinueForm();
+
+      // Informal conference time
+      cy.url().should(
+        'include',
+        chapters.informalConference.pages.conferenceTime.path,
+      );
+      cy.tabToElement('[name="root_informalConferenceTime"]');
+      cy.chooseRadio(data.informalConferenceTime);
+      cy.tabToContinueForm();
+
+      // Review & submit page
+      cy.url().should('include', 'review-and-submit');
+      cy.tabToElement('[name="privacyAgreementAccepted"]');
+      cy.realPress('Space');
+      cy.tabToSubmitForm();
+
+      // Check confirmation page print button
+      cy.url().should('include', 'confirmation');
+      cy.get('button.screen-only').should('exist');
+    });
+  });
+});


### PR DESCRIPTION
## Description

To improve accessibility testing, we need to add keyboard-only navigation of the Higher-Level Review app end-to-end testing.

Notice of Disagreements keyboard-only e2e test was also updated - it's still failing in production build, so hopefully these updates will fix it (once it's re-enabled)

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41768

## Testing done

Passing HLR e2e test

## Screenshots

N/A

## Acceptance criteria
- [x] Add HLR keyboard-only e2e test
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
