### PR TITLE
43971 - CDP - [Markup and meta data] HTML markup isn't valid. (09.01.1) - Staging Review Launch Blocker

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -29,21 +29,13 @@ const DebtSummaryCard = ({ debt }) => {
       <h4 className="vads-u-margin-y--2 vads-u-font-weight--normal">
         {debtCardHeading}
       </h4>
-      <span
-        hidden
-        id={`${debt.fileNumber +
-          debt.deductionCode}-debt-summary-card-link-description`}
-      >
-        Check details and resolve this {debtCardHeading}
-      </span>
       {debtCardSubHeading}
       <div className="vads-u-margin-right--5 vads-u-margin-top--2 vads-u-font-weight--bold">
         <Link
           data-testid="debt-details-button"
           onClick={() => setActiveDebt(debt)}
           to={`/debt-balances/details/${debt.fileNumber + debt.deductionCode}`}
-          aria-describedby={`${debt.fileNumber +
-            debt.deductionCode}-debt-summary-card-link-description`}
+          aria-label={`Check details and resolve this ${debtCardHeading}`}
         >
           Check details and resolve this debt
           <i


### PR DESCRIPTION
## Description
Per platform review switching to usage of Label for proper screenreader experience. Using description would have been obtrusive and confusing to users.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43971

## Screenshots
![image](https://user-images.githubusercontent.com/29178824/178011993-a860e96c-a539-49c3-863f-a5560d0c4db5.png)

## Acceptance criteria
- [ X ] Aria described by replaced with label, extra character already removed in previous PR

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
