### PR TITLE
42354 coe intro page header fix

### DIFF
--- a/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
@@ -44,17 +44,17 @@ const IntroductionPage = ({ coe, downloadUrl, loggedIn, route, status }) => {
 
   return (
     <>
-      <FormTitle title="Request a VA home loan Certificate of Eligibility (COE)" />
-      <p className="vads-u-padding-bottom--3">
-        Request for a Certificate of Eligibility (VA Form 26-1880)
-      </p>
+      <FormTitle
+        title="Request a VA home loan Certificate of Eligibility (COE)"
+        subTitle="Request for a Certificate of Eligibility (VA Form 26-1880)"
+      />
       {content}
     </>
   );
 };
 
 const mapStateToProps = state => ({
-  coe: state.certificateOfEligibility.coe,
+  coe: state.certificateOfEligibility.coe || {},
   downloadUrl: state.certificateOfEligibility.downloadUrl,
   loggedIn: isLoggedIn(state),
   status: state.certificateOfEligibility.generateAutoCoeStatus,

--- a/src/applications/lgy/coe/form/containers/introduction-content/loggedInContent.jsx
+++ b/src/applications/lgy/coe/form/containers/introduction-content/loggedInContent.jsx
@@ -6,13 +6,7 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 
 import SubwayMap from '../../components/SubwayMap';
 
-const shouldShowHeader = status => {
-  const showStatuses = ['ineligible', 'pending', 'pending-upload'];
-
-  return showStatuses.includes(status);
-};
-
-const LoggedInContent = ({ route, status }) => (
+const LoggedInContent = ({ route }) => (
   <>
     <SaveInProgressIntro
       testActionLink
@@ -24,11 +18,9 @@ const LoggedInContent = ({ route, status }) => (
       startText="Request a Certificate of Eligibility"
       headingLevel={2}
     />
-    {shouldShowHeader(status) && (
-      <h2 className="vads-u-margin-top--5">
-        Follow these steps to request a VA home loan COE
-      </h2>
-    )}
+    <h2 className="vads-u-font-size--h3 vads-u-margin-top--5">
+      Follow these steps to request a VA home loan COE
+    </h2>
     <SubwayMap />
     <div className="vads-u-margin-bottom--5">
       <SaveInProgressIntro


### PR DESCRIPTION
Original Ticket: [#42354](https://app.zenhub.com/workspaces/benefits-team-1-6138d7b57a2631001a4b7562/issues/department-of-veterans-affairs/va.gov-team/42354)

URL of change: http://localhost:3001/housing-assistance/home-loans/request-coe-form-26-1880/introduction?postLogin=true

# Expected behavior

This page should be passing axeDev scan for accessibility purposes.

## Current behavior

The headers on the page were organized such that it went from `<h1>` to `<h3>`. 

## Your fix

The sentence `Follow these steps to request a VA home loan COE` has the appropriate header size. It is an `h2` for proper order but it is an `h3` for styling because `h2` would be too big.

## How has this been tested?

- Ran locally with headingsMap extension to verify visually
- Ran AxeDev scan on the page to confirm the heading levels pass accessibility requirements as show in screenshot below

## Screenshot

<details><summary>COE Introduction page after logging in with ID.me test user</summary>

<!-- leave a blank line above -->
<img width="996" alt="Certificate of Eligibility form introduction page" src="https://user-images.githubusercontent.com/37054305/176270947-b7c851ff-a27f-4af6-8c77-f57711726acd.png"></details>

## Acceptance criteria
- [x] Order for headers passes accessibility test

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
