### PR TITLE
Updated external link to not detect based on resolvedLanguage.

### DIFF
--- a/src/applications/check-in/components/ExternalLink.jsx
+++ b/src/applications/check-in/components/ExternalLink.jsx
@@ -7,7 +7,7 @@ function ExternalLink({ children, href, hrefLang }) {
   return (
     <a {...{ href, hrefLang }}>
       {children}
-      {hrefLang !== i18n?.resolvedLanguage ? (
+      {!i18n?.language.startsWith(hrefLang) ? (
         <> ({t(`in-${hrefLang}`)})</>
       ) : null}
     </a>


### PR DESCRIPTION
## Description
resolvedLanguage has been un-reliable during browser detection. Switched external link to use language property instead and check with a statsWith.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43993