### PR TITLE
Display Error Confirmation Page if Null Claim Status After 1 Minute

### DIFF
--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -116,7 +116,7 @@ export function fetchClaimStatus() {
     dispatch({ type: FETCH_CLAIM_STATUS });
     const timeoutResponse = {
       attributes: {
-        claimStatus: CLAIM_STATUS_RESPONSE_IN_PROGRESS,
+        claimStatus: CLAIM_STATUS_RESPONSE_ERROR,
         receivedDate: getNowDate(),
       },
     };
@@ -124,8 +124,7 @@ export function fetchClaimStatus() {
     poll({
       endpoint: CLAIM_STATUS_ENDPOINT,
       validate: response =>
-        response.data.attributes &&
-        response.data.attributes.claimStatus &&
+        response?.data?.attributes?.claimStatus &&
         response.data.attributes.claimStatus !==
           CLAIM_STATUS_RESPONSE_IN_PROGRESS,
       dispatch,


### PR DESCRIPTION
## Description
After the My Education Benefits form is submitted, we poll every 5 seconds for 1 minute to receive a claim status. If the claim status is null after that minute, display an error message, rather than the "In Progress" status.