### PR TITLE
added online event location

### DIFF
--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -128,6 +128,20 @@ export const Results = ({
                 </div>
 
                 {/* Where */}
+                {event?.fieldLocationType === 'online' && (
+                  <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
+                    <p className="vads-u-margin--0 vads-u-margin-right--0p5">
+                      <strong>Where:</strong>
+                    </p>
+
+                    <div className="vads-u-display--flex vads-u-flex-direction--column">
+                      <p className="vads-u-margin--0">
+                        This is an online event.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
                 {locations?.length > 0 && (
                   <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
                     <p className="vads-u-margin--0 vads-u-margin-right--0p5">


### PR DESCRIPTION
## Description
Location of "This is an online event" added to event location for online events
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9718

## Original issue(s)
department-of-veterans-affairs/va.gov-team#9718


## Testing done
Visual confirmation locally

## Screenshots
<img width="871" alt="Screen Shot 2022-07-12 at 10 52 11 AM" src="https://user-images.githubusercontent.com/61624970/178519777-6804aa9f-f905-4116-8beb-de7befef1572.png">


## Acceptance criteria
- [ ] "Where: This is an online event" displays on event listings for online events

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
