### PR TITLE
[CDP] MCP Fixing download statement focus highlighting when selected

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
@@ -29,33 +29,27 @@ const DownloadStatement = ({ statementId, statementDate, fullName }) => {
     <article className="vads-u-padding--0">
       <div className="vads-u-margin-top--2">
         <a
+          className="vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--flex-start"
           onClick={() => handleDownloadClick(statementDate)}
           download={downloadFileName}
           href={pdfStatementUri}
           type="application/pdf"
           rel="noreferrer"
         >
-          <span
+          <i
             aria-hidden="true"
-            className="vads-u-display--flex vads-u-align-items--flex-start"
-          >
-            <i
-              className="fas fa-download vads-u-margin-top--0p5 vads-u-padding-right--1"
-              role="img"
-            />
-            <p className="vads-u-margin-y--0">
-              Download your {formattedStatementDate} statement{' '}
-              <dfn>
-                <abbr title="Portable Document Format">(PDF)</abbr>
-              </dfn>
-            </p>
+            className="fas fa-download vads-u-margin-top--0p5 vads-u-padding-right--1"
+            role="img"
+          />
+          <span aria-hidden="true">
+            Download your {formattedStatementDate} statement{' '}
           </span>
           <span className="sr-only">
             Download {formattedStatementDate} dated medical copay statement{' '}
-            <dfn>
-              <abbr title="Portable Document Format">(PDF)</abbr>
-            </dfn>
           </span>
+          <dfn>
+            <abbr title="Portable Document Format">(PDF)</abbr>
+          </dfn>
         </a>
       </div>
     </article>


### PR DESCRIPTION
## Description
Download statements link wasn't highlighting when selected. Removed flexbox styling an p tag around text and highlighting is now working appropriately. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43975

## Screenshots
![image](https://user-images.githubusercontent.com/25368370/178339531-0019413e-2ce0-4fc9-9cf6-3a85b99aae98.png)


## Acceptance criteria
- [x] download debt letter link highlights when focused on

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
