### PR TITLE
[mDot] Disability benefits 2346 Fixing failing Cypress tests

### DIFF
--- a/src/applications/disability-benefits/2346/tests/data/happyPath.json
+++ b/src/applications/disability-benefits/2346/tests/data/happyPath.json
@@ -35,18 +35,18 @@
         "productGroup": "Battery",
         "productId": 1,
         "availableForReorder": true,
-        "lastOrderDate": "2019-12-25",
-        "nextAvailabilityDate": "2020-01-01",
+        "lastOrderDate": "2021-12-25",
+        "nextAvailabilityDate": "2022-01-01",
         "quantity": 60,
-        "prescribedDate": "2019-12-20"
+        "prescribedDate": "2021-12-20"
       },
       {
         "productName": "DOME",
         "productGroup": "Accessory",
         "productId": 3,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10,
         "size": "6mm"
       },
@@ -55,8 +55,8 @@
         "productGroup": "Accessory",
         "productId": 4,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10,
         "size": "7mm"
       },
@@ -65,8 +65,8 @@
         "productGroup": "Accessory",
         "productId": 5,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10
       }
     ]

--- a/src/applications/disability-benefits/2346/tests/data/noAccessories.json
+++ b/src/applications/disability-benefits/2346/tests/data/noAccessories.json
@@ -34,16 +34,16 @@
         "productGroup": "Battery",
         "productId": 1,
         "availableForReorder": true,
-        "lastOrderDate": "2020-01-01",
-        "nextAvailabilityDate": "2020-01-01",
+        "lastOrderDate": "2022-01-01",
+        "nextAvailabilityDate": "2022-01-01",
         "quantity": 60,
-        "prescribedDate": "2020-12-20"
+        "prescribedDate": "2022-12-20"
       },
       {
         "productName": "DOME",
         "productGroup": "Accessory",
         "productId": 3,
-        "lastOrderDate": "2019-06-30",
+        "lastOrderDate": "2021-06-30",
         "nextAvailabilityDate": "2022-12-15",
         "quantity": 10,
         "size": "6mm"
@@ -52,7 +52,7 @@
         "productName": "DOME",
         "productGroup": "Accessory",
         "productId": 4,
-        "lastOrderDate": "2019-06-30",
+        "lastOrderDate": "2021-06-30",
         "nextAvailabilityDate": "2022-12-15",
         "quantity": 10,
         "size": "7mm"
@@ -61,7 +61,7 @@
         "productName": "WaxBuster Single Unit",
         "productGroup": "Accessory",
         "productId": 5,
-        "lastOrderDate": "2019-06-30",
+        "lastOrderDate": "2021-06-30",
         "nextAvailabilityDate": "2022-12-15",
         "quantity": 10
       }

--- a/src/applications/disability-benefits/2346/tests/data/noBatteries.json
+++ b/src/applications/disability-benefits/2346/tests/data/noBatteries.json
@@ -33,18 +33,18 @@
         "productName": "ZA1239",
         "productGroup": "Battery",
         "productId": 1,
-        "lastOrderDate": "2020-01-01",
+        "lastOrderDate": "2022-01-01",
         "nextAvailabilityDate": "2022-09-01",
         "quantity": 60,
-        "prescribedDate": "2020-12-20"
+        "prescribedDate": "2022-12-20"
       },
       {
         "productName": "DOME",
         "productGroup": "Accessory",
         "productId": 3,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10,
         "size": "6mm"
       },
@@ -53,8 +53,8 @@
         "productGroup": "Accessory",
         "productId": 4,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10,
         "size": "7mm"
       },
@@ -63,8 +63,8 @@
         "productGroup": "Accessory",
         "productId": 5,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10
       }
     ]

--- a/src/applications/disability-benefits/2346/tests/data/noTempAddress.json
+++ b/src/applications/disability-benefits/2346/tests/data/noTempAddress.json
@@ -28,18 +28,18 @@
         "productGroup": "Battery",
         "productId": 1,
         "availableForReorder": true,
-        "lastOrderDate": "2019-12-25",
-        "nextAvailabilityDate": "2020-01-01",
+        "lastOrderDate": "2021-12-25",
+        "nextAvailabilityDate": "2022-01-01",
         "quantity": 60,
-        "prescribedDate": "2019-12-20"
+        "prescribedDate": "2021-12-20"
       },
       {
         "productName": "DOME",
         "productGroup": "Accessory",
         "productId": 3,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10,
         "size": "6mm"
       },
@@ -48,8 +48,8 @@
         "productGroup": "Accessory",
         "productId": 4,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10,
         "size": "7mm"
       },
@@ -58,8 +58,8 @@
         "productGroup": "Accessory",
         "productId": 5,
         "availableForReorder": true,
-        "lastOrderDate": "2019-06-30",
-        "nextAvailabilityDate": "2019-12-15",
+        "lastOrderDate": "2021-06-30",
+        "nextAvailabilityDate": "2021-12-15",
         "quantity": 10
       }
     ]

--- a/src/applications/disability-benefits/2346/tests/mdot.cypress.spec.js
+++ b/src/applications/disability-benefits/2346/tests/mdot.cypress.spec.js
@@ -56,6 +56,8 @@ const testConfig = createTestConfig(
       supplies: () => {
         cy.get('@testKey').then(testKey => {
           if (testKey === 'noBatteries') {
+            // #1 is "Order batteries for this device"
+            // #3 & #5 are "order this accessory" for the available accessories
             cy.get('#3').click({ force: true });
             cy.get('#5').click({ force: true });
           } else if (testKey === 'noAccessories') {
@@ -144,7 +146,7 @@ const testConfig = createTestConfig(
         cy.route('POST', '/v0/mdot/supplies', postData);
       });
     },
-    skip: true,
+    skip: false,
   },
   manifest,
   formConfig,

--- a/src/applications/disability-benefits/2346/tests/mdot.cypress.spec.js
+++ b/src/applications/disability-benefits/2346/tests/mdot.cypress.spec.js
@@ -74,10 +74,9 @@ const testConfig = createTestConfig(
     setupPerTest: () => {
       let postData = [];
       cy.get('@testKey').then(testKey => {
-        cy.server();
         cy.login(testKey);
         if (testKey === 'noBatteries') {
-          cy.route('GET', '/v0/user', noBatteries);
+          cy.intercept('GET', '/v0/user', noBatteries);
           postData = [
             {
               status: 'Order Processed',
@@ -91,7 +90,7 @@ const testConfig = createTestConfig(
             },
           ];
         } else if (testKey === 'noAccessories') {
-          cy.route('GET', '/v0/user', noAccessories);
+          cy.intercept('GET', '/v0/user', noAccessories);
           postData = [
             {
               status: 'Order Processed',
@@ -100,7 +99,7 @@ const testConfig = createTestConfig(
             },
           ];
         } else if (testKey === 'noTempAddress') {
-          cy.route('GET', '/v0/user', noTempAddress);
+          cy.intercept('GET', '/v0/user', noTempAddress);
           postData = [
             {
               status: 'Order Processed',
@@ -119,7 +118,7 @@ const testConfig = createTestConfig(
             },
           ];
         } else {
-          cy.route('GET', '/v0/user', happyPath);
+          cy.intercept('GET', '/v0/user', happyPath);
           postData = [
             {
               status: 'Order Processed',
@@ -140,10 +139,10 @@ const testConfig = createTestConfig(
         }
       });
       cy.get('@testData').then(testData => {
-        cy.route('GET', '/v0/in_progress_forms/MDOT', testData);
+        cy.intercept('GET', '/v0/in_progress_forms/MDOT', testData);
       });
       cy.get('@testKey').then(() => {
-        cy.route('POST', '/v0/mdot/supplies', postData);
+        cy.intercept('POST', '/v0/mdot/supplies', postData);
       });
     },
     skip: false,


### PR DESCRIPTION
## Description
Cypress tests started failing on 07/01/2022. The mock data became out of date for the form which prevented the test from completing since it didn't meet the requirements to reorder. 

This PR updates those dates to within the acceptable range so the test can continue to pass. We have created a [tech-debt ticket to revisit](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/43839) and see if we can dynamically input those dates when the team has more bandwidth. Based on the last time this was update and when it broke, this fix should be effective for ~2 years. 

This PR also removes some deprecated Cypress `server()` and `route()` calls and replaces them with the appropriate `intercept`. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43808


## Acceptance criteria
- [x] mDot Cypress tests passing

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
