### PR TITLE
42872 - [CDP] - Incorporate accessibility feedback from the midpoint review: 'Check details' link

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -35,6 +35,7 @@ const DebtSummaryCard = ({ debt }) => {
           data-testid="debt-details-button"
           onClick={() => setActiveDebt(debt)}
           to={`/debt-balances/details/${debt.fileNumber + debt.deductionCode}`}
+          aria-describedby={`Check details and resolve this ${debtCardHeading}`}
         >
           Check details and resolve this debt
           <i

--- a/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
@@ -88,6 +88,7 @@ const BalanceCard = ({ id, amount, facility, city, date }) => {
         to={`/copay-balances/${id}/detail`}
         data-testid={`detail-link-${id}`}
         aria-label={linkText}
+        aria-describedby={`Check details and resolve this debt for ${facility}`}
       >
         {linkText}
         <i


### PR DESCRIPTION
## Description
Added aria descriptions per axe feedback from Angela.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42872

## Screenshots
![42872_Working](https://user-images.githubusercontent.com/29178824/177574863-90ff47a7-07b0-4aa2-808f-bd3dfd3aa34e.png)

## Acceptance criteria
- [ X ] Aria descriptions added per accessibility testing request.

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
