### PR TITLE
[CST] Add the ability to mock fetching a list of claims

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -26,7 +26,7 @@ import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 import { mockApi } from '../tests/e2e/fixtures/mocks/mock-api';
 
 // NOTE: This should only be TRUE when developing locally
-const USE_MOCKS = environment.isLocalhost();
+const USE_MOCKS = environment.isLocalhost() && !window.Cypress;
 
 // -------------------- v2 and v1 -------------
 export const FETCH_APPEALS_SUCCESS = 'FETCH_APPEALS_SUCCESS';

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -31,8 +31,8 @@ import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 // Used to mock fetching a list of claims
 import mockClaimsList from '../tests/e2e/fixtures/mocks/claims-list.json';
 
-// NOTE: This should be FALSE when in production
-const USE_MOCKS = !environment.isProduction();
+// NOTE: This should only be TRUE when developing locally
+const USE_MOCKS = environment.isLocalhost();
 
 // -------------------- v2 and v1 -------------
 export const FETCH_APPEALS_SUCCESS = 'FETCH_APPEALS_SUCCESS';

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -24,11 +24,12 @@ import {
 } from '../utils/appeals-v2-helpers';
 import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 
-// Uncomment this import out, along with the code in `getClaimDetail`, then load
-// http://localhost:3001/track-claims/your-claims/600219085/status
-// import mockDetails from '../tests/e2e/fixtures/mocks/claim-detail.json';
+// Used to mock fetching the details for a specific claim
+// URL: http://localhost:3001/track-claims/your-claims/600219085/status
+import mockDetails from '../tests/e2e/fixtures/mocks/claim-detail.json';
 
 // Used to mock fetching a list of claims
+// URL: http://localhost:3001/track-claims/your-claims
 import mockClaimsList from '../tests/e2e/fixtures/mocks/claims-list.json';
 
 // NOTE: This should only be TRUE when developing locally
@@ -244,8 +245,7 @@ export function getClaimsV2(options = {}) {
     poll({
       onError: response => {
         if (USE_MOCKS) {
-          dispatch(fetchClaimsSuccess(mockClaimsList));
-          return;
+          return dispatch(fetchClaimsSuccess(mockClaimsList));
         }
 
         const errorCode = getErrorStatus(response);
@@ -272,7 +272,7 @@ export function getClaimsV2(options = {}) {
             error: errorCode,
           });
         }
-        dispatch({ type: FETCH_CLAIMS_ERROR });
+        return dispatch({ type: FETCH_CLAIMS_ERROR });
       },
       onSuccess: response => {
         recordClaimsAPIEvent({
@@ -329,22 +329,17 @@ export function getClaimDetail(id, router, poll = pollRequest) {
     });
     poll({
       onError: response => {
-        /* Claim status development
-           comment out the next block of code to access the claim status, file &
-           details tabs for development
-        /* * /
-        return dispatch({
-          type: SET_CLAIM_DETAIL,
-          claim: mockDetails.data,
-          meta: mockDetails.meta,
-        });
-        /* */
-        if (response.status !== 404 || !router) {
-          dispatch({ type: SET_CLAIMS_UNAVAILABLE });
-        } else {
-          router.replace('your-claims');
+        if (USE_MOCKS) {
+          return dispatch({
+            type: SET_CLAIM_DETAIL,
+            claim: mockDetails.data,
+            meta: mockDetails.meta,
+          });
         }
-        /* */
+
+        if (response.status !== 404 || !router)
+          return dispatch({ type: SET_CLAIMS_UNAVAILABLE });
+        return router.replace('your-claims');
       },
       onSuccess: response =>
         dispatch({

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -272,6 +272,7 @@ export function getClaimsV2(options = {}) {
             error: errorCode,
           });
         }
+
         return dispatch({ type: FETCH_CLAIMS_ERROR });
       },
       onSuccess: response => {
@@ -337,8 +338,10 @@ export function getClaimDetail(id, router, poll = pollRequest) {
           });
         }
 
-        if (response.status !== 404 || !router)
+        if (response.status !== 404 || !router) {
           return dispatch({ type: SET_CLAIMS_UNAVAILABLE });
+        }
+
         return router.replace('your-claims');
       },
       onSuccess: response =>

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -24,14 +24,6 @@ import {
 } from '../utils/appeals-v2-helpers';
 import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 
-// Used to mock fetching the details for a specific claim
-// URL: http://localhost:3001/track-claims/your-claims/600219085/status
-import mockDetails from '../tests/e2e/fixtures/mocks/claim-detail.json';
-
-// Used to mock fetching a list of claims
-// URL: http://localhost:3001/track-claims/your-claims
-import mockClaimsList from '../tests/e2e/fixtures/mocks/claims-list.json';
-
 // NOTE: This should only be TRUE when developing locally
 const USE_MOCKS = environment.isLocalhost();
 
@@ -245,7 +237,11 @@ export function getClaimsV2(options = {}) {
     poll({
       onError: response => {
         if (USE_MOCKS) {
-          return dispatch(fetchClaimsSuccess(mockClaimsList));
+          return import('../tests/e2e/fixtures/mocks/claims-list.json').then(
+            mockClaimsList => {
+              return dispatch(fetchClaimsSuccess(mockClaimsList));
+            },
+          );
         }
 
         const errorCode = getErrorStatus(response);
@@ -331,11 +327,15 @@ export function getClaimDetail(id, router, poll = pollRequest) {
     poll({
       onError: response => {
         if (USE_MOCKS) {
-          return dispatch({
-            type: SET_CLAIM_DETAIL,
-            claim: mockDetails.data,
-            meta: mockDetails.meta,
-          });
+          return import('../tests/e2e/fixtures/mocks/claim-detail.json').then(
+            mockDetails => {
+              return dispatch({
+                type: SET_CLAIM_DETAIL,
+                claim: mockDetails.data,
+                meta: mockDetails.meta,
+              });
+            },
+          );
         }
 
         if (response.status !== 404 || !router) {

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/claims-list.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/claims-list.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": 11,
+      "id": "189685",
       "type": "evss_claims",
       "attributes": {
         "evssId": 189685,
@@ -19,10 +19,10 @@
       }
     },
     {
-      "id": 12,
+      "id": "189686",
       "type": "evss_claims",
       "attributes": {
-        "evssId": 189685,
+        "evssId": 189686,
         "dateFiled": "2008-09-23",
         "minEstDate": "2013-05-02",
         "maxEstDate": "2014-01-02",

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claim-received.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claim-received.json
@@ -1,0 +1,170 @@
+{
+    "data": {
+        "id": "claim-received",
+        "type": "evss_claims",
+        "attributes": {
+            "evssId": 600308036,
+            "dateFiled": "2022-06-01",
+            "minEstDate": "2022-07-21",
+            "maxEstDate": "2022-08-19",
+            "phaseChangeDate": "2022-06-01",
+            "open": true,
+            "waiverSubmitted": false,
+            "documentsNeeded": false,
+            "developmentLetterSent": false,
+            "decisionLetterSent": false,
+            "phase": 1,
+            "everPhaseBack": false,
+            "currentPhaseBack": false,
+            "requestedDecision": false,
+            "claimType": "Dependency",
+            "updatedAt": "2022-06-08T14:18:59.888Z",
+            "contentionList": [],
+            "vaRepresentative": "AMERICAN LEGION",
+            "eventsTimeline": [
+                {
+                    "type": "filed",
+                    "date": "2022-06-01"
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                }
+            ]
+        }
+    },
+    "meta": {
+        "syncStatus": "SUCCESS"
+    }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims-list.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims-list.json
@@ -1,0 +1,117 @@
+{
+    "data": [
+      {
+        "id": "claim-received",
+        "type": "evss_claims",
+        "attributes": {
+          "evssId": 600308036,
+          "dateFiled": "2022-06-01",
+          "minEstDate": "2022-07-21",
+          "maxEstDate": "2022-08-19",
+          "phaseChangeDate": "2022-06-01",
+          "open": true,
+          "waiverSubmitted": false,
+          "documentsNeeded": false,
+          "developmentLetterSent": false,
+          "decisionLetterSent": false,
+          "phase": 1,
+          "everPhaseBack": false,
+          "currentPhaseBack": false,
+          "requestedDecision": false,
+          "claimType": "Dependency",
+          "updatedAt": "2022-06-08T14:18:59.888Z"
+        }
+      },
+      {
+        "id": "initial-review",
+        "type": "evss_claims",
+        "attributes": {
+          "evssId": 600282890,
+          "dateFiled": "2022-01-20",
+          "minEstDate": "2022-05-08",
+          "maxEstDate": "2022-07-26",
+          "phaseChangeDate": "2022-01-20",
+          "open": true,
+          "waiverSubmitted": false,
+          "documentsNeeded": false,
+          "developmentLetterSent": false,
+          "decisionLetterSent": false,
+          "phase": 2,
+          "everPhaseBack": false,
+          "currentPhaseBack": false,
+          "requestedDecision": false,
+          "claimType": "Compensation",
+          "updatedAt": "2022-06-08T14:20:30.112Z"
+        }
+      },
+      {
+        "id": "phase3",
+        "type": "evss_claims",
+        "attributes": {
+          "evssId": 18968500,
+          "dateFiled": "2021-09-16",
+          "minEstDate": null,
+          "maxEstDate": null,
+          "phaseChangeDate": "2021-09-19",
+          "open": true,
+          "waiverSubmitted": false,
+          "documentsNeeded": false,
+          "developmentLetterSent": false,
+          "decisionLetterSent": false,
+          "phase": 3,
+          "everPhaseBack": false,
+          "currentPhaseBack": false,
+          "requestedDecision": false,
+          "claimType": "Compensation",
+          "updatedAt": "2022-06-08T03:34:10.967Z"
+        }
+      },
+      {
+        "id": "decision-mailed",
+        "type": "evss_claims",
+        "attributes": {
+          "evssId": 600259072,
+          "dateFiled": "2021-09-16",
+          "minEstDate": null,
+          "maxEstDate": null,
+          "phaseChangeDate": "2021-09-17",
+          "open": false,
+          "waiverSubmitted": false,
+          "documentsNeeded": false,
+          "developmentLetterSent": false,
+          "decisionLetterSent": true,
+          "phase": 8,
+          "everPhaseBack": false,
+          "currentPhaseBack": false,
+          "requestedDecision": false,
+          "claimType": "Compensation",
+          "updatedAt": "2022-06-08T03:34:10.967Z"
+        }
+      },
+      {
+        "id": "closed",
+        "type": "evss_claims",
+        "attributes": {
+          "evssId": 600207281,
+          "dateFiled": "2020-09-29",
+          "minEstDate": null,
+          "maxEstDate": null,
+          "phaseChangeDate": "2021-01-22",
+          "open": false,
+          "waiverSubmitted": false,
+          "documentsNeeded": false,
+          "developmentLetterSent": false,
+          "decisionLetterSent": false,
+          "phase": 8,
+          "everPhaseBack": false,
+          "currentPhaseBack": false,
+          "requestedDecision": false,
+          "claimType": "Dependency",
+          "updatedAt": "2022-06-08T19:01:57.543Z"
+        }
+      }
+    ],
+    "meta": {
+      "syncStatus": "SUCCESS"
+    }
+  }

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/closed.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/closed.json
@@ -1,0 +1,178 @@
+{
+  "data": {
+    "id": "closed",
+    "type": "evss_claims",
+    "attributes": {
+      "evssId": 600207281,
+      "dateFiled": "2020-09-29",
+      "minEstDate": null,
+      "maxEstDate": null,
+      "phaseChangeDate": "2021-01-22",
+      "open": false,
+      "waiverSubmitted": false,
+      "documentsNeeded": false,
+      "developmentLetterSent": false,
+      "decisionLetterSent": false,
+      "phase": 8,
+      "everPhaseBack": false,
+      "currentPhaseBack": false,
+      "requestedDecision": false,
+      "claimType": "Dependency",
+      "updatedAt": "2022-06-08T19:01:57.543Z",
+      "contentionList": [],
+      "vaRepresentative": "AMERICAN LEGION",
+      "eventsTimeline": [
+        {
+          "type": "phase7",
+          "date": "2021-01-22"
+        },
+        {
+          "type": "completed",
+          "date": "2021-01-22"
+        },
+        {
+          "type": "filed",
+          "date": "2020-09-29"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "UNKNOWN",
+          "documentType": "UNKNOWN",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-0960C-1 Parkinsons Disease Disability Benefits Questionnaire",
+          "documentType": "L568",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Certificate of Release or Discharge From Active Duty (e.g. DD 214, NOAA 56-16, PHS 1867)",
+          "documentType": "L029",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "STR - Dental - Photocopy",
+          "documentType": "L450",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Military Personnel Record",
+          "documentType": "L034",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-674 Report of School Attendance",
+          "documentType": "L133",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-0781, Statement in Support of Claim for PTSD",
+          "documentType": "L228",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-8940 Veterans Application for Increased Compensation Based on Unemployability",
+          "documentType": "L149",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-0779 Request for Nursing Home Info In Connection with Claim for Aid and Attendance",
+          "documentType": "L222",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-4502 Application for Automobile or Other Conveyance and Adaptive Equipment Under 38 U.S.C. 3901-3904",
+          "documentType": "L117",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Military Personnel Record",
+          "documentType": "L034",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 28-1900 Disabled Veterans Application for Vocational Rehabilitation",
+          "documentType": "L162",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Military Personnel Record",
+          "documentType": "L034",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "STR - Medical - Photocopy",
+          "documentType": "L451",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Medical Treatment Record - Non-Government Facility",
+          "documentType": "L049",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        }
+      ]
+    }
+  },
+  "meta": {
+    "syncStatus": "SUCCESS"
+  }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/decision-mailed.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/decision-mailed.json
@@ -1,0 +1,167 @@
+{
+  "data": {
+    "id": "decision-mailed",
+    "type": "evss_claims",
+    "attributes": {
+      "evssId": 600259072,
+      "dateFiled": "2021-09-16",
+      "minEstDate": null,
+      "maxEstDate": null,
+      "phaseChangeDate": "2021-09-17",
+      "open": false,
+      "waiverSubmitted": false,
+      "documentsNeeded": false,
+      "developmentLetterSent": false,
+      "decisionLetterSent": true,
+      "phase": 8,
+      "everPhaseBack": false,
+      "currentPhaseBack": false,
+      "requestedDecision": false,
+      "claimType": "Compensation",
+      "updatedAt": "2022-06-08T03:34:10.967Z",
+      "contentionList": [],
+      "vaRepresentative": "AMERICAN LEGION",
+      "eventsTimeline": [
+        { "type": "phase7", "date": "2021-09-17" },
+        { "type": "completed", "date": "2021-09-17" },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-686c Application Request To Add And/Or Remove Dependents",
+          "documentType": "L139",
+          "filename": "Declaration Of Status Of Dependents_21-686c.pdf",
+          "uploadDate": "2021-09-16",
+          "type": "other_documents_list",
+          "date": "2021-09-16"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-674 Report of School Attendance",
+          "documentType": "L133",
+          "filename": "Application for Approval of School Attendance_21-674_Mike_Test - (w/d)andrew Jackson University (correspondence)withdrawn.pdf",
+          "uploadDate": "2021-09-16",
+          "type": "other_documents_list",
+          "date": "2021-09-16"
+        },
+        { "type": "filed", "date": "2021-09-16" },
+        {
+          "trackedItemId": null,
+          "fileType": "STR - Dental - Photocopy",
+          "documentType": "L450",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-526EZ, Fully Developed Claim (Compensation)",
+          "documentType": "L533",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Disability Benefits Questionnaire (DBQ) - Veteran Provided",
+          "documentType": "L702",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Birth Certificate",
+          "documentType": "L014",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Certificate of Release or Discharge From Active Duty (e.g. DD 214, NOAA 56-16, PHS 1867)",
+          "documentType": "L029",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Appeal Substitution Review",
+          "documentType": "L590",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Photographs",
+          "documentType": "L070",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Medical Treatment Record - Non-Government Facility",
+          "documentType": "L049",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "SSA Profile and Benefit Data",
+          "documentType": "L873",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 28-1900 Disabled Veterans Application for Vocational Rehabilitation",
+          "documentType": "L162",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-2680 Examination for Housebound Status or Permanent Need for Regular Aid and Attendance",
+          "documentType": "L102",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-8940 Veterans Application for Increased Compensation Based on Unemployability",
+          "documentType": "L149",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": null
+        }
+      ]
+    }
+  },
+  "meta": { "syncStatus": "SUCCESS" }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/index.js
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/index.js
@@ -1,0 +1,14 @@
+const getClaimList = () => {
+  return import('./claims-list.json');
+};
+
+const getClaimDetails = id => {
+  return import(`./${id}.json`).catch(() => {
+    return import('./phase3.json');
+  });
+};
+
+export const mockApi = {
+  getClaimDetails,
+  getClaimList,
+};

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/initial-review.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/initial-review.json
@@ -1,0 +1,176 @@
+{
+    "data": {
+        "id": "initial-review",
+        "type": "evss_claims",
+        "attributes": {
+            "evssId": 600282890,
+            "dateFiled": "2022-01-20",
+            "minEstDate": "2022-05-08",
+            "maxEstDate": "2022-07-26",
+            "phaseChangeDate": "2022-01-20",
+            "open": true,
+            "waiverSubmitted": false,
+            "documentsNeeded": false,
+            "developmentLetterSent": false,
+            "decisionLetterSent": false,
+            "phase": 2,
+            "everPhaseBack": false,
+            "currentPhaseBack": false,
+            "requestedDecision": false,
+            "claimType": "Compensation",
+            "updatedAt": "2022-06-08T14:20:30.112Z",
+            "contentionList": [
+                "lung condition (New)"
+            ],
+            "vaRepresentative": "AMERICAN LEGION",
+            "eventsTimeline": [
+                {
+                    "trackedItemId": null,
+                    "fileType": "VA 21-526EZ, Fully Developed Claim (Compensation)",
+                    "documentType": "L533",
+                    "filename": "CODY_GARZA_600282890_526.pdf",
+                    "uploadDate": "2022-01-20",
+                    "type": "other_documents_list",
+                    "date": "2022-01-20"
+                },
+                {
+                    "type": "phase1",
+                    "date": "2022-01-20"
+                },
+                {
+                    "type": "filed",
+                    "date": "2022-01-20"
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                },
+                {
+                    "trackedItemId": null,
+                    "fileType": "STR - Dental - Photocopy",
+                    "documentType": "L450",
+                    "filename": null,
+                    "uploadDate": null,
+                    "type": "other_documents_list",
+                    "date": null
+                }
+            ]
+        }
+    },
+    "meta": {
+        "syncStatus": "SUCCESS"
+    }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/phase3.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/phase3.json
@@ -1,0 +1,198 @@
+{
+  "data": {
+    "id": "phase3",
+    "type": "evss_claims",
+    "attributes": {
+      "evssId": 18968500,
+      "dateFiled": "2021-07-12",
+      "minEstDate": null,
+      "maxEstDate": "2022-02-02",
+      "phaseChangeDate": "2021-01-22",
+      "open": true,
+      "waiverSubmitted": false,
+      "documentsNeeded": false,
+      "developmentLetterSent": false,
+      "decisionLetterSent": false,
+      "phase": 3,
+      "everPhaseBack": false,
+      "currentPhaseBack": false,
+      "requestedDecision": false,
+      "claimType": "Compensation",
+      "updatedAt": "2022-03-14T18:57:22.614Z",
+      "contentionList": ["tinnitus (New)"],
+      "vaRepresentative": null,
+      "eventsTimeline": [
+        {
+          "type": "phase3",
+          "date": "2022-01-01"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "additional_info.pdf",
+          "uploadDate": "2022-01-05",
+          "type": "other_documents_list",
+          "date": "2022-01-05"
+        },
+        {
+          "type": "received_from_others_list",
+          "trackedItemId": 4,
+          "description": "What was received item two.",
+          "displayName": "Request 11",
+          "overdue": false,
+          "status": "ACCEPTED",
+          "uploaded": true,
+          "uploadsAllowed": false,
+          "openedDate": null,
+          "requestedDate": null,
+          "receivedDate": "2022-01-04",
+          "closedDate": null,
+          "suspenseDate": null,
+          "documents": [
+            {
+              "trackedItemId": 4,
+              "fileType": "Correspondence",
+              "documentType": "L102",
+              "filename": "name4.pdf",
+              "uploadDate": "2022-01-04"
+            },
+            {
+              "trackedItemId": 5,
+              "fileType": "Correspondence",
+              "documentType": "L023",
+              "filename": "benefits.pdf",
+              "uploadDate": "2021-08-22",
+              "type": "other_documents_list",
+              "date": "2022-01-04"
+            }
+          ],
+          "date": "2022-01-04"
+        },
+        {
+          "type": "phase2",
+          "date": "2022-01-01"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "Large_BDD_STR_Test_part_2_of_3.pdf",
+          "uploadDate": "2021-09-22",
+          "type": "other_documents_list",
+          "date": "2021-09-22"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "Large_BDD_STR_Test_part_1_of_3.pdf",
+          "uploadDate": "2021-09-22",
+          "type": "other_documents_list",
+          "date": "2021-09-22"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "Large_BDD_STR_Test_part_3_of_3.pdf",
+          "uploadDate": "2021-09-22",
+          "type": "other_documents_list",
+          "date": "2021-09-22"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-526EZ, Fully Developed Claim (Compensation)",
+          "documentType": "L533",
+          "filename": "CARA_BARTLETT_600219085_526.pdf",
+          "uploadDate": "2021-08-22",
+          "type": "other_documents_list",
+          "date": "2021-08-22"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "occupational_therapy.pdf",
+          "uploadDate": "2021-06-04",
+          "type": "other_documents_list",
+          "date": "2021-06-04"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "progress_note.pdf",
+          "uploadDate": "2021-04-15",
+          "type": "other_documents_list",
+          "date": "2021-04-15"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "physical_therapy.pdf",
+          "uploadDate": "2021-02-20",
+          "type": "other_documents_list",
+          "date": "2021-02-20"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "Doctor_note.pdf",
+          "uploadDate": "2021-02-20",
+          "type": "other_documents_list",
+          "date": "2021-02-20"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA 21-526EZ, Fully Developed Claim (Compensation)",
+          "documentType": "L533",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": "2021-02-10"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "Buddy / Lay Statement",
+          "documentType": "L015",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": "2021-02-10"
+        },
+        {
+          "type": "phase1",
+          "date": "2021-01-22"
+        },
+        {
+          "type": "filed",
+          "date": "2021-01-12"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA Form 21-4142 Authorization for Release of Information",
+          "documentType": "L107",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": "2021-01-06"
+        },
+        {
+          "trackedItemId": null,
+          "fileType": "VA Form 21-4142 Authorization for Release of Information",
+          "documentType": "L107",
+          "filename": null,
+          "uploadDate": null,
+          "type": "other_documents_list",
+          "date": "2021-01-06"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "syncStatus": "SUCCESS"
+  }
+}

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -4,12 +4,14 @@ const Timeouts = require('platform/testing/e2e/timeouts.js');
 class TrackClaimsPage {
   loadPage(claimsList, mock = null, submitForm = false) {
     if (submitForm) {
-      cy.intercept('POST', `/v0/evss_claims/11/request_decision`, {
+      cy.intercept('POST', `/v0/evss_claims/189685/request_decision`, {
         body: {},
       }).as('askVA');
     }
     if (mock) {
-      cy.intercept('GET', `/v0/evss_claims_async/11`, mock).as('detailRequest');
+      cy.intercept('GET', `/v0/evss_claims_async/189685`, mock).as(
+        'detailRequest',
+      );
     }
     cy.intercept('GET', '/v0/evss_claims_async', claimsList);
     cy.login();
@@ -84,7 +86,7 @@ class TrackClaimsPage {
     cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
       .click()
       .then(() => {
-        cy.url().should('contain', '/your-claims/11/status');
+        cy.url().should('contain', '/your-claims/189685/status');
       });
   }
 
@@ -119,7 +121,7 @@ class TrackClaimsPage {
         cy.injectAxeThenAxeCheck();
       });
 
-    cy.url().should('contain', '/your-claims/11/status');
+    cy.url().should('contain', '/your-claims/189685/status');
 
     // Disabled until COVID-19 message removed
     // cy.get('.claim-completion-desc').should('contain', 'We estimated your claim would be completed by now');
@@ -216,7 +218,7 @@ class TrackClaimsPage {
         cy.get('.claim-details').should('be.visible');
         cy.injectAxeThenAxeCheck();
       });
-    cy.url().should('contain', '/your-claims/11/details');
+    cy.url().should('contain', '/your-claims/189685/details');
   }
 
   verifyClaimDetails() {

--- a/src/platform/testing/e2e/cypress/support/commands/mockHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/mockHelpers.js
@@ -3,7 +3,7 @@ Cypress.Commands.add(
   (decisionLetterSent, documentsNeeded, waiverSubmitted, phase, estDate) => {
     return {
       data: {
-        id: '11',
+        id: '189685',
         type: 'evss_claims',
         attributes: {
           evssId: 189685,


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/42401

## Background
When attempting to view a list of claims in the claims status tool while doing local development, the api call made to retrieve the list of claims errors. This makes it impossible to view the list unless the developer either mocks the data in `vets-api` or `vets-website`. In `vets-website` we already have a set of fixtures that we use for testing; I think that it makes sense to utilize those fixtures to solve this problem.

## Build notes
* You should not need to use a specific staging user for this to work

## Steps to test
* Log in with any staging user
* Navigate to `localhost:3001/track-claims/your-claims`
* Scroll down to the section labeled `Your claims or appeals`
* You should see a list containing 2 claims
* Claims can be differentiated from appeals by the heading text. It should be `Claim for ...` for claims

## Code changes
* Adding a `USE_MOCKS` boolean that should be `true` when developing locally and `false` when in dev, staging and production
* Importing the `claims-list.json` file from our fixtures folder
* In `getClaimsV2`, we are using the `claims-list.json` content as part of a call to `fetchClaimsSuccess` in the `onError` callback. **Note:** Since the call to `vets-api` will always fail, we will end up in the `onError` callback

## How was your code tested
Tests continue to pass

## Acceptance criteria
- [x] Visiting `/track-claims/your-claims` should display a list of mocked claims