### PR TITLE
[VA 9681] Add event location to events listing page

### DIFF
--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -149,6 +149,19 @@ export const Results = ({
                     </p>
 
                     <div className="vads-u-display--flex vads-u-flex-direction--column">
+                      {event.fieldFacilityLocation?.entity?.entityUrl?.path &&
+                        event.fieldFacilityLocation?.entity?.title && (
+                          <p className="vads-u-margin--0">
+                            <a
+                              href={
+                                event.fieldFacilityLocation.entity.entityUrl
+                                  .path
+                              }
+                            >
+                              {event.fieldFacilityLocation.entity.title}
+                            </a>
+                          </p>
+                        )}
                       {locations?.map(location => (
                         <p className="vads-u-margin--0" key={location}>
                           {location}


### PR DESCRIPTION
## Description

The Events Listing page doesn't show the facility as part of the location, even though the individual event page does. This adds the facility with a link to it on that page.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9681

## Testing done

Visual

## Screenshots

<img width="782" alt="Screen Shot 2022-07-07 at 11 13 28 AM" src="https://user-images.githubusercontent.com/10790736/177809601-87d93201-cccd-454e-86b3-045541014bae.png">

## Acceptance criteria

- [x] On the Events Listing page, events with locations have the facility included in the location with a link
- [x] Events without a facility location don't show it

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
