### PR TITLE
VACMS-9332: Removes chatbot gate

### DIFF
--- a/src/applications/static-pages/contact-chatbot-cta/components/App/index.js
+++ b/src/applications/static-pages/contact-chatbot-cta/components/App/index.js
@@ -3,28 +3,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-const restrictWidgetStorageKey = 'restrict-chatbot-cta';
-const displayThreshold = 50;
+// const restrictWidgetStorageKey = 'restrict-chatbot-cta';
+// const displayThreshold = 50;
 
 export const App = () => {
-  // restrict view to roughly 50% of users
-  const restrictDisplay = () => {
-    const restrict = window.localStorage.getItem(restrictWidgetStorageKey);
-    if (restrict) {
-      return Number.parseInt(restrict, 10) <= displayThreshold;
-    }
-    const restrictVar = Math.random().toFixed(2) * 100;
-    window.localStorage.setItem(
-      restrictWidgetStorageKey,
-      restrictVar.toString(),
-    );
-    return restrictVar <= displayThreshold;
-  };
+  /**
+   * NOTE:
+   *
+   * Currently, all traffic should be allowed. Keeping this function
+   * in place but commented so the option of gating is still available.
+   *
+   * When it's determined that it is no longer needed, this function
+   * can be removed, in addition to the const values defined above and
+   * the check for !isAllowed below.
+   */
 
-  const isAllowed = restrictDisplay();
-  if (!isAllowed) {
-    return null;
-  }
+  // const restrictDisplay = () => {
+  //   const restrict = window.localStorage.getItem(restrictWidgetStorageKey);
+  //   if (restrict) {
+  //     return Number.parseInt(restrict, 10) <= displayThreshold;
+  //   }
+  //   const restrictVar = Math.random().toFixed(2) * 100;
+  //   window.localStorage.setItem(
+  //     restrictWidgetStorageKey,
+  //     restrictVar.toString(),
+  //   );
+  //   return restrictVar <= displayThreshold;
+  // };
+
+  // const isAllowed = restrictDisplay();
+  // if (!isAllowed) {
+  //   return null;
+  // }
 
   return (
     <va-alert status="info">

--- a/src/applications/static-pages/contact-chatbot-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/contact-chatbot-cta/components/App/index.unit.spec.js
@@ -6,7 +6,16 @@ import { shallow } from 'enzyme';
 import { App } from '.';
 
 describe('Contact Chatbot CTA <App>', () => {
-  it('does not render when feature toggle is falsey', () => {
+  /**
+   * NOTE:
+   *
+   * These tests need some work. The `show` property is not doing anything.
+   * This first test will fail inconsistently based on the random number
+   * generation. For now, skipping the tests while we have the gate
+   * logic commented out in index.js. Should revisit this when we decide
+   * to permanently remove gate logic.
+   */
+  it.skip('does not render when feature toggle is falsey', () => {
     const wrapper = shallow(<App show={false} />);
     expect(wrapper.type()).to.equal(null);
     wrapper.unmount();


### PR DESCRIPTION
## Description
Goal is to show this widget to all traffic, but leave the logic in place in case we need to employ the gating mechanism in the future. This PR just comments out the gating mechanism and shows the widget unconditionally. This is preferred to changing the value to 100 and keeping the logic live, as this would be unnecessary processing.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9332


## Testing done
Locally, widget shows on all page loads.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/173880357-ae9b1e68-69e8-4ea6-8224-b0850ba8b2bd.png)

