### PR TITLE
fix for Cannot read properties of undefined (reading 'startTime')

### DIFF
--- a/src/applications/check-in/day-of/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/index.jsx
@@ -6,8 +6,10 @@ import CheckInConfirmation from './CheckInConfirmation';
 import { triggerRefresh } from '../../../actions/day-of';
 import { makeSelectConfirmationData } from '../../../selectors';
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
+import { useFormRouting } from '../../../hooks/useFormRouting';
+import { URLS } from '../../../utils/navigation';
 
-const Confirmation = () => {
+const Confirmation = props => {
   const dispatch = useDispatch();
   const refreshAppointments = useCallback(
     () => {
@@ -15,12 +17,12 @@ const Confirmation = () => {
     },
     [dispatch],
   );
-
+  const { router } = props;
+  const { jumpToPage } = useFormRouting(router);
   const selectConfirmationData = useMemo(makeSelectConfirmationData, []);
   const { appointments, selectedAppointment } = useSelector(
     selectConfirmationData,
   );
-
   const {
     getShouldSendDemographicsFlags,
     setShouldSendDemographicsFlags,
@@ -34,12 +36,26 @@ const Confirmation = () => {
     [getShouldSendDemographicsFlags, setShouldSendDemographicsFlags],
   );
 
+  useEffect(
+    () => {
+      if (!selectedAppointment) {
+        triggerRefresh();
+        jumpToPage(URLS.DETAILS);
+      }
+    },
+    [selectedAppointment],
+  );
+
   return (
-    <CheckInConfirmation
-      selectedAppointment={selectedAppointment}
-      appointments={appointments}
-      triggerRefresh={refreshAppointments}
-    />
+    <>
+      {selectedAppointment && (
+        <CheckInConfirmation
+          selectedAppointment={selectedAppointment}
+          appointments={appointments}
+          triggerRefresh={refreshAppointments}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/applications/check-in/day-of/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/index.jsx
@@ -43,7 +43,7 @@ const Confirmation = props => {
         jumpToPage(URLS.DETAILS);
       }
     },
-    [selectedAppointment],
+    [selectedAppointment, jumpToPage],
   );
 
   return (


### PR DESCRIPTION
## Description
Looking at the logs in sentry, it seems like this is only coming from `/appointment-check-in/complete` most likely when a vet re-opens their browser sometime after already completing checkin. On reload, the app no longer has the appointment data and the app routes to the error page. The error where the page was trying to read non-existent appointment data from logs to sentry.

This fix adds two things:

1.  The component that displays the appointment details is not displayed if the `selectedAppointment` is undefined, stopping the error getting logged to Sentry.
2.  If there is no `selectedAppointment` data, the user gets routed back to the appointments list page and a refresh is triggered. Most likely this scenario would not happen, but is good for an edge case. Most of the time the session will be gone entirely and the user will get routed to the error page. I don't think this will cause a log to Sentry like it does on the confirmation screen though.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39561

