### PR TITLE
[CDP] 42655  Adding new Combined Debt Portal widget

### DIFF
--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -80,7 +80,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.COMBINED_DEBT_PORTAL]: {
     id: CTA_WIDGET_TYPES.COMBINED_DEBT_PORTAL,
     deriveToolUrlDetails: () => ({
-      url: 'mange-debt-and-bills/summary',
+      url: '/mange-debt-and-bills/summary',
       redirect: false,
     }),
     hasRequiredMhvAccount: () => false,

--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -17,6 +17,7 @@ export const CTA_WIDGET_TYPES = {
   ADD_REMOVE_DEPENDENTS: 'add-remove-dependents',
   CHANGE_ADDRESS: 'change-address',
   CLAIMS_AND_APPEALS: 'claims-and-appeals',
+  COMBINED_DEBT_PORTAL: 'combined-debt-portal',
   DIRECT_DEPOSIT: 'direct-deposit',
   DISABILITY_BENEFITS: 'disability-benefits',
   DISABILITY_RATINGS: 'disability-ratings',
@@ -75,6 +76,18 @@ export const ctaWidgetsLookup = {
       backendServices.APPEALS_STATUS,
     ],
     serviceDescription: 'see your claim or appeal status',
+  },
+  [CTA_WIDGET_TYPES.COMBINED_DEBT_PORTAL]: {
+    id: CTA_WIDGET_TYPES.COMBINED_DEBT_PORTAL,
+    deriveToolUrlDetails: () => ({
+      url: 'mange-debt-and-bills/summary',
+      redirect: false,
+    }),
+    hasRequiredMhvAccount: () => false,
+    isHealthTool: false,
+    mhvToolName: null,
+    requiredServices: null,
+    serviceDescription: 'manage your VA debt and bills',
   },
   [CTA_WIDGET_TYPES.DIRECT_DEPOSIT]: {
     id: CTA_WIDGET_TYPES.DIRECT_DEPOSIT,


### PR DESCRIPTION
## Description
Adding widget for combined debt portal, using the `manage-debt-and-bills` based URL. This may be updated to the `manage-va-debt` later to meet updated requirements. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42655

## Screenshot(s)
![image](https://user-images.githubusercontent.com/25368370/176210300-be8e1204-cefd-4e6e-8640-f4eefd772b04.png)


## Acceptance criteria
- [ ] Widget for combined debt portal Drupal page has been added

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
