### PR TITLE
Adds script to delete node_modules folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "list-imports:plat": "node script/list-imports.js --app-dir platform",
     "migrate-component": "node script/component-migration/index.js",
     "mock-api": "node src/platform/testing/e2e/mockapi.js",
+    "modulesf:del": "./script/delete-modules-f.sh",
     "new:app": "yo @department-of-veterans-affairs/vets-website && npm run lint:js:untracked:fix",
     "pact:can-i-deploy": "node ./script/can-i-deploy.js",
     "pact:publish": "node ./script/publish-pacts.js",

--- a/script/delete-modules-f.sh
+++ b/script/delete-modules-f.sh
@@ -1,0 +1,25 @@
+# get  argument or default to "."
+d="${1-.}"
+
+#sanitize input: resolve to ".", "./src", or a path under "./src"
+if [ $d != "." ]; then 
+    if [ $d == "/" ]; then
+        d="./src"
+    else 
+        d=${d%/}
+        d=${d#/}
+        d="./src/$d"
+    fi
+fi
+# confirm
+echo "Delete folders named 'node_modules' in $d:" 
+find ${d} -name "node_modules" -type d -prune
+read -p "Are you sure you want to delete the directories listed above (Y/N)? "
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    # do delete
+    find ${d} -name "node_modules" -type d -prune -exec rm -rf "{}" +
+    echo "Deletion complete."
+else
+    echo "Action Canceled."
+fi
+


### PR DESCRIPTION
## Description
Adds a bash script command to delete node_module folder(s). This is meant to assist in Yarn Workspaces developemnt. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44078

## Testing done
[x] Script gives warning before delete process occurs
[x] Only deletes directories named 'node_modules'
[x] Only deletes target in the root directory of the  script, or under.

## Screenshots

## Acceptance criteria

## Definition of done
- [ ] Documentation has been updated, if applicable

