### PR TITLE
DHP-292 Introduce a loading indicator

### DIFF
--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -5,7 +5,14 @@ import { AuthenticatedPageContent } from '../components/AuthenticatedPageContent
 import { FrequentlyAskedQuestions } from '../components/FrequentlyAskedQuestions';
 
 export default function App() {
-  const isLoggedIn = useSelector(state => state.user.login.currentlyLoggedIn);
+  const isLoggedIn = useSelector(state => state?.user.login.currentlyLoggedIn);
+  const isLoading = useSelector(state => state?.featureToggles?.loading);
+  const pageContent = isLoggedIn ? (
+    <AuthenticatedPageContent />
+  ) : (
+    <UnauthenticatedPageContent />
+  );
+  const content = isLoading ? <va-loading-indicator set-focus /> : pageContent;
 
   return (
     <div className="usa-grid-full margin landing-page">
@@ -25,10 +32,7 @@ export default function App() {
             your VA care team. If you have concerns about any specific shared
             data, you must contact your care team directly.
           </p>
-          {/* Show sign in button if user not logged in */}
-          {!isLoggedIn && <UnauthenticatedPageContent />}
-          {/* show your devices and Connect device section if user is logged in */}
-          {isLoggedIn && <AuthenticatedPageContent />}
+          {content}
           <FrequentlyAskedQuestions />
         </article>
       </div>

--- a/src/applications/dhp-connected-devices/tests/containers/App.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/containers/App.spec.jsx
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import React from 'react';
+import { render } from 'enzyme';
+import { Provider } from 'react-redux';
+import App from '../../containers/App';
+
+function getStore(loading = false, currentlyLoggedIn = false) {
+  return {
+    getState: () => ({
+      featureToggles: {
+        loading,
+      },
+      user: {
+        login: {
+          currentlyLoggedIn,
+        },
+        profile: {
+          loa: {
+            current: 1,
+          },
+          userFullName: {
+            first: null,
+          },
+        },
+      },
+    }),
+  };
+}
+
+describe('App', () => {
+  it('renders the the loading indicator when page is loading', () => {
+    const mockStore = getStore(true, true);
+    const wrapper = render(
+      <Provider store={mockStore}>
+        <App />
+      </Provider>,
+    );
+
+    expect(wrapper.find('va-loading-indicator').length).to.equal(1);
+  });
+
+  it('renders the authenticated page content when a user is logged in', () => {
+    const mockStore = getStore(false, true);
+    const wrapper = render(
+      <Provider store={mockStore}>
+        <App />
+      </Provider>,
+    );
+
+    expect(wrapper.find('va-loading-indicator').length).to.equal(0);
+    expect(
+      wrapper
+        .find('h2')
+        .first()
+        .text(),
+    ).to.eq('Your connected devices');
+  });
+
+  it('renders the un-authenticated page content when a user is logged out', () => {
+    const mockStore = getStore(false, false);
+    const wrapper = render(
+      <Provider store={mockStore}>
+        <App />
+      </Provider>,
+    );
+
+    expect(wrapper.find('va-loading-indicator').length).to.equal(0);
+    expect(
+      wrapper
+        .find('h3')
+        .first()
+        .text(),
+    ).to.eq('Please sign in to connect a device');
+  });
+});


### PR DESCRIPTION
## Description
* Improved user experience on the connected-devices page by adding a loading indicator while the app determines whether the user is logged in or not. See example here: https://www.va.gov/health-care/secure-messaging/

## Testing done
* Added tests to the App container
* Manual tests

## Screen
![Screen Shot 2022-05-26 at 12 08 40 PM](https://user-images.githubusercontent.com/1357047/170549418-8aa17eae-2634-4ce9-8cdb-ba9bfb23b5b5.png)
shots
