### PR TITLE
36054 claim sync warning a11y lint

### DIFF
--- a/src/applications/claims-status/components/ClaimSyncWarning.jsx
+++ b/src/applications/claims-status/components/ClaimSyncWarning.jsx
@@ -17,13 +17,12 @@ export default function ClaimSyncWarning({ olderVersion }) {
       <div className="usa-alert-body">
         <h4 className="usa-alert-heading">Claim status is temporarily down</h4>
         <p className="usa-alert-text">
-          Please{' '}
-          <a href="#" onClick={handleClick}>
-            refresh the page
-          </a>{' '}
-          or try again later.
+          Please refresh the page or try again later.
           {additionalText}
         </p>
+        <button type="button" className="usa-button" onClick={handleClick}>
+          Refresh the page
+        </button>
       </div>
     </div>
   );

--- a/src/applications/claims-status/components/ClaimSyncWarning.jsx
+++ b/src/applications/claims-status/components/ClaimSyncWarning.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function ClaimSyncWarning({ olderVersion }) {
   let additionalText;
@@ -27,3 +28,7 @@ export default function ClaimSyncWarning({ olderVersion }) {
     </div>
   );
 }
+
+ClaimSyncWarning.propTypes = {
+  olderVersion: PropTypes.bool,
+};


### PR DESCRIPTION
## Description
Improves accessibility by changing `<a>` to a `<button>`. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#36054


## Screenshots

### Before
<img width="701" alt="Screen Shot 2022-05-26 at 1 58 49 PM" src="https://user-images.githubusercontent.com/1094951/170590509-73ce5868-1515-40da-998e-46b9a518ef9b.png">

### After
<img width="669" alt="Screen Shot 2022-05-26 at 2 04 22 PM" src="https://user-images.githubusercontent.com/1094951/170590542-1550e85c-73a0-4ec5-8303-2f3b1a2fb96c.png">


## Acceptance criteria
- [x] Tests still pass

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## How to evaluate
1. To use Claim Details, [follow these steps use mock data](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/claim-appeal-status/engineering/CST_frontend_details.md#claim-detail-testing).
2. Go to line `50` in `/src/applications/claims-status/components/ClaimDetailLayout.jsx` and update the condition to `{synced && <ClaimSyncWarning olderVersion={!synced} />}`, removing the `!`.
3. Go to the status page, we used this path /track-claims/your-claims/1196201/status.
