### PR TITLE
[VA-9384] Fix bug with event filter switching

### DIFF
--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -64,10 +64,6 @@ export const Search = ({ onSearch }) => {
   const [fullDateError, setFullDateError] = useState(false);
 
   const updatefullDateValue = (dateVal, position) => {
-    if (!dateVal) {
-      return null;
-    }
-
     const isInvalidDateRange = dateCheck => {
       const enoughCharacters = dateCheck.split('').length === 10;
       const enoughFields = dateCheck.split('-').length === 3;
@@ -75,7 +71,7 @@ export const Search = ({ onSearch }) => {
       return !enoughCharacters || !enoughFields;
     };
 
-    if (isInvalidDateRange(dateVal)) {
+    if (!dateVal || isInvalidDateRange(dateVal)) {
       return null;
     }
 
@@ -99,8 +95,13 @@ export const Search = ({ onSearch }) => {
     setEndDateFull(getFullDate(endDateDay, endDateMonth, endDateYear));
   }, []);
 
-  useEffect(() => updatefullDateValue(startDateFull, 'start'), [startDateFull]);
-  useEffect(() => updatefullDateValue(endDateFull, 'end'), [endDateFull]);
+  useEffect(
+    () => {
+      updatefullDateValue(startDateFull, 'start');
+      updatefullDateValue(endDateFull, 'end');
+    },
+    [selectedOption, startDateFull, endDateFull],
+  );
 
   const onFilterByChange = event => {
     const filterByOption = filterByOptions?.find(


### PR DESCRIPTION
## Description

The events filter is throwing errors when switching between searches with Specific Date and Custom Date Range. There were error bars with no updated results but no error messages.

The technical cause of the issue was the filters would show the full date in the form fields, but the full component state wasn't being updated properly. The date field would appear filled out but it wasn't being used to update the data as needed to do the filtering. This fix makes sure that anytime the type of filtering or either date field is updated, everything else is updated as needed.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9384

## Testing done

Visual

## Screenshots

https://user-images.githubusercontent.com/10790736/172878197-6982ab9f-961a-4e6e-b89d-eb0e3fa84321.mov

## Acceptance criteria

- [ ] Switching between date filters always results in correct on screen errors and filter result text.
- [ ] Switching between date filters and Past / upcoming events filters, and back to date filters, always results in correct on screen errors and filter result text.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


