### PR TITLE
Add text description to contact info page of health care application

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const ContactInfoDescription = () => (
+  <div className="vads-u-margin-bottom--5">
+    <p>
+      Adding your email and phone number is optional. But this information helps
+      us contact you faster if we need to follow up with you about your
+      application. If you don’t add this information, we’ll use your address to
+      contact you by mail.
+    </p>
+    <p>
+      <strong>Note:</strong> We’ll always mail you a copy of our decision on
+      your application for your records.
+    </p>
+  </div>
+);

--- a/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
@@ -9,6 +9,7 @@ import {
   HIGH_DISABILITY,
   emptyObjectSchema,
 } from '../../../helpers';
+import { ContactInfoDescription } from '../../../components/FormDescriptions';
 
 const { email } = fullSchemaHca.properties;
 const { phone } = fullSchemaHca.definitions;
@@ -29,6 +30,9 @@ export default {
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
     },
+    'view:contactInfoDescription': {
+      'ui:description': ContactInfoDescription,
+    },
     'ui:validations': [validateMatch('email', 'view:emailConfirmation')],
     email: emailUI(),
     'view:emailConfirmation': emailUI('Re-enter email address'),
@@ -40,6 +44,7 @@ export default {
     properties: {
       'view:contactShortFormMessage': emptyObjectSchema,
       'view:prefillMessage': emptyObjectSchema,
+      'view:contactInfoDescription': emptyObjectSchema,
       email,
       'view:emailConfirmation': email,
       homePhone: phone,


### PR DESCRIPTION
## Description
This PR adds description content to the contact information page of the 10-10EZ health care application. The purpose of the content is to entice users to provide additional means of contact regarding application status.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42291

## Screenshot(s)
<img width="620" alt="68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3630356339353131336636306361633134623530333039622f31316662626335312d356365322d343337342d393733312d336433653236623234623839" src="https://user-images.githubusercontent.com/6738544/175341876-b123e352-8f2d-4fee-9b47-b5f3e4f61b8a.png">


## Acceptance criteria
- [ ] Content successfully on correct form page


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
