### PR TITLE
Add description to Health Care application contact form

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const ContactInfoDescription = () => (
+  <div className="vads-u-margin-bottom--5">
+    <p>
+      Adding your email and phone number is optional. But this information helps
+      us contact you faster if we need to follow up with you about your
+      application. If you don’t add this information, we’ll use your address to
+      contact you by mail.
+    </p>
+    <p>
+      <strong>Note:</strong> We’ll always mail you a copy of our decision on
+      your application for your records.
+    </p>
+  </div>
+);

--- a/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
@@ -9,12 +9,14 @@ import {
   HIGH_DISABILITY,
   emptyObjectSchema,
 } from '../../../helpers';
+import { ContactInfoDescription } from '../../../components/FormDescriptions';
 
 const { email } = fullSchemaHca.properties;
 const { phone } = fullSchemaHca.definitions;
 
 export default {
   uiSchema: {
+    'ui:description': ContactInfoDescription,
     'view:contactShortFormMessage': {
       'ui:description': shortFormMessage,
       'ui:options': {


### PR DESCRIPTION
## Description
This PR adds introduction verbiage to the optional contact info form within the Health Care application. The goal with the verbiage to entice folks to fill out the optional fields.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#42291


## Screenshot(s)
![Screen Shot 2022-06-16 at 1 43 07 PM](https://user-images.githubusercontent.com/6738544/174133340-3a72ad8e-5c70-4267-85d9-af6bbfaad28f.png)



## Acceptance criteria
- [ ] Content block renders on contact info form page


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
