### PR TITLE
Updating manage-va-debt CTA widget for testing

### DIFF
--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -1,40 +1,54 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { getAppUrl } from 'platform/utilities/registry-helpers';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+// import feature toggle
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 const debtLettersUrl = getAppUrl('your-debt');
+
 const fsrUrl = getAppUrl('request-debt-help-form-5655');
 
-const ManageVADebtCTA = () => (
-  <>
-    <Breadcrumbs>
-      <a href="/">Home</a>
-      <a href="/manage-va-debt">Manage your VA debt</a>
-    </Breadcrumbs>
-    <h1>Manage your VA debt</h1>
-    <p>
-      Check the status of debt related to VA disability compensation,
-      non-service-connected pension, or education benefits. And make payments or
-      request help now if you’d like.
-    </p>
-    <h3>Check the status of your VA benefit debt</h3>
-    <a
-      className="usa-button-primary va-button-primary"
-      target="_self"
-      href={debtLettersUrl}
-    >
-      Manage your VA debt
-    </a>
-    <hr />
-    <h3>Request help with VA debt (VA Form 5655)</h3>
-    <a
-      className="usa-button-primary va-button-primary"
-      target="_self"
-      href={fsrUrl}
-    >
-      Request help with VA debt
-    </a>
-  </>
-);
+const ManageVADebtCTA = () => {
+  const isCombinedPortalActive = useSelector(
+    state => toggleValues(state)[FEATURE_FLAG_NAMES.combinedDebtPortalAccess],
+  );
+
+  return (
+    <>
+      <va-breadcrumbs>
+        <a href="/">Home</a>
+        <a href="/manage-va-debt">Manage your VA debt</a>
+      </va-breadcrumbs>
+      <h1>Manage your VA debt</h1>
+      <p>
+        Check the status of debt related to VA disability compensation,
+        non-service-connected pension, or education benefits. And make payments
+        or request help now if you’d like.
+      </p>
+      <h3>Check the status of your VA benefit debt</h3>
+      <a
+        className="usa-button-primary va-button-primary"
+        target="_self"
+        href={
+          isCombinedPortalActive
+            ? '/manage-debt-and-bills/summary'
+            : debtLettersUrl
+        }
+      >
+        Manage your VA debt
+      </a>
+      <hr />
+      <h3>Request help with VA debt (VA Form 5655)</h3>
+      <a
+        className="usa-button-primary va-button-primary"
+        target="_self"
+        href={fsrUrl}
+      >
+        Request help with VA debt
+      </a>
+    </>
+  );
+};
 
 export default ManageVADebtCTA;

--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -14,12 +14,9 @@ const ManageVADebtCTA = () => {
     state => toggleValues(state)[FEATURE_FLAG_NAMES.combinedDebtPortalAccess],
   );
 
-  return (
+  return !isCombinedPortalActive ? (
     <>
-      <va-breadcrumbs>
-        <a href="/">Home</a>
-        <a href="/manage-va-debt">Manage your VA debt</a>
-      </va-breadcrumbs>
+      <va-breadcrumbs />
       <h1>Manage your VA debt</h1>
       <p>
         Check the status of debt related to VA disability compensation,
@@ -30,11 +27,7 @@ const ManageVADebtCTA = () => {
       <a
         className="usa-button-primary va-button-primary"
         target="_self"
-        href={
-          isCombinedPortalActive
-            ? '/manage-debt-and-bills/summary'
-            : debtLettersUrl
-        }
+        href={debtLettersUrl}
       >
         Manage your VA debt
       </a>
@@ -46,6 +39,23 @@ const ManageVADebtCTA = () => {
         href={fsrUrl}
       >
         Request help with VA debt
+      </a>
+    </>
+  ) : (
+    <>
+      <va-breadcrumbs />
+      <h1>Manage VA debt for benefit overpayments and copay bills</h1>
+      <p>
+        Review your current VA benefit debt or copay bill balances online. And
+        find out how to make payments or request help now.
+      </p>
+      <h3>Review your benefit debt and copay bills online</h3>
+      <a
+        className="usa-button-primary va-button-primary"
+        target="_self"
+        href="/manage-debt-and-bills/summary"
+      >
+        Manage your VA debts and bills
       </a>
     </>
   );


### PR DESCRIPTION
## Description
Redirecting existing manage-va-debt CTA widget to point to new Combined Debt Portal application for usability testing. 
Decision was made to use the existing debt-letter url instead of the new combined portal `manage-debt-and-bills`. Content is updating the existing drupal page, so we're fixing the widget to point to the new app for the usability testing before we update the combined portal with the new URL schema

## Acceptance criteria
- [ ] `manage-va-debt` widget redirects to `mange-debt-and-bills/summary` while combined debt portal feature flag is true 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
