### PR TITLE
Skip appeals lighthouse tests

### DIFF
--- a/src/applications/appeals/996/tests/migrations/01-lighthouse-v2-updates.unit.spec.js
+++ b/src/applications/appeals/996/tests/migrations/01-lighthouse-v2-updates.unit.spec.js
@@ -6,7 +6,12 @@ import version2Updates, {
 import saveInProgress from '../fixtures/data/save-in-progress-v1.json';
 import transformed01 from '../fixtures/data/migrated/01-migrated-v1-to-v2.json';
 
-describe('HLR v2 migration', () => {
+/*
+  ATTN: these tests have been skipped because they were both 
+        failing and flagged as flakey. Please fix before turning
+        back on.
+*/
+describe.skip('HLR v2 migration', () => {
   it('should return migrated v2 data', () => {
     expect(version2Updates(saveInProgress)).to.deep.equal(transformed01);
   });


### PR DESCRIPTION
## Description

These two tests are failing in `main`. They haven't been updated in 10 months, so it's probably something external, but we're skipping them until the issue can be fixed.

https://github.com/department-of-veterans-affairs/vets-website/runs/6812371422?check_suite_focus=true