### PR TITLE
benefit defaults to ch33 anytime military status changes.

### DIFF
--- a/src/applications/gi/components/SearchBenefits.jsx
+++ b/src/applications/gi/components/SearchBenefits.jsx
@@ -39,7 +39,7 @@ const SearchBenefits = ({
       if (value === 'spouse' || value === 'child') {
         setIsDisabled(false);
       }
-      // setGiBillChapter('33a');
+      setGiBillChapter('33a');
     }
   };
 
@@ -113,7 +113,6 @@ const SearchBenefits = ({
         value={giBillChapter}
         alt="Which GI Bill benefit do you want to use?"
         visible
-        // disabled={isDisabled}
         onChange={e => {
           recordEvent({
             event: 'gibct-form-change',


### PR DESCRIPTION
## Description
When the military status is changed. The benefit type should default to Post 9/11 Gi-Bill on the in search by name page.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#42475](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42475)

## Testing done
local environment

## Acceptance criteria
- [ ] Benefit resets to ch33a anytime military status changes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
