### PR TITLE
Remove deprecated alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -63,7 +63,6 @@
           "@department-of-veterans-affairs/component-library/LoadingIndicator": "@department-of-veterans-affairs/react-components/LoadingIndicator",
           "@department-of-veterans-affairs/component-library/AlertBox": "@department-of-veterans-affairs/react-components/AlertBox",
           "@department-of-veterans-affairs/component-library/ProgressButton": "@department-of-veterans-affairs/react-components/ProgressButton",
-          "@department-of-veterans-affairs/component-library/CollapsiblePanel": "@department-of-veterans-affairs/react-components/CollapsiblePanel",
           "@department-of-veterans-affairs/component-library/RadioButtons": "@department-of-veterans-affairs/react-components/RadioButtons",
           "@department-of-veterans-affairs/component-library/Breadcrumbs": "@department-of-veterans-affairs/react-components/Breadcrumbs",
           "@department-of-veterans-affairs/component-library/Modal": "@department-of-veterans-affairs/react-components/Modal",


### PR DESCRIPTION
## Description
This PR removes an alias for a deprecated component.

## Original issue(s)
Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1016


## Acceptance criteria
- [x] Remove deprecated alias 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
