### PR TITLE
[VA-9366] Remove legacy events

### DIFF
--- a/src/applications/static-pages/events/components/App/index.js
+++ b/src/applications/static-pages/events/components/App/index.js
@@ -1,23 +1,10 @@
 // Node modules.
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 // Relative imports.
 import Events from '../Events';
-import { hideLegacyEvents, showLegacyEvents } from '../../helpers';
 
-export const App = ({ rawEvents, showEventsV2 }) => {
-  // If the feature toggle is disabled, do not render.
-  if (!showEventsV2) {
-    // Ensure the legacy liquid page has display: flex.
-    showLegacyEvents();
-
-    // Escape early and do not render.
-    return null;
-  }
-  // Ensure the legacy liquid page has display: none.
-  hideLegacyEvents();
-  // Show the events listing page v2.
+export const App = ({ rawEvents }) => {
   return <Events rawEvents={rawEvents} />;
 };
 
@@ -41,15 +28,6 @@ App.propTypes = {
       title: PropTypes.string,
     }),
   ).isRequired,
-  // From mapStateToProps.
-  showEventsV2: PropTypes.bool,
 };
 
-const mapStateToProps = state => ({
-  showEventsV2: state?.featureToggles?.showEventsV2,
-});
-
-export default connect(
-  mapStateToProps,
-  null,
-)(App);
+export default App;

--- a/src/applications/static-pages/events/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/App/index.unit.spec.js
@@ -6,20 +6,9 @@ import { shallow } from 'enzyme';
 import { App } from '.';
 
 describe('Events <App>', () => {
-  it('does not render when feature toggle disabled', () => {
+  it('renders what we expect', () => {
     // Set up.
     const wrapper = shallow(<App />);
-
-    // Assertions.
-    expect(wrapper.type()).to.equal(null);
-
-    // Clean up.
-    wrapper.unmount();
-  });
-
-  it('renders what we expect with feature toggle enabled', () => {
-    // Set up.
-    const wrapper = shallow(<App showEventsV2 />);
 
     // Assertions.
     expect(wrapper.find('Events')).to.have.length(1);

--- a/src/applications/static-pages/events/helpers/index.js
+++ b/src/applications/static-pages/events/helpers/index.js
@@ -314,46 +314,6 @@ export const deriveEventLocations = event => {
   return locations;
 };
 
-export const hideLegacyEvents = () => {
-  // Derive the legacy events page.
-  const legacyEvents = document.querySelector('div[id="events-v1"]');
-  // Show the new header.
-  const eventsv2Header = document.querySelector('.events-v2');
-  eventsv2Header?.classList.remove('vads-u-display--none');
-  if (!eventsv2Header?.classList.contains('vads-u-display--flex')) {
-    eventsv2Header?.classList.add('vads-u-display--flex');
-  }
-  // Escape early if the legacy events page doesn't exist.
-  if (!legacyEvents) {
-    return;
-  }
-  // Add `vads-u-display--none` to the legacy events page if it doesn't already have it.
-  if (!legacyEvents.classList.contains('vads-u-display--none')) {
-    legacyEvents.classList.add('vads-u-display--none');
-  }
-};
-
-export const showLegacyEvents = () => {
-  // Derive the legacy events page.
-  const legacyEvents = document.querySelector('div[id="events-v1"]');
-  // Hide the new header.
-  const eventsv2Header = document.querySelector('.events-v2');
-  eventsv2Header?.classList.remove('vads-u-display--flex');
-  if (!eventsv2Header?.classList.contains('vads-u-display--none')) {
-    eventsv2Header?.classList.add('vads-u-display--none');
-  }
-
-  // Escape early if the legacy events page doesn't exist.
-  if (!legacyEvents) {
-    return;
-  }
-
-  // Add `vads-u-display--none` to the legacy events page if it doesn't already have it.
-  if (legacyEvents.classList.contains('vads-u-display--none')) {
-    legacyEvents.classList.remove('vads-u-display--none');
-  }
-};
-
 export const updateQueryParams = (queryParamsLookup = {}) => {
   // Derive the query params on the URL.
   const queryParams = new URLSearchParams(window.location.search);

--- a/src/applications/static-pages/events/helpers/index.unit.spec.js
+++ b/src/applications/static-pages/events/helpers/index.unit.spec.js
@@ -9,8 +9,6 @@ import {
   deriveStartsAtUnix,
   filterByOptions,
   filterEvents,
-  hideLegacyEvents,
-  showLegacyEvents,
 } from '.';
 
 describe('deriveMostRecentDate', () => {
@@ -316,17 +314,5 @@ describe('deriveEventLocations', () => {
         fieldAddress: { locality: 'foo', administrativeArea: 'bar' },
       }),
     ).to.deep.equal(['foo, bar']);
-  });
-});
-
-describe('hideLegacyEvents', () => {
-  it('returns what we expect with no arguments', () => {
-    expect(hideLegacyEvents()).to.equal(undefined);
-  });
-});
-
-describe('showLegacyEvents', () => {
-  it('returns what we expect with no arguments', () => {
-    expect(showLegacyEvents()).to.equal(undefined);
   });
 });

--- a/src/platform/polyfills/index.js
+++ b/src/platform/polyfills/index.js
@@ -28,7 +28,7 @@ if (navigator.userAgent.includes('Edge/14')) {
       cancelable: false,
       detail: null,
     };
-    const evt = document.createEvent('CustomEvent');
+    const evt = document?.createEvent('CustomEvent');
     evt.initCustomEvent(
       event,
       customParams.bubbles,

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -64,7 +64,6 @@ const responses = {
     data: {
       type: 'feature_toggles',
       features: [
-        { name: 'showEventsV2', value: true },
         { name: 'showExpandableVamcAlert', value: true },
         { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -105,7 +105,6 @@ export default Object.freeze({
   showFinancialStatusReport: 'show_financial_status_report',
   showFinancialStatusReportWizard: 'show_financial_status_report_wizard',
   showFormI18n: 'show_form_i18n',
-  showEventsV2: 'show_events_v2',
   showMebMockEndpoints: 'show_meb_mock_endpoints',
   showUpdatedToeApp: 'show_updated_toe_app',
   showMedicalCopays: 'show_medical_copays',
@@ -124,7 +123,7 @@ export default Object.freeze({
   subform89404192: 'subform_8940_4192',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
   vaGlobalDowntimeNotification: 'va_global_downtime_notification',
-  vaHomePreview: 
+  vaHomePreview:
   'va_home_preview',
   vaOnlineFacilitySelectionV22: 'va_online_scheduling_facility_selection_v2_2',
   vaOnlineScheduling: 'va_online_scheduling',


### PR DESCRIPTION
## Description

Events V2 is up and running, and legacy events need to go. This closes #9366.

## Original issue(s)

department-of-veterans-affairs/va.gov-cms#9366

## Testing done

Visual

## Screenshots

<img width="1124" alt="Screen Shot 2022-06-08 at 2 37 29 PM" src="https://user-images.githubusercontent.com/10790736/172692244-6fcf2ec9-61f8-4cb5-9deb-918f4dc08e19.png">


## Acceptance criteria

- [ ] Events and filters are visible here `alaska-health-care/events/` and here `outreach-and-events/events/`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
