### PR TITLE
(fix) use captureMessage for sentry api reporting

### DIFF
--- a/src/applications/personalization/profile/util/analytics/index.js
+++ b/src/applications/personalization/profile/util/analytics/index.js
@@ -33,17 +33,19 @@ const captureError = (error, details) => {
   }
 
   if (error?.source === ERROR_SOURCES.API) {
+    const { eventName } = details;
     Sentry.withScope(scope => {
-      const { eventName, code, title, detail, status } = details;
       scope.setTags({
-        'profile-client-api-error-event': eventName,
-        'profile-client-api-error-code': code,
-        'profile-client-api-error-title': title,
-        'profile-client-api-error-detail': detail,
-        'profile-client-api-error-status': status,
+        'profile-client-api-error': eventName,
       });
 
-      Sentry.captureException(error);
+      const message = `profile_client_api_error-${eventName}`;
+      scope.setContext(message, {
+        details,
+        error,
+      });
+
+      Sentry.captureMessage(message);
     });
     return;
   }
@@ -51,7 +53,7 @@ const captureError = (error, details) => {
   Sentry.withScope(scope => {
     const message = `profile_client_error`;
     scope.setContext(message, {
-      error: error.message,
+      error: JSON.stringify(error),
     });
 
     scope.setTag('profile-client-error-message', error?.message);


### PR DESCRIPTION
## Description
Reworks the reporting to Sentry for API errors to use the `captureMessage` message instead of `captureException`. This PR also strips the tags down to a single tag, and adds context for relevant data collection.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43081


## Testing done
N/A 

## Acceptance criteria
- [x] API sentry error refactored for captureMessage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
