### PR TITLE
[CDP] Adding colon to end of sentence before list

### DIFF
--- a/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
@@ -45,7 +45,7 @@ ComboAlert.Zero = () => {
         haven’t received a copay bill in the past 6 months.
       </p>
       <h3 className="vads-u-font-size--h4">
-        What to do if you think you have a VA debt or copay bill
+        What to do if you think you have a VA debt or copay bill:
       </h3>
       <ul>
         <li>

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -16,7 +16,7 @@ const alertMessage = (alertType, appType) => {
             </p>
           </>
         ),
-        secondHeader: `What to do if you think you have a VA debt or copay bill`,
+        secondHeader: `What to do if you think you have a VA debt or copay bill:`,
         secondBody: (
           <ul>
             <li className="vads-u-font-family--sans">


### PR DESCRIPTION
## Description
Colon was missing from sentence that was introducing a list

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#43967](https://github.com/department-of-veterans-affairs/va.gov-team/issues/43967)


## Screenshots
![image](https://user-images.githubusercontent.com/20892803/178775064-1f90715c-dfd9-4065-a9d2-c773f09c75a5.png)


## Acceptance criteria
- [x] Colon is appended to list comment

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
