### PR TITLE
Revert `actions/setup-node` version to fix CI

### DIFF
--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -122,7 +122,7 @@ jobs:
         working-directory: qa-standards-dashboard-data
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 

--- a/.github/workflows/init-data-repo/action.yml
+++ b/.github/workflows/init-data-repo/action.yml
@@ -18,7 +18,7 @@ runs:
       working-directory: qa-standards-dashboard-data
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -28,7 +28,7 @@ runs:
       run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -78,7 +78,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -191,7 +191,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 


### PR DESCRIPTION
## Description
CI has been failing due to a `tar` command in the `setup-node` action failing. Reverting `setup-node` to `v2` seems to fix it.

## Acceptance criteria
- [ ] CI passes.