### PR TITLE
43973 - CDP - Markup and meta data] HTML markup isn't valid. (09.01.2) - Staging Review Launch Blocker

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
@@ -83,15 +83,11 @@ const BalanceCard = ({ id, amount, facility, city, date }) => {
           <PastDueContent id={id} date={date} amount={amount} />
         )}
       </div>
-      <span hidden id={`${id}-balance-card-link-description`}>
-        Check details and resolve this debt for ${facility}
-      </span>
       <Link
         className="vads-u-font-size--sm vads-u-font-weight--bold"
         to={`/copay-balances/${id}/detail`}
         data-testid={`detail-link-${id}`}
-        aria-label={linkText}
-        aria-describedby={`${id}-balance-card-link-description`}
+        aria-label={`Check details and resolve this debt for ${facility}`}
       >
         {linkText}
         <i


### PR DESCRIPTION
## Description
Replaced Aria described and hidden span with label per platform review. Used NVDA to confirm that it did not read aloud in an obtrusive manner and was able to see the label successfully in the html.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43973

## Screenshots
![image](https://user-images.githubusercontent.com/29178824/178039144-57d6c4a5-d66e-4fe1-b5b5-a37cdd8bbe2a.png)

## Acceptance criteria
- [ X ] Remove aria described by for label for proper behavior

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
