### PR TITLE
Bump component-library for TextInput & Select fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.17.7",
-    "@department-of-veterans-affairs/component-library": "^10.2.2",
+    "@department-of-veterans-affairs/component-library": "^10.3.1-0",
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.17.7",
-    "@department-of-veterans-affairs/component-library": "^10.3.1-0",
+    "@department-of-veterans-affairs/component-library": "^10.3.1",
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,13 +2712,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^10.2.2":
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.2.2.tgz#97197687bf0832149b8e9c5b2f6be7bfc68087fc"
-  integrity sha512-WSK6wUyEeHaLZ125Yn6WrfQuAxwLva4cuyxBjCXk0mK59f/v+Ho4HZg+Ep09NKCJ1M6FoSyBfh/j6ROY/p5ddw==
+"@department-of-veterans-affairs/component-library@^10.3.1-0":
+  version "10.3.1-0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.3.1-0.tgz#cc86c3be2dae9f2bc88d60f5026b365ddc1beef0"
+  integrity sha512-zzndwoXyxMmCQbBRZ0ieYMZn7w6FgGo2dbcS+Xpu6X/rnws1fCUVID6YXt/Xr0dzwWIIWWwxpRaF5Xw4Up9wNQ==
   dependencies:
-    "@department-of-veterans-affairs/react-components" "6.1.2"
-    "@department-of-veterans-affairs/web-components" "4.1.1"
+    "@department-of-veterans-affairs/react-components" "6.1.3-0"
+    "@department-of-veterans-affairs/web-components" "4.2.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2776,10 +2776,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/react-components@6.1.2":
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-6.1.2.tgz#606270e03f1f5eed17e83ff511719da408312fff"
-  integrity sha512-EwljMLBQq8BCAGLXOLXsdXP0WbSLVgOP8iNp4h94zxEIRmguha0YmXLX3yjN/ricajOO0u0v7uv5k4bNnVA1kQ==
+"@department-of-veterans-affairs/react-components@6.1.3-0":
+  version "6.1.3-0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-6.1.3-0.tgz#1dd4772281b26ef037fa482de93413bbd4d7b840"
+  integrity sha512-sMHdMlJCfLCDojCIcSK6VxKjMSLFST5/TkbNOo/SXc0uvYKg3iFOmW6bu+c7M5eJ/cMyshrLZxO1xOOUGpq4Sw==
   dependencies:
     classnames "^2.2.6"
     prop-types "^15.6.2"
@@ -2827,10 +2827,10 @@
     intersection-observer "^0.12.0"
     postcss-url "^10.1.1"
 
-"@department-of-veterans-affairs/web-components@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.1.1.tgz#428efbfa916d57e8e3ccbc20f0df71b30f767d54"
-  integrity sha512-ojqb8aDLiJlaUICszFUFRf6Imlu3gd7PRlrZS5Kh3YpU01NFLVnG8rQc3jD+wwrqtNPzPjc8djaKg49Q0+0aeg==
+"@department-of-veterans-affairs/web-components@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.2.1.tgz#83a8193f12d057f4808e7e38f84726b9cdfc5796"
+  integrity sha512-xEe/56AgUlgzqOesAa9U89Cd+mPIZPCHoiWOhSrvxGLZh0f0y50bV98PjhCnt5Ue+RO9WRf9u/jUcTwVpUGpaw==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,12 +2712,12 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^10.3.1-0":
-  version "10.3.1-0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.3.1-0.tgz#cc86c3be2dae9f2bc88d60f5026b365ddc1beef0"
-  integrity sha512-zzndwoXyxMmCQbBRZ0ieYMZn7w6FgGo2dbcS+Xpu6X/rnws1fCUVID6YXt/Xr0dzwWIIWWwxpRaF5Xw4Up9wNQ==
+"@department-of-veterans-affairs/component-library@^10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.3.1.tgz#78b1578ed237d5fe6ec08d288bb5fe13a9870d70"
+  integrity sha512-vJbWRY1qD2lLTUcQu4hNVniX2ROxfdCJQoIvhD05GUJNz/TNL5ttSz3FtUJaM/I64xFEr0HM2rLtm09lT3JigQ==
   dependencies:
-    "@department-of-veterans-affairs/react-components" "6.1.3-0"
+    "@department-of-veterans-affairs/react-components" "6.1.3"
     "@department-of-veterans-affairs/web-components" "4.2.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
@@ -2776,10 +2776,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/react-components@6.1.3-0":
-  version "6.1.3-0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-6.1.3-0.tgz#1dd4772281b26ef037fa482de93413bbd4d7b840"
-  integrity sha512-sMHdMlJCfLCDojCIcSK6VxKjMSLFST5/TkbNOo/SXc0uvYKg3iFOmW6bu+c7M5eJ/cMyshrLZxO1xOOUGpq4Sw==
+"@department-of-veterans-affairs/react-components@6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-6.1.3.tgz#9ba45d99b50ac6f862c633b9bc41591a05723e6f"
+  integrity sha512-mVgRheEsFAJ9HPCCDUVWIDM+GE10MYbfbjmjPnfLsDYj+XWASp+OhlA5AUiyMqKMTAXEfSSMVyP9rnU+LM5cZg==
   dependencies:
     classnames "^2.2.6"
     prop-types "^15.6.2"


### PR DESCRIPTION
## Description
This updates the `component-library` version so that `<TextInput>` and `<Select>` components will initialize the i18next library if the instance that is being imported is not initialized. This is to ensure that text displays for default imports that are using a file name instead of named imports from the root package bundle, such as:

https://github.com/department-of-veterans-affairs/vets-website/blob/545bce74b6fbfe9250af979c657df66e8057bcc2/src/applications/veteran-id-card/containers/EmailCapture.jsx#L5

## Original issue(s)
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/41999


## Testing done

I made these local changes for testing:

```diff
diff --git a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
index 365c6650fb..bdeeea2c8d 100644
--- a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router';
 import recordEvent from 'platform/monitoring/record-event';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import ProgressButton from '@department-of-veterans-affairs/component-library/ProgressButton';
+import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import { focusElement } from 'platform/utilities/ui';
@@ -66,6 +67,11 @@ class IntroductionPage extends React.Component {
   render() {
     return (
       <div className="schemaform-intro">
+        <TextInput
+          label="Testing"
+          field={{ dirty: false, value: '' }}
+          required
+        />
         <br />
         <FormTitle title="Sign up to get a COVID-19 vaccine at VA" />
         <span>
```

## Screenshots

With local changes using old version of `component-library`:

!["Required" text not present on TextInput component](https://user-images.githubusercontent.com/2008881/171741934-2ea21674-a3ca-4202-a7f4-49521353068d.png)

Using the new version of `component-library`:

!["Required" text is present on TextInput component](https://user-images.githubusercontent.com/2008881/171742144-8a84195d-c62a-42a0-a9e7-4290522239f9.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
