### PR TITLE
Fix eslint error in breadcrumb test

### DIFF
--- a/src/applications/claims-status/tests/components/Breadcrumbs.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/Breadcrumbs.unit.spec.jsx
@@ -8,13 +8,13 @@ describe('<Breadcrumbs>', () => {
   it('should render first two items', () => {
     const tree = SkinDeep.shallowRender(
       <ClaimsBreadcrumbs>
-        <a href="#">Testing</a>
+        <a href="/test">Testing</a>
       </ClaimsBreadcrumbs>,
     );
 
     const items = tree.everySubTree('a');
     expect(items[0].props.href).to.equal('/');
-    expect(items[1].props.href).to.equal('#');
+    expect(items[1].props.href).to.equal('/test');
     expect(items[1].text()).to.equal('Testing');
   });
 });


### PR DESCRIPTION
## Description
Fixes eslint error in Breadcrumb test. Replaces `#` in `href` with a placeholder path.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36054


## Acceptance criteria
- [x] Tests continue to pass

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
