### PR TITLE
(fix) update profile contact-info links

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
@@ -3,11 +3,11 @@ import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
+import { useHistory } from 'react-router-dom';
 import FormButtons from '../../components/FormButtons';
 
 import { getCovid19VaccineFormPageInfo } from '../redux/selectors';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
-import { useHistory } from 'react-router-dom';
 import * as actions from '../redux/actions';
 import NewTabAnchor from '../../components/NewTabAnchor';
 
@@ -40,7 +40,10 @@ const uiSchema = {
         Want to update your contact information for more VA benefits and
         services?
         <br />
-        <NewTabAnchor href="/profile">Go to your VA profile</NewTabAnchor>.
+        <NewTabAnchor href="/profile/contact-information">
+          Go to your VA profile
+        </NewTabAnchor>
+        .
       </p>
     </>
   ),

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -9,6 +9,7 @@ import {
   selectVAPMobilePhoneString,
 } from 'platform/user/selectors';
 import recordEvent from 'platform/monitoring/record-event';
+import { useHistory } from 'react-router-dom';
 import FormButtons from '../../components/FormButtons';
 
 import {
@@ -17,7 +18,6 @@ import {
   selectPageChangeInProgress,
 } from '../redux/selectors';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
-import { useHistory } from 'react-router-dom';
 import {
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
@@ -118,7 +118,10 @@ export default function ContactInfoPage() {
           Want to update your contact information for more VA benefits and
           services?
           <br />
-          <NewTabAnchor href="/profile">Go to your VA profile</NewTabAnchor>.
+          <NewTabAnchor href="/profile/contact-information">
+            Go to your VA profile
+          </NewTabAnchor>
+          .
         </p>
       </>
     ),


### PR DESCRIPTION
## Description
Updates a link for profile to the new path structure `profile/contact-information`

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/40351

## Testing done
Manually tested

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
