### PR TITLE
Add telephone appointment feature toggle for check-in application

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -63,7 +63,7 @@ const generateFeatureToggles = (toggles = {}) => {
           value: checkInExperienceEditMessagingEnabled,
         },
         {
-          name: 'check_in_experience_phone_appointments',
+          name: 'check_in_experience_phone_appointments_enabled',
           value: checkInExperiencePhoneAppointmentsEnabled,
         },
       ],

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -11,6 +11,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceDayOfDemographicsFlagsEnabled = true,
     checkInExperienceLorotaSecurityUpdatesEnabled = false,
     checkInExperienceEditMessagingEnabled = false,
+    checkInExperiencePhoneAppointmentsEnabled = false,
   } = toggles;
 
   return {
@@ -60,6 +61,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'check_in_experience_edit_messaging_enabled',
           value: checkInExperienceEditMessagingEnabled,
+        },
+        {
+          name: 'check_in_experience_phone_appointments',
+          value: checkInExperiencePhoneAppointmentsEnabled,
         },
       ],
     },

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -153,7 +153,7 @@ Though we have the HOC, its now considered best practice to query redux using th
 - `check_in_experience_edit_messaging_enabled` : Enables or disables edit messaging.
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
 - `check_in_experience_phone_appointments_enabled` : Enables or disables telephone appointments as an alternate type to in-person
-  - when to sunset: once we have successfully tested this geature in production with users
+  - when to sunset: once we have successfully tested this feature in production with users
 
 ### How to test this?
 

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -152,6 +152,8 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
 - `check_in_experience_edit_messaging_enabled` : Enables or disables edit messaging.
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
+- `check_in_experience_phone_appointments_enabled` : Enables or disables telephone appointments as an alternate type to in-person
+  - when to sunset: once we have successfully tested this geature in production with users
 
 ### How to test this?
 

--- a/src/applications/check-in/pre-check-in/README.md
+++ b/src/applications/check-in/pre-check-in/README.md
@@ -101,6 +101,8 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
 - `check_in_experience_edit_messaging_enabled` : Enables or disables edit messaging.
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
+- `check_in_experience_phone_appointments_enabled` : Enables or disables telephone appointments as an alternate type to in-person
+  - when to sunset: once we have successfully tested this geature in production with users
 
 ### How to test this?
 

--- a/src/applications/check-in/pre-check-in/README.md
+++ b/src/applications/check-in/pre-check-in/README.md
@@ -102,7 +102,7 @@ Though we have the HOC, its now considered best practice to query redux using th
 - `check_in_experience_edit_messaging_enabled` : Enables or disables edit messaging.
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
 - `check_in_experience_phone_appointments_enabled` : Enables or disables telephone appointments as an alternate type to in-person
-  - when to sunset: once we have successfully tested this geature in production with users
+  - when to sunset: once we have successfully tested this feature in production with users
 
 ### How to test this?
 

--- a/src/applications/check-in/utils/selectors/feature-toggles.js
+++ b/src/applications/check-in/utils/selectors/feature-toggles.js
@@ -39,6 +39,9 @@ const selectFeatureToggles = createSelector(
     isEditMessagingEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.checkInExperienceEditMessagingEnabled
     ],
+    isPhoneAppointmentsEnabled: toggleValues(state)[
+      FEATURE_FLAG_NAMES.checkInExperiencePhoneAppointmentsEnabled
+    ],
   }),
   toggles => toggles,
 );

--- a/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
+++ b/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
@@ -20,6 +20,7 @@ describe('check-in', () => {
         check_in_experience_day_of_demographics_flags_enabled: false,
         check_in_experience_lorota_security_updates_enabled: false,
         check_in_experience_edit_messaging_enabled: false,
+        check_in_experience_phone_appointments_enabled: false,
         loading: false,
       },
     };
@@ -40,6 +41,7 @@ describe('check-in', () => {
           isDayOfDemographicsFlagsEnabled: false,
           isLorotaSecurityUpdatesEnabled: false,
           isEditMessagingEnabled: false,
+          isPhoneAppointmentsEnabled: false,
         });
       });
     });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -24,6 +24,7 @@ export default Object.freeze({
   checkInExperienceDayOfDemographicsFlagsEnabled: 'check_in_experience_day_of_demographics_flags_enabled',
   checkInExperienceLorotaSecurityUpdatesEnabled: 'check_in_experience_lorota_security_updates_enabled',
   checkInExperienceEditMessagingEnabled: 'check_in_experience_edit_messaging_enabled',
+  checkInExperiencePhoneAppointmentsEnabled: 'check_in_experience_phone_appointments_enabled',
   coeAccess: 'coe_access',
   combinedDebtPortalAccess: 'combined_debt_portal_access',
   covidVaccineSchedulingFrontend: 'covid_vaccine_scheduling_frontend',


### PR DESCRIPTION
## Description
This PR adds the
`check_in_experience_phone_appointments_enabled` feature toggle to the app. The toggle is currently non functional.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40839

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
