### PR TITLE
VACMS-9524: add ea.oit.va.gov to domain list 

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -57,6 +57,11 @@
       "cookieOnly": true
     },
     {
+      "hostname": "ea.oit.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
       "hostname": "www.ea.oit.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": true


### PR DESCRIPTION
## Description
Very similar to this PR: https://github.com/department-of-veterans-affairs/vets-website/pull/21423

Added ea.oit.va.gov in addition to www.ea.oit.va.gov to ensure both get the injected header

## Original issue(s)
[/department-of-veterans-affairs/va.gov-cms/issues/9524](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9524)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
