### PR TITLE
 Correct letter case of POA feature toggle in Caregivers application

### DIFF
--- a/src/applications/caregivers/README.md
+++ b/src/applications/caregivers/README.md
@@ -108,4 +108,3 @@ index 28ce0a625..c3d81d8f4 100644
        @store_dir = form_attachment_guid
      end 
 ```
-

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -40,7 +40,7 @@ export const IntroductionPage = ({
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setFormData, canAutofill1010cgAddress, canUpload1010cgPOA],
+    [canAutofill1010cgAddress, canUpload1010cgPOA],
   );
 
   const startForm = useCallback(
@@ -279,7 +279,7 @@ export const IntroductionPage = ({
 const mapStateToProps = state => ({
   formData: state.form.data,
   canAutofill1010cgAddress: state.featureToggles?.canAutofill1010cgAddress,
-  canUpload1010cgPOA: state.featureToggles?.canUpload1010cgPOA,
+  canUpload1010cgPOA: state.featureToggles?.canUpload1010cgPoa,
 });
 
 const mapDispatchToProps = {

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -115,7 +115,7 @@
         "value": true
       },
       {
-        "name": "canUpload1010cgPOA",
+        "name": "canUpload1010cgPoa",
         "value": true
       },
       {


### PR DESCRIPTION
## Description
This PR corrects the letter casing of the POA feature toggle. This toggle and value was not being pulled in from state due to incorrect letter casing on the key name

## Acceptance criteria
- [ ] Toggle key and value get added to component and form data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
