### PR TITLE
Fix incorrect feature toggle letter case in Caregivers application

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -25,7 +25,7 @@ export const IntroductionPage = ({
   formData,
   setFormData,
   canAutofill1010cgAddress,
-  canUpload1010cgPOA,
+  canUpload1010cgPoa,
 }) => {
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
@@ -35,12 +35,12 @@ export const IntroductionPage = ({
     () => {
       setFormData({
         ...formData,
-        'view:canUpload1010cgPOA': canUpload1010cgPOA,
+        'view:canUpload1010cgPOA': canUpload1010cgPoa,
         'view:canAutofill1010cgAddress': canAutofill1010cgAddress,
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setFormData, canAutofill1010cgAddress, canUpload1010cgPOA],
+    [canAutofill1010cgAddress, canUpload1010cgPoa],
   );
 
   const startForm = useCallback(
@@ -104,7 +104,7 @@ export const IntroductionPage = ({
                   </div>
                 </va-additional-info>
               </div>
-              {canUpload1010cgPOA && (
+              {canUpload1010cgPoa && (
                 <p
                   data-testid="poa-info-note"
                   className="vads-u-margin-bottom--4"
@@ -279,7 +279,7 @@ export const IntroductionPage = ({
 const mapStateToProps = state => ({
   formData: state.form.data,
   canAutofill1010cgAddress: state.featureToggles?.canAutofill1010cgAddress,
-  canUpload1010cgPOA: state.featureToggles?.canUpload1010cgPOA,
+  canUpload1010cgPoa: state.featureToggles?.canUpload1010cgPoa,
 });
 
 const mapDispatchToProps = {
@@ -288,7 +288,7 @@ const mapDispatchToProps = {
 
 IntroductionPage.propTypes = {
   canAutofill1010cgAddress: PropTypes.bool,
-  canUpload1010cgPOA: PropTypes.bool,
+  canUpload1010cgPoa: PropTypes.bool,
   formData: PropTypes.object,
   route: PropTypes.object,
   router: PropTypes.object,

--- a/src/applications/caregivers/tests/containers/IntroductionPage.unit.spec.js
+++ b/src/applications/caregivers/tests/containers/IntroductionPage.unit.spec.js
@@ -4,18 +4,18 @@ import { expect } from 'chai';
 import { Provider } from 'react-redux';
 import { IntroductionPage } from '../../containers/IntroductionPage';
 
-const getData = ({ canUpload1010cgPOA = true } = {}) => ({
+const getData = ({ canUpload1010cgPoa = true } = {}) => ({
   mockProps: {
     router: [],
     route: { formConfig: {} },
     formData: {},
     setFormData: () => {},
-    canUpload1010cgPOA,
+    canUpload1010cgPoa,
   },
   mockStore: {
     getState: () => ({
       featureToggles: {
-        canUpload1010cgPOA,
+        canUpload1010cgPoa,
       },
       scheduledDowntime: {
         globalDowntime: null,
@@ -34,7 +34,7 @@ const getData = ({ canUpload1010cgPOA = true } = {}) => ({
 
 describe('IntroductionPage', () => {
   it('should render poa note', () => {
-    const { mockProps, mockStore } = getData({ canUpload1010cgPOA: true });
+    const { mockProps, mockStore } = getData({ canUpload1010cgPoa: true });
     const view = render(
       <Provider store={mockStore}>
         <IntroductionPage {...mockProps} />,
@@ -48,7 +48,7 @@ describe('IntroductionPage', () => {
   });
 
   it('should not render poa note', () => {
-    const { mockProps, mockStore } = getData({ canUpload1010cgPOA: false });
+    const { mockProps, mockStore } = getData({ canUpload1010cgPoa: false });
     const view = render(
       <Provider store={mockStore}>
         <IntroductionPage {...mockProps} />,

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -115,7 +115,7 @@
         "value": true
       },
       {
-        "name": "canUpload1010cgPOA",
+        "name": "canUpload1010cgPoa",
         "value": true
       },
       {


### PR DESCRIPTION
## Description
This PR fixes a letter case issue with a feature toggle name in the Caregivers application. This bug isnt allowing us to use the toggle, as its not being populated in the component props.

## Acceptance criteria
- [ ] Feature toggle value is populated in component props and form data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
