### PR TITLE
[CDP] 42092 Updated CDP styling for consistency 

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/CombinedPortalApp.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/CombinedPortalApp.jsx
@@ -12,7 +12,6 @@ import {
   combinedPortalAccess,
   selectLoadingFeatureFlags,
 } from '../utils/helpers';
-import LoadingSpinner from '../components/LoadingSpinner';
 
 const CombinedPortalApp = ({ children }) => {
   const dispatch = useDispatch();
@@ -47,12 +46,22 @@ const CombinedPortalApp = ({ children }) => {
   // Authentication!
   if (!profileLoading && !userLoggedIn) {
     window.location.replace('/manage-debt-and-bills/');
-    return <LoadingSpinner margin={5} />;
+    return (
+      <va-loading-indicator
+        label="Loading"
+        message="Please wait while we load the application for you."
+      />
+    );
   }
 
   // Hold off on loading until everyone is ready
   if (isPlatformLoading || isMcpLoading || isDebtLoading) {
-    return <LoadingSpinner />;
+    return (
+      <va-loading-indicator
+        label="Loading"
+        message="Please wait while we load the application for you."
+      />
+    );
   }
 
   if (!isCombinedPortalActive) {
@@ -62,7 +71,6 @@ const CombinedPortalApp = ({ children }) => {
         <va-loading-indicator
           label="Loading"
           message="Please wait while we load the application for you."
-          set-focus
         />
       </div>
     );
@@ -71,14 +79,12 @@ const CombinedPortalApp = ({ children }) => {
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0 vads-u-margin-bottom--5">
       <div className="vads-l-row vads-u-margin-x--neg2p5">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--8 large-screen:vads-l-col--8">
-          <DowntimeNotification
-            appTitle="Debts and bills application"
-            dependencies={[externalServices.mvi, externalServices.vbs]}
-          >
-            {children}
-          </DowntimeNotification>
-        </div>
+        <DowntimeNotification
+          appTitle="Debts and bills application"
+          dependencies={[externalServices.mvi, externalServices.vbs]}
+        >
+          {children}
+        </DowntimeNotification>
       </div>
     </div>
   );

--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -34,43 +34,45 @@ const OverviewPage = () => {
 
   return (
     <>
-      <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
+      <va-breadcrumbs className="vads-u-font-family--sans" label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/manage-debt-and-bills">Review and manage VA debt and bills</a>
         <a href="/manage-debt-and-bills/summary">Your VA debt and bills</a>
       </va-breadcrumbs>
-      <h1 data-testid="overview-page-title">{title}</h1>
-      <p className="vads-u-font-size--lg vads-u-font-family--serif">
-        Check the details of debt you might have from VA education, disability
-        compensation, or pension programs, or VA health care and prescription
-        charges from VA health care facilities. Find out how to make payments or
-        request financial help.
-      </p>
-      {bothError || bothZero ? (
-        <ComboAlerts
-          alertType={bothError ? ALERT_TYPES.ERROR : ALERT_TYPES.ZERO}
-        />
-      ) : (
-        <>
-          <h2>Debt and bill overview</h2>
-          <Balances />
-          <h2>What to do if you have questions about your debt and bills</h2>
-          <h3>Questions about benefit debt</h3>
-          <p>
-            Call the Debt Management Center (DMC) at{' '}
-            <va-telephone contact="800-827-0648" /> (TTY:{' '}
-            <va-telephone contact="711" />
-            ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-          </p>
-          <h3>Questions about medical copayment bills</h3>
-          <p>
-            Call the VA Health Resource Center at{' '}
-            <va-telephone contact="866-400-1238" /> (TTY:{' '}
-            <va-telephone contact="711" />
-            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-          </p>
-        </>
-      )}
+      <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
+        <h1 data-testid="overview-page-title">{title}</h1>
+        <p className="vads-u-font-size--lg vads-u-font-family--serif">
+          Check the details of debt you might have from VA education, disability
+          compensation, or pension programs, or VA health care and prescription
+          charges from VA health care facilities. Find out how to make payments
+          or request financial help.
+        </p>
+        {bothError || bothZero ? (
+          <ComboAlerts
+            alertType={bothError ? ALERT_TYPES.ERROR : ALERT_TYPES.ZERO}
+          />
+        ) : (
+          <>
+            <h2>Debt and bill overview</h2>
+            <Balances />
+            <h2>What to do if you have questions about your debt and bills</h2>
+            <h3>Questions about benefit debt</h3>
+            <p>
+              Call the Debt Management Center (DMC) at{' '}
+              <va-telephone contact="800-827-0648" /> (TTY:{' '}
+              <va-telephone contact="711" />
+              ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+            </p>
+            <h3>Questions about medical copayment bills</h3>
+            <p>
+              Call the VA Health Resource Center at{' '}
+              <va-telephone contact="866-400-1238" /> (TTY:{' '}
+              <va-telephone contact="711" />
+              ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            </p>
+          </>
+        )}
+      </div>
     </>
   );
 };

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
@@ -45,15 +45,11 @@ const DebtDetailsCard = ({ debt }) => {
           {debtCardContent.showMakePayment && (
             <div>
               <a
-                className="vads-u-font-size--md vads-u-font-weight--bold"
                 aria-label="Make a payment"
-                href="https://www.pay.va.gov/"
+                className="vads-c-action-link--blue"
                 data-testid="link-make-payment"
+                href="https://www.pay.va.gov/"
               >
-                <i
-                  aria-hidden="true"
-                  className="fas fa-chevron-circle-right fa-2x vads-u-margin-right--1"
-                />
                 Make a payment
               </a>
             </div>
@@ -61,15 +57,11 @@ const DebtDetailsCard = ({ debt }) => {
           {debtCardContent.showRequestHelp && (
             <div>
               <a
-                className="vads-u-font-size--md vads-u-font-weight--bold"
                 aria-label="Request help with your debt"
-                href="/manage-va-debt/request-debt-help-form-5655"
+                className="vads-c-action-link--blue"
                 data-testid="link-request-help"
+                href="/manage-va-debt/request-debt-help-form-5655"
               >
-                <i
-                  className="fas fa-chevron-circle-right fa-2x vads-u-margin-right--1"
-                  aria-hidden="true"
-                />
                 Request help with your debt
               </a>
             </div>

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -30,17 +30,19 @@ const DebtSummaryCard = ({ debt }) => {
         {debtCardHeading}
       </h4>
       {debtCardSubHeading}
-      <Link
-        data-testclass="debt-details-button"
-        onClick={() => setActiveDebt(debt)}
-        to={`/debt-balances/details/${debt.fileNumber + debt.deductionCode}`}
-      >
-        Check details and resolve this debt
-        <i
-          className="fa fa-chevron-right vads-u-margin-left--1"
-          aria-hidden="true"
-        />
-      </Link>
+      <div className="vads-u-margin-right--5 vads-u-margin-top--2">
+        <Link
+          data-testclass="debt-details-button"
+          onClick={() => setActiveDebt(debt)}
+          to={`/debt-balances/details/${debt.fileNumber + debt.deductionCode}`}
+        >
+          Check details and resolve this debt
+          <i
+            aria-hidden="true"
+            className="fa fa-chevron-right vads-u-font-size--sm vads-u-margin-left--0p5"
+          />
+        </Link>
+      </div>
     </article>
   );
 };

--- a/src/applications/combined-debt-portal/debt-letters/components/HistoryTable.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HistoryTable.jsx
@@ -3,32 +3,34 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { renderLetterHistory } from '../const/diary-codes';
 
-const HistoryTable = ({ history }) => (
-  <table className="vads-u-margin-y--4">
-    <thead>
-      <tr>
-        <th className="vads-u-font-weight--bold" scope="col">
-          Date
-        </th>
-        <th className="vads-u-font-weight--bold" scope="col">
-          Letter
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      {history.map((debt, index) => (
-        <tr key={`${debt.date}-${index}`}>
-          <td>{moment(debt.date, 'MM-DD-YYYY').format('MMMM D, YYYY')}</td>
-          <td>
-            <div className="vads-u-margin-top--0">
-              {renderLetterHistory(debt.letterCode)}
-            </div>
-          </td>
+const HistoryTable = ({ history }) => {
+  return (
+    <table className="debt-letters-table vads-u-margin-y--4">
+      <thead>
+        <tr>
+          <th className="vads-u-font-weight--bold" scope="col">
+            Date
+          </th>
+          <th className="vads-u-font-weight--bold" scope="col">
+            Letter
+          </th>
         </tr>
-      ))}
-    </tbody>
-  </table>
-);
+      </thead>
+      <tbody>
+        {history.map((debt, index) => (
+          <tr key={`${debt.date}-${index}`}>
+            <td>{moment(debt.date, 'MM-DD-YYYY').format('MMMM D, YYYY')}</td>
+            <td>
+              <div className="vads-u-margin-top--0">
+                {renderLetterHistory(debt.letterCode)}
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 HistoryTable.propTypes = {
   history: PropTypes.arrayOf(

--- a/src/applications/combined-debt-portal/debt-letters/components/HistoryTable.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HistoryTable.jsx
@@ -5,30 +5,26 @@ import { renderLetterHistory } from '../const/diary-codes';
 
 const HistoryTable = ({ history }) => {
   return (
-    <table className="debt-letters-table vads-u-margin-y--4">
-      <thead>
-        <tr>
-          <th className="vads-u-font-weight--bold" scope="col">
-            Date
-          </th>
-          <th className="vads-u-font-weight--bold" scope="col">
-            Letter
-          </th>
-        </tr>
-      </thead>
-      <tbody>
+    <div className=" vads-u-margin-y--4">
+      <va-table>
+        <va-table-row slot="headers">
+          <span>Date</span>
+          <span>Letter</span>
+        </va-table-row>
         {history.map((debt, index) => (
-          <tr key={`${debt.date}-${index}`}>
-            <td>{moment(debt.date, 'MM-DD-YYYY').format('MMMM D, YYYY')}</td>
-            <td>
+          <va-table-row key={`${debt.date}-${index}`}>
+            <span>
+              {moment(debt.date, 'MM-DD-YYYY').format('MMMM D, YYYY')}
+            </span>
+            <span>
               <div className="vads-u-margin-top--0">
                 {renderLetterHistory(debt.letterCode)}
               </div>
-            </td>
-          </tr>
+            </span>
+          </va-table-row>
         ))}
-      </tbody>
-    </table>
+      </va-table>
+    </div>
   );
 };
 

--- a/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
+++ b/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
@@ -10,8 +10,8 @@ const TriangleIcon = () => (
 );
 const CircleIcon = () => (
   <div className="vads-u-margin-top--0p5 vads-u-margin-right--1">
-    <i aria-hidden="true" className="fas fa-exclamation-triangle" />
-    <span className="sr-only">Alert</span>
+    <i aria-hidden="true" className="fas fa-info-circle" />
+    <span className="sr-only">Information</span>
   </div>
 );
 

--- a/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
+++ b/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
@@ -3,22 +3,16 @@ import { addDays } from 'date-fns';
 import { formatDate } from '../../../combined/utils/helpers';
 
 const TriangleIcon = () => (
-  <>
-    <i
-      aria-hidden="true"
-      className="fas fa-exclamation-triangle vads-u-margin-right--1"
-    />
+  <div className="vads-u-margin-top--0p5 vads-u-margin-right--1">
+    <i aria-hidden="true" className="fas fa-exclamation-triangle" />
     <span className="sr-only">Alert</span>
-  </>
+  </div>
 );
 const CircleIcon = () => (
-  <>
-    <i
-      aria-hidden="true"
-      className="fas fa-exclamation-triangle vads-u-margin-right--1"
-    />
+  <div className="vads-u-margin-top--0p5 vads-u-margin-right--1">
+    <i aria-hidden="true" className="fas fa-exclamation-triangle" />
     <span className="sr-only">Alert</span>
-  </>
+  </div>
 );
 
 export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
@@ -27,23 +21,32 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
   switch (diaryCode) {
     case '71':
       return (
-        <p>
-          <TriangleIcon /> Contact us to verify your military status
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Contact us to verify your military status
+          </p>
+        </div>
       );
     case '655':
     case '817':
       return (
-        <p>
-          <TriangleIcon /> Submit a Financial Status Report so that we can make
-          a decision on your request
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Submit a Financial Status Report so that we can make a decision on
+            your request
+          </p>
+        </div>
       );
     case '212':
       return (
-        <p>
-          <TriangleIcon /> Contact us to update your address
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Contact us to update your address
+          </p>
+        </div>
       );
     case '061':
     case '065':
@@ -53,81 +56,110 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '448':
     case '453':
       return (
-        <p>
-          <CircleIcon /> We’ve paused collection on this debt as you requested
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <CircleIcon />
+          <p className="vads-u-margin-y--0">
+            We’ve paused collection on this debt as you requested
+          </p>
+        </div>
       );
     case '439': // TODO: Date logic TBD
     case '449':
     case '459': // This one is 30 days
       return (
-        <p>
-          <TriangleIcon /> Pay your {balance} balance now or request help by{' '}
-          {dateOfLetter && endDate(dateOfLetter, 30)}
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your {balance} balance now or request help by{' '}
+            {dateOfLetter && endDate(dateOfLetter, 30)}
+          </p>
+        </div>
       );
     case '109':
       return (
-        <p>
-          <TriangleIcon /> Pay your {balance} balance now or request help by{' '}
-          {dateOfLetter && endDate(dateOfLetter, 30)}
-          to avoid more interest charges
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your {balance} balance now or request help by{' '}
+            {dateOfLetter && endDate(dateOfLetter, 30)}
+            to avoid more interest charges
+          </p>
+        </div>
       );
     case '100': // TODO: Date Not Listed
     case '102':
     case '130':
     case '140':
       return (
-        <p>
-          <TriangleIcon /> Pay your {balance} balance now or request help by{' '}
-          {dateOfLetter && endDate(dateOfLetter, 30)}.
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your {balance} balance now or request help by{' '}
+            {dateOfLetter && endDate(dateOfLetter, 30)}.
+          </p>
+        </div>
       );
     case '117':
       return (
-        <p>
-          <TriangleIcon /> Pay your {balance} past due balance in full or
-          request help before {dateOfLetter && endDate(dateOfLetter, 60)}
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your {balance} past due balance in full or request help before{' '}
+            {dateOfLetter && endDate(dateOfLetter, 60)}
+          </p>
+        </div>
       );
     case '123':
       return (
-        <p>
-          <TriangleIcon /> Pay your {balance} past due balance now or request
-          help by {dateOfLetter && endDate(dateOfLetter, 60)}
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your {balance} past due balance now or request help by{' '}
+            {dateOfLetter && endDate(dateOfLetter, 60)}
+          </p>
+        </div>
       );
     case '680':
       return (
-        <p>
-          <TriangleIcon /> Pay your {balance} balance now or request help
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your {balance} balance now or request help
+          </p>
+        </div>
       );
     case '681':
     case '682':
       return (
-        <p>
-          <TriangleIcon /> The U.S. Department of the Treasury is offsetting
-          your federal payments until your debt is paid
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            The U.S. Department of the Treasury is offsetting your federal
+            payments until your debt is paid
+          </p>
+        </div>
       );
     // case '18': Passthrough status for a CRA referral being made
     case '600':
     case '601':
       return (
-        <p>
-          <TriangleIcon /> Continue making monthly payments until your balance
-          is paid
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Continue making monthly payments until your balance is paid
+          </p>
+        </div>
       );
     case '430':
     case '431':
       return (
-        <p>
-          <CircleIcon /> We’re offsetting your education benefits each month
-          until your debt is paid
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <CircleIcon />
+          <p className="vads-u-margin-y--0">
+            We’re offsetting your education benefits each month until your debt
+            is paid
+          </p>
+        </div>
       );
     case '101':
     case '450':
@@ -140,18 +172,24 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '615':
     case '617':
       return (
-        <p>
-          <CircleIcon /> We’re offsetting your benefit payments each month until
-          your debt is paid
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <CircleIcon />
+          <p className="vads-u-margin-y--0">
+            We’re offsetting your benefit payments each month until your debt is
+            paid
+          </p>
+        </div>
       );
     case '603': // TODO: Date Not Listed
     case '613':
       return (
-        <p>
-          <TriangleIcon /> Make a payment on your {balance} balance or request
-          help by {dateOfLetter && endDate(dateOfLetter, 30)}
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Make a payment on your {balance} balance or request help by{' '}
+            {dateOfLetter && endDate(dateOfLetter, 30)}
+          </p>
+        </div>
       );
     // case '122': TODO: Passthrough status for a CRA referral being made
     case '080':
@@ -160,30 +198,41 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '860':
     case '855':
       return (
-        <p>
-          <TriangleIcon /> Contact the U.S. Department of the Treasury to pay
-          this debt
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Contact the U.S. Department of the Treasury to pay this debt
+          </p>
+        </div>
       );
     case '811':
       return (
-        <p>
-          <TriangleIcon /> Continue making monthly payments while we review your
-          compromise offer
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Continue making monthly payments while we review your compromise
+            offer
+          </p>
+        </div>
       );
     case '815': // TODO: Date Not Listed
       return (
-        <p>
-          <TriangleIcon /> Pay your one time payment as part of your compromise
-          agreement by {dateOfLetter && endDate(dateOfLetter, 30)}
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Pay your one time payment as part of your compromise agreement by{' '}
+            {dateOfLetter && endDate(dateOfLetter, 30)}
+          </p>
+        </div>
       );
     case '816':
       return (
-        <p>
-          <CircleIcon /> We’re processing your compromise offer payment
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <CircleIcon />
+          <p className="vads-u-margin-y--0">
+            We’re processing your compromise offer payment
+          </p>
+        </div>
       );
     case '801':
     case '802':
@@ -192,32 +241,42 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '809':
     case '820':
       return (
-        <p>
-          <TriangleIcon /> Continue making monthly payments while we review your
-          waiver request
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Continue making monthly payments while we review your waiver request
+          </p>
+        </div>
       );
     // case '818', '819', '830', '842' Omitted
     case '822':
       return (
-        <p>
-          <TriangleIcon /> Continue making monthly payments while we review your
-          dispute
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Continue making monthly payments while we review your dispute
+          </p>
+        </div>
       );
     case '825':
       return (
-        <p>
-          <TriangleIcon /> Continue making monthly payments while we review your
-          request for a hearing
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Continue making monthly payments while we review your request for a
+            hearing
+          </p>
+        </div>
       );
     case '821':
       return (
-        <p>
-          <TriangleIcon /> Continue making monthly payments while we review your
-          Notice of Disagreement
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">
+            Continue making monthly payments while we review your Notice of
+            Disagreement
+          </p>
+        </div>
       );
     case '002':
     case '005':
@@ -230,18 +289,20 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '422':
     case '627':
       return (
-        <p>
-          <CircleIcon /> We’re updating your account
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <CircleIcon />
+          <p className="vads-u-margin-y--0">We’re updating your account</p>
+        </div>
       );
     case '481':
     case '482':
     case '483':
     case '484':
       return (
-        <p>
-          <CircleIcon /> We’re reviewing your account
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <CircleIcon />
+          <p className="vads-u-margin-y--0">We’re reviewing your account</p>
+        </div>
       );
 
     //
@@ -255,9 +316,10 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '503':
     default:
       return (
-        <p>
-          <TriangleIcon /> We’re updating your account.
-        </p>
+        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+          <TriangleIcon />
+          <p className="vads-u-margin-y--0">We’re updating your account.</p>
+        </div>
       );
   }
 };

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
@@ -7,6 +7,7 @@ import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from '../components/HowDoIPay';
 import NeedHelp from '../components/NeedHelp';
 import OnThisPageLinks from '../components/OnThisPageLinks';
+import '../sass/debt-letters.scss';
 import HistoryTable from '../components/HistoryTable';
 import { setPageFocus, getCurrentDebt } from '../utils/page';
 import {
@@ -44,40 +45,39 @@ const DebtDetails = () => {
   if (Object.keys(currentDebt).length === 0) {
     window.location.replace('/manage-debt-and-bills/summary/debt-balances/');
     return (
-      <div className="vads-u-font-family--sans vads-u-margin--0 vads-u-padding--1">
-        <va-loading-indicator
-          label="Loading"
-          message="Please wait while we load the application for you."
-          set-focus
-        />
-      </div>
+      <va-loading-indicator
+        label="Loading"
+        message="Please wait while we load the application for you."
+      />
     );
   }
 
   return (
-    <div>
-      <va-breadcrumbs label="Breadcrumb">
-        <a href="/">Home</a>
-        <a href="/manage-debt-and-bills/">Manage your VA debt and bills</a>
-        <Link to="/manage-debt-and-bills/summary/">
-          Your debt and bills summary
-        </Link>
-        <Link to="/debt-balances/">Benefit debt balances</Link>
-        <Link
-          to={`/debt-balances/details/${selectedDebt.fileNumber +
-            selectedDebt.deductionCode}`}
+    <>
+      <div className="vads-l-col--9 small-desktop-screen:vads-l-col--12">
+        <va-breadcrumbs label="Breadcrumb">
+          <a href="/">Home</a>
+          <a href="/manage-debt-and-bills/">Manage your VA debt and bills</a>
+          <Link to="/manage-debt-and-bills/summary/">
+            Your debt and bills summary
+          </Link>
+          <Link to="/debt-balances/">Benefit debt balances</Link>
+          <Link
+            to={`/debt-balances/details/${selectedDebt.fileNumber +
+              selectedDebt.deductionCode}`}
+          >
+            Debt details
+          </Link>
+        </va-breadcrumbs>
+      </div>
+      <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
+        <h1
+          className="vads-u-font-family--serif vads-u-margin-bottom--2"
+          tabIndex="-1"
         >
-          Debt details
-        </Link>
-      </va-breadcrumbs>
-      <h1
-        className="vads-u-font-family--serif vads-u-margin-bottom--2"
-        tabIndex="-1"
-      >
-        Your {deductionCodes[currentDebt.deductionCode]}
-      </h1>
-      <section className="vads-l-row">
-        <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-right--2p5 vads-l-col--12 vads-u-font-family--sans">
+          Your {deductionCodes[currentDebt.deductionCode]}
+        </h1>
+        <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-font-family--sans">
           {dateUpdated && (
             <p className="va-introtext vads-u-font-family--sans vads-u-margin-top--0">
               Updated on
@@ -134,8 +134,8 @@ const DebtDetails = () => {
           <HowDoIPay userData={howToUserData} />
           <NeedHelp />
         </div>
-      </section>
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
@@ -19,17 +19,19 @@ const DebtLettersDownload = () => {
   });
 
   return (
-    <div className="vads-l-row large-screen:vads-u-margin-x--neg2p5">
-      <va-breadcrumbs label="Breadcrumb">
-        <a href="/">Home</a>
-        <a href="/manage-debt-and-bills/">Manage your VA debt and bills</a>
-        <a href="/manage-debt-and-bills/summary/">
-          Your debt and bills summary
-        </a>
-        <Link to="/debt-balances/">Benefit debt balances</Link>
-        <Link to="/debt-balances/letters">Debt letters</Link>
-      </va-breadcrumbs>
-      <div>
+    <>
+      <div className="vads-l-col--9 small-desktop-screen:vads-l-col--12">
+        <va-breadcrumbs label="Breadcrumb">
+          <a href="/">Home</a>
+          <a href="/manage-debt-and-bills/">Manage your VA debt and bills</a>
+          <a href="/manage-debt-and-bills/summary/">
+            Your debt and bills summary
+          </a>
+          <Link to="/debt-balances/">Benefit debt balances</Link>
+          <Link to="/debt-balances/letters">Debt letters</Link>
+        </va-breadcrumbs>
+      </div>
+      <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
         <h1
           id="downloadDebtLetters"
           className="vads-u-margin-bottom--2"
@@ -75,18 +77,9 @@ const DebtLettersDownload = () => {
             </a>
             to learn about your payment options.
           </p>
-          <p>
-            <Link
-              className="vads-u-font-family--sans vads-u-font-size--sm"
-              to="/debt-balances/"
-            >
-              <i aria-hidden="true" className="fa fa-chevron-left" /> Return to
-              your list of debts.
-            </Link>
-          </p>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -74,13 +74,10 @@ const DebtLettersSummary = () => {
 
   if (isDebtPending || isPendingVBMS || isProfileUpdating) {
     return (
-      <div className="vads-u-margin--5">
-        <va-loading-indicator
-          label="Loading"
-          message="Please wait while we load the application for you."
-          set-focus
-        />
-      </div>
+      <va-loading-indicator
+        label="Loading"
+        message="Please wait while we load the application for you."
+      />
     );
   }
 
@@ -88,11 +85,8 @@ const DebtLettersSummary = () => {
     !debtError && debts.length === 0 && debtLinks.length === 0;
 
   return (
-    <div className="vads-l-grid-container vads-u-padding-x--0">
-      <va-breadcrumbs
-        className="vads-l-col--12 vads-u-padding-x--0"
-        label="Breadcrumb"
-      >
+    <>
+      <va-breadcrumbs label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/manage-debt-and-bills/">Manage your VA debt and bills</a>
         <a href="/manage-debt-and-bills/summary/">
@@ -100,9 +94,8 @@ const DebtLettersSummary = () => {
         </a>
         <Link to="/debt-balances">Benefit debt balances</Link>
       </va-breadcrumbs>
-
-      <section
-        className="vads-l-row vads-u-margin-x--neg2p5"
+      <div
+        className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8"
         data-testid="current-va-debt"
       >
         <h1
@@ -111,66 +104,60 @@ const DebtLettersSummary = () => {
         >
           Current VA debt
         </h1>
-
-        <div className="vads-u-display--block">
-          <div className="vads-l-col--12">
-            <p className="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">
-              Check the details of VA debt you might have related to your
-              education, disability compensation, or pension benefits. Find out
-              how to pay your debt and what to do if you need financial
-              assistance.
-            </p>
+        <p className="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">
+          Check the details of VA debt you might have related to your education,
+          disability compensation, or pension benefits. Find out how to pay your
+          debt and what to do if you need financial assistance.
+        </p>
+        <>
+          {debtError || allDebtsEmpty ? (
             <>
-              {debtError || allDebtsEmpty ? (
-                <>
-                  {debtError &&
-                    renderAlert(
-                      mcpError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
-                      mcpStatements?.length,
-                    )}
+              {debtError &&
+                renderAlert(
+                  mcpError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
+                  mcpStatements?.length,
+                )}
 
-                  {allDebtsEmpty &&
-                    renderAlert(ALERT_TYPES.ZERO, mcpStatements?.length)}
-                </>
-              ) : (
-                <>
-                  <OnThisPageLinks />
-
-                  <DebtCardsList />
-
-                  {renderOtherVA(mcpStatements?.length, mcpError)}
-
-                  <section>
-                    <h3
-                      id="downloadDebtLetters"
-                      className="vads-u-margin-top--4 vads-u-font-size--h2"
-                    >
-                      Download debt letters
-                    </h3>
-                    <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
-                      You can download some of your letters for education,
-                      compensation and pension debt.
-                    </p>
-
-                    <Link
-                      to="/debt-balances/letters"
-                      className="vads-u-margin-top--1 vads-u-font-family--sans"
-                      data-testid="download-letters-link"
-                    >
-                      Download letters related to your VA debt
-                    </Link>
-                  </section>
-
-                  <HowDoIPay />
-
-                  <NeedHelp />
-                </>
-              )}
+              {allDebtsEmpty &&
+                renderAlert(ALERT_TYPES.ZERO, mcpStatements?.length)}
             </>
-          </div>
-        </div>
-      </section>
-    </div>
+          ) : (
+            <>
+              <OnThisPageLinks />
+
+              <DebtCardsList />
+
+              {renderOtherVA(mcpStatements?.length, mcpError)}
+
+              <section>
+                <h3
+                  id="downloadDebtLetters"
+                  className="vads-u-margin-top--4 vads-u-font-size--h2"
+                >
+                  Download debt letters
+                </h3>
+                <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
+                  You can download some of your letters for education,
+                  compensation and pension debt.
+                </p>
+
+                <Link
+                  to="/debt-balances/letters"
+                  className="vads-u-margin-top--1 vads-u-font-family--sans"
+                  data-testid="download-letters-link"
+                >
+                  Download letters related to your VA debt
+                </Link>
+              </section>
+
+              <HowDoIPay />
+
+              <NeedHelp />
+            </>
+          )}
+        </>
+      </div>
+    </>
   );
 };
 

--- a/src/applications/combined-debt-portal/debt-letters/sass/debt-letters.scss
+++ b/src/applications/combined-debt-portal/debt-letters/sass/debt-letters.scss
@@ -9,79 +9,15 @@
   list-style: none;
 }
 
-.right-heading {
-  font-family: "Bitter";
-  border-bottom: 3px solid $color-blue;
-  margin: 10px 0 10px;
-  padding-bottom: 9px;
-  font-size: 1.35em;
-  line-height: 1.2;
-  font-weight: bold;
-  width: 100%;
-}
-
-a i {
-  font-size: 8px;
-  margin-left: 4px;
-  margin-bottom: 1px;
-}
-
-.mobile-button {
-  padding: 4px;
-  border: 2px solid $color-purple;
-  border-radius: 5px;
-  background-color: $color-white;
-  background-size: cover;
-  font-size: 16px;
-  color: $color-purple;
-  text-decoration: none solid $color-blue;
-  text-align: center;
-
-  &:visited {
-    color: $color-visited;
-  }
-}
-
-.debt-details-nextstep {
-  background-color: $color-aqua-lightest;
-  padding: 0 23px;
-  margin: 15px 0;
-}
-
 h1:focus {
   outline: none !important;
 }
 
-.chapter33-alert {
-  i {
-    position: absolute;
-    left: 22px;
-    top: 37px;
-  }
-
-  p {
-    width: 101%;
-  }
-
-  i.fas.fa-angle-down {
-    display: none;
-  }
-}
-
-// debt details table
-.details-table {
-  display: table;
-  margin: 0 0 32px 0;
-  .details-row {
-    display: table-row;
-    .details-title,
-    .details-data {
-      display: table-cell;
-      padding: 5px;
-    }
-    .details-title {
-      font-weight: bold;
-      width: 150px;
+.debt-letters-table {
+  tr {
+    td {
+      border-right: 0;
+      border-left: 0;
     }
   }
 }

--- a/src/applications/combined-debt-portal/debt-letters/tests/DebtSummaryCard.unit.spec.js
+++ b/src/applications/combined-debt-portal/debt-letters/tests/DebtSummaryCard.unit.spec.js
@@ -100,7 +100,7 @@ describe('DebtSummaryCard', () => {
     expect(wrapper.find('h3').text()).to.equal('$10,000.00');
     expect(wrapper.find('h4').text()).to.equal('Chapter 35 education debt');
     expect(wrapper.find('p').text()).to.equal(
-      'Alert Pay your $10,000.00 balance now or request help',
+      'Pay your $10,000.00 balance now or request help',
     );
   });
 });

--- a/src/applications/combined-debt-portal/debt-letters/tests/e2e/details-card-content.cypress.spec.js
+++ b/src/applications/combined-debt-portal/debt-letters/tests/e2e/details-card-content.cypress.spec.js
@@ -18,11 +18,12 @@ describe('Debt Balances Page Diary Codes', () => {
 
   it('renders expected content for diary code: 080, 850, 852, 860, 855', () => {
     // Get Summary Card & navigate to it's details page
-    cy.get('[data-testid="debt-summary-item"]')
-      .contains('Contact the U.S. Department of the Treasury to pay this debt')
-      .parent()
+    cy.contains(
+      '[data-testid="debt-summary-item"]',
+      'Contact the U.S. Department of the Treasury to pay this debt',
+    )
       .find('a')
-      .click();
+      .click({ waitForAnimations: true });
     // Get Alert's Children
     cy.get('va-alert').as('alert-content');
     // Check Alert Header
@@ -42,13 +43,12 @@ describe('Debt Balances Page Diary Codes', () => {
   });
 
   it('renders expected content for diary code: 100, 102, 130, 140', () => {
-    cy.get('[data-testid="debt-summary-item"]')
-      .contains(
-        'Pay your $120.40 balance now or request help by October 18, 2012',
-      )
-      .parent()
+    cy.contains(
+      '[data-testid="debt-summary-item"]',
+      'Pay your $120.40 balance now or request help by October 18, 2012',
+    )
       .find('a')
-      .click();
+      .click({ waitForAnimations: true });
     cy.get('va-alert').as('alert-content');
     cy.get('@alert-content')
       .find('h3')
@@ -65,11 +65,10 @@ describe('Debt Balances Page Diary Codes', () => {
   });
 
   it('renders expected content for diary code: 101, 450, 602, 607, 608, 610, 611, 614, 615, 617', () => {
-    cy.get('[data-testid="debt-summary-item"]')
-      .contains(
-        'We’re offsetting your benefit payments each month until your debt is paid',
-      )
-      .parent()
+    cy.contains(
+      '[data-testid="debt-summary-item"]',
+      'We’re offsetting your benefit payments each month until your debt is paid',
+    )
       .find('a')
       .click({ waitForAnimations: true });
     cy.get('va-alert').as('alert-content');
@@ -88,11 +87,10 @@ describe('Debt Balances Page Diary Codes', () => {
   });
 
   it('renders expected content for diary code: 117', () => {
-    cy.get('[data-testid="debt-summary-item"]')
-      .contains(
-        'Pay your $1,000.00 past due balance in full or request help before May 31, 2017',
-      )
-      .parent()
+    cy.contains(
+      '[data-testid="debt-summary-item"]',
+      'Pay your $1,000.00 past due balance in full or request help before May 31, 2017',
+    )
       .find('a')
       .click({ waitForAnimations: true });
     cy.get('va-alert').as('alert-content');
@@ -111,11 +109,10 @@ describe('Debt Balances Page Diary Codes', () => {
   });
 
   it('renders expected content for diary code: 123', () => {
-    cy.get('[data-testid="debt-summary-item"]')
-      .contains(
-        'Pay your $200.00 past due balance now or request help by October 7, 2018',
-      )
-      .parent()
+    cy.contains(
+      '[data-testid="debt-summary-item"]',
+      'Pay your $200.00 past due balance now or request help by October 7, 2018',
+    )
       .find('a')
       .click({ waitForAnimations: true });
     cy.get('va-alert').as('alert-content');

--- a/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
@@ -35,17 +35,27 @@ const DownloadStatement = ({ statementId, statementDate, fullName }) => {
           type="application/pdf"
           rel="noreferrer"
         >
-          <span aria-hidden="true">
-            <i role="img" className="fas fa-download vads-u-padding-right--1" />
-            Download your {formattedStatementDate} statement{' '}
+          <span
+            aria-hidden="true"
+            className="vads-u-display--flex vads-u-align-items--flex-start"
+          >
+            <i
+              className="fas fa-download vads-u-margin-top--0p5 vads-u-padding-right--1"
+              role="img"
+            />
+            <p className="vads-u-margin-y--0">
+              Download your {formattedStatementDate} statement{' '}
+              <dfn>
+                <abbr title="Portable Document Format">(PDF)</abbr>
+              </dfn>
+            </p>
           </span>
           <span className="sr-only">
-            Download {formattedStatementDate} dated medical copay statement
+            Download {formattedStatementDate} dated medical copay statement{' '}
+            <dfn>
+              <abbr title="Portable Document Format">(PDF)</abbr>
+            </dfn>
           </span>
-
-          <dfn>
-            <abbr title="Portable Document Format">(PDF)</abbr>
-          </dfn>
         </a>
       </div>
     </article>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageDetails.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageDetails.jsx
@@ -4,43 +4,58 @@ export const OnThisPageDetails = () => (
   <>
     <h2>On this page</h2>
     <div className="vads-u-font-family--sans vads-u-display--flex vads-u-flex-direction--column">
-      <a href="#statement-list" className="vads-u-margin-y--1">
+      <a
+        href="#statement-list"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         Your statements
       </a>
-      <a href="#how-to-pay" className="vads-u-margin-y--1">
+      <a
+        href="#how-to-pay"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         How to pay your copay bill
       </a>
-      <a href="#how-to-get-financial-help" className="vads-u-margin-y--1">
+      <a
+        href="#how-to-get-financial-help"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         How to get financial help for your copays
       </a>
-      <a href="#dispute-charges" className="vads-u-margin-y--1">
+      <a
+        href="#dispute-charges"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         How to dispute your copay charges
       </a>
-      <a href="#balance-questions" className="vads-u-margin-y--1">
+      <a
+        href="#balance-questions"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         What to do if you have questions about your balance
       </a>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageOverview.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageOverview.jsx
@@ -5,43 +5,58 @@ export const OnThisPageOverview = ({ multiple }) => (
   <>
     <h2>On this page</h2>
     <div className="vads-u-font-family--sans vads-u-display--flex vads-u-flex-direction--column">
-      <a href="#balance-list" className="vads-u-margin-y--1">
+      <a
+        href="#balance-list"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         What you owe to your {multiple ? 'facilities' : 'facility'}
       </a>
-      <a href="#how-to-pay" className="vads-u-margin-y--1">
+      <a
+        href="#how-to-pay"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         How to pay your copay bill
       </a>
-      <a href="#how-to-get-financial-help" className="vads-u-margin-y--1">
+      <a
+        href="#how-to-get-financial-help"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         How to get financial help for your copays
       </a>
-      <a href="#dispute-charges" className="vads-u-margin-y--1">
+      <a
+        href="#dispute-charges"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         How to dispute your copay charges
       </a>
-      <a href="#balance-questions" className="vads-u-margin-y--1">
+      <a
+        href="#balance-questions"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
         <i
           aria-hidden="true"
           role="img"
-          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
         />
         What to do if you have questions about your balance
       </a>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export const OnThisPageStatements = () => (
+  <>
+    <h2>On this page</h2>
+    <div className="vads-u-font-family--sans vads-u-display--flex vads-u-flex-direction--column">
+      <a
+        href="#account-summary"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
+        <i
+          aria-hidden="true"
+          role="img"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
+        />
+        Account summary
+      </a>
+      <a
+        href="#statement-charges"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
+        <i
+          aria-hidden="true"
+          role="img"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
+        />
+        Statement charges
+      </a>
+      <a
+        href="#statement-addresses"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
+        <i
+          aria-hidden="true"
+          role="img"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
+        />
+        Statement addresses
+      </a>
+      <a
+        href="#what-do-questions"
+        className="vads-u-margin-y--1 vads-u-display--flex vads-u-align-items--flex-start"
+      >
+        <i
+          aria-hidden="true"
+          role="img"
+          className="fas fa-arrow-down vads-u-padding-right--1 vads-u-font-size--sm vads-u-margin-top--0p5"
+        />
+        What to do if you have questions about your statement
+      </a>
+    </div>
+  </>
+);

--- a/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Table from '@department-of-veterans-affairs/component-library/Table';
 import moment from 'moment';
 
 const StatementCharges = ({ copay }) => {
@@ -10,25 +9,21 @@ const StatementCharges = ({ copay }) => {
     .subtract(1, 'month')
     .format('MMMM D, YYYY');
 
-  const fields = [
-    { label: 'Description', value: 'desc' },
-    { label: 'Billing Reference', value: 'billref' },
-    { label: 'Amount', value: 'amount' },
-  ];
-
-  const tableData = copay.details.map(item => ({
-    desc: item.pDTransDescOutput,
-    billref: item.pDRefNo,
-    amount: (
-      <div>
-        $
-        {item.pDTransAmtOutput
-          .replace('&nbsp', '')
+  const tableData = copay.details.map(item => {
+    return (
+      <va-table-row
+        key={`${item.pDRefNo}-${item.pDTransAmtOutput
           .replace('-', '')
-          .replace(/[^\d.-]/g, '')}
-      </div>
-    ),
-  }));
+          .replace(/[^\d.-]/g, '')}`}
+      >
+        <span>{item.pDTransDescOutput}</span>
+        <span>{item.pDRefNo}</span>
+        <span>
+          ${item.pDTransAmtOutput.replace('-', '').replace(/[^\d.-]/g, '')}
+        </span>
+      </va-table-row>
+    );
+  });
 
   return (
     <>
@@ -39,11 +34,14 @@ const StatementCharges = ({ copay }) => {
         This statement shows charges you received between{' '}
         {previousCopaysStartDate} and {today}
       </p>
-      <Table
-        data={tableData}
-        fields={fields}
-        className="statement-charges-table"
-      />
+      <va-table>
+        <va-table-row slot="headers">
+          <span>Description</span>
+          <span> Billing reference</span>
+          <span>Amount</span>
+        </va-table-row>
+        {tableData}
+      </va-table>
     </>
   );
 };

--- a/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
@@ -13,6 +13,7 @@ const StatementCharges = ({ copay }) => {
     return (
       <va-table-row
         key={`${item.pDRefNo}-${item.pDTransAmtOutput
+          .replace('&nbsp', '')
           .replace('-', '')
           .replace(/[^\d.-]/g, '')}`}
       >

--- a/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
@@ -19,7 +19,11 @@ const StatementCharges = ({ copay }) => {
         <span>{item.pDTransDescOutput}</span>
         <span>{item.pDRefNo}</span>
         <span>
-          ${item.pDTransAmtOutput.replace('-', '').replace(/[^\d.-]/g, '')}
+          $
+          {item.pDTransAmtOutput
+            .replace('&nbsp', '')
+            .replace('-', '')
+            .replace(/[^\d.-]/g, '')}
         </span>
       </va-table-row>
     );

--- a/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
@@ -39,7 +39,7 @@ const StatementCharges = ({ copay }) => {
         This statement shows charges you received between{' '}
         {previousCopaysStartDate} and {today}
       </p>
-      <va-table>
+      <va-table role="table">
         <va-table-row slot="headers">
           <span>Description</span>
           <span> Billing reference</span>

--- a/src/applications/combined-debt-portal/medical-copays/containers/DetailPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/DetailPage.jsx
@@ -53,30 +53,32 @@ const DetailPage = ({ match }) => {
           Copay bill for {selectedCopay?.station.facilityName}
         </a>
       </va-breadcrumbs>
-      <h1 data-testid="detail-page-title">{title}</h1>
-      <p className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-margin-bottom--5">
-        Updated on
-        <time
-          dateTime={statementDate}
-          className="vads-u-margin-x--0p5"
-          data-testid="updated-date"
-        >
-          {statementDate}
-        </time>
-      </p>
-      <Alert type={alert} copay={selectedCopay} />
-      <OnThisPageDetails />
-      <HTMLStatementList selectedId={selectedId} />
-      <HowToPay acctNum={acctNum} facility={selectedCopay?.station} />
-      <FinancialHelp />
-      <DisputeCharges />
-      <BalanceQuestions
-        facilityLocation={selectedCopay?.station.facilityName}
-        facilityPhone={selectedCopay?.station.teLNum}
-      />
-      <Modals title="Notice of rights and responsibilities">
-        <Modals.Rights />
-      </Modals>
+      <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
+        <h1 data-testid="detail-page-title">{title}</h1>
+        <p className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-margin-bottom--5">
+          Updated on
+          <time
+            dateTime={statementDate}
+            className="vads-u-margin-x--0p5"
+            data-testid="updated-date"
+          >
+            {statementDate}
+          </time>
+        </p>
+        <Alert type={alert} copay={selectedCopay} />
+        <OnThisPageDetails />
+        <HTMLStatementList selectedId={selectedId} />
+        <HowToPay acctNum={acctNum} facility={selectedCopay?.station} />
+        <FinancialHelp />
+        <DisputeCharges />
+        <BalanceQuestions
+          facilityLocation={selectedCopay?.station.facilityName}
+          facilityPhone={selectedCopay?.station.teLNum}
+        />
+        <Modals title="Notice of rights and responsibilities">
+          <Modals.Rights />
+        </Modals>
+      </div>
     </>
   );
 };

--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -31,7 +31,7 @@ const HTMLStatementPage = ({ match }) => {
 
   return (
     <>
-      <article>
+      <div className="vads-l-col--12 small-desktop-screen:vads-l-col--10">
         <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
           <a href="/">Home</a>
           <a href="/manage-debt-and-bills">Manage your VA debt and bills</a>
@@ -48,6 +48,8 @@ const HTMLStatementPage = ({ match }) => {
           </a>
           <a href={`/copay-balances/${selectedId}/detail/statement`}>{title}</a>
         </va-breadcrumbs>
+      </div>
+      <article className="vads-u-padding--0 medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
         <h1 data-testid="statement-page-title">{title}</h1>
         <p
           className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-font-family--sarif"
@@ -80,7 +82,7 @@ const HTMLStatementPage = ({ match }) => {
           copay={selectedCopay}
         />
         <h2 id="if-i-have-questions">
-          What if I have questions about my statement?
+          What to do if you have questions about your statement
         </h2>
         <p>
           Contact the VA Health Resource Center at{' '}

--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -8,6 +8,7 @@ import StatementAddresses from '../components/StatementAddresses';
 import AccountSummary from '../components/AccountSummary';
 import StatementCharges from '../components/StatementCharges';
 import DownloadStatement from '../components/DownloadStatement';
+import { OnThisPageStatements } from '../components/OnThisPageStatements';
 import '../sass/medical-copays.scss';
 
 const HTMLStatementPage = ({ match }) => {
@@ -57,7 +58,7 @@ const HTMLStatementPage = ({ match }) => {
         >
           {`${selectedCopay?.station.facilityName}`}
         </p>
-        <va-on-this-page className="vads-u-margin-top--0" />
+        <OnThisPageStatements />
         <AccountSummary
           currentBalance={selectedCopay.pHNewBalance}
           newCharges={selectedCopay.pHTotCharges}
@@ -81,7 +82,7 @@ const HTMLStatementPage = ({ match }) => {
           data-testid="statement-addresses"
           copay={selectedCopay}
         />
-        <h2 id="if-i-have-questions">
+        <h2 id="what-do-questions">
           What to do if you have questions about your statement
         </h2>
         <p>

--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -107,33 +107,35 @@ const OverviewPage = () => {
           Current copay balances
         </a>
       </va-breadcrumbs>
-      <h1 data-testid="overview-page-title">{title}</h1>
-      <p className="vads-u-font-size--lg vads-u-font-family--sans">
-        Check the balance of VA health care and prescription charges from each
-        of your facilities. Find out how to make payments or request financial
-        help.
-      </p>
-      {mcpError || statementsEmpty ? (
-        <>
-          {mcpError &&
-            renderAlert(
-              debtError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
-              debts?.length,
-            )}
+      <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
+        <h1 data-testid="overview-page-title">{title}</h1>
+        <p className="vads-u-font-size--lg vads-u-font-family--sans">
+          Check the balance of VA health care and prescription charges from each
+          of your facilities. Find out how to make payments or request financial
+          help.
+        </p>
+        {mcpError || statementsEmpty ? (
+          <>
+            {mcpError &&
+              renderAlert(
+                debtError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
+                debts?.length,
+              )}
 
-          {statementsEmpty && renderAlert(ALERT_TYPES.ZERO, debts?.length)}
-        </>
-      ) : (
-        <>
-          <OnThisPageOverview multiple={statements?.length > 1} />
-          <Balances statements={statementsByUniqueFacility} />
-          {renderOtherVA(debts?.length, debtError)}
-          <HowToPay />
-          <FinancialHelp />
-          <DisputeCharges />
-          <BalanceQuestions />
-        </>
-      )}
+            {statementsEmpty && renderAlert(ALERT_TYPES.ZERO, debts?.length)}
+          </>
+        ) : (
+          <>
+            <OnThisPageOverview multiple={statements?.length > 1} />
+            <Balances statements={statementsByUniqueFacility} />
+            {renderOtherVA(debts?.length, debtError)}
+            <HowToPay />
+            <FinancialHelp />
+            <DisputeCharges />
+            <BalanceQuestions />
+          </>
+        )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Description
Medical copays and debt letters still have vastly different stylings post merge, this merge is focused on getting the main styling consistent across both (now one) app. Updating margins, and spacings for different screen sizes, so both apps feel the same on any device.

### debt-letters
* Separated breadcrumbs from content to help with awkward wrapping
  * See [Breadcrumb wrapping](#breadcrumb-wrapping) below
* Removed a bunch of superfluous styling tags, and emptied out the css of unused styles
* Fixed history table to use appropriate `va-table` component
* Fixed debt details summary card layouts
  * Icon was not centered on first line, text was wrapping underneath on smaller screens
    * See [Text wrapping under symbols](#text-wrapping-under-symbols) below
  * Link text was awkwardly wrapping on smaller screens, it's been adjusted
* Updated Details card to use `action-link` platform styling
* Updated Loading spinner to just use `va-loading-indicator`

### medical-copays
* Updated Overview, Details, and Statement page margins for breadcrumb wrapping and other uniform styling
  * See [Breadcrumb wrapping](#breadcrumb-wrapping) below
* Updated Download letter symbol so the text wraps correctly on smaller screens
    * See [Text wrapping under symbols](#text-wrapping-under-symbols) below
* Updated On This Page icon text wrappings for smaller screen sizes
    * See [Text wrapping under symbols](#text-wrapping-under-symbols) below
* Updated Statement page table to remove deprecated Table and use `va-table`

## Screenshots
### Breadcrumb wrapping
<details><summary>Before (click to expand)</summary>
<img width="890" alt="image" src="https://user-images.githubusercontent.com/25368370/174106982-db3a9d31-cf90-419e-b1f0-f660c4748ad9.png">

</details>
<details><summary>After (click to expand)</summary>
<img width="885" alt="image" src="https://user-images.githubusercontent.com/25368370/174107053-8893d94a-3727-428c-b706-f88bd776175f.png">

</details>

### Text wrapping under symbols
<details><summary>Before (click to expand)</summary>
<img width="285" alt="image" src="https://user-images.githubusercontent.com/25368370/174105092-8691a53a-4446-4f49-b75d-ca7e5ed3e419.png">

</details>
<details><summary>After (click to expand)</summary>
<img width="287" alt="image" src="https://user-images.githubusercontent.com/25368370/174105717-16f95606-fa7e-44a9-b9b5-aef5239143ce.png">

</details>

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42092

## Acceptance criteria
- [ ] CDP has consistent styling throughout
