### PR TITLE
Changed commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#901cc443a8f7e217287883067c87efde99cbd3b5",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6072dd15bf0d5c907c178b414201b0f4d1750d8f",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20107,9 +20107,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#901cc443a8f7e217287883067c87efde99cbd3b5":
-  version "20.20.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#901cc443a8f7e217287883067c87efde99cbd3b5"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6072dd15bf0d5c907c178b414201b0f4d1750d8f":
+  version "20.20.4"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6072dd15bf0d5c907c178b414201b0f4d1750d8f"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/43282)

[URL of fix](/education/apply-for-education-benefits/application/1990E/review-and-submit)

# Expected behavior
When a Veteran gets finished filling out the 1990e form for education benefits they should be able to submit the form successfully.

## Current behavior
Currently when the Veteran tries to submit the 1990e form it takes a really long time to try to submit and then often times it fails. It turns out that there was some code added that is pulling data called `fetchedSponsorsComplete` that is then injected into the form data however the JSON schema was not updated to allow for this extra data so the form is not passing validation.

## Your fix
To allow for the extra data to go through I switched the `additionalProperties` to be `true` instead of false so that the validation will allow the extra data to go through. This PR bumps the commit hash to include the new schema.

## How has this been tested?
I tested this locally and will also test on staging once this is merged in

## Acceptance criteria
- [ ] The 1990e form now submits without a validation error in Sentry
