### PR TITLE
update edit content, fix add-edit event for gender identity

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoTable.jsx
@@ -33,6 +33,12 @@ const TableTitle = ({ namedAnchor, children, level }) => {
   );
 };
 
+TableTitle.propTypes = {
+  children: PropTypes.node,
+  level: numberBetween(1, 6),
+  namedAnchor: PropTypes.string,
+};
+
 const ProfileInfoTable = ({
   data,
   dataTransformer,

--- a/src/applications/personalization/profile/components/ProfileInformationView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationView.jsx
@@ -4,6 +4,7 @@ import Telephone from '@department-of-veterans-affairs/component-library/Telepho
 
 import { FIELD_NAMES } from '@@vap-svc/constants';
 import * as VAP_SERVICE from '@@vap-svc/constants';
+import { isFieldEmpty } from '@@profile/util';
 
 import {
   addresses,
@@ -17,14 +18,6 @@ import {
 } from '@@profile/util/personal-information/personalInformationUtils';
 import { formatAddress } from '~/platform/forms/address/helpers';
 
-const shouldShowUnsetFieldTitleSpan = (data, fieldName) => {
-  // show if there is no data or a gender identity code is not present in data object
-  return (
-    !data ||
-    (fieldName === FIELD_NAMES.GENDER_IDENTITY && !data?.[fieldName]?.code)
-  );
-};
-
 const ProfileInformationView = props => {
   const { data, fieldName, title, id } = props;
 
@@ -34,11 +27,9 @@ const ProfileInformationView = props => {
   const titleFormatted =
     fieldName !== FIELD_NAMES.PRONOUNS ? `a ${titleLower}` : titleLower;
 
-  const unsetFieldTitleSpan = (
-    <span>Edit your profile to add {titleFormatted}.</span>
-  );
+  const unsetFieldTitleSpan = <span>Choose edit to add {titleFormatted}.</span>;
 
-  if (shouldShowUnsetFieldTitleSpan(data, fieldName)) {
+  if (isFieldEmpty(data, fieldName)) {
     return unsetFieldTitleSpan;
   }
 

--- a/src/applications/personalization/profile/mocks/personal-information/index.js
+++ b/src/applications/personalization/profile/mocks/personal-information/index.js
@@ -11,10 +11,10 @@ const basicUserPersonalInfo = {
     attributes: {
       gender: 'M',
       birthDate: '1986-05-06',
-      preferredName: 'WES',
+      preferredName: '',
       pronouns: ['heHimHis', 'theyThemTheirs'],
       pronounsNotListedText: 'Other/pronouns/here',
-      genderIdentity: { code: 'M', name: 'Male' },
+      genderIdentity: { code: null, name: null },
       sexualOrientation: ['straightOrHeterosexual'],
       sexualOrientationNotListedText: 'Some other orientation',
     },

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-blank-state.cypress.spec.js
@@ -11,20 +11,20 @@ describe('Content on the personal information page', () => {
 
     cy.findByText('Preferred name').should('exist');
     cy.findByTestId('preferredName').contains(
-      'Edit your profile to add a preferred name.',
+      'Choose edit to add a preferred name.',
     );
 
     cy.findByText('Pronouns').should('exist');
-    cy.findByTestId('pronouns').contains('Edit your profile to add pronouns.');
+    cy.findByTestId('pronouns').contains('Choose edit to add pronouns.');
 
     cy.findByText('Gender identity').should('exist');
     cy.findByTestId('genderIdentity').contains(
-      'Edit your profile to add a gender identity.',
+      'Choose edit to add a gender identity.',
     );
 
     cy.findByText('Sexual orientation').should('exist');
     cy.findByTestId('sexualOrientation').contains(
-      'Edit your profile to add a sexual orientation.',
+      'Choose edit to add a sexual orientation.',
     );
 
     cy.injectAxeThenAxeCheck();

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-gender-identity.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-gender-identity.cypress.spec.js
@@ -49,7 +49,7 @@ describe('Gender identity field tests on the personal information page', () => {
     setup({ isEnhanced: true, personalInfo: unsetUserPersonalInfo });
 
     cy.findByTestId('genderIdentity')
-      .contains('Edit your profile to add a gender identity.')
+      .contains('Choose edit to add a gender identity.')
       .should('exist');
 
     cy.injectAxeThenAxeCheck();

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
@@ -50,7 +50,7 @@ describe('Preferred name field tests on the personal information page', () => {
     setup({ isEnhanced: true, personalInfo: unsetUserPersonalInfo });
 
     cy.findByTestId('preferredName')
-      .contains('Edit your profile to add a preferred name.')
+      .contains('Choose edit to add a preferred name.')
       .should('exist');
 
     cy.injectAxeThenAxeCheck();

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -1,4 +1,5 @@
 import { apiRequest } from 'platform/utilities/api';
+import { FIELD_NAMES } from '@@vap-svc/constants';
 
 // possible values for the `key` property on error messages we get from the server
 const ACCOUNT_FLAGGED_FOR_FRAUD_KEY = 'cnp.payment.flashes.on.record.message';
@@ -130,4 +131,13 @@ export const createCNPDirectDepositAnalyticsDataObject = (
     'profile-section': `cnp-direct-deposit-information`,
     [key]: errorCode,
   };
+};
+
+// checks for basic field data or data for nested object like gender identity
+export const isFieldEmpty = (data, fieldName) => {
+  // checks whether data is available and in the case of gender identity if there is a code present
+  return (
+    !data ||
+    (fieldName === FIELD_NAMES.GENDER_IDENTITY && !data?.[fieldName]?.code)
+  );
 };

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -35,6 +35,8 @@ import ProfileInformationEditView from '@@profile/components/ProfileInformationE
 import ProfileInformationView from '@@profile/components/ProfileInformationView';
 
 import { getInitialFormValues } from '@@profile/util/contact-information/formValues';
+import { isFieldEmpty } from '@@profile/util';
+
 import { isVAPatient } from '~/platform/user/selectors';
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 import recordEvent from '~/platform/monitoring/record-event';
@@ -512,7 +514,7 @@ export const mapStateToProps = (state, ownProps) => {
     selectVAPContactInfoField(state, fieldName) ||
     selectVAProfilePersonalInformation(state, fieldName);
 
-  const isEmpty = !data;
+  const isEmpty = isFieldEmpty(data, fieldName);
   const addressValidationType = selectAddressValidationType(state);
   const activeEditView = selectCurrentlyOpenEditModal(state);
   const showValidationView =


### PR DESCRIPTION
## Description
Changes text for when a field does not have data yet. Also refactored the check for data, since i noticed the `add-link` event wasn't firing for Gender Identity being 'first time added' due to its slightly different data structure.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/41909

## Testing done
Updated E2E tests for field help text

## Screenshots
NEW CONTENT
![Screen Shot 2022-06-22 at 12 35 32 PM](https://user-images.githubusercontent.com/8332986/175126801-bac52fa1-fb33-410a-b726-21c2276e18b1.png)


## Acceptance criteria
- [x] New content shown when field is without a value

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
