### PR TITLE
VA-9320: Fix bug if static COVID data is unavailable

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
@@ -14,18 +14,6 @@ const store = createCommonStore({
 const LocationCovidStatus = ({ supplementalStatus }) => {
   const [showVamcAlert, setShowVamcAlert] = useState(true);
 
-  const staticCovidStatuses = useStaticDrupalData(
-    'vamc-facility-supplemental-status',
-  );
-
-  const covidStatus = staticCovidStatuses.find(status => {
-    const activeCovidStatus = supplementalStatus?.find(activeStatus =>
-      activeStatus.id.includes('COVID'),
-    );
-
-    return status.status_id === activeCovidStatus?.id;
-  });
-
   useEffect(() => {
     connectFeatureToggle(store.dispatch);
     store.subscribe(() => {
@@ -38,6 +26,22 @@ const LocationCovidStatus = ({ supplementalStatus }) => {
       }
     });
   }, []);
+
+  const staticCovidStatuses = useStaticDrupalData(
+    'vamc-facility-supplemental-status',
+  );
+
+  if (!staticCovidStatuses) {
+    return <></>;
+  }
+
+  const covidStatus = staticCovidStatuses.find(status => {
+    const activeCovidStatus = supplementalStatus?.find(activeStatus =>
+      activeStatus.id.includes('COVID'),
+    );
+
+    return status.status_id === activeCovidStatus?.id;
+  });
 
   if (!covidStatus || !showVamcAlert) {
     return <></>;

--- a/src/platform/site-wide/hooks/static-drupal-data.js
+++ b/src/platform/site-wide/hooks/static-drupal-data.js
@@ -17,5 +17,5 @@ export default function useStaticDrupalData(file) {
     [file, API_ENDPOINT],
   );
 
-  return staticDrupalData;
+  return staticDrupalData || false;
 }

--- a/src/platform/site-wide/hooks/static-drupal-data.js
+++ b/src/platform/site-wide/hooks/static-drupal-data.js
@@ -4,17 +4,17 @@ import { useEffect, useState } from 'react';
 export default function useStaticDrupalData(file) {
   const [staticDrupalData, setStaticDrupalData] = useState([]);
 
-  const API_ENDPOINT = environment.isLocalhost()
+  const BASE_ENDPOINT = environment.isLocalhost()
     ? 'http://localhost:3002'
-    : environment.API_URL;
+    : environment.BASE_URL;
 
   useEffect(
     () => {
-      fetch(`${API_ENDPOINT}/data/cms/${file}.json`)
+      fetch(`${BASE_ENDPOINT}/data/cms/${file}.json`)
         .then(res => res.json())
         .then(data => setStaticDrupalData(data));
     },
-    [file, API_ENDPOINT],
+    [file, BASE_ENDPOINT],
   );
 
   return staticDrupalData || false;


### PR DESCRIPTION
## Description

The new hook for pulling static Drupal data should use the base URL instead of the API endpoint, since that's where the static data is being exposed. This PR also includes a fallback in case a similar data failure happens for this component so it fails gracefully without removing all the facility results.

## Original issue(s)

department-of-veterans-affairs/va.gov-cms#9320

## Testing done

Visual

## Screenshots

(With failing data endpoint)

<img width="1203" alt="Screen Shot 2022-06-06 at 9 58 19 AM" src="https://user-images.githubusercontent.com/10790736/172175913-39f4bc58-b0f4-42be-8236-2d29ba49f55e.png">


## Acceptance criteria

- [ ] Proper data endpoint is used for live environments
- [ ] Failing data endpoint still shows facility results

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
