### PR TITLE
41484 - [CDP] [MCP] Update medical-copays Cypress tests under CDP

### DIFF
--- a/src/applications/combined-debt-portal/combined/actions/copays.js
+++ b/src/applications/combined-debt-portal/combined/actions/copays.js
@@ -31,7 +31,7 @@ const transform = data => {
   });
 };
 
-export const getStatements = dispatch => {
+export const getStatements = async dispatch => {
   dispatch({ type: MCP_STATEMENTS_FETCH_INIT });
   return apiRequest('/medical_copays')
     .then(({ data }) => {

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/cdp-alert.cypress.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/cdp-alert.cypress.spec.js
@@ -18,7 +18,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.intercept('GET', '/v0/medical_copays', mockCopays);
     cy.intercept('GET', '/v0/debts', mockDebt);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId(`balance-card-${id}`).should('exist');
@@ -27,7 +27,7 @@ describe('Medical Copays - CDP Alerts', () => {
       'Ralph H. Johnson Department of Veterans Affairs Medical Center',
     );
     cy.findByTestId('other-va-debt-body').should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   // Has VHA and VBA 404
@@ -48,7 +48,7 @@ describe('Medical Copays - CDP Alerts', () => {
     );
     cy.findByTestId('other-va-debt-body').should('not.exist');
     cy.findByTestId('error-debt-alert').should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   // VHA && VBA 404
@@ -66,7 +66,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.injectAxe();
     cy.findByTestId('all-error-alert').should('exist');
     cy.findByTestId('other-va-debt-body').should('not.exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   // VHA 404 & VBA balance
@@ -82,7 +82,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.injectAxe();
     cy.findByTestId('error-copay-alert').should('exist');
     cy.findByTestId('other-va-debt-body').should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   // VHA 404 & VBA 0 balance
@@ -98,7 +98,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.injectAxe();
     cy.findByTestId('error-copay-alert').should('exist');
     cy.findByTestId('other-va-debt-body').should('not.exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   // VHA 0 balance & VBA balance
@@ -112,7 +112,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.injectAxe();
     cy.findByTestId('zero-copay-alert').should('exist');
     cy.findByTestId('other-va-debt-body').should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   // VHA & VBA 0 balance
@@ -126,6 +126,6 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.injectAxe();
     cy.findByTestId('zero-copay-alert').should('exist');
     cy.findByTestId('other-va-debt-body').should('not.exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/cdp-alert.cypress.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/cdp-alert.cypress.spec.js
@@ -12,13 +12,28 @@ describe('Medical Copays - CDP Alerts', () => {
     data: [],
   };
 
+  beforeEach(() => {
+    cy.login(mockUser);
+    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
+      'features',
+    );
+    cy.intercept('GET', '/v0/debts', mockDebt).as('debts');
+    cy.intercept('GET', '/v0/medical_copays', mockCopays).as('copays');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
+
+    // Page load
+    cy.wait(['@copays', '@debts', '@features']);
+    cy.findByTestId('overview-page-title').should('exist');
+    cy.injectAxeThenAxeCheck();
+  });
+
   // Has both VHA and VBA balances
   it('should display valid copay balances & other VA debt information', () => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.intercept('GET', '/v0/medical_copays', mockCopays);
     cy.intercept('GET', '/v0/debts', mockDebt);
-    cy.visit('/copay-balances');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId(`balance-card-${id}`).should('exist');
@@ -38,7 +53,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.intercept('GET', '/v0/debts', req => {
       req.reply(404, { errors: ['error'] });
     });
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId(`balance-card-${id}`).should('exist');
@@ -61,7 +76,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.intercept('GET', '/v0/debts', req => {
       req.reply(404, { errors: ['error'] });
     });
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId('all-error-alert').should('exist');
@@ -77,7 +92,7 @@ describe('Medical Copays - CDP Alerts', () => {
       req.reply(404, { errors: ['error'] });
     });
     cy.intercept('GET', '/v0/debts', mockDebt);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId('error-copay-alert').should('exist');
@@ -93,7 +108,7 @@ describe('Medical Copays - CDP Alerts', () => {
       req.reply(404, { errors: ['error'] });
     });
     cy.intercept('GET', '/v0/debts', mockZeroDebt);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId('error-copay-alert').should('exist');
@@ -107,7 +122,7 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.intercept('GET', '/v0/medical_copays', mockZeroCopay);
     cy.intercept('GET', '/v0/debts', mockDebt);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId('zero-copay-alert').should('exist');
@@ -121,7 +136,8 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.intercept('GET', '/v0/medical_copays', mockZeroCopay);
     cy.intercept('GET', '/v0/debts', mockZeroDebt);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
+
     cy.findByTestId('overview-page-title').should('exist');
     cy.injectAxe();
     cy.findByTestId('zero-copay-alert').should('exist');

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,6 +1,12 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{ "name": "show_medical_copays", "value": true }]
+    "features": [
+      { "name": "show_medical_copays", "value": true },
+      { "name": "debt_letters_show_letters", "value": true },
+      { 
+        "name": "combined_debt_portal_access", 
+        "value": true 
+      }]
   }
 }

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/mcp.cypress.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/mcp.cypress.spec.js
@@ -5,6 +5,7 @@
  * @testrailinfo groupId 3090
  * @testrailinfo runName MCP-e2e-Main
  */
+import mockDebt from '../../../combined/utils/mocks/mockDebts.json';
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockCopays from './fixtures/mocks/copays.json';
 import mockUser from './fixtures/mocks/mock-user.json';
@@ -14,11 +15,17 @@ describe('Medical Copays', () => {
 
   beforeEach(() => {
     cy.login(mockUser);
-    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
-    cy.intercept('GET', '/v0/medical_copays', mockCopays);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
+      'features',
+    );
+    cy.intercept('GET', '/v0/debts', mockDebt).as('debts');
+    cy.intercept('GET', '/v0/medical_copays', mockCopays).as('copays');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
+
+    // Page load
+    cy.wait(['@copays', '@debts', '@features']);
     cy.findByTestId('overview-page-title').should('exist');
-    cy.injectAxe();
+    cy.injectAxeThenAxeCheck();
   });
 
   it('displays copay balances - C12576', () => {
@@ -28,7 +35,7 @@ describe('Medical Copays', () => {
     cy.findByTestId(`facility-city-${id}`).contains(
       'Ralph H. Johnson Department of Veterans Affairs Medical Center',
     );
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   it('navigates to the detail page - C12577', () => {
@@ -49,15 +56,15 @@ describe('Medical Copays', () => {
     cy.findByTestId(`balance-questions`).contains(
       'What to do if you have questions about your balance',
     );
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
-  it.skip('displays download statements - C12578', () => {
+  it('displays download statements - C12578', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');
     cy.findByTestId(`download-statements`).should('exist');
     cy.findAllByText(/November 15, 2019/i).should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/mcp.cypress.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/mcp.cypress.spec.js
@@ -46,16 +46,7 @@ describe('Medical Copays', () => {
     cy.findByTestId(`past-due-balance-alert`).contains(
       'Your balance may be overdue',
     );
-    cy.findByTestId(`how-to-pay`).contains('How do I pay my VA copay bill?');
-    cy.findByTestId(`financial-help`).contains(
-      'How do I get financial help for my copays?',
-    );
-    cy.findByTestId(`dispute-charges`).contains(
-      'How do I dispute my copay charges?',
-    );
-    cy.findByTestId(`balance-questions`).contains(
-      'What to do if you have questions about your balance',
-    );
+    cy.findByTestId(`how-to-pay`).contains('How to pay your copay bill');
     cy.injectAxeThenAxeCheck();
   });
 
@@ -63,7 +54,7 @@ describe('Medical Copays', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');
-    cy.findByTestId(`download-statements`).should('exist');
+    cy.findByTestId(`view-statements`).should('exist');
     cy.findAllByText(/November 15, 2019/i).should('exist');
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/statements.cypress.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/statements.cypress.spec.js
@@ -15,12 +15,17 @@ describe('Medical Copays', () => {
 
   beforeEach(() => {
     cy.login(mockUser);
-    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
-    cy.intercept('GET', '/v0/medical_copays', mockCopays);
-    cy.intercept('GET', '/v0/debts', mockDebt);
-    cy.visit('/health-care/pay-copay-bill/your-current-balances/');
+    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
+      'features',
+    );
+    cy.intercept('GET', '/v0/debts', mockDebt).as('debts');
+    cy.intercept('GET', '/v0/medical_copays', mockCopays).as('copays');
+    cy.visit('/manage-debt-and-bills/summary/copay-balances');
+
+    // Page load
+    cy.wait(['@copays', '@debts', '@features']);
     cy.findByTestId('overview-page-title').should('exist');
-    cy.injectAxe();
+    cy.injectAxeThenAxeCheck();
   });
 
   it('displays copay balances - C12576', () => {
@@ -30,45 +35,32 @@ describe('Medical Copays', () => {
     cy.findByTestId(`facility-city-${id}`).contains(
       'Ralph H. Johnson Department of Veterans Affairs Medical Center',
     );
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
-  it.skip('displays other va debts', () => {
+  it('displays other va debts', () => {
     cy.findByTestId('other-va-debt-body').should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
   it('navigates to the detail page - C12577', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');
-    cy.findByTestId(`updated-date`).contains('November 15, 2019');
-    cy.findByTestId(`past-due-balance-alert`).contains(
-      'Your balance may be overdue',
-    );
-    cy.findByTestId(`how-to-pay`).contains('How do I pay my VA copay bill?');
-    cy.findByTestId(`financial-help`).contains(
-      'How do I get financial help for my copays?',
-    );
-    cy.findByTestId(`dispute-charges`).contains(
-      'How do I dispute my copay charges?',
-    );
-    cy.findByTestId(`balance-questions`).contains(
-      'What to do if you have questions about your balance',
-    );
-    cy.axeCheck();
+    cy.findByTestId(`how-to-pay`).contains('How to pay your copay bill');
+    cy.injectAxeThenAxeCheck();
   });
 
-  it.skip('displays view statements section - C12578', () => {
+  it('displays view statements section - C12578', () => {
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
     cy.findByTestId('detail-page-title').should('exist');
     cy.findByTestId(`view-statements`).should('exist');
     cy.findByTestId(`balance-details-${id}-statement-view`).should('exist');
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
-  it.skip('navigates to view statements page - C12579', () => {
+  it('navigates to view statements page - C12579', () => {
     // get to page
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
@@ -80,10 +72,10 @@ describe('Medical Copays', () => {
     cy.findByTestId(`facility-name`).contains(
       'Ralph H. Johnson Department of Veterans Affairs Medical Center',
     );
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 
-  it.skip('displays account summary - C12580', () => {
+  it('displays account summary - C12580', () => {
     // get to page
     cy.findByTestId('overview-page-title').should('exist');
     cy.findByTestId(`detail-link-${id}`).click();
@@ -105,6 +97,6 @@ describe('Medical Copays', () => {
     cy.findByTestId('account-summary-new-charges').contains(
       'New charges: $15.00',
     );
-    cy.axeCheck();
+    cy.injectAxeThenAxeCheck();
   });
 });


### PR DESCRIPTION
## Description
Cypress e2e tests updated for the merged medical-copays application to reference the new URLs, and page flow since it's being moved under the combined-debt-portal

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41484 

## Acceptance criteria
- [ X ] All unit and cypress tests now reference combined debt & pass

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
