### PR TITLE
CST: associate file requirements with upload button

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -170,19 +170,22 @@ class AddFilesForm extends React.Component {
             buttonText="Add Files"
             name="fileUpload"
             additionalErrorClass="claims-upload-input-error-message"
+            aria-describedby="file-requirements"
           />
         </div>
-        <div className="file-requirements">
-          <p className="file-requirement-header">Accepted file types:</p>
-          <p className="file-requirement-text">{displayTypes}</p>
-          <p className="file-requirement-header">Maximum file size:</p>
-          <p className="file-requirement-text">
-            {`${MAX_FILE_SIZE_MB}MB (non-PDF)`}
-          </p>
-          <p className="file-requirement-text">
-            {`${MAX_PDF_SIZE_MB}MB (PDF only)`}
-          </p>
-        </div>
+        <dl className="file-requirements" id="file-requirements">
+          <dt className="file-requirement-header">Accepted file types:</dt>
+          <dd className="file-requirement-text">{displayTypes}</dd>
+          <dt className="file-requirement-header">Maximum file size:</dt>
+          <dd>
+            <p className="file-requirement-text">
+              {`${MAX_FILE_SIZE_MB}MB (non-PDF)`}
+            </p>
+            <p className="file-requirement-text">
+              {`${MAX_PDF_SIZE_MB}MB (PDF only)`}
+            </p>
+          </dd>
+        </dl>
         {this.props.files.map(
           ({ file, docType, isEncrypted, password }, index) => (
             <div key={index} className="document-item-container">

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -40,6 +40,9 @@ describe('<AddFilesForm>', () => {
       />,
     );
     expect(tree.everySubTree('FileInput')).not.to.be.empty;
+    expect(tree.everySubTree('FileInput')[0].props['aria-describedby']).to.eq(
+      'file-requirements',
+    );
     expect(tree.everySubTree('Modal')[0].props.visible).to.be.false;
   });
 


### PR DESCRIPTION
[Original Ticket #41814](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41814)

URL of fix: https://staging.va.gov/track-claims/your-claims/600219085/files; log in with HLR/NOD user `vetsgov+test233@id.me` (Cara)

# Expected behavior

When a screenreader user selects the "Add Files" button, it reads out the add files button text and continues to read out the accepted file types and maximum file sizes to give the screenreader user context

## Current behavior

When a screenreader user selects the "Add Files" button, it reads out "Select files to upload and one more item, alert, Add Files, button" only

## Your fix

- Added an ID to the wrapper around the accepted file types and maximum file size blocks.
- Converted the paragraph tags into a [description list set](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl).
- Added an `aria-describedby` property to the `FileInput` component pointing to the wrapper ID.
- Added a unit test

## How has this been tested?

Screenreader testing

## Screenshots
<details><summary>Upload "button" with <code>aria-describedby</code></summary>

<!-- leave a blank line above -->
<img width="419" alt="html showing the label (with button role) and an aria-describedby attribute" src="https://user-images.githubusercontent.com/136959/170529614-ea4fcf37-673f-410c-90d3-83feecde5d2f.png"></details>

<details><summary>Screenreader window showing file requirements text with focus on the upload button</summary>

<!-- leave a blank line above -->
<img width="727" alt="voiceover window showing text from the file requirements block" src="https://user-images.githubusercontent.com/136959/170529678-7d2c94e7-49a3-4e37-96ae-f79c9c0458fe.png"></details>

## Acceptance criteria
- [x] File requirement block text is read out by screenreader when "Add files" is focused
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
