### PR TITLE
Add Feature Flag for New Fry/DEA Form

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -114,6 +114,7 @@ export default Object.freeze({
     'show_new_schedule_view_appointments_page',
   showNewSecureMessagingPage: 'show_new_secure_messaging_page',
   showNewViewTestLabResultsPage: 'show_new_view_test_lab_results_page',
+  showUpdatedFryDeaApp: 'show_updated_fry_dea_app',
   stemAutomatedDecision: 'stem_automated_decision',
   stemSCOEmail: 'stem_sco_email',
   subform89404192: 'subform_8940_4192',


### PR DESCRIPTION
## Description
Add a feature flag for the new Fry/DEA (5490) form. The corresponding vets-api PR is https://github.com/department-of-veterans-affairs/vets-api/pull/9950. 