### PR TITLE
[CDP] 43340 Alert message fixes

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -30,7 +30,8 @@ const OverviewPage = () => {
   const totalDebts = calculateTotalDebts(debts);
   const bills = mcp.statements;
   const totalBills = calculateTotalBills(bills);
-  const bothZero = totalDebts === 0 && totalBills === 0;
+  const bothZero =
+    totalDebts === 0 && totalBills === 0 && !billError && !debtError;
 
   return (
     <>


### PR DESCRIPTION
## Description
Fixing issue with alert messages showing both zero balance when one endpoint errors. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43340

## Screenshots


## Acceptance criteria
- [x] Correct alert messages appear when one enpoint has zero balance and another has an error

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
