### PR TITLE
(fix) update profile link for contact-information

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
@@ -79,7 +79,7 @@ export const contactInfoUpdateHelpDescription = () => (
       Any updates you make here to your contact information will only apply to
       this application. If you want to update your contact information for all
       of your VA accounts,{' '}
-      <a href="/profile">please go to your profile page.</a>
+      <a href="/profile/contact-information">please go to your profile page.</a>
     </p>
   </div>
 );


### PR DESCRIPTION
## Description
A small update to fix the link to the new profile contact page.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/40351


## Acceptance criteria
- [x] Profile contact info link updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
