### PR TITLE
VACMS-9393: Updates CTA link on get-lab-results page

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -21,7 +21,7 @@ export const AuthContent = ({
       otherFacilities={otherFacilities}
       linksHeaderText="View lab and test results from:"
       myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'labs-tests')}
-      myVAHealthLink={getCernerURL('/pages/health_record/results/labs')}
+      myVAHealthLink={getCernerURL('/pages/health_record/results')}
     />
     <div>
       <div itemScope itemType="http://schema.org/Question">


### PR DESCRIPTION
## Description
Changes CTA link from `/pages/health_record/results/labs` to `/pages/health_record/results`.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9393
