### PR TITLE
Remove content-build files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,16 +49,6 @@ all-links.csv
 !.vscode/extensions.json
 !.vscode/launch.json
 
-# Ignore the hashed build files for comparison
-standaloneContentBuildHash.txt
-websiteContentBuildHash.txt
-
-cms.diff
-graphql-data.json
-/content-object-diffs
-content-object-diff.json
-comparison-output/
-
 # Ignore custom generated Cypress-TestRail configs
 my-cypress-testrail.json
 script/cypress-testrail-helper/my-config.json


### PR DESCRIPTION
## Description
Removes `content-build` files from `.gitignore`. These files can no longer be generated since the scripts for them have been removed from the repo.

## Acceptance criteria
- [x] Files related to the `content-build` are removed from the `.gitignore`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
