### PR TITLE
Fix certificate issue in E2E proxy test

### DIFF
--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -1,15 +1,18 @@
 name: E2E Proxy Rewrite Injection Test
 
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: 0 14 * * 1-5
+on: [push]
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: 0 14 * * 1-5
 
 jobs:
   cypress-tests:
     name: Cypress E2E Proxy Rewrite Header/Footer Injection Test
     runs-on: self-hosted
+    container:
+      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
+      options: -u 1001:1001 -v /usr/local/share:/share
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -1,10 +1,10 @@
 name: E2E Proxy Rewrite Injection Test
 
 
-on: [push]
-  # workflow_dispatch:
-  # schedule:
-  #   - cron: 0 14 * * 1-5
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 14 * * 1-5
 
 jobs:
   cypress-tests:

--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -14,6 +14,10 @@ jobs:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
 
+    env:
+      CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
+      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/21229. This PR fixes a certificate issue in the `e2e-injection-test.yml` workflow that was causing failures during the `yarn install`.

## Testing done
Ran failing tests in CI.