### PR TITLE
42910 - CDP - Sanitize Text in Statement Table

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
@@ -21,7 +21,11 @@ const StatementCharges = ({ copay }) => {
     billref: item.pDRefNo,
     amount: (
       <div>
-        ${item.pDTransAmtOutput.replace('-', '').replace(/[^\d.-]/g, '')}
+        $
+        {item.pDTransAmtOutput
+          .replace('&nbsp', '')
+          .replace('-', '')
+          .replace(/[^\d.-]/g, '')}
       </div>
     ),
   }));


### PR DESCRIPTION
## Description
Sanitized text received and displayed to remove non-breaking spaces.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42910 

## Screenshots
![42910_Working](https://user-images.githubusercontent.com/29178824/174082644-a6275fde-ddfb-4c1f-b659-340e9c0402ea.png)

## Acceptance criteria
- [ X ] Text no longer renders nbsp characters

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
