### PR TITLE
Update incorrect heading levels and sentence case chapter titles in healthcare application

### DIFF
--- a/src/applications/hca/components/ServiceConnectedPayConfirmation.jsx
+++ b/src/applications/hca/components/ServiceConnectedPayConfirmation.jsx
@@ -33,10 +33,10 @@ const ServiceConnectedPayConfirmation = ({ goBack, goForward }) => {
       <div className="hca-id-form-wrapper vads-u-margin-bottom--2 vads-u-margin-x--neg1p5">
         <div className="vads-u-background-color--primary-alt-lightest vads-u-padding-top--1 vads-u-padding-bottom--2p5  vads-u-margin-bottom--3">
           <div className="vads-u-padding-x--4">
-            <p className="vads-u-font-family--serif vads-u-font-size--lg vads-u-font-weight--bold">
+            <h3>
               Please confirm that you receive service-connected pay for a 50% or
               higher disability rating.
-            </p>
+            </h3>
             <p>
               You selected that you currently receive service-connected
               disability pay for a 50% or higher disability rating. Because your
@@ -44,7 +44,7 @@ const ServiceConnectedPayConfirmation = ({ goBack, goForward }) => {
             </p>
             <p>
               <strong>Note:</strong> We’ll confirm your information when we
-              receive your application.{' '}
+              receive your application.
             </p>
             <div className="vads-u-margin-y--4">
               <va-additional-info trigger="Why do I need to confirm my disability pay?">

--- a/src/applications/hca/config/chapters/householdInformation/deductibleExpenses.js
+++ b/src/applications/hca/config/chapters/householdInformation/deductibleExpenses.js
@@ -19,7 +19,7 @@ const {
 
 export default {
   uiSchema: {
-    'ui:title': 'Previous Calendar Year\u2019s Deductible Expenses',
+    'ui:title': 'Previous calendar year\u2019s deductible expenses',
     'ui:description': deductibleExpensesDescription,
     deductibleMedicalExpenses: set(
       'ui:validations',

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility.js
@@ -39,7 +39,7 @@ export default {
       },
     },
     'view:vaFacilityTitle': {
-      'ui:title': 'VA Facility',
+      'ui:title': 'VA facility',
     },
     isEssentialAcaCoverage: {
       'ui:title':

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -161,7 +161,7 @@ const formConfig = {
   },
   chapters: {
     veteranInformation: {
-      title: 'Veteran Information',
+      title: 'Veteran information',
       pages: {
         veteranProfileInformation: {
           path: 'veteran-information/personal-information',
@@ -273,7 +273,7 @@ const formConfig = {
       },
     },
     vaBenefits: {
-      title: 'VA Benefits',
+      title: 'VA benefits',
       pages: {
         vaBenefits: {
           path: 'va-benefits/basic-information',
@@ -306,7 +306,7 @@ const formConfig = {
       },
     },
     militaryService: {
-      title: 'Military Service',
+      title: 'Military service',
       pages: {
         serviceInformation: {
           path: 'military-service/service-information',
@@ -333,7 +333,7 @@ const formConfig = {
       },
     },
     householdInformation: {
-      title: 'Household Information',
+      title: 'Household information',
       pages: {
         financialDisclosure: {
           path: 'household-information/financial-disclosure',
@@ -387,7 +387,7 @@ const formConfig = {
       },
     },
     insuranceInformation: {
-      title: 'Insurance Information',
+      title: 'Insurance information',
       pages: {
         medicaid: {
           path: 'insurance-information/medicaid',

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -57,13 +57,13 @@ export class ConfirmationPage extends React.Component {
           <strong>Please print this page for your records.</strong>
         </p>
         <div className="inset">
-          <h4 className="schemaform-confirmation-claim-header">
+          <h2 className="schemaform-confirmation-claim-header">
             Thank you for submitting your application
-          </h4>
-          <h5>
+          </h2>
+          <h3 className="vads-u-font-size--h5">
             Health Care Benefit Claim{' '}
             <span className="additional">(Form 10-10EZ)</span>
-          </h5>
+          </h3>
           <span>
             for {first} {middle} {last} {suffix}
           </span>
@@ -79,9 +79,9 @@ export class ConfirmationPage extends React.Component {
           )}
         </div>
         <div className="confirmation-guidance-container">
-          <h4 className="confirmation-guidance-heading">
+          <h3 className="confirmation-guidance-heading vads-u-font-size--h5">
             How long will it take VA to make a decision on my application?
-          </h4>
+          </h3>
           <p className="how-long">
             We usually decide on applications within <strong>1 week</strong>.
           </p>
@@ -101,9 +101,9 @@ export class ConfirmationPage extends React.Component {
             at <va-telephone contact="877-222-8387" />. We’re here Monday
             through Friday, 8:00 am to 8:00 pm ET.
           </p>
-          <h4 className="confirmation-guidance-heading">
+          <h3 className="confirmation-guidance-heading vads-u-font-size--h5">
             How will I know if I’m enrolled in VA health care?
-          </h4>
+          </h3>
           <p>
             If enrolled, you’ll receive a Veterans Health Benefits Handbook in
             the mail within about 10 days.
@@ -118,9 +118,9 @@ export class ConfirmationPage extends React.Component {
               Find out what happens after you apply
             </a>
           </p>
-          <h4 className="confirmation-guidance-heading">
+          <h3 className="confirmation-guidance-heading vads-u-font-size--h5">
             What if I have more questions?
-          </h4>
+          </h3>
           <p className="confirmation-guidance-message">
             Please call <va-telephone contact="877-222-8387" /> and select 2.
             We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.

--- a/src/applications/hca/tests/e2e/helpers.js
+++ b/src/applications/hca/tests/e2e/helpers.js
@@ -172,7 +172,7 @@ export const shortFormSelfDisclosureToSubmit = () => {
 
   // check review page for self disclosure of va compensation type
   cy.get(`button.usa-button-unstyled`)
-    .contains(/^VA Benefits$/)
+    .contains(/^VA benefits$/)
     .click();
   cy.findByText(/Do you receive VA disability compensation?/i, {
     selector: 'dt',


### PR DESCRIPTION
## Description
Throughout the entire Healthcare application form title case has been used for form chapter titles. This is outdated. This PR converts all titles to sentence case and fixes a couple heading levels found during an accessibility review. 


## Original issue(s)
department-of-veterans-affairs/va.gov-team#42287


## Acceptance criteria
- [ ] All form chapter titles are in sentence case

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
