### PR TITLE
common composite actions from global repo

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -425,7 +425,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
+        uses: ./.github/workflows/configure-bigquery
 
       - name: Upload app list to BigQuery
         run: yarn generate-app-list
@@ -628,7 +628,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
+        uses: ./.github/workflows/configure-bigquery
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -740,7 +740,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
+        uses: ./.github/workflows/configure-bigquery
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -829,7 +829,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
+        uses: ./.github/workflows/configure-bigquery
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -909,7 +909,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
+        uses: ./.github/workflows/configure-bigquery
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -422,10 +422,10 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
+        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
 
       - name: Upload app list to BigQuery
         run: yarn generate-app-list
@@ -597,7 +597,7 @@ jobs:
 
       - name: Notify Slack about Contract test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.contract-tests.result == 'failure' }}
-        uses: ./.github/workflows/slack-notify
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
@@ -625,10 +625,10 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
+        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -709,7 +709,7 @@ jobs:
 
       - name: Notify Slack about Unit test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.result == 'failure' }}
-        uses: ./.github/workflows/slack-notify
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
@@ -737,10 +737,10 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
+        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -826,10 +826,10 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
+        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -878,7 +878,7 @@ jobs:
 
       - name: Notify Slack about Cypress test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
-        uses: ./.github/workflows/slack-notify
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
@@ -906,10 +906,10 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
+        uses: department-of-veterans-affairs/platform-release-tools-actions/configure-bigquery@main
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -1187,7 +1187,7 @@ jobs:
 
       - name: Notify application team in Slack
         if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
-        uses: ./.github/workflows/slack-notify
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
         continue-on-error: true
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${{steps.get-changed-apps.outputs.slack_groups}} CI for your application failed on the `main` branch in `vets-website`: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>\n For help troubleshooting, see the <https://depo-platform-documentation.scrollhelp.site/developer-docs/Handling-failed-single%2Fgrouped-application-pipelines.2066645150.html|documentation> on failed workflow runs."}}]}]}'
@@ -1197,7 +1197,7 @@ jobs:
 
       - name: Notify Slack
         if: steps.get-changed-apps.outputs.slack_groups == ''
-        uses: ./.github/workflows/slack-notify
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
         continue-on-error: true
         with:
           payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "`main` branch CI in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'


### PR DESCRIPTION
## Description
This is an effort to move the composite actions that are common and have the possibility to be able to be called globally from another repo.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/39265

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39265


## Testing done
yes

## Screenshots


## Acceptance criteria
- [X] successful run of CI execution of the respective composite actions going to the global action repo

## Definition of done
- [X] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
