### PR TITLE
[CDP] Updating styling for smaller screens

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/CombinedPortalApp.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/CombinedPortalApp.jsx
@@ -78,7 +78,7 @@ const CombinedPortalApp = ({ children }) => {
 
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0 vads-u-margin-bottom--5">
-      <div className="vads-l-row vads-u-margin-x--neg2p5">
+      <div className="vads-l-row medium-screen:vads-u-margin-x--neg2p5">
         <DowntimeNotification
           appTitle="Debts and bills application"
           dependencies={[externalServices.mvi, externalServices.vbs]}


### PR DESCRIPTION
## Description
Updated margin setting on medium-screen and up to prevent content from slipping off screen on smaller screen sizes.

## Acceptance criteria
- [ ] Screens now showing proper margins for `small` & `xsmall` screens. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
