### PR TITLE
Revert "Updated the Breadcrumbs component in the VAOS app (#21169)"

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import PropTypes from 'prop-types';
+import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectFeatureStatusImprovement } from '../redux/selectors';
 import { updateBreadcrumb } from '../appointment-list/redux/actions';
@@ -14,11 +13,7 @@ export default function VAOSBreadcrumbs({ children }) {
   const breadcrumbs = useSelector(state => state.appointments.breadcrumbs);
 
   return (
-    <VaBreadcrumbs
-      className="medium-screen:vads-u-padding-x--0 vaos-appts__breadcrumbs"
-      aria-label="Breadcrumbs"
-      role="navigation"
-    >
+    <Breadcrumbs className="medium-screen:vads-u-padding-x--0 vaos-appts__breadcrumbs">
       <a href="/" key="home">
         Home
       </a>
@@ -54,9 +49,6 @@ export default function VAOSBreadcrumbs({ children }) {
           );
         })}
       {children}
-    </VaBreadcrumbs>
+    </Breadcrumbs>
   );
 }
-VAOSBreadcrumbs.propTypes = {
-  children: PropTypes.object,
-};

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
@@ -225,9 +225,7 @@ describe('VAOS <AppointmentsPageV2>', () => {
       });
 
       // and breadcrumbs should be updated
-      const navigation = screen.getByRole('navigation', {
-        name: 'Breadcrumbs',
-      });
+      const navigation = screen.getByRole('navigation', { name: 'Breadcrumb' });
       expect(navigation).to.be.ok;
       expect(within(navigation).queryByRole('link', { name: 'Pending' })).not.to
         .exist;
@@ -308,7 +306,7 @@ describe('VAOS <AppointmentsPageV2>', () => {
       });
 
       // and breadcrumbs should be updated
-      navigation = screen.getByRole('navigation', { name: 'Breadcrumbs' });
+      navigation = screen.getByRole('navigation', { name: 'Breadcrumb' });
       expect(within(navigation).queryByRole('link', { name: 'Pending' })).to.be
         .ok;
       expect(within(navigation).queryByRole('link', { name: 'Past' })).not.to
@@ -383,7 +381,7 @@ describe('VAOS <AppointmentsPageV2>', () => {
       });
 
       // and breadcrumbs should be updated
-      navigation = screen.getByRole('navigation', { name: 'Breadcrumbs' });
+      navigation = screen.getByRole('navigation', { name: 'Breadcrumb' });
       expect(within(navigation).queryByRole('link', { name: 'Pending' })).not.to
         .be.ok;
       expect(within(navigation).queryByRole('link', { name: 'Past' })).to.exist;


### PR DESCRIPTION
This reverts commit 5a7438e19de56530242a5e83fac42de7137a10fd which had replaced the VAOS breadcrumb component with the new [breadcrumb web component](https://design.va.gov/components/breadcrumbs). More work needs to be done on implementing the change to the web component and will be done in a different pull request.

## Description


## Original issue(s)
[department-of-veterans-affairs/va.gov-team/issues/40139](https://github.com/department-of-veterans-affairs/va.gov-team/issues/40139)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
