### PR TITLE
[VA-9324] Facility Locator COVID Unit Tests

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
+import useStaticDrupalData from 'platform/site-wide/hooks/static-drupal-data';
 import LocationPhoneLink from './common/LocationPhoneLink';
 import LocationDirectionsLink from './common/LocationDirectionsLink';
 import { isVADomain } from '../../utils/helpers';
@@ -28,6 +29,11 @@ const VaFacilityResult = ({
     },
     [index, location],
   );
+
+  const staticCovidStatuses = useStaticDrupalData(
+    'vamc-facility-supplemental-status',
+  );
+
   return (
     <div className="facility-result" id={location.id} key={location.id}>
       <>
@@ -54,6 +60,7 @@ const VaFacilityResult = ({
         {!!operatingStatus?.supplementalStatus?.length && (
           <LocationCovidStatus
             supplementalStatus={operatingStatus.supplementalStatus}
+            staticCovidStatuses={staticCovidStatuses}
           />
         )}
         <LocationAddress location={location} />

--- a/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import createCommonStore from 'platform/startup/store';
-import useStaticDrupalData from 'platform/site-wide/hooks/static-drupal-data';
 import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 import { FeatureToggleReducer } from 'platform/site-wide/feature-toggles/reducers';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
@@ -11,7 +10,7 @@ const store = createCommonStore({
   FeatureToggleReducer,
 });
 
-const LocationCovidStatus = ({ supplementalStatus }) => {
+const LocationCovidStatus = ({ supplementalStatus, staticCovidStatuses }) => {
   const [showVamcAlert, setShowVamcAlert] = useState(true);
 
   useEffect(() => {
@@ -26,10 +25,6 @@ const LocationCovidStatus = ({ supplementalStatus }) => {
       }
     });
   }, []);
-
-  const staticCovidStatuses = useStaticDrupalData(
-    'vamc-facility-supplemental-status',
-  );
 
   if (!staticCovidStatuses) {
     return <></>;
@@ -65,6 +60,7 @@ const LocationCovidStatus = ({ supplementalStatus }) => {
 };
 
 LocationCovidStatus.propTypes = {
+  staticCovidStatuses: PropTypes.array,
   supplementalStatus: PropTypes.array,
 };
 

--- a/src/applications/facility-locator/tests/components/search-results/common/LocationCovidStatus.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/common/LocationCovidStatus.unit.spec.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import LocationCovidStatus from '../../../../components/search-results-items/common/LocationCovidStatus';
+
+const covidSupplementalStatus = {
+  dataID: 'covid_high-message',
+  obj: [
+    {
+      id: 'COVID_HIGH',
+      label: 'COVID-19 health protection: Levels High',
+    },
+  ],
+};
+
+const staticCovidStatuses = [
+  {
+    description: '<p>COVID Low</p>',
+    name: 'COVID-19 health protection: Levels low',
+    // eslint-disable-next-line camelcase
+    status_id: 'COVID_LOW',
+  },
+  {
+    description: '<p>COVID Medium</p>',
+    name: 'COVID-19 health protection: Levels medium',
+    // eslint-disable-next-line camelcase
+    status_id: 'COVID_MEDIUM',
+  },
+  {
+    description: '<p>COVID High</p>',
+    name: 'COVID-19 health protection: Levels high',
+    // eslint-disable-next-line camelcase
+    status_id: 'COVID_HIGH',
+  },
+];
+
+describe('LocationCovidStatus', () => {
+  it('Should render the expected status', () => {
+    const covidStatus = covidSupplementalStatus;
+    const wrapper = shallow(
+      <LocationCovidStatus
+        supplementalStatus={covidStatus.obj}
+        staticCovidStatuses={staticCovidStatuses}
+      />,
+    );
+
+    expect(wrapper.find('va-alert-expandable').props()['data-testid']).to.eq(
+      covidStatus.dataID,
+    );
+    wrapper.unmount();
+  });
+
+  it('Should not render if there is no static data', () => {
+    const covidStatus = covidSupplementalStatus;
+    const wrapper = shallow(
+      <LocationCovidStatus
+        supplementalStatus={covidStatus.obj}
+        staticCovidStatuses={[]}
+      />,
+    );
+    expect(wrapper.find('va-alert-expandable')).to.be.empty;
+    wrapper.unmount();
+  });
+
+  it('Should not render if there is no matching statuses', () => {
+    const covidStatus = covidSupplementalStatus;
+    const fakeCovidStatus = [
+      {
+        description: '<p>COVID Sassafras</p>',
+        name: 'COVID-19 health protection: Levels Sassafras',
+        // eslint-disable-next-line camelcase
+        status_id: 'COVID_Sassafras',
+      },
+    ];
+
+    const wrapper = shallow(
+      <LocationCovidStatus
+        supplementalStatus={covidStatus.obj}
+        staticCovidStatuses={fakeCovidStatus}
+      />,
+    );
+    expect(wrapper.find('va-alert-expandable')).to.be.empty;
+    wrapper.unmount();
+  });
+
+  it('passes an axeCheck', () => {
+    const covidStatus = covidSupplementalStatus;
+
+    axeCheck(
+      <LocationCovidStatus
+        supplementalStatus={covidStatus.obj}
+        staticCovidStatuses={staticCovidStatuses}
+      />,
+    );
+  });
+});


### PR DESCRIPTION
## Description

This adds unit tests to the LocationCOVIDStatus component, as well as editing the component so it's more easily testable.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9324

## Testing done

Unit testing by running `npm test src/applications/facility-locator/tests/components/search-results/common/LocationCovidStatus.unit.spec.jsx`

## Screenshots

N/A

## Acceptance criteria

- [ ] All unit tests for the LocationCOVIDStatus component pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
