### PR TITLE
Update self-report confirmation alert markup in Health Care application

### DIFF
--- a/src/applications/hca/components/ServiceConnectedPayConfirmation.jsx
+++ b/src/applications/hca/components/ServiceConnectedPayConfirmation.jsx
@@ -1,70 +1,49 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
 
-import ProgressButton from '~/platform/forms-system/src/js/components/ProgressButton';
-
-const ServiceConnectedPayConfirmation = ({ goBack, goForward }) => {
-  const FormNavButtons = () => (
+const ServiceConnectedPayConfirmation = ({ goBack, goForward }) => (
+  <va-alert
+    class="vads-u-margin-x--neg2p5 vads-u-margin-top--2p5"
+    status="info"
+    background-only
+  >
+    <h3 className="vads-u-margin-top--0">
+      Confirm that you receive service-connected pay for a 50% or higher
+      disability rating.
+    </h3>
+    <p>
+      You selected that you currently receive service-connected disability pay
+      for a 50% or higher disability rating. This means that you meet one of our
+      eligibility criteria and we don’t need to ask your questions about other
+      criteria, like income and military service.
+    </p>
     <div className="row form-progress-buttons schemaform-buttons">
-      <div className="small-6 medium-5 columns">
+      <div className="small-5 medium-4 columns">
         {goBack && (
           <ProgressButton
-            // eslint-disable-next-line react/jsx-no-bind
+            buttonClass="hca-progress-button usa-button-secondary"
             onButtonClick={goBack}
             buttonText="Back"
-            buttonClass="usa-button-secondary"
             beforeText="«"
           />
         )}
       </div>
-      <div className="small-6 medium-5 end columns">
+      <div className="small-5 medium-4 end columns">
         <ProgressButton
+          buttonClass="hca-progress-button usa-button-primary"
           onButtonClick={goForward}
           buttonText="Confirm"
-          buttonClass="usa-button-primary"
           afterText="»"
         />
       </div>
     </div>
-  );
-
-  return (
-    <div>
-      <div className="hca-id-form-wrapper vads-u-margin-bottom--2 vads-u-margin-x--neg1p5">
-        <div className="vads-u-background-color--primary-alt-lightest vads-u-padding-top--1 vads-u-padding-bottom--2p5  vads-u-margin-bottom--3">
-          <div className="vads-u-padding-x--4">
-            <h3>
-              Please confirm that you receive service-connected pay for a 50% or
-              higher disability rating.
-            </h3>
-            <p>
-              You selected that you currently receive service-connected
-              disability pay for a 50% or higher disability rating. Because your
-              rating is 50% or higher, we can ask you fewer questions.
-            </p>
-            <p>
-              <strong>Note:</strong> We’ll confirm your information when we
-              receive your application.
-            </p>
-            <div className="vads-u-margin-y--4">
-              <va-additional-info trigger="Why do I need to confirm my disability pay?">
-                We want to make sure that we ask you all the questions we need
-                to make a decision about your application. This helps you get a
-                decision faster and avoids the need to ask you for more
-                information later.
-              </va-additional-info>
-            </div>
-            <FormNavButtons />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-export default ServiceConnectedPayConfirmation;
+  </va-alert>
+);
 
 ServiceConnectedPayConfirmation.propTypes = {
   goBack: PropTypes.func,
   goForward: PropTypes.func,
 };
+
+export default ServiceConnectedPayConfirmation;

--- a/src/applications/hca/sass/hca.scss
+++ b/src/applications/hca/sass/hca.scss
@@ -52,3 +52,8 @@
 .bullet-disc {
   list-style-type: disc;
 }
+
+.hca-progress-button {
+  box-sizing: border-box;
+  width: 100%;
+}

--- a/src/applications/hca/tests/e2e/helpers.js
+++ b/src/applications/hca/tests/e2e/helpers.js
@@ -125,7 +125,7 @@ export const shortFormSelfDisclosureToSubmit = () => {
 
   goToNextPage('/va-benefits/confirm-service-pay');
   cy.findByText(
-    /please confirm that you receive service-connected pay for a 50% or higher disability rating./i,
+    /confirm that you receive service-connected pay for a 50% or higher disability rating./i,
   )
     .first()
     .should('exist');


### PR DESCRIPTION
## Description
This PR updates the text content and markup for the self-report confirmation alert in the health care application. The previous markup created an alert that is identical to the background-only option from `va-alert`. With that we can use `va-alert` to display this content. 


## Original issue(s)
department-of-veterans-affairs/va.gov-team#43435


## Testing done
- [x] Unit tests


## Screenshots
![Screen Shot 2022-06-28 at 12 33 37 PM](https://user-images.githubusercontent.com/6738544/176233114-42610f23-6903-4d43-9807-3c25525a58ac.png)


## Acceptance criteria
- [ ] Alert utilizes correct web component
- [ ] Alert contains updated content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
