### PR TITLE
(feature) add GA to military info GET

### DIFF
--- a/src/applications/personalization/profile/actions/index.js
+++ b/src/applications/personalization/profile/actions/index.js
@@ -68,13 +68,13 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
       const response = await getData(baseUrl);
 
       if (response.errors || response.error) {
-        const err = response.error || response.errors;
+        const error = response.error || response.errors;
         let errorName = 'unknown';
-        if (err) {
-          if (err.length > 0) {
-            errorName = err[0].title;
+        if (error) {
+          if (error.length > 0) {
+            errorName = error[0].title;
           } else {
-            errorName = err?.title || 'unknown-title';
+            errorName = error?.title || 'unknown-title';
           }
         }
 
@@ -86,7 +86,7 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
         });
 
         captureMilitaryInfoErrorResponse({
-          error: { ...err, source: ERROR_SOURCES.API },
+          error: { ...error, source: ERROR_SOURCES.API },
           apiEventName: 'profile-get-military-information-failed',
         });
 
@@ -94,7 +94,7 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
           type: FETCH_MILITARY_INFORMATION_FAILED,
           militaryInformation: {
             serviceHistory: {
-              err,
+              error,
             },
           },
         });


### PR DESCRIPTION
## Description
- Adds GA events for military information API GET requests.
- Fixes GA event name for first time adds of gender identity by checking for existence of data on that field

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43087


## Testing done
All existing tests passing.


## Acceptance criteria
- [x] GA event being called with military info api GETs

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
