### PR TITLE
10-10CG - Added signAsRepresentative property to submission  payload

### DIFF
--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -66,6 +66,7 @@ export const submitTransform = (formConfig, form) => {
 
     const sortedDataByChapter = {
       [chapterName]: {},
+      signAsRepresentative: false, // sign as veteran is default and false
     };
 
     const lowerCaseFirstLetter = string =>
@@ -82,8 +83,12 @@ export const submitTransform = (formConfig, form) => {
 
         const documentUpload = data[key][0].guid;
         sortedDataByChapter.poaAttachmentId = documentUpload;
-
-        // if has same prefix
+      } else if (key === 'signAsRepresentativeYesNo') {
+        if (data[key] === 'yes') {
+          sortedDataByChapter.signAsRepresentative = true; // sign as representative
+        } else {
+          sortedDataByChapter.signAsRepresentative = false; // sign as veteran
+        }
       } else if (key.includes(dataPrefix)) {
         // if preferredFacility grab the nested "plannedClinic" value, and surface it
         if (key === 'veteranPreferredFacility') {


### PR DESCRIPTION
## Description
Either the Veteran or the legal representative can sign and submit the 10-10cg form. We would like to gain visibility and be able to report on whether the legal rep or the Veteran submitted an application form ; this will help us understand whether the changes for the legal-rep section have had a positive impact on submissions and reduced failures etc.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38163


## Testing done
verified unit tests
verified e2e tests

