### PR TITLE
Add appointment time to aria-label of check-in button

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
@@ -77,6 +77,9 @@ const AppointmentAction = props => {
       return (
         <CheckInButton
           checkInWindowEnd={parseISO(appointment.checkInWindowEnd)}
+          appointmentTime={
+            appointment.startTime ? parseISO(appointment.startTime) : null
+          }
           onClick={onClick}
           router={router}
         />

--- a/src/applications/check-in/components/AppointmentDisplay/CheckInButton.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/CheckInButton.jsx
@@ -9,6 +9,7 @@ import { createAnalyticsSlug } from '../../utils/analytics';
 
 const CheckInButton = ({
   checkInWindowEnd,
+  appointmentTime,
   onClick,
   eventRecorder = recordEvent,
   router,
@@ -32,6 +33,7 @@ const CheckInButton = ({
     },
     [checkInWindowEnd, eventRecorder, getCurrentPageFromRouter, onClick],
   );
+
   return (
     <button
       type="button"
@@ -39,7 +41,13 @@ const CheckInButton = ({
       onClick={handleClick}
       data-testid="check-in-button"
       disabled={isCheckingIn}
-      aria-label={t('check-in-now-for-your-appointment')}
+      aria-label={
+        appointmentTime
+          ? t('check-in-now-for-your-time-appointment', {
+              time: appointmentTime,
+            })
+          : t('check-in-now-for-your-appointment')
+      }
     >
       {isCheckingIn ? (
         <span role="status">{t('loading')}</span>
@@ -51,6 +59,7 @@ const CheckInButton = ({
 };
 
 CheckInButton.propTypes = {
+  appointmentTime: PropTypes.instanceOf(Date),
   checkInWindowEnd: PropTypes.instanceOf(Date),
   eventRecorder: PropTypes.object,
   router: PropTypes.object,

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -17,6 +17,7 @@
   "check-in-at-va": "Check in at VA",
   "check-in-now": "Check in now",
   "check-in-now-for-your-appointment": "Check in now for your appointment",
+  "check-in-now-for-your-time-appointment": "Check in now for your {{ time, time }} appointment",
   "check-in-with-a-staff-member": "Check in with a staff member",
   "child-in-law": "Child in-law",
   "city-is-required": "City is required",


### PR DESCRIPTION
## Description
This PR adds the appointment time to the aria-label of the check-in button, to make it more clear when there are multiple appointments.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43523


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
