### PR TITLE
Update eslint-plugin to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.9.12",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.1.0",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.2.1",
     "@department-of-veterans-affairs/generator-vets-website": "^3.6.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,10 +2737,10 @@
     react-scroll "^1.7.16"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.1.0.tgz#fcfb3651485aaddb66f1f46f227b670b2adce7da"
-  integrity sha512-QLtevzdk7axqtFVVI0NRc9qhbCcSAdgmv/PkQF0kUPNZagKlDImL8acZRK0U74cixKIL1JUSkk8FSi761phL6w==
+"@department-of-veterans-affairs/eslint-plugin@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.2.1.tgz#98186933a21d3ef4a1790d1aa2585232849cd176"
+  integrity sha512-4QRsPsm5in1hTIS2RILjNYycICrbXWpGXXug+qhCDKfOK78hjgbzQXhyZ0KXh0NXB47NR4JA1H9jjy9oKemxwg==
 
 "@department-of-veterans-affairs/formation@^7.0.1":
   version "7.0.1"


### PR DESCRIPTION
## Description
This PR updates eslint-plugin dependency to 1.2.1 to deprecate the infamous green button.

## Original issue(s)
Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/653


## Testing done
<img width="1346" alt="Screen Shot 2022-06-16 at 19 20 02" src="https://user-images.githubusercontent.com/36863582/174193776-a20ae431-b1a0-4bfc-be99-836c25507243.png">

## Screenshots
<img width="1015" alt="Screen Shot 2022-06-16 at 19 23 54" src="https://user-images.githubusercontent.com/36863582/174194125-9e57ae64-c0d0-415a-b1a2-c09a9f724025.png">


## Acceptance criteria
- [x] vets-website is using `@department-of-veterans-affairs/eslint-plugin` v1.2.1

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
