### PR TITLE
stubs transformForSubmit in a sandbox

### DIFF
--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -1,7 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
 
-import * as helpers from 'platform/forms-system/src/js/helpers';
 import { customCOEsubmit } from '../../config/helpers';
 
 const form = {
@@ -40,16 +38,9 @@ const result = JSON.stringify({
   },
 });
 
-const sandbox = sinon.sandbox.create();
-
-afterEach(() => {
-  sandbox.restore();
-});
-
 describe.skip('coe helpers', () => {
   describe('customCOEsubmit', () => {
     it('should correctly format the form data', () => {
-      sandbox.stub(helpers, 'transformForSubmit').returns(formattedProperties);
       expect(customCOEsubmit({}, form)).to.equal(result);
     });
   });

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -40,10 +40,16 @@ const result = JSON.stringify({
   },
 });
 
+const sandbox = sinon.sandbox.create();
+
+afterEach(() => {
+  sandbox.restore();
+});
+
 describe.skip('coe helpers', () => {
   describe('customCOEsubmit', () => {
     it('should correctly format the form data', () => {
-      sinon.stub(helpers, 'transformForSubmit').returns(formattedProperties);
+      sandbox.stub(helpers, 'transformForSubmit').returns(formattedProperties);
       expect(customCOEsubmit({}, form)).to.equal(result);
     });
   });


### PR DESCRIPTION
## Description
This creates a testing Sandbox in which we stub the `transformForSubmit` helper in the LGY application.

The reason for this change was to resolve an issue w/ polluting the global namespace because the previous stub was never reset upon completion.