### PR TITLE
Adds version to Sign in Service URL

### DIFF
--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -5,12 +5,15 @@ import environment from '../../utilities/environment';
 import { eauthEnvironmentPrefixes } from '../../utilities/sso/constants';
 
 export const API_VERSION = 'v1';
+export const SIS_API_VERSION = 'v0';
 
 export const API_SESSION_URL = ({ version = API_VERSION, type = null }) =>
   `${environment.API_URL}/${version}/sessions/${type}/new`;
 
-export const API_SIGN_IN_SERVICE_URL = ({ type = null }) =>
-  `${environment.API_URL}/sign_in/${type}/authorize`;
+export const API_SIGN_IN_SERVICE_URL = ({
+  version = SIS_API_VERSION,
+  type = null,
+}) => `${environment.API_URL}/${version}/sign_in/${type}/authorize`;
 
 export const AUTH_EVENTS = {
   MODAL_LOGIN: 'login-link-clicked-modal',


### PR DESCRIPTION
## Description
This PR adds version control for the Sign in Service URL (`v0`).  (Backend PR for SiS version control: https://github.com/department-of-veterans-affairs/vets-api/pull/9914)

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#41849


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] The Sign in Service URL is changed to include `v0`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
