### PR TITLE
Convert address autofill key to viewfield in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/FormFieldsets/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFieldsets/AddressWithAutofill.jsx
@@ -42,7 +42,7 @@ const PrimaryAddressWithAutofill = props => {
     },
   };
 
-  // define our custom input label map
+  // define our custom input labels
   const inputLabelMap = {
     primaryAddress: primaryInputLabel,
     secondaryOneAddress: secondaryOneInputLabel,
@@ -62,11 +62,11 @@ const PrimaryAddressWithAutofill = props => {
   // define our checkbox input change event
   const handleCheck = useCallback(
     event => {
-      formData.autofill = event.target.checked;
+      formData['view:autofill'] = event.target.checked;
       // transform and send data back to the form
-      const dataToSend = formData.autofill
+      const dataToSend = formData['view:autofill']
         ? { ...formData, ...veteranAddress }
-        : { autofill: false };
+        : { 'view:autofill': false };
       addDirtyField('autofill');
       onChange(dataToSend);
     },
@@ -79,7 +79,7 @@ const PrimaryAddressWithAutofill = props => {
       const fieldName = event.target.name.split('_').pop();
       formData[fieldName] = event.target.value;
       // uncheck autofill since we have modified the input value
-      if (formData.autofill) formData.autofill = false;
+      if (formData['view:autofill']) formData['view:autofill'] = false;
       // send updated date to the form
       addDirtyField(fieldName);
       onChange(formData);
@@ -131,8 +131,8 @@ const PrimaryAddressWithAutofill = props => {
 
       {canAutofillAddress && (
         <VaCheckbox
-          id={idSchema.autofill.$id}
-          checked={formData.autofill}
+          id={idSchema['view:autofill'].$id}
+          checked={formData['view:autofill']}
           label="Use the same address as the Veteran"
           className="vads-u-margin-left--neg3"
           style={{ marginLeft: '-24px' }}

--- a/src/applications/caregivers/components/FormFieldsets/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFieldsets/AddressWithAutofill.jsx
@@ -131,7 +131,7 @@ const PrimaryAddressWithAutofill = props => {
 
       {canAutofillAddress && (
         <VaCheckbox
-          id={idSchema['view:autofill'].$id}
+          id="root_primaryAddress_autofill"
           checked={formData['view:autofill']}
           label="Use the same address as the Veteran"
           className="vads-u-margin-left--neg3"

--- a/src/applications/caregivers/components/FormFieldsets/AddressWithAutofillReviewField.jsx
+++ b/src/applications/caregivers/components/FormFieldsets/AddressWithAutofillReviewField.jsx
@@ -14,7 +14,7 @@ export const AddressWithAutofillReviewField = ({
   return (
     <>
       {canAutofillAddress &&
-        formData.autofill && (
+        formData['view:autofill'] && (
           <div className="review-row">
             <dt>Use the same address as the Veteran</dt>
             <dd>Selected</dd>

--- a/src/applications/caregivers/config/chapters/primary/primaryContact.js
+++ b/src/applications/caregivers/config/chapters/primary/primaryContact.js
@@ -49,7 +49,10 @@ const primaryContactInfoPage = {
     properties: {
       [primaryCaregiverFields.address]: {
         ...address,
-        properties: { ...address.properties, autofill: { type: 'boolean' } },
+        properties: {
+          ...address.properties,
+          'view:autofill': { type: 'boolean' },
+        },
       },
       [primaryCaregiverFields.primaryPhoneNumber]:
         primaryCaregiverProps.primaryPhoneNumber,

--- a/src/applications/caregivers/config/chapters/secondaryOne/secondaryCaregiverContact.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/secondaryCaregiverContact.js
@@ -55,7 +55,10 @@ const secondaryCaregiverContactPage = {
     properties: {
       [secondaryOneFields.address]: {
         ...address,
-        properties: { ...address.properties, autofill: { type: 'boolean' } },
+        properties: {
+          ...address.properties,
+          'view:autofill': { type: 'boolean' },
+        },
       },
       [secondaryOneFields.primaryPhoneNumber]:
         secondaryCaregiverOneProps.primaryPhoneNumber,

--- a/src/applications/caregivers/config/chapters/secondaryTwo/secondaryTwoContactInfo.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/secondaryTwoContactInfo.js
@@ -52,7 +52,10 @@ const secondaryTwoContactPage = {
     properties: {
       [secondaryTwoFields.address]: {
         ...address,
-        properties: { ...address.properties, autofill: { type: 'boolean' } },
+        properties: {
+          ...address.properties,
+          'view:autofill': { type: 'boolean' },
+        },
       },
       [secondaryTwoFields.primaryPhoneNumber]:
         secondaryCaregiverTwoProps.primaryPhoneNumber,


### PR DESCRIPTION
## Description
The address autofill feature in the caregivers application is unable to be submitted to vets-api due to a key/value pair in the address object that is not in the schema. We don't need that value for anything other than frontend function control. This PR converts that key to a `view:` key that will be filtered out in the `submitTransform` form method to eliminate the schema error on the backend.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#41869


## Acceptance criteria
- [ ] No schema-related errors are thrown on form submit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
