### PR TITLE
Va 9456 recurring event listings

### DIFF
--- a/src/applications/static-pages/events/components/App/index.js
+++ b/src/applications/static-pages/events/components/App/index.js
@@ -3,9 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 // Relative imports.
 import Events from '../Events';
+import { fleshOutRecurringEvents, removeDuplicateEvents } from '../../helpers';
 
 export const App = ({ rawEvents }) => {
-  return <Events rawEvents={rawEvents} />;
+  return (
+    <Events
+      rawEvents={fleshOutRecurringEvents(removeDuplicateEvents(rawEvents))}
+    />
+  );
 };
 
 App.propTypes = {

--- a/src/applications/static-pages/events/helpers/index.unit.spec.js
+++ b/src/applications/static-pages/events/helpers/index.unit.spec.js
@@ -125,6 +125,7 @@ describe('filterEvents', () => {
 
   const upcomingEvent = {
     id: 'upcoming',
+    entityId: '1',
     fieldDatetimeRangeTimezone: [
       {
         endValue: now
@@ -143,6 +144,7 @@ describe('filterEvents', () => {
 
   const nextWeekEvent = {
     id: 'next-week',
+    entityId: '2',
     fieldDatetimeRangeTimezone: [
       {
         endValue: now
@@ -164,6 +166,7 @@ describe('filterEvents', () => {
 
   const nextMonthEvent = {
     id: 'next-month',
+    entityId: '3',
     fieldDatetimeRangeTimezone: [
       {
         endValue: now
@@ -185,6 +188,7 @@ describe('filterEvents', () => {
 
   const pastEvent = {
     id: 'past',
+    entityId: '4',
     fieldDatetimeRangeTimezone: [
       {
         endValue: now


### PR DESCRIPTION
## Description

The events listing filters need to better display recurring events.

* "Past Events" should show all instances of a recurring event
* "Upcoming Events" should only show the most recent instance of a recurring event

Here, the "Custom Date Range" filter will also show all the instances of a recurring event (can be changed if needed).

The code solution basically takes any event with recurring times, and makes copies of them where each collection of start times begins with a different one. That way they're all still seen as recurring events while being sortable and avoiding any repeats. For filters showing future events, an extra filter is used only to keep the most recent future one.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9456

## Testing done

Visual

## Screenshots

### Upcoming Events (No Repeats)

<img width="648" alt="Screen Shot 2022-06-27 at 6 14 13 PM" src="https://user-images.githubusercontent.com/10790736/176045050-70fc6c0f-fa86-4a19-bb59-5dc85f67edf2.png">

### Past Events (Show Repeats)

<img width="621" alt="Screen Shot 2022-06-27 at 6 14 34 PM" src="https://user-images.githubusercontent.com/10790736/176045051-8af3abff-756f-4b55-80f8-6085b6d37cd7.png">

## Acceptance criteria
- [ ] Visit http://localhost:3002/preview?nodeId=8207 as a test event page
- [ ] Check that none of the same repeating events show up multiple times on "Upcoming Events"
- [ ] Check that any repeating events show up multiple times (each time they occurred) on "Past Events" and/or in a specific custom date range.

If this doesn't work, then it can also be confirmed by adding or subtracting months from the `now` parameter on `applications/static-pages/events/helpers/index.js:169` with something like `now = moment().subtract(2, 'months')`. Recurring events that have multiple dates appearing for "Past Events" should only show one event (at the soonest possible time) when enough time is subtracted.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
