### PR TITLE
Rated Disability | Fix issue with effectiveDate being invalid

### DIFF
--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
@@ -10,8 +10,9 @@ import SortSelect from './SortSelect';
 // Need to transform date string into a meaningful format and extract any special issues.
 const formalizeData = data => {
   return data.map(d => {
+    // example effectiveDate: '2004-06-14T05:00:00.000+0000'
     const effectiveDate = d.effectiveDate
-      ? moment(d.effectiveDate, 'YYYY-DD-MMThh:mm:ss.SSSZ')
+      ? moment(d.effectiveDate, 'YYYY-MM-DDThh:mm:ss.SSSZ')
       : null;
 
     return { ...d, effectiveDate };

--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
@@ -72,12 +72,19 @@ const noDisabilityRatingContent = errorCode => {
   );
 };
 
-const RatedDisabilityList = props => {
+const RatedDisabilityList = ({
+  fetchRatedDisabilities,
+  ratedDisabilities,
+  sortToggle,
+}) => {
   const [sortBy, setSortBy] = useState('effectiveDate.desc');
 
-  useEffect(() => {
-    props.fetchRatedDisabilities();
-  }, []);
+  useEffect(
+    () => {
+      fetchRatedDisabilities();
+    },
+    [fetchRatedDisabilities],
+  );
 
   const sortFunc = (a, b) => {
     const [sortKey, direction] = sortBy.split('.');
@@ -87,17 +94,17 @@ const RatedDisabilityList = props => {
       : b[sortKey] - a[sortKey];
   };
 
-  if (!props.ratedDisabilities) {
+  if (!ratedDisabilities) {
     return <va-loading-indicator message="Loading your information..." />;
   }
 
   if (
-    props?.ratedDisabilities?.errors ||
-    props?.ratedDisabilities?.ratedDisabilities.length === 0
+    ratedDisabilities?.errors ||
+    ratedDisabilities?.ratedDisabilities.length === 0
   ) {
     // There are instances when a 200 response is received but evss sends an empty array.
     // In this scenario errorCode is explicitly set to 404 to ensure a defined value is passed to noDisabilityRatingContent
-    const errorCode = props?.ratedDisabilities?.errors?.[0]?.code || 404;
+    const errorCode = ratedDisabilities?.errors?.[0]?.code || 404;
     return (
       <div className="usa-width-one-whole">
         {noDisabilityRatingContent(errorCode)}
@@ -106,7 +113,7 @@ const RatedDisabilityList = props => {
   }
 
   const formattedDisabilities = formalizeData(
-    props?.ratedDisabilities?.ratedDisabilities,
+    ratedDisabilities?.ratedDisabilities,
   ).sort(sortFunc);
 
   return (
@@ -114,7 +121,7 @@ const RatedDisabilityList = props => {
       <h2 id="individual-ratings" className="vads-u-margin-y--1p5">
         Your individual ratings
       </h2>
-      {props.sortToggle && (
+      {sortToggle && (
         <div id="ratings-sort-select-ab" className="vads-u-margin-bottom--2">
           <SortSelect onSelect={setSortBy} sortBy={sortBy} />
         </div>
@@ -131,6 +138,7 @@ const RatedDisabilityList = props => {
 RatedDisabilityList.propTypes = {
   fetchRatedDisabilities: PropTypes.func.isRequired,
   ratedDisabilities: PropTypes.shape({
+    errors: PropTypes.array,
     ratedDisabilities: PropTypes.array,
   }),
   sortToggle: PropTypes.bool,

--- a/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityList.unit.spec.jsx
+++ b/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityList.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('<RatedDisabilityList/>', () => {
     );
     const date = moment(
       ratedDisabilities.ratedDisabilities[0].effectiveDate,
-    ).format('DD/MM/YYYY');
+    ).format('MM/DD/YYYY');
     expect(wrapper.getByText(date)).to.exist;
   });
 


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43647

## URL of fix
[/disability/view-disability-rating/rating](/disability/view-disability-rating/rating)

## Expected behavior
When viewing the list of rated disabilities, the effective dates for each item in the list should be displayed as `MM/DD/YYYY`

## Current behavior
Currently, the format template used to create the moment object is `YYYY-DD-MMThh:mm:ss.SSSZ`. An example of a date that doesn't work with this is: `2004-06-14T05:00:00.000+0000`. For the date just listed, the effective date shows as `Invalid date`

## Your fix
I updated the format template used to create the moment object from `YYYY-DD-MMThh:mm:ss.SSSZ` to `YYYY-MM-DDThh:mm:ss.SSSZ`

## How has this been tested?
There are existing unit tests, but also manually testing to make sure that dates like `2004-06-14T05:00:00.000+0000` display `06/14/2004` instead of `Invalid date`

## Screenshots
### Before
![Screen Shot 2022-06-29 at 12 24 36 PM](https://user-images.githubusercontent.com/13838621/176498653-83271d20-8b29-4a4b-aa6b-0114ac2924a5.png)

### After
![Screen Shot 2022-06-29 at 12 27 26 PM](https://user-images.githubusercontent.com/13838621/176499057-d930e1cf-95e0-4614-b963-c9106ad90bc4.png)


## Acceptance criteria
- [ ] Effective date template is set to `YYYY-MM-DDThh:mm:ss.SSSZ` instead of `YYYY-DD-MMThh:mm:ss.SSSZ`


## Definition of done
- [ ] *