### PR TITLE
hooks up referenceNumber on COE ConfirmationPage

### DIFF
--- a/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
@@ -13,8 +13,6 @@ const printPage = () => window.print();
 
 const statusUrl = getAppUrl('coe-status');
 
-const referenceNumber = 'XXXXXXXX';
-
 const ConfirmationPage = ({ form }) => {
   useEffect(() => {
     focusElement('.schemaform-title > h1');
@@ -23,6 +21,7 @@ const ConfirmationPage = ({ form }) => {
 
   const { data, submission } = form;
   const name = data.fullName;
+  const { referenceNumber } = submission.response.attributes;
 
   return (
     <div className="vads-u-margin-bottom--9">

--- a/src/applications/lgy/coe/shared/actions/index.js
+++ b/src/applications/lgy/coe/shared/actions/index.js
@@ -51,9 +51,8 @@ export const generateCoe = (skip = '') => async dispatch => {
       }
     }
     return response;
-  } else {
-    dispatch({ type: SKIP_AUTOMATIC_COE_CHECK });
   }
 
+  dispatch({ type: SKIP_AUTOMATIC_COE_CHECK });
   return null;
 };


### PR DESCRIPTION
Resolves [#42286](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42286).

Relevant [form](https://staging.va.gov/housing-assistance/home-loans/request-coe-form-26-1880/introduction).

# Expected behavior
The COE Reference Number should appear on the forms Confirmation page.

## Current behavior
There was a placeholder for the Reference Number being displayed.

## Your fix
Hooks up the reference number to the data returned from the form submission.

Additionally, this addresses the following ESLint warning in the shared actions file:
- "Unnecessary else after return"

## How has this been tested?
Mocked data locally based on the JSON response from the COE controller's _submit_coe_claim_ action.

## Screenshots
<img width="811" alt="Confirmation page" src="https://user-images.githubusercontent.com/969752/173370897-2758e039-52ed-401c-ab76-2df514ece752.png">

## Acceptance criteria
- [x] Reference number appears on confirmation screen in form.