### PR TITLE
utilizes va-process-list component on COE intro

### DIFF
--- a/src/applications/lgy/coe/form/components/SubwayMap.jsx
+++ b/src/applications/lgy/coe/form/components/SubwayMap.jsx
@@ -1,114 +1,112 @@
 import React from 'react';
 
 const SubwayMap = () => (
-  <div className="process schemaform-process">
-    <ol>
-      <li className="process-step list-one">
-        <h3>Check your service requirements</h3>
+  <va-process-list class="vads-u-padding-bottom--0">
+    <li>
+      <h3>Check your service requirements</h3>
+      <p>
+        Make sure you meet our VA home loan eligibility requirements before you
+        request a COE. You may be able to get a COE if you:
+      </p>
+      <ul>
+        <li>
+          Didn’t receive a dishonorable discharge, <strong>and</strong>
+        </li>
+        <li>Meet the minimum service requirement based on when you served</li>
+      </ul>
+      <a href="/housing-assistance/home-loans/eligibility">
+        Eligibility requirements for VA home loan programs
+      </a>
+    </li>
+    <li>
+      <h3>Gather your information</h3>
+      <p>Here’s what you’ll need to request a COE:</p>
+      <ul>
+        <li>
+          Your Social Security number, date of birth and current contact
+          information.
+        </li>
+        <li>
+          The property location and dates of past VA loans (if you have or had a
+          VA-backed loan)
+        </li>
+        <li>
+          <strong>If you’re a Veteran,</strong> you’ll need a copy of your
+          discharge or separation papers (DD214).
+        </li>
+        <li>
+          <strong>If you’re an active-duty service member,</strong> you’ll need
+          a statement of service—signed by your commander, adjutant, or
+          personnel officer.
+        </li>
+        <li>
+          <strong>
+            If you’re a current or former activated National Guard or Reserve
+            member,
+          </strong>{' '}
+          you’ll need a copy of your discharge or separation papers (DD214).
+        </li>
+        <li>
+          <strong>
+            If you’re a current member of the National Guard or Reserves who’s
+            never been activated,
+          </strong>{' '}
+          you’ll need a statement of service—signed by your commander, adjutant,
+          or personnel officer.
+        </li>
+        <li>
+          <strong>
+            If you’re a discharged member of the National Guard and were never
+            activated,
+          </strong>{' '}
+          you’ll need your Report of Separation and Record of Service (NGB Form
+          22) and your Retirement Points Statement (NGB Form 23).
+        </li>
+        <li>
+          <strong>
+            If you’re a discharged member of the Reserves who has never been
+            activated,
+          </strong>{' '}
+          you’ll need a copy of your latest annual retirement points and proof
+          of your honorable service.
+        </li>
+      </ul>
+      <va-additional-info trigger="What’s a statement of service?">
         <p>
-          Make sure you meet our VA home loan eligibility requirements before
-          you request a COE. You may be able to get a COE if you:
+          A statement of service—signed by your commander, adjutant, or
+          personnel officer—is a letter showing this information:
         </p>
-        <ul>
-          <li>
-            Didn’t receive a dishonorable discharge, <strong>and</strong>
-          </li>
-          <li>Meet the minimum service requirement based on when you served</li>
+        <ul id="sos-info-list">
+          <li>Your full name</li>
+          <li>Your Social Security number</li>
+          <li>Your date of birth</li>
+          <li>The date you entered duty</li>
+          <li>Your total number of creditable years of service</li>
+          <li>The duration of any lost time</li>
+          <li>The name of the command providing the information</li>
         </ul>
-        <a href="/housing-assistance/home-loans/eligibility">
-          Eligibility requirements for VA home loan programs
-        </a>
-      </li>
-      <li className="process-step list-two">
-        <h3>Gather your information</h3>
-        <p>Here’s what you’ll need to request a COE:</p>
-        <ul>
-          <li>
-            Your Social Security number, date of birth and current contact
-            information.
-          </li>
-          <li>
-            The property location and dates of past VA loans (if you have or had
-            a VA-backed loan)
-          </li>
-          <li>
-            <strong>If you’re a Veteran,</strong> you’ll need a copy of your
-            discharge or separation papers (DD214).
-          </li>
-          <li>
-            <strong>If you’re an active-duty service member,</strong> you’ll
-            need a statement of service—signed by your commander, adjutant, or
-            personnel officer.
-          </li>
-          <li>
-            <strong>
-              If you’re a current or former activated National Guard or Reserve
-              member,
-            </strong>{' '}
-            you’ll need a copy of your discharge or separation papers (DD214).
-          </li>
-          <li>
-            <strong>
-              If you’re a current member of the National Guard or Reserves who’s
-              never been activated,
-            </strong>{' '}
-            you’ll need a statement of service—signed by your commander,
-            adjutant, or personnel officer.
-          </li>
-          <li>
-            <strong>
-              If you’re a discharged member of the National Guard and were never
-              activated,
-            </strong>{' '}
-            you’ll need your Report of Separation and Record of Service (NGB
-            Form 22) and your Retirement Points Statement (NGB Form 23).
-          </li>
-          <li>
-            <strong>
-              If you’re a discharged member of the Reserves who has never been
-              activated,
-            </strong>{' '}
-            you’ll need a copy of your latest annual retirement points and proof
-            of your honorable service.
-          </li>
-        </ul>
-        <va-additional-info trigger="What’s a statement of service?">
-          <p>
-            A statement of service—signed by your commander, adjutant, or
-            personnel officer—is a letter showing this information:
-          </p>
-          <ul id="sos-info-list">
-            <li>Your full name</li>
-            <li>Your Social Security number</li>
-            <li>Your date of birth</li>
-            <li>The date you entered duty</li>
-            <li>Your total number of creditable years of service</li>
-            <li>The duration of any lost time</li>
-            <li>The name of the command providing the information</li>
-          </ul>
-        </va-additional-info>
-      </li>
-      <li className="process-step list-three">
-        <h3>Start your request</h3>
-        <p>
-          Complete the form to request a VA home loan Certificate of
-          Eligibility. It should take about 15 minutes.
+      </va-additional-info>
+    </li>
+    <li className="vads-u-padding-bottom--3">
+      <h3>Start your request</h3>
+      <p>
+        Complete the form to request a VA home loan Certificate of Eligibility.
+        It should take about 15 minutes.
+      </p>
+      <va-additional-info trigger="What happens after I request a COE?">
+        <p className="vads-u-margin-bottom--0p5">
+          After submitting your request, you’ll get a confirmation message. It
+          will include details about your next steps. We may contact you if we
+          have questions or need more information.
+          <br />
+          <br />
+          We process requests in the order we receive them. If you qualify for a
+          Certificate of Eligibility, we’ll notify you by email about how you
+          can get your COE document.
         </p>
-        <va-additional-info trigger="What happens after I request a COE?">
-          <p className="vads-u-margin-bottom--0p5">
-            After submitting your request, you’ll get a confirmation message. It
-            will include details about your next steps. We may contact you if we
-            have questions or need more information.
-            <br />
-            <br />
-            We process requests in the order we receive them. If you qualify for
-            a Certificate of Eligibility, we’ll notify you by email about how
-            you can get your COE document.
-          </p>
-        </va-additional-info>
-      </li>
-    </ol>
-  </div>
+      </va-additional-info>
+    </li>
+  </va-process-list>
 );
 
 export default SubwayMap;

--- a/src/applications/lgy/coe/form/containers/introduction-content/loggedInContent.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/loggedInContent.jsx
@@ -25,10 +25,12 @@ const LoggedInContent = ({ route, status }) => (
       headingLevel={2}
     />
     {shouldShowHeader(status) && (
-      <h2>Follow these steps to request a VA home loan COE</h2>
+      <h2 className="vads-u-margin-top--5">
+        Follow these steps to request a VA home loan COE
+      </h2>
     )}
     <SubwayMap />
-    <div className="vads-u-margin-bottom--4">
+    <div className="vads-u-margin-bottom--5">
       <SaveInProgressIntro
         buttonOnly
         testActionLink

--- a/src/applications/lgy/coe/form/sass/coe.scss
+++ b/src/applications/lgy/coe/form/sass/coe.scss
@@ -2,7 +2,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "../../../../../platform/forms/sass/m-form-confirmation";
 @import "../../../../../platform/forms/sass/m-schemaform";
 


### PR DESCRIPTION
## Description

This swaps out the process list `ol` for the `va-process-list` web component. Additionally, this adjusts the vertical spacing surround the list utilizing utility classes to get as close as possible to the provided designs.


## Original issue(s)
resolves [department-of-veterans-affairs/va.gov-team#42355](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42355)

## Testing done
No relevant tests found, none added.

## Screenshots
<img width="575" alt="Update" src="https://user-images.githubusercontent.com/969752/172632399-3441c591-2205-4bd8-8704-d8027fa773e0.png">

## Acceptance criteria
- [x] Switch to use va-process-list
- [x] Adjust margins above and below the va-process-list as appropriate
- [x] Compare changes with design (if it can be found)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
