### PR TITLE
Combines and refactors miscellaneous OAuth & SAML authentication

### DIFF
--- a/src/platform/user/authentication/components/AccountLink.jsx
+++ b/src/platform/user/authentication/components/AccountLink.jsx
@@ -2,12 +2,21 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 import * as authUtilities from 'platform/user/authentication/utilities';
+import { updateStateAndVerifier } from 'platform/utilities/oauth/utilities';
 import { CSP_CONTENT, AUTH_EVENTS, LINK_TYPES } from '../constants';
 
-function signupHandler(loginType, eventBase) {
-  recordEvent({ event: `${eventBase}-${loginType}` });
+function signupHandler(loginType, eventBase, isOAuth) {
+  recordEvent({ event: `${eventBase}-${loginType}${isOAuth && '-oauth'}` });
+
+  if (isOAuth) {
+    updateStateAndVerifier(loginType);
+  }
 }
-export default function AccountLink({ csp, type = LINK_TYPES.CREATE }) {
+export default function AccountLink({
+  csp,
+  type = LINK_TYPES.CREATE,
+  useOAuth = false,
+}) {
   const [href, setHref] = useState('');
 
   const { children, eventBase } = {
@@ -39,7 +48,7 @@ export default function AccountLink({ csp, type = LINK_TYPES.CREATE }) {
       href={href}
       className={`vads-c-action-link--blue vads-u-padding-y--2p5 vads-u-width--full ${csp}`}
       data-testid={csp}
-      onClick={() => signupHandler(csp, eventBase)}
+      onClick={() => signupHandler(csp, eventBase, useOAuth)}
     >
       {children}
     </a>
@@ -50,4 +59,5 @@ AccountLink.propTypes = {
   csp: PropTypes.string,
   isDisabled: PropTypes.bool,
   type: PropTypes.string,
+  useOAuth: PropTypes.bool,
 };

--- a/src/platform/user/authentication/components/AccountLink.jsx
+++ b/src/platform/user/authentication/components/AccountLink.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 import * as authUtilities from 'platform/user/authentication/utilities';
@@ -7,14 +7,10 @@ import { CSP_CONTENT, AUTH_EVENTS, LINK_TYPES } from '../constants';
 function signupHandler(loginType, eventBase) {
   recordEvent({ event: `${eventBase}-${loginType}` });
 }
-
 export default function AccountLink({ csp, type = LINK_TYPES.CREATE }) {
-  if (!csp) return null;
-  const { href, children, eventBase } = {
-    href:
-      type !== LINK_TYPES.CREATE
-        ? authUtilities.sessionTypeUrl({ type: csp })
-        : authUtilities.signupUrl(csp),
+  const [href, setHref] = useState('');
+
+  const { children, eventBase } = {
     children:
       type !== LINK_TYPES.CREATE
         ? `Sign in with ${CSP_CONTENT[csp].COPY} account`
@@ -23,11 +19,26 @@ export default function AccountLink({ csp, type = LINK_TYPES.CREATE }) {
       type !== LINK_TYPES.CREATE ? AUTH_EVENTS.LOGIN : AUTH_EVENTS.REGISTER,
   };
 
+  useEffect(
+    () => {
+      async function updateHref(passedCSP, passedType) {
+        const url =
+          passedType !== LINK_TYPES.CREATE
+            ? await authUtilities.sessionTypeUrl({ type: csp })
+            : await authUtilities.signupUrl(passedCSP);
+
+        setHref(url);
+      }
+      updateHref(csp, type);
+    },
+    [csp, type],
+  );
+
   return (
     <a
       href={href}
       className={`vads-c-action-link--blue vads-u-padding-y--2p5 vads-u-width--full ${csp}`}
-      data-csp={csp}
+      data-testid={csp}
       onClick={() => signupHandler(csp, eventBase)}
     >
       {children}

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -21,7 +21,7 @@ export default function LoginActions({ externalApplication }) {
           <h2 className="vads-u-margin-top--3">Or create an account</h2>
           <div className="vads-u-display--flex vads-u-flex-direction--column">
             {reduceAllowedProviders(allowedSignUpProviders).map(csp => (
-              <AccountLink key={csp} csp={csp} />
+              <AccountLink key={csp} csp={csp} useOAuth={useSignInService} />
             ))}
           </div>
         </div>

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { externalApplicationsConfig } from '../usip-config';
-import {
-  reduceAllowedProviders,
-  getQueryParams,
-  isExternalRedirect,
-} from '../utilities';
+import { reduceAllowedProviders, getQueryParams } from '../utilities';
 import LoginButton from './LoginButton';
 import AccountLink from './AccountLink';
 
@@ -13,13 +9,13 @@ export default function LoginActions({ externalApplication }) {
   const { allowedSignInProviders, allowedSignUpProviders, OAuthEnabled } =
     externalApplicationsConfig[externalApplication] ??
     externalApplicationsConfig.default;
-  const useSignInService = OAuthEnabled && OAuth && !isExternalRedirect();
+  const useSignInService = OAuthEnabled && OAuth === 'true';
 
   return (
     <div className="row">
       <div className="columns small-12" id="sign-in-wrapper">
         {reduceAllowedProviders(allowedSignInProviders).map(csp => (
-          <LoginButton csp={csp} key={csp} useSis={useSignInService} />
+          <LoginButton csp={csp} key={csp} useOAuth={useSignInService} />
         ))}
         <div id="create-account">
           <h2 className="vads-u-margin-top--3">Or create an account</h2>

--- a/src/platform/user/authentication/components/LoginButton.jsx
+++ b/src/platform/user/authentication/components/LoginButton.jsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import * as authUtilities from 'platform/user/authentication/utilities';
-import { createOAuthRequest } from 'platform/utilities/oauth/utilities';
 import { CSP_CONTENT } from '../constants';
 
-export function loginHandler(loginType, useWebSiS) {
-  recordEvent({ event: `login-attempted-${loginType}` });
-  if (useWebSiS) {
-    createOAuthRequest(loginType);
-  } else {
-    authUtilities.login({ policy: loginType });
-  }
+export function loginHandler(loginType, isOAuth) {
+  const isOAuthAttempt = isOAuth && '-oauth';
+  recordEvent({ event: `login-attempted-${loginType}${isOAuthAttempt}` });
+  authUtilities.login({ policy: loginType });
 }
 
 export default function LoginButton({
   csp,
   onClick = loginHandler,
-  useSis = false,
+  useOAuth = false,
 }) {
   if (!csp) return null;
   return (
@@ -25,7 +21,7 @@ export default function LoginButton({
       aria-label={`Sign in with ${CSP_CONTENT[csp].COPY}`}
       className={`usa-button ${csp}-button vads-u-margin-y--1p5 vads-u-padding-y--2`}
       data-csp={csp}
-      onClick={() => onClick(csp, useSis)}
+      onClick={() => onClick(csp, useOAuth)}
     >
       {CSP_CONTENT[csp].LOGO}
     </button>

--- a/src/platform/user/authentication/config/constants.js
+++ b/src/platform/user/authentication/config/constants.js
@@ -15,3 +15,13 @@ export const defaultMobileQueryParams = {
   allowPostLogin: false,
   allowRedirect: false,
 };
+
+export const defaultMobileOAuthOptions = {
+  clientId: 'mobile',
+  acr: 'ial2',
+};
+
+export const defaultWebOAuthOptions = {
+  clientId: 'web',
+  acr: 'min',
+};

--- a/src/platform/user/authentication/config/dev.config.js
+++ b/src/platform/user/authentication/config/dev.config.js
@@ -3,6 +3,8 @@ import {
   defaultSignUpProviders,
   defaultSignInProviders,
   defaultMobileQueryParams,
+  defaultWebOAuthOptions,
+  defaultMobileOAuthOptions,
 } from './constants';
 
 export default {
@@ -15,6 +17,7 @@ export default {
       allowPostLogin: true,
       allowRedirect: false,
     },
+    oAuthOptions: defaultWebOAuthOptions,
     OAuthEnabled: true,
     requiresVerification: false,
   },
@@ -64,6 +67,7 @@ export default {
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
     requiresVerification: true,
+    oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_FLAGSHIP_MOBILE],
   },
   [EXTERNAL_APPS.VA_OCC_MOBILE]: {
@@ -73,6 +77,7 @@ export default {
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
     requiresVerification: true,
+    oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_OCC_MOBILE],
   },
 };

--- a/src/platform/user/authentication/config/staging.config.js
+++ b/src/platform/user/authentication/config/staging.config.js
@@ -3,6 +3,8 @@ import {
   defaultSignUpProviders,
   defaultSignInProviders,
   defaultMobileQueryParams,
+  defaultWebOAuthOptions,
+  defaultMobileOAuthOptions,
 } from './constants';
 
 export default {
@@ -15,6 +17,7 @@ export default {
       allowPostLogin: true,
       allowRedirect: false,
     },
+    oAuthOptions: defaultWebOAuthOptions,
     OAuthEnabled: true,
     requiresVerification: false,
   },
@@ -64,6 +67,7 @@ export default {
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
     requiresVerification: true,
+    oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_FLAGSHIP_MOBILE],
   },
   [EXTERNAL_APPS.VA_OCC_MOBILE]: {
@@ -73,6 +77,7 @@ export default {
     queryParams: { ...defaultMobileQueryParams },
     OAuthEnabled: true,
     requiresVerification: true,
+    oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_OCC_MOBILE],
   },
 };

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -95,6 +95,8 @@ export const GA = {
   queryParamKey: 'ga_client_id',
 };
 
+export const IDME_TYPES = ['idme', 'idme_signup'];
+
 export const POLICY_TYPES = {
   VERIFY: 'verify',
   MFA: 'mfa',

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -148,5 +148,6 @@ export const AUTH_PARAMS = {
   OAuth: 'oauth',
   codeChallenge: 'code_challenge',
   codeChallengeMethod: 'code_challenge_method',
+  clientId: 'client_id',
   to: 'to',
 };

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -2,6 +2,7 @@ import appendQuery from 'append-query';
 import * as Sentry from '@sentry/browser';
 import 'url-search-params-polyfill';
 import environment from 'platform/utilities/environment';
+import { createOAuthRequest } from 'platform/utilities/oauth/utilities';
 import { setLoginAttempted } from 'platform/utilities/sso/loginAttempted';
 import { externalApplicationsConfig } from './usip-config';
 import {
@@ -16,7 +17,6 @@ import {
   SIGNUP_TYPES,
   API_SESSION_URL,
   EBENEFITS_DEFAULT_PATH,
-  API_SIGN_IN_SERVICE_URL,
   AUTH_PARAMS,
 } from './constants';
 import recordEvent from '../../monitoring/record-event';
@@ -106,6 +106,23 @@ export const createExternalApplicationUrl = () => {
   return URL;
 };
 
+export const getGAClientId = () => {
+  try {
+    // eslint-disable-next-line no-undef
+    const trackers = ga.getAll();
+
+    const tracker = trackers.find(t => {
+      const trackingId = t.get(GA.trackingIdKey);
+      return GA.trackingIds.includes(trackingId);
+    });
+
+    const clientId = tracker && tracker.get(GA.clientIdKey);
+    return clientId && { gaClientId: clientId };
+  } catch (e) {
+    return {};
+  }
+};
+
 // Return URL is where a user will be forwarded post successful authentication
 export const createAndStoreReturnUrl = () => {
   let returnUrl;
@@ -125,23 +142,6 @@ export const createAndStoreReturnUrl = () => {
   return returnUrl;
 };
 
-export const generateConfigQueryParams = ({ config, params }) => {
-  const { queryParams, OAuthEnabled } = config;
-  const isOauthEnabled =
-    OAuthEnabled && queryParams.allowOAuth && params.oauth === 'true';
-  return {
-    ...(isOauthEnabled && {
-      [AUTH_PARAMS.codeChallenge]: params.codeChallenge,
-      [AUTH_PARAMS.codeChallengeMethod]: params.codeChallengeMethod,
-      oauth: params.oauth,
-    }),
-    ...(queryParams.allowPostLogin && { postLogin: true }),
-    ...(queryParams.allowRedirect && {
-      redirect: createExternalApplicationUrl(),
-    }),
-  };
-};
-
 export function sessionTypeUrl({
   type = '',
   queryParams = {},
@@ -157,6 +157,7 @@ export function sessionTypeUrl({
     OAuth,
     codeChallenge,
     codeChallengeMethod,
+    clientId,
   } = getQueryParams();
 
   const externalRedirect = isExternalRedirect();
@@ -180,26 +181,47 @@ export function sessionTypeUrl({
       ? '_verified'
       : '';
 
+  // Passes GA Client ID if it is an `ID.me` type
+  const { gaClientId } = type === 'idme' && getGAClientId();
+  const passGAClientId = type === 'idme' && gaClientId;
+
   const appendParams =
     externalRedirect && isLogin
-      ? generateConfigQueryParams({
-          config,
-          params: {
-            codeChallenge,
-            codeChallengeMethod,
-            ...(useOAuth && { oauth: OAuth }),
-          },
-        })
+      ? {
+          ...(config.queryParams.allowPostLogin && { postLogin: true }),
+          ...(config.queryParams.allowRedirect && {
+            redirect: createExternalApplicationUrl(),
+          }),
+        }
       : {};
 
+  if (useOAuth && (isLogin || isSignup)) {
+    return createOAuthRequest({
+      application,
+      clientId,
+      type,
+      config,
+      passedQueryParams: {
+        codeChallenge,
+        codeChallengeMethod,
+        ...(passGAClientId && { gaClientId }),
+      },
+    });
+  }
+
   return appendQuery(
-    useOAuth
-      ? API_SIGN_IN_SERVICE_URL({ type })
-      : API_SESSION_URL({
-          version,
-          type: `${type}${requireVerification}`,
-        }),
-    { ...queryParams, ...appendParams, application },
+    API_SESSION_URL({
+      version,
+      type: `${type}${requireVerification}`,
+    }),
+    {
+      ...queryParams,
+      ...appendParams,
+      ...(passGAClientId && {
+        [GA.queryParamKey]: gaClientId,
+      }),
+      application,
+    },
   );
 }
 
@@ -210,27 +232,6 @@ export function setSentryLoginType(loginType) {
 export function clearSentryLoginType() {
   Sentry.setTag('loginType', undefined);
 }
-
-export const redirectWithGAClientId = redirectUrl => {
-  try {
-    // eslint-disable-next-line no-undef
-    const trackers = ga.getAll();
-
-    const tracker = trackers.find(t => {
-      const trackingId = t.get(GA.trackingIdKey);
-      return GA.trackingIds.includes(trackingId);
-    });
-
-    const clientId = tracker && tracker.get(GA.clientIdKey);
-
-    window.location = clientId
-      ? // eslint-disable-next-line camelcase
-        appendQuery(redirectUrl, { [GA.queryParamKey]: clientId })
-      : redirectUrl;
-  } catch (e) {
-    window.location = redirectUrl;
-  }
-};
 
 export function redirect(redirectUrl, clickedEvent) {
   const { application } = getQueryParams();
@@ -256,20 +257,16 @@ export function redirect(redirectUrl, clickedEvent) {
     });
   }
 
-  if (redirectUrl.includes(CSP_IDS.ID_ME)) {
-    redirectWithGAClientId(redirectUrl);
-  } else {
-    window.location = redirectUrl;
-  }
+  window.location = redirectUrl;
 }
 
-export function login({
+export async function login({
   policy,
   version = API_VERSION,
   queryParams = {},
   clickedEvent = AUTH_EVENTS.MODAL_LOGIN,
 }) {
-  const url = sessionTypeUrl({ type: policy, version, queryParams });
+  const url = await sessionTypeUrl({ type: policy, version, queryParams });
 
   if (!isExternalRedirect()) {
     setLoginAttempted();
@@ -304,9 +301,12 @@ export function logout(
   );
 }
 
-export function signup({ version = API_VERSION, csp = CSP_IDS.ID_ME } = {}) {
+export async function signup({
+  version = API_VERSION,
+  csp = CSP_IDS.ID_ME,
+} = {}) {
   return redirect(
-    sessionTypeUrl({
+    await sessionTypeUrl({
       type: `${csp}_signup`,
       version,
       ...(csp === CSP_IDS.ID_ME && { queryParams: { op: 'signup' } }),

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -18,6 +18,7 @@ import {
   API_SESSION_URL,
   EBENEFITS_DEFAULT_PATH,
   AUTH_PARAMS,
+  IDME_TYPES,
 } from './constants';
 import recordEvent from '../../monitoring/record-event';
 
@@ -182,8 +183,8 @@ export function sessionTypeUrl({
       : '';
 
   // Passes GA Client ID if it is an `ID.me` type
-  const { gaClientId } = type === 'idme' && getGAClientId();
-  const passGAClientId = type === 'idme' && gaClientId;
+  const { gaClientId } = IDME_TYPES.includes(type) && getGAClientId();
+  const passGAClientId = IDME_TYPES.includes(type) && gaClientId;
 
   const appendParams =
     externalRedirect && isLogin

--- a/src/platform/user/tests/authentication/components/AccountLink.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/AccountLink.unit.spec.js
@@ -1,62 +1,52 @@
 import React from 'react';
 import {
-  CSP_IDS,
   CSP_CONTENT,
   LINK_TYPES,
 } from 'platform/user/authentication/constants';
 import { expect } from 'chai';
 import * as authUtilities from 'platform/user/authentication/utilities';
 import AccountLink from 'platform/user/authentication/components/AccountLink';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
-const csps = Object.values(CSP_IDS).filter(csp => csp !== 'myhealthevet');
+const csps = ['logingov', 'idme'];
 
 describe('AccountLink', () => {
-  it('should not render without a `csp`', () => {
-    const wrapper = shallow(<AccountLink />);
-    expect(wrapper.exists('a')).to.be.false;
-    wrapper.unmount();
-  });
   csps.forEach(csp => {
-    it(`should render correctly for ${csp}`, () => {
-      const wrapper = shallow(<AccountLink csp={csp} />);
-      const anchor = wrapper.find('a');
+    it(`should render correctly for each ${csp}`, async () => {
+      const screen = render(<AccountLink csp={csp} />);
+      const anchor = await screen.findByTestId(csp);
 
-      expect(anchor.prop('data-csp')).to.equal(csp);
-      expect(anchor.text()).to.equal(
+      expect(anchor.textContent).to.include(
         `Create an account with ${CSP_CONTENT[csp].COPY}`,
       );
 
-      wrapper.unmount();
+      screen.unmount();
     });
 
-    it(`should set correct href for ${csp} type=create`, () => {
-      const wrapper = shallow(
-        <AccountLink csp={csp} type={LINK_TYPES.CREATE} />,
-      );
-      const anchor = wrapper.find('a');
+    it(`should set correct href for ${csp} type=create`, async () => {
+      const screen = render(<AccountLink csp={csp} type={LINK_TYPES.CREATE} />);
+      const anchor = await screen.findByTestId(csp);
+      const href = await authUtilities.signupUrl(csp);
 
-      expect(anchor.prop('href')).to.equal(authUtilities.signupUrl(csp));
-      expect(anchor.text()).to.equal(
+      expect(anchor.href).to.eql(href);
+      expect(anchor.textContent).to.include(
         `Create an account with ${CSP_CONTENT[csp].COPY}`,
       );
 
-      wrapper.unmount();
+      screen.unmount();
     });
 
-    it(`should set correct href for ${csp} type=signin`, () => {
-      const wrapper = shallow(
-        <AccountLink csp={csp} type={LINK_TYPES.SIGNIN} />,
-      );
-      const anchor = wrapper.find('a');
-      expect(anchor.prop('href')).to.equal(
-        authUtilities.sessionTypeUrl({ type: csp }),
-      );
-      expect(anchor.text()).to.equal(
+    it(`should set correct href for ${csp} type=create`, async () => {
+      const screen = render(<AccountLink csp={csp} type={LINK_TYPES.SIGNIN} />);
+      const anchor = await screen.findByTestId(csp);
+      const href = await authUtilities.sessionTypeUrl({ type: csp });
+
+      expect(anchor.href).to.eql(href);
+      expect(anchor.textContent).to.include(
         `Sign in with ${CSP_CONTENT[csp].COPY} account`,
       );
 
-      wrapper.unmount();
+      screen.unmount();
     });
   });
 });

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -6,7 +6,7 @@ import {
   getLoginAttempted,
   removeLoginAttempted,
 } from 'platform/utilities/sso/loginAttempted';
-import { mockCrypto } from 'platform/utilities/oauth/crypto';
+import { mockCrypto } from 'platform/utilities/oauth/mockCrypto';
 import * as authUtilities from '../../authentication/utilities';
 import {
   AUTHN_SETTINGS,

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -6,6 +6,7 @@ import {
   getLoginAttempted,
   removeLoginAttempted,
 } from 'platform/utilities/sso/loginAttempted';
+import { mockCrypto } from 'platform/utilities/oauth/crypto';
 import * as authUtilities from '../../authentication/utilities';
 import {
   AUTHN_SETTINGS,
@@ -20,7 +21,6 @@ import {
   EBENEFITS_DEFAULT_PATH,
   POLICY_TYPES,
   AUTH_EVENTS,
-  AUTH_PARAMS,
 } from '../../authentication/constants';
 
 const originalLocation = global.window.location;
@@ -49,6 +49,7 @@ const mockGADefaultArgs = {
 const setup = ({ path, mockGA = mockGADefaultArgs }) => {
   global.window.location = path ? new URL(`${base}${path}`) : originalLocation;
   global.ga = originalGA;
+  global.window.crypto = mockCrypto;
   removeLoginAttempted();
 
   const { mockGAActive, trackingId, throwGAError } = mockGA;
@@ -163,60 +164,6 @@ describe('Authentication Utilities', () => {
     });
   });
 
-  describe('generateConfigQueryParams', () => {
-    const defaultConfig = {
-      allowSkipDupe: false,
-      allowOAuth: true,
-      allowPostLogin: false,
-    };
-
-    const params = {
-      codeChallenge: 'bob',
-      codeChallengeMethod: '256S',
-      oauth: 'true',
-    };
-
-    it('should generate OAuth config', () => {
-      const config = {
-        queryParams: {
-          ...defaultConfig,
-        },
-        OAuthEnabled: true,
-      };
-
-      const expected = authUtilities.generateConfigQueryParams({
-        config,
-        params,
-      });
-
-      expect(expected).to.contains({
-        oauth: 'true',
-        [AUTH_PARAMS.codeChallenge]: 'bob',
-        [AUTH_PARAMS.codeChallengeMethod]: '256S',
-      });
-    });
-
-    it('should not generate OAuth config', () => {
-      const config = {
-        queryParams: {
-          ...defaultConfig,
-          allowOAuth: false,
-          allowPostLogin: true,
-        },
-        OAuthEnabled: true,
-      };
-
-      const expected = authUtilities.generateConfigQueryParams({
-        config,
-        params,
-      });
-
-      expect(expected).to.contains({
-        postLogin: true,
-      });
-    });
-  });
-
   describe('sessionTypeUrl', () => {
     const type = CSP_IDS.ID_ME;
     const typeVerified = `${type}_verified`;
@@ -285,13 +232,12 @@ describe('Authentication Utilities', () => {
       );
     });
 
-    it('should return the SIS session URL if oauth is set', () => {
+    it('should return the SIS session URL if oauth is set', async () => {
       setup({ path: usipPathWithParams(normalPathWithParams) });
-      expect(
-        authUtilities.sessionTypeUrl({
-          type,
-        }),
-      ).to.equal(API_SIGN_IN_SERVICE_URL({ type }));
+      const url = await authUtilities.sessionTypeUrl({
+        type: 'logingov',
+      });
+      expect(url).to.include(`v0/sign_in`);
     });
 
     it('should NOT return session url with _verified appended to type for types other than login/signup', () => {
@@ -315,14 +261,14 @@ describe('Authentication Utilities', () => {
       );
     });
 
-    it('should use `API_SIGN_IN_SERVICE_URL` when `useOAuth` is true', () => {
+    it('should use `API_SIGN_IN_SERVICE_URL` when `useOAuth` is true', async () => {
       setup({
         path: usipPathWithParams(
           `${flagshipUsipParams}&oauth=true&code_challenge=hello&code_challenge_method=S256`,
         ),
       });
       expect(
-        authUtilities.sessionTypeUrl({
+        await authUtilities.sessionTypeUrl({
           type,
         }),
       ).to.include(appendQuery(API_SIGN_IN_SERVICE_URL({ type })));
@@ -344,44 +290,36 @@ describe('Authentication Utilities', () => {
     });
   });
 
-  describe('redirectWithGAClientId', () => {
-    it('should redirect to redirectUrl without client_id if it does not find one', () => {
+  describe('getGAClientId', () => {
+    it('should return the GA client id', () => {
+      setup({
+        mockGA: {
+          mockGAActive: true,
+          trackingId: GA.trackingIds[0],
+        },
+      });
+      expect(authUtilities.getGAClientId()).includes({
+        gaClientId: mockGAClientId,
+      });
+    });
+    it('should return an empty object if clientId is invalid', () => {
       setup({
         mockGA: {
           mockGAActive: true,
           trackingId: mockInvalidGATrackingId,
         },
       });
-      expect(global.window.location).to.not.equal(base);
-      authUtilities.redirectWithGAClientId(base);
-      expect(global.window.location).to.equal(base);
+      expect(authUtilities.getGAClientId()).to.include({});
     });
-
-    it('should redirect to redirectUrl with client_id param appended when necessary', () => {
+    it('should return an empty object if clientId is invalid', () => {
       setup({
         mockGA: {
-          mockGAActive: true,
-          trackingId: GA.trackingIds[0],
-        },
-      });
-      expect(global.window.location).to.not.equal(base);
-      authUtilities.redirectWithGAClientId(base);
-      expect(global.window.location).to.equal(
-        `${base}/?ga_client_id=${mockGAClientId}`,
-      );
-    });
-
-    it('should redirect to redirectUrl without client_id if an error is thrown', () => {
-      setup({
-        mockGA: {
-          mockGAActive: true,
           throwGAError: true,
-          trackingId: GA.trackingIds[0],
+          mockGAActive: true,
+          trackingId: mockInvalidGATrackingId,
         },
       });
-      expect(global.window.location).to.not.equal(base);
-      authUtilities.redirectWithGAClientId(base);
-      expect(global.window.location).to.equal(base);
+      expect(authUtilities.getGAClientId()).to.include({});
     });
   });
 
@@ -479,7 +417,7 @@ describe('Authentication Utilities', () => {
       );
     });
 
-    it('should redirect with GA Client ID appended for redirects that include `idme`', () => {
+    it('should redirect with GA Client ID appended for redirects that include `idme`', async () => {
       setup({
         path: base,
         mockGA: {
@@ -488,21 +426,27 @@ describe('Authentication Utilities', () => {
         },
       });
 
-      authUtilities.redirect(`${base}/idme`);
+      const url = await authUtilities.sessionTypeUrl({
+        type: 'idme',
+      });
+
+      await authUtilities.redirect(url);
       expect(
-        String(global.window.location).includes(`client_id=${mockGAClientId}`),
+        String(global.window.location).includes(
+          `ga_client_id=${mockGAClientId}`,
+        ),
       ).to.be.true;
     });
   });
 
   describe('login', () => {
     it('should setLoginAttempted and redirect to login session url for all CSPs not on USiP', () => {
-      Object.values(CSP_IDS).forEach(policy => {
+      Object.values(CSP_IDS).forEach(async policy => {
         setup({ path: nonUsipPath });
 
-        authUtilities.login({ policy });
+        await authUtilities.login({ policy });
         expect(global.window.location).to.equal(
-          authUtilities.sessionTypeUrl({ type: policy }),
+          await authUtilities.sessionTypeUrl({ type: policy }),
         );
         expect(getLoginAttempted()).to.equal('true');
         expect(sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL)).to.equal(
@@ -513,12 +457,12 @@ describe('Authentication Utilities', () => {
     });
 
     it('should setLoginAttempted and redirect to login session url for all CSPs on USiP authenticating internally', () => {
-      Object.values(CSP_IDS).forEach(policy => {
+      Object.values(CSP_IDS).forEach(async policy => {
         setup({ path: usipPath });
 
-        authUtilities.login({ policy });
+        await authUtilities.login({ policy });
         expect(global.window.location).to.equal(
-          authUtilities.sessionTypeUrl({ type: policy }),
+          await authUtilities.sessionTypeUrl({ type: policy }),
         );
         expect(getLoginAttempted()).to.equal('true');
         expect(sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL)).to.equal(
@@ -529,12 +473,14 @@ describe('Authentication Utilities', () => {
     });
 
     it('should redirect to login session url for all CSPs on USiP authenticating externally', () => {
-      Object.values(CSP_IDS).forEach(policy => {
+      Object.values(CSP_IDS).forEach(async policy => {
         setup({ path: usipPathWithParams(mhvUsipParams) });
         const externalApplicationUrl = authUtilities.createExternalApplicationUrl();
-        const expectedRedirect = authUtilities.sessionTypeUrl({ type: policy });
+        const expectedRedirect = await authUtilities.sessionTypeUrl({
+          type: policy,
+        });
 
-        authUtilities.login({ policy });
+        await authUtilities.login({ policy });
         expect(global.window.location).to.equal(expectedRedirect);
         expect(sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL)).to.equal(
           externalApplicationUrl,
@@ -584,26 +530,26 @@ describe('Authentication Utilities', () => {
   });
 
   describe('signup', () => {
-    it('should redirect to the ID.me signup session url by default', () => {
+    it('should redirect to the ID.me signup session url by default', async () => {
       setup({ path: nonUsipPath });
-      authUtilities.signup();
+      await authUtilities.signup();
       expect(global.window.location).to.include(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
       );
     });
 
-    it('should append op=signup param for ID.me signups', () => {
+    it('should append op=signup param for ID.me signups', async () => {
       setup({ path: nonUsipPath });
-      authUtilities.signup();
+      await authUtilities.signup();
       expect(global.window.location).to.contain.all(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
         'op=signup',
       );
     });
 
-    it('should redirect to the provided CSPs signup session url', () => {
+    it('should redirect to the provided CSPs signup session url', async () => {
       setup({ path: nonUsipPath });
-      authUtilities.signup({ csp: CSP_IDS.LOGIN_GOV });
+      await authUtilities.signup({ csp: CSP_IDS.LOGIN_GOV });
       expect(global.window.location).to.equal(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.LOGIN_GOV] }),
       );
@@ -611,27 +557,27 @@ describe('Authentication Utilities', () => {
   });
 
   describe('signupUrl', () => {
-    it('should generate an ID.me session signup url by default', () => {
-      expect(authUtilities.signupUrl()).to.include(
+    it('should generate an ID.me session signup url by default', async () => {
+      expect(await authUtilities.signupUrl()).to.include(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
       );
     });
 
-    it('should append op=signup param for ID.me signups', () => {
-      expect(authUtilities.signupUrl(CSP_IDS.ID_ME)).to.contain.all(
+    it('should append op=signup param for ID.me signups', async () => {
+      expect(await authUtilities.signupUrl(CSP_IDS.ID_ME)).to.contain.all(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
         'op=signup',
       );
     });
 
-    it('should generate a session signup url for the given type', () => {
-      expect(authUtilities.signupUrl(CSP_IDS.LOGIN_GOV)).to.include(
+    it('should generate a session signup url for the given type', async () => {
+      expect(await authUtilities.signupUrl(CSP_IDS.LOGIN_GOV)).to.include(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.LOGIN_GOV] }),
       );
     });
 
-    it('should generate an ID.me session signup url if the given type is not valid', () => {
-      expect(authUtilities.signupUrl('test')).to.include(
+    it('should generate an ID.me session signup url if the given type is not valid', async () => {
+      expect(await authUtilities.signupUrl('test')).to.include(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
       );
     });

--- a/src/platform/utilities/oauth/constants.js
+++ b/src/platform/utilities/oauth/constants.js
@@ -56,3 +56,8 @@ export const OAUTH_ERROR_RESPONSES = {
   'Code is not valid': OAUTH_ERRORS.OAUTH_INVALID_REQUEST,
   default: OAUTH_ERRORS.OAUTH_DEFAULT_ERROR,
 };
+
+export const CLIENT_IDS = {
+  WEB: 'web',
+  MOBILE: 'mobile',
+};

--- a/src/platform/utilities/oauth/constants.js
+++ b/src/platform/utilities/oauth/constants.js
@@ -4,26 +4,35 @@ export const OAUTH_KEYS = {
   CODE_CHALLENGE_METHOD: 'code_challenge_method',
   REDIRECT_URI: 'redirect_uri',
   RESPONSE_TYPE: 'response_type',
-  SCOPE: 'scope',
   STATE: 'state',
   GRANT_TYPE: 'grant_type',
   CODE: 'code',
   CODE_VERIFIER: 'code_verifier',
+  ACR: 'acr',
 };
 
 const generateOAuthKeysWithout = array =>
-  Object.keys(OAUTH_KEYS).reduce((acc, cv) => {
-    let tempAcc = acc;
-    if (!array.includes(cv)) {
-      tempAcc = { ...acc, [cv]: OAUTH_KEYS[cv] };
-    }
-    return tempAcc;
-  }, {});
+  Object.keys(OAUTH_KEYS).reduce(
+    (acc, cv) => ({
+      ...acc,
+      ...(!array.includes(cv) && { [cv]: OAUTH_KEYS[cv] }),
+    }),
+    {},
+  );
 
-export const AUTHORIZE_KEYS = generateOAuthKeysWithout([
+export const AUTHORIZE_KEYS_WEB = generateOAuthKeysWithout([
   'GRANT_TYPE',
   'CODE_VERIFIER',
   'CODE',
+  'REDIRECT_URI',
+]);
+
+export const AUTHORIZE_KEYS_MOBILE = generateOAuthKeysWithout([
+  'GRANT_TYPE',
+  'CODE_VERIFIER',
+  'CODE',
+  'STATE',
+  'REDIRECT_URI',
 ]);
 
 export const TOKEN_KEYS = generateOAuthKeysWithout([

--- a/src/platform/utilities/oauth/crypto.js
+++ b/src/platform/utilities/oauth/crypto.js
@@ -1,5 +1,3 @@
-import { createHash, randomFillSync } from 'crypto';
-
 // Decimal to Hexadecimal
 const decimal2hex = dec => `0${dec.toString(16)}`.substr(-2);
 
@@ -43,34 +41,3 @@ export function generateRandomString(length = 28) {
   window.crypto.getRandomValues(arr);
   return Array.from(arr, decimal2hex).join('');
 }
-
-function getArrayBufferOrView(buffer) {
-  if (Buffer.isBuffer(buffer)) {
-    return buffer;
-  }
-  if (typeof buffer === 'string') {
-    return Buffer.from(buffer, 'utf8');
-  }
-  return buffer;
-}
-
-// Only use for unit-tests
-export const mockCrypto = {
-  getRandomValues(buffer) {
-    return randomFillSync(buffer);
-  },
-  subtle: {
-    digest(algorithm = 'SHA-256', data) {
-      const _algorithm = algorithm.toLowerCase().replace('-', '');
-      const _data = getArrayBufferOrView(data);
-
-      return new Promise((resolve, _) => {
-        resolve(
-          createHash(_algorithm)
-            .update(_data)
-            .digest(),
-        );
-      });
-    },
-  },
-};

--- a/src/platform/utilities/oauth/crypto.js
+++ b/src/platform/utilities/oauth/crypto.js
@@ -1,3 +1,5 @@
+import { createHash, randomFillSync } from 'crypto';
+
 // Decimal to Hexadecimal
 const decimal2hex = dec => `0${dec.toString(16)}`.substr(-2);
 
@@ -41,3 +43,34 @@ export function generateRandomString(length = 28) {
   window.crypto.getRandomValues(arr);
   return Array.from(arr, decimal2hex).join('');
 }
+
+function getArrayBufferOrView(buffer) {
+  if (Buffer.isBuffer(buffer)) {
+    return buffer;
+  }
+  if (typeof buffer === 'string') {
+    return Buffer.from(buffer, 'utf8');
+  }
+  return buffer;
+}
+
+// Only use for unit-tests
+export const mockCrypto = {
+  getRandomValues(buffer) {
+    return randomFillSync(buffer);
+  },
+  subtle: {
+    digest(algorithm = 'SHA-256', data) {
+      const _algorithm = algorithm.toLowerCase().replace('-', '');
+      const _data = getArrayBufferOrView(data);
+
+      return new Promise((resolve, _) => {
+        resolve(
+          createHash(_algorithm)
+            .update(_data)
+            .digest(),
+        );
+      });
+    },
+  },
+};

--- a/src/platform/utilities/oauth/mockCrypto.js
+++ b/src/platform/utilities/oauth/mockCrypto.js
@@ -1,0 +1,32 @@
+import { createHash, randomFillSync } from 'crypto';
+
+function getArrayBufferOrView(buffer) {
+  if (Buffer.isBuffer(buffer)) {
+    return buffer;
+  }
+  if (typeof buffer === 'string') {
+    return Buffer.from(buffer, 'utf8');
+  }
+  return buffer;
+}
+
+// Only use for unit-tests
+export const mockCrypto = {
+  getRandomValues(buffer) {
+    return randomFillSync(buffer);
+  },
+  subtle: {
+    digest(algorithm = 'SHA-256', data) {
+      const _algorithm = algorithm.toLowerCase().replace('-', '');
+      const _data = getArrayBufferOrView(data);
+
+      return new Promise((resolve, _) => {
+        resolve(
+          createHash(_algorithm)
+            .update(_data)
+            .digest(),
+        );
+      });
+    },
+  },
+};

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -1,10 +1,12 @@
 import environment from 'platform/utilities/environment';
 import {
   API_SIGN_IN_SERVICE_URL,
+  EXTERNAL_APPS,
   GA,
+  SIGNUP_TYPES,
 } from 'platform/user/authentication/constants';
 import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
-import { OAUTH_KEYS } from './constants';
+import { OAUTH_KEYS, CLIENT_IDS } from './constants';
 import * as oauthCrypto from './crypto';
 
 export async function pkceChallengeFromVerifier(v) {
@@ -13,7 +15,7 @@ export async function pkceChallengeFromVerifier(v) {
   return { codeChallenge: oauthCrypto.base64UrlEncode(hashed) };
 }
 
-export const saveStateAndVerifier = () => {
+export const saveStateAndVerifier = type => {
   /*
     Ensures saved state is not overwritten if location has state parameter.
   */
@@ -26,8 +28,15 @@ export const saveStateAndVerifier = () => {
   // Create and store a new PKCE code_verifier (the plaintext random secret)
   const codeVerifier = oauthCrypto.generateRandomString(64);
 
-  storage.setItem('state', state);
-  storage.setItem('code_verifier', codeVerifier);
+  // Sign up/Create account
+  if (Object.values(SIGNUP_TYPES).includes(type)) {
+    storage.setItem(`${type}_state`, state);
+    storage.setItem(`${type}_code_verifier`, codeVerifier);
+  } else {
+    // Sign in
+    storage.setItem(`state`, state);
+    storage.setItem(`code_verifier`, codeVerifier);
+  }
 
   return { state, codeVerifier };
 };
@@ -37,6 +46,27 @@ export const removeStateAndVerifier = () => {
 
   storage.removeItem('state');
   storage.removeItem('code_verifier');
+};
+
+export const updateStateAndVerifier = csp => {
+  const storage = window.sessionStorage;
+
+  storage.setItem(`state`, storage.getItem(`${csp}_signup_state`));
+  storage.setItem(
+    `code_verifier`,
+    storage.getItem(`${csp}_signup_code_verifier`),
+  );
+
+  const signupTypesMap = Object.values(SIGNUP_TYPES).flatMap(type => [
+    `${type}_state`,
+    `${type}_code_verifier`,
+  ]);
+
+  Object.keys(storage)
+    .filter(key => signupTypesMap.includes(key))
+    .forEach(key => {
+      storage.removeItem(key);
+    });
 };
 
 /**
@@ -50,9 +80,11 @@ export async function createOAuthRequest({
   passedQueryParams = {},
   type = '',
 }) {
-  const isDefaultOAuth = !application || clientId === 'web';
+  const isDefaultOAuth = !application || clientId === CLIENT_IDS.WEB;
   const isMobileOAuth =
-    ['vamobile', 'vaoccmobile'].includes(application) || clientId === 'mobile';
+    [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE, EXTERNAL_APPS.VA_OCC_MOBILE].includes(
+      application,
+    ) || clientId === CLIENT_IDS.MOBILE;
   const { oAuthOptions } =
     config ??
     (externalApplicationsConfig[application] ||
@@ -61,7 +93,7 @@ export async function createOAuthRequest({
   /*
     Web - Generate state & codeVerifier if default oAuth
   */
-  const { state, codeVerifier } = isDefaultOAuth && saveStateAndVerifier();
+  const { state, codeVerifier } = isDefaultOAuth && saveStateAndVerifier(type);
 
   /*
     Mobile - Use passed code_challenge

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -9,7 +9,7 @@ import {
   AUTHORIZE_KEYS_WEB,
   AUTHORIZE_KEYS_MOBILE,
 } from '../../oauth/constants';
-import { mockCrypto } from '../../oauth/crypto';
+import { mockCrypto } from '../../oauth/mockCrypto';
 import * as oAuthUtils from '../../oauth/utilities';
 
 describe('OAuth - Utilities', () => {

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -4,41 +4,16 @@ import {
   setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
-import { createHash, randomFillSync } from 'crypto';
-import { AUTHORIZE_KEYS } from '../../oauth/constants';
-import * as oAuthUtils from '../../oauth/utilities';
 
-function getArrayBufferOrView(buffer) {
-  if (Buffer.isBuffer(buffer)) {
-    return buffer;
-  }
-  if (typeof buffer === 'string') {
-    return Buffer.from(buffer, 'utf8');
-  }
-  return buffer;
-}
+import {
+  AUTHORIZE_KEYS_WEB,
+  AUTHORIZE_KEYS_MOBILE,
+} from '../../oauth/constants';
+import { mockCrypto } from '../../oauth/crypto';
+import * as oAuthUtils from '../../oauth/utilities';
 
 describe('OAuth - Utilities', () => {
   const globalCrypto = global.crypto;
-  const mockCrypto = {
-    getRandomValues(buffer) {
-      return randomFillSync(buffer);
-    },
-    subtle: {
-      digest(algorithm = 'SHA-256', data) {
-        const _algorithm = algorithm.toLowerCase().replace('-', '');
-        const _data = getArrayBufferOrView(data);
-
-        return new Promise((resolve, _) => {
-          resolve(
-            createHash(_algorithm)
-              .update(_data)
-              .digest(),
-          );
-        });
-      },
-    },
-  };
 
   beforeEach(() => {
     window.crypto = mockCrypto;
@@ -50,8 +25,12 @@ describe('OAuth - Utilities', () => {
 
   describe('pkceChallengeFromVerifier', () => {
     it('should generate a code challenge from verifier', async () => {
-      const codeChallenge = await oAuthUtils.pkceChallengeFromVerifier('hello');
-      const codeChallenge2 = await oAuthUtils.pkceChallengeFromVerifier(
+      const { codeChallenge } = await oAuthUtils.pkceChallengeFromVerifier(
+        'hello',
+      );
+      const {
+        codeChallenge: codeChallenge2,
+      } = await oAuthUtils.pkceChallengeFromVerifier(
         'somesuperlongrandomsecurestring',
       );
       expect(codeChallenge).to.eql(
@@ -90,25 +69,39 @@ describe('OAuth - Utilities', () => {
   });
 
   describe('createOAuthRequest', () => {
-    it('should generate the proper url based on `csp`', () => {
-      ['logingov', 'idme'].forEach(async csp => {
-        await oAuthUtils.createOAuthRequest(csp);
-        expect(window.location.href).to.include(csp);
+    it('should generate the proper url based on `csp` for web', () => {
+      ['logingov', 'idme', 'dslogon', 'mhv'].forEach(async csp => {
+        const url = await oAuthUtils.createOAuthRequest({ type: csp });
+        expect(url).to.include(`type=${csp}`);
+        expect(url).to.include(`ial=min`);
+        expect(url).to.include(`client_id=web`);
+      });
+    });
+    it('should generate the proper url based on `csp` for mobile', () => {
+      ['logingov', 'idme', 'dslogon', 'mhv'].forEach(async csp => {
+        const url = await oAuthUtils.createOAuthRequest({
+          type: csp,
+          application: 'vamobile',
+        });
+        expect(url).to.include(`type=${csp}`);
+        expect(url).to.include(`ial=ial2`);
+        expect(url).to.include(`client_id=mobile`);
       });
     });
     it('should append additional params', async () => {
-      expect(window.location.search).to.eql('');
-      await oAuthUtils.createOAuthRequest('logingov');
-      Object.values(AUTHORIZE_KEYS).forEach(key => {
-        const searchParams = new URLSearchParams(window.location.search);
+      const webUrl = await oAuthUtils.createOAuthRequest({ type: 'logingov' });
+      Object.values(AUTHORIZE_KEYS_WEB).forEach(key => {
+        const searchParams = new URLSearchParams(webUrl);
         expect(searchParams.has(key)).to.be.true;
       });
-    });
-    it('should change window.location to url', async () => {
-      const originalLocation = window.location.href;
-      expect(originalLocation).to.eql('http://localhost/');
-      await oAuthUtils.createOAuthRequest('idme');
-      expect(window.location.href).to.not.eql(originalLocation);
+      const mobileUrl = await oAuthUtils.createOAuthRequest({
+        type: 'logingov',
+        application: 'vaoccmobile',
+      });
+      Object.values(AUTHORIZE_KEYS_MOBILE).forEach(key => {
+        const searchParams = new URLSearchParams(mobileUrl);
+        expect(searchParams.has(key)).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description
This PR does a lot of refactoring around the SAML & OAuth mechanisms for authentication (outlined below).

- Updates AccountLink component to use hook-based updates to href when called asynchronously
    - Updates AccountLink unit test to test for appropriate changes
    - Adds a function call to update the state & verifier when clicked (and removes the others)
- Refactors LoginActions component to remove externalRedirect dependency
- Refactors LoginButton component to use login method and updates GA event recording for oAuth
- Updates USiP config
    - Updates default OAuth options for both `mobile` and `web`
    - Adds both to dev & staging configs
- Adds `client_id` for AUTH_PARAMS to allow the ability to force the passed client_id
- `Authentication/utilities.js`
    - Removes `redirectWithGAClientID` and `generateConfigQueryParams` functions
    - Adds `getGAClientId` to attempt to get the Google Analytics trackingIDs
    - Modifies `sessionTypeUrl` function
        - Passes the Google Analytics `ga_client_id` if `type` is `idme or idme_signup`
        - Condenses `appendParams` to only config based (ie doesn’t include OAuth stuff)
        - Adds conditionals for (OAuth | Sign in Service) only logic and uses the `createOAuthRequest` method to generate a proper URL
        - Updates default (SAML | SessionController) function to ensure original implementation remains unchanged
    - Updates both `login` and `signup` functions to be async and forcing them to wait on the `sessionTypeUrl` method (because of the hash computing for the code challenge & verifier
    - Updates the `redirect` to remove the `redirectWithGAClientID` and just adds it as a part of the `sessionTypeUrl`
    - Additionally modifies the auth/utilities unit test to ensure appropriate functionality
- In the oauth/constants.js file
    - Removes unused constants from oauth/constants.js
    - Modifies the `generateOAuthKeysWithout` function for the AUTHORIZE_KEY_WEB & AUTHORIZE_KEY_MOBILE (for unit test)
- Moves the `mockCrypto` object to the `oauth/mockCrypto.js` file (for unit testing)
- In the `oauth/utilities.js` file
    - Update the `pkceChallengeFromVerifier` method to return an object containing the `codeChallenge`
    - Refactors `createOAuthRequest`
        - Adds additional parameters
        - Adds ability to differentiate mobile vs web OAuth
        - Adds ability to conditionally set state, code verifier, and code challenge (for web) and use passed code challenge (for mobile)
        - Updates the oAuthParams builder to include `acr` and conditionals for `state` and `ga_client_id`
        - Updates the function to return a URL string rather than do the redirect
    - Updates unit test for updated functionality
    - Fixes the `saveStateAndVerifier` to save state based off of type (differentiate between create account and sign in (state and cv)
    - Creates the `updateStateAndVerifier` that only occurs on a single create account link, which essentially takes the clicked CSPs state & cv and adds it to the normal state & cv and removes the rest from sessionStorage

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#42054


## Testing done
Unit

## Screenshots
n/a

## Acceptance criteria
- [ ] I can sign in with either SAML (eAuth) or OAuth (Sign in Service)
- [x] On the USiP page (without vets-api running),
  - [x] When adding the parameters `application=vamobile`, `oauth=true`, `code_challenge=<some value>`, and `code_challenge_method=S256`, the Sign in URL should include `acr=ial2`, `client_id=mobile`, and use the Sign in Service URL (aka `v0/sign_in/authorize...`)
  - [x] From above, removing the `oauth=true`, the Sign in URL should default to Session Controller route `v1/sessions/<csp>/new`
  - [x] When no `application` parameter is set, but `oauth=true` and clicking the Sign in button the URL should include `acr=min`, `client_id=web`, use the SiS URL (aka `v0/sign_in/authorize`) along with a generated `code_challenge` parameter.  Additionally there should be a `state` and `code_verifier` in session storage
  - [x] When no `oauth=true` value is set and clicking the Sign in button, the URL should use the Sessions Controller URL (aka `v1/sessions/<csp>/new`
  - [x] When no `application` parameter is set, but `oauth=true` confirm the following:
    - [x] In Session Storage, state & code verifiers exists for each csp (login.gov and id.me) (capture or record one of them)
    - [x] Clicking on the Create account with ID.me URL (you'll be directed to vets-api, WITHOUT clicking the back button, navigate to `localhost:3001`
    - [x] Verify the newly created `state` and `code_verifier` are created in session storage and match the captured/recorded state & code verifier.  Also confirm only 1 `state` and `code_verifier` exists.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
