### PR TITLE
SaveInProgressIntro default heading update

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -434,7 +434,7 @@ SaveInProgressIntro.defaultProps = {
       appType: '',
     },
   },
-  headingLevel: 3,
+  headingLevel: 2,
   ariaLabel: null,
   ariaDescribedby: null,
 };


### PR DESCRIPTION
## Description
Update the default value for the headingLevel prop to be 2, instead of 3.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/439


## Testing done
Yes

## Screenshots
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/5934582/176793225-ff9096c3-877f-4a59-b9a9-de33e2702058.png">


## Acceptance criteria
- [x] Ensure that the default value for the headingLevel prop is 2

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
