### PR TITLE
Avoid conflicts with DS langauge detection prefs

### DIFF
--- a/src/applications/check-in/day-of/tests/e2e/app-enabled/enabled.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/app-enabled/enabled.cypress.spec.js
@@ -18,7 +18,7 @@ describe('Check In Experience -- ', () => {
     it('C5742 - Feature is enabled', () => {
       cy.visitWithUUID();
       cy.injectAxeThenAxeCheck();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/already.checked.in.appointment.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/already.checked.in.appointment.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess({ appointments });
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.bad.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.bad.status.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess({ appointments });
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.eligible.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.eligible.status.cypress.spec.js
@@ -21,7 +21,7 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeCheckInDataGet.withSuccess({ appointments });
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.page.is.refreshed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.page.is.refreshed.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Check In Experience -- ', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();
@@ -47,7 +47,7 @@ describe('Check In Experience -- ', () => {
       cy.injectAxeThenAxeCheck();
       // refresh the page
       cy.reload();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.early.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.early.status.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess({ appointments });
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.late.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.too.late.status.cypress.spec.js
@@ -22,7 +22,7 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
       initializeCheckInDataGet.withSuccess({ appointments });
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.unknown.reason.status.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointment.unknown.reason.status.cypress.spec.js
@@ -23,7 +23,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess({ appointments });
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/appointments.are.sorted.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/appointments.are.sorted.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Check In Experience -- ', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/bad.formatted.datetime.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/bad.formatted.datetime.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Check In Experience -- ', () => {
       initializeCheckInDataGet.withSuccess({ appointments });
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/posting.appointment.data.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/posting.appointment.data.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -46,7 +46,7 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/back-button/back.button.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/back-button/back.button.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Check In Experience', () => {
     it('happy path', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Check In Experience -- ', () => {
       initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
@@ -48,7 +48,7 @@ describe('Check In Experience', () => {
     it('happy path with confirmed demographics', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
@@ -136,7 +136,7 @@ describe('Check In Experience', () => {
     it('check-in confirmation with demographics API error', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
@@ -218,7 +218,7 @@ describe('Check In Experience', () => {
       );
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
     });

--- a/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.see.staff.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.see.staff.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Check In Experience', () => {
     it('see staff with demographics update', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
@@ -66,7 +66,7 @@ describe('Check In Experience', () => {
     it('see staff with emergency contact update', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
@@ -104,7 +104,7 @@ describe('Check In Experience', () => {
     it('see staff with next of kin update', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
@@ -168,7 +168,7 @@ describe('Check In Experience', () => {
     it('see staff with demographics update - API error', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/dob-validation/dob.validation.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/dob-validation/dob.validation.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Check In Experience ', () => {
   it('Validate with DOB', () => {
     cy.visitWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     ValidateVeteran.validateVeteranDob();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();
@@ -40,7 +40,7 @@ describe('Check In Experience ', () => {
   it('only allows current and past years', () => {
     cy.visitWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     ValidateVeteran.validateVeteranDobInvalidYear();
     ValidateVeteran.attemptToGoToNextPage();
     ValidateVeteran.getDobError();

--- a/src/applications/check-in/day-of/tests/e2e/emergency-contact-display/emergency-contact.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/emergency-contact-display/emergency-contact.display.cypress.spec.js
@@ -20,7 +20,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
@@ -26,7 +26,7 @@ describe('Check In Experience -- ', () => {
     initializeCheckInDataPost.withFailure(200);
 
     cy.visitWithUUID();
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     ValidateVeteran.validateVeteran();
     ValidateVeteran.attemptToGoToNextPage();
     Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Check In Experience ', () => {
   it('Render Error is caught', () => {
     cy.visitWithUUID();
 
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.validateVeteran();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.check-in.cypress.spec.js
@@ -27,7 +27,7 @@ describe('Check In Experience -- ', () => {
     initializeCheckInDataPost.withFailure(500);
 
     cy.visitWithUUID();
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     ValidateVeteran.validateVeteran();
     ValidateVeteran.attemptToGoToNextPage();
     Demographics.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -23,7 +23,7 @@ describe('Check In Experience -- ', () => {
         numberOfCheckInAbledAppointments: 1,
       });
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
@@ -19,7 +19,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.attemptToGoToNextPage();
     });
     afterEach(() => {
@@ -29,7 +29,7 @@ describe('Check In Experience', () => {
     });
     it('validation failed shows error messages', () => {
       cy.injectAxeThenAxeCheck();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
 
       ValidateVeteran.attemptToGoToNextPage();
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -19,7 +19,7 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withValidation();
       initializeCheckInDataGet.withSuccess();
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Check In Experience', () => {
     it('happy path', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
@@ -56,7 +56,7 @@ describe('Check In Experience', () => {
     });
     it('everything Happy path', () => {
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
 
       ValidateVeteran.validateVeteran();

--- a/src/applications/check-in/day-of/tests/e2e/routing/routing.refresh.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/routing/routing.refresh.cypress.spec.js
@@ -48,7 +48,7 @@ describe('Check In Experience', () => {
     it('validate that demographics check still happens', () => {
       cy.visitWithUUID();
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.display.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.validatePageLoaded();

--- a/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.routing.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/see-staff-display/SeeStaff.routing.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.validatePageLoaded();

--- a/src/applications/check-in/day-of/tests/e2e/session/no.data.in.redux.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/no.data.in.redux.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Check In Experience -- ', () => {
     cy.visit(featureRoute);
     // redirected back to landing page to reload the data
     cy.url().should('match', /verify/);
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/session.is.saved.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Check In Experience', () => {
   });
   it('C5753 - Data is saved to session storage', () => {
     cy.visitWithUUID();
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     cy.injectAxeThenAxeCheck();
     cy.window().then(window => {
       const data = window.sessionStorage.getItem(

--- a/src/applications/check-in/day-of/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Check In Experience -- ', () => {
   });
   it('C5755 - On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
     cy.visitWithUUID();
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     cy.injectAxeThenAxeCheck();
     cy.window().then(window => {
       const data = window.sessionStorage.getItem(
@@ -30,7 +30,7 @@ describe('Check In Experience -- ', () => {
       // redirected back to landing page to reload the data
       cy.url().should('match', /id=46bebc0a-b99c-464f-a5c5-560bc9eae287/);
 
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Check In Experience', () => {
     });
     cy.visitWithUUID();
     cy.injectAxeThenAxeCheck();
-    ValidateVeteran.validatePageLoaded('Check in at VA');
+    ValidateVeteran.validatePage.dayOf();
     cy.window().then(window => {
       const data = window.sessionStorage.getItem(
         'health.care.check-in.current.uuid',

--- a/src/applications/check-in/day-of/tests/e2e/translation/language-picker.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/translation/language-picker.cypress.spec.js
@@ -1,0 +1,46 @@
+import '../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
+import Demographics from '../../../../tests/e2e/pages/Demographics';
+import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
+
+describe('Check In Experience -- ', () => {
+  beforeEach(() => {
+    const {
+      initializeCheckInDataGet,
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+    } = ApiInitializer;
+    initializeFeatureToggle.withDayOfTranslationEnabled();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeSessionPost.withSuccess();
+    initializeCheckInDataGet.withSuccess();
+    // Verifies that browser language detection is working.
+    cy.visitWithUUID(null, 'es');
+  });
+  afterEach(() => {
+    cy.window().then(window => {
+      window.sessionStorage.clear();
+    });
+  });
+  it('Page language may be switched', () => {
+    // App is translated.
+    ValidateVeteran.validatePage.dayOf('es');
+    cy.get('[data-testid="translate-button-en"]').click();
+    ValidateVeteran.validatePage.dayOf('en');
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+  it('Language preference persists when navigating', () => {
+    // App is translated.
+    ValidateVeteran.validatePage.dayOf('es');
+    cy.get('[data-testid="translate-button-en"]').click();
+    ValidateVeteran.validatePage.dayOf('en');
+    ValidateVeteran.validateVeteran();
+    ValidateVeteran.attemptToGoToNextPage();
+    Demographics.validatePageLoaded();
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+});

--- a/src/applications/check-in/day-of/tests/e2e/translation/validate-veteran-page-is-translated.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/translation/validate-veteran-page-is-translated.cypress.spec.js
@@ -1,13 +1,13 @@
 import '../../../../tests/e2e/commands';
 
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
-import Error from '../pages/Error';
+import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 
 describe('Check In Experience -- ', () => {
   beforeEach(() => {
     const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withDayOfTranslationEnabled();
-    initializeSessionGet.withFailure();
+    initializeSessionGet.withSuccessfulNewSession();
     // Verifies that browser language detection is working.
     cy.visitWithUUID(null, 'es');
   });
@@ -16,8 +16,15 @@ describe('Check In Experience -- ', () => {
       window.sessionStorage.clear();
     });
   });
-  it('Error page - spanish', () => {
-    Error.validatePageLoaded(null, 'es');
+  it('Validate Veteran page - spanish', () => {
+    // App is translated.
+    ValidateVeteran.validatePage.dayOf('es');
+    // DS components are translated.
+    cy.get('[data-testid="last-name-input"]')
+      .shadow()
+      .find('label')
+      .should('be.visible')
+      .and('have.text', 'Su apellido (*Requerido)');
     cy.injectAxe();
     cy.axeCheck();
   });

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Check In Experience', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
     });

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Check In Experience', () => {
       });
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
     });

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.demographics.only.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.demographics.only.path.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Check In Experience -- ', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
     });

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.next.of.kin.only.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.next.of.kin.only.path.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Check In Experience -- ', () => {
       initializeCheckInDataPost.withSuccess();
 
       cy.visitWithUUID();
-      ValidateVeteran.validatePageLoaded('Check in at VA');
+      ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
     });

--- a/src/applications/check-in/pre-check-in/tests/e2e/analytics/passing.checkInType.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/analytics/passing.checkInType.cypress.spec.js
@@ -46,7 +46,7 @@ describe('Pre-Check In Experience ', () => {
     it('Sending checkInType for pre-check-in App', () => {
       cy.visitPreCheckInWithUUID();
       // page: Validate
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       cy.injectAxeThenAxeCheck();
       ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/app-enabled/enabled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/app-enabled/enabled.cypress.spec.js
@@ -15,7 +15,7 @@ describe('Pre-Check In Experience', () => {
   });
   it('Feature is enabled', () => {
     cy.visitPreCheckInWithUUID();
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/back-button/back.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/back-button/back.button.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Pre-Check In Experience ', () => {
   it('Happy Path w/Emergency Contact', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/confirmation-display/confirmation.reloads.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/confirmation-display/confirmation.reloads.cypress.spec.js
@@ -42,7 +42,7 @@ describe('Pre-Check In Experience', () => {
     it('reloads of confirmation page should redirect back to verify page', () => {
       cy.injectAxeThenAxeCheck();
       cy.reload();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
 
       // moved afterEach here to
       // avoid async clearing of session storage

--- a/src/applications/check-in/pre-check-in/tests/e2e/dob-validation/dob.validation.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/dob-validation/dob.validation.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Pre-Check In Experience ', () => {
   it('Validate with DOB', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteranDob();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();
@@ -39,7 +39,7 @@ describe('Pre-Check In Experience ', () => {
   it('only allows current and past years', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteranDobInvalidYear();
     ValidateVeteran.attemptToGoToNextPage();
     ValidateVeteran.getDobError();

--- a/src/applications/check-in/pre-check-in/tests/e2e/edit-demographics/feature-toggle/hides.the.edit.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/edit-demographics/feature-toggle/hides.the.edit.button.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Pre-Check In Experience ', () => {
   it('Edit is disabled', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/edit-demographics/feature-toggle/shows.the.edit.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/edit-demographics/feature-toggle/shows.the.edit.button.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Pre-Check In Experience ', () => {
   it('Edit is enabled', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Pre-Check In Experience ', () => {
       it('bad status code(400)', () => {
         cy.visitPreCheckInWithUUID();
         // page: Validate
-        ValidateVeteran.validatePageLoaded();
+        ValidateVeteran.validatePage.preCheckIn();
         cy.injectAxeThenAxeCheck();
         ValidateVeteran.validateVeteran();
         ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/get-pre-check-in/non.200.status.code.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Pre-Check In Experience ', () => {
       it('error in the body', () => {
         cy.visitPreCheckInWithUUID();
         // page: Validate
-        ValidateVeteran.validatePageLoaded();
+        ValidateVeteran.validatePage.preCheckIn();
         cy.injectAxeThenAxeCheck();
         ValidateVeteran.validateVeteran();
         ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec.js
@@ -37,7 +37,7 @@ describe('Pre-Check In Experience ', () => {
       it('error in the body', () => {
         cy.visitPreCheckInWithUUID();
         // page: Validate
-        ValidateVeteran.validatePageLoaded();
+        ValidateVeteran.validatePage.preCheckIn();
         ValidateVeteran.validateVeteran();
         cy.injectAxeThenAxeCheck();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/non.200.status.code.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/post-pre-check-in/non.200.status.code.cypress.spec.js
@@ -37,7 +37,7 @@ describe('Pre-Check In Experience ', () => {
       it('bad status code (400)', () => {
         cy.visitPreCheckInWithUUID();
         // page: Validate
-        ValidateVeteran.validatePageLoaded();
+        ValidateVeteran.validatePage.preCheckIn();
         ValidateVeteran.validateVeteran();
         cy.injectAxeThenAxeCheck();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
@@ -27,7 +27,7 @@ describe('Pre-Check In Experience ', () => {
   it('Render Error is caught', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
@@ -27,7 +27,7 @@ describe('Pre-Check In Experience ', () => {
   it('Canceled Appointments are taken to Error Page', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/render-error-is-caught/catching.render.error.cypress.spec.js
@@ -27,7 +27,7 @@ describe('Pre-Check In Experience ', () => {
   it('Render Error is caught', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -22,7 +22,7 @@ describe('Pre-Check In Experience', () => {
     });
     it('validation failed', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       cy.injectAxeThenAxeCheck();
 
       cy.get('[label="Your last name"]')

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Pre-Check In Experience', () => {
     it('validation trims white space before posting', () => {
       cy.visitPreCheckInWithUUID();
       cy.injectAxeThenAxeCheck();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran('Smith        ', '1234          ');
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
@@ -26,7 +26,7 @@ describe('Pre-Check In Experience', () => {
     });
     it('validation failed shows error messages', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
 
       ValidateVeteran.attemptToGoToNextPage();
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
@@ -22,7 +22,7 @@ describe('Pre-Check In Experience', () => {
     });
     it('only allows typing 4 characters', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       cy.injectAxeThenAxeCheck();
 
       ValidateVeteran.typeLast4('12345');

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/last4.shows.number.keypad.cypress.spec.js
@@ -22,7 +22,7 @@ describe('Pre-Check In Experience', () => {
     });
     it('shows the numeric keypad on mobile devices', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       cy.injectAxeThenAxeCheck();
 
       cy.get('[label="Last 4 digits of your Social Security number"]').should(

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -20,7 +20,7 @@ describe('Pre-Check In Experience', () => {
       initializeSessionPost.withValidation();
       initializePreCheckInDataGet.withSuccess();
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded('Start pre-check-in');
+      ValidateVeteran.validatePage.preCheckIn();
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
@@ -26,7 +26,7 @@ describe('Pre-Check In Experience ', () => {
     cy.visitPreCheckInWithUUID();
 
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
@@ -35,7 +35,7 @@ describe('Pre-Check In Experience ', () => {
   it('Happy Path', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/loading-session/new.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/loading-session/new.session.cypress.spec.js
@@ -17,6 +17,6 @@ describe('Pre-Check In Experience ', () => {
   it('a new sessions redirects to validate page', () => {
     cy.visitPreCheckInWithUUID();
     cy.injectAxeThenAxeCheck();
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
@@ -42,7 +42,7 @@ describe('Pre-Check In Experience ', () => {
   it('Answered yes to both questions', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.validateVeteran();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.yes.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.yes.to.three.questions.cypress.spec.js
@@ -42,7 +42,7 @@ describe('Pre-Check In Experience ', () => {
   it('Answered yes to both questions', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.validateVeteran();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/requires-form/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/requires-form/session.reloads.on.refresh.cypress.spec.js
@@ -25,13 +25,13 @@ describe('Pre Check In Experience', () => {
     });
     it('On page reload, on verify, this should redirect to the landing page', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
 
       cy.reload();
       // redirected back to landing page to reload the data
       cy.url().should('match', /id=0429dda5-4165-46be-9ed1-1e652a8dfd83/);
 
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/routing/browser.back.button.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/routing/browser.back.button.cypress.spec.js
@@ -35,7 +35,7 @@ describe('Pre-Check In Experience ', () => {
   it('Browser back button still works with routing', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
-    ValidateVeteran.validatePageLoaded();
+    ValidateVeteran.validatePage.preCheckIn();
     ValidateVeteran.validateVeteran();
     cy.injectAxeThenAxeCheck();
     ValidateVeteran.attemptToGoToNextPage();

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/no.data.in.redux.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/no.data.in.redux.cypress.spec.js
@@ -35,7 +35,7 @@ describe('Pre Check In Experience', () => {
       const featureRoute = '/health-care/appointment-pre-check-in/introduction';
       cy.visit(featureRoute);
       // redirected back to landing page to reload the data
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       cy.injectAxeThenAxeCheck();
     });
   });

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.is.saved.cypress.spec.js
@@ -23,7 +23,7 @@ describe('Pre Check In Experience', () => {
     });
     it('Data is saved to session storage', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       cy.window().then(window => {
         const data = window.sessionStorage.getItem(
           'health.care.pre.check.in.current.uuid',

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -26,7 +26,7 @@ describe('Pre Check In Experience', () => {
     });
     it('On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();
@@ -43,7 +43,7 @@ describe('Pre Check In Experience', () => {
         // redirected back to landing page to reload the data
         cy.url().should('match', /id=0429dda5-4165-46be-9ed1-1e652a8dfd83/);
 
-        ValidateVeteran.validatePageLoaded();
+        ValidateVeteran.validatePage.preCheckIn();
         cy.injectAxeThenAxeCheck();
       });
     });

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/url.is.priotized.over.session.cypress.spec.js
@@ -42,7 +42,7 @@ describe('Pre Check In Experience', () => {
         expect(data).to.equal(sample);
       });
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
 
       cy.injectAxeThenAxeCheck();
       cy.window().then(window => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Pre Check In Experience', () => {
       initializePreCheckInDataPost.withSuccess();
 
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.demographics.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.demographics.path.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Pre Check In Experience', () => {
       initializePreCheckInDataPost.withSuccess();
 
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.emergency.contact.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.emergency.contact.path.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Pre Check In Experience', () => {
       initializePreCheckInDataPost.withSuccess();
 
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.next.of.kin.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/skip.next.of.kin.path.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Pre Check In Experience', () => {
       initializePreCheckInDataPost.withSuccess();
 
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();

--- a/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Pre Check In Experience', () => {
       initializePreCheckInDataPost.withSuccess();
 
       cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePageLoaded();
+      ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();
       ValidateVeteran.attemptToGoToNextPage();
       Introduction.validatePageLoaded();

--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -1,5 +1,17 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
+const messages = {
+  title: {
+    dayOf: {
+      en: 'Check in at VA',
+      es: 'Registrarse en VA',
+    },
+    preCheckIn: {
+      en: 'Check in at VA',
+    },
+  },
+};
+
 class ValidateVeteran {
   validatePageLoaded = (title = 'Start pre-check-in') => {
     cy.get('h1', { timeout: Timeouts.slow })
@@ -8,11 +20,11 @@ class ValidateVeteran {
   };
 
   validatePage = {
-    dayOf: () => {
-      this.validatePageLoaded('Check in at VA');
+    dayOf: (language = 'en') => {
+      this.validatePageLoaded(messages.title.dayOf[language]);
     },
-    preCheckIn: () => {
-      this.validatePageLoaded('Start pre-check-in');
+    preCheckIn: (language = 'en') => {
+      this.validatePageLoaded(messages.title.preCheckIn[language]);
     },
   };
 

--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -7,13 +7,13 @@ const messages = {
       es: 'Registrarse en VA',
     },
     preCheckIn: {
-      en: 'Check in at VA',
+      en: 'Start pre-check-in',
     },
   },
 };
 
 class ValidateVeteran {
-  validatePageLoaded = (title = 'Start pre-check-in') => {
+  validatePageLoaded = title => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', title);

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -6,6 +6,15 @@ import { format as formatDate, isDate } from 'date-fns';
 import { enUS as en, es } from 'date-fns/locale';
 import enTranslation from '../../locales/en/translation.json';
 
+/**
+ * Helper function to set language on main element for DS component detection.
+ *
+ * @param {string} language
+ */
+const setPageLanguage = language => {
+  document.getElementById('main')?.setAttribute('lang', language);
+};
+
 const locales = { en, es };
 
 i18n
@@ -25,6 +34,11 @@ i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
+    detection: {
+      order: ['localStorage', 'sessionStorage', 'navigator'],
+      lookupLocalStorage: 'checkin-i18nextLng',
+      lookupSessionStorage: 'checkin-i18nextLng',
+    },
     fallbackLng: 'en',
     debug: true,
     interpolation: {
@@ -71,9 +85,11 @@ i18n
     },
   });
 
-// Sets lang attribute on main element, this is what the DS components use to detect the active language.
+// This is necessary for DS components to use our language preference on initial load.
+setPageLanguage(i18n.language);
+
 i18n.on('languageChanged', language => {
-  document.getElementById('main')?.setAttribute('lang', language);
+  setPageLanguage(language);
 });
 
 export default i18n;

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -40,7 +40,7 @@ i18n
       lookupSessionStorage: 'checkin-i18nextLng',
     },
     fallbackLng: 'en',
-    debug: true,
+    debug: false,
     interpolation: {
       escapeValue: false,
       format: (value, format, lng) => {


### PR DESCRIPTION
## Description

This PR uses explicit language detection preferences in check-in to avoid conflicts with DS component language detection.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42559

## Testing done

- manual testing
- added/updated e2e tests

## Acceptance criteria
- [ ] browser language detection works
  - [ ] for our app
  - [ ] for DS components
  - [ ] language picker still works
  - [ ] language picker preference overrides browser detection and is sticky from page to page
