### PR TITLE
Supplemental Claims | Add Veteran Information page

### DIFF
--- a/src/applications/appeals/995/components/VeteranInformation.jsx
+++ b/src/applications/appeals/995/components/VeteranInformation.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+import { genderLabels } from 'platform/static-data/labels';
+import { selectProfile } from 'platform/user/selectors';
+
+import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
+
+// separate each number so the screenreader reads "number ending with 1 2 3 4"
+// instead of "number ending with 1,234"
+const mask = value => {
+  const number = (value || '').toString().slice(-4);
+  return srSubstitute(
+    `●●●–●●–${number}`,
+    `ending with ${number.split('').join(' ')}`,
+  );
+};
+
+const VeteranInformation = ({ profile = {}, veteran = {} }) => {
+  const { ssnLastFour, vaFileLastFour } = veteran;
+  const { dob, gender, userFullName = {} } = profile;
+
+  const { first, middle, last, suffix } = userFullName;
+  const momentDob = moment(dob || null); // called with undefined = today's date
+
+  return (
+    <>
+      <p>This is the personal information we have on file for you.</p>
+      <br />
+      <div className="blue-bar-block">
+        <strong className="name">
+          {`${first || ''} ${middle || ''} ${last || ''}`}
+          {suffix ? `, ${suffix}` : null}
+        </strong>
+        {ssnLastFour ? (
+          <p className="ssn">Social Security number: {mask(ssnLastFour)}</p>
+        ) : null}
+        {vaFileLastFour ? (
+          <p className="vafn">VA file number: {mask(vaFileLastFour)}</p>
+        ) : null}
+        <p>
+          Date of birth:{' '}
+          {momentDob.isValid() ? (
+            <span className="dob">{momentDob.format('LL')}</span>
+          ) : null}
+        </p>
+        <p>
+          Gender: <span className="gender">{genderLabels?.[gender] || ''}</span>
+        </p>
+      </div>
+      <br />
+      <p>
+        <strong>Note:</strong> If you need to update your personal information,
+        please call Veterans Benefits Assistance toll free at{' '}
+        <va-telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
+        8:00 a.m. to 9:00 p.m. ET.
+      </p>
+    </>
+  );
+};
+
+VeteranInformation.propTypes = {
+  profile: PropTypes.shape({
+    dob: PropTypes.string,
+    gender: PropTypes.string,
+    userFullName: PropTypes.shape({
+      first: PropTypes.string,
+      middle: PropTypes.string,
+      last: PropTypes.string,
+      suffix: PropTypes.string,
+    }),
+  }),
+  veteran: PropTypes.shape({
+    ssnLastFour: PropTypes.string,
+    vaFileLastFour: PropTypes.string,
+  }),
+};
+
+const mapStateToProps = state => {
+  const profile = selectProfile(state);
+  const veteran = state.form?.data.veteran;
+  return { profile, veteran };
+};
+
+export { VeteranInformation };
+
+export default connect(mapStateToProps)(VeteranInformation);

--- a/src/applications/appeals/995/pages/veteranInfo.js
+++ b/src/applications/appeals/995/pages/veteranInfo.js
@@ -1,8 +1,16 @@
-export default {
-  uiSchema: {},
+import VeteranInformation from '../components/VeteranInformation';
 
+const veteranInformation = {
+  uiSchema: {
+    'ui:description': VeteranInformation,
+    'ui:options': {
+      hideOnReview: true,
+    },
+  },
   schema: {
     type: 'object',
     properties: {},
   },
 };
+
+export default veteranInformation;

--- a/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import { $ } from '../../utils/ui';
+import { VeteranInformation } from '../../components/VeteranInformation';
+
+describe('<VeteranInformation>', () => {
+  it('should render with empty data', () => {
+    const { container } = render(<VeteranInformation />);
+    expect($('.blue-bar-block', container)).to.exist;
+  });
+
+  it('should render profile data', () => {
+    const data = {
+      profile: {
+        userFullName: {
+          first: 'uno',
+          middle: 'dos',
+          last: 'tres',
+        },
+        dob: '2000-01-05',
+        gender: 'F',
+      },
+      veteran: {
+        vaFileLastFour: '8765',
+        ssnLastFour: '5678',
+      },
+    };
+    const { container } = render(<VeteranInformation {...data} />);
+
+    expect($('.name', container).textContent).to.equal('uno dos tres');
+    expect($('.ssn', container).textContent).to.contain('5678');
+    expect($('.vafn', container).textContent).to.contain('8765');
+    expect($('.dob', container).textContent).to.contain('January 5, 2000');
+    expect($('.gender', container).textContent).to.contain('Female');
+  });
+});


### PR DESCRIPTION
Original Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/43580

URL of change: `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/veteran-information`

## Background

We're building out the Supplemental Claims form, and the Veteran information page is displaying the logged in Veteran's information because in this initial version of our online form, we are not yet supporting non-Veteran claimant types

## Steps to test

1. Pull in branch or use review instance
2. Log into user 233 (Cara) - an HLR user
3. Go to `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995`, and then navigate through the form to the `/veteran-information` page

## Code changes

Added Supplemental Claims Veteran Information page

## How was your code tested

Added unit test

## Acceptance criteria
- [x] Add Veteran Information page
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
