### PR TITLE
Remove unused toggles for gender and fax number

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/phone-numbers/PhoneNumbersTable.jsx
+++ b/src/applications/personalization/profile/components/contact-information/phone-numbers/PhoneNumbersTable.jsx
@@ -1,58 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 
-import { profileShowFaxNumber } from '@@profile/selectors';
-
 import ProfileInfoTable from '../../ProfileInfoTable';
 
-const PhoneNumbersTable = ({ className, shouldProfileShowFaxNumber }) => {
+const PhoneNumbersTable = ({ className }) => {
   const tableFields = [
-    ...[
-      {
-        title: 'Home',
-        id: FIELD_IDS[FIELD_NAMES.HOME_PHONE],
-        value: (
-          <ProfileInformationFieldController
-            fieldName={FIELD_NAMES.HOME_PHONE}
-          />
-        ),
-      },
-      {
-        title: 'Work',
-        id: FIELD_IDS[FIELD_NAMES.WORK_PHONE],
-        value: (
-          <ProfileInformationFieldController
-            fieldName={FIELD_NAMES.WORK_PHONE}
-          />
-        ),
-      },
-      {
-        title: 'Mobile',
-        id: FIELD_IDS[FIELD_NAMES.MOBILE_PHONE],
-        value: (
-          <ProfileInformationFieldController
-            fieldName={FIELD_NAMES.MOBILE_PHONE}
-          />
-        ),
-      },
-    ],
-    ...(shouldProfileShowFaxNumber
-      ? [
-          {
-            title: 'Fax',
-            id: FIELD_IDS[FIELD_NAMES.FAX_NUMBER],
-            value: (
-              <ProfileInformationFieldController
-                fieldName={FIELD_NAMES.FAX_NUMBER}
-              />
-            ),
-          },
-        ]
-      : []),
+    {
+      title: 'Home',
+      id: FIELD_IDS[FIELD_NAMES.HOME_PHONE],
+      value: (
+        <ProfileInformationFieldController fieldName={FIELD_NAMES.HOME_PHONE} />
+      ),
+    },
+    {
+      title: 'Work',
+      id: FIELD_IDS[FIELD_NAMES.WORK_PHONE],
+      value: (
+        <ProfileInformationFieldController fieldName={FIELD_NAMES.WORK_PHONE} />
+      ),
+    },
+    {
+      title: 'Mobile',
+      id: FIELD_IDS[FIELD_NAMES.MOBILE_PHONE],
+      value: (
+        <ProfileInformationFieldController
+          fieldName={FIELD_NAMES.MOBILE_PHONE}
+        />
+      ),
+    },
   ];
 
   return (
@@ -70,10 +48,4 @@ PhoneNumbersTable.propTypes = {
   className: PropTypes.string,
 };
 
-export const mapStateToProps = state => {
-  return {
-    shouldProfileShowFaxNumber: profileShowFaxNumber(state),
-  };
-};
-
-export default connect(mapStateToProps)(PhoneNumbersTable);
+export default PhoneNumbersTable;

--- a/src/applications/personalization/profile/components/personal-information/LegacyGenderAndDOBSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/LegacyGenderAndDOBSection.jsx
@@ -2,20 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
-import { profileShowGender } from '../../selectors';
-import {
-  renderGender,
-  renderDOB,
-} from '../../util/personal-information/personalInformationUtils';
+import { renderDOB } from '../../util/personal-information/personalInformationUtils';
 
 import ProfileInfoTable from '../ProfileInfoTable';
 
-const LegacyGenderAndDOBSection = ({
-  gender,
-  dob,
-  className,
-  shouldProfileShowGender,
-}) => (
+const LegacyGenderAndDOBSection = ({ dob, className }) => (
   <div className={className}>
     <div className="vads-u-margin-bottom--2">
       <AdditionalInfo triggerText="How do I update my personal information?">
@@ -43,12 +34,7 @@ const LegacyGenderAndDOBSection = ({
     </div>
     <ProfileInfoTable
       title="Personal information"
-      data={[
-        { title: 'Date of birth', value: renderDOB(dob) },
-        ...(shouldProfileShowGender
-          ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
-          : []),
-      ]}
+      data={[{ title: 'Date of birth', value: renderDOB(dob) }]}
       className="vads-u-margin-bottom--3"
       level={2}
     />
@@ -57,15 +43,11 @@ const LegacyGenderAndDOBSection = ({
 
 LegacyGenderAndDOBSection.propTypes = {
   dob: PropTypes.string.isRequired,
-  shouldProfileShowGender: PropTypes.bool.isRequired,
   className: PropTypes.string,
-  gender: PropTypes.string,
 };
 
 const mapStateToProps = state => ({
   dob: state.vaProfile?.personalInformation?.birthDate,
-  gender: state.vaProfile?.personalInformation?.gender,
-  shouldProfileShowGender: profileShowGender(state),
 });
 
 export default connect(mapStateToProps)(LegacyGenderAndDOBSection);

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -2,24 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import {
-  profileShowGender,
-  profileShowPronounsAndSexualOrientation,
-} from '@@profile/selectors';
+import { profileShowPronounsAndSexualOrientation } from '@@profile/selectors';
 
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
-import {
-  renderGender,
-  renderDOB,
-} from '@@profile/util/personal-information/personalInformationUtils';
+import { renderDOB } from '@@profile/util/personal-information/personalInformationUtils';
 import ProfileInfoTable from '../ProfileInfoTable';
 import GenderIdentityAdditionalInfo from './GenderIdentityAdditionalInfo';
 
 const PersonalInformationSection = ({
-  gender,
   dob,
-  shouldProfileShowGender,
   shouldShowPronounsAndSexualOrientation,
 }) => {
   const tableFields = [
@@ -49,9 +41,6 @@ const PersonalInformationSection = ({
             ),
           },
         ]
-      : []),
-    ...(shouldProfileShowGender
-      ? [{ title: 'Sex assigned at birth', value: renderGender(gender) }]
       : []),
     {
       title: 'Gender identity',
@@ -138,13 +127,11 @@ PersonalInformationSection.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  gender: state.vaProfile?.personalInformation?.gender,
   dob: state.vaProfile?.personalInformation?.birthDate,
   preferredName: state.vaProfile?.personalInformation?.preferredName,
   pronouns: state.vaProfile?.personalInformation?.pronouns,
   genderIdentity: state.vaProfile?.personalInformation?.genderIdentity,
   sexualOrientation: state.vaProfile?.personalInformation?.sexualOrientation,
-  shouldProfileShowGender: profileShowGender(state),
   shouldShowPronounsAndSexualOrientation: profileShowPronounsAndSexualOrientation(
     state,
   ),

--- a/src/applications/personalization/profile/mocks/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/feature-toggles/index.js
@@ -8,8 +8,6 @@ const generateFeatureToggles = (toggles = {}) => {
     profileShowBadAddressIndicator = true,
     profileShowDemographics = false,
     profileForceBadAddressIndicator = false,
-    profileShowFaxNumber = false,
-    profileShowGender = false,
     profileShowProfile2 = false,
     profileShowPronounsAndSexualOrientation = false,
     profileShowReceiveTextNotifications = true,
@@ -43,12 +41,10 @@ const generateFeatureToggles = (toggles = {}) => {
           value: profileShowBadAddressIndicator,
         },
         { name: 'profile_show_demographics', value: profileShowDemographics },
-        { name: 'profile_show_fax_number', value: profileShowFaxNumber },
         {
           name: 'profile_force_bad_address_indicator',
           value: profileForceBadAddressIndicator,
         },
-        { name: 'profile_show_gender', value: profileShowGender },
         { name: 'profile_show_profile_2.0', value: profileShowProfile2 },
         {
           name: 'profile_show_pronouns_and_sexual_orientation',

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -102,12 +102,6 @@ export const profileShowAddressChangeModal = state =>
   toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowAddressChangeModal] ||
   false;
 
-export const profileShowFaxNumber = state =>
-  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowFaxNumber];
-
-export const profileShowGender = state =>
-  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowGender];
-
 export const profileShowPronounsAndSexualOrientation = state =>
   toggleValues(state)?.[
     FEATURE_FLAG_NAMES.profileShowPronounsAndSexualOrientation

--- a/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
@@ -3,13 +3,10 @@ import { expect } from 'chai';
 import {
   formatMultiSelectAndText,
   createNotListedTextKey,
-  renderGender,
   createBooleanSchemaPropertiesFromOptions,
   createUiTitlePropertiesFromOptions,
   formatIndividualLabel,
 } from '@@profile/util/personal-information/personalInformationUtils';
-
-import { NOT_SET_TEXT } from '@@profile/constants';
 
 describe('formatMultiSelectAndText utility', () => {
   it('returns single pronouns', () => {
@@ -60,20 +57,6 @@ describe('createNotListedTextKey utility', () => {
     expect(createNotListedTextKey('pronouns')).to.equal(
       'pronounsNotListedText',
     );
-  });
-});
-
-describe('renderGender utility', () => {
-  it('returns Male', () => {
-    expect(renderGender('M')).to.equal('Male');
-  });
-
-  it('returns Female', () => {
-    expect(renderGender('F')).to.equal('Female');
-  });
-
-  it('returns NOT_SET_TEXT', () => {
-    expect(renderGender('')).to.equal(NOT_SET_TEXT);
   });
 });
 

--- a/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
+++ b/src/applications/personalization/profile/util/personal-information/personalInformationUtils.js
@@ -188,11 +188,4 @@ export const formatMultiSelectAndText = (data, fieldName) => {
   return null;
 };
 
-export const renderGender = gender => {
-  let content = NOT_SET_TEXT;
-  if (gender === 'M') content = 'Male';
-  else if (gender === 'F') content = 'Female';
-  return content;
-};
-
 export const renderDOB = dob => (dob ? moment(dob).format('LL') : NOT_SET_TEXT);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -82,8 +82,6 @@ export default Object.freeze({
   profileEnhancements: 'profile_enhancements',
   profileShowAddressChangeModal: 'profile_show_address_change_modal',
   profileShowBadAddressIndicator: 'profile_show_bad_address_indicator',
-  profileShowFaxNumber: 'profile_show_fax_number',
-  profileShowGender: 'profile_show_gender',
   profileShowPronounsAndSexualOrientation: 'profile_show_pronouns_and_sexual_orientation',
   profileShowNewDirectDepositCTAMessage: 'profile_show_new_direct_deposit_cta_message',
   profileUseVaosV2Api:'profile_use_vaos_v2_api',
@@ -124,7 +122,7 @@ export default Object.freeze({
   subform89404192: 'subform_8940_4192',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
   vaGlobalDowntimeNotification: 'va_global_downtime_notification',
-  vaHomePreview: 
+  vaHomePreview:
   'va_home_preview',
   vaOnlineFacilitySelectionV22: 'va_online_scheduling_facility_selection_v2_2',
   vaOnlineScheduling: 'va_online_scheduling',


### PR DESCRIPTION
## Description
Removing 2 feature toggles, redux selectors, and associated FE code around them.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/42358

This PR will accompany a BE PR to remove the toggles from the api


## Testing done
Removed unit test around rendering gender. All other tests continuing to pass


## Acceptance criteria
- [x] Toggles removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
