### PR TITLE
36054 upload status a11y lint error

### DIFF
--- a/src/applications/claims-status/components/UploadStatus.jsx
+++ b/src/applications/claims-status/components/UploadStatus.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default function UploadStatus({ progress, files, onCancel }) {
+export default function UploadStatus({ files, onCancel, progress }) {
   const handleClick = evt => {
     evt.preventDefault();
     onCancel();
@@ -29,3 +30,9 @@ export default function UploadStatus({ progress, files, onCancel }) {
     </div>
   );
 }
+
+UploadStatus.propTypes = {
+  files: PropTypes.number,
+  progress: PropTypes.number,
+  onCancel: PropTypes.func,
+};

--- a/src/applications/claims-status/components/UploadStatus.jsx
+++ b/src/applications/claims-status/components/UploadStatus.jsx
@@ -12,18 +12,17 @@ export default function UploadStatus({ progress, files, onCancel }) {
           ...
         </h4>
         <va-progress-bar percent={progress * 100} />
-        Your files are uploading. Please do not close this window.
-        <p>
-          <a
-            onClick={evt => {
-              evt.preventDefault();
-              onCancel();
-            }}
-            href="#"
-          >
-            Cancel
-          </a>
-        </p>
+        <p>Your files are uploading. Please do not close this window.</p>
+        <button
+          type="button"
+          className="usa-button-secondary"
+          onClick={evt => {
+            evt.preventDefault();
+            onCancel();
+          }}
+        >
+          Cancel
+        </button>
       </div>
     </div>
   );

--- a/src/applications/claims-status/components/UploadStatus.jsx
+++ b/src/applications/claims-status/components/UploadStatus.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 
 export default function UploadStatus({ progress, files, onCancel }) {
+  const handleClick = evt => {
+    evt.preventDefault();
+    onCancel();
+  };
+
   return (
     <div>
       <div className="claims-status-upload-header" id="upload-status-title">
@@ -16,10 +21,7 @@ export default function UploadStatus({ progress, files, onCancel }) {
         <button
           type="button"
           className="usa-button-secondary"
-          onClick={evt => {
-            evt.preventDefault();
-            onCancel();
-          }}
+          onClick={handleClick}
         >
           Cancel
         </button>

--- a/src/applications/claims-status/tests/components/UploadStatus.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/UploadStatus.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('<UploadStatus>', () => {
       <UploadStatus files={1} onCancel={onCancel} progress={0.5} />,
     );
 
-    tree.subTree('a').props.onClick({
+    tree.subTree('button').props.onClick({
       preventDefault: () => {},
     });
     expect(onCancel.called).to.be.true;


### PR DESCRIPTION
department-of-veterans-affairs/va.gov-team#36054

# Expected behavior
- There should no eslint accessibility errors
- Links should be used to places, button should be used perform actions

## Current behavior
- There are eslint accessibility errors
- A link element is being used to perform a button action

## Your fix
This work updates the modal to chance `<a>` to `<button>` to cancel an upload, improving accessibility. 

## How has this been tested?
- Verify eslint complaints resolved
- Manual check in the web browser

### To evaluate locally
1. To use Claim Details, [follow these steps use mock data](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/claim-appeal-status/engineering/CST_frontend_details.md#claim-detail-testing).
2. Go to the **files page**, we used this path `/track-claims/your-claims/1196201/files`. 
3. Scroll down to **Additional Evidence** and choose a valid file.
4. You will need to select the checkbox and choose a description.
5. Click **Submit Files for Review**.
6. You should see the cancel button as a button instead of a text.

## Screenshots
**This is how the modal looks before**

![Screen Recording 2022-05-26 at 05 08 42 PM](https://user-images.githubusercontent.com/1094951/170584897-e41829d8-f511-47f7-9f3f-1a6f7a6301ad.gif)

**This is how the modal looks with the new HTML button**

![Screen Recording 2022-05-26 at 05 17 42 PM](https://user-images.githubusercontent.com/1094951/170584984-fda446a8-04c0-4528-8194-03ec5d363bd6.gif)


## Acceptance criteria
- [x] Tests still pass


## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
