### PR TITLE
Exclude Cypress lint rules in unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,8 @@ module.exports = {
         'no-restricted-imports': ['error', 'raven'],
         'no-unused-expressions': 0,
         'react/no-find-dom-node': 0,
+        '@department-of-veterans-affairs/axe-check-required': 0,
+        '@department-of-veterans-affairs/cypress-viewport-deprecated': 0,
       },
     },
     {

--- a/src/applications/appeals/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/submit.unit.spec.js
@@ -369,6 +369,6 @@ describe('getPhone', () => {
 describe('getTimeZone', () => {
   it('should return a string', () => {
     // result will be a location string, not stubbing for this test
-    expect(getTimeZone().length).to.be.greaterThan(1);
+    expect(getTimeZone().length).to.be.greaterThan(0);
   });
 });

--- a/src/applications/appeals/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/submit.unit.spec.js
@@ -369,6 +369,6 @@ describe('getPhone', () => {
 describe('getTimeZone', () => {
   it('should return a string', () => {
     // result will be a location string, not stubbing for this test
-    expect(getTimeZone().length).to.be.greaterThan(0);
+    expect(getTimeZone().length).to.be.greaterThan(1);
   });
 });


### PR DESCRIPTION
## Description
Cypress lint rules were being included in unit test files after the the move to `@department-of-veterans-affairs/eslint-plugin`. This PR disables these rules in unit tests.

## Acceptance criteria
- [ ] CI passes.