### PR TITLE
Update Place of Birth fields in Health Care application

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -1,5 +1,20 @@
 import React from 'react';
 
+export const BirthInfoDescription = () => (
+  <>
+    <p className="vads-u-margin-top--0 vads-u-margin-bottom--4">
+      Enter your place of birth, including city and state, province or region.
+    </p>
+    <va-additional-info
+      trigger="Why we ask for this information"
+      class="vads-u-margin-bottom--4"
+    >
+      We ask for place of birth as an identity marker for record keeping. This
+      will not impact your health care eligibility.
+    </va-additional-info>
+  </>
+);
+
 export const ContactInfoDescription = () => (
   <div className="vads-u-margin-bottom--5">
     <p>

--- a/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
@@ -25,7 +25,7 @@ export default {
       },
     },
     'view:placeOfBirth': {
-      'ui:title': 'Place of birth',
+      'ui:title': 'Your place of birth',
       'ui:description': BirthInfoDescription,
       cityOfBirth: {
         'ui:title': 'City',

--- a/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
@@ -6,10 +6,13 @@ import { BirthInfoDescription } from '../../../components/FormDescriptions';
 import { HIGH_DISABILITY, emptyObjectSchema } from '../../../helpers';
 
 const { cityOfBirth } = fullSchemaHca.properties;
-const states = Object.values(constants.states)
-  .reverse()
-  .flat()
-  .filter((val, idx, arr) => arr.indexOf(val) === idx);
+const states = [
+  ...new Set(
+    Object.values(constants.states)
+      .reverse()
+      .flat(),
+  ),
+];
 
 export default {
   uiSchema: {

--- a/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
@@ -1,16 +1,15 @@
-import React from 'react';
-import { hasSession } from 'platform/user/profile/utilities';
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
-import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
-import { states } from 'platform/forms/address';
-
-import { HIGH_DISABILITY, emptyObjectSchema } from '../../../helpers';
 import AuthenticatedShortFormAlert from '../../../components/FormAlerts/AuthenticatedShortFormAlert';
+import { BirthInfoDescription } from '../../../components/FormDescriptions';
+import { HIGH_DISABILITY, emptyObjectSchema } from '../../../helpers';
 
 const { cityOfBirth } = fullSchemaHca.properties;
-
-const stateLabels = createUSAStateLabels(states);
+const states = Object.values(constants.states)
+  .reverse()
+  .flat()
+  .filter((val, idx, arr) => arr.indexOf(val) === idx);
 
 export default {
   uiSchema: {
@@ -25,27 +24,14 @@ export default {
           ),
       },
     },
-    'view:applicationDescription': {
-      'ui:options': {
-        hideIf: () => !hasSession(),
-      },
-      'ui:description': (
-        <p>
-          You don’t have to fill in all these fields. But we can review your
-          application faster if you provide more information.
-        </p>
-      ),
-    },
     'view:placeOfBirth': {
       'ui:title': 'Place of birth',
+      'ui:description': BirthInfoDescription,
       cityOfBirth: {
         'ui:title': 'City',
       },
       stateOfBirth: {
-        'ui:title': 'State',
-        'ui:options': {
-          labels: stateLabels,
-        },
+        'ui:title': 'State/Province/Region',
       },
     },
   },
@@ -53,14 +39,14 @@ export default {
     type: 'object',
     properties: {
       'view:authShortFormAlert': emptyObjectSchema,
-      'view:applicationDescription': emptyObjectSchema,
       'view:placeOfBirth': {
         type: 'object',
         properties: {
           cityOfBirth,
           stateOfBirth: {
             type: 'string',
-            enum: states.USA.map(state => state.value),
+            enum: [...states.map(object => object.value), 'Other'],
+            enumNames: [...states.map(object => object.label), 'Other'],
           },
         },
       },


### PR DESCRIPTION
## Description
This PR creates an additional description for the Place of Birth fieldset in the 10-10EZ Health Care application. The description contains expanded context as to why we are asking for the birthplace information. We are also expanding the options for state to include both Mexico and Canada, along with allowing for the user to select "Other" if they were born outside of North America. These expanded options match the default schema.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#40883


## Testing done
- [x] Unit tests
- [x] e2e tests


## Screenshots
![Screen Shot 2022-06-30 at 12 13 14 PM](https://user-images.githubusercontent.com/6738544/176726819-d63f27a0-66f1-4746-9782-601fb5bf23f7.png)


## Acceptance criteria
- [ ] Updates the field labels with new content ("Your place of birth", etc.)
- [ ] Adds the expandable info component and content
- [ ] Updates the state select component with all North American states/provinces
- [ ] Adds "Other" as an option to the state select component


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
