### PR TITLE
CST | Replace form elements with web components

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -4,12 +4,12 @@ import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
 import {
+  VaModal,
   VaSelect,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import FileInput from '@department-of-veterans-affairs/component-library/FileInput';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import FileInput from '@department-of-veterans-affairs/component-library/FileInput';
 
 import {
   readAndCheckFile,
@@ -263,7 +263,7 @@ class AddFilesForm extends React.Component {
                 <div className="clearfix" />
                 <VaSelect
                   required
-                  errorMessage={
+                  error={
                     validateIfDirty(docType, isNotBlank)
                       ? undefined
                       : 'Please provide a response'
@@ -275,7 +275,7 @@ class AddFilesForm extends React.Component {
                     this.handleDocTypeChange(e.target.value, index)
                   }
                 >
-                  <option>Select a description</option>
+                  <option value="">Select a description</option>
                   {DOC_TYPES.map(({ label, value }, i) => (
                     <option key={i} value={value}>
                       {label}
@@ -316,20 +316,17 @@ class AddFilesForm extends React.Component {
             Cancel
           </Link>
         </div>
-        <Modal
-          onClose={() => true}
-          visible={this.props.uploading}
-          hideCloseButton
-          cssClass=""
+        <VaModal
           id="upload-status"
-          contents={
-            <UploadStatus
-              progress={this.props.progress}
-              files={this.props.files.length}
-              onCancel={this.props.onCancel}
-            />
-          }
-        />
+          onCloseEvent={() => true}
+          visible={this.props.uploading}
+        >
+          <UploadStatus
+            progress={this.props.progress}
+            files={this.props.files.length}
+            onCancel={this.props.onCancel}
+          />
+        </VaModal>
       </>
     );
   }
@@ -346,6 +343,7 @@ AddFilesForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   backUrl: PropTypes.string,
   mockReadAndCheckFile: PropTypes.bool,
+  progress: PropTypes.number,
   uploading: PropTypes.bool,
 };
 

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -319,7 +319,7 @@ class AddFilesForm extends React.Component {
         <VaModal
           id="upload-status"
           onCloseEvent={() => true}
-          visible={this.props.uploading}
+          visible={Boolean(this.props.uploading)}
         >
           <UploadStatus
             progress={this.props.progress}

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -275,7 +275,9 @@ class AddFilesForm extends React.Component {
                     this.handleDocTypeChange(e.target.value, index)
                   }
                 >
-                  <option value="">Select a description</option>
+                  <option disabled value="">
+                    Select a description
+                  </option>
                   {DOC_TYPES.map(({ label, value }, i) => (
                     <option key={i} value={value}>
                       {label}

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -85,11 +85,17 @@ class AddFilesForm extends React.Component {
   };
 
   handleDocTypeChange = (docType, index) => {
-    this.props.onFieldChange(`files[${index}].docType`, docType);
+    this.props.onFieldChange(`files[${index}].docType`, {
+      value: docType,
+      dirty: true,
+    });
   };
 
   handlePasswordChange = (password, index) => {
-    this.props.onFieldChange(`files[${index}].password`, password);
+    this.props.onFieldChange(`files[${index}].password`, {
+      value: password,
+      dirty: true,
+    });
   };
 
   add = async files => {

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
+import {
+  VaSelect,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FileInput from '@department-of-veterans-affairs/component-library/FileInput';
-import Select from '@department-of-veterans-affairs/component-library/Select';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
-
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import {
@@ -16,12 +17,11 @@ import {
   checkIsEncryptedPdf,
   FILE_TYPE_MISMATCH_ERROR,
 } from 'platform/forms-system/src/js/utilities/file';
-import scrollTo from 'platform/utilities/ui/scrollTo';
 import { getScrollOptions } from 'platform/utilities/ui';
+import scrollTo from 'platform/utilities/ui/scrollTo';
 
-import UploadStatus from './UploadStatus';
-import mailMessage from './MailMessage';
 import { displayFileSize, DOC_TYPES, getTopPosition } from '../utils/helpers';
+import { setFocus } from '../utils/page';
 import {
   validateIfDirty,
   isNotBlank,
@@ -35,7 +35,8 @@ import {
   MAX_FILE_SIZE_MB,
   MAX_PDF_SIZE_MB,
 } from '../utils/validations';
-import { setFocus } from '../utils/page';
+import UploadStatus from './UploadStatus';
+import mailMessage from './MailMessage';
 
 const displayTypes = FILE_TYPES.join(', ');
 
@@ -81,6 +82,14 @@ class AddFilesForm extends React.Component {
     return validateIfDirty(this.props.field, () => this.props.files.length > 0)
       ? undefined
       : 'Please select a file first';
+  };
+
+  handleDocTypeChange = (docType, index) => {
+    this.props.onFieldChange(`files[${index}].docType`, docType);
+  };
+
+  handlePasswordChange = (password, index) => {
+    this.props.onFieldChange(`files[${index}].password`, password);
   };
 
   add = async files => {
@@ -163,14 +172,13 @@ class AddFilesForm extends React.Component {
 
   render() {
     return (
-      <div>
-        <div>
-          <p>
-            <va-additional-info trigger="Need to mail your files?">
-              {mailMessage}
-            </va-additional-info>
-          </p>
-        </div>
+      <>
+        <va-additional-info
+          class="vads-u-margin-y--2"
+          trigger="Need to mail your files?"
+        >
+          {mailMessage}
+        </va-additional-info>
         <Element name="filesList" />
         <div>
           <FileInput
@@ -231,27 +239,23 @@ class AddFilesForm extends React.Component {
                       able to view the document, we will need the password to
                       decrypt it.
                     </p>
-                    <TextInput
+                    <VaTextInput
                       required
-                      errorMessage={
+                      error={
                         validateIfDirty(password, isNotBlank)
                           ? undefined
                           : 'Please provide a password to decrypt this file'
                       }
-                      name="password"
                       label="PDF password"
-                      field={password}
-                      onValueChange={update => {
-                        this.props.onFieldChange(
-                          `files[${index}].password`,
-                          update,
-                        );
-                      }}
+                      name="password"
+                      onInput={e =>
+                        this.handlePasswordChange(e.target.value, index)
+                      }
                     />
                   </>
                 )}
                 <div className="clearfix" />
-                <Select
+                <VaSelect
                   required
                   errorMessage={
                     validateIfDirty(docType, isNotBlank)
@@ -260,13 +264,18 @@ class AddFilesForm extends React.Component {
                   }
                   name="docType"
                   label="What type of document is this?"
-                  options={DOC_TYPES}
                   value={docType}
-                  emptyDescription="Select a description"
-                  onValueChange={update =>
-                    this.props.onFieldChange(`files[${index}].docType`, update)
+                  onVaSelect={e =>
+                    this.handleDocTypeChange(e.target.value, index)
                   }
-                />
+                >
+                  <option>Select a description</option>
+                  {DOC_TYPES.map(({ label, value }, i) => (
+                    <option key={i} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </VaSelect>
               </div>
             </div>
           ),
@@ -315,7 +324,7 @@ class AddFilesForm extends React.Component {
             />
           }
         />
-      </div>
+      </>
     );
   }
 }

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -16,6 +16,15 @@ import {
   MAX_PDF_SIZE_MB,
 } from '../../utils/validations';
 
+// NOTE: Trying to extract the web components that use React bindings with skin-deep is
+// a nightmare. Normally you can use something like the name of the component
+// as a selector, but because of the way that the React bindings are created, it seems
+// that that doesn't work here. Some of the web components have a `name` prop, so I created
+// this matcher to select nodes based on the `name` prop
+const byName = name => {
+  return node => node?.props?.name === name;
+};
+
 describe('<AddFilesForm>', () => {
   it('should render component', () => {
     const files = [];
@@ -43,7 +52,9 @@ describe('<AddFilesForm>', () => {
     expect(tree.everySubTree('FileInput')[0].props['aria-describedby']).to.eq(
       'file-requirements',
     );
-    expect(tree.everySubTree('Modal')[0].props.visible).to.be.false;
+
+    // VaModal has an id of `upload-status` so we can use that as the selector here
+    expect(tree.everySubTree('#upload-status')[0].props.visible).to.be.false;
   });
 
   it('should show uploading modal', () => {
@@ -69,7 +80,9 @@ describe('<AddFilesForm>', () => {
         onDirtyFields={onDirtyFields}
       />,
     );
-    expect(tree.everySubTree('Modal')[0].props.visible).to.be.true;
+
+    // VaModal has an id of `upload-status` so we can use that as the selector here
+    expect(tree.everySubTree('#upload-status')[0].props.visible).to.be.true;
   });
 
   it('should include mail info additional info', () => {
@@ -523,6 +536,8 @@ describe('<AddFilesForm>', () => {
       />,
     );
     expect(tree.getMountedInstance().state.errorMessage).to.be.null;
-    expect(tree.subTree('TextInput')).to.exist;
+
+    // VaTextInput has a name prop set to 'password'
+    expect(tree.everySubTree('*', byName('password'))[0]).to.exist;
   });
 });


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/42283

## URL of change
[/track-claims/your-claims/{claimId}/files](/track-claims/your-claims/{claimId}/files)

## Background
We are using the old React components in the `AddFilesForm` component. Several of these can be updated to the new web components, including:
* Modal -> va-modal
* Select -> va-select
* TextInput -> va-text-input

## Steps to test
**NOTE:** You will need a password-protected PDF such as [this one (password is 'password123')](https://github.com/department-of-veterans-affairs/vets-website/files/9004250/TestPDF-password123.pdf)

* Login and Navigate to `/track-claims/your-claims/`
* Select one of the claims in the list and click 'View details'
* This should navigate to a new page
* On this new page, select the 'Files' tab
* Under `Select files to upload` click the `Add Files` button
* Select your password-protected PDF and click 'Open'
* You should see a box with a heading that matches the name of the file you selected
* Under this box you should see two inputs:
    * A text input labeled 'PDF password', AND
    * A select box labeled 'What type of document is this?'
* Type a wrong password in the text input and select any of the types in under the select
* Check the checkbox labeled 'The files I uploaded are supporting documents for this claim only.'
* Click the 'Submit Files for Review' button
* You should see a modal quickly appear and disappear
* After the modal disappears, a red alert should show up under the 'Additional Evidence' header

## Code changes
#### Main
* The `Modal` component was converted to `VaModal`
* The `Select` component was converted to `VaSelect`
* The `TextInput` component was converted to `VaTextInput`
#### Miscellaneous
* Added `progress` to `propTypes`
* Rearranged some of the imports
* Fixed an issue with the `va-additional-info` being wrapped in a `p` tag, which made Chrome's DOM validator unhappy
* Moved the code for updating the file fields into separate handlers
    * These handlers manually set the `dirty` flag to true, because the events emitted by the web components don't include a dirty flag anymore

## How was your code tested
Unit tests still pass

## Acceptance criteria
- [x] `TextInput` replaced with `va-text-input`
- [x] `Select` replaced with `va-select`
- [x] `Modal` replaced with `va-modal`
- [ ] Tests are updated and passing

## Definition of done
- [ ] *