### PR TITLE
Update short form alert content on Health Care application

### DIFF
--- a/src/applications/hca/components/AuthenticatedShortFormAlert.jsx
+++ b/src/applications/hca/components/AuthenticatedShortFormAlert.jsx
@@ -8,39 +8,37 @@ const AuthenticatedShortFormAlert = ({ formData }) => {
   const disabilityRating = formData['view:totalDisabilityRating'];
   return (
     <div className="vads-u-margin-y--5 vads-u-margin-x--neg1p5">
-      <va-alert close-btn-aria-label="Close notification" status="info" visible>
+      <va-alert status="info">
         <h3 slot="headline">You can fill out a shorter application</h3>
-        <div>
+        <p>
           Our records show that you have a{' '}
           <strong>
             VA service-connected disability rating of {disabilityRating}
             %.
           </strong>{' '}
-          Because your rating is 50% or higher, we can ask you fewer questions.
-        </div>
-        <div>
-          <va-additional-info trigger="What if I don’t think my rating information is correct here?">
-            <p>
-              Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re
-              here Monday through Friday, 8:00 a.m. to 9:00 p.m.{' '}
-              <abbr title="eastern time">ET</abbr>. If you have hearing loss,
-              call TTY: <va-telephone contact={CONTACTS['711']} />.
-            </p>
-          </va-additional-info>
-        </div>
+          This means that you meet one of our eligibility criteria and we don’t
+          need to ask you questions about other criteria, like income and
+          military service.
+        </p>
+        <va-additional-info trigger="What if I don’t think my rating information is correct here?">
+          <p>
+            Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re
+            here Monday through Friday, 8:00 a.m. to 9:00 p.m.{' '}
+            <abbr title="eastern time">ET</abbr>. If you have hearing loss, call
+            TTY: <va-telephone contact={CONTACTS['711']} />.
+          </p>
+        </va-additional-info>
       </va-alert>
     </div>
   );
 };
 
-const mapStateToProps = state => {
-  return {
-    formData: state.form.data,
-  };
-};
-
-export default connect(mapStateToProps)(AuthenticatedShortFormAlert);
-
 AuthenticatedShortFormAlert.propTypes = {
   formData: PropTypes.object,
 };
+
+const mapStateToProps = state => ({
+  formData: state.form.data,
+});
+
+export default connect(mapStateToProps)(AuthenticatedShortFormAlert);


### PR DESCRIPTION
## Description
This PR updates the content displayed to authenticated users with >=50% Disability Rating in the health care application. Those that meet the requirement are able to complete a shorter application and this content update better spells out the reasons for utilizing the short form. 


## Original issue(s)
department-of-veterans-affairs/va.gov-team#43438


## Acceptance criteria
- [ ] Alert renders with appropriate content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
