### PR TITLE
Add expandable alert component to Healthcare application short form

### DIFF
--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -578,6 +578,7 @@ export const shortFormMessage = (
   <va-alert-expandable
     trigger="You’re filling out a shortened application!"
     status="success"
+    class="vads-u-margin-y--5"
   >
     <div>
       Your service-connected disability rating is 50% or higher. This is one of

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -575,21 +575,16 @@ export const medicarePartADescription = (
 );
 
 export const shortFormMessage = (
-  <div className="vads-u-display--flex vads-u-align-items--baseline vads-u-background-color--green-lightest vads-u-margin-y--5 vads-u-padding--2p5 vads-u-padding-bottom--1p5">
-    <i className="fa fa-check vads-u-color--green" />
-    <div className="vads-u-margin-top--neg1 vads-u-margin-left--2p5">
-      <va-additional-info
-        disable-border
-        trigger="You’re filling out a shortened application!"
-      >
-        <div>
-          Your service-connected disability rating is 50% or higher. This is one
-          of our eligibility criteria. This means that we don’t have to ask you
-          questions about other criteria like income and military service.{' '}
-        </div>
-      </va-additional-info>
+  <va-alert-expandable
+    trigger="You’re filling out a shortened application!"
+    status="success"
+  >
+    <div>
+      Your service-connected disability rating is 50% or higher. This is one of
+      our eligibility criteria. This means that we don’t have to ask you
+      questions about other criteria like income and military service.
     </div>
-  </div>
+  </va-alert-expandable>
 );
 
 export const shortFormAlert = (

--- a/src/applications/hca/tests/e2e/helpers.js
+++ b/src/applications/hca/tests/e2e/helpers.js
@@ -109,11 +109,9 @@ export const advanceToServiceInfoPage = () => {
 };
 
 export const shortFormAdditionalHelpAssertion = () => {
-  cy.get('va-additional-info')
+  cy.get('va-alert-expandable')
     .shadow()
-    .findByText(/you’re filling out a shortened application!/i, {
-      selector: '.additional-info-title',
-    })
+    .findByText(/you’re filling out a shortened application!/i)
     .first()
     .should('exist');
 };


### PR DESCRIPTION
## Description
In the healthcare application short form, we have a `va-additional-info` component that is styled like an alert. There is a new component (`va-alert-expandable`) in the Design System that merges background-only alerts with the additional info accordion. This PR implements that new component in place of our custom-styled additional-info component.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#41497


## Testing done
- [x] e2e testing


## Acceptance criteria
- [ ] va-alert-expandable web component successfully renders and functions

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
