### PR TITLE
Fix formatting linting warnings in Caregivers application

### DIFF
--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -44,16 +44,14 @@ export default {
     'view:uploadSuccessAlert': {
       'ui:options': {
         hideIf: formData => {
-          if (
+          // return false to show, not hide
+          return !(
             formData.signAsRepresentativeDocumentUpload &&
             formData.signAsRepresentativeDocumentUpload.length > 0 &&
             formData.signAsRepresentativeDocumentUpload[0].guid &&
             formData.signAsRepresentativeDocumentUpload[0].name &&
             !formData.signAsRepresentativeDocumentUpload[0].errorMessage
-          ) {
-            return false; // return false to show, not not hide
-          }
-          return true;
+          );
         },
       },
       'ui:description': UploadSuccessAlertDescription,

--- a/src/applications/caregivers/config/chapters/veteran/vetMedicalCenter.js
+++ b/src/applications/caregivers/config/chapters/veteran/vetMedicalCenter.js
@@ -8,9 +8,10 @@ import {
   preferredFacilityView,
 } from 'applications/caregivers/definitions/UIDefinitions/veteranUI';
 
-const plannedClinic = fullSchema.properties.veteran.properties.plannedClinic;
-const lastTreatmentFacility =
-  fullSchema.properties.veteran.properties.lastTreatmentFacility;
+const {
+  lastTreatmentFacility,
+  plannedClinic,
+} = fullSchema.properties.veteran.properties;
 
 const vetMedicalCenterPage = {
   uiSchema: {
@@ -36,9 +37,7 @@ const vetMedicalCenterPage = {
               state => !!medicalCentersByState[state],
             ),
           },
-          [veteranFields.plannedClinic]: Object.assign({}, plannedClinic, {
-            enum: [],
-          }),
+          [veteranFields.plannedClinic]: { ...plannedClinic, enum: [] },
         },
       },
     },


### PR DESCRIPTION
## Description
There are ESlint warnings in multiple files within the Caregivers application that are related to preferred code formatting. This PR updates the codebase to eliminate these warnings

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41878

## Acceptance criteria
- [ ] Application no longer shows ESLint warnings related to preferred format

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
