### PR TITLE
1010EZ - use user.login.currentlyLoggedIn instead of hasSession for conditionally showing pages

### DIFF
--- a/src/applications/hca/HealthCareApp.jsx
+++ b/src/applications/hca/HealthCareApp.jsx
@@ -18,6 +18,7 @@ const HealthCareEntry = ({
   setFormData,
   formData,
   hasSavedForm,
+  isLoggedIn,
 }) => {
   useEffect(
     // included veteranFullName to reset view flipper toggles when starting a new application from save-in-progress
@@ -29,12 +30,14 @@ const HealthCareEntry = ({
           ...formData,
           'view:caregiverSIGIEnabled': caregiverSIGIEnabled,
           'view:hcaAmericanIndianEnabled': hcaAmericanIndianEnabled,
+          'view:isLoggedIn': isLoggedIn,
         });
       } else {
         setFormData({
           ...formData,
           'view:caregiverSIGIEnabled': caregiverSIGIEnabled,
           'view:hcaAmericanIndianEnabled': hcaAmericanIndianEnabled,
+          'view:isLoggedIn': isLoggedIn,
           'view:hcaShortFormEnabled': hcaShortFormEnabled,
         });
       }
@@ -47,6 +50,7 @@ const HealthCareEntry = ({
       hcaShortFormEnabled,
       formData.veteranFullName,
       hasSavedForm,
+      isLoggedIn,
     ],
   );
 
@@ -71,6 +75,7 @@ const mapStateToProps = state => ({
   hasSavedForm: state?.user?.profile?.savedForms.some(
     form => form.form === VA_FORM_IDS.FORM_10_10EZ,
   ),
+  isLoggedIn: state?.user?.login?.currentlyLoggedIn,
 });
 
 const mapDispatchToProps = {
@@ -83,6 +88,7 @@ HealthCareEntry.propTypes = {
   hasSavedForm: PropTypes.bool,
   hcaAmericanIndianEnabled: PropTypes.bool,
   hcaShortFormEnabled: PropTypes.bool,
+  isLoggedIn: PropTypes.bool,
   setFormData: PropTypes.func,
 };
 

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -5,7 +5,6 @@ import environment from 'platform/utilities/environment';
 import preSubmitInfo from 'platform/forms/preSubmitInfo';
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import { VA_FORM_IDS } from 'platform/forms/constants';
-import { hasSession } from 'platform/user/profile/utilities';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
 
 // HCA internal app imports
@@ -139,7 +138,7 @@ const formConfig = {
       path: 'id-form',
       component: IDPage,
       pageKey: 'id-form',
-      depends: () => !hasSession(),
+      depends: formData => !formData['view:isLoggedIn'],
     },
   ],
   confirmation: ConfirmationPage,
@@ -169,7 +168,7 @@ const formConfig = {
           CustomPage: PersonalAuthenticatedInformation,
           CustomPageReview: null,
           initialData: {},
-          depends: () => hasSession(),
+          depends: formData => formData['view:isLoggedIn'],
           uiSchema: {},
           schema: {
             type: 'object',
@@ -180,7 +179,7 @@ const formConfig = {
           path: 'veteran-information/profile-information',
           title: 'Veteran name',
           initialData: {},
-          depends: () => !hasSession(),
+          depends: formData => !formData['view:isLoggedIn'],
           uiSchema: veteranInformation.uiSchema,
           schema: veteranInformation.schema,
         },
@@ -188,7 +187,7 @@ const formConfig = {
           path: 'veteran-information/profile-information-ssn',
           title: 'Social Security number',
           initialData: {},
-          depends: () => !hasSession(),
+          depends: formData => !formData['view:isLoggedIn'],
           uiSchema: personalInformationSsn.uiSchema,
           schema: personalInformationSsn.schema,
         },
@@ -196,7 +195,7 @@ const formConfig = {
           path: 'veteran-information/profile-information-dob',
           title: 'Date of birth',
           initialData: {},
-          depends: () => !hasSession(),
+          depends: formData => !formData['view:isLoggedIn'],
           uiSchema: personalInformationDOB.uiSchema,
           schema: personalInformationDOB.schema,
         },


### PR DESCRIPTION
## Description
Change using hasSession to currentlyLoggedIn in form.js depends functions to determine to display static page for authenticated users or input pages for unauthenticated users.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41339


## Testing done
verified unit tests
verified e2e tests


