### PR TITLE
Deprecate and migrate textarea

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,10 @@ module.exports = {
         name: '@department-of-veterans-affairs/component-library/ProgressBar',
         use: '<va-progress-bar>',
       },
+      {
+        name: '@department-of-veterans-affairs/component-library/TextArea',
+        use: '<va-textarea>',
+      },
     ],
     'jsx-a11y/control-has-associated-label': 1, // 2
     'jsx-a11y/click-events-have-key-events': 1, // 24

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.17.7",
-    "@department-of-veterans-affairs/component-library": "^10.6.0",
+    "@department-of-veterans-affairs/component-library": "^10.6.5",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "0.0.2",

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -685,18 +685,9 @@ textarea:focus {
   }
 }
 
-textarea.resize-none {
-  resize: none;
-}
-
-textarea.resize-y {
+.resize-y {
   resize: vertical;
 }
-
-textarea.resize-x {
-  resize: horizontal;
-}
-
 
 .blue-bar-block {
   border-left: 7px solid $color-primary;

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import TextArea from '@department-of-veterans-affairs/component-library/TextArea';
 import Select from '@department-of-veterans-affairs/component-library/Select';
 
 import environment from 'platform/utilities/environment';
@@ -109,13 +108,13 @@ const SipsDevModal = props => {
           onCloseEvent={handlers.closeSipsModal}
         >
           <>
-            <TextArea
-              errorMessage={errorMessage}
+            <va-textarea
+              error={errorMessage}
               label="Form data"
               name="sips_data"
-              additionalClass="resize-y"
-              field={{ value: textData }}
-              onValueChange={field => handlers.onChange(field.value)}
+              class="resize-y"
+              value={textData}
+              onInput={e => handlers.onChange(e.target.value)}
             />
             <Select
               label="Return url"

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -101,7 +101,7 @@ describe('Schemaform <SipsDevModal>', () => {
     const dom = getFormDOM(modal);
     // open the sips modal
     dom.click('.va-button-link');
-    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('va-textarea', JSON.stringify(newData));
     dom.fillData('select', '/page-2');
     dom.click('.usa-button-primary'); // replace button
     expect(result).to.deep.equal({
@@ -134,7 +134,7 @@ describe('Schemaform <SipsDevModal>', () => {
     const dom = getFormDOM(modal);
     // open the sips modal
     dom.click('.va-button-link');
-    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('va-textarea', JSON.stringify(newData));
     dom.fillData('select', '/page-2');
     // replace button
     dom.click('.usa-button-primary');
@@ -169,7 +169,7 @@ describe('Schemaform <SipsDevModal>', () => {
     const dom = getFormDOM(modal);
     // open the sips modal
     dom.click('.va-button-link');
-    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('va-textarea', JSON.stringify(newData));
     dom.fillData('select', '/page-1');
     // merge button
     dom.click('.usa-button-secondary');
@@ -204,7 +204,7 @@ describe('Schemaform <SipsDevModal>', () => {
     const dom = getFormDOM(modal);
     // open the sips modal
     dom.click('.va-button-link');
-    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('va-textarea', JSON.stringify(newData));
     dom.fillData('select', '/page-1');
     // merge button
     dom.click('.usa-button-secondary');

--- a/src/platform/testing/unit/schemaform-utils.jsx
+++ b/src/platform/testing/unit/schemaform-utils.jsx
@@ -2,7 +2,6 @@
  * Utilities for testing forms built with our schema based form library
  */
 
-import set from '../../utilities/data/set';
 import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
@@ -10,18 +9,20 @@ import sinon from 'sinon';
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import { fillDate as oldFillDate } from './helpers';
 
 import {
   replaceRefSchemas,
   updateSchemaAndData,
 } from 'platform/forms-system/src/js/state/helpers';
 import { fireEvent } from '@testing-library/dom';
+import { fillDate as oldFillDate } from './helpers';
+import set from '../../utilities/data/set';
 
 function getDefaultData(schema) {
   if (schema.type === 'array') {
     return [];
-  } else if (schema.type === 'object') {
+  }
+  if (schema.type === 'object') {
     return {};
   }
 
@@ -68,7 +69,9 @@ export class DefinitionTester extends React.Component {
       uiSchema,
     };
   }
+
   debouncedAutoSave = sinon.spy();
+
   handleChange = data => {
     const { schema, uiSchema, formData } = this.state;
     const { pagePerItemIndex, arrayPath } = this.props;
@@ -91,6 +94,7 @@ export class DefinitionTester extends React.Component {
       uiSchema,
     });
   };
+
   render() {
     let { schema, uiSchema, formData } = this.state;
     const { pagePerItemIndex, arrayPath } = this.props;
@@ -200,6 +204,11 @@ export function getFormDOM(form) {
 
   formDOM.fillData = function fillDataFn(id, value) {
     ReactTestUtils.Simulate.change(this.getElement(id), {
+      target: {
+        value,
+      },
+    });
+    ReactTestUtils.Simulate.input(this.getElement(id), {
       target: {
         value,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,13 +2712,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^10.6.0":
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.6.0.tgz#bcd9f0b12c550f15a6a34d3ce7113cb5d7a3bafe"
-  integrity sha512-jraiRAIFuFIH/jLGUEYwPBgiAAxVuLXz2tz8cj23d0+8L0dh/1qNk+eH6yCMNJJ142blZdNmKULK3P+HW2nxtw==
+"@department-of-veterans-affairs/component-library@^10.6.5":
+  version "10.6.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-10.6.5.tgz#b026f08c15218477b17563030a89351cf60e58a0"
+  integrity sha512-fEJDS9V+CmvL2oOJX+67JrqVF/K8gLW6cPuWZHwP4SpkEQ/swBBdpgE5CQQusI+Z4VS3nuLz7zay3NOrT8iWmA==
   dependencies:
     "@department-of-veterans-affairs/react-components" "6.1.3"
-    "@department-of-veterans-affairs/web-components" "4.5.0"
+    "@department-of-veterans-affairs/web-components" "4.5.5"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2827,10 +2827,10 @@
     intersection-observer "^0.12.0"
     postcss-url "^10.1.1"
 
-"@department-of-veterans-affairs/web-components@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.5.0.tgz#7833534343da7fb8b21b23545648672812868716"
-  integrity sha512-Bxql8ExxCu/dNZWo/S3VOvIMxgkjSEwvMQMiy76Hhn/8Z8CJI2Ok4DppQ5OkMqPSv8nWQJG5QBz4F6hnevXecg==
+"@department-of-veterans-affairs/web-components@4.5.5":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.5.5.tgz#aed63e765b48a24d7806e09b22a9a2d30aeb8ee7"
+  integrity sha512-cLKPoFpB9zuuVPEuwsIr4nQD/KKFA/N5uD0qu8p24X6bj7BHU35tyGLNimyFmc0ggIM1dLqCwPbq9wISo+gq2Q==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description

This PR:

- Deprecates the `TextArea` import
- Replaces the only use of `TextArea` with `<va-textarea>`
- Bumps the `component-library` version to get the `<va-textarea>` fix for the CSS `resize` property
- Removes some unused CSS classes related to textarea things

## Original issue(s)
Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/40176


## Testing done

Local browser testing :eyes: 


## Screenshots
 
![onInput handler triggering an error message when a curly brace is deleted](https://user-images.githubusercontent.com/2008881/176007312-92d034a4-ef13-4c36-ac13-835c790e005a.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
