### PR TITLE
Adds the Sign in Service Feature flag

### DIFF
--- a/src/applications/health-care-questionnaire/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.disabled.json
+++ b/src/applications/health-care-questionnaire/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.disabled.json
@@ -149,6 +149,10 @@
         {
            "name":"show_healthcare_experience_questionnaire",
            "value":false
+        },
+        {
+           "name":"sign_in_service_enabled",
+           "value":false
         }
      ]
   }

--- a/src/applications/health-care-questionnaire/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.enabled.json
+++ b/src/applications/health-care-questionnaire/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.enabled.json
@@ -149,6 +149,10 @@
         {
            "name":"show_healthcare_experience_questionnaire",
            "value":true
+        },
+        {
+           "name":"sign_in_service_enabled",
+           "value":true
         }
      ]
   }

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -35,8 +35,8 @@ export class SignInPage extends React.Component {
 
     if (
       useSignInService &&
-      !location.search.includes('oauth') &&
-      !location.search.includes('application')
+      !window.location.search.includes('oauth') &&
+      !window.location.search.includes('application')
     ) {
       router.push(`?oauth=true`);
     }

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -33,8 +33,12 @@ export class SignInPage extends React.Component {
       router.push(appendQuery('/verify', window.location.search.slice(1)));
     }
 
-    if (useSignInService && !window.location.search.includes('oauth')) {
-      router.push('?oauth=true');
+    if (
+      useSignInService &&
+      !location.search.includes('oauth') &&
+      !location.search.includes('application')
+    ) {
+      router.push(`?oauth=true`);
     }
   }
 

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -6,21 +6,35 @@ import 'url-search-params-polyfill';
 import AutoSSO from 'platform/site-wide/user-nav/containers/AutoSSO';
 import LoginContainer from 'platform/user/authentication/components/LoginContainer';
 
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
+import {
+  isAuthenticatedWithSSOe,
+  signInServiceEnabled,
+} from 'platform/user/authentication/selectors';
 import { selectProfile } from 'platform/user/selectors';
 import { EXTERNAL_APPS } from 'platform/user/authentication/constants';
 
 export class SignInPage extends React.Component {
   componentDidUpdate() {
-    const { router, location, authenticatedWithSSOe, profile } = this.props;
+    const {
+      router,
+      location,
+      authenticatedWithSSOe,
+      profile,
+      useSignInService,
+    } = this.props;
     const { query } = location;
     const { application } = query;
+
     if (
       authenticatedWithSSOe &&
       !profile.verified &&
       application === EXTERNAL_APPS.MY_VA_HEALTH
     ) {
       router.push(appendQuery('/verify', window.location.search.slice(1)));
+    }
+
+    if (useSignInService && !window.location.search.includes('oauth')) {
+      router.push('?oauth=true');
     }
   }
 
@@ -46,6 +60,7 @@ export class SignInPage extends React.Component {
 const mapStateToProps = state => ({
   profile: selectProfile(state),
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
+  useSignInService: signInServiceEnabled(state),
 });
 
 export default connect(mapStateToProps)(SignInPage);

--- a/src/applications/login/tests/containers/SignInApp.unit.spec.js
+++ b/src/applications/login/tests/containers/SignInApp.unit.spec.js
@@ -61,12 +61,28 @@ describe('SignInApp', () => {
     defaultProps.location.query = { application: EXTERNAL_APPS.MY_VA_HEALTH };
     defaultProps.router = { push: routerPushSpy };
     defaultProps.authenticatedWithSSOe = true;
+    defaultProps.useSignInService = false;
     defaultProps.profile = {};
 
     const component = shallow(<SignInPage {...defaultProps} />);
     component.setProps({ profile: { verified: false } });
     expect(routerPushSpy.calledOnce).to.be.true;
     expect(routerPushSpy.args[0][0]).to.contain('/verify');
+    component.unmount();
+  });
+
+  it('should append the `?oauth=true` parameter if useSignInService is true and oauth=true is not already appended', () => {
+    const routerPushSpy = sinon.spy();
+    defaultProps.location.query = { oauth: true };
+    defaultProps.router = { push: routerPushSpy };
+    defaultProps.useSignInService = true;
+
+    const component = shallow(<SignInPage {...defaultProps} />);
+    expect(routerPushSpy.calledOnce).to.be.false;
+
+    component.setProps({ location: { query: {} } });
+    expect(routerPushSpy.calledOnce).to.be.true;
+    expect(routerPushSpy.args[0][0]).to.contain('?oauth=true');
     component.unmount();
   });
 });

--- a/src/applications/login/tests/containers/SignInApp.unit.spec.js
+++ b/src/applications/login/tests/containers/SignInApp.unit.spec.js
@@ -71,7 +71,7 @@ describe('SignInApp', () => {
     component.unmount();
   });
 
-  it('should append the `?oauth=true` parameter if useSignInService is true and oauth=true is not already appended', () => {
+  it('should append the `?oauth=true` parameter if useSignInService is true and oauth=true is not already appended and application is undefined', () => {
     const routerPushSpy = sinon.spy();
     defaultProps.location.query = { oauth: true };
     defaultProps.router = { push: routerPushSpy };

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -110,6 +110,9 @@ export class Main extends Component {
     pageTitle = '',
     useSiS = true,
   } = {}) {
+    if (url === 'loginModal' && this.getNextParameter()) {
+      return null;
+    }
     const location = window.location.toString();
     const nextQuery = {
       next: url,
@@ -119,9 +122,6 @@ export class Main extends Component {
     const nextPath = appendQuery(path, nextQuery);
     history.pushState({}, pageTitle, nextPath);
 
-    if (url === 'loginModal' && this.getNextParameter()) {
-      return null;
-    }
     return nextQuery;
   }
 

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -110,13 +110,12 @@ export class Main extends Component {
     pageTitle = '',
     useSiS = true,
   } = {}) {
+    const location = window.location.toString();
     const nextQuery = {
       next: url,
       ...(useSiS && this.props.useSignInService && { oauth: true }),
     };
-    const path = useSiS
-      ? window.location.toString()
-      : window.location.href.replace('&oauth=true', '');
+    const path = useSiS ? location : location.replace('&oauth=true', '');
     const nextPath = appendQuery(path, nextQuery);
     history.pushState({}, pageTitle, nextPath);
 

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -263,12 +263,24 @@ describe('<Main>', () => {
   it('should append ?next=loginModal when the login modal is opened', () => {
     const wrapper = shallow(<Main {...props} />);
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    const signInModalProps = wrapper.find('SignInModal').props();
+    expect(signInModalProps.useSiS).to.be.false;
     expect(props.getBackendStatuses.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledWith(true, 'header')).to.be.true;
     expect(appendSpy.calledWith()).to.be.true;
     expect(appendSpy.returnValues[0].next).to.equal('loginModal');
 
+    wrapper.unmount();
+  });
+
+  it('should append `&oauth=true` when the login modal is opened and signInServiceEnabled feature flag is true', () => {
+    const wrapper = shallow(<Main {...props} useSignInService />);
+    wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    const signInModalProps = wrapper.find('SignInModal').props();
+    expect(signInModalProps.useSiS).to.be.true;
+    expect(appendSpy.returnValues[0].next).to.equal('loginModal');
+    expect(appendSpy.returnValues[0].oauth).to.equal(true);
     wrapper.unmount();
   });
 

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -21,6 +21,7 @@ describe('<Main>', () => {
     showTransitionSuccessModal: false,
     showTransitionModal: false,
     utilitiesMenuIsOpen: { search: false, help: false, account: false },
+    useSignInService: false,
     getBackendStatuses: sinon.spy(),
     toggleFormSignInModal: sinon.spy(),
     toggleLoginModal: sinon.spy(),
@@ -34,7 +35,7 @@ describe('<Main>', () => {
   };
 
   let oldWindow = null;
-  const appendSpy = sinon.spy(Main.prototype, 'appendNextParameter');
+  const appendSpy = sinon.spy(Main.prototype, 'appendOrRemoveParameter');
 
   beforeEach(() => {
     oldWindow = global.window;

--- a/src/platform/user/authentication/components/AccountLink.jsx
+++ b/src/platform/user/authentication/components/AccountLink.jsx
@@ -40,7 +40,7 @@ export default function AccountLink({
       }
       updateHref(csp, type);
     },
-    [csp, type],
+    [csp, type, useOAuth],
   );
 
   return (

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -8,10 +8,11 @@ import recordEvent from 'platform/monitoring/record-event';
 
 export default class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
+    const isOAuthEvent = this.props.useSiS && '-oauth';
     if (!prevProps.visible && this.props.visible) {
-      recordEvent({ event: 'login-modal-opened' });
+      recordEvent({ event: `login-modal-opened${isOAuthEvent}` });
     } else if (prevProps.visible && !this.props.visible) {
-      recordEvent({ event: 'login-modal-closed' });
+      recordEvent({ event: `login-modal-closed${isOAuthEvent}` });
     }
   }
 
@@ -31,6 +32,7 @@ export default class SignInModal extends React.Component {
 }
 
 SignInModal.propTypes = {
-  onClose: PropTypes.func,
+  useSiS: PropTypes.bool,
   visible: PropTypes.bool,
+  onClose: PropTypes.func,
 };

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -8,7 +8,7 @@ import recordEvent from 'platform/monitoring/record-event';
 
 export default class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
-    const isOAuthEvent = this.props.useSiS && '-oauth';
+    const isOAuthEvent = this.props.useSiS ? '-oauth' : '';
     if (!prevProps.visible && this.props.visible) {
       recordEvent({ event: `login-modal-opened${isOAuthEvent}` });
     } else if (prevProps.visible && !this.props.visible) {

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -1,3 +1,5 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectProfile } from 'platform/user/selectors';
 
 export const hasCheckedKeepAlive = state =>
@@ -17,3 +19,6 @@ export const ssoeTransactionId = state =>
 
 export const transitionMHVAccount = state =>
   selectProfile(state)?.mhvTransitionEligible;
+
+export const signInServiceEnabled = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.signInServiceEnabled];

--- a/src/platform/user/tests/authentication/components/SignInModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/SignInModal.unit.spec.js
@@ -9,6 +9,7 @@ import SignInModal from 'platform/user/authentication/components/SignInModal';
 const defaultProps = {
   visible: true,
   onClose: () => {},
+  useSiS: false,
 };
 
 describe('SignInModal', () => {

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -111,6 +111,7 @@ export default Object.freeze({
   showNewSecureMessagingPage: 'show_new_secure_messaging_page',
   showNewViewTestLabResultsPage: 'show_new_view_test_lab_results_page',
   showUpdatedFryDeaApp: 'show_updated_fry_dea_app',
+  signInServiceEnabled: 'sign_in_service_enabled',
   stemAutomatedDecision: 'stem_automated_decision',
   stemSCOEmail: 'stem_sco_email',
   subform89404192: 'subform_8940_4192',


### PR DESCRIPTION
## Description
This PR adds the `sign_in_service_enabled` feature flag for conditional rollout of the Sign in Service.  It additionally modifies some components (Main.jsx and SignInApp.jsx) to append the `oauth=true` query parameter when the feature flag is enabled, creates the `signInServiceEnabled` Redux selector, and modifies/adds unit tests to test for the addition of the query parameter as necessary.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#43665


## Testing done
Unit

## Screenshots
n/a

## Acceptance criteria
- [x] Setting `sign_in_service_enabled` to `false`, will not append the `oauth=true` query parameter when navigating to the SignInPage (`/sign-in`) nor opening the SignInModal
- [x] Setting `sign_in_service_enabled` to `true`, appends the `oauth=true` query parameter when navigating to the SignInPage (`/sign-in`) or opening the SignInModal

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
