### PR TITLE
Fix Cypress install issues in proxy rewrite E2E test

### DIFF
--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cypress-tests:
     name: Cypress E2E Proxy Rewrite Header/Footer Injection Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
           yarn_cache_folder: .cache/yarn
           path: |
             .cache/yarn
-            /home/runner/.cache/Cypress
+            /github/home/.cache/Cypress
             node_modules
       
       - name: Start server

--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -22,7 +22,7 @@ jobs:
           yarn_cache_folder: .cache/yarn
           path: |
             .cache/yarn
-            /github/home/.cache/Cypress
+            /home/runner/.cache/Cypress
             node_modules
       
       - name: Start server


### PR DESCRIPTION
## Description
This PR fixes a caching issue in the `e2e-injection-test` workflow. The cache path for the Cypress binary was the path used for self-hosted runners and not GitHub runners, causing a failure. Switching to a self-hosted runner in this workflow fixes the failure.