### PR TITLE
Revert "chore: update eslint-plugin dependency (#21361)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.9.12",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.2.0",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.1.0",
     "@department-of-veterans-affairs/generator-vets-website": "^3.6.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,10 +2737,10 @@
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.2.0.tgz#f006323471502ac9a0c0b961c0600372b521ef5c"
-  integrity sha512-kmsVSJx4Ug6f2b+nO0TSh8j2BblCHnBmtX95KuY5d7cT8Tc2r2Aeu7czvlEJOwKtFsuifwOZB3dWYE9bq/CPcA==
+"@department-of-veterans-affairs/eslint-plugin@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.1.0.tgz#fcfb3651485aaddb66f1f46f227b670b2adce7da"
+  integrity sha512-QLtevzdk7axqtFVVI0NRc9qhbCcSAdgmv/PkQF0kUPNZagKlDImL8acZRK0U74cixKIL1JUSkk8FSi761phL6w==
 
 "@department-of-veterans-affairs/formation@^7.0.1":
   version "7.0.1"


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets-website/pull/21361 upgraded our custom eslint-plugin to version 1.2.0. Linting succeeded in the PR itself when linting only changed files, but failed when linting all apps in `main`. Rolling back the the PR here to allow main CI to succeed.

## Original issue(s)
N/A

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
