### PR TITLE
34176 - 508-defect-4 [SEMANTIC MARKUP]: Consider using `ul` and `li` elements for the cards list

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
@@ -61,45 +61,55 @@ const BalanceCard = ({ id, amount, facility, city, date }) => {
       className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--2"
       data-testid={`balance-card-${id}`}
     >
-      <h3
-        aria-describedby={`copay-balance-${id}`}
-        className="card-balance vads-u-margin-top--0"
-        data-testid={`amount-${id}`}
-      >
-        {currency(amount)}
-      </h3>
-      <p
-        id={`copay-balance-${id}`}
-        className="card-heading vads-u-margin-top--0"
-        data-testid={`facility-city-${id}`}
-      >
-        {facility} - {city}
-      </p>
-      <div className="card-content">
-        <i
-          aria-hidden="true"
-          role="img"
-          className="fa fa-exclamation-triangle"
-        />
-        <span className="sr-only">Alert</span>
-        {isCurrentBalance ? (
-          <CurrentContent id={id} date={date} />
-        ) : (
-          <PastDueContent id={id} date={date} amount={amount} />
-        )}
-      </div>
-      <Link
-        className="vads-u-font-size--sm vads-u-font-weight--bold"
-        to={`/copay-balances/${id}/detail`}
-        data-testid={`detail-link-${id}`}
-        aria-label={linkText}
-      >
-        {linkText}
-        <i
-          className="fa fa-chevron-right vads-u-margin-left--1"
-          aria-hidden="true"
-        />
-      </Link>
+      <ul className="no-bullets">
+        <li>
+          <h3
+            aria-describedby={`copay-balance-${id}`}
+            className="card-balance vads-u-margin-top--0"
+            data-testid={`amount-${id}`}
+          >
+            {currency(amount)}
+          </h3>
+        </li>
+        <li>
+          <p
+            id={`copay-balance-${id}`}
+            className="card-heading vads-u-margin-top--0"
+            data-testid={`facility-city-${id}`}
+          >
+            {facility} - {city}
+          </p>
+        </li>
+        <li>
+          <div className="card-content">
+            <i
+              aria-hidden="true"
+              role="img"
+              className="fa fa-exclamation-triangle"
+            />
+            <span className="sr-only">Alert</span>
+            {isCurrentBalance ? (
+              <CurrentContent id={id} date={date} />
+            ) : (
+              <PastDueContent id={id} date={date} amount={amount} />
+            )}
+          </div>
+        </li>
+        <li>
+          <Link
+            className="vads-u-font-size--sm vads-u-font-weight--bold"
+            to={`/copay-balances/${id}/detail`}
+            data-testid={`detail-link-${id}`}
+            aria-label={linkText}
+          >
+            {linkText}
+            <i
+              className="fa fa-chevron-right vads-u-margin-left--1"
+              aria-hidden="true"
+            />
+          </Link>
+        </li>
+      </ul>
     </div>
   );
 };

--- a/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
@@ -61,55 +61,45 @@ const BalanceCard = ({ id, amount, facility, city, date }) => {
       className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--2"
       data-testid={`balance-card-${id}`}
     >
-      <ul className="no-bullets">
-        <li>
-          <h3
-            aria-describedby={`copay-balance-${id}`}
-            className="card-balance vads-u-margin-top--0"
-            data-testid={`amount-${id}`}
-          >
-            {currency(amount)}
-          </h3>
-        </li>
-        <li>
-          <p
-            id={`copay-balance-${id}`}
-            className="card-heading vads-u-margin-top--0"
-            data-testid={`facility-city-${id}`}
-          >
-            {facility} - {city}
-          </p>
-        </li>
-        <li>
-          <div className="card-content">
-            <i
-              aria-hidden="true"
-              role="img"
-              className="fa fa-exclamation-triangle"
-            />
-            <span className="sr-only">Alert</span>
-            {isCurrentBalance ? (
-              <CurrentContent id={id} date={date} />
-            ) : (
-              <PastDueContent id={id} date={date} amount={amount} />
-            )}
-          </div>
-        </li>
-        <li>
-          <Link
-            className="vads-u-font-size--sm vads-u-font-weight--bold"
-            to={`/copay-balances/${id}/detail`}
-            data-testid={`detail-link-${id}`}
-            aria-label={linkText}
-          >
-            {linkText}
-            <i
-              className="fa fa-chevron-right vads-u-margin-left--1"
-              aria-hidden="true"
-            />
-          </Link>
-        </li>
-      </ul>
+      <h3
+        aria-describedby={`copay-balance-${id}`}
+        className="card-balance vads-u-margin-top--0"
+        data-testid={`amount-${id}`}
+      >
+        {currency(amount)}
+      </h3>
+      <p
+        id={`copay-balance-${id}`}
+        className="card-heading vads-u-margin-top--0"
+        data-testid={`facility-city-${id}`}
+      >
+        {facility} - {city}
+      </p>
+      <div className="card-content">
+        <i
+          aria-hidden="true"
+          role="img"
+          className="fa fa-exclamation-triangle"
+        />
+        <span className="sr-only">Alert</span>
+        {isCurrentBalance ? (
+          <CurrentContent id={id} date={date} />
+        ) : (
+          <PastDueContent id={id} date={date} amount={amount} />
+        )}
+      </div>
+      <Link
+        className="vads-u-font-size--sm vads-u-font-weight--bold"
+        to={`/copay-balances/${id}/detail`}
+        data-testid={`detail-link-${id}`}
+        aria-label={linkText}
+      >
+        {linkText}
+        <i
+          className="fa fa-chevron-right vads-u-margin-left--1"
+          aria-hidden="true"
+        />
+      </Link>
     </div>
   );
 };

--- a/src/applications/combined-debt-portal/medical-copays/components/Balances.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/Balances.jsx
@@ -12,23 +12,26 @@ export const Balances = ({ statements }) => {
   return (
     <>
       {statements?.length === 1 ? single : multiple}
+      <ul className="no-bullets">
+        {statements?.map((balance, idx) => {
+          const facilityName =
+            balance.station.facilityName ||
+            getMedicalCenterNameByID(balance.station.facilitYNum);
 
-      {statements?.map((balance, idx) => {
-        const facilityName =
-          balance.station.facilityName ||
-          getMedicalCenterNameByID(balance.station.facilitYNum);
-
-        return (
-          <BalanceCard
-            id={balance.id}
-            amount={balance.pHAmtDue}
-            date={balance.pSStatementDateOutput}
-            city={balance.station.city}
-            facility={facilityName}
-            key={balance.id ? balance.id : `${idx}-${balance.facilitYNum}`}
-          />
-        );
-      })}
+          return (
+            <li key={idx}>
+              <BalanceCard
+                id={balance.id}
+                amount={balance.pHAmtDue}
+                date={balance.pSStatementDateOutput}
+                city={balance.station.city}
+                facility={facilityName}
+                key={balance.id ? balance.id : `${idx}-${balance.facilitYNum}`}
+              />
+            </li>
+          );
+        })}
+      </ul>
     </>
   );
 };

--- a/src/applications/combined-debt-portal/medical-copays/sass/medical-copays.scss
+++ b/src/applications/combined-debt-portal/medical-copays/sass/medical-copays.scss
@@ -7,6 +7,10 @@
   white-space: nowrap;
 }
 
+.no-bullets {
+  list-style: none;
+}
+
 .card-balance {
   font-family: "Bitter";
   font-size: 24px;


### PR DESCRIPTION
## Description
Replaced div with ul and li for semantic markup per Platform suggestion.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34176

## Screenshots

![34176_Working](https://user-images.githubusercontent.com/29178824/171431941-7874d1c3-1343-444d-a746-c3594ffe2704.png)

## Acceptance criteria
- [ X ] Nested divs and header elements are replaced by unordered list

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
