### PR TITLE
don't use babel path aliases in workspaces

### DIFF
--- a/src/applications/vaos/tests/e2e/vaos-cypress-v2-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-v2-helpers.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { mockContactInformation } from '~/platform/user/profile/vap-svc/util/local-vapsvc';
+import { mockContactInformation } from 'platform/user/profile/vap-svc/util/local-vapsvc';
 import moment from '../../lib/moment-tz';
 import schedulingConfigurations from '../../services/mocks/v2/scheduling_configurations.json';
 import { getVAOSAppointmentMock } from '../mocks/v2';

--- a/src/platform/forms-system/src/js/components/FormNavButtons.jsx
+++ b/src/platform/forms-system/src/js/components/FormNavButtons.jsx
@@ -7,7 +7,7 @@ import ProgressButton from './ProgressButton';
  *
  * If `goBack` is not present, the back button will not appear. If
  * `FormNavButtons` are rendered inside a form (such as
- * ~/platform/forms/formulate-integration/Form), use `submitToContinue` and pass
+ * platform/forms/formulate-integration/Form), use `submitToContinue` and pass
  * the `goForward` function to the form's `onSubmit` instead. Doing this will
  * navigate the user to the next page only if validation is successful.
  */

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
+import classNames from 'classnames';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { isReactComponent, getScrollOptions } from 'platform/utilities/ui';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
-import classNames from 'classnames';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import FormNavButtons from '../components/FormNavButtons';
 import SchemaForm from '../components/SchemaForm';
 import { setData, uploadFile } from '../actions';
@@ -16,7 +17,6 @@ import {
   checkValidPagePath,
 } from '../routing';
 import { focusElement } from '../utilities/ui';
-import { isReactComponent, getScrollOptions } from '~/platform/utilities/ui';
 
 function focusForm() {
   focusElement('.nav-header > h2');

--- a/src/platform/forms/address/helpers.js
+++ b/src/platform/forms/address/helpers.js
@@ -1,4 +1,4 @@
-import countries from '@@vap-svc/constants/countries.json';
+import countries from 'platform/user/profile/vap-svc/constants/countries.json';
 import ADDRESS_DATA from './data';
 
 const STATE_NAMES = ADDRESS_DATA.states;

--- a/src/platform/forms/formulate-integration/Form.jsx
+++ b/src/platform/forms/formulate-integration/Form.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { useFormikContext, Form as FormikForm } from 'formik';
 import { isEqual } from 'lodash';
 
-import { setData as setDataAction } from '~/platform/forms-system/src/js/actions';
+import { setData as setDataAction } from 'platform/forms-system/src/js/actions';
 
 export const Form = ({ setData, ...rest }) => {
   const { values } = useFormikContext();

--- a/src/platform/site-wide/banners/index.js
+++ b/src/platform/site-wide/banners/index.js
@@ -1,8 +1,8 @@
 // Node modules.
 import React from 'react';
 // Relative imports.
+import widgetTypes from 'applications/static-pages/widgetTypes';
 import startReactApp from '../../startup/react';
-import widgetTypes from '~/applications/static-pages/widgetTypes';
 
 // Are you looking for where this is used?
 // Search for `data-widget-type="banner"` and `data-widget-type="maintenance-banner"` to find all the places this React widget is used.

--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -2,14 +2,14 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 // Relative imports.
+import { isBrowserIE } from 'platform/site-wide/helpers/detection/is-browser';
+import { useOnLoaded } from 'platform/site-wide/hooks/events/use-on-loaded';
 import LogoRow from '../LogoRow';
 import Menu from '../../containers/Menu';
 import OfficialGovtWebsite from '../OfficialGovtWebsite';
 import VeteranCrisisLine from '../VeteranCrisisLine';
 import addFocusBehaviorToCrisisLineModal from '../../../accessible-VCL-modal';
 import { addOverlayTriggers } from '../../../legacy/menu';
-import { isBrowserIE } from '~/platform/site-wide/helpers/detection/is-browser';
-import { useOnLoaded } from '~/platform/site-wide/hooks/events/use-on-loaded';
 
 export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/platform/site-wide/header/components/Header/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Header/index.unit.spec.js
@@ -5,8 +5,8 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 // 1st-party imports
-import * as isBrowser from '~/platform/site-wide/helpers/detection/is-browser';
-import * as useOnLoadedHook from '~/platform/site-wide/hooks/events/use-on-loaded';
+import * as isBrowser from 'platform/site-wide/helpers/detection/is-browser';
+import * as useOnLoadedHook from 'platform/site-wide/hooks/events/use-on-loaded';
 import { Header } from '.';
 
 describe('Header <Header>', () => {

--- a/src/platform/site-wide/helpers/team-sites/get-asset-path.js
+++ b/src/platform/site-wide/helpers/team-sites/get-asset-path.js
@@ -1,4 +1,4 @@
-import buckets from '~/site/constants/buckets';
+import buckets from 'site/constants/buckets';
 
 /**
  * Performs a static lookup from the `buckets` dictionary of AWS S3 Bucket URLs.

--- a/src/platform/site-wide/helpers/team-sites/web-components.js
+++ b/src/platform/site-wide/helpers/team-sites/web-components.js
@@ -1,5 +1,5 @@
-import { getAssetPath } from '~/platform/site-wide/helpers/team-sites/get-asset-path';
-import { getTargetEnv } from '~/platform/site-wide/helpers/team-sites/get-target-env';
+import { getAssetPath } from 'platform/site-wide/helpers/team-sites/get-asset-path';
+import { getTargetEnv } from 'platform/site-wide/helpers/team-sites/get-target-env';
 
 /*
  * This file is intended to support legacy pages.

--- a/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
@@ -6,7 +6,7 @@
  * @testrailinfo runName SH-e2e-MegaMenu
  */
 // Relative imports.
-import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import { mockUser } from 'applications/personalization/profile/tests/fixtures/users/user.js';
 
 Cypress.Commands.add(
   'checkMenuItem',

--- a/src/platform/site-wide/side-nav/index.js
+++ b/src/platform/site-wide/side-nav/index.js
@@ -1,9 +1,9 @@
 // Dependencies
 import React from 'react';
 // Relative
+import widgetTypes from 'applications/static-pages/widgetTypes';
 import startReactApp from '../../startup/react';
 import { normalizeSideNavData } from './helpers';
-import widgetTypes from '~/applications/static-pages/widgetTypes';
 
 // Are you looking for where this is used?
 // Search for `<div data-widget-type="side-nav"></div>` to find all the places

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -3,15 +3,15 @@ import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 import {
   isVAProfileServiceConfigured,
   mockContactInformation,
-} from '@@vap-svc/util/local-vapsvc';
+} from 'platform/user/profile/vap-svc/util/local-vapsvc';
+import localStorage from 'platform/utilities/storage/localStorage';
+
+import { ssoKeepAliveSession } from 'platform/utilities/sso';
+import { removeInfoToken } from 'platform/utilities/oauth/utilities';
 import {
   setSentryLoginType,
   clearSentryLoginType,
 } from '../../authentication/utilities';
-import localStorage from '~/platform/utilities/storage/localStorage';
-
-import { ssoKeepAliveSession } from '~/platform/utilities/sso';
-import { removeInfoToken } from '~/platform/utilities/oauth/utilities';
 
 const commonServices = {
   EMIS: 'EMIS',

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -1,10 +1,16 @@
 import * as Sentry from '@sentry/browser';
 
-import { ADDRESS_POU, FIELD_NAMES } from '@@vap-svc/constants';
-import { showAddressValidationModal, inferAddressType } from '@@vap-svc/util';
-import { apiRequest } from '~/platform/utilities/api';
-import { refreshProfile } from '~/platform/user/profile/actions';
-import recordEvent from '~/platform/monitoring/record-event';
+import {
+  ADDRESS_POU,
+  FIELD_NAMES,
+} from 'platform/user/profile/vap-svc/constants';
+import {
+  showAddressValidationModal,
+  inferAddressType,
+} from 'platform/user/profile/vap-svc/util';
+import { apiRequest } from 'platform/utilities/api';
+import { refreshProfile } from 'platform/user/profile/actions';
+import recordEvent from 'platform/monitoring/record-event';
 
 import localVAProfileService, {
   isVAProfileServiceConfigured,

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressEditModal.jsx
@@ -4,9 +4,13 @@ import pickBy from 'lodash/pickBy';
 import ADDRESS_DATA from 'platform/forms/address/data';
 import { focusElement } from 'platform/utilities/ui';
 
-import { ADDRESS_POU, FIELD_NAMES, USA } from '@@vap-svc/constants';
+import {
+  ADDRESS_POU,
+  FIELD_NAMES,
+  USA,
+} from 'platform/user/profile/vap-svc/constants';
+import CopyMailingAddress from 'platform/user/profile/vap-svc/containers/CopyMailingAddress';
 import VAPServiceEditModal from '../base/VAPServiceEditModal';
-import CopyMailingAddress from '@@vap-svc/containers/CopyMailingAddress';
 import ContactInfoForm from '../ContactInfoForm';
 
 class AddressEditModal extends React.Component {

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressField.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressField.jsx
@@ -9,9 +9,9 @@ import {
   ADDRESS_TYPES,
   ADDRESS_POU,
   USA,
-} from '@@vap-svc/constants';
+} from 'platform/user/profile/vap-svc/constants';
 
-import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
+import VAPServiceProfileField from 'platform/user/profile/vap-svc/containers/VAPServiceProfileField';
 
 import AddressEditModal from './AddressEditModal';
 import AddressValidationModal from '../../containers/AddressValidationModal';

--- a/src/platform/user/profile/vap-svc/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vap-svc/components/AddressField/address-schemas.js
@@ -3,7 +3,10 @@ import React from 'react';
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 
-import { ADDRESS_FORM_VALUES, USA } from '@@vap-svc/constants';
+import {
+  ADDRESS_FORM_VALUES,
+  USA,
+} from 'platform/user/profile/vap-svc/constants';
 
 // Regex that uses a negative lookahead to check that a string does NOT contain
 // things like `http`, `www.`, or a few common TLDs. Let's cross our fingers and

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmRemoveModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmRemoveModal.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
-import { FIELD_NAMES } from '@@vap-svc/constants';
-import VAPServiceEditModalErrorMessage from '~/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import { FIELD_NAMES } from 'platform/user/profile/vap-svc/constants';
+import VAPServiceEditModalErrorMessage from 'platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage';
 
 const ConfirmRemoveModal = ({
   cancelAction,
@@ -18,7 +18,7 @@ const ConfirmRemoveModal = ({
 }) => {
   return (
     <Modal
-      title={`Are you sure?`}
+      title="Are you sure?"
       cssClass="overflow-auto"
       status="warning"
       visible={isVisible}

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ContactInformationUpdateSuccessAlert.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ContactInformationUpdateSuccessAlert.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { useLastLocation } from 'react-router-last-location';
-import { PROFILE_PATHS } from '@@profile/constants';
-import { FIELD_NAMES } from '@@vap-svc/constants';
-import { selectVAPContactInfoField } from '@@vap-svc/selectors';
+import { PROFILE_PATHS } from 'applications/personalization/profile/constants';
+import { FIELD_NAMES } from 'platform/user/profile/vap-svc/constants';
+import { selectVAPContactInfoField } from 'platform/user/profile/vap-svc/selectors';
 
-import { focusElement } from '~/platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 const ContactInformationUpdateSuccessAlert = ({ fieldName }) => {
   const fieldData = useSelector(state => {

--- a/src/platform/user/profile/vap-svc/components/EmailField/EmailField.jsx
+++ b/src/platform/user/profile/vap-svc/components/EmailField/EmailField.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { API_ROUTES, FIELD_NAMES } from '@@vap-svc/constants';
+import {
+  API_ROUTES,
+  FIELD_NAMES,
+} from 'platform/user/profile/vap-svc/constants';
 
-import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
+import VAPServiceProfileField from 'platform/user/profile/vap-svc/containers/VAPServiceProfileField';
 
 import EmailEditModal from './EmailEditModal';
 import EmailView from './EmailView';

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -8,11 +8,11 @@ import {
   FIELD_TITLES,
   PHONE_TYPE,
   USA,
-} from '@@vap-svc/constants';
+} from 'platform/user/profile/vap-svc/constants';
 
-import PhoneNumberWidget from '~/platform/forms-system/src/js/widgets/PhoneNumberWidget';
+import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
-import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
+import VAPServiceProfileField from 'platform/user/profile/vap-svc/containers/VAPServiceProfileField';
 
 import PhoneEditModal from './PhoneEditModal';
 import PhoneView from './PhoneView';

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -2,19 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import * as VAP_SERVICE from '@@vap-svc/constants';
+import * as VAP_SERVICE from 'platform/user/profile/vap-svc/constants';
 
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from '@@vap-svc/util/transactions';
+} from 'platform/user/profile/vap-svc/util/transactions';
 
 import {
   createTransaction,
   refreshTransaction,
   clearTransactionRequest,
   openModal,
-} from '@@vap-svc/actions';
+} from 'platform/user/profile/vap-svc/actions';
 
 import {
   selectAddressValidationType,
@@ -23,26 +23,29 @@ import {
   selectVAPServiceTransaction,
   selectEditViewData,
   selectMostRecentlyUpdatedField,
-} from '@@vap-svc/selectors';
+} from 'platform/user/profile/vap-svc/selectors';
 
-import { selectVAProfilePersonalInformation } from '@@profile/selectors';
+import { selectVAProfilePersonalInformation } from 'applications/personalization/profile/selectors';
 
-import { ACTIVE_EDIT_VIEWS, FIELD_NAMES } from '@@vap-svc/constants';
-import VAPServiceTransaction from '@@vap-svc/components/base/VAPServiceTransaction';
-import AddressValidationView from '@@vap-svc/containers/AddressValidationView';
+import {
+  ACTIVE_EDIT_VIEWS,
+  FIELD_NAMES,
+} from 'platform/user/profile/vap-svc/constants';
+import VAPServiceTransaction from 'platform/user/profile/vap-svc/components/base/VAPServiceTransaction';
+import AddressValidationView from 'platform/user/profile/vap-svc/containers/AddressValidationView';
 
-import ProfileInformationEditView from '@@profile/components/ProfileInformationEditView';
-import ProfileInformationView from '@@profile/components/ProfileInformationView';
+import ProfileInformationEditView from 'applications/personalization/profile/components/ProfileInformationEditView';
+import ProfileInformationView from 'applications/personalization/profile/components/ProfileInformationView';
 
-import { getInitialFormValues } from '@@profile/util/contact-information/formValues';
-import { isFieldEmpty } from '@@profile/util';
+import { getInitialFormValues } from 'applications/personalization/profile/util/contact-information/formValues';
+import { isFieldEmpty } from 'applications/personalization/profile/util';
 
-import { isVAPatient } from '~/platform/user/selectors';
-import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
-import recordEvent from '~/platform/monitoring/record-event';
-import { focusElement } from '~/platform/utilities/ui';
+import { isVAPatient } from 'platform/user/selectors';
+import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
+import recordEvent from 'platform/monitoring/record-event';
+import { focusElement } from 'platform/utilities/ui';
 
-import getProfileInfoFieldAttributes from '~/applications/personalization/profile/util/getProfileInfoFieldAttributes';
+import getProfileInfoFieldAttributes from 'applications/personalization/profile/util/getProfileInfoFieldAttributes';
 
 import CannotEditModal from './ContactInformationFieldInfo/CannotEditModal';
 import ConfirmCancelModal from './ContactInformationFieldInfo/ConfirmCancelModal';

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from '@@vap-svc/util/transactions';
+} from 'platform/user/profile/vap-svc/util/transactions';
 import VAPServiceEditModalActionButtons from './VAPServiceEditModalActionButtons';
 import VAPServiceEditModalErrorMessage from './VAPServiceEditModalErrorMessage';
 

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalActionButtons.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalActionButtons.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { toLower } from 'lodash';
 
-import recordEvent from '~/platform/monitoring/record-event';
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import recordEvent from 'platform/monitoring/record-event';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 class VAPServiceEditModalActionButtons extends React.Component {
   constructor(props) {

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -7,7 +7,7 @@ import {
   INVALID_EMAIL_ADDRESS_ERROR_CODES,
   LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
   INVALID_PHONE_ERROR_CODES,
-} from '@@vap-svc/util/transactions';
+} from 'platform/user/profile/vap-svc/util/transactions';
 
 function hasError(codes, errors) {
   return errors.some(error => codes.has(error.code));

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransaction.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransaction.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import {
   isPendingTransaction,
   isFailedTransaction,
-} from '@@vap-svc/util/transactions';
+} from 'platform/user/profile/vap-svc/util/transactions';
 
 import VAPServiceTransactionInlineErrorMessage from './VAPServiceTransactionInlineErrorMessage';
 import VAPServiceTransactionPending from './VAPServiceTransactionPending';

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionErrorBanner.jsx
@@ -11,7 +11,7 @@ import {
   hasMVIError,
   hasMVINotFoundError,
   hasVAProfileInitError,
-} from '@@vap-svc/util/transactions';
+} from 'platform/user/profile/vap-svc/util/transactions';
 
 export function GenericUpdateError(props) {
   return (

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
@@ -4,8 +4,15 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import { formatAddress } from '~/platform/forms/address/helpers';
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import { formatAddress } from 'platform/forms/address/helpers';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import { focusElement } from 'platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
+import {
+  isFailedTransaction,
+  isPendingTransaction,
+} from 'platform/user/profile/vap-svc/util/transactions';
+import VAPServiceEditModalErrorMessage from 'platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage';
 import {
   openModal,
   createTransaction,
@@ -14,19 +21,10 @@ import {
   closeModal,
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
-import { focusElement } from '~/platform/utilities/ui';
 import { getValidationMessageKey } from '../util';
 import { ADDRESS_VALIDATION_MESSAGES } from '../constants/addressValidationMessages';
-import recordEvent from '~/platform/monitoring/record-event';
 
 import * as VAP_SERVICE from '../constants';
-
-import {
-  isFailedTransaction,
-  isPendingTransaction,
-} from '@@vap-svc/util/transactions';
-
-import VAPServiceEditModalErrorMessage from '@@vap-svc/components/base/VAPServiceEditModalErrorMessage';
 
 class AddressValidationModal extends React.Component {
   componentWillUnmount() {
@@ -273,8 +271,7 @@ class AddressValidationModal extends React.Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { transaction } = ownProps;
-  const addressValidationType =
-    state.vapService.addressValidation.addressValidationType;
+  const { addressValidationType } = state.vapService.addressValidation;
 
   return {
     analyticsSectionName:

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -5,13 +5,13 @@ import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from '@@vap-svc/util/transactions';
-import { selectAddressValidation } from '@@vap-svc/selectors';
-import VAPServiceEditModalErrorMessage from '@@vap-svc/components/base/VAPServiceEditModalErrorMessage';
-import { formatAddress } from '~/platform/forms/address/helpers';
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
-import recordEvent from '~/platform/monitoring/record-event';
-import { focusElement } from '~/platform/utilities/ui';
+} from 'platform/user/profile/vap-svc/util/transactions';
+import { selectAddressValidation } from 'platform/user/profile/vap-svc/selectors';
+import VAPServiceEditModalErrorMessage from 'platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage';
+import { formatAddress } from 'platform/forms/address/helpers';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import recordEvent from 'platform/monitoring/record-event';
+import { focusElement } from 'platform/utilities/ui';
 
 import * as VAP_SERVICE from '../constants';
 import {

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -4,9 +4,13 @@ import PropTypes from 'prop-types';
 import pick from 'lodash/pick';
 import mapValues from 'lodash/mapValues';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
-import { areAddressesEqual } from '@@vap-svc/util';
+import { areAddressesEqual } from 'platform/user/profile/vap-svc/util';
 
-import { FIELD_NAMES, USA, ADDRESS_PROPS } from '@@vap-svc/constants';
+import {
+  FIELD_NAMES,
+  USA,
+  ADDRESS_PROPS,
+} from 'platform/user/profile/vap-svc/constants';
 
 import { selectVAPContactInfoField, selectEditedFormField } from '../selectors';
 

--- a/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 
-import recordEvent from '~/platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 import * as VAP_SERVICE from '../constants';
 
@@ -273,8 +273,7 @@ export const mapStateToProps = (state, ownProps) => {
   );
   const data = selectVAPContactInfoField(state, fieldName);
   const isEmpty = !data;
-  const addressValidationType =
-    state.vapService.addressValidation.addressValidationType;
+  const { addressValidationType } = state.vapService.addressValidation;
   const showValidationModal =
     ownProps.ValidationModal &&
     addressValidationType === fieldName &&

--- a/src/platform/user/profile/vap-svc/reducers/index.js
+++ b/src/platform/user/profile/vap-svc/reducers/index.js
@@ -1,8 +1,8 @@
-import * as VAP_SERVICE from '@@vap-svc/constants';
+import * as VAP_SERVICE from 'platform/user/profile/vap-svc/constants';
 
 import { isEmpty, isEqual, pickBy } from 'lodash';
 
-import { COPY_ADDRESS_MODAL_STATUS } from '@@vap-svc/constants';
+import { COPY_ADDRESS_MODAL_STATUS } from 'platform/user/profile/vap-svc/constants';
 
 import { isFailedTransaction } from '../util/transactions';
 

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -1,8 +1,8 @@
-import backendServices from '~/platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 import {
   selectAvailableServices,
   selectVAPContactInfo,
-} from '~/platform/user/selectors';
+} from 'platform/user/selectors';
 
 import {
   VAP_SERVICE_INITIALIZATION_STATUS,

--- a/src/platform/user/profile/vap-svc/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/ContactInformationField.unit.spec.jsx
@@ -6,8 +6,8 @@ import sinon from 'sinon';
 import {
   ProfileInformationFieldController,
   mapStateToProps,
-} from '@@vap-svc/components/ProfileInformationFieldController';
-import { FIELD_NAMES } from '@@vap-svc/constants';
+} from 'platform/user/profile/vap-svc/components/ProfileInformationFieldController';
+import { FIELD_NAMES } from 'platform/user/profile/vap-svc/constants';
 
 describe('<ProfileInformationFieldController/>', () => {
   let props = null;

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModal.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModal.unit.spec.jsx
@@ -3,7 +3,7 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 import VAPServiceEditModal from '../../components/base/VAPServiceEditModal';
 

--- a/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import enzyme from 'enzyme';
 import { expect } from 'chai';
 
-import CopyMailingAddress from '@@vap-svc/containers/CopyMailingAddress';
+import CopyMailingAddress from 'platform/user/profile/vap-svc/containers/CopyMailingAddress';
 
 describe('<CopyMailingAddress/>', () => {
   describe('the checkbox', () => {

--- a/src/platform/user/profile/vap-svc/tests/helpers/addressValidationMessages.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/helpers/addressValidationMessages.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import {
   getValidationMessageKey,
   showAddressValidationModal,
-} from '@@vap-svc/util';
+} from 'platform/user/profile/vap-svc/util';
 
 describe('getValidationMessageKey', () => {
   it('returns showSuggestionsOverride key', () => {

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import backendServices from '~/platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
-import { wait } from '@@profile/tests/unit-test-helpers';
+import { wait } from 'applications/personalization/profile/tests/unit-test-helpers';
 
 import {
   TRANSACTION_STATUS,

--- a/src/platform/user/profile/vap-svc/tests/util/transactions.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/util/transactions.unit.spec.js
@@ -4,7 +4,7 @@ import {
   isFailedTransaction,
   isPendingTransaction,
   isSuccessfulTransaction,
-} from '@@vap-svc/util/transactions';
+} from 'platform/user/profile/vap-svc/util/transactions';
 
 describe('isPendingTransaction', () => {
   it('returns `false` if passed nothing', () => {

--- a/src/platform/user/profile/vap-svc/util/id-factory.js
+++ b/src/platform/user/profile/vap-svc/util/id-factory.js
@@ -1,6 +1,6 @@
 import { kebabCase } from 'lodash';
 
-import * as VAP_SERVICE from '@@vap-svc/constants';
+import * as VAP_SERVICE from 'platform/user/profile/vap-svc/constants';
 
 export const getEditButtonId = fieldName => {
   return `edit-${kebabCase(VAP_SERVICE.FIELD_TITLES[fieldName])}`;

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.js
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { mapRawUserDataToState } from '~/platform/user/profile/utilities';
-import { VA_FORM_IDS } from '~/platform/forms/constants';
-import { CSP_IDS } from '~/platform/user/authentication/constants';
+import { mapRawUserDataToState } from 'platform/user/profile/utilities';
+import { VA_FORM_IDS } from 'platform/forms/constants';
+import { CSP_IDS } from 'platform/user/authentication/constants';
 
 /* eslint-disable camelcase */
 function createDefaultData() {


### PR DESCRIPTION
## Description
This PR updates paths that use babel aliases for imports in yarn workspaces. These paths are not resolved by eslint and so are made relative to `src` instead.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
