### PR TITLE
(chore) update supporting rx notif facilities

### DIFF
--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -50,31 +50,39 @@ export const ACCOUNT_TYPES_OPTIONS = {
   savings: 'Savings',
 };
 
-// 517	Beckley VA Medical Center (Beckley, WV)
-// 554	VA Eastern Colorado Health Care System(ECHCS) (Denver, CO)
-// 581	Huntington VA Medical Center (Huntington, WV)
-// 598	Central Arkansas Veterans Healthcare System John L. McClellan Memorial Veterans Hospital (Little Rock, AR)
-// 608	Manchester VA Medical Center (Manchester, NH)
-// 613	Martinsburg VA Medical Center (Martinsburg, WV)
-// 637	Asheville VA Medical Center (Asheville, NC)
-// 658	Salem VA Medical Center (Salem, VA)
-// 659	Salisbury - W.G. (Bill) Hefner VA Medical Center (Salisbury, NC)
-// 663	VA Puget Sound Health Care System - Seattle Division (Seattle, WA)
-// 688	Washington DC VA Medical Center (Washington, DC)
-// 983: test-only facility ID, used by user 36 among others
 export const RX_TRACKING_SUPPORTING_FACILITIES = new Set([
-  '517',
-  '554',
-  '581',
-  '598',
-  '608',
-  '613',
-  '637',
-  '658',
-  '659',
-  '663',
-  '688',
-  '983',
+  '512', // VA Maryland Health Care System
+  '517', // Beckley VA Medical Center (Beckley, WV)
+  '520', // Biloxi VAMC
+  '539', // Cincinnati
+  '548', // West Palm Beach VAMC
+  '550', // Illiana HCS
+  '554', // VA Eastern Colorado Health Care System(ECHCS) (Denver, CO)
+  '556', // Captn James Lovell Fed Hlt Ctr
+  '573', // N. Florida, S. Georgia HCS
+  '578', // Hines IL VAMC
+  '581', // Huntington VA Medical Center (Huntington, WV)
+  '583', // Richard L. Roudebush VAMC
+  '585', // Iron Mountain VAMC
+  '590', // Hampton VAMC
+  '598', // Central Arkansas Veterans Healthcare System John L. McClellan Memorial Veterans Hospital (Little Rock, AR)
+  '603', // Roblex Rex VAMC
+  '608', // Manchester VA Medical Center (Manchester, NH)
+  '610', // Marion VAMC
+  '613', // Martinsburg VA Medical Center (Martinsburg, WV)
+  '621', // James H. Quillen VAMC
+  '637', // Asheville VA Medical Center (Asheville, NC)
+  '650', // Providence VAMC
+  '656', // St. Cloud VA HCS
+  '658', // Salem VA Medical Center (Salem, VA)
+  '659', // Salisbury - W.G. (Bill) Hefner VA Medical Center (Salisbury, NC)
+  '663', // VA Puget Sound Health Care System - Seattle Division (Seattle, WA)
+  '675', // Orlando VAMC
+  '676', // Tomah VAMC
+  '688', // Washington DC VA Medical Center (Washington, DC)
+  '695', // Milwaukee VAMC
+  '756', // El Paso VA HS
+  '983', // test-only facility ID, used by user 36 among others
 ]);
 
 export const NOT_SET_TEXT = 'This information is not available right now.';


### PR DESCRIPTION
## Description
Adds several VAMCs to the supported facilities for RX tracking notifications 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43206


## Testing done
unit tests still passing, otherwise just facility numbers were updated

## Screenshots


## Acceptance criteria
- [x] Updated set of facility numbers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
