### PR TITLE
CDP - 42709 - Bold Link in Debt Details Card

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -30,9 +30,9 @@ const DebtSummaryCard = ({ debt }) => {
         {debtCardHeading}
       </h4>
       {debtCardSubHeading}
-      <div className="vads-u-margin-right--5 vads-u-margin-top--2">
+      <div className="vads-u-margin-right--5 vads-u-margin-top--2 vads-u-font-weight--bold">
         <Link
-          data-testclass="debt-details-button"
+          data-testid="debt-details-button"
           onClick={() => setActiveDebt(debt)}
           to={`/debt-balances/details/${debt.fileNumber + debt.deductionCode}`}
         >

--- a/src/applications/combined-debt-portal/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/combined-debt-portal/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -17,7 +17,7 @@ describe('Debt Letters', () => {
 
   it('displays the current debts section and navigates to debt details', () => {
     cy.findByTestId('debts-jumplink').click({ waitForAnimations: true });
-    cy.get('[data-testclass="debt-details-button"]')
+    cy.get('[data-testid="debt-details-button"]')
       .first()
       .click();
     cy.get('#debtLetterHistory').should('be.visible');


### PR DESCRIPTION
## Description
Fixed bold text issue in correct place per convo with Tze and switched test attribute to Id per same convo.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42709

https://github.com/department-of-veterans-affairs/va.gov-team/issues/42709#issuecomment-1172564271

## Screenshots
![42709_Working](https://user-images.githubusercontent.com/29178824/176944753-f5b3dc4e-2449-47d6-b16d-961033c2b8dd.png)

## Acceptance criteria
- [ X ] Link renders in bold

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
