### PR TITLE
Fix link text for MailMessage

### DIFF
--- a/src/applications/claims-status/components/MailMessage.jsx
+++ b/src/applications/claims-status/components/MailMessage.jsx
@@ -11,13 +11,12 @@ const mailMessage = (
       <li>Make copies of the documents.</li>
       <li>Make sure you write your name and claim number on every page.</li>
       <li>
-        Mail them to the{' '}
         <a
           target="_blank"
           rel="noopener noreferrer"
           href="http://www.benefits.va.gov/COMPENSATION/mailingaddresses.asp"
         >
-          VA Claims Intake Center.
+          Mail them to the VA Claims Intake Center.
         </a>
       </li>
     </ol>


### PR DESCRIPTION
## Original issue(s)
department-of-veterans-affairs/va.gov-team#41817

# Expected behavior
VA Claims Intake Center link text should include purpose e.g. mail them to to make the reason clear for screenreader users.

## Current behavior
Link text only includes "VA Claims Intake Center," lacking context for screen readers

## Your fix
Included the "Mail them to…" text in the link

## How has this been tested?
Visual confirmation

## Screenshots
<img width="637" alt="Screen Shot 2022-06-06 at 10 16 58 AM" src="https://user-images.githubusercontent.com/1094951/172179047-a34a44ed-553e-4493-bd25-7346b6e65d88.png">

## Acceptance criteria
- [x] Include "mail them to" text within the VA Claims Intake Center link
- [x] Tests passing

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
