### PR TITLE
Replace anchors and telephone component with va-telephone in Health Care application

### DIFF
--- a/src/applications/hca/components/AuthenticatedShortFormAlert.jsx
+++ b/src/applications/hca/components/AuthenticatedShortFormAlert.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 const AuthenticatedShortFormAlert = ({ formData }) => {
   const disabilityRating = formData['view:totalDisabilityRating'];
@@ -21,9 +21,10 @@ const AuthenticatedShortFormAlert = ({ formData }) => {
         <div>
           <va-additional-info trigger="What if I don’t think my rating information is correct here?">
             <p>
-              Call us at <va-telephone contact="877-222-8387" />. We’re here
-              Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-              hearing loss, call TTY: <va-telephone contact={CONTACTS[711]} />.
+              Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re
+              here Monday through Friday, 8:00 a.m. to 9:00 p.m.{' '}
+              <abbr title="eastern time">ET</abbr>. If you have hearing loss,
+              call TTY: <va-telephone contact={CONTACTS['711']} />.
             </p>
           </va-additional-info>
         </div>

--- a/src/applications/hca/components/DowntimeMessage.jsx
+++ b/src/applications/hca/components/DowntimeMessage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import classNames from 'classnames';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export default function DowntimeMessage({ isAfterSteps }) {
   return (
@@ -19,9 +20,10 @@ export default function DowntimeMessage({ isAfterSteps }) {
         </p>
         <p>
           In the meantime, you can call{' '}
-          <a href="tel:+18772228387">877-222-8387</a>, Monday &#8211; Friday,
-          8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and
-          press 2 to complete this application over the phone.
+          <va-telephone contact={CONTACTS['222_VETS']} />, Monday &#8211;{' '}
+          Friday, 8:00 a.m. &#8211; 8:00 p.m. (
+          <abbr title="eastern time">ET</abbr>) and press 2 to complete this
+          application over the phone.
         </p>
       </div>
     </AlertBox>

--- a/src/applications/hca/components/ErrorMessage.jsx
+++ b/src/applications/hca/components/ErrorMessage.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export default function ErrorMessage() {
   return (
     <p>
       If you’d like to complete this form by phone, please call{' '}
-      <a href="tel:+18772228387">877-222-8387</a> and press 2, Monday &#8211;
-      Friday, 8:00 a.m. &#8211; 8:00 p.m. ET.
+      <va-telephone contact={CONTACTS['222_VETS']} /> and press 2. We’re here
+      Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+      <abbr title="eastern time">ET</abbr>.
     </p>
   );
 }

--- a/src/applications/hca/components/GetFormHelp.jsx
+++ b/src/applications/hca/components/GetFormHelp.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 function GetFormHelp() {
   return (
@@ -9,12 +7,8 @@ function GetFormHelp() {
       <p className="help-talk">
         <strong> If you have trouble using this online application,</strong>{' '}
         call our MyVA411 main information line at{' '}
-        <a href="tel:+18006982411">800-698-2411</a> (TTY:{' '}
-        <Telephone
-          contact={CONTACTS['711']}
-          pattern={'###'}
-          ariaLabel={'7 1 1.'}
-        />
+        <va-telephone contact={CONTACTS.HELP_DESK} /> (TTY:{' '}
+        <va-telephone contact={CONTACTS['711']} />
         ). We’re here 24/7.
       </p>
       <p>
@@ -27,15 +21,12 @@ function GetFormHelp() {
         </a>
       </p>
       <p className="help-talk">
-        <strong>If you have questions about VA health care, </strong>
-        call our Health Eligibility Center at{' '}
-        <a href="tel:+18772228387">877-222-8387</a> (TTY:{' '}
-        <Telephone
-          contact={CONTACTS['711']}
-          pattern={'###'}
-          ariaLabel={'7 1 1.'}
-        />
-        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+        <strong>If you have questions about VA health care,</strong> call our
+        Health Eligibility Center at{' '}
+        <va-telephone contact={CONTACTS['222_VETS']} /> (TTY:{' '}
+        <va-telephone contact={CONTACTS['711']} />
+        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+        <abbr title="eastern time">ET</abbr>.
       </p>
     </div>
   );

--- a/src/applications/hca/components/HCASubwayMap.jsx
+++ b/src/applications/hca/components/HCASubwayMap.jsx
@@ -173,7 +173,8 @@ export default function HCASubwayMap() {
                 you apply, please don’t apply again. Call us at{' '}
                 <va-telephone contact={CONTACTS['222_VETS']} />
                 (TTY: <va-telephone contact={CONTACTS[711]} />
-                ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+                ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+                <abbr title="eastern time">ET</abbr>.
               </p>
             </va-additional-info>
           </li>

--- a/src/applications/hca/components/PersonalAuthenticatedInformation.jsx
+++ b/src/applications/hca/components/PersonalAuthenticatedInformation.jsx
@@ -79,12 +79,12 @@ const PersonalAuthenticatedInformation = ({
               </div>
             </div>
             <p>
-              <strong>Note: </strong>
-              If you need to update your personal information, call our VA
-              benefits hotline at{' '}
-              <va-telephone contact={CONTACTS.VA_BENEFITS} />
-              (TTY: <va-telephone contact={CONTACTS[711]} />
-              ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+              <strong>Note:</strong> If you need to update your personal
+              information, call our VA benefits hotline at{' '}
+              <va-telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
+              <va-telephone contact={CONTACTS[711]} />
+              ), Monday through Friday, 8:00 a.m. to 9:00 p.m.{' '}
+              <abbr title="eastern time">ET</abbr>.
             </p>
             <p>
               You can also call your VA medical center (

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -60,7 +60,8 @@ const VerificationRequiredAlert = () => (
           Or call us at <va-telephone contact={CONTACTS['222_VETS']} />. If you
           have hearing hearing loss, call TTY:{' '}
           <va-telephone contact={CONTACTS.HELP_TTY} />. We’re here Monday
-          through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+          <abbr title="eastern time">ET</abbr>.
         </li>
       </ul>
       <p>


### PR DESCRIPTION
## Description
The `<Telephone>` component is utilized multiple times throughout the 10-10EZ Health Care application markup. While this component has not yet been deprecated by the Design team, the preferred/recommended component to use is `<va-telephone>`. We need to upgrade the Health Care app to utilize the preferred component. This PR updates all telephone component with `<va-telephone>` and replaces anchor tags with hard-coded phone numbers with `<va-telephone>` components and numbers from the contacts directory.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#43078


## Acceptance criteria
- [ ] Application utilizes the most up-to-date Design System telephone component


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
