### PR TITLE
[Check-in] Move duplicated mock appointments to an import

### DIFF
--- a/src/applications/check-in/components/tests/PreCheckinConfirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/PreCheckinConfirmation.test.unit.spec.jsx
@@ -6,6 +6,11 @@ import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import { shallow } from 'enzyme';
 
+import {
+  singleAppointment,
+  multipleAppointments,
+} from '../../tests/unit/mocks/mock-appointments';
+
 import PreCheckinConfirmation from '../PreCheckinConfirmation';
 
 describe('pre-check-in', () => {
@@ -34,21 +39,7 @@ describe('pre-check-in', () => {
 
   describe('Confirmation page', () => {
     describe('appointment without friendly name', () => {
-      const appointments = [
-        {
-          facility: 'LOMA LINDA VA CLINIC',
-          clinicPhoneNumber: '5551234567',
-          clinicFriendlyName: '',
-          clinicName: 'LOM ACC CLINIC TEST',
-          appointmentIen: 'some-ien',
-          startTime: '2021-11-30T17:12:10.694Z',
-          eligibility: 'ELIGIBLE',
-          facilityId: 'some-facility',
-          checkInWindowStart: '2021-11-30T17:12:10.694Z',
-          checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-          checkedInTime: '',
-        },
-      ];
+      const appointments = singleAppointment;
       it('renders loading screen', () => {
         const wrapper = shallow(
           <PreCheckinConfirmation
@@ -74,47 +65,7 @@ describe('pre-check-in', () => {
       });
     });
     describe('appointments with friendly name', () => {
-      const appointments = [
-        {
-          facility: 'LOMA LINDA VA CLINIC',
-          clinicPhoneNumber: '5551234567',
-          clinicFriendlyName: 'TEST CLINIC',
-          clinicName: 'LOM ACC CLINIC TEST',
-          appointmentIen: 'some-ien',
-          startTime: '2021-11-30T17:12:10.694Z',
-          eligibility: 'ELIGIBLE',
-          facilityId: 'some-facility',
-          checkInWindowStart: '2021-11-30T17:12:10.694Z',
-          checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-          checkedInTime: '',
-        },
-        {
-          facility: 'LOMA LINDA VA CLINIC',
-          clinicPhoneNumber: '5551234567',
-          clinicFriendlyName: 'TEST CLINIC',
-          clinicName: 'LOM ACC CLINIC TEST',
-          appointmentIen: 'some-ien',
-          startTime: '2021-11-30T17:12:10.694Z',
-          eligibility: 'ELIGIBLE',
-          facilityId: 'some-facility',
-          checkInWindowStart: '2021-11-30T17:12:10.694Z',
-          checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-          checkedInTime: '',
-        },
-        {
-          facility: 'LOMA LINDA VA CLINIC',
-          clinicPhoneNumber: '5551234567',
-          clinicFriendlyName: 'TEST CLINIC',
-          clinicName: 'LOM ACC CLINIC TEST',
-          appointmentIen: 'some-other-ien',
-          startTime: '2021-11-30T17:12:10.694Z',
-          eligibility: 'ELIGIBLE',
-          facilityId: 'some-facility',
-          checkInWindowStart: '2021-11-30T17:12:10.694Z',
-          checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-          checkedInTime: '',
-        },
-      ];
+      const appointments = multipleAppointments;
       it('renders page - no updates', () => {
         const screen = render(
           <Provider store={store}>

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
@@ -6,49 +6,37 @@ import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import { createMockRouter } from '../../../../tests/unit/mocks/router';
 import Confirmation from '../index';
+import {
+  multipleAppointments,
+  singleAppointment,
+} from '../../../../tests/unit/mocks/mock-appointments';
 import PreCheckinConfirmation from '../../../../components/PreCheckinConfirmation';
 
 describe('pre-check-in', () => {
   describe('Confirmation page', () => {
     describe('redux store without friendly name', () => {
-      let initState;
-      let store;
-      beforeEach(() => {
-        initState = {
-          checkInData: {
-            appointments: [
-              {
-                facility: 'LOMA LINDA VA CLINIC',
-                clinicPhoneNumber: '5551234567',
-                clinicFriendlyName: '',
-                clinicName: 'LOM ACC CLINIC TEST',
-                appointmentIen: 'some-ien',
-                startTime: '2021-11-30T17:12:10.694Z',
-                eligibility: 'ELIGIBLE',
-                facilityId: 'some-facility',
-                checkInWindowStart: '2021-11-30T17:12:10.694Z',
-                checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-                checkedInTime: '',
-              },
-            ],
-            veteranData: { demographics: {} },
-            form: {
-              pages: [],
-              data: {
-                demographicsUpToDate: 'yes',
-                nextOfKinUpToDate: 'yes',
-                emergencyContactUpToDate: 'yes',
-              },
-            },
-            context: {
-              token: 'token',
+      const initState = {
+        checkInData: {
+          appointments: singleAppointment,
+          veteranData: { demographics: {} },
+          form: {
+            pages: [],
+            data: {
+              demographicsUpToDate: 'yes',
+              nextOfKinUpToDate: 'yes',
+              emergencyContactUpToDate: 'yes',
             },
           },
-        };
-        const middleware = [];
-        const mockStore = configureStore(middleware);
-        store = mockStore(initState);
-      });
+          context: {
+            token: 'token',
+          },
+        },
+      };
+      initState.checkInData.appointments[0].clinicFriendlyName = '';
+      const middleware = [];
+      const mockStore = configureStore(middleware);
+      const store = mockStore(initState);
+
       it('passes the correct props to the pre-checkin confirmation component', () => {
         const testRenderer = TestRenderer.create(
           <Provider store={store}>
@@ -70,47 +58,7 @@ describe('pre-check-in', () => {
       beforeEach(() => {
         initState = {
           checkInData: {
-            appointments: [
-              {
-                facility: 'LOMA LINDA VA CLINIC',
-                clinicPhoneNumber: '5551234567',
-                clinicFriendlyName: 'TEST CLINIC',
-                clinicName: 'LOM ACC CLINIC TEST',
-                appointmentIen: 'some-ien',
-                startTime: '2021-11-30T17:12:10.694Z',
-                eligibility: 'ELIGIBLE',
-                facilityId: 'some-facility',
-                checkInWindowStart: '2021-11-30T17:12:10.694Z',
-                checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-                checkedInTime: '',
-              },
-              {
-                facility: 'LOMA LINDA VA CLINIC',
-                clinicPhoneNumber: '5551234567',
-                clinicFriendlyName: 'TEST CLINIC',
-                clinicName: 'LOM ACC CLINIC TEST',
-                appointmentIen: 'some-ien',
-                startTime: '2021-11-30T17:12:10.694Z',
-                eligibility: 'ELIGIBLE',
-                facilityId: 'some-facility',
-                checkInWindowStart: '2021-11-30T17:12:10.694Z',
-                checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-                checkedInTime: '',
-              },
-              {
-                facility: 'LOMA LINDA VA CLINIC',
-                clinicPhoneNumber: '5551234567',
-                clinicFriendlyName: 'TEST CLINIC',
-                clinicName: 'LOM ACC CLINIC TEST',
-                appointmentIen: 'some-other-ien',
-                startTime: '2021-11-30T17:12:10.694Z',
-                eligibility: 'ELIGIBLE',
-                facilityId: 'some-facility',
-                checkInWindowStart: '2021-11-30T17:12:10.694Z',
-                checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-                checkedInTime: '',
-              },
-            ],
+            appointments: multipleAppointments,
             veteranData: { demographics: {} },
             form: {
               pages: [],

--- a/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
@@ -4,6 +4,10 @@ import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
+import {
+  singleAppointment,
+  multipleAppointments,
+} from '../../../../tests/unit/mocks/mock-appointments';
 import Demographics from '../index';
 
 import { createMockRouter } from '../../../../tests/unit/mocks/router';
@@ -16,47 +20,7 @@ describe('pre-check-in', () => {
       const mockStore = configureStore(middleware);
       const initState = {
         checkInData: {
-          appointments: [
-            {
-              facility: 'LOMA LINDA VA CLINIC',
-              clinicPhoneNumber: '5551234567',
-              clinicFriendlyName: 'TEST CLINIC',
-              clinicName: 'LOM ACC CLINIC TEST',
-              appointmentIen: 'some-ien',
-              startTime: '2021-11-30T17:12:10.694Z',
-              eligibility: 'ELIGIBLE',
-              facilityId: 'some-facility',
-              checkInWindowStart: '2021-11-30T17:12:10.694Z',
-              checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-              checkedInTime: '',
-            },
-            {
-              facility: 'LOMA LINDA VA CLINIC',
-              clinicPhoneNumber: '5551234567',
-              clinicFriendlyName: 'TEST CLINIC',
-              clinicName: 'LOM ACC CLINIC TEST',
-              appointmentIen: 'some-ien',
-              startTime: '2021-11-30T17:12:10.694Z',
-              eligibility: 'ELIGIBLE',
-              facilityId: 'some-facility',
-              checkInWindowStart: '2021-11-30T17:12:10.694Z',
-              checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-              checkedInTime: '',
-            },
-            {
-              facility: 'LOMA LINDA VA CLINIC',
-              clinicPhoneNumber: '5551234567',
-              clinicFriendlyName: 'TEST CLINIC',
-              clinicName: 'LOM ACC CLINIC TEST',
-              appointmentIen: 'some-other-ien',
-              startTime: '2021-11-30T17:12:10.694Z',
-              eligibility: 'ELIGIBLE',
-              facilityId: 'some-facility',
-              checkInWindowStart: '2021-11-30T17:12:10.694Z',
-              checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-              checkedInTime: '',
-            },
-          ],
+          appointments: multipleAppointments,
           veteranData: {
             demographics: {
               nextOfKin1: {
@@ -206,21 +170,7 @@ describe('pre-check-in', () => {
     let store;
     const initState = {
       checkInData: {
-        appointments: [
-          {
-            facility: 'LOMA LINDA VA CLINIC',
-            clinicPhoneNumber: '5551234567',
-            clinicFriendlyName: 'TEST CLINIC',
-            clinicName: 'LOM ACC CLINIC TEST',
-            appointmentIen: 'some-ien',
-            startTime: '2022-01-03T14:56:04.788Z',
-            eligibility: 'ELIGIBLE',
-            facilityId: 'some-facility',
-            checkInWindowStart: '2022-01-03T14:56:04.788Z',
-            checkInWindowEnd: '2022-01-03T14:56:04.788Z',
-            checkedInTime: '',
-          },
-        ],
+        appointments: singleAppointment,
         context: {
           token: '',
         },

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -11,7 +11,7 @@ import MockDate from 'mockdate';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
 
 import i18n from '../../../../utils/i18n/i18n';
-
+import { singleAppointment } from '../../../../tests/unit/mocks/mock-appointments';
 import Error from '../index';
 
 describe('check-in', () => {
@@ -23,21 +23,7 @@ describe('check-in', () => {
         const mockStore = configureStore(middleware);
         const initState = {
           checkInData: {
-            appointments: [
-              {
-                facility: 'LOMA LINDA VA CLINIC',
-                clinicPhoneNumber: '5551234567',
-                clinicFriendlyName: 'TEST CLINIC',
-                clinicName: 'LOM ACC CLINIC TEST',
-                appointmentIen: 'some-ien',
-                startTime: '2022-01-03T14:56:04.788Z',
-                eligibility: 'ELIGIBLE',
-                facilityId: 'some-facility',
-                checkInWindowStart: '2022-01-03T14:56:04.788Z',
-                checkInWindowEnd: '2022-01-03T14:56:04.788Z',
-                checkedInTime: '',
-              },
-            ],
+            appointments: singleAppointment,
             veteranData: {},
           },
           featureToggles: {

--- a/src/applications/check-in/pre-check-in/pages/Introduction/tests/IntroductionDisplay.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/tests/IntroductionDisplay.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import { multipleAppointments } from '../../../../tests/unit/mocks/mock-appointments';
 import IntroductionDisplay from '../IntroductionDisplay';
 
 describe('pre-check-in', () => {
@@ -12,47 +13,7 @@ describe('pre-check-in', () => {
       const mockStore = configureStore(middleware);
       const initState = {
         checkInData: {
-          appointments: [
-            {
-              facility: 'LOMA LINDA VA CLINIC',
-              clinicPhoneNumber: '5551234567',
-              clinicFriendlyName: 'TEST CLINIC',
-              clinicName: 'LOM ACC CLINIC TEST',
-              appointmentIen: 'some-ien',
-              startTime: '2021-11-30T17:12:10.694Z',
-              eligibility: 'ELIGIBLE',
-              facilityId: 'some-facility',
-              checkInWindowStart: '2021-11-30T17:12:10.694Z',
-              checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-              checkedInTime: '',
-            },
-            {
-              facility: 'LOMA LINDA VA CLINIC',
-              clinicPhoneNumber: '5551234567',
-              clinicFriendlyName: 'TEST CLINIC',
-              clinicName: 'LOM ACC CLINIC TEST',
-              appointmentIen: 'some-ien',
-              startTime: '2021-11-30T17:12:10.694Z',
-              eligibility: 'ELIGIBLE',
-              facilityId: 'some-facility',
-              checkInWindowStart: '2021-11-30T17:12:10.694Z',
-              checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-              checkedInTime: '',
-            },
-            {
-              facility: 'LOMA LINDA VA CLINIC',
-              clinicPhoneNumber: '5551234567',
-              clinicFriendlyName: 'TEST CLINIC',
-              clinicName: 'LOM ACC CLINIC TEST',
-              appointmentIen: 'some-other-ien',
-              startTime: '2021-11-30T17:12:10.694Z',
-              eligibility: 'ELIGIBLE',
-              facilityId: 'some-facility',
-              checkInWindowStart: '2021-11-30T17:12:10.694Z',
-              checkInWindowEnd: '2021-11-30T17:12:10.694Z',
-              checkedInTime: '',
-            },
-          ],
+          appointments: multipleAppointments,
           veteranData: {
             demographics: {
               nextOfKin1: {

--- a/src/applications/check-in/tests/unit/mocks/mock-appointments.js
+++ b/src/applications/check-in/tests/unit/mocks/mock-appointments.js
@@ -1,0 +1,59 @@
+const singleAppointment = [
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien',
+    startTime: '2022-01-03T14:56:04.788Z',
+    eligibility: 'ELIGIBLE',
+    facilityId: 'some-facility',
+    checkInWindowStart: '2022-01-03T14:56:04.788Z',
+    checkInWindowEnd: '2022-01-03T14:56:04.788Z',
+    checkedInTime: '',
+  },
+];
+
+const multipleAppointments = [
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien',
+    startTime: '2021-11-30T17:12:10.694Z',
+    eligibility: 'ELIGIBLE',
+    facilityId: 'some-facility',
+    checkInWindowStart: '2021-11-30T17:12:10.694Z',
+    checkInWindowEnd: '2021-11-30T17:12:10.694Z',
+    checkedInTime: '',
+  },
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien',
+    startTime: '2021-11-30T17:12:10.694Z',
+    eligibility: 'ELIGIBLE',
+    facilityId: 'some-facility',
+    checkInWindowStart: '2021-11-30T17:12:10.694Z',
+    checkInWindowEnd: '2021-11-30T17:12:10.694Z',
+    checkedInTime: '',
+  },
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-other-ien',
+    startTime: '2021-11-30T17:12:10.694Z',
+    eligibility: 'ELIGIBLE',
+    facilityId: 'some-facility',
+    checkInWindowStart: '2021-11-30T17:12:10.694Z',
+    checkInWindowEnd: '2021-11-30T17:12:10.694Z',
+    checkedInTime: '',
+  },
+];
+
+export { singleAppointment, multipleAppointments };


### PR DESCRIPTION
## Description
So many of our tests are using copy and pasted appointments. This PR moves the duplicated appointments into an import to clean up code files. For now this is just a single and a multiple appointment test case. As we expand phone appointments, it might be worth adding that here as well. Any one-off test appointment cases with unique properties I left in place.


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
