### PR TITLE
VACMS-8876: Updates Mapbox Token

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,6 +60,19 @@ jobs:
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Mapbox Token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token
+          env_variable_name: MAPBOX_TOKEN
+
       - name: Build
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
         timeout-minutes: 30

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -2,6 +2,7 @@
 
 require('core-js/stable');
 require('regenerator-runtime/runtime');
+require('dotenv').config();
 const fs = require('fs');
 const fetch = require('node-fetch');
 const path = require('path');
@@ -403,6 +404,12 @@ module.exports = async (env = {}) => {
       },
     },
     plugins: [
+      new webpack.DefinePlugin({
+        'process.env.MAPBOX_TOKEN': JSON.stringify(
+          process.env.MAPBOX_TOKEN || '',
+        ),
+      }),
+
       new webpack.DefinePlugin({
         __BUILDTYPE__: JSON.stringify(buildtype),
         __API__: JSON.stringify(buildOptions.api),

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -405,15 +405,12 @@ module.exports = async (env = {}) => {
     },
     plugins: [
       new webpack.DefinePlugin({
-        'process.env.MAPBOX_TOKEN': JSON.stringify(
-          process.env.MAPBOX_TOKEN || '',
-        ),
-      }),
-
-      new webpack.DefinePlugin({
         __BUILDTYPE__: JSON.stringify(buildtype),
         __API__: JSON.stringify(buildOptions.api),
         __REGISTRY__: JSON.stringify(appRegistry),
+        'process.env.MAPBOX_TOKEN': JSON.stringify(
+          process.env.MAPBOX_TOKEN || '',
+        ),
       }),
 
       new webpack.SourceMapDevToolPlugin({

--- a/src/applications/facility-locator/utils/mapboxToken.js
+++ b/src/applications/facility-locator/utils/mapboxToken.js
@@ -1,2 +1,3 @@
 export const mapboxToken =
-  'pk.eyJ1IjoiYWRob2MiLCJhIjoiY2l2Y3VlNWp5MDBoNjJvbHZ2a3R4bnN2cyJ9.2LoUhwRmz2OiCtRirnc6Pw';
+  process.env.MAPBOX_TOKEN ||
+  'pk.eyJ1IjoiYWRob2MiLCJhIjoiY2wyZjNwM3dxMDZ4YjNjbzVwbTZ5aWQ1dyJ9.D8TZ1a4WobqcdYLWntXV_w';


### PR DESCRIPTION
## Description
Updates Mapbox token (for Facility Locator). 

### Context
- The Mapbox token that has been in use is visible to the world for a couple reasons. One of these, simply, is that it's hard-coded in code and the file in question is committed to source control.
- Because this is the case, one part of the solution being implemented is to set URL restrictions on the token (via Mapbox configuration). Then, a publicly visible token is not a problem because actors with bad intentions will not be able to steal the token for use on their own sites.
- This solution works well when we can easily define a URL, but it works less well in other situations (localhost, review instances, etc.).
- So, we need a second step. This second step is to use a non-URL-restricted token in these other situations, since these other situations are more "private" (require VA network access).
- We can have the URL-restricted token in source control, but not the other token. This other token needs to be stored somewhere private (AWS param store) and loaded from there during the build as an environment variable.

### Code changes implemented
#### Previously 
- [Non-URL-restricted token added as environment variable on review instances](https://github.com/department-of-veterans-affairs/devops/pull/11204)
#### This PR
- Non-URL-restricted token added as environment variable in CI.
- Webpack config updated to read environment variable
- Added logic to populate token from environment variable, if present, otherwise a fallback. The fallback is the URL-restricted token.

### Note
- In production (and dev, staging), no env variables need to be set. The fallback (URL-restricted token) is used.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8876


## Testing done
- Built locally with local .env file defining non-URL-restricted token; confirms this token is being used locally.
- Built on review instance; confirms non-URL-restricted token is being used.
- E2E tests pass on review instance.
