### PR TITLE
34177 - 508-defect-3 [SEMANTIC MARKUP]: Download link for statements should have download attribute and should not open in a new tab

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
@@ -30,7 +30,7 @@ const DownloadStatement = ({ statementId, statementDate, fullName }) => {
       <div className="vads-u-margin-top--2">
         <a
           onClick={() => handleDownloadClick(statementDate)}
-          target="_blank"
+          download={downloadFileName}
           href={pdfStatementUri}
           type="application/pdf"
           rel="noreferrer"


### PR DESCRIPTION
## Description
Updated component to not open in new page by removal of target and added requested download attribute per Platform suggestion.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#34177

## Acceptance criteria
- [ X ] Download attribute added
- [ X ] Target blank removed

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
