### PR TITLE
[508] CST: Focus on pagination info after pagination update

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -24,7 +24,7 @@ import {
   sortByLastUpdated,
   getVisibleRows,
 } from '../utils/appeals-v2-helpers';
-import { setUpPage, setPageFocus } from '../utils/page';
+import { setUpPage } from '../utils/page';
 
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import ClaimsAppealsUnavailable from '../components/ClaimsAppealsUnavailable';
@@ -79,10 +79,6 @@ class YourClaimsPageV2 extends React.Component {
   // componentWillReceiveProps(newProps) {
   // an initial sort needs to happen in componentDidMount
   // }
-
-  componentDidUpdate() {
-    setPageFocus();
-  }
 
   changePage(page) {
     const { changePageV2 } = this.props;

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -22,7 +22,7 @@ import {
   appealsAvailability,
   sortByLastUpdated,
   getVisibleRows,
-  ROWS_PER_PAGE,
+  getPageRange,
 } from '../utils/appeals-v2-helpers';
 import { setUpPage, setPageFocus } from '../utils/page';
 
@@ -172,11 +172,12 @@ class YourClaimsPageV2 extends React.Component {
       if (!emptyList) {
         pageInfo = null;
         if (pages > 1) {
-          const firstItem = (page - 1) * ROWS_PER_PAGE + 1;
-          const lastItem = firstItem + ROWS_PER_PAGE - 1;
+          const range = getPageRange(page, listLength);
           pageInfo = (
             <p id="pagination-info">
-              {`Showing ${firstItem} \u2012 ${lastItem} of ${listLength} events`}
+              {`Showing ${range.start} \u2012 ${
+                range.end
+              } of ${listLength} events`}
             </p>
           );
         }

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -22,10 +22,23 @@ describe('<YourClaimsPageV2>', () => {
       {
         type: 'claimSeries',
         id: '1122334455',
+        attributes: {
+          dateField: '2022-01-01',
+          decisionLetterSent: true,
+          phase: null,
+        },
       },
       {
         type: 'legacyAppeal',
         id: '1122334455',
+        attributes: {
+          updated: '2018-05-29T19:38:40-04:00',
+          events: [{ date: '2018-06-01' }],
+          issues: [],
+          status: {
+            details: {},
+          },
+        },
       },
     ],
     pages: 1,
@@ -78,8 +91,16 @@ describe('<YourClaimsPageV2>', () => {
   });
 
   it('should render Pagination', () => {
-    const wrapper = shallow(<YourClaimsPageV2 {...defaultProps} />);
-    expect(wrapper.find('Pagination').length).to.equal(1);
+    const props = {
+      ...defaultProps,
+      pages: 2,
+      list: new Array(12).fill(defaultProps.list[0]),
+      listLength: 12,
+    };
+    const wrapper = shallow(<YourClaimsPageV2 {...props} />);
+    expect(wrapper.text()).to.include('Showing 1 \u2012 10 of 12 events');
+    // web component isn't rendering? But page info does...
+    // expect(wrapper.find('va-pagination').length).to.equal(1);
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -3,6 +3,12 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
 import {
+  mockFetch,
+  setFetchJSONFailure,
+  setFetchJSONResponse,
+} from 'platform/testing/unit/helpers';
+
+import {
   groupTimelineActivity,
   isPopulatedClaim,
   hasBeenReviewed,
@@ -31,12 +37,8 @@ import {
   isolateAppeal,
   STATUS_TYPES,
   AOJS,
+  getPageRange,
 } from '../../utils/appeals-v2-helpers';
-import {
-  mockFetch,
-  setFetchJSONFailure,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
 
 describe('Disability benefits helpers: ', () => {
   describe('groupTimelineActivity', () => {
@@ -671,6 +673,19 @@ describe('Disability benefits helpers: ', () => {
       expect(roundToNearest({ interval: 5000, value: 2000 })).to.equal(0);
       expect(roundToNearest({ interval: 5000, value: 23123 })).to.equal(25000);
       expect(roundToNearest({ interval: 1000, value: 11450 })).to.equal(11000);
+    });
+  });
+
+  describe('getPageRangeText', () => {
+    it('returns the correct item range based on the page', () => {
+      // ROWS_PER_PAGE constant used
+      expect(getPageRange(1, 5)).to.deep.equal({ start: 1, end: 5 });
+      expect(getPageRange(1, 12)).to.deep.equal({ start: 1, end: 10 });
+      expect(getPageRange(1, 25)).to.deep.equal({ start: 1, end: 10 });
+      expect(getPageRange(2, 12)).to.deep.equal({ start: 11, end: 12 });
+      expect(getPageRange(2, 22)).to.deep.equal({ start: 11, end: 20 });
+      expect(getPageRange(2, 25)).to.deep.equal({ start: 11, end: 20 });
+      expect(getPageRange(3, 25)).to.deep.equal({ start: 21, end: 25 });
     });
   });
 });

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -2182,3 +2182,23 @@ export function getVisibleRows(list, currentPage) {
   }
   return list.slice(currentIndex, currentIndex + ROWS_PER_PAGE);
 }
+
+/**
+ * Calculate the item range based on the current page and number of rows/page.
+ * This is used to
+ * @param {Number} page - current page
+ * @param {Number} totalItems - total number of entries
+ * @returns
+ */
+export const getPageRange = (page, totalItems) => {
+  const firstItem = (page - 1) * ROWS_PER_PAGE + 1;
+  const itemsLeftToShow = totalItems - (page - 1) * ROWS_PER_PAGE;
+  const lastItem =
+    itemsLeftToShow > ROWS_PER_PAGE
+      ? firstItem + ROWS_PER_PAGE - 1
+      : firstItem + itemsLeftToShow - 1;
+  return {
+    start: firstItem,
+    end: lastItem,
+  };
+};

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/browser';
 import environment from 'platform/utilities/environment';
 import localStorage from 'platform/utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
-import { SET_UNAUTHORIZED } from '../actions/index.jsx';
+import { SET_UNAUTHORIZED } from '../actions/index';
 
 const evidenceGathering = 'Evidence gathering, review, and decision';
 
@@ -26,7 +26,8 @@ export function getPhaseDescription(phase) {
 export function getUserPhaseDescription(phase) {
   if (phase < 3) {
     return phaseMap[phase];
-  } else if (phase === 3) {
+  }
+  if (phase === 3) {
     return evidenceGathering;
   }
 
@@ -41,7 +42,8 @@ export function getPhaseDescriptionFromEvent(event) {
 export function getUserPhase(phase) {
   if (phase < 3) {
     return phase;
-  } else if (phase >= 3 && phase < 7) {
+  }
+  if (phase >= 3 && phase < 7) {
     return 3;
   }
 
@@ -51,9 +53,11 @@ export function getUserPhase(phase) {
 export function getItemDate(item) {
   if (item.receivedDate) {
     return item.receivedDate;
-  } else if (item.documents && item.documents.length) {
+  }
+  if (item.documents && item.documents.length) {
     return item.documents[item.documents.length - 1].uploadDate;
-  } else if (item.type === 'other_documents_list' && item.uploadDate) {
+  }
+  if (item.type === 'other_documents_list' && item.uploadDate) {
     return item.uploadDate;
   }
 
@@ -214,7 +218,7 @@ export function hasBeenReviewed(trackedItem) {
 // Adapted from http://stackoverflow.com/a/26230989/487883
 export function getTopPosition(elem) {
   const box = elem.getBoundingClientRect();
-  const body = document.body;
+  const { body } = document;
   const docEl = document.documentElement;
 
   const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;

--- a/src/applications/claims-status/utils/page.js
+++ b/src/applications/claims-status/utils/page.js
@@ -1,12 +1,5 @@
-import Scroll from 'react-scroll';
-
-const scroller = Scroll.animateScroll;
-
-import { getScrollOptions } from 'platform/utilities/ui';
-
-export function scrollToTop() {
-  scroller.scrollToTop(getScrollOptions());
-}
+import { scrollAndFocus } from 'platform/utilities/ui';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 export function setFocus(selector) {
   const el =
@@ -20,7 +13,7 @@ export function setFocus(selector) {
 export function setPageFocus(selector = '.va-nav-breadcrumbs') {
   const el = document.querySelector(selector);
   if (el) {
-    setFocus(el);
+    scrollAndFocus(el);
   } else {
     setFocus('#main h1');
   }
@@ -33,7 +26,7 @@ export function setUpPage(
   if (!scroll) {
     scrollToTop();
   }
-  setPageFocus(focusSelector);
+  scrollAndFocus(document.querySelector(focusSelector));
 }
 
 export function isTab(url) {


### PR DESCRIPTION
[Original Ticket #41812](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41812)

URL of fix: [Claim Status Tool main page](https://staging.va.gov/track-claims/your-claims), log in using user 228 (Colder)

## Expected behavior

When a Veteran has more than 10 events showing in the CST, the pager will show multiple pages. If the page is changed, the focus should be moved to a paragraph of text immediately before the list. In this case, this would be similar behavior to the [search results page focus management](https://staging.va.gov/search/?page=1&query=veteran) 

## Current behavior

Now, when the pagination is activated, the focus is shifted to the breadcrumbs and the page is scrolled to the top. Additionally, the `Pagination` React component is not accessible using the <kbd>Tab</kbd> key.

<details><summary>Focus moves to breadcrumbs</summary>

<!-- leave a blank line above -->
![showing voice over window, after clicking on a new page, focus shifts to the breadcrumb](https://user-images.githubusercontent.com/136959/170339480-0a4e6fa6-4456-4da5-90d6-39469cdffd0c.gif)</details>

## Your fix

### Improve focus management & a11y:

- Removed code that was shifting focus to the page breadcrumbs after every update, but retained the code that does focus on the breadcrumbs on initial page load.
- A new paragraph stating "Showing {x} through {y} of {total} events" was added above the event cards. This paragraph now receives focus after the page is changed
- Replaced `Pagination` React component with `va-pagination` web component

### Additional changes:

- Switched to platform scrolling code
- Added unit tests for calculating start & end item numbers
- Linting cleanup
- Opened 2 related tickets regarding this implementation:
  - [A design system review of "Showing..." pattern](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41832)
  - [A content review of the "Showing..." text](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41835)

## How has this been tested?

Added unit test for current visible items calculations
Ran e2e tests to ensure they are still passing

## Screenshots

<img width="558" alt="After changing pages, focus is now set on the 'Showing 11 - 20 of 40 events' paragraph above the list" src="https://user-images.githubusercontent.com/136959/170330259-df456264-8179-4a6f-9289-fa8503084b60.png">

## Acceptance criteria
- [x] Fix focus management
- [x] Add page info focus paragraph above list & open tickets to establish a pattern
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
