### PR TITLE
Adds conditional check to CI Mapbox-token step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -61,6 +61,7 @@ jobs:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Configure AWS Credentials
+        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -68,6 +69,7 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get Mapbox Token
+        if: ${{ matrix.buildtype == 'vagovprod' }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token


### PR DESCRIPTION
## Description
See discussion here: https://dsva.slack.com/archives/CBU0KDSB1/p1654030189641779?thread_ts=1652129452.416949&cid=CBU0KDSB1

Pulling the Mapbox token in the CI build can only happen on the prod build.

## Testing done
CI test pass. Need to deploy in order to confirm this works in dev/stage/prod.
