### PR TITLE
[CDP] Updating Summary page to calculate copay sums and totals correclty 

### DIFF
--- a/src/applications/combined-debt-portal/combined/components/Balances.jsx
+++ b/src/applications/combined-debt-portal/combined/components/Balances.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { isAfter } from 'date-fns';
 import { useSelector } from 'react-redux';
+import { uniqBy } from 'lodash';
 import BalanceCard from './BalanceCard';
 import ZeroBalanceCard from './ZeroBalanceCard';
 import AlertCard from './AlertCard';
@@ -10,7 +11,7 @@ import {
   getLatestDebt,
   getLatestBill,
 } from '../utils/balance-helpers';
-import { APP_TYPES } from '../utils/helpers';
+import { APP_TYPES, sortStatementsByDate } from '../utils/helpers';
 
 // Some terminology that could be helpful:
 // debt(s) = debtLetters
@@ -31,7 +32,8 @@ const Balances = () => {
   const latestDebt = getLatestDebt(debts);
 
   // get Bill info
-  const bills = mcp.statements;
+  const sortedStatements = sortStatementsByDate(mcp.statements ?? []);
+  const bills = uniqBy(sortedStatements, 'pSFacilityNum');
   const totalBills = calculateTotalBills(bills);
   const latestBill = getLatestBill(bills);
 


### PR DESCRIPTION
## Description
There was a mismatch between the number of bills and totals on the CDP summary page and the totals on the medical copays overview page. We've updated the CDP summary page total bills calculation to match how it has been done in the existing medical copays app. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42711

## Acceptance criteria
- [ ] Total number of copays and balances sum to the same amount from summary to overview pages.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
