### PR TITLE
(fix) remove $ from alert message

### DIFF
--- a/src/applications/personalization/profile/components/alerts/LoadFail.jsx
+++ b/src/applications/personalization/profile/components/alerts/LoadFail.jsx
@@ -12,7 +12,7 @@ export default function LoadFail({ information }) {
   return (
     <va-alert status="warning" visible data-testid="service-is-down-banner">
       <h2 slot="headline">
-        We can’t access your ${information} information right now.
+        We can’t access your {information} information right now.
       </h2>
       <p>
         We’re sorry. Something went wrong on our end. Please refresh this page


### PR DESCRIPTION
## Description
HOTFIX Removes the `$` from the alert message, since before is was using a template literal and now is not.

OLD ALERT:

![image](https://user-images.githubusercontent.com/8332986/176503686-247219ba-4281-4d60-821c-8365bf4c30b3.png)
