### PR TITLE
Prevent undefined pageList JS error

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -41,14 +41,14 @@ const SipsDevModal = props => {
 
   useEffect(
     () => {
-      if (showLink && isModalVisible && pageList.length) {
+      if (showLink && isModalVisible && pageList?.length) {
         setAvailablePaths(getAvailablePaths(pageList, sipsData));
       }
     },
     [pageList, sipsData, showLink, isModalVisible],
   );
 
-  if (!showLink || pageList.length === 0) {
+  if (!showLink || (pageList || []).length === 0) {
     return null;
   }
 

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -225,4 +225,11 @@ describe('Schemaform <SipsDevModal>', () => {
     expect(dom.querySelector('.va-button-link')).to.be.null;
     expect(dom.querySelector('va-modal')).to.be.null;
   });
+  it('should not show link, or modal, with an undefined pageList', () => {
+    setLoc();
+    const dom = document.createElement('div');
+    ReactDOM.render(<SipsDevModal {...props} pageList={undefined} />, dom);
+    expect(dom.querySelector('.va-button-link')).to.be.null;
+    expect(dom.querySelector('va-modal')).to.be.null;
+  });
 });


### PR DESCRIPTION
## Description

The save-in-progress dev modal is checking for a `pageList` length, but in some cases, this value may be undefined. This causes a JS error on the review & submit page. 

In the screenshot, the submit endpoint is not yet complete, so it's returning a 503 error. During the update of the review & submit page, one instance passes an undefined `pageList` causing the JS error and breaking page render.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/40372

## Testing done

Added unit test with an `undefined` `pageList` value.

## Screenshots

<img width="779" alt="page showing on the breadcrumbs. The dev console shows an 'Cannot read properties of undefined (reading length)' error message" src="https://user-images.githubusercontent.com/136959/174889513-848c897d-29c6-4dee-802e-7da2801a851d.png">

## Acceptance criteria
- [x] Prevent JS error when `pageList` is `undefined`
- [x] Add test and all other tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
