### PR TITLE
Accessibility improvements for the ReviewCollapsibleChapter component

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import uniqueId from 'lodash/uniqueId';
+import classNames from 'classnames';
+import { getScrollOptions } from 'platform/utilities/ui';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
-import classNames from 'classnames';
 
 import ProgressButton from '../components/ProgressButton';
 import { focusOnChange } from '../utilities/ui';
-import { getScrollOptions } from 'platform/utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema, showReviewField } from '../helpers';
 import ArrayField from './ArrayField';
@@ -18,8 +18,7 @@ import { isValidForm } from '../validation';
 import { reduceErrors } from '../utilities/data/reduceErrors';
 import { setFormErrors } from '../actions';
 
-const Element = Scroll.Element;
-const scroller = Scroll.scroller;
+const { Element, scroller } = Scroll;
 
 /*
  * Displays all the pages in a chapter on the review page
@@ -29,6 +28,7 @@ class ReviewCollapsibleChapter extends React.Component {
     super();
     this.handleEdit = this.handleEdit.bind(this);
   }
+
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this.id = uniqueId();
@@ -361,13 +361,13 @@ class ReviewCollapsibleChapter extends React.Component {
                 aria-expanded={this.props.open ? 'true' : 'false'}
                 aria-controls={`collapsible-${this.id}`}
                 onClick={this.props.toggleButtonClicked}
+                id={`collapsibleButton${this.id}`}
               >
                 {chapterTitle || ''}
               </button>
               {this.props.hasUnviewedPages && (
                 <span
-                  role="presentation"
-                  aria-hidden="true"
+                  aria-describedby={`collapsibleButton${this.id}`}
                   className="schemaform-review-chapter-warning-icon"
                 />
               )}

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -657,6 +657,44 @@ describe('<ReviewCollapsibleChapter>', () => {
     tree.unmount();
   });
 
+  it('should render a collapsible button with a unique id attribute', () => {
+    const pages = [
+      {
+        title: '',
+        pageKey: 'test2',
+      },
+    ];
+    const chapterKey = 'chapterX';
+    const chapter = {};
+    const form = {
+      pages: {
+        test: {
+          title: '',
+          schema: {
+            properties: {},
+          },
+          uiSchema: {},
+        },
+      },
+      data: {},
+    };
+
+    const wrapper = mount(
+      <ReviewCollapsibleChapter
+        viewedPages={new Set()}
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    const button = wrapper.find('.usa-button-unstyled');
+    expect(button.props().id).to.contain('collapsibleButton');
+
+    wrapper.unmount();
+  });
+
   describe('updateFormData', () => {
     it('should be called on normal pages', () => {
       const setData = sinon.spy();


### PR DESCRIPTION
## Description
Remove attributes on the warning icons that prevent screenreaders from seeing it. Also attach an `aria-describedby` attribute to the warning icon, which reads the associated button text.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/379


## Testing done
Yes

## Screenshots
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/5934582/175697424-f7c386f1-0e92-4384-a1d4-bc9d82bd516f.png">


## Acceptance criteria
- [x] Remove presentation role and aria-hidden attribute on the icon element
- [x] Add aria-describedby attribute on the icon element that relates back to the associated accordion button

## Definition of done
- [x] Feature is covered by a unit test
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
