### PR TITLE
bumps vets-json-schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ecdb84139a36c0e698fe8e090361cf1fd08b3fa6",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#901cc443a8f7e217287883067c87efde99cbd3b5",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/src/applications/lgy/coe/form/tests/config/applicantInformation.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/config/applicantInformation.unit.spec.jsx
@@ -6,9 +6,9 @@ import { Provider } from 'react-redux';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import createCommonStore from 'platform/startup/store';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 const defaultStore = createCommonStore();
 
@@ -31,7 +31,7 @@ describe('COE applicant information', () => {
     );
     const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input').length).to.equal(7);
+    expect(formDOM.querySelectorAll('input').length).to.equal(6);
   });
 
   it('Should not submit without required fields', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20112,9 +20112,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ecdb84139a36c0e698fe8e090361cf1fd08b3fa6":
-  version "20.20.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ecdb84139a36c0e698fe8e090361cf1fd08b3fa6"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#901cc443a8f7e217287883067c87efde99cbd3b5":
+  version "20.20.3"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#901cc443a8f7e217287883067c87efde99cbd3b5"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description

This simply updates the `json-vet-schema` to the lastest commit:


[901cc443a8f7e217287883067c87efde99cbd3b5](https://github.com/department-of-veterans-affairs/vets-json-schema/commit/901cc443a8f7e217287883067c87efde99cbd3b5#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L1)

These schema changes relate to Certificate of Eligibility, specifically:
1. allowing the vets mailing address zip code to use the 9 digit variant
2. removing street address 3 from the form

## Original issue(s)
Original Related Issue [#42284](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42284)