### PR TITLE
[CDP] Updating setfocus for each page

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -1,9 +1,8 @@
 import React, { useEffect } from 'react';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { useSelector } from 'react-redux';
 import Balances from '../components/Balances';
 import ComboAlerts from '../components/ComboAlerts';
-import { ALERT_TYPES } from '../utils/helpers';
+import { ALERT_TYPES, setPageFocus } from '../utils/helpers';
 import {
   calculateTotalDebts,
   calculateTotalBills,
@@ -13,7 +12,7 @@ const OverviewPage = () => {
   const title = 'Your VA debt and bills';
 
   useEffect(() => {
-    scrollToTop();
+    setPageFocus('h1');
   }, []);
 
   const { debtLetters, mcp } = useSelector(

--- a/src/applications/combined-debt-portal/combined/utils/helpers.js
+++ b/src/applications/combined-debt-portal/combined/utils/helpers.js
@@ -111,20 +111,13 @@ export const transform = data => {
   });
 };
 
-export const setFocus = selector => {
-  const el =
-    typeof selector === 'string' ? document.querySelector(selector) : selector;
+export const setPageFocus = selector => {
+  const el = document.querySelector(selector);
   if (el) {
     el.setAttribute('tabIndex', -1);
     el.focus();
-  }
-};
-
-export const setPageFocus = (selector = '.va-nav-breadcrumbs') => {
-  const el = document.querySelector(selector);
-  if (el) {
-    setFocus(el);
   } else {
-    setFocus('#main h1');
+    document.querySelector('#main h1').setAttribute('tabIndex', -1);
+    document.querySelector('#main h1').focus();
   }
 };

--- a/src/applications/combined-debt-portal/combined/utils/helpers.js
+++ b/src/applications/combined-debt-portal/combined/utils/helpers.js
@@ -110,3 +110,21 @@ export const transform = data => {
     };
   });
 };
+
+export const setFocus = selector => {
+  const el =
+    typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (el) {
+    el.setAttribute('tabIndex', -1);
+    el.focus();
+  }
+};
+
+export const setPageFocus = (selector = '.va-nav-breadcrumbs') => {
+  const el = document.querySelector(selector);
+  if (el) {
+    setFocus(el);
+  } else {
+    setFocus('#main h1');
+  }
+};

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
@@ -3,13 +3,13 @@ import { Link, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import moment from 'moment';
 import last from 'lodash/last';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from '../components/HowDoIPay';
 import NeedHelp from '../components/NeedHelp';
 import OnThisPageLinks from '../components/OnThisPageLinks';
 import '../sass/debt-letters.scss';
 import HistoryTable from '../components/HistoryTable';
-import { setPageFocus, getCurrentDebt } from '../utils/page';
+import { getCurrentDebt } from '../utils/page';
+import { setPageFocus } from '../../combined/utils/helpers';
 import {
   deductionCodes,
   renderWhyMightIHaveThisDebt,
@@ -38,7 +38,6 @@ const DebtDetails = () => {
   };
 
   useEffect(() => {
-    scrollToTop();
     setPageFocus('h1');
   }, []);
 

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { setPageFocus } from '../utils/page';
+import { setPageFocus } from '../../combined/utils/helpers';
 import DebtLettersTable from '../components/DebtLettersTable';
 import { DownloadLettersAlert } from '../components/Alerts';
 
@@ -14,7 +13,6 @@ const DebtLettersDownload = () => {
   const showError = isError || isVBMSError;
 
   useEffect(() => {
-    scrollToTop();
     setPageFocus('h1');
   });
 

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -1,7 +1,11 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import {
+  setPageFocus,
+  ALERT_TYPES,
+  APP_TYPES,
+} from '../../combined/utils/helpers';
 import HowDoIPay from '../components/HowDoIPay';
 import NeedHelp from '../components/NeedHelp';
 import DebtCardsList from '../components/DebtCardsList';
@@ -10,7 +14,6 @@ import '../sass/debt-letters.scss';
 // TODO: OtherVA Update
 import OtherVADebts from '../../combined/components/OtherVADebts';
 import alertMessage from '../../combined/utils/alert-messages';
-import { ALERT_TYPES, APP_TYPES } from '../../combined/utils/helpers';
 
 const renderAlert = (alertType, statements) => {
   const alertInfo = alertMessage(alertType, APP_TYPES.DEBT);
@@ -69,7 +72,7 @@ const DebtLettersSummary = () => {
   const { statements: mcpStatements, error: mcpError } = mcp;
 
   useEffect(() => {
-    scrollToTop();
+    setPageFocus('h1');
   }, []);
 
   if (isDebtPending || isPendingVBMS || isProfileUpdating) {

--- a/src/applications/combined-debt-portal/debt-letters/utils/page.js
+++ b/src/applications/combined-debt-portal/debt-letters/utils/page.js
@@ -1,21 +1,3 @@
-export const setFocus = selector => {
-  const el =
-    typeof selector === 'string' ? document.querySelector(selector) : selector;
-  if (el) {
-    el.setAttribute('tabIndex', -1);
-    el.focus();
-  }
-};
-
-export const setPageFocus = (selector = '.va-nav-breadcrumbs') => {
-  const el = document.querySelector(selector);
-  if (el) {
-    setFocus(el);
-  } else {
-    setFocus('#main h1');
-  }
-};
-
 export const currency = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',

--- a/src/applications/combined-debt-portal/medical-copays/containers/DetailPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/DetailPage.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import PropTypes from 'prop-types';
 import HTMLStatementList from '../components/HTMLStatementList';
 import BalanceQuestions from '../components/BalanceQuestions';
@@ -10,7 +9,11 @@ import FinancialHelp from '../components/FinancialHelp';
 import Modals from '../components/Modals';
 import Alert from '../../combined/components/MCPAlerts';
 import { OnThisPageDetails } from '../components/OnThisPageDetails';
-import { formatDate, verifyCurrentBalance } from '../../combined/utils/helpers';
+import {
+  formatDate,
+  verifyCurrentBalance,
+  setPageFocus,
+} from '../../combined/utils/helpers';
 import '../sass/medical-copays.scss';
 
 const DetailPage = ({ match }) => {
@@ -26,12 +29,15 @@ const DetailPage = ({ match }) => {
     ? selectedCopay?.pHAccountNumber.toString()
     : selectedCopay?.pHCernerAccountNumber.toString();
 
+  useEffect(() => {
+    setPageFocus('h1');
+  }, []);
+
   useEffect(
     () => {
       if (!isCurrentBalance) {
         setAlert('past-due-balance');
       }
-      scrollToTop();
     },
     [isCurrentBalance],
   );

--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { setPageFocus } from '../../combined/utils/helpers';
 import Modals from '../components/Modals';
 import StatementAddresses from '../components/StatementAddresses';
 import AccountSummary from '../components/AccountSummary';
@@ -27,7 +27,7 @@ const HTMLStatementPage = ({ match }) => {
     : `${userFullName.first} ${userFullName.last}`;
 
   useEffect(() => {
-    scrollToTop();
+    setPageFocus();
   }, []);
 
   return (

--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -27,7 +27,7 @@ const HTMLStatementPage = ({ match }) => {
     : `${userFullName.first} ${userFullName.last}`;
 
   useEffect(() => {
-    setPageFocus();
+    setPageFocus('h1');
   }, []);
 
   return (

--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -1,14 +1,14 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { uniqBy } from 'lodash';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import Balances from '../components/Balances';
-import BalanceQuestions from '../components/BalanceQuestions';
 import {
+  setPageFocus,
   sortStatementsByDate,
   ALERT_TYPES,
   APP_TYPES,
 } from '../../combined/utils/helpers';
+import Balances from '../components/Balances';
+import BalanceQuestions from '../components/BalanceQuestions';
 import OtherVADebts from '../../combined/components/OtherVADebts';
 import alertMessage from '../../combined/utils/alert-messages';
 import DisputeCharges from '../components/DisputeCharges';
@@ -79,7 +79,7 @@ const OverviewPage = () => {
   const title = 'Current copay balances';
 
   useEffect(() => {
-    scrollToTop();
+    setPageFocus('h1');
   }, []);
 
   if (debtLoading || mcpLoading) {


### PR DESCRIPTION
## Description
Moved focus setting helpers to combined utilities, and set focus for each page for accessibility functionality.  

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43972

## Testing done
Tested with VoiceOver Utility on Mac, and between page navigation focus is set on `h1` and announced by SR.

## Acceptance criteria
- [x] Navigation to CDP pages starts with focus on `h1` titles and announces them.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
