### PR TITLE
Upgrade generator-vets-website to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.9.12",
     "@department-of-veterans-affairs/eslint-config-vagov": "^0.0.1",
-    "@department-of-veterans-affairs/generator-vets-website": "^3.5.4",
+    "@department-of-veterans-affairs/generator-vets-website": "^3.6.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",
     "@sentry/browser": "^6.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,10 +2752,10 @@
     element-closest "^3.0.1"
     foundation-sites "5"
 
-"@department-of-veterans-affairs/generator-vets-website@^3.5.4":
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.5.4.tgz#503dd6c0e1affb00a30a685b906ae571f0d1c431"
-  integrity sha512-hvMZA7MXnQWrGUjO5pRq18Mwf45BLwR74ge8c0FTny3prSx+vmqiMMsqeEYj26XbzonhsATQlXq48twLWr73cA==
+"@department-of-veterans-affairs/generator-vets-website@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.6.0.tgz#a13175a8624b131e09c9d25e9c6c1a6ed64b0e2f"
+  integrity sha512-Z51IDeRU9z/urKqImy8tOfFyvnJOvQhk384Z1KpcC1PZ78u1wsj0FAZClgVyybE1ciMSykBy4M9phOf/AkH4uw==
   dependencies:
     chalk "^4.1.0"
     yeoman-generator "^5.6.1"


### PR DESCRIPTION
## Description
Update `generator-vets-website` to v3.6.0 so changes from this [PR](https://github.com/department-of-veterans-affairs/generator-vets-website/pull/250) take effect.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40854

## Testing done
Tested locally.

## Acceptance criteria
- [x] The app generator is updated to the latest version.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
