### PR TITLE
Fixed Alerts and breadcrumbs to match mocks on CDP Overview page

### DIFF
--- a/src/applications/combined-debt-portal/combined/components/Balances.jsx
+++ b/src/applications/combined-debt-portal/combined/components/Balances.jsx
@@ -4,14 +4,13 @@ import { useSelector } from 'react-redux';
 import BalanceCard from './BalanceCard';
 import ZeroBalanceCard from './ZeroBalanceCard';
 import AlertCard from './AlertCard';
-import ComboAlerts from './ComboAlerts';
 import {
   calculateTotalDebts,
   calculateTotalBills,
   getLatestDebt,
   getLatestBill,
 } from '../utils/balance-helpers';
-import { APP_TYPES, ALERT_TYPES } from '../utils/helpers';
+import { APP_TYPES } from '../utils/helpers';
 
 // Some terminology that could be helpful:
 // debt(s) = debtLetters
@@ -26,11 +25,6 @@ const Balances = () => {
   const billError = mcp.error;
   const debtError = debtLetters.errors?.length > 0;
 
-  // Both Error, show combo alert
-  if (billError && debtError) {
-    return <ComboAlerts alertType={ALERT_TYPES.ERROR} />;
-  }
-
   // get Debt info
   const { debts } = debtLetters;
   const totalDebts = calculateTotalDebts(debts);
@@ -40,11 +34,6 @@ const Balances = () => {
   const bills = mcp.statements;
   const totalBills = calculateTotalBills(bills);
   const latestBill = getLatestBill(bills);
-
-  // If there are no debts or bills, show zero balance card
-  if (totalDebts === 0 && totalBills === 0) {
-    return <ComboAlerts alertType={ALERT_TYPES.ZERO} />;
-  }
 
   // Sort two valid BalancCards by date
   if (!debtError && !billError && totalDebts > 0 && totalBills > 0) {

--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect } from 'react';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { useSelector } from 'react-redux';
 import Balances from '../components/Balances';
+import ComboAlerts from '../components/ComboAlerts';
+import { ALERT_TYPES } from '../utils/helpers';
+import {
+  calculateTotalDebts,
+  calculateTotalBills,
+} from '../utils/balance-helpers';
 
 const OverviewPage = () => {
   const title = 'Your VA debt and bill';
@@ -9,11 +16,28 @@ const OverviewPage = () => {
     scrollToTop();
   }, []);
 
+  const { debtLetters, mcp } = useSelector(
+    ({ combinedPortal }) => combinedPortal,
+  );
+
+  // Get errors
+  const billError = mcp.error;
+  const debtError = debtLetters.errors?.length > 0;
+  const bothError = billError && debtError;
+
+  // get totals
+  const { debts } = debtLetters;
+  const totalDebts = calculateTotalDebts(debts);
+  const bills = mcp.statements;
+  const totalBills = calculateTotalBills(bills);
+  const bothZero = totalDebts === 0 && totalBills === 0;
+
   return (
     <>
       <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
         <a href="/">Home</a>
-        <a href="/debt-and-bills">Your VA debt and bills</a>
+        <a href="/manage-debt-and-bills">Review and manage VA debt and bills</a>
+        <a href="/manage-debt-and-bills/summary">Your VA debt and bills</a>
       </va-breadcrumbs>
       <h1 data-testid="overview-page-title">{title}</h1>
       <p className="vads-u-font-size--lg vads-u-font-family--serif">
@@ -22,23 +46,31 @@ const OverviewPage = () => {
         charges from VA health care facilities. Find out how to make payments or
         request financial help.
       </p>
-      <h2>Debt and bill overview</h2>
-      <Balances />
-      <h2>What to do if you have questions about your debt and bills</h2>
-      <h3>Questions about benefit debt</h3>
-      <p>
-        Call the Debt Management Center (DMC) at{' '}
-        <va-telephone contact="800-827-0648" /> (TTY:{' '}
-        <va-telephone contact="711" />
-        ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-      </p>
-      <h3>Questions about medical copayment bills</h3>
-      <p>
-        Call the VA Health Resource Center at{' '}
-        <va-telephone contact="866-400-1238" /> (TTY:{' '}
-        <va-telephone contact="711" />
-        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-      </p>
+      {bothError || bothZero ? (
+        <ComboAlerts
+          alertType={bothError ? ALERT_TYPES.ERROR : ALERT_TYPES.ZERO}
+        />
+      ) : (
+        <>
+          <h2>Debt and bill overview</h2>
+          <Balances />
+          <h2>What to do if you have questions about your debt and bills</h2>
+          <h3>Questions about benefit debt</h3>
+          <p>
+            Call the Debt Management Center (DMC) at{' '}
+            <va-telephone contact="800-827-0648" /> (TTY:{' '}
+            <va-telephone contact="711" />
+            ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+          </p>
+          <h3>Questions about medical copayment bills</h3>
+          <p>
+            Call the VA Health Resource Center at{' '}
+            <va-telephone contact="866-400-1238" /> (TTY:{' '}
+            <va-telephone contact="711" />
+            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          </p>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description
CDP Overview page was not showing Alert messages correctly for if both endpoints 404'd or had zero balances. The Breadcrumbs needed to be updated to match the new layout as well. 

## Screenshots
<details><summary>Both APIs 404 (click to expand)</summary>

![image](https://user-images.githubusercontent.com/25368370/171438744-431bf8b1-2b15-4281-9afc-dd64872a3c7f.png)

</details>
<details><summary>Both balances 0 (click to expand)</summary>

![image](https://user-images.githubusercontent.com/25368370/171439946-c93b5f46-b5b5-414a-870f-aee7863f8701.png)

</details>

## Acceptance criteria
- [x] Both endpoints 404 alert message populating to match mocks
- [x] Both balances 0 alert message populating to match mocks

