### PR TITLE
Use 'radio' instead of RadioWidget in ui:schema for personal info

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-edit-state.cypress.spec.js
@@ -17,6 +17,8 @@ const checkPersonalInfoFields = () => {
     .should('exist')
     .blur();
 
+  cy.axeCheck();
+
   cy.findAllByTestId('cancel-edit-button')
     .should('exist')
     .click();
@@ -46,6 +48,8 @@ const checkPersonalInfoFields = () => {
     'If not listed, please provide your preferred pronouns (255 characters maximum)',
   ).should('exist');
 
+  cy.axeCheck();
+
   cy.findAllByTestId('cancel-edit-button')
     .should('exist')
     .click();
@@ -56,13 +60,18 @@ const checkPersonalInfoFields = () => {
 
   // gender fields
   const genderEditButtonLabel = 'Edit Gender identity';
-  const genderEditInputLabel = 'Select your gender identity';
+  const genderEditInputLegend = 'Select your gender identity';
 
   cy.findByLabelText(genderEditButtonLabel)
     .should('exist')
     .click();
 
-  cy.findByText(genderEditInputLabel).should('exist');
+  cy.findByText(genderEditInputLegend).should('exist');
+
+  // radio options should be grouped into fieldset with a legend element
+  cy.findByRole('group', {
+    name: /Select your gender identity/i,
+  }).should('exist');
 
   cy.findByText('Woman').should('exist');
   cy.findByText('Man').should('exist');
@@ -72,11 +81,13 @@ const checkPersonalInfoFields = () => {
   cy.findByText('Prefer not to answer').should('exist');
   cy.findByText('A gender not listed here').should('exist');
 
+  cy.axeCheck();
+
   cy.findAllByTestId('cancel-edit-button')
     .should('exist')
     .click();
 
-  cy.findByText(genderEditInputLabel).should('not.exist');
+  cy.findByText(genderEditInputLegend).should('not.exist');
 
   // sexual orientation fields
   const sexualOrientationEditButtonLabel = 'Edit Sexual orientation';
@@ -99,6 +110,8 @@ const checkPersonalInfoFields = () => {
     'exist',
   );
 
+  cy.axeCheck();
+
   cy.findAllByTestId('cancel-edit-button')
     .should('exist')
     .click();
@@ -112,16 +125,16 @@ describe('Content in EDIT state on the personal information page', () => {
   it('should render each edit field with update/cancel buttons and remove field on cancel, when enhanced api data is present.', () => {
     setup({ isEnhanced: true });
 
-    checkPersonalInfoFields();
-
     cy.injectAxeThenAxeCheck();
+
+    checkPersonalInfoFields();
   });
 
   it('should render each edit field with update/cancel buttons even when no applicable data is present', () => {
     setup({ isEnhanced: false });
 
-    checkPersonalInfoFields();
-
     cy.injectAxeThenAxeCheck();
+
+    checkPersonalInfoFields();
   });
 });

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -1,7 +1,6 @@
 import { mapValues } from 'lodash';
 import moment from 'moment';
 
-import RadioWidget from 'platform/forms-system/src/js/widgets/RadioWidget';
 import TextWidget from 'platform/forms-system/src/js/widgets/TextWidget';
 import OtherTextField from '@@profile/components/personal-information/OtherTextField';
 import { NOT_SET_TEXT } from '../../constants';
@@ -133,7 +132,7 @@ export const personalInformationUiSchemas = {
   },
   genderIdentity: {
     genderIdentity: {
-      'ui:widget': RadioWidget,
+      'ui:widget': 'radio',
       'ui:title': `Select your gender identity`,
       'ui:options': {
         labels: genderLabels,


### PR DESCRIPTION
## Description
- Changes the Preferred Name ui:widget from RadioWidget to 'radio'

Importing the RadioWidget instead of using `radio` in the ui:widget results in a label being used instead of the more accessible fieldset/legend combination of elements, and this PR fixes this

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/41803


## Testing done
Added a11y tests for 'edit' state of each field, and also e2e test for legend being present within Preferred Name

## Acceptance criteria
- [x] Preferred Name appears as a `fieldset` element with a `legend` within it

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
