### PR TITLE
Add custom applicant description text to Health Care application

### DIFF
--- a/src/applications/hca/components/HCAApplicantDescription.jsx
+++ b/src/applications/hca/components/HCAApplicantDescription.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
+
+const HCAApplicantDescription = ({ formContext }) => (
+  <div>
+    <p>
+      You don’t have to fill in all these fields. But we can review your
+      application faster if you provide more information.
+    </p>
+    <PrefillMessage formContext={formContext} />
+  </div>
+);
+
+HCAApplicantDescription.propTypes = {
+  formContext: PropTypes.object,
+};
+
+export default HCAApplicantDescription;

--- a/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
@@ -31,7 +31,7 @@ export default {
       },
       'ui:description': (
         <p>
-          You aren’t required to fill in all fields, but we can review your
+          You don’t have to fill in all these fields. But we can review your
           application faster if you provide more information.
         </p>
       ),

--- a/src/applications/hca/config/chapters/veteranInformation/personalnformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/personalnformation.js
@@ -1,14 +1,14 @@
 import merge from 'lodash/merge';
 
-import applicantDescription from 'platform/forms/components/ApplicantDescription';
 import fullNameUI from 'platform/forms/definitions/fullName';
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
+import HCAApplicantDescription from 'applications/hca/components/HCAApplicantDescription';
 
 const { veteranFullName } = fullSchemaHca.properties;
 
 export default {
   uiSchema: {
-    'ui:description': applicantDescription,
+    'ui:description': HCAApplicantDescription,
     veteranFullName: merge({}, fullNameUI, {
       first: {
         'ui:errorMessages': {


### PR DESCRIPTION
## Description
This PR creates a custom component to utilize in place of the standard `<ApplicantDescription>` in the 10-10EZ Health Care application. Our UX team wanted to deviate slightly from the forms system applicant description text, thus requiring a custom component.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#41985


## Screenshot(s)
![Screen Shot 2022-06-16 at 12 10 23 PM](https://user-images.githubusercontent.com/6738544/174116651-a920f9c1-5831-49f6-8c6e-a917fa5b9ded.png)


## Acceptance criteria
- [ ] Custom component renders as expected on applicant name page in Step 1 of the form


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
