### PR TITLE
Add appt kind to pre-check-in mocks

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -4,6 +4,7 @@ const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
 const alreadyPreCheckedInUUID = '4d523464-c450-49dc-9a18-c04b3f1642ee';
 const canceledAppointmentUUID = '9d7b7c15-d539-4624-8d15-b740b84e8548';
 const expiredUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
+const phoneApptUUID = '258d753c-262a-4ab2-b618-64b645884daf';
 
 const isoDateWithoutTimezoneFormat = "yyyy-LL-dd'T'HH:mm:ss";
 const isoDateWithOffsetFormat = "yyyy-LL-dd'T'HH:mm:ss.SSSxxx";
@@ -19,6 +20,8 @@ const createMockSuccessResponse = (
 ) => {
   const mockTime =
     token === expiredUUID ? new Date() : dateFns.add(new Date(), { days: 1 });
+
+  let apptKind = 'clinic';
 
   let checkInSteps = [];
   let status = '';
@@ -49,6 +52,8 @@ const createMockSuccessResponse = (
     ];
   } else if (token === canceledAppointmentUUID) {
     status = 'CANCELLED BY CLINIC';
+  } else if (token === phoneApptUUID) {
+    apptKind = 'phone';
   }
 
   const formattedStartTime = dateFns.format(
@@ -132,6 +137,7 @@ const createMockSuccessResponse = (
       appointments: [
         {
           facility: 'LOMA LINDA VA CLINIC',
+          kind: apptKind,
           checkInSteps,
           clinicPhoneNumber: '5551234567',
           clinicFriendlyName: 'TEST CLINIC',
@@ -147,6 +153,7 @@ const createMockSuccessResponse = (
         },
         {
           facility: 'LOMA LINDA VA CLINIC',
+          kind: apptKind,
           checkInSteps,
           clinicPhoneNumber: '5551234567',
           clinicFriendlyName: 'TEST CLINIC',


### PR DESCRIPTION
## Description

This updates the pre-check-in mock to add a `kind` property to appointments, so that we can begin phone appointment work. This work follows VAOS' data structure here: https://github.com/department-of-veterans-affairs/vets-api/blob/f25a6eeef4df078d5778a1d165b84aacbfb0db1f/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml#L798

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38266

## Acceptance criteria
- [ ] mock appointments have `kind` property
  - [ ] defaults to `clinic`
  - [ ] is `phone` when using the UUID `258d753c-262a-4ab2-b618-64b645884daf`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
