### PR TITLE
DHP-277 Use reactive button to toggle login modal

### DIFF
--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -1,7 +1,12 @@
-import React from 'react';
-import UserNav from 'platform/site-wide/user-nav/containers/Main';
+import React, { useCallback } from 'react';
+import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
-export const UnauthenticatedPageContent = () => {
+export const UnauthenticatedPageContent = toggleLoginModal => {
+  const onSignInClicked = useCallback(() => toggleLoginModal(true), [
+    toggleLoginModal,
+  ]);
   return (
     <>
       <h2>Connected devices</h2>
@@ -16,10 +21,23 @@ export const UnauthenticatedPageContent = () => {
           If you don’t have any of these accounts, you can create a free ID.me
           account now.
         </div>
-        <div className="dhp-login-button">
-          <UserNav isHeaderV2 />
-        </div>
+        <button type="button" className="usa-button" onClick={onSignInClicked}>
+          Sign in or create an account
+        </button>
       </va-alert>
     </>
   );
+};
+
+const mapDispatchToProps = dispatch => ({
+  toggleLoginModal: open => dispatch(toggleLoginModalAction(open)),
+});
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(UnauthenticatedPageContent);
+
+UnauthenticatedPageContent.propTypes = {
+  toggleLoginModal: PropTypes.func,
 };

--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -13,11 +13,13 @@ export const UnauthenticatedPageContent = ({ toggleLoginModal }) => {
         visible
       >
         <h3 slot="headline">Please sign in to connect a device</h3>
-        <div>
-          Sign in with your existing ID.me, DS Logon, or My HealtheVet account.
-          If you don’t have any of these accounts, you can create a free ID.me
-          account now.
-        </div>
+        <p>
+          <div>
+            Sign in with your existing ID.me, DS Logon, or My HealtheVet
+            account. If you don’t have any of these accounts, you can create a
+            free ID.me account now.
+          </div>
+        </p>
         <button type="button" className="usa-button" onClick={toggleLoginModal}>
           Sign in or create an account
         </button>

--- a/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
+++ b/src/applications/dhp-connected-devices/components/UnauthenticatedPageContent.jsx
@@ -1,12 +1,9 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-export const UnauthenticatedPageContent = toggleLoginModal => {
-  const onSignInClicked = useCallback(() => toggleLoginModal(true), [
-    toggleLoginModal,
-  ]);
+export const UnauthenticatedPageContent = ({ toggleLoginModal }) => {
   return (
     <>
       <h2>Connected devices</h2>
@@ -21,7 +18,7 @@ export const UnauthenticatedPageContent = toggleLoginModal => {
           If you don’t have any of these accounts, you can create a free ID.me
           account now.
         </div>
-        <button type="button" className="usa-button" onClick={onSignInClicked}>
+        <button type="button" className="usa-button" onClick={toggleLoginModal}>
           Sign in or create an account
         </button>
       </va-alert>
@@ -30,7 +27,7 @@ export const UnauthenticatedPageContent = toggleLoginModal => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  toggleLoginModal: open => dispatch(toggleLoginModalAction(open)),
+  toggleLoginModal: () => dispatch(toggleLoginModalAction(true)),
 });
 
 export default connect(

--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { UnauthenticatedPageContent } from '../components/UnauthenticatedPageContent';
+import UnauthenticatedPageContent from '../components/UnauthenticatedPageContent';
 import { AuthenticatedPageContent } from '../components/AuthenticatedPageContent';
 import { FrequentlyAskedQuestions } from '../components/FrequentlyAskedQuestions';
 

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -29,7 +29,7 @@ describe('Device disconnection card modal', () => {
   beforeEach(async () => {
     screen = render(<DeviceDisconnectionCard device={device} />);
     const disconnectBtn = screen.getByRole('button', { name: 'Disconnect' });
-    await fireEvent.click(disconnectBtn);
+    fireEvent.click(disconnectBtn);
     modal = screen.getByTestId('disconnect-modal');
   });
 

--- a/src/applications/dhp-connected-devices/tests/components/UnauthenticatedPageContent.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/UnauthenticatedPageContent.spec.js
@@ -1,13 +1,28 @@
 import React from 'react';
 import { expect } from 'chai';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
-import DhpApp from '../../containers/App';
+import { fireEvent, waitFor, render } from '@testing-library/react';
+import { UnauthenticatedPageContent } from '../../components/UnauthenticatedPageContent';
 
 describe('connect health devices landing page, user not logged in', () => {
-  it('App renders', () => {
-    const dhpContainer = renderInReduxProvider(<DhpApp />);
-    const title = 'Connect your health devices to share data';
+  it('renders the unauthenticated page', () => {
+    const dhpContainer = renderInReduxProvider(<UnauthenticatedPageContent />);
+    const title = 'Please sign in to connect a device';
 
     expect(dhpContainer.getByText(title)).to.exist;
+  });
+
+  it('should open the login modal when the "Sign in or create an account" button is clicked', async () => {
+    const screen = render(<UnauthenticatedPageContent />);
+    const title = 'Sign in or create an account';
+    const button = screen.getByRole('button', { name: title });
+    expect(button).to.exist;
+
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(screen.findByText('Having trouble signing in?')).to.exist;
+    });
+    expect(screen.findByText('Sign in with Login.gov')).to.exist;
+    expect(screen.findByText('Sign in with ID.me')).to.exist;
   });
 });

--- a/src/applications/dhp-connected-devices/tests/containers/App.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/containers/App.spec.jsx
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import { render } from 'enzyme';
 import { Provider } from 'react-redux';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import App from '../../containers/App';
 
 function getStore(loading = false, currentlyLoggedIn = false) {
@@ -26,6 +27,15 @@ function getStore(loading = false, currentlyLoggedIn = false) {
 }
 
 describe('App', () => {
+  it('renders the shared page content', () => {
+    const dhpContainer = renderInReduxProvider(<App />);
+    const title = 'Connect your health devices to share data';
+    const faq = 'Frequently asked questions';
+
+    expect(dhpContainer.getByText(title)).to.exist;
+    expect(dhpContainer.getByText(faq)).to.exist;
+  });
+
   it('renders the the loading indicator when page is loading', () => {
     const mockStore = getStore(true, true);
     const wrapper = render(

--- a/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
+++ b/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
@@ -2,27 +2,32 @@ import manifest from '../manifest.json';
 
 describe(manifest.appName, () => {
   it('is accessible', () => {
-    cy.visit(manifest.rootUrl)
-      .injectAxe()
-      .axeCheck();
+    cy.visit(manifest.rootUrl);
+    cy.injectAxe();
+    cy.axeCheck();
+
     cy.url().should(
       'eq',
       'http://localhost:3001/health-care/connected-devices/',
     );
   });
 
-  it("displays login modal after clicking 'Sign in' for veteran NOT logged in", () => {
-    cy.findAllByText('Sign in').click({
+  it("displays login modal after clicking 'Sign in or create an account' for veteran NOT logged in", () => {
+    cy.findAllByText('Sign in or create an account').click({
       multiple: true,
       force: true,
       waitForAnimations: true,
     });
     // Tests that login modal appears after clicking
-    cy.url().should(
-      'eq',
-      'http://localhost:3001/health-care/connected-devices/?next=loginModal',
-    );
-    // Tests that the .login div is loaded
-    cy.get('.login').should('be.visible');
+    cy.get('#signin-signup-modal').should('be.visible');
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.get('.va-modal-close').click({
+      multiple: true,
+      force: true,
+      waitForAnimations: true,
+    });
+    cy.get('#signin-signup-modal').should('not.exist');
   });
 });


### PR DESCRIPTION
## Description
This PR
* Updates login button to be reactive
* Updates button text to "Sign in or create an account" per original requirement
* Adds unit tests to unauthorized view

## Screenshots
Before:
<img width="704" alt="Screen Shot 2022-05-19 at 10 03 33 AM" src="https://user-images.githubusercontent.com/1357047/172094055-e4ae3d87-6fdf-49d3-b930-bae1c168fc3a.png">

After:
<img width="695" alt="Screen Shot 2022-06-05 at 9 17 53 PM" src="https://user-images.githubusercontent.com/1357047/172094039-8b4f6771-54b3-4004-857d-110ea3113f2a.png">
