### PR TITLE
VACMS-8687: Manage-healthcare widgets conditionally use Drupal as EHR data source

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -4,10 +4,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
+import {
+  selectPatientFacilities,
+  selectPatientFacilitiesDsot,
+} from 'platform/user/selectors';
 import AuthContent from '../AuthContent';
 import UnauthContent from '../UnauthContent';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
-import { selectPatientFacilities } from 'platform/user/selectors';
 
 export const App = ({ facilities, authenticatedWithSSOe }) => {
   const cernerFacilities = facilities?.filter(f => f.usesCernerMedicalRecords);
@@ -43,7 +46,9 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
-  facilities: selectPatientFacilities(state),
+  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
+    ? selectPatientFacilitiesDsot(state)
+    : selectPatientFacilities(state),
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
@@ -2,10 +2,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
+    connectDrupalSourceOfTruthCerner(store.dispatch);
     import(/* webpackChunkName: "get-medical-records-page" */
     './components/App').then(module => {
       const App = module.default;

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -5,7 +5,10 @@ import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
-import { selectPatientFacilities } from 'platform/user/selectors';
+import {
+  selectPatientFacilities,
+  selectPatientFacilitiesDsot,
+} from 'platform/user/selectors';
 import AuthContent from '../AuthContent';
 import UnauthContent from '../UnauthContent';
 
@@ -43,7 +46,9 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
-  facilities: selectPatientFacilities(state),
+  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
+    ? selectPatientFacilitiesDsot(state)
+    : selectPatientFacilities(state),
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/index.js
@@ -2,10 +2,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
+    connectDrupalSourceOfTruthCerner(store.dispatch);
     import(/* webpackChunkName: "refill-track-prescriptions-page" */
     './components/App').then(module => {
       const App = module.default;

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -4,9 +4,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
+import {
+  selectPatientFacilities,
+  selectPatientFacilitiesDsot,
+} from 'platform/user/selectors';
 import AuthContent from '../AuthContent';
 import UnauthContent from '../UnauthContent';
-import { selectPatientFacilities } from 'platform/user/selectors';
 
 export const App = ({ facilities }) => {
   const cernerFacilities = facilities?.filter(f => f.usesCernerAppointments);
@@ -39,7 +42,9 @@ App.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  facilities: selectPatientFacilities(state),
+  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
+    ? selectPatientFacilitiesDsot(state)
+    : selectPatientFacilities(state),
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/index.js
@@ -2,10 +2,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
+    connectDrupalSourceOfTruthCerner(store.dispatch);
     import(/* webpackChunkName: "schedule-view-va-appointments-page" */
     './components/App').then(module => {
       const App = module.default;

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -4,10 +4,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
+import {
+  selectPatientFacilities,
+  selectPatientFacilitiesDsot,
+} from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import AuthContent from '../AuthContent';
 import UnauthContent from '../UnauthContent';
-import { selectPatientFacilities } from 'platform/user/selectors';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
 export const App = ({ authenticatedWithSSOe, facilities }) => {
   const cernerFacilities = facilities?.filter(f => f.usesCernerMessaging);
@@ -43,7 +46,9 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
-  facilities: selectPatientFacilities(state),
+  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
+    ? selectPatientFacilitiesDsot(state)
+    : selectPatientFacilities(state),
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/index.js
@@ -2,10 +2,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
+    connectDrupalSourceOfTruthCerner(store.dispatch);
     import(/* webpackChunkName: "secure-messaging-page" */
     './components/App').then(module => {
       const App = module.default;

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -4,10 +4,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
+import {
+  selectPatientFacilities,
+  selectPatientFacilitiesDsot,
+} from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import AuthContent from '../AuthContent';
 import UnauthContent from '../UnauthContent';
-import { selectPatientFacilities } from 'platform/user/selectors';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
 export const App = ({ authenticatedWithSSOe, facilities }) => {
   const cernerFacilities = facilities?.filter(f => f.usesCernerTestResults);
@@ -43,7 +46,9 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
-  facilities: selectPatientFacilities(state),
+  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
+    ? selectPatientFacilitiesDsot(state)
+    : selectPatientFacilities(state),
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/index.js
@@ -2,10 +2,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
+    connectDrupalSourceOfTruthCerner(store.dispatch);
     import(/* webpackChunkName: "view-test-and-lab-results-page" */
     './components/App').then(module => {
       const App = module.default;

--- a/src/platform/site-wide/drupal-static-data/reducers/index.js
+++ b/src/platform/site-wide/drupal-static-data/reducers/index.js
@@ -12,7 +12,7 @@ export default function drupalStaticData(state = initialState, action) {
         ...state,
         [action.payload.statePropName]: {
           loading: true,
-          data: {},
+          data: action?.payload?.data || {},
         },
       };
     case FETCH_STATIC_DATA_SUCCEEDED:

--- a/src/platform/utilities/drupal-static-data/connect.js
+++ b/src/platform/utilities/drupal-static-data/connect.js
@@ -15,6 +15,7 @@ export const connectDrupalStaticDataFile = async (dispatch, dataFile) => {
     type: FETCH_STATIC_DATA_STARTED,
     payload: {
       statePropName,
+      data: [],
     },
   });
 


### PR DESCRIPTION
## Description
There are five manage-healthcare widgets managed by the Public Websites team:
1. https://www.va.gov/health-care/refill-track-prescriptions/
2. https://www.va.gov/health-care/secure-messaging/
3. https://www.va.gov/health-care/schedule-view-va-appointments/
4. https://www.va.gov/health-care/view-test-and-lab-results/
5. https://www.va.gov/health-care/get-medical-records/

The behavior of these widgets depends on whether the currently authenticated user belongs to any Cerner facilities. Previously, these widgets determined which facilities are Cerner based on a hard-coded list in `src/platform/utilities/cerner/index.js`. This PR updates that behavior with the following changes:
1. Wires all five widgets to be able to use Drupal as the source of truth
2. Conditionally uses Drupal/hard-coded based on Flipper feature flag.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8687


## Testing done
Tested locally. Confirmed that source of truth changes according to feature toggle. Sets `isCerner` boolean to opposite values in hard-coded vs. Drupal data source to demonstrate the difference.

