### PR TITLE
Skip flaky daily-product-scan and save-in-progress tests

### DIFF
--- a/script/github-actions/daily-product-scan/tests/index.unit.spec.js
+++ b/script/github-actions/daily-product-scan/tests/index.unit.spec.js
@@ -19,7 +19,7 @@ describe('daily-product-scan', () => {
       ({ status, message, data } = await main({ octokit }));
     });
 
-    it('sets the status return prop to the correct value', () => {
+    it.skip('sets the status return prop to the correct value', () => {
       expect(status).to.equal('Success');
     });
 

--- a/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
@@ -123,7 +123,7 @@ describe('Schemaform <SaveFormLink>', () => {
     expect(tree.text()).to.contain('Sorry, you’re signed out.');
     expect(tree.subTree('a')).not.to.be.null;
   });
-  it('should call saveInProgressForm if logged in', () => {
+  it.skip('should call saveInProgressForm if logged in', () => {
     saveInProgressForm.reset(); // Just because it's good practice for a shared spy
     const tree = ReactTestUtils.renderIntoDocument(
       // Wrapped in a div because I SaveFormLink only returns an anchor and I


### PR DESCRIPTION
## Description
Skipping flaky tests where we've seen multiple failures on `main` recently:

```
     daily-product-scan
       success, changes ARE detected
         "before each" hook for "sets the message return prop to the correct value":
     Error: "before each" hook for "sets the message return prop to the correct value": Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/runner4/_work/vets-website/vets-website/script/github-actions/daily-product-scan/tests/index.unit.spec.js)
```

and also

```
     Schemaform <SaveFormLink>
       should call saveInProgressForm if logged in:
     Error: An error was thrown inside one of your components, but React doesn't know what it was. This is likely due to browser flakiness. React does its best to preserve the "Pause on exceptions" behavior of the DevTools, which requires some DEV-mode only tricks. It's possible that these don't work in your browser. Try triggering the error in production mode, or switching to a modern browser. If you suspect that this is actually an issue with React, please file an issue.
```

## Original issue(s)
N/A

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
