### PR TITLE
Switched from DS component to get label to compliy with standards.

### DIFF
--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -47,6 +47,7 @@ const Footer = ({ header, message }) => {
           </p>
           <p>
             {t('if-you-have-hearing-loss-call')}{' '}
+            {/* Not using the va-telephone component due to issues with 711 link. To re-evaluate after component is fixed. */}
             <a href="tel:711" aria-label="TTY. 7 1 1.">
               {t('tty-711')}
             </a>

--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -47,7 +47,9 @@ const Footer = ({ header, message }) => {
           </p>
           <p>
             {t('if-you-have-hearing-loss-call')}{' '}
-            <va-telephone contact="711">{t('tty-711')}</va-telephone>.
+            <a href="tel:711" aria-label="TTY. 7 1 1.">
+              {t('tty-711')}
+            </a>
           </p>
         </>
       ) : (


### PR DESCRIPTION
## Description
Switched to using an <a> instead of the DS telephone component to get the aria-label to comply with the standards for 711 links. Also logged support request to have it fixed in DS: https://dsva.slack.com/archives/CBU0KDSB1/p1657574631117129

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43522
