### PR TITLE
use named imports for textinput and select DS components

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -4,10 +4,11 @@ import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
 import FileInput from '@department-of-veterans-affairs/component-library/FileInput';
-import Select from '@department-of-veterans-affairs/component-library/Select';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
-
+import {
+  TextInput,
+  Select,
+} from '@department-of-veterans-affairs/component-library';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import {

--- a/src/applications/discharge-wizard/components/questions/DischargeMonth.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeMonth.jsx
@@ -4,10 +4,10 @@ import Scroll from 'react-scroll';
 
 // Relative Imports
 import { months } from 'platform/static-data/options-for-select.js';
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import { Select } from '@department-of-veterans-affairs/component-library';
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const DischargeMonthQuestion = ({
   formValues,

--- a/src/applications/discharge-wizard/components/questions/DischargeMonth.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeMonth.jsx
@@ -4,7 +4,7 @@ import Scroll from 'react-scroll';
 
 // Relative Imports
 import { months } from 'platform/static-data/options-for-select.js';
-import { Select } from '@department-of-veterans-affairs/component-library';
+import Select from '@department-of-veterans-affairs/component-library/Select';
 import { shouldShowQuestion } from '../../helpers';
 
 const { Element } = Scroll;

--- a/src/applications/discharge-wizard/components/questions/DischargeYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeYear.jsx
@@ -4,7 +4,7 @@ import { range } from 'lodash';
 import Scroll from 'react-scroll';
 
 // Relative Imports
-import { Select } from '@department-of-veterans-affairs/component-library';
+import Select from '@department-of-veterans-affairs/component-library/Select';
 import { shouldShowQuestion } from '../../helpers';
 
 const { Element } = Scroll;

--- a/src/applications/discharge-wizard/components/questions/DischargeYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeYear.jsx
@@ -4,10 +4,10 @@ import { range } from 'lodash';
 import Scroll from 'react-scroll';
 
 // Relative Imports
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import { Select } from '@department-of-veterans-affairs/component-library';
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const DischargeYearQuestion = ({
   formValues,

--- a/src/applications/financial-status-report/components/EmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EmploymentRecord.jsx
@@ -6,9 +6,9 @@ import { setData } from 'platform/forms-system/src/js/actions';
 import {
   MonthYear,
   Select,
+  TextInput,
 } from '@department-of-veterans-affairs/component-library';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
 import { parseISODate } from 'platform/forms-system/src/js/helpers';
 
 const defaultRecord = [

--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import environment from 'platform/utilities/environment';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
 
 const PreSubmitSignature = ({
   formData,

--- a/src/applications/financial-status-report/components/ResolutionDebtCards.jsx
+++ b/src/applications/financial-status-report/components/ResolutionDebtCards.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 import { setData } from 'platform/forms-system/src/js/actions';

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
 import { connect } from 'react-redux';
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import { Select } from '@department-of-veterans-affairs/component-library';
 
 // Relative imports.
 import recordEvent from 'platform/monitoring/record-event';
@@ -153,7 +153,7 @@ export const SearchResults = ({
   // Show loading indicator if we are fetching.
   if (fetching) {
     return (
-      <va-loading-indicator setFocus message={'Loading search results...'} />
+      <va-loading-indicator setFocus message="Loading search results..." />
     );
   }
 
@@ -283,7 +283,7 @@ export const SearchResults = ({
             document.getElementById(prevFocusedLink).focus();
           }}
           title="Download this PDF and open it in Acrobat Reader"
-          initialFocusSelector={'#va-modal-title'}
+          initialFocusSelector="#va-modal-title"
           visible={isOpen}
         >
           <div className="vads-u-display--flex vads-u-flex-direction--column">

--- a/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/CalculateYourBenefitsForm.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import classNames from 'classnames';
 
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
 import recordEvent from 'platform/monitoring/record-event';
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import scrollTo from 'platform/utilities/ui/scrollTo';

--- a/src/applications/lgy/coe/status/components/DocumentUploader/DocumentUploader.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentUploader/DocumentUploader.jsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/jsx-no-bind */
 import React, { useState } from 'react';
 import FileInput from '@department-of-veterans-affairs/component-library/FileInput';
-import Select from '@department-of-veterans-affairs/component-library/Select';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import {
+  TextInput,
+  Select,
+} from '@department-of-veterans-affairs/component-library';
 import { submitToAPI } from './submit';
 import { addFile } from './addFile';
 import { DOCUMENT_TYPES, FILE_TYPES } from '../../constants';

--- a/src/applications/veteran-id-card/containers/EmailCapture.jsx
+++ b/src/applications/veteran-id-card/containers/EmailCapture.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import { TextInput } from '@department-of-veterans-affairs/component-library';
 import { submitEmail, setEmail } from '../actions';
 
 class EmailCapture extends React.Component {
@@ -53,12 +52,12 @@ class EmailCapture extends React.Component {
             <a href="/privacy-policy/">See our privacy policy</a>
           </p>
           <form onSubmit={this.handleSubmit}>
-            <TextInput
-              errorMessage={this.props.errors && this.props.errors[0].title}
-              label={<span>Email address</span>}
+            <va-text-input
+              error={this.props.errors && this.props.errors[0].title}
+              label="Email address"
               name="email"
-              field={this.props.email}
-              onValueChange={update => this.props.setEmail(update)}
+              value={this.props.email}
+              onInput={e => this.props.setEmail(e.target.value)}
               required
             />
             <div>

--- a/src/applications/veteran-id-card/containers/EmailCapture.jsx
+++ b/src/applications/veteran-id-card/containers/EmailCapture.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { submitEmail, setEmail } from '../actions';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
+import { submitEmail, setEmail } from '../actions';
 
 class EmailCapture extends React.Component {
   constructor(props) {
@@ -29,7 +29,7 @@ class EmailCapture extends React.Component {
           <h1>Printed Veteran ID Card</h1>
           <AlertBox
             headline="Thank you for your email address. We will follow up with instructions on how to proceed with the application."
-            content={''}
+            content=""
             isVisible
             status="success"
           />

--- a/src/applications/veteran-id-card/reducers/emailForm.js
+++ b/src/applications/veteran-id-card/reducers/emailForm.js
@@ -9,19 +9,11 @@ const initialState = {
   errors: null,
   submitting: false,
   success: false,
-  email: {
-    value: '',
-    dirty: false,
-  },
+  email: '',
 };
 
 function validEmail(email) {
-  const { value, dirty } = email;
-
-  if (dirty) {
-    return value.match(/[^@\s]+@([^@\s]+\.)+[^@\s]+/);
-  }
-  return true;
+  return email.match(/[^@\s]+@([^@\s]+\.)+[^@\s]+/);
 }
 
 function emailForm(state = initialState, action) {

--- a/src/platform/forms-system/src/js/components/FormSignature.jsx
+++ b/src/platform/forms-system/src/js/components/FormSignature.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import set from 'platform/utilities/data/set';
-import { TextInput } from '@department-of-veterans-affairs/component-library';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 
 /**
@@ -38,7 +37,7 @@ export const FormSignature = ({
   onSectionComplete,
 }) => {
   // Input states
-  const [signature, setSignature] = useState({ value: '', dirty: false });
+  const [signature, setSignature] = useState('');
   const [checked, setChecked] = useState(false);
 
   // Validation states
@@ -62,7 +61,7 @@ export const FormSignature = ({
       setSignatureError(
         validations.reduce(
           (errorMessage, validator) =>
-            errorMessage || validator(signature.value, formData),
+            errorMessage || validator(signature, formData),
           null,
         ),
       );
@@ -85,7 +84,7 @@ export const FormSignature = ({
   // Update signature in formData
   useEffect(
     () => {
-      setFormData(set(signaturePath, signature.value, formData));
+      setFormData(set(signaturePath, signature, formData));
     },
     // Don't re-execute when formData changes because this changes formData
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -107,12 +106,12 @@ export const FormSignature = ({
 
   return (
     <>
-      <TextInput
+      <va-text-input
         label={signatureLabel}
-        field={signature}
-        onValueChange={setSignature}
+        value={signature}
+        onInput={setSignature}
         required={required}
-        errorMessage={(showError || signature.dirty) && signatureError}
+        error={showError && signatureError}
       />
       <Checkbox
         label={checkboxLabel}
@@ -137,7 +136,7 @@ FormSignature.propTypes = {
   /**
    * The label for the signature input
    */
-  signatureLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  signatureLabel: PropTypes.string,
 
   /**
    * The path in the formData to the signature value

--- a/src/platform/forms-system/src/js/components/FormSignature.jsx
+++ b/src/platform/forms-system/src/js/components/FormSignature.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import set from 'platform/utilities/data/set';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 
 /**

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
 
 const ShowPdfPassword = ({
   file,
@@ -17,7 +17,7 @@ const ShowPdfPassword = ({
   return (
     <div className="vads-u-margin-bottom--2">
       <TextInput
-        label={'PDF password'}
+        label="PDF password"
         errorMessage={
           showError && 'Please provide a password to decrypt this file'
         }

--- a/src/platform/forms-system/test/js/components/FormSignature.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormSignature.unit.spec.jsx
@@ -21,23 +21,19 @@ describe('Forms library - Forms signature component', () => {
 
   describe('signature input', () => {
     it('should render input with default label', () => {
-      const { getByLabelText } = render(<FormSignature {...signatureProps} />);
-      expect(getByLabelText('Veteran’s full name')).to.exist;
+      render(<FormSignature {...signatureProps} />);
+
+      expect(
+        document.querySelector('va-text-input[label="Veteran’s full name"]'),
+      ).to.exist;
     });
 
     it('should render input with custom string label', () => {
-      const { getByLabelText } = render(
+      render(
         <FormSignature {...signatureProps} signatureLabel="Custom text here" />,
       );
-      expect(getByLabelText('Custom text here')).to.exist;
-    });
-
-    it('should render input input with custom React element label', () => {
-      const customLabel = <span>Custom text here</span>;
-      const { getByLabelText } = render(
-        <FormSignature {...signatureProps} signatureLabel={customLabel} />,
-      );
-      expect(getByLabelText('Custom text here')).to.exist;
+      expect(document.querySelector('va-text-input[label="Custom text here"]'))
+        .to.exist;
     });
   });
 
@@ -166,8 +162,9 @@ describe('Forms library - Forms signature component', () => {
       // Uncheck box
       userEvent.click(checkbox);
 
+      const textInput = document.querySelector('va-text-input');
       // Not called if the box isn't checked
-      userEvent.type(getByLabelText(/Veteran’s full name/), 'asdf');
+      userEvent.type(textInput, 'asdf');
       expect(oscSpy.called).to.be.false;
     });
 

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import TextArea from '@department-of-veterans-affairs/component-library/TextArea';
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import { Select } from '@department-of-veterans-affairs/component-library';
 
 import environment from 'platform/utilities/environment';
 import { getActivePages } from 'platform/forms-system/src/js/helpers';


### PR DESCRIPTION
## Description
Changing the imports of the TextInput and Select design system components to use a named import in order to ensure that hard-coded text displays properly

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41999


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
