### PR TITLE
Fixes defect that showed IE-deprecation notice on non-IE browsers.

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -1,6 +1,28 @@
 import { isBrowserIE } from '~/platform/site-wide/helpers/detection/is-browser';
 import { replaceWithStagingDomain } from '~/platform/utilities/environment/stagingDomains';
 
+// In the case of IE display the IE deprecation notice to the user.
+// Solutioned for: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9075
+if (isBrowserIE()) {
+  window.addEventListener('load', () => {
+    const ie11VaBanner = `
+      <va-banner
+        class="ie-deprecation-warning"
+        headline="You'll need to use a different web browser"
+        show-close
+        type="warning"
+        visible
+      >
+        You're using Internet Explorer right now to access VA.gov. Microsoft stopped supporting all versions of this browser on June 15, 2022. This means that you'll need to switch to another browser, like Microsoft Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
+      </va-banner>
+    `;
+    const ieMessageEl = document.body.querySelector(
+      '.ie-deprecation-warning-wrapper',
+    );
+    ieMessageEl.innerHTML = ie11VaBanner;
+  });
+}
+
 export default `
   <!-- Header -->
   <header class="header merger" role="banner">
@@ -103,24 +125,7 @@ export default `
       </div>
 
       <!-- Hidden for modern browsers. -->
-      <va-banner
-        class="ie-deprecation-warning"
-        headline="You'll need to use a different web browser"
-        show-close
-        type="warning"
-        visible="false"
-      >
-        You're using Internet Explorer right now to access VA.gov. Microsoft stopped supporting all versions of this browser on June 15, 2022. This means that you'll need to switch to another browser, like Microsoft Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
-      </va-banner>
+      <div class="ie-deprecation-warning-wrapper"></div>
     </div>
   </header>
 `;
-
-// In the case of IE display the IE deprecation notice to the user.
-// Solutioned for: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9075
-if (isBrowserIE()) {
-  window.addEventListener('load', () => {
-    const ieMessageEl = document.body.querySelector('.ie-deprecation-warning');
-    ieMessageEl.setAttribute('visible', '');
-  });
-}


### PR DESCRIPTION
## Description
IE-deprecation notice uses `<va-banner>` component, and uses the `visible` property on that component to control whether it's displayed. When IE, visible = true. Otherwise, visible = false.

But that web component is not loaded on legacy pages unless the browser is IE. This resulted the browser having no idea what `<va-banner>` was, and therefore didn't respect the `visible` property. It just treated it like a `<div>`. The contents of that component then displayed to the screen even though `visible` was set to false.

This PR changes the approach. Instead of including the `<va-banner>` component by default, this PR changes things to only include the component in the markup if the browser is IE. 

## Screenshots
Before: (this wasn't spotted initially because, luckily, it's dark text on a dark background)
![image](https://user-images.githubusercontent.com/6863534/176933534-a7d97d67-de3d-49e1-b7a4-45d9ebdd7de2.png)

