### PR TITLE
[VA-9161] Update Covid Status for precaution guidelines

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
@@ -51,7 +51,7 @@ const VaFacilityResult = ({
           operatingStatus.code !== OperatingStatus.NORMAL && (
             <LocationOperationStatus operatingStatus={operatingStatus} />
           )}
-        {operatingStatus && (
+        {!!operatingStatus.supplementalStatus?.length && (
           <LocationCovidStatus
             supplementalStatus={operatingStatus.supplementalStatus}
           />

--- a/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
@@ -51,7 +51,7 @@ const VaFacilityResult = ({
           operatingStatus.code !== OperatingStatus.NORMAL && (
             <LocationOperationStatus operatingStatus={operatingStatus} />
           )}
-        {!!operatingStatus.supplementalStatus?.length && (
+        {!!operatingStatus?.supplementalStatus?.length && (
           <LocationCovidStatus
             supplementalStatus={operatingStatus.supplementalStatus}
           />

--- a/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import createCommonStore from 'platform/startup/store';
+import useStaticDrupalData from 'platform/site-wide/hooks/static-drupal-data';
 import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 import { FeatureToggleReducer } from 'platform/site-wide/feature-toggles/reducers';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
@@ -12,9 +13,18 @@ const store = createCommonStore({
 
 const LocationCovidStatus = ({ supplementalStatus }) => {
   const [showVamcAlert, setShowVamcAlert] = useState(true);
-  const covidStatus = supplementalStatus?.find(status =>
-    status.status_id.includes('COVID'),
+
+  const staticCovidStatuses = useStaticDrupalData(
+    'vamc-facility-supplemental-status',
   );
+
+  const covidStatus = staticCovidStatuses.find(status => {
+    const activeCovidStatus = supplementalStatus?.find(activeStatus =>
+      activeStatus.id.includes('COVID'),
+    );
+
+    return status.status_id === activeCovidStatus?.id;
+  });
 
   useEffect(() => {
     connectFeatureToggle(store.dispatch);

--- a/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
@@ -13,7 +13,7 @@ const store = createCommonStore({
 const LocationCovidStatus = ({ supplementalStatus }) => {
   const [showVamcAlert, setShowVamcAlert] = useState(true);
   const covidStatus = supplementalStatus?.find(status =>
-    status.id.includes('COVID'),
+    status.status_id.includes('COVID'),
   );
 
   useEffect(() => {
@@ -34,16 +34,19 @@ const LocationCovidStatus = ({ supplementalStatus }) => {
   }
 
   return (
-    <va-alert
-      background-only
-      show-icon
+    <va-alert-expandable
+      class="vads-u-margin-x--0"
       status="info"
-      visible
-      data-testid={`${covidStatus.id.toLowerCase()}-message`}
-      class="vads-u-margin-y--2"
+      trigger={covidStatus.name}
+      data-testid={`${covidStatus.status_id.toLowerCase()}-message`}
     >
-      <div tabIndex={0}>{covidStatus.label}</div>
-    </va-alert>
+      {/* eslint-disable react/no-danger */}
+      <div
+        dangerouslySetInnerHTML={{
+          __html: covidStatus.description,
+        }}
+      />
+    </va-alert-expandable>
   );
 };
 

--- a/src/platform/site-wide/hooks/static-drupal-data.js
+++ b/src/platform/site-wide/hooks/static-drupal-data.js
@@ -1,0 +1,21 @@
+import environment from 'platform/utilities/environment';
+import { useEffect, useState } from 'react';
+
+export default function useStaticDrupalData(file) {
+  const [staticDrupalData, setStaticDrupalData] = useState([]);
+
+  const API_ENDPOINT = environment.isLocalhost()
+    ? 'http://localhost:3002'
+    : environment.API_URL;
+
+  useEffect(
+    () => {
+      fetch(`${API_ENDPOINT}/data/cms/${file}.json`)
+        .then(res => res.json())
+        .then(data => setStaticDrupalData(data));
+    },
+    [file, API_ENDPOINT],
+  );
+
+  return staticDrupalData;
+}


### PR DESCRIPTION
## Description

The facility locator only shows a brief alert about COVID facility guidelines. This PR updates the GraphQL endpoint and locator component to show all the guideline details with an expandable component.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9161 and closes department-of-veterans-affairs/va.gov-cms#9162

## Testing done

Visual.

## Screenshots

![Screen Shot 2022-05-27 at 2 49 29 PM](https://user-images.githubusercontent.com/10790736/170772597-2677ed59-0103-40fb-8835-8adacdea522e.png)

## Acceptance criteria

- [ ] Facility locator shows an expandable alert with the facility's COVID status, with the guidelines inside it.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
