### PR TITLE
Change build artifact bucket due to CORS issue (#41668)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1075,7 +1075,7 @@ jobs:
       - name: Upload build
         run: |
           aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
-          aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload/$GITHUB_SHA/BUILD_ARTIFACT.txt --acl public-read --region us-gov-west-1
+          aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
 
   get-latest-run-number:
     name: Get Latest Workflow Run Number


### PR DESCRIPTION
## Description
We were storing `BUILD_ARTIFACT.txt` in the `vetsgov-website-builds-s3-upload` bucket. Since we are unable to safely modify the CORS allowlist for that bucket, the dashboard can't fetch files from the bucket. This PR modifies the upload location of BUILD_ARTIFACT.txt to be the `vetsgov-website-builds-s3-upload-test` bucket where we can easily update CORS rules.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41668

## Testing done
- Check that BUILD_ARTIFACT.txt is uploaded correctly to the new bucket

## Screenshots


## Acceptance criteria
- [x] BUILD_ARTIFACT.txt is uploaded correctly to the etsgov-website-builds-s3-upload-test bucket

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
