### PR TITLE
Added 5 second delay to demographics patch responses in test.

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -382,8 +382,11 @@ class ApiInitializer {
         req.reply(checkInData.patch.createMockSuccessResponse());
       }).as('demographicsPatchSuccessAlias');
     },
-    withFailure: (errorCode = 400) => {
+    withFailure: (errorCode = 400, delay = 0) => {
       cy.intercept('PATCH', `/check_in/v2/demographics/*`, req => {
+        req.on('response', res => {
+          res.setDelay(delay);
+        });
         req.reply(errorCode, checkInData.patch.createMockFailedResponse({}));
       }).as('demographicsPatchFailureAlias');
     },

--- a/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
@@ -126,7 +126,8 @@ describe('Check In Experience', () => {
         numberOfCheckInAbledAppointments: 2,
       });
       initializeCheckInDataPost.withSuccess();
-      initializeDemographicsPatch.withFailure(400);
+      // Response delayed by 5 seconds.
+      initializeDemographicsPatch.withFailure(400, 5000);
     });
     afterEach(() => {
       cy.window().then(window => {


### PR DESCRIPTION
## Description
Ensures that the user isn't routed to an error page with a delayed error response.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#39810
