### PR TITLE
Enforce Node version in `package.json`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-ignore-engines true
+ignore-engines false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vets-website",
   "version": "1.0.1",
-  "description": "Frontend build for vets.gov website static assets.",
+  "description": "Frontend build for VA.gov website static assets.",
   "scripts": {
     "analyze": "webpack-bundle-analyzer build/vagovprod/generated/stats.json",
     "apps": "./script/app-list.sh",

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.15.0 <16",
     "yarn": ">=1.21.1"
   },
   "private": true,


### PR DESCRIPTION
## Description
This PR enables checking the local Node version when running yarn commands. With Node 16+, `yarn install` fails, so we should enforce that the correct Node version is being used through the `package.json`.

## Testing done
Ran `yarn install` with different Node versions.

## Acceptance criteria
- [ ] CI passes.