### PR TITLE
[CDP] 39378 - Debt 2.0 Summary Card updates

### DIFF
--- a/src/applications/combined-debt-portal/combined/components/OtherVADebts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/OtherVADebts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { APP_TYPES } from '../../combined/utils/helpers';
+import { APP_TYPES } from '../utils/helpers';
 
 const OtherVADebts = ({ module, subHeading }) => {
   return (

--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -4,10 +4,7 @@ import { Link } from 'react-router-dom';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 export const DownloadLettersAlert = () => (
-  <va-alert
-    class="vads-u-margin-top--4 vads-u-margin-bottom--4"
-    status="warning"
-  >
+  <va-alert status="warning">
     <h3 slot="headline">
       Letters sent after December 9th, 2021 are unavailable for download
     </h3>
@@ -17,21 +14,11 @@ export const DownloadLettersAlert = () => (
       mail.
     </p>
     <p className="vads-u-font-size--base vads-u-font-family--sans">
-      If you have any questions, call us at
-      <va-telephone contact="800-827-0648" className="vads-u-margin-x--0p5" />
-      (or
-      <va-telephone
-        contact="1-612-713-6415"
-        className="vads-u-margin-x--0p5"
-        international
-      />
-      from overseas). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m.
-      ET. If you have hearing loss, call TTY:
-      <va-telephone
-        contact={CONTACTS[711]}
-        className="vads-u-margin-left--0p5"
-      />
-      .
+      If you have any questions, call us at{' '}
+      <va-telephone contact="800-827-0648" /> (or{' '}
+      <va-telephone contact="1-612-713-6415" international /> from overseas).
+      We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET. If you have
+      hearing loss, call TTY: <va-telephone contact={CONTACTS[711]} />.
     </p>
     <p className="vads-u-font-size--base vads-u-font-family--sans">
       We’re working to fix this problem as fast as we can. Check back soon for
@@ -42,9 +29,8 @@ export const DownloadLettersAlert = () => (
 
 export const DowntimeMessage = () => {
   return (
-    <va-alert status="error" class="vads-u-margin-bottom--4">
+    <va-alert status="error">
       <h3 slot="headline">Nightly tool maintenance</h3>
-
       <p className="vads-u-font-size--base vads-u-font-family--sans">
         We’re working on this tool right now. If you have trouble signing in or
         using this tool, check back after we’re finished.
@@ -69,95 +55,74 @@ export const DowntimeMessage = () => {
           download your debt letters.
         </Link>
         If you need help resolving a debt, or you would like to get information
-        about a debt that has been resolved, call the Debt Management Center at
-        <va-telephone
-          className="vads-u-margin-left--0p5"
-          contact="8008270648"
-        />
-        .
+        about a debt that has been resolved, call the Debt Management Center at{' '}
+        <va-telephone contact="8008270648" />.
       </p>
     </va-alert>
   );
 };
 
 export const ErrorMessage = () => (
-  <va-alert class="vads-u-margin-top--0 vads-u-padding--3" status="error">
-    <div className="usa-alert-body">
-      <h3 className="usa-alert-heading">
-        Information about your current debts is unavailable
-      </h3>
-      <p className="vads-u-font-family--sans">
-        We’re sorry. You can’t view information about your current debts because
-        something went wrong on our end. Please check back soon.
-      </p>
-      <h4>What you can do</h4>
-      <p className="vads-u-font-family--sans vads-u-margin-y--0">
-        If you continue having trouble viewing information about your current
-        debts, email us at{' '}
-        <a href="mailto:dmcops.vbaspl@va.gov">dmcops.vbaspl@va.gov</a>.
-      </p>
-    </div>
+  <va-alert status="error">
+    <h3 slot="headline">Information about your current debts is unavailable</h3>
+    <p className="vads-u-font-family--sans">
+      We’re sorry. You can’t view information about your current debts because
+      something went wrong on our end. Please check back soon.
+    </p>
+    <h4>What you can do</h4>
+    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+      If you continue having trouble viewing information about your current
+      debts, email us at{' '}
+      <a href="mailto:dmcops.vbaspl@va.gov">dmcops.vbaspl@va.gov</a>.
+    </p>
   </va-alert>
 );
 
 export const ErrorAlert = () => (
-  <va-alert class="vads-u-margin-top--0 vads-u-padding--3" status="error">
-    <div className="usa-alert-body">
-      <h3 className="usa-alert-heading">
-        Your debt letters are currently unavailable.
-      </h3>
-      <p className="vads-u-font-family--sans">
-        You can’t download your debt letters because something went wrong on our
-        end.
-      </p>
-      <h4>What you can do</h4>
-      <p className="vads-u-font-family--sans vads-u-margin-y--0">
-        You can check back later or call the Debt Management Center at
-        <va-telephone
-          className="vads-u-margin-x--0p5"
-          contact="8008270648"
-        />{' '}
-        to find out more information about how to resolve your debt.
-      </p>
-    </div>
+  <va-alert status="error">
+    <h3 slot="headline">Your debt letters are currently unavailable.</h3>
+    <p className="vads-u-font-family--sans">
+      You can’t download your debt letters because something went wrong on our
+      end.
+    </p>
+    <h4>What you can do</h4>
+    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+      You can check back later or call the Debt Management Center at{' '}
+      <va-telephone contact="8008270648" /> to find out more information about
+      how to resolve your debt.
+    </p>
   </va-alert>
 );
 
 export const DependentDebt = () => (
-  <va-alert class="vads-u-margin-top--0 vads-u-padding--3" status="error">
-    <div className="usa-alert-body">
-      <h3 className="usa-alert-heading">
-        Your debt letters are currently unavailable.
-      </h3>
-      <p className="vads-u-font-family--sans">
-        You can’t download your debt letters because something went wrong on our
-        end.
-      </p>
-      <h4>What you can do</h4>
-      <p className="vads-u-font-family--sans vads-u-margin-y--0">
-        If you need to access debt letters that were mailed to you, call the
-        Debt Management Center at <va-telephone contact="8008270648" />.
-      </p>
-    </div>
+  <va-alert status="error">
+    <h3 slot="headline">Your debt letters are currently unavailable.</h3>
+    <p className="vads-u-font-family--sans">
+      You can’t download your debt letters because something went wrong on our
+      end.
+    </p>
+    <h4>What you can do</h4>
+    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+      If you need to access debt letters that were mailed to you, call the Debt
+      Management Center at <va-telephone contact="8008270648" />.
+    </p>
   </va-alert>
 );
 
 export const NoDebtLinks = () => (
-  <va-alert class="vads-u-padding--3 vads-u-margin-bottom--2" status="error">
-    <div className="usa-alert-body">
-      <h3 className="usa-alert-heading">You don’t have any VA debt letters</h3>
-      <p className="vads-u-font-family--sans">
-        Our records show you don’t have any debt letters related to VA benefits.
-        If you think this is an error, please contact the Debt Management Center
-        at <va-telephone contact="8008270648" />.
-      </p>
-      <p className="vads-u-font-family--sans vads-u-margin-y--0">
-        If you have VA health care copay debt, go to our
-        <Link className="vads-u-margin-x--0p5" to="/copay-balances/">
-          Pay your VA copay bill
-        </Link>
-        page to learn about your payment options.
-      </p>
-    </div>
+  <va-alert status="error">
+    <h3 slot="headline">You don’t have any VA debt letters</h3>
+    <p className="vads-u-font-family--sans">
+      Our records show you don’t have any debt letters related to VA benefits.
+      If you think this is an error, please contact the Debt Management Center
+      at <va-telephone contact="8008270648" />.
+    </p>
+    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+      If you have VA health care copay debt, go to our
+      <Link className="vads-u-margin-x--0p5" to="/copay-balances/">
+        Pay your VA copay bill
+      </Link>
+      page to learn about your payment options.
+    </p>
   </va-alert>
 );

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
@@ -1,52 +1,11 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import DebtSummaryCard from './DebtSummaryCard';
-import { ErrorMessage, DowntimeMessage } from './Alerts';
-// TODO: OtherVA Update
-import OtherVADebts from '../../../medical-copays/components/OtherVADebts';
-import alertMessage from '../../combined/utils/alert-messages';
-import { ALERT_TYPES, APP_TYPES } from '../../combined/utils/helpers';
 
 const DebtCardsList = () => {
-  const { debts, errors } = useSelector(
+  const { debts } = useSelector(
     ({ combinedPortal }) => combinedPortal.debtLetters,
   );
-  const { statements: mcpStatements, error: mcpError } = useSelector(
-    ({ combinedPortal }) => combinedPortal.mcp,
-  );
-  const error = errors.length ? errors[0] : [];
-
-  const renderError = () => {
-    if (error.status === '504') {
-      return <DowntimeMessage />;
-    }
-    return <ErrorMessage />;
-  };
-
-  const renderOtherVA = () => {
-    const alertInfo = alertMessage(ALERT_TYPES.ERROR, APP_TYPES.COPAY);
-    if (mcpStatements?.length) {
-      return <OtherVADebts module={APP_TYPES.COPAY} />;
-    }
-    if (mcpError) {
-      return (
-        <>
-          <h3>Your other VA bills</h3>
-          <va-alert
-            data-testid={alertInfo.testID}
-            status={alertInfo.alertStatus}
-          >
-            <h4 slot="headline" className="vads-u-font-size--h3">
-              {alertInfo.header}
-            </h4>
-            {alertInfo.body}
-          </va-alert>
-        </>
-      );
-    }
-    return <></>;
-  };
 
   return (
     <>
@@ -56,76 +15,11 @@ const DebtCardsList = () => {
       >
         Current debts
       </h2>
-
-      {error?.status && renderError()}
-
-      {!error?.status &&
-        debts.length < 1 && (
-          <section
-            className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3"
-            data-testid="debt-list-no-items"
-          >
-            <h3 className="vads-u-font-family--serif vads-u-margin-top--0 vads-u-font-size--h4">
-              Our records show that you don’t have any current debts
-            </h3>
-            <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-              If you believe that you have a debt with the VA, call the Debt
-              Management Center at
-              <va-telephone
-                className="vads-u-margin-left--0p5"
-                contact="8008270648"
-              />
-              .
-            </p>
-            <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-              For medical copayment debts, visit
-              <a
-                className="vads-u-margin-x--0p5"
-                href="/health-care/pay-copay-bill/"
-              >
-                Pay your VA copay bill
-              </a>
-              to learn about your payment options.
-            </p>
-          </section>
-        )}
-
-      {!error?.status &&
-        debts.length > 0 && (
-          <>
-            <div className="vads-u-margin-top--3" data-testid="debt-list">
-              {debts.map((debt, index) => (
-                <DebtSummaryCard
-                  key={`${index}-${debt.fileNumber}`}
-                  debt={debt}
-                />
-              ))}
-            </div>
-          </>
-        )}
-
-      <section>
-        {renderOtherVA()}
-
-        <h3
-          id="downloadDebtLetters"
-          className="vads-u-margin-top--4 vads-u-font-size--h2"
-        >
-          Download debt letters
-        </h3>
-        <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
-          You can download some of your letters for education, compensation and
-          pension debt.
-        </p>
-
-        <Link
-          to="/debt-balances/letters"
-          className="vads-u-margin-top--1 vads-u-font-family--sans"
-          data-testid="download-letters-link"
-        >
-          Download letters related to your VA debt
-        </Link>
-      </section>
+      <div className="vads-u-margin-top--3" data-testid="debt-list">
+        {debts.map((debt, index) => (
+          <DebtSummaryCard key={`${index}-${debt.fileNumber}`} debt={debt} />
+        ))}
+      </div>
     </>
   );
 };

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { PATTERNS } from '@department-of-veterans-affairs/component-library/Telephone';
 import DebtSummaryCard from './DebtSummaryCard';
 import { ErrorMessage, DowntimeMessage } from './Alerts';
 // TODO: OtherVA Update

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtCardsList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { PATTERNS } from '@department-of-veterans-affairs/component-library/Telephone';
 import DebtSummaryCard from './DebtSummaryCard';
 import { ErrorMessage, DowntimeMessage } from './Alerts';
 // TODO: OtherVA Update

--- a/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
+++ b/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
@@ -1,24 +1,28 @@
 import React from 'react';
-import moment from 'moment';
+import { addDays } from 'date-fns';
+import { formatDate } from '../../../combined/utils/helpers';
 
 const TriangleIcon = () => (
-  <i
-    aria-hidden="true"
-    className="fas fa-exclamation-triangle vads-u-margin-right--1"
-  />
+  <>
+    <i
+      aria-hidden="true"
+      className="fas fa-exclamation-triangle vads-u-margin-right--1"
+    />
+    <span className="sr-only">Alert</span>
+  </>
 );
 const CircleIcon = () => (
-  <i
-    aria-hidden="true"
-    className="fas fa-exclamation-triangle vads-u-margin-right--1"
-  />
+  <>
+    <i
+      aria-hidden="true"
+      className="fas fa-exclamation-triangle vads-u-margin-right--1"
+    />
+    <span className="sr-only">Alert</span>
+  </>
 );
 
 export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
-  const endDate = (date, days) =>
-    moment(date, 'MM-DD-YYYY')
-      .add(days, 'days')
-      .format('MMMM Do, YYYY,');
+  const endDate = (date, days) => formatDate(addDays(new Date(date), days));
 
   switch (diaryCode) {
     case '71':

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
@@ -54,17 +54,14 @@ const DebtLettersDownload = () => {
           </h2>
           <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
             If you’ve received a letter about a VA debt that isn’t listed here,
-            call us at
-            <va-telephone
-              contact="800-827-0648"
-              className="vads-u-margin-x--0p5"
-            />
-            (or
-            <va-telephone
-              contact="1-612-713-6415"
-              className="vads-u-margin-x--0p5"
-              international
-            />
+            call us at{' '}
+            <span className="no-wrap">
+              <va-telephone contact="800-827-0648" />
+            </span>{' '}
+            (or{' '}
+            <span className="no-wrap">
+              <va-telephone contact="1-612-713-6415" international />
+            </span>{' '}
             from overseas). You can also call us to get information about your
             resolved debts.
           </p>

--- a/src/applications/combined-debt-portal/medical-copays/components/AlertView.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/AlertView.jsx
@@ -3,7 +3,7 @@ import Breadcrumbs from '@department-of-veterans-affairs/component-library/Bread
 import PropTypes from 'prop-types';
 import Alert from './Alerts';
 import alertMessage from '../../combined/utils/alert-messages';
-import OtherVADebts from './OtherVADebts';
+import OtherVADebts from '../../combined/components/OtherVADebts';
 import {
   ALERT_TYPES,
   APP_TYPES,

--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -11,7 +11,7 @@ import {
   APP_TYPES,
   API_RESPONSES,
 } from '../../combined/utils/helpers';
-import OtherVADebts from '../components/OtherVADebts';
+import OtherVADebts from '../../combined/components/OtherVADebts';
 import alertMessage from '../../combined/utils/alert-messages';
 import { fetchDebtResponseAsync } from './MedicalCopaysApp';
 

--- a/src/applications/combined-debt-portal/medical-copays/tests/unit/otherdebts.unit.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/unit/otherdebts.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import OtherVADebts from '../../components/OtherVADebts';
+import OtherVADebts from '../../../combined/components/OtherVADebts';
 import { APP_TYPES } from '../../../combined/utils/helpers';
 
 describe('other va debts component', () => {


### PR DESCRIPTION
## Description
Adding new summary cards to match new design specs for debt overview page. Included rework for debt alert messages to fix old references.
Added some QoL updates like moving OtherVA to more appropriate combined/ folder.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39378

## Screenshots
<details><summary>Some examples of new summary cards (click to expand)</summary>
<img width="647" alt="image" src="https://user-images.githubusercontent.com/25368370/171262464-080a3687-d2b3-4c8c-82ed-1e6d103f7f8e.png">

</details>

## Acceptance criteria
- [x] Debt Summary page has new alerts to match mocks
- [x] Alerts are working as intended again
