### PR TITLE
NOD: Include password in upload payload

### DIFF
--- a/src/applications/appeals/10182/utils/upload.js
+++ b/src/applications/appeals/10182/utils/upload.js
@@ -27,9 +27,15 @@ export const evidenceUploadUI = {
     fileTypes: SUPPORTED_UPLOAD_TYPES,
     maxSize: MAX_FILE_SIZE_BYTES,
     minSize: 1024,
-    createPayload: file => {
+    createPayload: (file, _formId, password) => {
       const payload = new FormData();
       payload.append('decision_review_evidence_attachment[file_data]', file);
+      if (password) {
+        payload.append(
+          'decision_review_evidence_attachment[password]',
+          password,
+        );
+      }
       return payload;
     },
     parseResponse: (response, { name }) => {


### PR DESCRIPTION
## Description

In the Notice of Disagreement form, when uploading a password-protected PDF with an incorrect password, the PDF is accepted. I originally thought it might be a backend issue, but it turns out that the frontend isn't passing along the Veteran-entered password once a password-protected PDF is detected. The backend is only gating on the password.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/41987

## Testing done

Manual testing

## Screenshots

N/A

## Acceptance criteria
- [x] A password is included in the payload for password-protected PDFs
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
