### PR TITLE
VACMS-9263: Sends user to search result page even if click tracking errors

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -147,7 +147,7 @@ class SearchApp extends React.Component {
     });
   };
 
-  onSearchResultClick = ({ bestBet, title, index, url }) => async e => {
+  onSearchResultClick = ({ bestBet, title, index, url }) => e => {
     e.preventDefault();
 
     // clear the &t query param which is used to track typeahead searches
@@ -175,10 +175,15 @@ class SearchApp extends React.Component {
     };
     const moduleCode = bestBet ? 'BOOS' : 'I14Y';
 
-    await apiRequest(
+    // By implementing in this fashion (i.e. a promise chain), code that follows is not blocked by this api request. Following the link at the end of the
+    // function should happen regardless of the result of this api request, and it can happen before this request resolves.
+    apiRequest(
       `/search_click_tracking?position=${searchResultPosition}&query=${encodedQuery}&url=${encodedUrl}&user_agent=${userAgent}&module_code=${moduleCode}`,
       apiRequestOptions,
-    );
+    ).catch(error => {
+      Sentry.captureException(error);
+      Sentry.captureMessage('search_click_tracking_error');
+    });
 
     if (bestBet) {
       recordEvent({


### PR DESCRIPTION
## Description
Currently, on search results page, a clicked link first pings a click-tracking API endpoint. If that ping returns successfully, the user is then passed to the desired page. If the API request fails, though, the user is not sent. This PR removes that dependency. The user is sent regardless. A failed click-tracking request should not ruin the veteran experience.
