### PR TITLE
[526] Using primary action links instead of buttons for Intro page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -60,6 +60,7 @@ class IntroductionPage extends React.Component {
       downtime: formConfig.downtime,
       retentionPeriod: '1 year',
       ariaDescribedby: 'main-content',
+      testActionLink: true,
     };
 
     return (

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -221,6 +221,15 @@ div.review {
   }
 }
 
+/* Introduction page */
+article[data-location="introduction"]
+{
+  a.vads-c-action-link--green {
+    display: block;
+    line-height: 1em;
+  }
+}
+
 /* Confirmation page */
 article[data-location="confirmation"] {
   h1[tabindex="-1"] {

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -66,7 +66,7 @@ const testConfig = createTestConfig(
             window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
           }
           // Start form
-          cy.findAllByText(/start/i, { selector: 'button' })
+          cy.findAllByText(/start the/i, { selector: 'a' })
             .first()
             .click();
         });


### PR DESCRIPTION
## Description
Using primary action links instead of buttons for 526 Introduction page. Introduced some custom styling as well to retain the existing look and feel.

## Original issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/41773

## Screenshots
<details><summary>Before with green button</summary>

<img width="659" alt="Screen Shot 2022-05-24 at 2 36 38 PM" src="https://user-images.githubusercontent.com/13838621/170120486-dd04b46e-b2d8-4f6f-8d85-09f4ed255c2e.png">
</details>

<details><summary>After with primary action link</summary>

<img width="650" alt="Screen Shot 2022-05-24 at 2 38 50 PM" src="https://user-images.githubusercontent.com/13838621/170120580-54b507b6-5a88-4034-bbfe-d6591d6a3e9f.png">
</details>

<details><summary>After with primary action link (no additional styling)</summary>

<img width="648" alt="Screen Shot 2022-05-24 at 2 40 23 PM" src="https://user-images.githubusercontent.com/13838621/170120690-244fdc77-304f-49ed-9533-9ff68f9516c5.png">
</details>

## Acceptance criteria
- [x] 526 Introduction page uses primary action links in place of action buttons

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
