### PR TITLE
Add link for phone number and tty

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -103,9 +103,7 @@ const PersonalInformationSection = ({
             photo ID that shows proof of the correct information. We’ll accept a
             government-issued photo ID, driver’s license, or passport as proof.
           </p>
-
           <p>Here’s how to request a correction:</p>
-
           <p>
             <span className="vads-u-font-weight--bold vads-u-display--block ">
               If you’re enrolled in the VA health care program
@@ -113,15 +111,16 @@ const PersonalInformationSection = ({
             Please contact your nearest VA medical center to update your
             personal information.
           </p>
-
           <a href="/find-locations/">Find your nearest VA medical center</a>
-
           <p className="vads-u-margin-bottom--0">
             <span className="vads-u-font-weight--bold vads-u-display--block">
               If you receive VA benefits, but aren’t enrolled in VA health care
             </span>
-            Call us at 800-827-1000 (TTY: +711). We’re here Monday through
-            Friday, 8:00 a.m. to 9:00 p.m. ET.
+            Call us at <va-telephone contact="800-827-1000" /> (
+            <a href="tel:711" aria-label="TTY: 7 1 1.">
+              TTY: +711
+            </a>
+            ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
           </p>
         </va-additional-info>
       </div>


### PR DESCRIPTION
## Description
Changes the text in the 'How to fix an error in your name or date of birth' to be a link for the 800 number listed

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/42758


## Testing done
Tested locally, just content changes

## Screenshots

**Before**

![Screen Shot 2022-06-16 at 10 11 55 AM](https://user-images.githubusercontent.com/8332986/174118817-3141d80d-4ff6-41f5-8a0e-01eb0681b7b9.png)

**After**

![Screen Shot 2022-06-16 at 10 12 23 AM](https://user-images.githubusercontent.com/8332986/174118804-2b45d175-526d-4adc-9703-7d0847628224.png)



## Acceptance criteria
- [x] Number updated to be a link

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
