### PR TITLE
Remove obsolete ESLint react-bindings import rule

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -6,13 +6,5 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 2,
     'jsx-a11y/label-has-associated-control': 1,
     'jsx-a11y/no-static-element-interactions': 2,
-    'deprecate/import': [
-      2,
-      {
-        name: 'web-components/react-bindings',
-        use:
-          '@department-of-veterans-affairs/component-library/dist/react-bindings',
-      },
-    ],
   },
 };


### PR DESCRIPTION
## Description
This PR removes an ESLint rule that is no longer needed because the babel alias was removed in a [previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/21127).

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35528


## Acceptance criteria
- [x] Remove `web-components/react-bindings` import rule

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
