### PR TITLE
42278 incorrect dates

### DIFF
--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -23,6 +23,7 @@ export const customCOEsubmit = (formConfig, form) => {
         return {
           ...loan,
           dateRange: {
+            //  our form months are 1-12 (Jan-Dec) but a Date() month starts 0
             from: new Date(fromYear, fromMonth - 1).toISOString(),
             to: new Date(toYear, toMonth - 1).toISOString(),
           },

--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -3,7 +3,36 @@ import cloneDeep from 'platform/utilities/data/cloneDeep';
 
 export const customCOEsubmit = (formConfig, form) => {
   const formCopy = cloneDeep(form);
-  const formData = transformForSubmit(formConfig, formCopy);
+
+  const { periodsOfService = [], relevantPriorLoans = [] } = formCopy.data;
+
+  const formattedForm = {
+    ...formCopy,
+    data: {
+      ...form.data,
+      periodsOfService: periodsOfService.map(period => ({
+        ...period,
+        dateRange: {
+          from: new Date(period.dateRange.from).toISOString(),
+          to: new Date(period.dateRange.to).toISOString(),
+        },
+      })),
+      relevantPriorLoans: relevantPriorLoans.map(loan => {
+        const [fromYear, fromMonth] = loan.dateRange.from.split('-');
+        const [toYear, toMonth] = loan.dateRange.to.split('-');
+        return {
+          ...loan,
+          dateRange: {
+            from: new Date(fromYear, fromMonth - 1).toISOString(),
+            to: new Date(toYear, toMonth - 1).toISOString(),
+          },
+        };
+      }),
+    },
+  };
+
+  const formData = transformForSubmit(formConfig, formattedForm);
+
   return JSON.stringify({
     lgyCoeClaim: {
       form: formData,

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import * as helpers from 'platform/forms-system/src/js/helpers';
+import { customCOEsubmit } from '../../config/helpers';
+
+const form = {
+  data: {
+    periodsOfService: [{ dateRange: { from: '2010-10-10', to: '2012-12-12' } }],
+    relevantPriorLoans: [
+      { dateRange: { from: '1990-01-XX', to: '1992-02-XX' } },
+    ],
+  },
+};
+
+const formattedProperties = {
+  periodsOfService: [
+    {
+      dateRange: {
+        from: '2010-10-10T00:00:00.000Z',
+        to: '2012-12-12T00:00:00.000Z',
+      },
+    },
+  ],
+  relevantPriorLoans: [
+    {
+      dateRange: {
+        from: '1990-01-01T05:00:00.000Z',
+        to: '1992-02-01T05:00:00.000Z',
+      },
+    },
+  ],
+};
+
+const result = JSON.stringify({
+  lgyCoeClaim: {
+    form: {
+      ...formattedProperties,
+    },
+  },
+});
+
+describe('coe helpers', () => {
+  describe('customCOEsubmit', () => {
+    it('should correctly format the form data', () => {
+      sinon.stub(helpers, 'transformForSubmit').returns(formattedProperties);
+      expect(customCOEsubmit({}, form)).to.equal(result);
+    });
+  });
+});


### PR DESCRIPTION
Closes [42278](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42278)

[Request COE Form 26-1880](http://staging.va.gov/housing-assistance/home-loans/request-coe-form-26-1880/)

# Expected behavior
Dates entered in VA.gov should be correctly formatted correctly so that the LGY Service accurately reads then.

## Current behavior
Dates aren't formatted correctly and are being misread, typically a day off.

## Your fix
Periods of Service and Relevant Prior Loans have date ranges which we're now iterating through and formatting correctly before submission.

## How has this been tested?
I've added a unit test for the `customCOEsubmit` function, but we'll need to confirm w/ LGY that the dates are now accurate on their end.

## Acceptance criteria
- [x] Dates entered in VA.gov are aligned with application dataset.