### PR TITLE
Remove Type of Care label on TMP appointments.

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -47,7 +47,7 @@ export default function DetailsVA({
       ? 'COVID-19 vaccine'
       : getTypeOfCareById(serviceType)?.name;
     return (
-      typeOfCare && (
+      !!typeOfCare && (
         <>
           <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
             Type of care:

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -47,12 +47,14 @@ export default function DetailsVA({
       ? 'COVID-19 vaccine'
       : getTypeOfCareById(serviceType)?.name;
     return (
-      <>
-        <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
-          Type of care:
-        </h2>
-        <div className="vads-u-display--inline"> {typeOfCare}</div>
-      </>
+      typeOfCare && (
+        <>
+          <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-display--inline-block">
+            Type of care:
+          </h2>
+          <div className="vads-u-display--inline"> {typeOfCare}</div>
+        </>
+      )
     );
   };
 


### PR DESCRIPTION
## Description
Updated logic to only show type of care label when type of care is provided.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42071


## Testing done


## Screenshots
<img width="1011" alt="Screen Shot 2022-06-03 at 6 04 24 PM" src="https://user-images.githubusercontent.com/47654119/171960242-557e397e-71cb-4d8d-814a-8dcb6089b755.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
