### PR TITLE
My VA Redirect current page bug

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -27,7 +27,7 @@ export function flagCurrentPageInTopLevelLinks(
 ) {
   return links.map(
     link =>
-      pathName.endsWith(link.href) || href === link.href
+      pathName.endsWith(link.href) || href.includes(link.href)
         ? { ...link, currentPage: true }
         : link,
   );


### PR DESCRIPTION
## Description
This PR fixes the `flagCurrentPageInTopLevelLinks` method to replace the strict equality (`a === b`) with a looser check `a.includes(b)`.  This way query parameters will not interfere with the checking of URL links

## Original issue(s)
Fix department-of-veterans-affairs/va.gov-team#43171


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] Using the My VA Redirect (aka logging in on the homepage), the My VA link in the mega menu should have the class `.current-page` and be styled appropriately

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
