### PR TITLE
40891 - CDP - Return to Facility Details Link

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -58,7 +58,7 @@ const HTMLStatementPage = ({ match }) => {
         </p>
         <Link
           className="vads-u-font-size--sm"
-          to={`/balance-details/${selectedId}`}
+          to={`/copay-balances/${selectedId}/detail`}
         >
           <i
             className="fa fa-chevron-left vads-u-margin-right--1"


### PR DESCRIPTION
## Description
Fixed link on statement page going to initial page rather than one back

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40891

## Acceptance criteria
- [ X ] Link now routes backwards without issuing page reload

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
