### PR TITLE
fixed store.dispatch not being called

### DIFF
--- a/src/platform/site-wide/alerts/showVaAlertExpandable.js
+++ b/src/platform/site-wide/alerts/showVaAlertExpandable.js
@@ -1,10 +1,10 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 
-export default function showVaExpandableAlert(state) {
-  connectFeatureToggle(state);
-  state.subscribe(() => {
-    const flags = toggleValues(state.getState());
+export default function showVaExpandableAlert(store) {
+  connectFeatureToggle(store.dispatch);
+  store.subscribe(() => {
+    const flags = toggleValues(store.getState());
 
     if (
       flags?.showExpandableVamcAlert === 'undefined' ||


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9467
Typo in VaAlertExpansion component causing an error in console.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#9467


## Testing done
Ensured error is no longer occurring on local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
