### PR TITLE
added proptypes, added logic to disable dropdown value

### DIFF
--- a/src/applications/gi/components/SearchBenefits.jsx
+++ b/src/applications/gi/components/SearchBenefits.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
-import Dropdown from './Dropdown';
-import LearnMoreLabel from './LearnMoreLabel';
+import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
+import PropTypes from 'prop-types';
+import LearnMoreLabel from './LearnMoreLabel';
+import Dropdown from './Dropdown';
 
 const SearchBenefits = ({
   cumulativeService,
@@ -21,7 +23,26 @@ const SearchBenefits = ({
   setMilitaryStatus,
   setSpouseActiveDuty,
 }) => {
+  const [isDisabled, setIsDisabled] = useState(true);
   const chapter33Check = giBillChapter === '33a' || giBillChapter === '33b';
+  const handleChange = e => {
+    const field = e.target.name;
+    const { value } = e.target;
+    recordEvent({
+      event: 'gibct-form-change',
+      'gibct-form-field': `What's your military status?`,
+      'gibct-form-value': e.target.value,
+    });
+    setMilitaryStatus(e.target.value);
+    if (!environment.isProduction() && field === 'militaryStatus') {
+      setIsDisabled(true);
+      if (value === 'spouse' || value === 'child') {
+        setIsDisabled(false);
+      }
+      // setGiBillChapter('33a');
+    }
+  };
+
   return (
     <div>
       <Dropdown
@@ -40,14 +61,7 @@ const SearchBenefits = ({
         value={militaryStatus}
         alt="What's your military status?"
         visible
-        onChange={e => {
-          recordEvent({
-            event: 'gibct-form-change',
-            'gibct-form-field': `What's your military status?`,
-            'gibct-form-value': e.target.value,
-          });
-          setMilitaryStatus(e.target.value);
-        }}
+        onChange={handleChange}
       />
 
       <Dropdown
@@ -93,11 +107,13 @@ const SearchBenefits = ({
             optionValue: '35',
             optionLabel:
               "Survivors' and Dependents' Educational Assistance (DEA) (Ch 35)",
+            optionDisabled: isDisabled,
           },
         ]}
         value={giBillChapter}
         alt="Which GI Bill benefit do you want to use?"
         visible
+        // disabled={isDisabled}
         onChange={e => {
           recordEvent({
             event: 'gibct-form-change',
@@ -233,4 +249,21 @@ const SearchBenefits = ({
   );
 };
 
+SearchBenefits.propTypes = {
+  cumulativeService: PropTypes.string,
+  dispatchShowModal: PropTypes.func,
+  eligForPostGiBill: PropTypes.string,
+  enlistmentService: PropTypes.string,
+  giBillChapter: PropTypes.string,
+  militaryStatus: PropTypes.string,
+  numberOfDependents: PropTypes.string,
+  setCumulativeService: PropTypes.func,
+  setEligForPostGiBill: PropTypes.func,
+  setEnlistmentService: PropTypes.func,
+  setGiBillChapter: PropTypes.func,
+  setMilitaryStatus: PropTypes.func,
+  setNumberOfDependents: PropTypes.func,
+  setSpouseActiveDuty: PropTypes.func,
+  spouseActiveDuty: PropTypes.string,
+};
 export default SearchBenefits;


### PR DESCRIPTION
## Description
The Search by location and search by name  filters currently allows Veterans/users to select Veteran, Active Duty, National Guard / Reserves from What's your military status? drop down and allow them to select "Survivors' and Dependents' Educational Assistance (DEA) (Ch 35) on the [search page](https://www.va.gov/education/gi-bill-comparison-tool/?search=name&name=Philippines%20).

Spouse and Child are the only options eligible for CH 35.

Please make sure to disable/grey-out Ch 35 if their first choice is NOT Spouse or Child.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#42472](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42472)


## Testing done
local environment

## Screenshots
<img width="1048" alt="Screen Shot 2022-06-08 at 1 40 22 PM" src="https://user-images.githubusercontent.com/18352271/172692486-26f74585-ebaa-458a-8168-f05f233a85ce.png">
<img width="1035" alt="Screen Shot 2022-06-08 at 1 40 40 PM" src="https://user-images.githubusercontent.com/18352271/172692497-97c0006a-0b46-4603-b775-9d77bd11b761.png">

## Acceptance criteria
- [ ] Disable/grey-out Ch 35 if their first choice is NOT Spouse or Child.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
