### PR TITLE
[CDP] 42785 Copay - Updating helper links to use relative paths

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/DisputeCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/DisputeCharges.jsx
@@ -15,15 +15,12 @@ const DisputeCharges = () => (
       dispute by mail, please include "Billing Dispute" on the mailing envelope.
     </p>
     <p>
-      <a
-        className="vads-c-action-link--blue"
-        href="https://www.va.gov/find-locations"
-      >
+      <a className="vads-c-action-link--blue" href="/find-locations">
         Find your nearest VA medical center
       </a>
     </p>
     <p>
-      <a href="https://www.va.gov/health-care/pay-copay-bill/dispute-charges/">
+      <a href="/health-care/pay-copay-bill/dispute-charges/">
         Learn more about disputing your copay charges
       </a>
     </p>


### PR DESCRIPTION
## Description
Updating reference links to use relative paths, so they will work no matter the environment. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42785

## Acceptance criteria
- [ ] Find Nearest.. and Learn more... are linking correctly and user can use back button to navigate

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
