### PR TITLE
Remove sub-message for phone appointments on demographics page

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -11,7 +11,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceDayOfDemographicsFlagsEnabled = true,
     checkInExperienceLorotaSecurityUpdatesEnabled = false,
     checkInExperienceEditMessagingEnabled = false,
-    checkInExperiencePhoneAppointmentsEnabled = true,
+    checkInExperiencePhoneAppointmentsEnabled = false,
   } = toggles;
 
   return {

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -11,7 +11,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceDayOfDemographicsFlagsEnabled = true,
     checkInExperienceLorotaSecurityUpdatesEnabled = false,
     checkInExperienceEditMessagingEnabled = false,
-    checkInExperiencePhoneAppointmentsEnabled = false,
+    checkInExperiencePhoneAppointmentsEnabled = true,
   } = toggles;
 
   return {

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
@@ -77,12 +77,7 @@ export default function DemographicsDisplay({
     <>
       <ConfirmablePage
         header={header || t('is-this-your-current-contact-information')}
-        subtitle={
-          subtitle ||
-          t(
-            'we-can-better-follow-up-with-you-after-your-appointment-when-we-have-your-current-information',
-          )
-        }
+        subtitle={subtitle}
         dataFields={demographicFields}
         data={demographics}
         isEditEnabled={isEditEnabled}

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.unit.spec.jsx
@@ -33,17 +33,19 @@ describe('pre-check-in experience', () => {
         );
       });
       it('renders with default values', () => {
-        const { getByText } = render(
+        const { queryByText } = render(
           <Provider store={store}>
             <DemographicsDisplay />
           </Provider>,
         );
-        expect(getByText('Is this your current contact information?')).to.exist;
+        expect(queryByText('Is this your current contact information?')).to
+          .exist;
+        // this subtitle should only appear when passed in
         expect(
-          getByText(
+          queryByText(
             'We can better follow up with you after your appointment when we have your current information.',
           ),
-        ).to.exist;
+        ).not.to.exist;
       });
       it('renders the footer if footer is supplied', () => {
         const { getByText } = render(

--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -84,6 +84,9 @@ const Demographics = props => {
         demographics={demographics}
         yesAction={yesClick}
         noAction={noClick}
+        subtitle={t(
+          'we-can-better-follow-up-with-you-after-your-appointment-when-we-have-your-current-information',
+        )}
         Footer={Footer}
       />
       <BackToHome />

--- a/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
@@ -28,10 +28,13 @@ const Demographics = props => {
   const { t } = useTranslation();
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const { isEditingPreCheckInEnabled } = useSelector(selectFeatureToggles);
+  const {
+    isEditingPreCheckInEnabled,
+    isPhoneAppointmentsEnabled,
+  } = useSelector(selectFeatureToggles);
 
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
-  const { demographics } = useSelector(selectVeteranData);
+  const { demographics, appointments } = useSelector(selectVeteranData);
 
   const selectPendingEdits = useMemo(makeSelectPendingEdits, []);
   const { pendingEdits } = useSelector(selectPendingEdits);
@@ -90,9 +93,15 @@ const Demographics = props => {
     },
     [isEditingPreCheckInEnabled, token, dispatch, goToNextPage],
   );
-  const subtitle = t(
-    'if-you-need-to-make-changes-please-talk-to-a-staff-member-when-you-check-in',
-  );
+  // check if appointment is in-person or phone
+  const apptType =
+    appointments && appointments.length ? appointments[0]?.kind : null;
+  const subtitle =
+    isPhoneAppointmentsEnabled && apptType === 'phone'
+      ? ''
+      : t(
+          'if-you-need-to-make-changes-please-talk-to-a-staff-member-when-you-check-in',
+        );
 
   return (
     <>

--- a/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
@@ -201,4 +201,93 @@ describe('pre-check-in', () => {
       expect(getByText('updated@email.com')).to.exist;
     });
   });
+
+  describe('Demographics sub message', () => {
+    let store;
+    const initState = {
+      checkInData: {
+        appointments: [
+          {
+            facility: 'LOMA LINDA VA CLINIC',
+            clinicPhoneNumber: '5551234567',
+            clinicFriendlyName: 'TEST CLINIC',
+            clinicName: 'LOM ACC CLINIC TEST',
+            appointmentIen: 'some-ien',
+            startTime: '2022-01-03T14:56:04.788Z',
+            eligibility: 'ELIGIBLE',
+            facilityId: 'some-facility',
+            checkInWindowStart: '2022-01-03T14:56:04.788Z',
+            checkInWindowEnd: '2022-01-03T14:56:04.788Z',
+            checkedInTime: '',
+          },
+        ],
+        context: {
+          token: '',
+        },
+        form: {
+          pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
+        },
+        veteranData: {
+          demographics: {
+            mailingAddress: {
+              street1: '123 Turtle Trail',
+              city: 'Treetopper',
+              state: 'Tennessee',
+              zip: '101010',
+            },
+            homeAddress: {
+              street1: '445 Fine Finch Fairway',
+              street2: 'Apt 201',
+              city: 'Fairfence',
+              state: 'Florida',
+              zip: '445545',
+            },
+            homePhone: '5552223333',
+            mobilePhone: '5553334444',
+            workPhone: '5554445555',
+            emailAddress: 'kermit.frog@sesameenterprises.us',
+          },
+        },
+      },
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        check_in_experience_phone_appointments_enabled: false,
+      },
+    };
+    const middleware = [];
+    const mockStore = configureStore(middleware);
+    beforeEach(() => {
+      store = mockStore(initState);
+    });
+    it('renders the sub-message for an in-person appointment', () => {
+      const component = render(
+        <Provider store={store}>
+          <Demographics router={createMockRouter()} />
+        </Provider>,
+      );
+      expect(
+        component.queryByText(
+          'If you need to make changes, please talk to a staff member when you check in.',
+        ),
+      ).to.exist;
+    });
+    it('does not render the sub-message for a phone appointment appointment', () => {
+      const phoneInitState = JSON.parse(JSON.stringify(initState));
+      phoneInitState.checkInData.appointments[0].kind = 'phone';
+      // eslint-disable-next-line camelcase
+      phoneInitState.featureToggles.check_in_experience_phone_appointments_enabled = true;
+      store = mockStore(phoneInitState);
+
+      const component = render(
+        <Provider store={store}>
+          <Demographics router={createMockRouter()} />
+        </Provider>,
+      );
+      expect(
+        component.queryByText(
+          'If you need to make changes, please talk to a staff member when you check in.',
+        ),
+      ).not.to.exist;
+    });
+  });
 });


### PR DESCRIPTION
## Description
This PR removes the sub-message on the demographics page for a telephone appointment for pre-check-in.

To test: enable phone appointment feature toggle, and use the telephone appointment UUID `258d753c-262a-4ab2-b618-64b645884daf`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#40832


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
