### PR TITLE
Auto switch from DEA (Ch 35) to Post-9/11 GI Bill (Ch 33)

### DIFF
--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -213,7 +213,9 @@ function CalculateYourBenefitsForm({
       if (value === 'spouse' || value === 'child') {
         setIsDisabled(false);
       }
-      eligibilityChange({ giBillChapter: '33a' });
+      if (!environment.isProduction()) {
+        eligibilityChange({ giBillChapter: '33a' });
+      }
     }
     if (!environment.isProduction()) recalculateBenefits();
   };

--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -48,7 +48,6 @@ function CalculateYourBenefitsForm({
     learningFormatAndSchedule: false,
     scholarshipsAndOtherFunding: false,
   });
-  const [isDisabled, setIsDisabled] = useState(true);
   const displayExtensionBeneficiaryZipcode = !inputs.classesoutsideus;
 
   const getExtensions = () => {
@@ -197,6 +196,8 @@ function CalculateYourBenefitsForm({
     if (!environment.isProduction()) recalculateBenefits();
   };
 
+  const [isDisabled, setIsDisabled] = useState(true);
+
   const updateEligibility = e => {
     const field = e.target.name;
     const { value } = e.target;
@@ -212,8 +213,8 @@ function CalculateYourBenefitsForm({
       if (value === 'spouse' || value === 'child') {
         setIsDisabled(false);
       }
+      eligibilityChange({ giBillChapter: '33a' });
     }
-
     if (!environment.isProduction()) recalculateBenefits();
   };
 


### PR DESCRIPTION
## Description
If I select for military status Spouse/Child the benefit DEA (ch 35), then I change the military status to Veteran, Active Duty or National Guard, the benefit DEA (ch 35) remains selected. Which is not correct (Spouse and Child are the only options eligible for DEA (ch 35)).

### Steps to Reproduce

- Navigate to: https://staging.va.gov/education/gi-bill-comparison-tool/institution/13957113
- In your military details accordions, select Spouse or Child for military status and select the benefit DEA (ch 35)
- Now, change the military status and select Veteran, Active Duty or National Guard
- Verify the DEA (Ch 35) still selected

## Desired behavior
Auto switch from DEA (Ch 35) benefit to post-9/11 GI Bill (Ch 33) when changing the status from Spouse/Child to Veteran, Active Duty or National Guard

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#41705](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/41705)

## Testing done
Local Environment


## Acceptance criteria
- [ ] Auto switch from DEA (Ch 35) benefit to post-9/11 GI Bill (Ch 33) when changing the status from Spouse/Child to Veteran, Active Duty or National Guard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
