### PR TITLE
Supplemental Claims | Add contact information pages

### DIFF
--- a/src/applications/appeals/995/components/ContactInformation.jsx
+++ b/src/applications/appeals/995/components/ContactInformation.jsx
@@ -9,22 +9,16 @@ import { selectProfile } from 'platform/user/selectors';
 
 import { readableList } from '../utils/helpers';
 
-export const ContactInfoDescription = ({
-  formContext,
-  profile,
-  /* homeless, */
-}) => {
+export const ContactInfoDescription = ({ formContext, profile }) => {
   const [hadError, setHadError] = useState(false);
   const { email = {}, mobilePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
   const { submitted } = formContext || {};
 
-  // Don't require an address if the Veteran is homeless
-  const requireAddress = 'address'; // homeless ? '' : 'address';
   const missingInfo = [
     email?.emailAddress ? '' : 'email',
     mobilePhone?.phoneNumber ? '' : 'phone',
-    mailingAddress?.addressLine1 ? '' : requireAddress,
+    mailingAddress?.addressLine1 ? '' : 'address',
   ].filter(Boolean);
 
   const list = readableList(missingInfo);
@@ -164,11 +158,9 @@ ContactInfoDescription.propTypes = {
   formContext: PropTypes.shape({
     submitted: PropTypes.bool,
   }),
-  // homeless: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
-  // homeless: state.form.data.homeless,
   profile: selectProfile(state),
 });
 

--- a/src/applications/appeals/995/components/ContactInformation.jsx
+++ b/src/applications/appeals/995/components/ContactInformation.jsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+
+import AddressView from '@@vap-svc/components/AddressField/AddressView';
+
+import { selectProfile } from 'platform/user/selectors';
+
+import { readableList } from '../utils/helpers';
+
+export const ContactInfoDescription = ({
+  formContext,
+  profile,
+  /* homeless, */
+}) => {
+  const [hadError, setHadError] = useState(false);
+  const { email = {}, mobilePhone = {}, mailingAddress = {} } =
+    profile?.vapContactInfo || {};
+  const { submitted } = formContext || {};
+
+  // Don't require an address if the Veteran is homeless
+  const requireAddress = 'address'; // homeless ? '' : 'address';
+  const missingInfo = [
+    email?.emailAddress ? '' : 'email',
+    mobilePhone?.phoneNumber ? '' : 'phone',
+    mailingAddress?.addressLine1 ? '' : requireAddress,
+  ].filter(Boolean);
+
+  const list = readableList(missingInfo);
+  const plural = missingInfo.length > 1;
+  const phoneNumber = `${mobilePhone?.areaCode ||
+    ''}${mobilePhone?.phoneNumber || ''}`;
+  const phoneExt = mobilePhone?.extension;
+
+  const handler = {
+    onSubmit: event => {
+      // This prevents this nested form submit event from passing to the
+      // outer form and causing a page advance
+      event.stopPropagation();
+    },
+  };
+
+  useEffect(
+    () => {
+      if (missingInfo.length) {
+        // page had an error flag, so we know when to show a success alert
+        setHadError(true);
+      }
+    },
+    [missingInfo],
+  );
+
+  // loop to separate pages when editing
+  const contactSection = (
+    <>
+      <h4 className="vads-u-font-size--h3">Mobile phone number</h4>
+      <va-telephone contact={phoneNumber} extension={phoneExt} not-clickable />
+      <p>
+        <Link to="/edit-mobile-phone" aria-label="Edit mobile phone number">
+          Edit
+        </Link>
+      </p>
+      <h4 className="vads-u-font-size--h3">Email address</h4>
+      <span>{email?.emailAddress || ''}</span>
+      <p>
+        <Link to="/edit-email-address" aria-label="Edit email address">
+          Edit
+        </Link>
+      </p>
+      <h4 className="vads-u-font-size--h3">Mailing address</h4>
+      <AddressView data={mailingAddress} />
+      <p>
+        <Link to="/edit-mailing-address" aria-label="Edit mailing address">
+          Edit
+        </Link>
+      </p>
+    </>
+  );
+
+  return (
+    <>
+      <h3 className="vads-u-margin-top--0">Contact Information</h3>
+      <p>
+        This is the contact information we have on file for you. We’ll send any
+        updates or information about your Supplemental Claim to this address.
+      </p>
+      <p>
+        <strong>Note:</strong> Any updates you make here will be reflected in
+        your VA.gov profile.
+      </p>
+      {hadError &&
+        missingInfo.length === 0 && (
+          <div className="vads-u-margin-top--1p5">
+            <va-alert status="success" background-only>
+              <div className="vads-u-font-size--base">
+                The missing information has been added to your application. You
+                may continue.
+              </div>
+            </va-alert>
+          </div>
+        )}
+      {missingInfo.length > 0 && (
+        <>
+          <p className="vads-u-margin-top--1p5">
+            <strong>Note:</strong>
+            {missingInfo[0].startsWith('p') ? ' A ' : ' An '}
+            {list} {plural ? 'are' : 'is'} required for this application.
+          </p>
+          {submitted && (
+            <div className="vads-u-margin-top--1p5" role="alert">
+              <va-alert status="error" background-only>
+                <div className="vads-u-font-size--base">
+                  We still don’t have your {list}. Please edit and update the
+                  field.
+                </div>
+              </va-alert>
+            </div>
+          )}
+          <div className="vads-u-margin-top--1p5" role="alert">
+            <va-alert status="warning" background-only>
+              <div className="vads-u-font-size--base">
+                Your {list} {plural ? 'are' : 'is'} missing. Please edit and
+                update the {plural ? 'fields' : 'field'}.
+              </div>
+            </va-alert>
+          </div>
+        </>
+      )}
+      <div className="blue-bar-block vads-u-margin-top--4">
+        <div className="va-profile-wrapper" onSubmit={handler.onSubmit}>
+          {contactSection}
+        </div>
+      </div>
+    </>
+  );
+};
+
+ContactInfoDescription.propTypes = {
+  profile: PropTypes.shape({
+    vapContactInfo: PropTypes.shape({
+      email: PropTypes.shape({
+        emailAddress: PropTypes.string,
+      }),
+      mobilePhone: PropTypes.shape({
+        countryCode: PropTypes.string,
+        areaCode: PropTypes.string,
+        phoneNumber: PropTypes.string,
+        extension: PropTypes.string,
+      }),
+      address: PropTypes.shape({
+        addressLine1: PropTypes.string,
+        addressLine2: PropTypes.string,
+        addressLine3: PropTypes.string,
+        city: PropTypes.string,
+        province: PropTypes.string,
+        stateCode: PropTypes.string,
+        countryCodeIso3: PropTypes.string,
+        zipCode: PropTypes.string,
+        internationalPostalCode: PropTypes.string,
+      }),
+    }),
+  }).isRequired,
+  formContext: PropTypes.shape({
+    submitted: PropTypes.bool,
+  }),
+  // homeless: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  // homeless: state.form.data.homeless,
+  profile: selectProfile(state),
+});
+
+export default connect(mapStateToProps)(ContactInfoDescription);

--- a/src/applications/appeals/995/components/EditContactInfo.jsx
+++ b/src/applications/appeals/995/components/EditContactInfo.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
+import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
+import { FIELD_NAMES } from '@@vap-svc/constants';
+
+const buildPage = ({ title, field, goToPath }) => {
+  const handlers = {
+    onSubmit: event => {
+      // This prevents this nested form submit event from passing to the
+      // outer form and causing a page advance
+      event.stopPropagation();
+    },
+    cancel: () => {
+      goToPath('/contact-information');
+    },
+    success: () => {
+      goToPath('/contact-information');
+    },
+  };
+
+  return (
+    <div className="va-profile-wrapper" onSubmit={handlers.onSubmit}>
+      <InitializeVAPServiceID>
+        <h3>{title}</h3>
+        <ProfileInformationFieldController
+          forceEditView
+          fieldName={FIELD_NAMES[field]}
+          isDeleteDisabled
+          cancelCallback={handlers.cancel}
+          successCallback={handlers.success}
+        />
+      </InitializeVAPServiceID>
+    </div>
+  );
+};
+
+export const EditPhone = ({ title, goToPath }) =>
+  buildPage({ title, goToPath, field: 'MOBILE_PHONE' });
+
+export const EditEmail = ({ title, goToPath }) =>
+  buildPage({ title, goToPath, field: 'EMAIL' });
+
+export const EditAddress = ({ title, goToPath }) =>
+  buildPage({ title, goToPath, field: 'MAILING_ADDRESS' });

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -1,9 +1,13 @@
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
+import preSubmitInfo from 'platform/forms/preSubmitInfo';
+import FormFooter from 'platform/forms/components/FormFooter';
+
 import migrations from '../migrations';
 
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import GetFormHelp from '../content/GetFormHelp';
 
 import addIssue from '../pages/addIssue';
 import benefitType from '../pages/benefitType';
@@ -61,7 +65,9 @@ const formConfig = {
       'Please sign in again to continue your application for VA Form 20-0995 (Supplemental Claim).',
   },
   title: 'Request a Supplemental Claim',
+  subTitle: 'VA Form 20-0995 (Supplemental Claim)',
   defaultDefinitions: {},
+  preSubmitInfo,
   chapters: {
     infoPages: {
       title: 'Veteran Details',
@@ -218,6 +224,8 @@ const formConfig = {
       },
     },
   },
+  footerContent: FormFooter,
+  getHelp: GetFormHelp,
 };
 
 export default formConfig;

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -8,13 +8,18 @@ import migrations from '../migrations';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../content/GetFormHelp';
+import {
+  EditPhone,
+  EditEmail,
+  EditAddress,
+} from '../components/EditContactInfo';
 
 import addIssue from '../pages/addIssue';
 import benefitType from '../pages/benefitType';
 import certifcationAndSignature from '../pages/certifcationAndSignature';
-import claimantName from '../pages/claimantName';
-import claimantType from '../pages/claimantType';
-import contactInfo from '../pages/contactInfo';
+// import claimantName from '../pages/claimantName';
+// import claimantType from '../pages/claimantType';
+import contactInfo from '../pages/contactInformation';
 import contestableIssues from '../pages/contestableIssues';
 import evidencePrivateAdd from '../pages/evidencePrivateAdd';
 import evidencePrivateRecords from '../pages/evidencePrivateRecords';
@@ -84,24 +89,51 @@ const formConfig = {
           uiSchema: veteranInfo.uiSchema,
           schema: veteranInfo.schema,
         },
-        claimantType: {
-          title: 'Claimant Type',
-          path: 'claimant-type',
-          uiSchema: claimantType.uiSchema,
-          schema: claimantType.schema,
-        },
-        claimantName: {
-          title: 'Claimant Name',
-          path: 'claimant-name',
-          uiSchema: claimantName.uiSchema,
-          schema: claimantName.schema,
-          depends: formData => formData.claimantType !== 'veteran',
-        },
-        contactInfo: {
-          title: 'Contact Information',
+        // claimantType: {
+        //   title: 'Claimant Type',
+        //   path: 'claimant-type',
+        //   uiSchema: claimantType.uiSchema,
+        //   schema: claimantType.schema,
+        // },
+        // claimantName: {
+        //   title: 'Claimant Name',
+        //   path: 'claimant-name',
+        //   uiSchema: claimantName.uiSchema,
+        //   schema: claimantName.schema,
+        //   depends: formData => formData.claimantType !== 'veteran',
+        // },
+        confirmContactInformation: {
+          title: 'Contact information',
           path: 'contact-information',
           uiSchema: contactInfo.uiSchema,
           schema: contactInfo.schema,
+        },
+        editMobilePhone: {
+          title: 'Edit mobile phone',
+          path: 'edit-mobile-phone',
+          CustomPage: EditPhone,
+          CustomPageReview: EditPhone,
+          depends: () => false, // accessed from contact info page
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+        },
+        editEmailAddress: {
+          title: 'Edit email address',
+          path: 'edit-email-address',
+          CustomPage: EditEmail,
+          CustomPageReview: EditEmail,
+          depends: () => false, // accessed from contact info page
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+        },
+        editMailingAddress: {
+          title: 'Edit mailing address',
+          path: 'edit-mailing-address',
+          CustomPage: EditAddress,
+          CustomPageReview: EditAddress,
+          depends: () => false, // accessed from contact info page
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
         },
       },
     },

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -1,12 +1,100 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import { selectProfile, isLoggedIn } from 'platform/user/selectors';
+
+import { setData } from 'platform/forms-system/src/js/actions';
+
 import formConfig from '../config/form';
 
-export default function App({ location, children }) {
-  return (
+export const Form0995App = ({
+  loggedIn,
+  location,
+  children,
+  profile,
+  formData,
+  setFormData,
+}) => {
+  const { email = {}, mobilePhone = {}, mailingAddress = {} } =
+    profile?.vapContactInfo || {};
+
+  useEffect(
+    () => {
+      if (loggedIn) {
+        const { veteran = {} } = formData || {};
+        if (
+          email?.emailAddress !== veteran.email ||
+          mobilePhone?.updatedAt !== veteran.phone?.updatedAt ||
+          mailingAddress?.updatedAt !== veteran.address?.updatedAt
+        ) {
+          setFormData({
+            ...formData,
+            veteran: {
+              ...veteran,
+              address: mailingAddress,
+              phone: mobilePhone,
+              email: email?.emailAddress,
+            },
+          });
+        }
+      }
+    },
+    [loggedIn, email, mobilePhone, mailingAddress, formData, setFormData],
+  );
+
+  const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
-}
+  return (
+    <article id="form-0995" data-location={`${location?.pathname?.slice(1)}`}>
+      {content}
+    </article>
+  );
+};
+
+Form0995App.propTypes = {
+  getContestableIssues: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  children: PropTypes.any,
+  contestableIssues: PropTypes.shape({}),
+  formData: PropTypes.shape({
+    additionalIssues: PropTypes.array,
+    areaOfDisagreement: PropTypes.array,
+    benefitType: PropTypes.string,
+    contestedIssues: PropTypes.array,
+    legacyCount: PropTypes.number,
+    informalConferenceRep: PropTypes.shape({}),
+  }),
+  legacyCount: PropTypes.number,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+  loggedIn: PropTypes.bool,
+  profile: PropTypes.shape({
+    vapContactInfo: PropTypes.shape({}),
+  }),
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+  savedForms: PropTypes.array,
+};
+
+const mapStateToProps = state => ({
+  loggedIn: isLoggedIn(state),
+  formData: state.form?.data || {},
+  profile: selectProfile(state) || {},
+  savedForms: state.user?.profile?.savedForms || [],
+});
+
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Form0995App);

--- a/src/applications/appeals/995/content/GetFormHelp.jsx
+++ b/src/applications/appeals/995/content/GetFormHelp.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
+
+const GetFormHelp = () => (
+  <>
+    <p className="help-talk">
+      If you have questions or need help filling out this form, please call our{' '}
+      {srSubstitute('MYVA411', 'My V. A. 4 1 1.')} main information line at{' '}
+      <va-telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
+      {srSubstitute('24/7', '24 hours a day, 7 days a week')}.
+    </p>
+    <p className="u-vads-margin-bottom--0">
+      If you have hearing loss, call TTY:{' '}
+      <va-telephone contact={CONTACTS['711']} />.
+    </p>
+  </>
+);
+
+export default GetFormHelp;

--- a/src/applications/appeals/995/content/contestableIssues.jsx
+++ b/src/applications/appeals/995/content/contestableIssues.jsx
@@ -60,7 +60,7 @@ export const MaxSelectionsAlert = ({ closeModal }) => (
     visible
   >
     You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each
-    Higher-Level Review request. If you would like to select more than{' '}
+    Supplemental Claims request. If you would like to select more than{' '}
     {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
     for the remaining issues.
   </VaModal>

--- a/src/applications/appeals/995/pages/contactInfo.js
+++ b/src/applications/appeals/995/pages/contactInfo.js
@@ -1,8 +1,0 @@
-export default {
-  uiSchema: {},
-
-  schema: {
-    type: 'object',
-    properties: {},
-  },
-};

--- a/src/applications/appeals/995/pages/contactInformation.js
+++ b/src/applications/appeals/995/pages/contactInformation.js
@@ -1,0 +1,22 @@
+import ContactInfoDescription from '../components/ContactInformation';
+import { contactInfoValidation } from '../validations';
+
+const contactInfo = {
+  uiSchema: {
+    'ui:title': ' ',
+    'ui:description': ContactInfoDescription,
+    'ui:required': () => true,
+    'ui:validations': [contactInfoValidation],
+    'ui:options': {
+      hideOnReview: true,
+      forceDivWrapper: true,
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+export default contactInfo;

--- a/src/applications/appeals/995/reducers/index.js
+++ b/src/applications/appeals/995/reducers/index.js
@@ -1,6 +1,10 @@
+import vapService from '@@vap-svc/reducers';
+
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+
 import formConfig from '../config/form';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),
+  vapService,
 };

--- a/src/applications/appeals/995/sass/995-supplemental-claim.scss
+++ b/src/applications/appeals/995/sass/995-supplemental-claim.scss
@@ -5,3 +5,27 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+
+.schemaform-intro {
+  padding: 0 0 2rem 0;
+
+  .process-step:last-child {
+    padding-bottom: 0;
+  }
+
+  .omb-info--container {
+    margin-top: 1em;
+  }
+}
+
+/* Global */
+.nowrap {
+  white-space: nowrap;
+}
+
+/* add/update & cancel buttons on edit contact info page */
+@media screen and (min-width: 481px) {
+  .va-profile-wrapper button {
+    width: auto;
+  }
+}

--- a/src/applications/appeals/995/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/contactInformation.unit.spec.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+
+import { $, $$ } from '../../utils/ui';
+
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.infoPages.pages.confirmContactInformation;
+
+const mockStore = data => ({
+  getState: () => ({
+    form: {
+      data,
+    },
+    formContext: {
+      onReviewPage: false,
+      reviewMode: false,
+      touched: {},
+      submitted: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => ({
+    setFormData: () => {},
+  }),
+});
+
+describe('contact information page', () => {
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <div>
+        <Provider store={mockStore()}>
+          <DefinitionTester
+            definitions={formConfig.defaultDefinitions}
+            schema={schema}
+            uiSchema={uiSchema}
+            data={{}}
+            formData={{}}
+          />
+        </Provider>
+      </div>,
+    );
+
+    const formDOM = getFormDOM(form);
+    expect($('h3', formDOM).textContent).to.contain('Contact Information');
+    expect($$('a[aria-label^="Edit "]', formDOM).length).to.eq(3);
+  });
+});


### PR DESCRIPTION
Original Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/43588

URL of change: `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/contact-information`

## Background

We're building out the Supplemental Claim form for Veterans only (Claimant types to be supported in a future iteration). So the pattern used by the Higher-Level Review & Notice of Disagreement forms for displaying and editing profile contact information is being copied over.

## Steps to test

1. Pull in branch or use review instance
2. Log into user 233 (Cara) - an HLR user
3. Go to `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995`, and then navigate through the form to the `/contact-information` page
4. Editing the user may not work in a mocked data environment, so you may need to wait until this work is available in staging

## Code changes

Added contact information page along with 3 edit pages, for editing email, mobile phone and mailing address.

## How was your code tested

Locally & added unit test

## Screenshots

<details><summary>Contact info page</summary>

<!-- leave a blank line above -->
<img width="671" alt="Supplemental claim edit contact information page showing mobile number, email and mailing address" src="https://user-images.githubusercontent.com/136959/178511469-1d323ff4-740d-4bf5-bd0f-f5da3deaea71.png">
</details>

<details><summary>Edit address page</summary>

<!-- leave a blank line above -->
<img width="538" alt="Editing the mailing address page" src="https://user-images.githubusercontent.com/136959/178511467-51692c80-ba24-44f9-bc6a-efc27e971be8.png"></details>

## Acceptance criteria
- [x] Add Supplemental Claims contact information page
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
