### PR TITLE
Add debug statements

### DIFF
--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -86,9 +86,15 @@ i18n
   });
 
 // This is necessary for DS components to use our language preference on initial load.
+// @TODO remove this.
+// eslint-disable-next-line no-console
+console.log('Setting page language on initial load');
 setPageLanguage(i18n.language);
 
 i18n.on('languageChanged', language => {
+  // @TODO remove this.
+  // eslint-disable-next-line no-console
+  console.log('Setting page language on language changed');
   setPageLanguage(language);
 });
 

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -85,11 +85,15 @@ i18n
     },
   });
 
-// This is necessary for DS components to use our language preference on initial load.
-// @TODO remove this.
-// eslint-disable-next-line no-console
-console.log('Setting page language on initial load');
-setPageLanguage(i18n.language);
+// Ugly hack to try and trigger DS language detection.
+window.addEventListener('load', () => {
+  // @TODO remove this.
+  // eslint-disable-next-line no-console
+  console.log('Setting page language after load.');
+  setTimeout(() => {
+    setPageLanguage(i18n.language);
+  }, 10);
+});
 
 i18n.on('languageChanged', language => {
   // @TODO remove this.

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -85,11 +85,17 @@ i18n
     },
   });
 
+// This is necessary for DS components to use our language preference on initial load.
+// @TODO remove this.
+// eslint-disable-next-line no-console
+console.log(`Setting page language to ${i18n.language} on initial load.`);
+setPageLanguage(i18n.language);
+
 // Ugly hack to try and trigger DS language detection.
 window.addEventListener('load', () => {
   // @TODO remove this.
   // eslint-disable-next-line no-console
-  console.log('Setting page language after load.');
+  console.log(`Setting page language to ${i18n.language} after load.`);
   setTimeout(() => {
     setPageLanguage(i18n.language);
   }, 10);

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -86,25 +86,16 @@ i18n
   });
 
 // This is necessary for DS components to use our language preference on initial load.
-// @TODO remove this.
-// eslint-disable-next-line no-console
-console.log(`Setting page language to ${i18n.language} on initial load.`);
 setPageLanguage(i18n.language);
 
-// Ugly hack to try and trigger DS language detection.
+// Ugly hack to trigger DS language detection.
 window.addEventListener('load', () => {
-  // @TODO remove this.
-  // eslint-disable-next-line no-console
-  console.log(`Setting page language to ${i18n.language} after load.`);
   setTimeout(() => {
     setPageLanguage(i18n.language);
   }, 10);
 });
 
 i18n.on('languageChanged', language => {
-  // @TODO remove this.
-  // eslint-disable-next-line no-console
-  console.log('Setting page language on language changed');
   setPageLanguage(language);
 });
 


### PR DESCRIPTION
## Description

This PR uses a workaround to deal with the fact that DS components [don't detect the language set on the main element](https://github.com/department-of-veterans-affairs/component-library/blob/master/packages/core/src/i18n/i18n-setup.js) if it is set between when their i18n instance is initialized and when the DOM is fully loaded. (I'll be submitting a separate issue in the DS queue)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42559


## Testing done

- tested on review environment

## Screenshots


## Acceptance criteria
- [ ] works on staging (we'll have to merge to find out...)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
