### PR TITLE
Update eslint-plugin dependency to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.9.12",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.1.0",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.2.0",
     "@department-of-veterans-affairs/generator-vets-website": "^3.6.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,10 +2737,10 @@
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.1.0.tgz#fcfb3651485aaddb66f1f46f227b670b2adce7da"
-  integrity sha512-QLtevzdk7axqtFVVI0NRc9qhbCcSAdgmv/PkQF0kUPNZagKlDImL8acZRK0U74cixKIL1JUSkk8FSi761phL6w==
+"@department-of-veterans-affairs/eslint-plugin@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.2.0.tgz#f006323471502ac9a0c0b961c0600372b521ef5c"
+  integrity sha512-kmsVSJx4Ug6f2b+nO0TSh8j2BblCHnBmtX95KuY5d7cT8Tc2r2Aeu7czvlEJOwKtFsuifwOZB3dWYE9bq/CPcA==
 
 "@department-of-veterans-affairs/formation@^7.0.1":
   version "7.0.1"


### PR DESCRIPTION
## Description
This PR updates `@department-of-veterans-affairs/eslint-plugin` to 1.2.0 which includes the deprecated-classes rule for the deprecation of the infamous green button.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/653

## Screenshots
<img width="1024" alt="Screen Shot 2022-06-15 at 12 09 40" src="https://user-images.githubusercontent.com/36863582/173876307-c1847354-85af-4d8b-bf02-dbe2e52f1397.png">


## Acceptance criteria
- [x] vets-website @department-of-veterans-affairs/eslint-plugin dependency is set to ^1.2.0

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
