### PR TITLE
adds relative position to view details anchor

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -121,7 +121,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
       )}
       {external && (
         <Link
-          aria-label={`View details of ${appealTitle} `}
+          aria-label={`View details of ${appealTitle}`}
           className="vads-c-action-link--blue"
           href={`/track-claims/appeals/${appeal.id}/status`}
         >

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -42,6 +42,10 @@
   }
 }
 
+.claim-list-item-container a {
+  position: relative;
+}
+
 @media (max-width: $medium-screen) {
   .claims-status-content .help-sidebar {
     margin-top: 0px;


### PR DESCRIPTION
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41819)

[URL of fix](http://localhost:3001/track-claims/your-claims)

# Expected behavior
The "View Details" link should be positioned correctly inside the containing card consistently in all browsers.

## Current behavior
In Safari, the "View Details" link inside the was pushing out of the containing cards bounds.

## Your fix
In the other browsers I tested against, this didn't seem to be an issue. So we needed to find a solution that fix the issue in Safari, while having no side effects in other browsers.

Ultimately, it came down to just adding a `position: relative` rule to this node due to the pseudo element contained within it, borking the positioning. So it's likely that this issue is present in other applications.

I looked in the Design system for positioning Utility classes, and it looks like they don't exist. So I just added another rule to this applications styles.

## How has this been tested?
Manually.

## Screenshots
Before:
![Previously](https://user-images.githubusercontent.com/969752/170736727-0bfd0806-cdf8-4504-b33f-1200827b52b8.PNG)

After:
<img width="648" alt="Safari" src="https://user-images.githubusercontent.com/969752/170736765-393d0304-3fef-407a-b6da-35b16695caf3.png">
