### PR TITLE
(feature) added stringify of errors

### DIFF
--- a/src/applications/personalization/profile/util/analytics/index.js
+++ b/src/applications/personalization/profile/util/analytics/index.js
@@ -43,6 +43,7 @@ const captureError = (error, details) => {
       scope.setContext(message, {
         details,
         error,
+        errorAsString: error ? JSON.stringify(error) : 'no error found',
       });
 
       Sentry.captureMessage(message);


### PR DESCRIPTION
## Description
We are getting this error in Sentry:
![Screen Shot 2022-06-29 at 10 41 46 AM](https://user-images.githubusercontent.com/1793923/176465647-5f12c51e-0e80-4f11-8ef0-88a182f71b84.png)

This added the error object stringified to better see what is going on. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/23312
