### PR TITLE
HLR: Allow starting with 404 error

### DIFF
--- a/src/applications/appeals/996/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/996/containers/IntroductionPage.jsx
@@ -30,6 +30,7 @@ import {
   showHasEmptyAddress,
 } from '../content/contestableIssueAlerts';
 import NeedsToVerify from '../components/NeedsToVerify';
+import { checkContestableIssueError } from '../utils/helpers';
 
 export class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -51,7 +52,7 @@ export class IntroductionPage extends React.Component {
       return <NeedsToVerify pathname={location.basename} />;
     }
 
-    if (contestableIssues?.error) {
+    if (checkContestableIssueError(contestableIssues?.error)) {
       return showContestableIssueError(contestableIssues, delay);
     }
 

--- a/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
@@ -21,6 +21,7 @@ import {
   processContestableIssues,
   readableList,
   returnPhoneObject,
+  checkContestableIssueError,
 } from '../../utils/helpers';
 
 describe('getEligibleContestableIssues', () => {
@@ -415,5 +416,21 @@ describe('returnPhoneObject', () => {
       phoneNumber: '5551212',
       phoneNumberExt: '',
     });
+  });
+});
+
+describe('checkContestableIssueError', () => {
+  it('should return false if no error', () => {
+    expect(checkContestableIssueError()).to.be.false;
+  });
+  it('should return false if 404 error', () => {
+    expect(checkContestableIssueError({ errors: [{ status: '404' }] })).to.be
+      .false;
+  });
+  it('should return true', () => {
+    expect(checkContestableIssueError({})).to.be.true;
+    expect(checkContestableIssueError({ error: 'blah' })).to.be.true;
+    expect(checkContestableIssueError({ errors: [{ status: '123' }] })).to.be
+      .true;
   });
 });

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -291,3 +291,14 @@ export const returnPhoneObject = phone => {
   }
   return result;
 };
+
+/**
+ * Contestable issues loading error check
+ * If there's an error, show an alert warning, but if the backend returns a 404
+ * error (no issues found), we need to allow the Veteran to start the form
+ * anyway
+ * @param {Object} error - error object or string (rejected invalid benefit type)
+ * @returns {Boolean}
+ */
+export const checkContestableIssueError = error =>
+  (error && error?.errors?.[0]?.status !== '404') || false;


### PR DESCRIPTION
## Description

Allow Veterans to start the Higher-Level Review form when the contestable issues endpoint returns a 404 (no contestable issues found).

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/42300

## Testing done

Added unit test

## Screenshots

N/A

## Acceptance criteria
- [x] Ignore contestable issues 404 error, and allow Veteran to start HLR
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
