### PR TITLE
36054 a11y lint ask va page

### DIFF
--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Link } from 'react-router';
+import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 import { submitRequest, getClaimDetail } from '../actions/index.jsx';
 import { setUpPage } from '../utils/page';
 
 import AskVAQuestions from '../components/AskVAQuestions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
-import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 
 class AskVAPage extends React.Component {
   constructor() {
@@ -15,10 +15,12 @@ class AskVAPage extends React.Component {
     this.setSubmittedDocs = this.setSubmittedDocs.bind(this);
     this.state = { submittedDocs: false };
   }
+
   componentDidMount() {
     document.title = 'Ask for your Claim Decision';
     setUpPage();
   }
+
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(props) {
     if (props.decisionRequested) {
@@ -26,12 +28,15 @@ class AskVAPage extends React.Component {
       this.goToStatusPage();
     }
   }
+
   setSubmittedDocs(val) {
     this.setState({ submittedDocs: val });
   }
+
   goToStatusPage() {
     this.props.router.push(`your-claims/${this.props.params.id}`);
   }
+
   render() {
     const { loadingDecisionRequest, decisionRequestError } = this.props;
     const submitDisabled =
@@ -99,12 +104,13 @@ class AskVAPage extends React.Component {
                 {buttonMsg}
               </button>
               {!loadingDecisionRequest ? (
-                <a
+                <button
                   className="usa-button-secondary"
                   onClick={this.goToStatusPage}
+                  type="button"
                 >
                   Not yet–I still have more evidence to submit
-                </a>
+                </button>
               ) : null}
             </div>
           </div>

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Link } from 'react-router';
+import PropTypes from 'prop-types';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 import { submitRequest, getClaimDetail } from '../actions';
 import { setUpPage } from '../utils/page';
-
 import AskVAQuestions from '../components/AskVAQuestions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 
@@ -50,6 +50,7 @@ class AskVAPage extends React.Component {
     } else if (decisionRequestError !== null) {
       buttonMsg = 'Something went wrong...';
     }
+
     return (
       <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
         <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
@@ -144,5 +145,15 @@ export default withRouter(
     mapDispatchToProps,
   )(AskVAPage),
 );
+
+AskVAPage.propTypes = {
+  decisionRequestError: PropTypes.string,
+  decisionRequested: PropTypes.bool,
+  getClaimDetail: PropTypes.func,
+  loadingDecisionRequest: PropTypes.bool,
+  params: PropTypes.object,
+  router: PropTypes.object,
+  submitRequest: PropTypes.func,
+};
 
 export { AskVAPage };

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -94,6 +94,7 @@ class AskVAPage extends React.Component {
               </div>
               <button
                 disabled={submitDisabled}
+                type="button"
                 className={
                   submitDisabled
                     ? 'usa-button-primary usa-button-disabled'

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -52,7 +52,7 @@ class AskVAPage extends React.Component {
     }
 
     return (
-      <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
+      <div className="vads-l-grid-container large-screen:vads-u-padding-x--0  vads-u-margin-bottom--7">
         <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
           <div className="vads-l-col--12">
             <ClaimsBreadcrumbs>

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Link } from 'react-router';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import { submitRequest, getClaimDetail } from '../actions/index.jsx';
+import { submitRequest, getClaimDetail } from '../actions';
 import { setUpPage } from '../utils/page';
 
 import AskVAQuestions from '../components/AskVAQuestions';


### PR DESCRIPTION
department-of-veterans-affairs/va.gov-team#36054

# Expected behavior
- Buttons should be used for actions, not links

## Current behavior
- Link is being used for an action

## Your fix
- Changed the text link to a secondary button. This should revert the design to what it used to be prior to removing support for button links.
- Addressed other eslint complaints
- Added props validations
- Added bottom margin to the main grid container to provide some breathing room

## How has this been tested?
- Tested in the browser
### To evaluate locally
1. To use Claim Details, [follow these steps use mock data](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/claim-appeal-status/engineering/CST_frontend_details.md#claim-detail-testing).
2. Go to the **Ask VA to Decide Page**, we used this path `track-claims/your-claims/1196201/ask-va-to-decide`. 

## Screenshots

### Before
<img width="1118" alt="Screen Shot 2022-06-01 at 1 29 53 PM" src="https://user-images.githubusercontent.com/1094951/171473080-8aa7c439-8a0d-4adf-aaec-339ef5048ecb.png">

### After
<img width="1141" alt="Screen Shot 2022-06-01 at 2 08 23 PM" src="https://user-images.githubusercontent.com/1094951/171473179-abccafee-fa4f-447e-8299-95afab18c3af.png">



## Acceptance criteria
- [ ] Tests continue to pass


## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

