### PR TITLE
[VA-9418] Remove validation error on initial load

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.17.7",
-    "@department-of-veterans-affairs/component-library": "^10.3.1",
+    "@department-of-veterans-affairs/component-library": "^10.6.0",
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,13 +2712,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^10.3.1":
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.3.1.tgz#78b1578ed237d5fe6ec08d288bb5fe13a9870d70"
-  integrity sha512-vJbWRY1qD2lLTUcQu4hNVniX2ROxfdCJQoIvhD05GUJNz/TNL5ttSz3FtUJaM/I64xFEr0HM2rLtm09lT3JigQ==
+"@department-of-veterans-affairs/component-library@^10.6.0":
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.6.0.tgz#bcd9f0b12c550f15a6a34d3ce7113cb5d7a3bafe"
+  integrity sha512-jraiRAIFuFIH/jLGUEYwPBgiAAxVuLXz2tz8cj23d0+8L0dh/1qNk+eH6yCMNJJ142blZdNmKULK3P+HW2nxtw==
   dependencies:
     "@department-of-veterans-affairs/react-components" "6.1.3"
-    "@department-of-veterans-affairs/web-components" "4.2.1"
+    "@department-of-veterans-affairs/web-components" "4.5.0"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2827,10 +2827,10 @@
     intersection-observer "^0.12.0"
     postcss-url "^10.1.1"
 
-"@department-of-veterans-affairs/web-components@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.2.1.tgz#83a8193f12d057f4808e7e38f84726b9cdfc5796"
-  integrity sha512-xEe/56AgUlgzqOesAa9U89Cd+mPIZPCHoiWOhSrvxGLZh0f0y50bV98PjhCnt5Ue+RO9WRf9u/jUcTwVpUGpaw==
+"@department-of-veterans-affairs/web-components@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.5.0.tgz#7833534343da7fb8b21b23545648672812868716"
+  integrity sha512-Bxql8ExxCu/dNZWo/S3VOvIMxgkjSEwvMQMiy76Hhn/8Z8CJI2Ok4DppQ5OkMqPSv8nWQJG5QBz4F6hnevXecg==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description

The Events filters validate as wrong when the page first loads. This doesn't give users the chance to try and put in date values before they're marked as right or wrong, and they see a lot of red errors right away.

This fix waits until the user has tried to submit the form once before marking all the fields as "required" and then showing any potential validation errors.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9418

## Testing done

Visual

## Screenshots

### Correct Date Values

https://user-images.githubusercontent.com/10790736/173422249-a3c353f1-5baa-47f3-aa3a-562676efc0f8.mov

### Incorrect Date Values

https://user-images.githubusercontent.com/10790736/173422247-5de1acb0-d796-4964-aace-6f15ec475153.mov

## Acceptance criteria

- [ ] The Events filters show no validation errors on page load until a filter search has been run
- [ ] Running a search with correct date values shows no validation errors
- [ ] Running a search with incorrect date values shows the expected validation errors
- [ ] All the above holds true with "Specific Date" and "Custom Date Range" options

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
