### PR TITLE
Display In-Progress Confirmation When Claim Status is Null After 1 Minute

### DIFF
--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -116,7 +116,7 @@ export function fetchClaimStatus() {
     dispatch({ type: FETCH_CLAIM_STATUS });
     const timeoutResponse = {
       attributes: {
-        claimStatus: CLAIM_STATUS_RESPONSE_ERROR,
+        claimStatus: CLAIM_STATUS_RESPONSE_IN_PROGRESS,
         receivedDate: getNowDate(),
       },
     };

--- a/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
@@ -12,7 +12,7 @@ import {
 
 import ConfirmationApproved from '../components/confirmation/ConfirmationApproved';
 import ConfirmationDenied from '../components/confirmation/ConfirmationDenied';
-import ConfirmationError from '../components/confirmation/ConfirmationError';
+// import ConfirmationError from '../components/confirmation/ConfirmationError';
 import LoadingIndicator from '../components/LoadingIndicator';
 import ConfirmationPending from '../components/confirmation/ConfirmationPending';
 
@@ -62,7 +62,8 @@ export const ConfirmationPage = ({
         />
       );
     }
-    case CLAIM_STATUS_RESPONSE_IN_PROGRESS: {
+    case CLAIM_STATUS_RESPONSE_IN_PROGRESS:
+    case CLAIM_STATUS_RESPONSE_ERROR: {
       return (
         <ConfirmationPending
           claimantName={claimantName}
@@ -71,9 +72,9 @@ export const ConfirmationPage = ({
         />
       );
     }
-    case CLAIM_STATUS_RESPONSE_ERROR: {
-      return <ConfirmationError />;
-    }
+    // case CLAIM_STATUS_RESPONSE_ERROR: {
+    //   return <ConfirmationError />;
+    // }
     default: {
       return (
         <LoadingIndicator


### PR DESCRIPTION
## Description
Change My Education Benefits confirmation page to display the In-Progress status if a claim status is still null after a minute of being processed. Note that this was changed from In-Progress to Error in #21371.