### PR TITLE
Supplemental Claims | Add Contestable issues page

### DIFF
--- a/src/applications/appeals/995/actions/index.js
+++ b/src/applications/appeals/995/actions/index.js
@@ -1,0 +1,54 @@
+import { apiRequest } from 'platform/utilities/api';
+
+import {
+  SUPPORTED_BENEFIT_TYPES,
+  DEFAULT_BENEFIT_TYPE,
+  CONTESTABLE_ISSUES_API,
+} from '../constants';
+
+export const FETCH_CONTESTABLE_ISSUES_INIT = 'FETCH_CONTESTABLE_ISSUES_INIT';
+export const FETCH_CONTESTABLE_ISSUES_SUCCEEDED =
+  'FETCH_CONTESTABLE_ISSUES_SUCCEEDED';
+export const FETCH_CONTESTABLE_ISSUES_FAILED =
+  'FETCH_CONTESTABLE_ISSUES_FAILED';
+
+export const getContestableIssues = props => {
+  const benefitType = props?.benefitType || DEFAULT_BENEFIT_TYPE;
+  return dispatch => {
+    dispatch({ type: FETCH_CONTESTABLE_ISSUES_INIT });
+
+    const foundBenefitType = SUPPORTED_BENEFIT_TYPES.find(
+      type => type.value === benefitType,
+    );
+
+    if (!foundBenefitType || !foundBenefitType?.isSupported) {
+      return Promise.reject({
+        error: 'invalidBenefitType',
+        type: foundBenefitType?.label || benefitType || 'Unknown',
+      }).catch(errors =>
+        dispatch({
+          type: FETCH_CONTESTABLE_ISSUES_FAILED,
+          errors,
+        }),
+      );
+    }
+
+    return apiRequest(`${CONTESTABLE_ISSUES_API}${benefitType}`, {
+      apiVersion: 'v1',
+    })
+      .then(response =>
+        dispatch({
+          type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+          response,
+          benefitType,
+        }),
+      )
+      .catch(errors =>
+        dispatch({
+          type: FETCH_CONTESTABLE_ISSUES_FAILED,
+          errors,
+          benefitType,
+        }),
+      );
+  };
+};

--- a/src/applications/appeals/995/components/AddIssue.jsx
+++ b/src/applications/appeals/995/components/AddIssue.jsx
@@ -1,0 +1,209 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  VaDate,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+// updatePage isn't available for CustomPage on non-review pages, see
+// https://github.com/department-of-veterans-affairs/va.gov-team/issues/33797
+import { setData } from 'platform/forms-system/src/js/actions';
+
+import { getSelected, calculateIndexOffset } from '../utils/helpers';
+import {
+  SELECTED,
+  MAX_LENGTH,
+  LAST_SC_ITEM,
+  CONTESTABLE_ISSUES_PATH,
+} from '../constants';
+
+import {
+  uniqueIssue,
+  missingIssueName,
+  maxNameLength,
+  checkValidations,
+} from '../validations/issues';
+import { validateDate } from '../validations/date';
+import {
+  addIssueTitle,
+  issueNameLabel,
+  issueNameHintText,
+  dateOfDecisionLabel,
+  dateOfDecisionHintText,
+} from '../content/addIssue';
+
+const ISSUES_PAGE = `/${CONTESTABLE_ISSUES_PATH}`;
+const REVIEW_AND_SUBMIT = '/review-and-submit';
+
+const AddIssue = props => {
+  const { data, goToPath, onReviewPage, setFormData, testingIndex } = props;
+  const { contestedIssues = [], additionalIssues = [] } = data || {};
+
+  const allIssues = contestedIssues.concat(additionalIssues);
+
+  // get index from url '/add-issue?index={index}' or testingIndex
+  const searchIndex = new URLSearchParams(window.location.search);
+  let index = parseInt(searchIndex.get('index') || testingIndex, 10);
+  if (Number.isNaN(index) || index < contestedIssues.length) {
+    index = allIssues.length;
+  }
+  const offsetIndex = calculateIndexOffset(index, contestedIssues.length);
+  const currentData = allIssues[index] || {};
+
+  // set session storage of edited item. This enables focusing on the item
+  // upon return to the eligible issues page (a11y)
+  window.sessionStorage.setItem(LAST_SC_ITEM, index);
+
+  const returnPath = onReviewPage ? REVIEW_AND_SUBMIT : ISSUES_PAGE;
+
+  const nameValidations = [missingIssueName, maxNameLength, uniqueIssue];
+  const dateValidations = [validateDate];
+  const uniqueValidations = [uniqueIssue];
+
+  const [issueName, setIssueName] = useState(currentData.issue || '');
+  const [inputDirty, setInputDirty] = useState(false);
+
+  const [issueDate, setIssueDate] = useState(currentData.decisionDate);
+  const [dateDirty, setDateDirty] = useState(false);
+
+  const [submitted, setSubmitted] = useState(false);
+
+  // check name
+  const nameErrorMessage = checkValidations(nameValidations, issueName, data);
+  // check dates
+  const dateErrorMessage = checkValidations(dateValidations, issueDate, data);
+  // check name & date combo uniqueness
+  const uniqueErrorMessage = checkValidations(uniqueValidations, '', {
+    contestedIssues,
+    additionalIssues: [
+      // remove current issue from list - clicking "update issue" won't show
+      // unique issue error message
+      ...additionalIssues.filter((_, indx) => offsetIndex !== indx),
+      { issue: issueName, decisionDate: issueDate },
+    ],
+  });
+  const showError = nameErrorMessage[0] || uniqueErrorMessage[0];
+
+  // submit issue with validation
+  const addOrUpdateIssue = () => {
+    setSubmitted(true);
+    if (!showError && dateErrorMessage.length === 0) {
+      const selectedCount =
+        getSelected(data).length + (currentData[SELECTED] ? 0 : 1);
+
+      const issues = [...additionalIssues];
+      // index based on combined contestable issues + additional issues
+      issues[offsetIndex] = {
+        issue: issueName,
+        decisionDate: issueDate,
+        // select new item, if the max number isn't already selected
+        [SELECTED]: selectedCount <= MAX_LENGTH.SELECTIONS,
+      };
+      setFormData({ ...data, additionalIssues: issues });
+      goToPath(returnPath);
+    }
+  };
+
+  const handlers = {
+    onSubmit: event => event.preventDefault(),
+    onIssueNameChange: event => {
+      setIssueName(event.target.value);
+    },
+    onInputBlur: () => {
+      setInputDirty(true);
+    },
+    onDateChange: event => {
+      setIssueDate(event.target.value);
+    },
+    onDateBlur: () => {
+      // this is currently called for each of the 3 elements
+      setDateDirty(true);
+    },
+    onCancel: event => {
+      event.preventDefault();
+      goToPath(returnPath);
+    },
+    onUpdate: event => {
+      event.preventDefault();
+      addOrUpdateIssue();
+    },
+  };
+
+  return (
+    <form onSubmit={handlers.onSubmit}>
+      <fieldset>
+        <legend
+          id="decision-date-description"
+          className="vads-u-font-family--serif"
+          name="addIssue"
+        >
+          {addIssueTitle}
+        </legend>
+        <VaTextInput
+          id="add-sc-issue"
+          name="add-sc-issue"
+          type="text"
+          label={issueNameLabel}
+          required
+          value={issueName}
+          onInput={handlers.onIssueNameChange}
+          onBlur={handlers.onInputBlur}
+          error={((submitted || inputDirty) && showError) || null}
+        >
+          {issueNameHintText}
+        </VaTextInput>
+        <br />
+        <VaDate
+          name="decision-date"
+          label={dateOfDecisionLabel}
+          required
+          onDateChange={handlers.onDateChange}
+          onDateBlur={handlers.onDateBlur}
+          value={issueDate}
+          error={((submitted || dateDirty) && dateErrorMessage[0]) || null}
+          ariaDescribedby="decision-date-description"
+        >
+          {dateOfDecisionHintText}
+        </VaDate>
+        <p>
+          <button
+            type="button"
+            id="cancel"
+            className="usa-button-secondary vads-u-width--auto"
+            onClick={handlers.onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            id="submit"
+            className="vads-u-width--auto"
+            onClick={handlers.onUpdate}
+          >
+            {`${currentData.issue ? 'Update' : 'Add'} issue`}
+          </button>
+        </p>
+      </fieldset>
+    </form>
+  );
+};
+
+AddIssue.propTypes = {
+  data: PropTypes.shape({}),
+  goToPath: PropTypes.func,
+  setFormData: PropTypes.func,
+  testingIndex: PropTypes.number,
+  onReviewPage: PropTypes.bool,
+};
+
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(AddIssue);
+
+export { AddIssue };

--- a/src/applications/appeals/995/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/995/components/ContestableIssuesWidget.jsx
@@ -1,0 +1,203 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router';
+
+import set from 'platform/utilities/data/set';
+import { setData } from 'platform/forms-system/src/js/actions';
+
+import { IssueCard } from './IssueCard';
+import { SELECTED, MAX_LENGTH, LAST_SC_ITEM } from '../constants';
+import {
+  NoneSelectedAlert,
+  MaxSelectionsAlert,
+} from '../content/contestableIssues';
+import {
+  getSelected,
+  someSelected,
+  isEmptyObject,
+  calculateIndexOffset,
+} from '../utils/helpers';
+
+/**
+ * ContestableIssuesWidget
+ * Form system parameters passed into this widget
+ * @typedef {Object}
+ * @property {Boolean} autofocus - should auto focus
+ * @property {Boolean} disabled -  is disabled?
+ * @property {Object} formContext -  state
+ * @property {String} id - ID base for form elements
+ * @property {String} label - label text
+ * @property {func} onBlur - blur callback
+ * @property {func} onChange - on change callback
+ * @property {Object} options - ui:options
+ * @property {String} placeholder - placeholder text
+ * @property {Boolean} readonly - readonly state
+ * @property {Object} registry - contains definitions, fields, widgets & templates
+ * @property {Boolean} required - Show required flag
+ * @property {Object} schema - array schema
+ * @property {Object[]} value - array value
+ */
+const ContestableIssuesWidget = props => {
+  const {
+    value = [],
+    id,
+    options,
+    formContext = {},
+    additionalIssues,
+    setFormData,
+    formData,
+  } = props;
+
+  const [showErrorModal, setShowErrorModal] = useState(false);
+
+  const onReviewPage = formContext?.onReviewPage || false;
+  // inReviewMode = true (review page view, not in edit mode)
+  // inReviewMode = false (in edit mode)
+  const inReviewMode = (onReviewPage && formContext.reviewMode) || false;
+  const showCheckbox = !onReviewPage || (onReviewPage && !inReviewMode);
+
+  // combine all issues for viewing
+  const items = value
+    .map(item => ({
+      ...item.attributes,
+      [SELECTED]: item[SELECTED],
+    }))
+    .concat(additionalIssues);
+
+  const hasSelected = someSelected(items);
+
+  if (onReviewPage && inReviewMode && items.length && !hasSelected) {
+    return (
+      <>
+        <dt>
+          <NoneSelectedAlert count={items.length} />
+        </dt>
+        <dd />
+      </>
+    );
+  }
+
+  const handlers = {
+    closeModal: () => setShowErrorModal(false),
+    onChange: (index, event) => {
+      let { checked } = event.target;
+      if (checked && getSelected(formData).length + 1 > MAX_LENGTH.SELECTIONS) {
+        setShowErrorModal(true);
+        event.preventDefault(); // prevent checking
+        checked = false;
+      } else if (index < value.length) {
+        // contestable issue check toggle
+        const changedItems = set(
+          `[${index}].${SELECTED}`,
+          checked,
+          props.value,
+        );
+        props.onChange(changedItems);
+      } else {
+        // additional issue check toggle
+        const adjustedIndex = calculateIndexOffset(index, value.length);
+        const updatedAdditionalIssues = additionalIssues.map(
+          (issue, indx) =>
+            adjustedIndex === indx ? { ...issue, [SELECTED]: checked } : issue,
+        );
+        setFormData({
+          ...formData,
+          additionalIssues: updatedAdditionalIssues,
+        });
+      }
+    },
+    onRemoveIssue: index => {
+      const adjustedIndex = calculateIndexOffset(index, value.length);
+      const updatedAdditionalIssues = additionalIssues.filter(
+        (issue, indx) => adjustedIndex !== indx,
+      );
+
+      // Focus management: target the previous issue if the last one was removed
+      // Done internally within the issue card component
+      const focusIndex =
+        index + (adjustedIndex >= updatedAdditionalIssues.length ? -1 : 0);
+      window.sessionStorage.setItem(LAST_SC_ITEM, focusIndex);
+
+      setFormData({
+        ...formData,
+        additionalIssues: updatedAdditionalIssues,
+      });
+    },
+  };
+
+  const content = items.map((item, index) => {
+    const itemIsSelected = !!item[SELECTED];
+    const hideCard = (inReviewMode && !itemIsSelected) || isEmptyObject(item);
+
+    const cardProps = {
+      id,
+      index,
+      item,
+      key: index,
+      options,
+      showCheckbox,
+      onChange: handlers.onChange,
+      // Don't allow editing or removing API-loaded issues
+      onRemove: item.ratingIssueSubjectText
+        ? null
+        : () => handlers.onRemoveIssue(index),
+    };
+
+    // Don't show un-selected ratings in review mode
+    return hideCard ? null : <IssueCard {...cardProps} />;
+  });
+
+  return (
+    <>
+      {formContext.submitted &&
+        !hasSelected && <NoneSelectedAlert count={value.length} />}
+      {onReviewPage && inReviewMode ? (
+        content
+      ) : (
+        <>
+          <dl className="review vads-u-border-bottom--1px">{content}</dl>
+          <Link
+            className="add-new-issue"
+            to={{ pathname: '/add-issue', search: `?index=${items.length}` }}
+          >
+            Add a new issue
+          </Link>
+        </>
+      )}
+      {showErrorModal && (
+        <MaxSelectionsAlert showModal closeModal={handlers.closeModal} />
+      )}
+    </>
+  );
+};
+
+ContestableIssuesWidget.propTypes = {
+  additionalIssues: PropTypes.array,
+  formContext: PropTypes.shape({
+    onReviewPage: PropTypes.bool,
+    reviewMode: PropTypes.bool,
+    submitted: PropTypes.bool,
+  }),
+  formData: PropTypes.shape({}),
+  id: PropTypes.string,
+  options: PropTypes.shape({}),
+  setFormData: PropTypes.func,
+  value: PropTypes.array,
+  onChange: PropTypes.func,
+};
+
+const mapStateToProps = state => ({
+  formData: state.form?.data || {},
+  additionalIssues: state.form?.data.additionalIssues || [],
+});
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+export { ContestableIssuesWidget };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ContestableIssuesWidget);

--- a/src/applications/appeals/995/components/IssueCard.jsx
+++ b/src/applications/appeals/995/components/IssueCard.jsx
@@ -1,0 +1,238 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import { Link } from 'react-router';
+
+import { scrollAndFocus } from 'platform/utilities/ui';
+
+import { SELECTED, FORMAT_READABLE, LAST_SC_ITEM } from '../constants';
+import { replaceDescriptionContent } from '../utils/replace';
+
+/** Copied from HLR v2 card */
+/**
+ * IssueCardContent
+ * @param {String} description - contestable issue description
+ * @param {String} ratingIssuePercentNumber - rating %, number with no %
+ * @param {String} approxDecisionDate - contestable issue date formatted as
+ *   "YYYY-MM-DD"
+ * @param {String} decisionDate - additional issue date formatted as
+ *   "YYYY-MM-DD"
+ * @return {React Component}
+ */
+export const IssueCardContent = ({
+  description,
+  ratingIssuePercentNumber,
+  approxDecisionDate,
+  decisionDate,
+}) => {
+  // May need to throw an error to Sentry if any of these don't exist
+  // A valid rated disability *can* have a rating percentage of 0%
+  const showPercentNumber = (ratingIssuePercentNumber || '') !== '';
+  const date = approxDecisionDate || decisionDate;
+
+  return (
+    <div className="widget-content-wrap">
+      {description && (
+        <p className="vads-u-margin-bottom--0">
+          {replaceDescriptionContent(description)}
+        </p>
+      )}
+      {showPercentNumber && (
+        <p className="vads-u-margin-bottom--0">
+          Current rating: <strong>{ratingIssuePercentNumber}%</strong>
+        </p>
+      )}
+      {date && (
+        <p>
+          Decision date: <strong>{moment(date).format(FORMAT_READABLE)}</strong>
+        </p>
+      )}
+    </div>
+  );
+};
+
+IssueCardContent.propTypes = {
+  approxDecisionDate: PropTypes.string,
+  decisionDate: PropTypes.string,
+  description: PropTypes.string,
+  ratingIssuePercentNumber: PropTypes.string,
+};
+
+/**
+ * ContestableIssue
+ * @typedef {Object}
+ * @property {String} ratingIssueSubjectText - contestable issue title
+ * @property {String} description - contestable issue description
+ * @property {String} ratingIssuePercentNumber - rating %, number with no %
+ * @property {String} approxDecisionDate - date formatted as "YYYY-MM-DD"
+ */
+/**
+ * AdditionalIssue
+ * @type {Object}
+ * @property {String} issue - user entered issue name
+ * @property {String} decisionDate - user entered decision date
+ */
+/**
+ * IssueCard
+ * @typedef {Object}
+ * @property {String} id - ID base for form elements
+ * @property {Number} index - index of item in list
+ * @property {ContestableIssue|AdditionalIssue} item - issue values
+ * @property {Object} options - ui:options
+ * @property {func} onChange - onChange callback
+ * @property {func} onRemove - remove issue callback
+ * @property {Boolean} showCheckbox - don't show checkbox on review & submit
+ *  page when not in edit mode
+ */
+export const IssueCard = ({
+  id,
+  index,
+  item = {},
+  options = {},
+  onChange,
+  showCheckbox,
+  onRemove,
+}) => {
+  // On the review & submit page, there may be more than one
+  // of these components in edit mode with the same content, e.g. 526
+  // ratedDisabilities & unemployabilityDisabilities causing
+  // duplicate input ids/names... an `appendId` value is added to the
+  // ui:options
+  const appendId = options.appendId ? `_${options.appendId}` : '';
+  const elementId = `${id}_${index}${appendId}`;
+  const scrollId = `issue-${window.sessionStorage.getItem(LAST_SC_ITEM)}`;
+
+  const wrapRef = useRef(null);
+
+  useEffect(
+    () => {
+      if (scrollId === wrapRef?.current.id) {
+        scrollAndFocus(wrapRef.current);
+        window.sessionStorage.removeItem(LAST_SC_ITEM);
+      }
+    },
+    [scrollId, wrapRef, index],
+  );
+
+  const itemIsSelected = item[SELECTED];
+  const isEditable = !!item.issue;
+  const issueName = item.issue || item.ratingIssueSubjectText;
+
+  const wrapperClass = [
+    'review-row',
+    'widget-wrapper-v2',
+    isEditable ? 'additional-issue' : '',
+    showCheckbox ? '' : 'checkbox-hidden',
+    showCheckbox ? 'vads-u-padding-top--3' : '',
+    'vads-u-padding-right--3',
+    'vads-u-margin-bottom--0',
+  ].join(' ');
+
+  const titleClass = [
+    'widget-title',
+    'vads-u-font-size--md',
+    'vads-u-font-weight--bold',
+    'vads-u-line-height--1',
+  ].join(' ');
+
+  const removeButtonClass = [
+    'remove-issue',
+    'usa-button-secondary',
+    'vads-u-width--auto',
+    'vads-u-margin-left--2',
+    'vads-u-margin-top--0',
+  ].join(' ');
+
+  const handlers = {
+    onRemove: event => {
+      event.preventDefault();
+      onRemove(index, item);
+    },
+    onChange: event => onChange(index, event),
+  };
+
+  const editControls =
+    showCheckbox && isEditable ? (
+      <div>
+        <Link
+          to={{
+            pathname: '/add-issue',
+            search: `?index=${index}`,
+          }}
+          className="change-issue-link"
+          aria-label={`Change ${issueName}`}
+        >
+          Change
+        </Link>
+        <button
+          type="button"
+          className={removeButtonClass}
+          aria-label={`remove ${issueName}`}
+          onClick={handlers.onRemove}
+        >
+          Remove
+        </button>
+      </div>
+    ) : null;
+
+  return (
+    <div
+      id={`issue-${index}`}
+      className={wrapperClass}
+      key={index}
+      ref={wrapRef}
+    >
+      <dt className="widget-checkbox-wrap">
+        {showCheckbox ? (
+          <>
+            <input
+              type="checkbox"
+              id={elementId}
+              name={elementId}
+              checked={itemIsSelected}
+              onChange={handlers.onChange}
+            />
+            <label className="schemaform-label" htmlFor={elementId}>
+              <span className="vads-u-visibility--screen-reader">
+                {issueName}
+              </span>
+            </label>
+          </>
+        ) : (
+          <div />
+        )}
+      </dt>
+      <dd
+        className={`${
+          editControls ? 'widget-editable vads-u-padding-bottom--1' : ''
+        } widget-content vads-u-font-weight--normal`}
+        data-index={index}
+      >
+        <div className={titleClass}>{issueName}</div>
+        <IssueCardContent {...item} />
+        {editControls}
+      </dd>
+    </div>
+  );
+};
+
+IssueCard.propTypes = {
+  id: PropTypes.string,
+  index: PropTypes.number,
+  item: PropTypes.shape({
+    issue: PropTypes.string,
+    decisionDate: PropTypes.string,
+    ratingIssueSubjectText: PropTypes.string,
+    description: PropTypes.string,
+    ratingIssuePercentNumber: PropTypes.string,
+    approxDecisionDate: PropTypes.string,
+    [SELECTED]: PropTypes.bool,
+  }),
+  options: PropTypes.shape({
+    appendId: PropTypes.string,
+  }),
+  showCheckbox: PropTypes.bool,
+  onChange: PropTypes.func,
+  onEdit: PropTypes.func,
+  onRemove: PropTypes.func,
+};

--- a/src/applications/appeals/995/components/ShowIssuesList.jsx
+++ b/src/applications/appeals/995/components/ShowIssuesList.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { getDate } from '../utils/dates';
+import { FORMAT_READABLE } from '../constants';
+
+export const ShowIssuesList = ({ issues }) => (
+  <ul>
+    {issues.map((issue, index) => (
+      <li key={index}>
+        <strong className="capitalize">
+          {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
+        </strong>
+        <div>
+          Decision date:{' '}
+          {getDate({
+            date:
+              issue.attributes?.approxDecisionDate || issue.decisionDate || '',
+            pattern: FORMAT_READABLE,
+          })}
+        </div>
+      </li>
+    ))}
+  </ul>
+);
+
+ShowIssuesList.propTypes = {
+  issues: PropTypes.arrayOf(
+    PropTypes.shape({
+      attributes: PropTypes.shape({
+        ratingIssueSubjectText: PropTypes.string,
+      }),
+    }),
+  ),
+};

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -13,6 +13,7 @@ import {
   EditEmail,
   EditAddress,
 } from '../components/EditContactInfo';
+import AddIssue from '../components/AddIssue';
 
 import addIssue from '../pages/addIssue';
 import benefitType from '../pages/benefitType';
@@ -36,6 +37,7 @@ import veteranInfo from '../pages/veteranInfo';
 import { appStateSelector, mayHaveLegacyAppeals } from '../utils/helpers';
 
 import manifest from '../manifest.json';
+import { CONTESTABLE_ISSUES_PATH } from '../constants';
 
 // import fullSchema from 'vets-json-schema/dist/20-0995-schema.json';
 // const { } = fullSchema.properties;
@@ -143,7 +145,7 @@ const formConfig = {
       pages: {
         contestableIssues: {
           title: ' ',
-          path: 'contestable-issues',
+          path: CONTESTABLE_ISSUES_PATH,
           uiSchema: contestableIssues.uiSchema,
           schema: contestableIssues.schema,
           appStateSelector,
@@ -152,7 +154,8 @@ const formConfig = {
           title: 'Add issues for review',
           path: 'add-issue',
           depends: () => false,
-          // CustomPage: AddIssue,
+          CustomPage: AddIssue,
+          CustomPageReview: null,
           uiSchema: addIssue.uiSchema,
           schema: addIssue.schema,
         },

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -30,6 +30,11 @@ export const CONTESTABLE_ISSUES_API =
 // key for contestedIssues to indicate that the user selected the issue
 export const SELECTED = 'view:selected';
 
+// Including a default until we determine how to get around the user restarting
+// the application after using the "Finish this application later" link
+// See https://dsva.slack.com/archives/C0113MPTGH5/p1600725048027200
+export const DEFAULT_BENEFIT_TYPE = 'compensation';
+
 export const errorMessages = {
   savedFormNotFound: 'Please start over to request a Supplemental Claim',
   savedFormNoAuth:
@@ -46,6 +51,9 @@ export const NULL_CONDITION_STRING = 'Unknown Condition';
 // contested issue dates
 export const FORMAT_YMD = 'YYYY-MM-DD';
 export const FORMAT_READABLE = 'LL';
+
+export const SAVED_CLAIM_TYPE = 'scClaimType';
+export const LAST_SC_ITEM = 'lastScItem'; // focus management across pages
 
 // Values from benefitTypes in Lighthouse 0995 schema
 // schema.definitions.scCreate.properties.data.properties.attributes.properties.benefitType.emum;
@@ -98,3 +106,5 @@ export const MAX_LENGTH = {
   CLAIMANT_OTHER: 25,
   EVIDENCE_LOCATION_AND_NAME: 255,
 };
+
+export const CONTESTABLE_ISSUES_PATH = 'contestable-issues';

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -6,8 +6,14 @@ import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { selectProfile, isLoggedIn } from 'platform/user/selectors';
 
 import { setData } from 'platform/forms-system/src/js/actions';
+import {
+  getContestableIssues as getContestableIssuesAction,
+  FETCH_CONTESTABLE_ISSUES_INIT,
+} from '../actions';
 
 import formConfig from '../config/form';
+import { SAVED_CLAIM_TYPE } from '../constants';
+import { issuesNeedUpdating, processContestableIssues } from '../utils/helpers';
 
 export const Form0995App = ({
   loggedIn,
@@ -16,18 +22,39 @@ export const Form0995App = ({
   profile,
   formData,
   setFormData,
+  // router,
+  // savedForms,
+  getContestableIssues,
+  contestableIssues = {},
+  legacyCount,
 }) => {
   const { email = {}, mobilePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
+
+  // Make sure we're only loading issues once - see
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
+  const [isLoadingIssues, setIsLoadingIssues] = useState(false);
 
   useEffect(
     () => {
       if (loggedIn) {
         const { veteran = {} } = formData || {};
-        if (
+        if (!isLoadingIssues && (contestableIssues?.status || '') === '') {
+          // load benefit type contestable issues
+          setIsLoadingIssues(true);
+          const benefitType =
+            sessionStorage.getItem(SAVED_CLAIM_TYPE) || formData.benefitType;
+          getContestableIssues({ benefitType });
+        } else if (
+          formData?.benefitType !== contestableIssues?.benefitType ||
           email?.emailAddress !== veteran.email ||
           mobilePhone?.updatedAt !== veteran.phone?.updatedAt ||
-          mailingAddress?.updatedAt !== veteran.address?.updatedAt
+          mailingAddress?.updatedAt !== veteran.address?.updatedAt ||
+          issuesNeedUpdating(
+            contestableIssues?.issues,
+            formData?.contestedIssues,
+          ) ||
+          contestableIssues.legacyCount !== formData.legacyCount
         ) {
           setFormData({
             ...formData,
@@ -37,18 +64,50 @@ export const Form0995App = ({
               phone: mobilePhone,
               email: email?.emailAddress,
             },
+            benefitType: contestableIssues?.benefitType || formData.benefitType,
+            contestedIssues: processContestableIssues(
+              contestableIssues?.issues,
+            ),
+            legacyCount: contestableIssues?.legacyCount,
           });
         }
       }
     },
-    [loggedIn, email, mobilePhone, mailingAddress, formData, setFormData],
+    [
+      loggedIn,
+      email,
+      mobilePhone,
+      mailingAddress,
+      formData,
+      setFormData,
+      contestableIssues,
+      isLoadingIssues,
+      getContestableIssues,
+      legacyCount,
+    ],
   );
 
-  const content = (
+  let content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
+
+  if (
+    loggedIn &&
+    ((contestableIssues?.status || '') === '' ||
+      contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT)
+  ) {
+    content = (
+      <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+        <va-loading-indicator
+          set-focus
+          message="Loading your previous decisions..."
+        />
+      </h1>
+    );
+  }
+
   return (
     <article id="form-0995" data-location={`${location?.pathname?.slice(1)}`}>
       {content}
@@ -88,10 +147,13 @@ const mapStateToProps = state => ({
   formData: state.form?.data || {},
   profile: selectProfile(state) || {},
   savedForms: state.user?.profile?.savedForms || [],
+  contestableIssues: state.contestableIssues || {},
+  legacyCount: state.legacyCount || 0,
 });
 
 const mapDispatchToProps = {
   setFormData: setData,
+  getContestableIssues: getContestableIssuesAction,
 };
 
 export default connect(

--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -30,7 +30,7 @@ class IntroductionPage extends React.Component {
     };
 
     return (
-      <article className="schemaform-intro">
+      <div className="schemaform-intro">
         <FormTitle
           title="Request a Supplemental Claim"
           subTitle="Equal to VA Form 20-0995 (Request a Supplemental Claim)"
@@ -86,7 +86,7 @@ class IntroductionPage extends React.Component {
         <SaveInProgressIntro {...saveInProgressProps} buttonOnly />
         <p />
         <OMBInfo resBurden={15} ombNumber="2900-0862" expDate="4/30/2024" />
-      </article>
+      </div>
     );
   }
 }

--- a/src/applications/appeals/995/content/contestableIssues.jsx
+++ b/src/applications/appeals/995/content/contestableIssues.jsx
@@ -60,7 +60,7 @@ export const MaxSelectionsAlert = ({ closeModal }) => (
     visible
   >
     You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each
-    Supplemental Claims request. If you would like to select more than{' '}
+    Higher-Level Review request. If you would like to select more than{' '}
     {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
     for the remaining issues.
   </VaModal>

--- a/src/applications/appeals/995/content/contestableIssues.jsx
+++ b/src/applications/appeals/995/content/contestableIssues.jsx
@@ -60,7 +60,7 @@ export const MaxSelectionsAlert = ({ closeModal }) => (
     visible
   >
     You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each
-    Higher-Level Review request. If you would like to select more than{' '}
+    Supplemental Claims request. If you would like to select more than{' '}
     {MAX_LENGTH.SELECTIONS}, please submit this request and create a new request
     for the remaining issues.
   </VaModal>

--- a/src/applications/appeals/995/content/issueSummary.jsx
+++ b/src/applications/appeals/995/content/issueSummary.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'react-router';
+import PropTypes from 'prop-types';
+
+import { getSelected } from '../utils/helpers';
+import { ShowIssuesList } from '../components/ShowIssuesList';
+import { CONTESTABLE_ISSUES_PATH } from '../constants';
+
+export const SummaryTitle = ({ formData }) => {
+  const issues = getSelected(formData);
+
+  return (
+    <>
+      <p className="vads-u-margin-top--0">
+        These are the issues you’re asking to get a Supplemental Claim.
+      </p>
+      {ShowIssuesList({ issues })}
+      <p>
+        If an issue is missing, please{' '}
+        <Link
+          aria-label="go back and add any missing issues for review"
+          to={{
+            pathname: CONTESTABLE_ISSUES_PATH,
+            search: '?redirect',
+          }}
+        >
+          go back and add it
+        </Link>
+        .
+      </p>
+    </>
+  );
+};
+
+SummaryTitle.propTypes = {
+  formData: PropTypes.shape({}),
+};

--- a/src/applications/appeals/995/pages/contestableIssues.js
+++ b/src/applications/appeals/995/pages/contestableIssues.js
@@ -1,8 +1,43 @@
-export default {
-  uiSchema: {},
+import ContestableIssuesWidget from '../components/ContestableIssuesWidget';
+
+import { ContestableIssuesTitle } from '../content/contestableIssues';
+
+import { selectionRequired, maxIssues } from '../validations/issues';
+import { SELECTED } from '../constants';
+
+/**
+ * contestable issues with add issue link (list loop)
+ */
+const contestableIssues = {
+  uiSchema: {
+    'ui:title': ContestableIssuesTitle,
+    'ui:options': {
+      itemName: 'issues eligible for review',
+    },
+    contestedIssues: {
+      'ui:title': ' ',
+      'ui:field': 'StringField',
+      'ui:widget': ContestableIssuesWidget,
+      'ui:options': {
+        keepInPageOnReview: true,
+      },
+      'ui:validations': [selectionRequired, maxIssues],
+    },
+  },
 
   schema: {
     type: 'object',
-    properties: {},
+    properties: {
+      contestedIssues: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {},
+          [SELECTED]: 'boolean',
+        },
+      },
+    },
   },
 };
+
+export default contestableIssues;

--- a/src/applications/appeals/995/pages/issueSummary.js
+++ b/src/applications/appeals/995/pages/issueSummary.js
@@ -1,5 +1,12 @@
+import { SummaryTitle } from '../content/issueSummary';
+
 export default {
-  uiSchema: {},
+  uiSchema: {
+    'ui:title': SummaryTitle,
+    'ui:options': {
+      forceDivWrapper: true,
+    },
+  },
 
   schema: {
     type: 'object',

--- a/src/applications/appeals/995/reducers/contestableIssues.js
+++ b/src/applications/appeals/995/reducers/contestableIssues.js
@@ -1,0 +1,48 @@
+import {
+  FETCH_CONTESTABLE_ISSUES_INIT,
+  FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+  FETCH_CONTESTABLE_ISSUES_FAILED,
+} from '../actions';
+import {
+  getEligibleContestableIssues,
+  getLegacyAppealsLength,
+} from '../utils/helpers';
+
+const initialState = {
+  issues: [],
+  status: '',
+  error: '',
+};
+
+export default function contestableIssues(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_CONTESTABLE_ISSUES_INIT: {
+      return {
+        ...state,
+        status: FETCH_CONTESTABLE_ISSUES_INIT,
+      };
+    }
+    case FETCH_CONTESTABLE_ISSUES_SUCCEEDED: {
+      return {
+        ...state,
+        issues: getEligibleContestableIssues(action.response?.data),
+        legacyCount: getLegacyAppealsLength(action.response?.data),
+        status: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+        error: '',
+        benefitType: action.benefitType,
+      };
+    }
+    case FETCH_CONTESTABLE_ISSUES_FAILED: {
+      return {
+        ...state,
+        issues: [],
+        legacyCount: 0,
+        status: FETCH_CONTESTABLE_ISSUES_FAILED,
+        error: action.errors,
+        benefitType: action.benefitType,
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/applications/appeals/995/reducers/index.js
+++ b/src/applications/appeals/995/reducers/index.js
@@ -3,8 +3,10 @@ import vapService from '@@vap-svc/reducers';
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 import formConfig from '../config/form';
+import contestableIssues from './contestableIssues';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),
+  contestableIssues,
   vapService,
 };

--- a/src/applications/appeals/995/sass/995-supplemental-claim.scss
+++ b/src/applications/appeals/995/sass/995-supplemental-claim.scss
@@ -23,6 +23,127 @@
   white-space: nowrap;
 }
 
+/* Step 2 */
+/*** Contested issues block ***/
+
+/* global definitions */
+// hide Required label (added to description)
+#root_contestedIssues-label {
+  display: none;
+}
+
+/* Contested issue cards (contested issue page & review/submit page)
+ * This could go in the schemaform css, it's used in form 526 & HLR
+ */
+dl.review {
+  /* v2 cards */
+  .widget-wrapper-v2 {
+    display: flex;
+
+    dt.widget-checkbox-wrap {
+      margin: 0;
+      width: 5rem;
+      min-width: 5rem;
+
+      [type="checkbox"] {
+        width: 1.8rem;
+        height: 1.8rem;
+        margin: 0;
+      }
+    }
+
+    dt label {
+      margin-top: 0;
+    }
+
+    .widget-title {
+      margin: 0;
+      white-space: nowrap;
+      text-transform: capitalize;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      width: calc(100% - 7rem);
+    }
+
+    dd.widget-content {
+      width: 100%;
+      margin-inline-start: 0; /* override user agent */
+      text-align: left;
+      margin: 0;
+    }
+    dd.widget-content.widget-edit {
+      margin-top: 0;
+      margin-right: 0;
+      display: flex;
+
+      .widget-content-wrap {
+        margin-top: 3rem;
+        margin-right: 0.5rem;
+        width: 100%;
+      }
+
+      .edit {
+        margin-top: 2rem;
+        /* position the edit button above the overlapping label */
+        position: relative;
+        z-index: 1;
+        align-self: center;
+      }
+    }
+    .change-issue-link:visited {
+      color: inherit;
+    }
+  }
+
+  .widget-outline {
+    background: transparent;
+    border: solid 4px $color-primary-alt-light;
+    border-radius: 7px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    max-width: auto; /* IE11 */
+    max-width: unset;
+
+    &.selected {
+      border-color: $color-primary;
+    }
+
+    &::before {
+      position: absolute;
+      margin-left: 1.5rem;
+      margin-top: 1.5rem;
+    }
+  }
+
+  .checkbox-hidden {
+    dt.widget-checkbox-wrap {
+      width: 0;
+    }
+
+    .widget-title {
+      margin-left: 0;
+      width: 100%;
+      overflow: visible;
+      white-space: normal;
+    }
+
+    .widget-content {
+      margin: 2rem 0 0 2rem;
+    }
+  }
+}
+
+.usa-input-error #root_additionalIssues_0_decisionDate-label {
+  font-weight: bold;
+}
+
+.review-row > dd {
+  word-break: break-word;
+}
+
 /* add/update & cancel buttons on edit contact info page */
 @media screen and (min-width: 481px) {
   .va-profile-wrapper button {

--- a/src/applications/appeals/995/tests/actions/actions.unit.spec.js
+++ b/src/applications/appeals/995/tests/actions/actions.unit.spec.js
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+
+import {
+  getContestableIssues,
+  FETCH_CONTESTABLE_ISSUES_INIT,
+  FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+  FETCH_CONTESTABLE_ISSUES_FAILED,
+} from '../../actions';
+
+describe('fetch contestable issues action', () => {
+  it('should dispatch an init action', () => {
+    const mockData = { data: 'asdf' };
+    const benefitType = 'compensation';
+    mockApiRequest(mockData);
+    const dispatch = sinon.spy();
+    return getContestableIssues({ benefitType })(dispatch).then(() => {
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FETCH_CONTESTABLE_ISSUES_INIT,
+      );
+      expect(dispatch.secondCall.args[0]).to.eql({
+        type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+        response: {
+          ...mockData,
+        },
+        benefitType,
+      });
+    });
+  });
+
+  it('should dispatch an add person failed action', () => {
+    const mockData = { data: 'asdf' };
+    const props = { benefitType: 'compensation' };
+    mockApiRequest(mockData, false);
+    const dispatch = sinon.spy();
+    return getContestableIssues(props)(dispatch).then(() => {
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FETCH_CONTESTABLE_ISSUES_INIT,
+      );
+      expect(dispatch.secondCall.args[0].type).to.equal(
+        FETCH_CONTESTABLE_ISSUES_FAILED,
+      );
+    });
+  });
+
+  it('should dispatch failed action from unsupported benefitType', () => {
+    const mockData = { data: 'asdf' };
+    mockApiRequest(mockData, false);
+    const dispatch = sinon.spy();
+    return getContestableIssues({ benefitType: 'foo' })(dispatch).then(() => {
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FETCH_CONTESTABLE_ISSUES_INIT,
+      );
+      expect(dispatch.secondCall.args[0].type).to.equal(
+        FETCH_CONTESTABLE_ISSUES_FAILED,
+      );
+    });
+  });
+});

--- a/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
@@ -1,0 +1,168 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { AddIssue } from '../../components/AddIssue';
+import { issueErrorMessages } from '../../content/addIssue';
+import { MAX_LENGTH, LAST_SC_ITEM } from '../../constants';
+import { getDate } from '../../utils/dates';
+import { $, $$ } from '../../utils/ui';
+
+describe('<AddIssue>', () => {
+  const validDate = getDate({ offset: { months: -2 } });
+  const contestedIssues = [
+    {
+      type: 'contestableIssue',
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: validDate,
+      },
+    },
+  ];
+  const setup = ({
+    index = null,
+    setFormData = () => {},
+    goToPath = () => {},
+    data = {},
+    onReviewPage = false,
+  } = {}) => {
+    if (index !== null) {
+      window.sessionStorage.setItem(LAST_SC_ITEM, index);
+    } else {
+      window.sessionStorage.removeItem(LAST_SC_ITEM);
+    }
+    return (
+      <div>
+        <AddIssue
+          setFormData={setFormData}
+          data={data}
+          goToPath={goToPath}
+          onReviewPage={onReviewPage}
+          testingIndex={index}
+          appStateData={data}
+        />
+      </div>
+    );
+  };
+
+  afterEach(() => {
+    window.sessionStorage.removeItem(LAST_SC_ITEM);
+  });
+
+  it('should render', () => {
+    const { container } = render(setup());
+    expect($('va-text-input')).to.exist;
+    expect($('va-date', container)).to.exist;
+  });
+  it('should prevent submission when empty', () => {
+    const goToPathSpy = sinon.spy();
+    const { container } = render(setup({ goToPath: goToPathSpy }));
+    $('button#submit', container).click();
+    const elems = $$('va-text-input, va-date', container);
+
+    expect(elems[0].error).to.contain(issueErrorMessages.missingIssue);
+    // expect(elems[1].error).to.contain(issueErrorMessages.missingDecisionDate);
+    // Returning invalidDate until va-date web component is updated
+    expect(elems[1].error).to.contain(issueErrorMessages.invalidDate);
+    expect(goToPathSpy.called).to.be.false;
+  });
+  it('should navigate on cancel', () => {
+    const goToPathSpy = sinon.spy();
+    const { container } = render(setup({ goToPath: goToPathSpy }));
+    $('button#cancel', container).click();
+
+    expect(goToPathSpy.called).to.be.true;
+  });
+
+  it('should show error when issue name is too long', () => {
+    const issue = 'abcdef '.repeat(MAX_LENGTH.ISSUE_NAME / 6);
+    const { container } = render(
+      setup({
+        data: { contestedIssues, additionalIssues: [{ issue }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const textInput = $('va-text-input', container);
+    expect(textInput.error).to.contain(issueErrorMessages.maxLength);
+  });
+  it('should show error when issue date is not in range', () => {
+    const decisionDate = getDate({ offset: { years: +200 } });
+    const { container } = render(
+      setup({
+        data: { contestedIssues, additionalIssues: [{ decisionDate }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const date = $('va-date', container);
+    expect(date.error).to.contain(
+      // partial match
+      issueErrorMessages.invalidDateRange('xxxx', '').split('xxxx')[0],
+    );
+  });
+  it('should show an error when the issue date is > 1 year in the future', () => {
+    const decisionDate = getDate({ offset: { months: +13 } });
+    const { container } = render(
+      setup({
+        data: { contestedIssues, additionalIssues: [{ decisionDate }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const date = $('va-date', container);
+    expect(date.error).to.contain(issueErrorMessages.pastDate);
+  });
+  it('should show an error when the issue date is > 1 year in the past', () => {
+    const decisionDate = getDate({ offset: { months: -13 } });
+    const { container } = render(
+      setup({
+        data: { contestedIssues, additionalIssues: [{ decisionDate }] },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const date = $('va-date', container);
+    expect(date.error).to.contain(issueErrorMessages.newerDate);
+  });
+
+  it('should show an error when the issue is not unique', () => {
+    const goToPathSpy = sinon.spy();
+    const additionalIssues = [{ issue: 'test', decisionDate: validDate }];
+    const { container } = render(
+      setup({
+        goToPath: goToPathSpy,
+        data: { contestedIssues, additionalIssues },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    const textInput = $('va-text-input', container);
+    expect(textInput.error).to.contain(issueErrorMessages.uniqueIssue);
+  });
+
+  it('should submit when everything is valid', () => {
+    const goToPathSpy = sinon.spy();
+    const additionalIssues = [
+      { issue: 'test', decisionDate: getDate({ offset: { months: -3 } }) },
+    ];
+    const { container } = render(
+      setup({
+        goToPath: goToPathSpy,
+        data: { contestedIssues, additionalIssues },
+        index: 1,
+      }),
+    );
+    $('button#submit', container).click();
+
+    expect($('va-text-input', container).error).to.be.null;
+    expect($('va-date', container).error).to.be.null;
+    expect(goToPathSpy.called).to.be.true;
+  });
+});

--- a/src/applications/appeals/995/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import { ContestableIssuesWidget } from '../../components/ContestableIssuesWidget';
+import { SELECTED } from '../../constants';
+
+describe('<ContestableIssuesWidget>', () => {
+  const getProps = ({
+    review = false,
+    submitted = false,
+    onChange = () => {},
+    setFormData = () => {},
+  } = {}) => ({
+    id: 'id',
+    value: [
+      { attributes: { ratingIssueSubjectText: 'issue-1' } },
+      { attributes: { ratingIssueSubjectText: 'issue-2' } },
+    ],
+    additionalIssues: [{ issue: 'issue-3' }],
+    onChange,
+    formContext: {
+      onReviewPage: review,
+      reviewMode: review,
+      submitted,
+    },
+    setFormData,
+  });
+
+  it('should render a list of check boxes (IssueCard component)', () => {
+    const props = getProps();
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+    expect(wrapper.find('input[type="checkbox"]').length).to.equal(
+      props.value.length + props.additionalIssues.length,
+    );
+    expect(
+      wrapper
+        .find('.widget-title')
+        .first()
+        .text(),
+    ).to.equal('issue-1');
+    wrapper.unmount();
+  });
+  it('should render change link & remove button', () => {
+    const props = getProps();
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+    const addLength = props.additionalIssues.length;
+    const link = wrapper.find('a.change-issue-link');
+    expect(link.length).to.equal(addLength);
+    expect(wrapper.find('button.remove-issue').length).to.equal(
+      props.additionalIssues.length,
+    );
+    wrapper.unmount();
+  });
+
+  it('should not wrap the checkboxes in a fieldset', () => {
+    const props = getProps();
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+    expect(wrapper.find('fieldset').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('should call onChange when the checkbox is toggled', () => {
+    const onChange = sinon.spy();
+    const props = getProps({ onChange });
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+    wrapper.find('.form-checkbox').forEach((element, index) => {
+      onChange.reset();
+
+      // "Click" the option
+      // .simulate('click') wasn't calling the onChange handler for some reason
+      element
+        .find('input')
+        .first()
+        .props()
+        .onChange({ target: { checked: true } });
+
+      // Check that it changed
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.firstCall.args[0][index]).to.eql({
+        ...props.value[index],
+        [SELECTED]: true,
+      });
+
+      // "Click" the option
+      element
+        .find('input')
+        .first()
+        .props()
+        .onChange({ target: { checked: false } });
+
+      // Check that it changed back
+      expect(onChange.callCount).to.equal(2);
+      expect(onChange.secondCall.args[0][index]).to.eql({
+        ...props.value[index],
+        [SELECTED]: false,
+      });
+    });
+    wrapper.unmount();
+  });
+  it('should not show an error on submission with one selection', () => {
+    const props = getProps({ submitted: true });
+    const issues = [{ [SELECTED]: true }];
+    const wrapper = mount(
+      <ContestableIssuesWidget {...props} additionalIssues={issues} />,
+    );
+    expect(wrapper.find('.usa-input-error').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('should show an error when submitted with no selections', () => {
+    const props = getProps({ submitted: true });
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+    expect(wrapper.find('va-alert h3').length).to.equal(1);
+    wrapper.unmount();
+  });
+  it('should show a message when no issues selected on review page', () => {
+    const props = getProps({ review: true });
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+    expect(wrapper.find('dt').text()).to.contain(
+      'at least one issue, so we can process your request',
+    );
+    wrapper.unmount();
+  });
+  it('should remove additional item', () => {
+    const setFormData = sinon.spy();
+    const props = getProps({ setFormData });
+    const wrapper = mount(<ContestableIssuesWidget {...props} />);
+
+    expect(props.additionalIssues.length).to.equal(1);
+
+    wrapper
+      .find('button.remove-issue')
+      .props()
+      .onClick({ preventDefault: () => {} });
+
+    expect(setFormData.called).to.be.true;
+    expect(setFormData.args[0][0].additionalIssues.length).to.equal(0);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/appeals/995/tests/components/IssueCard.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/IssueCard.unit.spec.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+import { IssueCardContent, IssueCard } from '../../components/IssueCard';
+import { SELECTED } from '../../constants';
+
+const getContestableIssue = (id, selected) => ({
+  ratingIssueSubjectText: `issue-${id}`,
+  description: 'blah',
+  ratingIssuePercentNumber: id,
+  approxDecisionDate: `2021-01-${id}`,
+  [SELECTED]: selected,
+});
+const getAdditionalIssue = (id, selected) => ({
+  issue: `new-issue-${id}`,
+  decisionDate: `2021-02-${id}`,
+  [SELECTED]: selected,
+});
+
+describe('<IssueCard>', () => {
+  const getProps = ({
+    showCheckbox = true,
+    onChange = () => {},
+    onEdit = null,
+  } = {}) => ({
+    id: 'id',
+    index: 0,
+    options: { appendId: 'z' },
+    showCheckbox,
+    onChange,
+    onEdit,
+  });
+
+  it('should render a Contestable issue', () => {
+    const props = getProps();
+    const issue = getContestableIssue('10');
+    const wrapper = mount(<IssueCard {...props} item={issue} />);
+    expect(wrapper.find('input[type="checkbox"]').length).to.equal(1);
+    expect(wrapper.find('.widget-title').text()).to.eq('issue-10');
+    expect(wrapper.find('.widget-content').text()).to.contain('blah');
+    expect(wrapper.find('.widget-content').text()).to.contain(
+      'Current rating: 10%',
+    );
+    expect(wrapper.find('.widget-content').text()).to.contain(
+      'Decision date: January 10, 2021',
+    );
+    expect(wrapper.find('a.change-issue-link').length).to.equal(0);
+    wrapper.unmount();
+  });
+  it('should render an Additional issue', () => {
+    const props = getProps({ onEdit: () => {} });
+    const issue = getAdditionalIssue('22');
+    const wrapper = mount(<IssueCard {...props} item={issue} />);
+    expect(wrapper.find('input[type="checkbox"]').length).to.equal(1);
+    expect(wrapper.find('.widget-title').text()).to.eq('new-issue-22');
+    expect(wrapper.find('.widget-content').text()).to.contain(
+      'Decision date: February 22, 2021',
+    );
+    const link = wrapper.find('a.change-issue-link');
+    expect(link.length).to.equal(1);
+    wrapper.unmount();
+  });
+  it('should render a selected issue with appendId included', () => {
+    const props = getProps();
+    const issue = getContestableIssue('01', true);
+    const wrapper = mount(<IssueCard {...props} item={issue} />);
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    expect(checkbox.length).to.equal(1);
+    expect(checkbox.props().id).to.equal('id_0_z'); // checks appendId
+    expect(checkbox.props().checked).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should render a selected additional issue without the checkbox or edit button', () => {
+    const props = getProps({ showCheckbox: false });
+    const issue = getAdditionalIssue('03', true);
+    const wrapper = mount(<IssueCard {...props} item={issue} />);
+    expect(wrapper.find('input[type="checkbox"]').length).to.equal(0);
+    expect(wrapper.find('.change-issue-link').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('should call onChange when the checkbox is toggled', () => {
+    const onChange = sinon.spy();
+    const props = getProps({ onChange });
+    const issue = getContestableIssue('01', true);
+    const wrapper = mount(<IssueCard {...props} item={issue} />);
+
+    const element = wrapper.find('input');
+    // "Click" the option
+    // .simulate('click') wasn't calling the onChange handler for some reason
+    element.props().onChange({ target: { checked: true } });
+    // Check that it changed
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.firstCall.args[1].target.checked).to.be.true;
+
+    // "Click" the option
+    element.props().onChange({ target: { checked: false } });
+    // Check that it changed back
+    expect(onChange.callCount).to.equal(2);
+    expect(onChange.secondCall.args[1].target.checked).to.be.false;
+    wrapper.unmount();
+  });
+});
+
+describe('<IssueCardContent>', () => {
+  it('should render an empty div', () => {
+    const wrapper = shallow(<IssueCardContent />);
+    expect(wrapper.find('.widget-content-wrap').text()).to.equal('');
+    wrapper.unmount();
+  });
+  it('should render Contestable issue content', () => {
+    const issue = getContestableIssue('20');
+    const wrapper = shallow(<IssueCardContent {...issue} />);
+    expect(wrapper.find('.widget-content-wrap').text()).to.contain('blah');
+    expect(wrapper.find('.widget-content-wrap').text()).to.contain(
+      'Current rating: 20%',
+    );
+    expect(wrapper.find('.widget-content-wrap').text()).to.contain(
+      'Decision date: January 20, 2021',
+    );
+    expect(wrapper.find('a.change-issue-link').length).to.equal(0);
+    wrapper.unmount();
+  });
+  it('should render AdditionalIssue content', () => {
+    const issue = getAdditionalIssue('21');
+    const wrapper = shallow(<IssueCardContent {...issue} />);
+    expect(wrapper.find('.widget-content-wrap').text()).to.contain(
+      'Decision date: February 21, 2021',
+    );
+    wrapper.unmount();
+  });
+});

--- a/src/applications/appeals/995/tests/components/ShowIssuesList.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ShowIssuesList.unit.spec.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import { ShowIssuesList } from '../../components/ShowIssuesList';
+
+// Already selected issues
+const issues = [
+  {
+    attributes: {
+      ratingIssueSubjectText: 'Issue 1',
+      approxDecisionDate: '2021-01-01',
+    },
+  },
+  {
+    attributes: {
+      ratingIssueSubjectText: 'Issue 2',
+      approxDecisionDate: '2021-01-02',
+    },
+  },
+  {
+    issue: 'Issue 3',
+    decisionDate: '2021-02-01',
+  },
+  {
+    issue: 'Issue 4',
+    decisionDate: '2021-02-02',
+  },
+];
+
+describe('ShowIssuesList', () => {
+  it('should render', () => {
+    const wrapper = shallow(<ShowIssuesList issues={issues} />);
+    const list = wrapper.find('ul');
+    expect(list.length).to.eq(1);
+    wrapper.unmount();
+  });
+  it('should render items', () => {
+    const wrapper = shallow(<ShowIssuesList issues={issues} />);
+    const list = wrapper.find('li');
+    expect(list.length).to.eq(4);
+    expect(list.first().text()).to.contain('Issue 1');
+    expect(list.first().text()).to.contain('Decision date: January 1, 2021');
+    expect(list.last().text()).to.contain('Issue 4');
+    expect(list.last().text()).to.contain('Decision date: February 2, 2021');
+    wrapper.unmount();
+  });
+});

--- a/src/applications/appeals/995/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/FormApp.unit.spec.jsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import moment from 'moment';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import { Provider } from 'react-redux';
+
+import { VA_FORM_IDS } from 'platform/forms/constants';
+
+import { Form0995App } from '../../containers/App';
+
+const profile = {
+  vapContactInfo: {
+    email: {
+      emailAddress: 'test@user.com',
+    },
+    mobilePhone: {
+      countryCode: '2',
+      areaCode: '345',
+      phoneNumber: '6789012',
+      phoneNumberExt: '34',
+      updatedAt: '2021-01-01',
+    },
+    mailingAddress: {
+      addressLine1: '123 test',
+      addressLine2: 'c/o foo',
+      addressLine3: 'suite 99',
+      city: 'Big City',
+      stateCode: 'NV',
+      zipCode: '10101',
+      countryName: 'USA',
+      internationalPostalCode: '12345',
+      updatedAt: '2021-01-01',
+    },
+  },
+};
+
+const saved0995 = [
+  {
+    form: VA_FORM_IDS.FORM_20_0995,
+    metadata: { lastUpdated: 3000, expiresAt: moment().unix() + 2000 },
+  },
+];
+
+const getData = ({
+  loggedIn = true,
+  mockProfile = profile,
+  savedForms = [],
+} = {}) => ({
+  props: {
+    loggedIn,
+    location: { pathname: '/introduction', search: '' },
+    children: <h1>Intro</h1>,
+    profile: mockProfile,
+    formData: { benefitType: 'compensation' },
+    setFormData: () => {},
+    getContestableIssues: () => {},
+    router: { push: () => {} },
+  },
+  mockStore: {
+    getState: () => ({
+      user: {
+        login: {
+          currentlyLoggedIn: loggedIn,
+        },
+        profile: { ...mockProfile, savedForms },
+      },
+      form: {
+        loadedStatus: 'success',
+        savedStatus: '',
+        loadedData: {
+          metadata: {},
+        },
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  },
+});
+
+describe('Form0995App', () => {
+  it('should render', () => {
+    const { props, mockStore } = getData({ loggedIn: false });
+    const tree = mount(
+      <Provider store={mockStore}>
+        <Form0995App {...props} />
+      </Provider>,
+    );
+    const article = tree.find('#form-0995');
+    expect(article).to.exist;
+    expect(article.props()['data-location']).to.eq('introduction');
+    expect(tree.find('h1').text()).to.eq('Intro');
+    expect(tree.find('Connect(RoutedSavableApp)')).to.exist;
+    expect(tree.find('va-loading-indicator')).to.have.lengthOf(0);
+
+    tree.unmount();
+  });
+
+  it('should show contestable issue loading indicator', () => {
+    const { props, mockStore } = getData({ savedForms: saved0995 });
+    const getIssues = sinon.spy();
+    const tree = mount(
+      <Provider store={mockStore}>
+        <Form0995App
+          {...props}
+          getContestableIssues={getIssues}
+          contestableIssues={{
+            issues: [],
+            status: '',
+            error: '',
+            benefitType: 'compensation',
+          }}
+        />
+      </Provider>,
+    );
+
+    tree.setProps();
+    expect(tree.find('va-loading-indicator').html()).to.contain(
+      'Loading your previous decision',
+    );
+    expect(getIssues.calledOnce).to.be.true;
+    tree.unmount();
+  });
+  it('should not call API if not logged in', () => {
+    const { props, mockStore } = getData({ loggedIn: false });
+    const getIssues = sinon.spy();
+    const tree = mount(
+      <Provider store={mockStore}>
+        <Form0995App {...props} getContestableIssues={getIssues} />
+      </Provider>,
+    );
+
+    tree.setProps();
+    expect(getIssues.notCalled).to.be.true;
+
+    tree.unmount();
+  });
+
+  it('should not throw an error if profile is null', () => {
+    const getIssues = sinon.spy();
+    const mockProfile = {
+      vapContactInfo: {
+        email: null,
+        mobilePhone: null,
+        mailingAddress: null,
+      },
+    };
+    const { props, mockStore } = getData({
+      mockProfile,
+      savedForms: saved0995,
+    });
+    const tree = mount(
+      <Provider store={mockStore}>
+        <Form0995App
+          {...props}
+          getContestableIssues={getIssues}
+          contestableIssues={{
+            issues: [],
+            status: '',
+            error: '',
+            benefitType: 'compensation',
+          }}
+        />
+      </Provider>,
+    );
+
+    tree.setProps();
+    expect(getIssues.calledOnce).to.be.true;
+
+    tree.unmount();
+  });
+
+  it('should set form data', () => {
+    const setFormData = sinon.spy();
+    const { props, mockStore } = getData({ savedForms: saved0995 });
+    const contestableIssues = {
+      status: 'done', // any truthy value to skip get contestable issues action
+      issues: [
+        {
+          type: 'contestableIssue',
+          attributes: {
+            ratingIssueSubjectText: 'tinnitus',
+            approxDecisionDate: '2020-01-01',
+            decisionIssueId: 1,
+            ratingIssueReferenceId: '2',
+            ratingDecisionReferenceId: '3',
+            ratingIssuePercentNumber: '10',
+          },
+        },
+        {
+          type: 'contestableIssue',
+          attributes: {
+            ratingIssueSubjectText: 'Sore foot',
+            approxDecisionDate: '2021-01-01',
+            decisionIssueId: 2,
+            ratingIssueReferenceId: '3',
+            ratingDecisionReferenceId: '2',
+            ratingIssuePercentNumber: '1',
+          },
+        },
+      ],
+    };
+    const tree = mount(
+      <Provider store={mockStore}>
+        <Form0995App
+          {...props}
+          setFormData={setFormData}
+          contestableIssues={contestableIssues}
+        />
+      </Provider>,
+    );
+
+    tree.setProps();
+    expect(setFormData.called).to.be.true;
+
+    const formData = setFormData.args[0][0];
+    const result = {
+      address: profile.vapContactInfo.mailingAddress,
+      phone: profile.vapContactInfo.mobilePhone,
+      email: profile.vapContactInfo.email.emailAddress,
+    };
+    expect(formData.veteran).to.deep.equal(result);
+    expect(formData.contestedIssues).to.deep.equal([
+      contestableIssues.issues[1],
+      contestableIssues.issues[0],
+    ]);
+    // check sorted
+    expect(formData.contestedIssues[0].attributes.approxDecisionDate).to.equal(
+      '2021-01-01',
+    );
+
+    tree.unmount();
+  });
+});

--- a/src/applications/appeals/995/tests/fixtures/mocks/application-submit.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/application-submit.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": "123456789",
+    "type": "higherLevelReview",
+    "attributes": {
+      "status": "processed"
+    }
+  }
+}

--- a/src/applications/appeals/995/tests/fixtures/mocks/application-submit.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/application-submit.json
@@ -1,9 +1,14 @@
 {
   "data": {
     "id": "123456789",
-    "type": "higherLevelReview",
+    "type": "supplementalClaim",
     "attributes": {
-      "status": "processed"
+      "status": "pending",
+      "updatedAt": "2022-01-02T03:04:05.067Z",
+      "createdAt": "2022-01-02T03:04:05.067Z",
+      "formData": {
+        "data": {}
+      }
     }
   }
 }

--- a/src/applications/appeals/995/tests/fixtures/mocks/in-progress-forms.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/in-progress-forms.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "id": "1234",
+    "type": "in_progress_forms",
+    "attributes": {
+      "formId": "20-0996",
+      "createdAt": "2021-06-03T00:00:00.000Z",
+      "updatedAt": "2021-06-03T00:00:00.000Z",
+      "metadata": {
+        "version": 1,
+        "returnUrl": "/review-and-submit",
+        "savedAt": 1593500000000,
+        "lastUpdated": 1593500000000,
+        "expiresAt": 99999999999
+      }
+    }
+  }
+}

--- a/src/applications/appeals/995/tests/fixtures/mocks/profile-status.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/profile-status.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_address_transactions",
+    "attributes": {
+      "transactionId": "bfedd909-9dc4-4b27-abc2-a6cccaece35d",
+      "transactionStatus": "COMPLETED_SUCCESS",
+      "type": "AsyncTransaction::VAProfile::AddressTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/appeals/995/tests/fixtures/mocks/telephone-update-success.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/telephone-update-success.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_telephone_transactions",
+    "attributes": {
+      "transactionId": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2",
+      "transactionStatus": "COMPLETED_SUCCESS",
+      "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/appeals/995/tests/fixtures/mocks/telephone-update.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/telephone-update.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "attributes": {
+      "transaction_status": "RECEIVED",
+      "transaction_id": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2",
+      "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/appeals/995/tests/fixtures/mocks/user.json
+++ b/src/applications/appeals/995/tests/fixtures/mocks/user.json
@@ -1,0 +1,123 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "form-save-in-progress",
+        "form-prefill",
+        "mhv-accounts",
+        "evss-claims",
+        "form526",
+        "user-profile",
+        "appeals-status",
+        "id-card",
+        "identity-proofed",
+        "vet360",
+        "evss_common_client",
+        "claim_increase",
+        "user-profile",
+        "vet360"
+      ],
+      "account": { "accountUuid": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2" },
+      "profile": {
+        "email": "vets.gov.user+36@gmail.com",
+        "firstName": "Mike",
+        "middleName": "",
+        "lastName": "Wazowski",
+        "birthDate": "2001-10-28",
+        "gender": "M",
+        "zip": "94608",
+        "lastSignedIn": "2020-07-21T00:04:51.589Z",
+        "loa": { "current": 3, "highest": 3 },
+        "multifactor": true,
+        "verified": true,
+        "signIn": { "serviceName": "idme", "accountType": "N/A", "ssoe": true },
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3"
+      },
+      "vaProfile": {
+        "status": "OK",
+        "birthDate": "20011028",
+        "familyName": "Wazowski",
+        "gender": "M",
+        "givenNames": ["Michael", ""],
+        "isCernerPatient": false,
+        "facilities": [{ "facilityId": "983", "isCerner": false }],
+        "vaPatient": true,
+        "mhvAccountState": "NONE"
+      },
+      "veteranStatus": {
+        "status": "OK",
+        "isVeteran": true,
+        "servedInMilitary": true
+      },
+      "inProgressForms": [],
+      "prefillsAvailable": [],
+      "vet360ContactInformation": {
+        "email": {
+          "emailAddress": "test@user.com"
+        },
+        "residentialAddress": {},
+        "mailingAddress": {
+          "addressLine1": "1200 Park Ave",
+          "addressLine2": "c/o Pixar",
+          "addressLine3": null,
+          "addressPou": "CORRESPONDENCE",
+          "addressType": "DOMESTIC",
+          "city": "Emeryville",
+          "countryName": "United States",
+          "countryCodeIso2": "US",
+          "countryCodeIso3": "USA",
+          "countryCodeFips": null,
+          "countyCode": null,
+          "countyName": null,
+          "createdAt": "2020-05-30T03:57:20.000+00:00",
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2020-07-10T20:10:45.000+00:00",
+          "id": 173917,
+          "internationalPostalCode": null,
+          "province": null,
+          "sourceDate": "2020-07-10T20:10:45.000+00:00",
+          "sourceSystemUser": null,
+          "stateCode": "CA",
+          "transactionId": "7139aa82-fd06-45ea-a217-9654869924bd",
+          "updatedAt": "2020-07-10T20:10:46.000+00:00",
+          "validationKey": null,
+          "vet360Id": "1273780",
+          "zipCode": "94608",
+          "zipCodeSuffix": null
+        },
+        "mobilePhone": {
+          "areaCode": "510",
+          "countryCode": "1",
+          "createdAt": "2020-06-12T16:56:37.000+00:00",
+          "extension": "17477",
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2020-07-14T19:07:45.000+00:00",
+          "id": 146766,
+          "isInternational": false,
+          "isTextable": null,
+          "isTextPermitted": null,
+          "isTty": null,
+          "isVoicemailable": null,
+          "phoneNumber": "9223000",
+          "phoneType": "HOME",
+          "sourceDate": "2020-07-14T19:07:45.000+00:00",
+          "sourceSystemUser": null,
+          "transactionId": "92c49d39-22b2-4bd6-92b4-0b7e7c63c6a9",
+          "updatedAt": "2020-07-14T19:07:46.000+00:00",
+          "vet360Id": "1273780"
+        },
+        "homePhone": {},
+        "workPhone": {},
+        "temporaryPhone": null,
+        "faxNumber": null,
+        "textPermission": null
+      }
+    }
+  },
+  "meta": { "errors": null }
+}

--- a/src/applications/appeals/995/tests/pages/contestableIssues.unit.spec.js
+++ b/src/applications/appeals/995/tests/pages/contestableIssues.unit.spec.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+
+import { $ } from '../../utils/ui';
+
+import formConfig from '../../config/form';
+
+const mockStore = data => ({
+  getState: () => ({
+    form: {
+      data: {
+        ...data,
+        contestedIssues: [],
+      },
+    },
+    formContext: {
+      onReviewPage: false,
+      reviewMode: false,
+      touched: {},
+      submitted: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => ({
+    setFormData: () => {},
+  }),
+});
+
+describe('add issue page', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.issues.pages.contestableIssues;
+
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <div>
+        <Provider store={mockStore()}>
+          <DefinitionTester
+            definitions={{}}
+            schema={schema}
+            uiSchema={uiSchema}
+            data={{}}
+          />
+        </Provider>
+      </div>,
+    );
+
+    const formDOM = getFormDOM(form);
+    expect($('a.add-new-issue', formDOM)).to.exist;
+  });
+});

--- a/src/applications/appeals/995/tests/reducers/reducers.unit.spec.js
+++ b/src/applications/appeals/995/tests/reducers/reducers.unit.spec.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import {
+  FETCH_CONTESTABLE_ISSUES_INIT,
+  FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+  FETCH_CONTESTABLE_ISSUES_FAILED,
+} from '../../actions';
+
+import reducers from '../../reducers';
+
+describe('contestableIssues reducer', () => {
+  const { contestableIssues } = reducers;
+  const initialState = {
+    status: '',
+  };
+
+  it('should handle FETCH_CONTESTABLE_ISSUES_INIT', () => {
+    const newState = contestableIssues(initialState, {
+      type: FETCH_CONTESTABLE_ISSUES_INIT,
+    });
+    expect(newState.status).to.equal(FETCH_CONTESTABLE_ISSUES_INIT);
+  });
+
+  it('should handle FETCH_CONTESTABLE_ISSUES_SUCCEEDED', () => {
+    const newState = contestableIssues(initialState, {
+      type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+    });
+    expect(newState.status).to.equal(FETCH_CONTESTABLE_ISSUES_SUCCEEDED);
+  });
+
+  it('should handle FETCH_CONTESTABLE_ISSUES_FAILED', () => {
+    const newState = contestableIssues(initialState, {
+      type: FETCH_CONTESTABLE_ISSUES_FAILED,
+    });
+    expect(newState.status).to.equal(FETCH_CONTESTABLE_ISSUES_FAILED);
+  });
+});

--- a/src/applications/appeals/995/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/dates.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import { FORMAT_YMD, FORMAT_READABLE } from '../../constants';
+import { getDate } from '../../utils/dates';
+
+describe('getDate', () => {
+  const dateString = '2021-02-10 00:00:00';
+  const date = new Date(dateString);
+
+  it('should return a date string from date object', () => {
+    expect(getDate()).to.equal(moment().format(FORMAT_YMD));
+  });
+  it('should return a date string from date string & offset', () => {
+    expect(getDate({ date, offset: { days: 3 } })).to.contain('2021-02-13');
+  });
+  it('should return a date string pattern based on date & offset', () => {
+    expect(getDate({ date, offset: { years: -1 } })).to.contain('2020-02-10');
+    expect(
+      getDate({
+        date,
+        offset: { years: -1 },
+        pattern: FORMAT_READABLE,
+      }),
+    ).to.contain('February 10, 2020');
+    expect(
+      getDate({ date: '2021-02-10 00:00:00', pattern: FORMAT_READABLE }),
+    ).to.contain('February 10, 2021');
+  });
+});

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -1,0 +1,425 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import { SELECTED, LEGACY_TYPE } from '../../constants';
+import { getDate } from '../../utils/dates';
+
+import {
+  getEligibleContestableIssues,
+  getLegacyAppealsLength,
+  mayHaveLegacyAppeals,
+  someSelected,
+  hasSomeSelected,
+  getSelected,
+  getSelectedCount,
+  getIssueName,
+  getIssueDate,
+  getIssueNameAndDate,
+  hasDuplicates,
+  isEmptyObject,
+  processContestableIssues,
+  readableList,
+  returnPhoneObject,
+  checkContestableIssueError,
+} from '../../utils/helpers';
+
+describe('getEligibleContestableIssues', () => {
+  const date = moment().startOf('day');
+
+  const eligibleIssue = {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'Issue 2',
+      description: '',
+      approxDecisionDate: getDate({ date, offset: { months: -10 } }),
+    },
+  };
+  const ineligibleIssue = [
+    {
+      type: 'contestableIssue',
+      attributes: {
+        ratingIssueSubjectText: 'Issue 1',
+        description: '',
+        approxDecisionDate: getDate({ date, offset: { years: -2 } }),
+      },
+    },
+  ];
+  const deferredIssue = {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'Issue 2',
+      description: 'this is a deferred issue',
+      approxDecisionDate: getDate({ date, offset: { months: -1 } }),
+    },
+  };
+
+  it('should return empty array', () => {
+    expect(getEligibleContestableIssues()).to.have.lengthOf(0);
+    expect(getEligibleContestableIssues([])).to.have.lengthOf(0);
+    expect(getEligibleContestableIssues([{}])).to.have.lengthOf(0);
+  });
+  it('should filter out dates more than one year in the past', () => {
+    expect(
+      getEligibleContestableIssues([ineligibleIssue, eligibleIssue]),
+    ).to.deep.equal([eligibleIssue]);
+  });
+  it('should filter out dates more than one year in the past', () => {
+    expect(
+      getEligibleContestableIssues([eligibleIssue, ineligibleIssue]),
+    ).to.deep.equal([eligibleIssue]);
+  });
+  it('should filter out deferred issues', () => {
+    expect(
+      getEligibleContestableIssues([
+        eligibleIssue,
+        deferredIssue,
+        ineligibleIssue,
+      ]),
+    ).to.deep.equal([eligibleIssue]);
+  });
+});
+
+describe('getLegacyAppealsLength', () => {
+  it('should return 0 with no issues', () => {
+    expect(getLegacyAppealsLength()).to.equal(0);
+  });
+  it('should return 0 with no legacy issues', () => {
+    expect(
+      getLegacyAppealsLength([{ type: 'one' }, { type: LEGACY_TYPE }]),
+    ).to.equal(0);
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: {} },
+      ]),
+    ).to.equal(0);
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: { issues: [] } },
+      ]),
+    ).to.equal(0);
+  });
+  it('should return a value > 0 with legacy issues', () => {
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: { issues: [{}, {}] } },
+      ]),
+    ).to.equal(2);
+    expect(
+      getLegacyAppealsLength([
+        { type: 'one' },
+        { type: LEGACY_TYPE, attributes: { issues: [{}, {}] } },
+        { type: LEGACY_TYPE, attributes: { issues: [] } },
+        { type: LEGACY_TYPE, attributes: { issues: [{}] } },
+      ]),
+    ).to.equal(3);
+  });
+});
+
+describe('mayHaveLegacyAppeals', () => {
+  it('should return false if there is no data', () => {
+    expect(mayHaveLegacyAppeals()).to.be.false;
+  });
+  it('should return false if there is no legacy & no additional issues', () => {
+    expect(mayHaveLegacyAppeals({ legacyCount: 0, additionalIssues: [] })).to.be
+      .false;
+  });
+  it('should return true if there are some legacy issues & no additional issues', () => {
+    expect(mayHaveLegacyAppeals({ legacyCount: 1, additionalIssues: [] })).to.be
+      .true;
+  });
+  it('should return true if there is no legacy & some additional issues', () => {
+    expect(mayHaveLegacyAppeals({ legacyCount: 0, additionalIssues: [{}] })).to
+      .be.true;
+  });
+});
+
+describe('someSelected', () => {
+  it('should return true for issues that have some selected values', () => {
+    expect(someSelected([{ [SELECTED]: true }, {}])).to.be.true;
+    expect(someSelected([{}, { [SELECTED]: true }, {}])).to.be.true;
+    expect(someSelected([{}, {}, {}, { [SELECTED]: true }])).to.be.true;
+  });
+  it('should return false for issues with no selected values', () => {
+    expect(someSelected()).to.be.false;
+    expect(someSelected([])).to.be.false;
+    expect(someSelected([{}, {}])).to.be.false;
+    expect(someSelected([{}, { [SELECTED]: false }, {}])).to.be.false;
+    expect(someSelected([{}, {}, {}, { [SELECTED]: false }])).to.be.false;
+  });
+});
+
+describe('hasSomeSelected', () => {
+  const testIssues = (contestedIssues, additionalIssues) =>
+    hasSomeSelected({ contestedIssues, additionalIssues });
+  it('should return true for issues that have some selected values', () => {
+    expect(testIssues([{ [SELECTED]: true }], [{}])).to.be.true;
+    expect(testIssues([{}], [{ [SELECTED]: true }, {}])).to.be.true;
+    expect(testIssues([{}], [{}, {}, { [SELECTED]: true }])).to.be.true;
+    expect(
+      testIssues([{}, { [SELECTED]: true }], [{}, {}, { [SELECTED]: true }]),
+    ).to.be.true;
+  });
+  it('should return false for no selected issues', () => {
+    expect(testIssues()).to.be.false;
+    expect(testIssues([], [])).to.be.false;
+    expect(testIssues([{}], [{}])).to.be.false;
+    expect(testIssues([{ [SELECTED]: false }], [{}])).to.be.false;
+    expect(testIssues([{}], [{ [SELECTED]: false }, {}])).to.be.false;
+    expect(testIssues([{}], [{}, {}, { [SELECTED]: false }])).to.be.false;
+    expect(
+      testIssues([{}, { [SELECTED]: false }], [{}, {}, { [SELECTED]: false }]),
+    ).to.be.false;
+  });
+});
+
+describe('getSelected & getSelectedCount', () => {
+  it('should return selected contested issues', () => {
+    const data = {
+      contestedIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
+  });
+  it('should return selected additional issues', () => {
+    const data = {
+      additionalIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
+  });
+  it('should return all selected issues', () => {
+    const data = {
+      contestedIssues: [
+        { type: 'no1', [SELECTED]: false },
+        { type: 'ok1', [SELECTED]: true },
+      ],
+      additionalIssues: [
+        { type: 'no2', [SELECTED]: false },
+        { type: 'ok2', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok1', [SELECTED]: true, index: 0 },
+      { type: 'ok2', [SELECTED]: true, index: 1 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(2);
+  });
+});
+
+describe('getIssueName', () => {
+  it('should return undefined', () => {
+    expect(getIssueName()).to.be.undefined;
+  });
+  it('should return a contested issue name', () => {
+    expect(
+      getIssueName({ attributes: { ratingIssueSubjectText: 'test' } }),
+    ).to.eq('test');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('getIssueDate', () => {
+  it('should return undefined', () => {
+    expect(getIssueDate()).to.eq('');
+  });
+  it('should return a contestable issue date', () => {
+    expect(
+      getIssueDate({ attributes: { approxDecisionDate: '2021-01-01' } }),
+    ).to.eq('2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueDate({ decisionDate: '2021-02-01' })).to.eq('2021-02-01');
+  });
+});
+
+describe('getIssueNameAndDate', () => {
+  it('should return empty string', () => {
+    expect(getIssueNameAndDate()).to.equal('');
+  });
+  it('should return a contested issue name', () => {
+    expect(
+      getIssueNameAndDate({
+        attributes: {
+          ratingIssueSubjectText: 'test',
+          approxDecisionDate: '2021-01-01',
+        },
+      }),
+    ).to.eq('test2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(
+      getIssueNameAndDate({ issue: 'test2', decisionDate: '2021-02-02' }),
+    ).to.eq('test22021-02-02');
+  });
+});
+
+describe('hasDuplicates', () => {
+  const contestedIssues = [
+    {
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: '2021-01-01',
+      },
+    },
+  ];
+
+  it('should be false with no duplicate additional issues', () => {
+    const result = hasDuplicates();
+    expect(result).to.be.false;
+  });
+  it('should be false when there are duplicate contestable issues', () => {
+    const result = hasDuplicates({
+      contestedIssues: [contestedIssues[0], contestedIssues[0]],
+    });
+    expect(result).to.be.false;
+  });
+  it('should be false when there are no duplicate issues (only date differs)', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-02' }],
+    });
+    expect(result).to.be.false;
+  });
+  it('should be true when there is a duplicate additional issue', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-01' }],
+    });
+    expect(result).to.be.true;
+  });
+  it('should be true when there is are multiple duplicate additional issues', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [
+        { issue: 'test2', decisionDate: '2021-02-01' },
+        { issue: 'test2', decisionDate: '2021-02-01' },
+      ],
+    });
+    expect(result).to.be.true;
+  });
+});
+
+describe('isEmptyObject', () => {
+  it('should return true for an empty object', () => {
+    expect(isEmptyObject({})).to.be.true;
+  });
+  it('should return true for non objects or filled objects', () => {
+    expect(isEmptyObject()).to.be.false;
+    expect(isEmptyObject('')).to.be.false;
+    expect(isEmptyObject([])).to.be.false;
+    expect(isEmptyObject('test')).to.be.false;
+    expect(isEmptyObject(null)).to.be.false;
+    expect(isEmptyObject(true)).to.be.false;
+    expect(isEmptyObject(() => {})).to.be.false;
+    expect(isEmptyObject({ test: '' })).to.be.false;
+  });
+});
+
+describe('processContestableIssues', () => {
+  const getIssues = dates =>
+    dates.map(date => ({
+      attributes: { ratingIssueSubjectText: 'a', approxDecisionDate: date },
+    }));
+  const getDates = dates =>
+    dates.map(date => date.attributes.approxDecisionDate);
+
+  it('should return an empty array with undefined issues', () => {
+    expect(getDates(processContestableIssues())).to.deep.equal([]);
+  });
+  it('should filter out issues missing a title', () => {
+    const issues = getIssues(['2020-02-01', '2020-03-01', '2020-01-01']);
+    issues[0].attributes.ratingIssueSubjectText = '';
+    const result = processContestableIssues(issues);
+    expect(getDates(result)).to.deep.equal(['2020-03-01', '2020-01-01']);
+  });
+  it('should sort issues spanning months with newest date first', () => {
+    const dates = ['2020-02-01', '2020-03-01', '2020-01-01'];
+    const result = processContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2020-03-01',
+      '2020-02-01',
+      '2020-01-01',
+    ]);
+  });
+  it('should sort issues spanning a year & months with newest date first', () => {
+    const dates = ['2021-01-31', '2020-12-01', '2021-02-02', '2021-02-01'];
+    const result = processContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2021-02-02',
+      '2021-02-01',
+      '2021-01-31',
+      '2020-12-01',
+    ]);
+  });
+});
+
+describe('readableList', () => {
+  it('should return an empty string', () => {
+    expect(readableList([])).to.eq('');
+    expect(readableList(['', null, 0])).to.eq('');
+  });
+  it('should return a combined list with commas with "and" for the last item', () => {
+    expect(readableList(['one'])).to.eq('one');
+    expect(readableList(['', 'one', null])).to.eq('one');
+    expect(readableList(['one', 'two'])).to.eq('one and two');
+    expect(readableList([1, 2, 'three'])).to.eq('1, 2 and three');
+    expect(readableList(['v', null, 'w', 'x', '', 'y', 'z'])).to.eq(
+      'v, w, x, y and z',
+    );
+  });
+});
+
+describe('returnPhoneObject', () => {
+  const emptyPhone = {
+    countryCode: '',
+    areaCode: '',
+    phoneNumber: '',
+    phoneNumberExt: '',
+  };
+  it('should return empty phone object', () => {
+    expect(returnPhoneObject()).to.deep.equal(emptyPhone);
+    expect(returnPhoneObject(undefined)).to.deep.equal(emptyPhone);
+    expect(returnPhoneObject(null)).to.deep.equal(emptyPhone);
+    expect(returnPhoneObject([])).to.deep.equal(emptyPhone);
+    expect(returnPhoneObject('1234')).to.deep.equal(emptyPhone);
+  });
+  it('should return a phone object', () => {
+    expect(returnPhoneObject('8005551212')).to.deep.equal({
+      countryCode: '1',
+      areaCode: '800',
+      phoneNumber: '5551212',
+      phoneNumberExt: '',
+    });
+  });
+});
+
+describe('checkContestableIssueError', () => {
+  it('should return false if no error', () => {
+    expect(checkContestableIssueError()).to.be.false;
+  });
+  it('should return false if 404 error', () => {
+    expect(checkContestableIssueError({ errors: [{ status: '404' }] })).to.be
+      .false;
+  });
+  it('should return true', () => {
+    expect(checkContestableIssueError({})).to.be.true;
+    expect(checkContestableIssueError({ error: 'blah' })).to.be.true;
+    expect(checkContestableIssueError({ errors: [{ status: '123' }] })).to.be
+      .true;
+  });
+});

--- a/src/applications/appeals/995/tests/utils/replace.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/replace.unit.spec.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import {
+  replaceDescriptionContent,
+  replaceSubmittedData,
+} from '../../utils/replace';
+
+describe('replaceDescriptionContent', () => {
+  it('should return an empty string', () => {
+    expect(replaceDescriptionContent()).to.eq('');
+    expect(replaceDescriptionContent(null)).to.eq('');
+    expect(replaceDescriptionContent('')).to.eq('');
+  });
+  it('should not alter an these strings', () => {
+    expect(replaceDescriptionContent('   ')).to.eq('   ');
+    expect(replaceDescriptionContent('abc 123')).to.eq('abc 123');
+  });
+  it('should replace percent with a % symbol', () => {
+    expect(replaceDescriptionContent('10 percent')).to.eq('10%');
+    expect(replaceDescriptionContent('10 percent.')).to.eq('10%.');
+    expect(replaceDescriptionContent('Percent effective')).to.eq('% effective');
+    expect(replaceDescriptionContent('Equal to 30 percent income')).to.eq(
+      'Equal to 30% income',
+    );
+  });
+  it('should not replace percent within words', () => {
+    expect(replaceDescriptionContent('Percentage due')).to.eq('Percentage due');
+    expect(replaceDescriptionContent('20 percentile')).to.eq('20 percentile');
+    expect(replaceDescriptionContent('percentpercent')).to.eq('percentpercent');
+  });
+});
+
+describe('replaceSubmittedData', () => {
+  it('should return an empty string', () => {
+    expect(replaceSubmittedData()).to.eq('');
+    expect(replaceSubmittedData(null)).to.eq('');
+    expect(replaceSubmittedData('')).to.eq('');
+  });
+  it('should not alter an these strings', () => {
+    expect(replaceSubmittedData('   ')).to.eq('   ');
+    expect(replaceSubmittedData('abc 123')).to.eq('abc 123');
+  });
+  it('should replace typographical apostrophes with a single quote', () => {
+    expect(replaceSubmittedData('don’t won’t can’t you’ll')).to.eq(
+      "don't won't can't you'll",
+    );
+    expect(replaceSubmittedData('’100’ times')).to.eq("'100' times");
+  });
+});

--- a/src/applications/appeals/995/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/submit.unit.spec.js
@@ -1,0 +1,200 @@
+import { expect } from 'chai';
+import { SELECTED } from '../../constants';
+import { getDate } from '../../utils/dates';
+
+import {
+  createIssueName,
+  getContestedIssues,
+  removeEmptyEntries,
+  getAddress,
+  getPhone,
+  getTimeZone,
+} from '../../utils/submit';
+
+const validDate1 = getDate({ offset: { months: -2 } });
+const issue1 = {
+  raw: {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'tinnitus',
+      description: 'both ears',
+      approxDecisionDate: validDate1,
+      decisionIssueId: 1,
+      ratingIssueReferenceId: '2',
+      ratingDecisionReferenceId: '3',
+      ratingIssuePercentNumber: '10',
+    },
+  },
+  result: {
+    type: 'contestableIssue',
+    attributes: {
+      issue: 'tinnitus - 10% - both ears',
+      decisionDate: validDate1,
+      decisionIssueId: 1,
+      ratingIssueReferenceId: '2',
+      ratingDecisionReferenceId: '3',
+    },
+  },
+};
+
+const validDate2 = getDate({ offset: { months: -4 } });
+const issue2 = {
+  raw: {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'left knee',
+      approxDecisionDate: validDate2,
+      decisionIssueId: 4,
+      ratingIssueReferenceId: '5',
+    },
+  },
+  result: {
+    type: 'contestableIssue',
+    attributes: {
+      issue: 'left knee - 0%',
+      decisionDate: validDate2,
+      decisionIssueId: 4,
+      ratingIssueReferenceId: '5',
+    },
+  },
+};
+
+describe('createIssueName', () => {
+  const getName = (name, description, percent) =>
+    createIssueName({
+      attributes: {
+        ratingIssueSubjectText: name,
+        ratingIssuePercentNumber: percent,
+        description,
+      },
+    });
+
+  it('should combine issue details into the name', () => {
+    // contestable issues only
+    expect(getName('test', 'foo', '10')).to.eq('test - 10% - foo');
+    expect(getName('test', 'xyz', null)).to.eq('test - 0% - xyz');
+    expect(getName('test')).to.eq('test - 0%');
+  });
+});
+
+describe('getContestedIssues', () => {
+  it('should return all issues', () => {
+    const formData = {
+      contestedIssues: [
+        { ...issue1.raw, [SELECTED]: true },
+        { ...issue2.raw, [SELECTED]: true },
+      ],
+    };
+    expect(getContestedIssues(formData)).to.deep.equal([
+      issue1.result,
+      issue2.result,
+    ]);
+  });
+  it('should return second issue', () => {
+    const formData = {
+      contestedIssues: [
+        { ...issue1.raw, [SELECTED]: false },
+        { ...issue2.raw, [SELECTED]: true },
+      ],
+    };
+    expect(getContestedIssues(formData)).to.deep.equal([issue2.result]);
+  });
+});
+
+describe('removeEmptyEntries', () => {
+  it('should remove empty string items', () => {
+    expect(removeEmptyEntries({ a: '', b: 1, c: 'x', d: '' })).to.deep.equal({
+      b: 1,
+      c: 'x',
+    });
+  });
+  it('should not remove null or undefined items', () => {
+    expect(removeEmptyEntries({ a: null, b: undefined, c: 3 })).to.deep.equal({
+      a: null,
+      b: undefined,
+      c: 3,
+    });
+  });
+});
+
+describe('getAddress', () => {
+  it('should return a cleaned up address object', () => {
+    const wrap = obj => ({
+      veteran: { address: obj },
+    });
+    expect(getAddress({})).to.deep.equal({});
+    expect(getAddress(wrap({}))).to.deep.equal({});
+    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal({});
+    expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
+      addressLine1: 'test',
+    });
+    expect(getAddress(wrap({ zipCode: '10101' }))).to.deep.equal({
+      zipCode5: '10101',
+    });
+    expect(
+      getAddress(
+        wrap({
+          addressLine1: '123 test',
+          addressLine2: 'c/o foo',
+          addressLine3: 'suite 99',
+          city: 'Big City',
+          stateCode: 'NV',
+          zipCode: '10101',
+          countryCodeIso2: 'US',
+          internationalPostalCode: '12345',
+          extra: 'will not be included',
+        }),
+      ),
+    ).to.deep.equal({
+      addressLine1: '123 test',
+      addressLine2: 'c/o foo',
+      addressLine3: 'suite 99',
+      city: 'Big City',
+      stateCode: 'NV',
+      zipCode5: '00000',
+      countryCodeISO2: 'US',
+      internationalPostalCode: '12345',
+    });
+    expect(
+      getAddress(wrap({ internationalPostalCode: '55555' })),
+    ).to.deep.equal({
+      zipCode5: '00000',
+      internationalPostalCode: '55555',
+    });
+  });
+});
+
+describe('getPhone', () => {
+  it('should return a cleaned up phone object', () => {
+    const wrap = obj => ({ veteran: { phone: obj } });
+    expect(getPhone()).to.deep.equal({});
+    expect(getPhone(wrap({}))).to.deep.equal({});
+    expect(getPhone(wrap({ temp: 'test' }))).to.deep.equal({});
+    expect(getPhone(wrap({ areaCode: '111' }))).to.deep.equal({
+      areaCode: '111',
+    });
+    expect(
+      getPhone(
+        wrap({
+          countryCode: '1',
+          areaCode: '222',
+          phoneNumber: '1234567',
+          phoneNumberExt: '0000',
+          extra: 'will not be included',
+        }),
+      ),
+    ).to.deep.equal({
+      countryCode: '1',
+      areaCode: '222',
+      phoneNumber: '1234567',
+      phoneNumberExt: '0000',
+    });
+  });
+});
+
+describe('getTimeZone', () => {
+  it('should return a string', () => {
+    // result will be a location string, not stubbing for this test
+    expect(getTimeZone().length).to.be.greaterThan(1);
+  });
+});

--- a/src/applications/appeals/995/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/date.unit.spec.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+
+import { getDate } from '../../utils/dates';
+import { validateDate, isValidDate } from '../../validations/date';
+
+describe('validateDate & isValidDate', () => {
+  let errorMessage = '';
+  const errors = {
+    addError: message => {
+      errorMessage = message || '';
+    },
+  };
+
+  beforeEach(() => {
+    errorMessage = '';
+  });
+
+  it('should allow valid dates', () => {
+    const date = getDate({ offset: { weeks: -1 } });
+    validateDate(errors, date);
+    expect(errorMessage).to.equal('');
+    expect(isValidDate(date)).to.be.true;
+  });
+  it('should throw a invalid date error', () => {
+    validateDate(errors, '200');
+    expect(errorMessage).to.contain('provide a valid date');
+    expect(isValidDate('200')).to.be.false;
+  });
+  it('should throw a range error for dates too old', () => {
+    validateDate(errors, '1899-01-01');
+    expect(errorMessage).to.contain('enter a year between');
+    expect(isValidDate('1899')).to.be.false;
+  });
+  it('should throw an error for dates in the future', () => {
+    const date = getDate({ offset: { weeks: 1 } });
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('past decision date');
+    expect(isValidDate(date)).to.be.false;
+  });
+  it('should throw an error for todays date', () => {
+    const date = getDate();
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('past decision date');
+    expect(isValidDate(date)).to.be.false;
+  });
+  it('should throw an error for dates more than a year in the past', () => {
+    const date = getDate({ offset: { weeks: -60 } });
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('date less than a year');
+    expect(isValidDate(date)).to.be.false;
+  });
+  it('should throw a invalid date for truncated dates', () => {
+    // Testing 'YYYY-MM-' (contact center reported errors; FE seeing this)
+    const date = getDate({ offset: { weeks: 1 } }).substring(0, 8);
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('provide a valid date');
+    expect(isValidDate(date)).to.be.false;
+  });
+  it('should throw a invalid date for truncated dates', () => {
+    // Testing 'YYYY--DD' (contact center reported errors; BE seeing this)
+    const date = getDate({ offset: { weeks: 1 } }).replace(/-.*-/, '--');
+    validateDate(errors, date);
+    expect(errorMessage).to.contain('provide a valid date');
+    expect(isValidDate(date)).to.be.false;
+  });
+});

--- a/src/applications/appeals/995/tests/validations/issues.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/issues.unit.spec.js
@@ -1,0 +1,149 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { getDate } from '../../utils/dates';
+import { SELECTED, MAX_LENGTH } from '../../constants';
+
+import {
+  uniqueIssue,
+  maxIssues,
+  selectionRequired,
+  missingIssueName,
+  maxNameLength,
+} from '../../validations/issues';
+
+describe('uniqueIssue', () => {
+  const _ = null;
+  const contestedIssues = [
+    {
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: '2021-01-01',
+      },
+    },
+  ];
+
+  it('should not show an error when there are no issues', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {});
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should not show an error when there are duplicate contested issues', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues: [contestedIssues[0], contestedIssues[0]],
+    });
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should not show an error when there are no duplicate issues (only date differs)', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-02' }],
+    });
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should show an error when there is a duplicate additional issue', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-01' }],
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error when there are multiple duplicate additional issue', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues,
+      additionalIssues: [
+        { issue: 'test2', decisionDate: '2021-02-01' },
+        { issue: 'test2', decisionDate: '2021-02-01' },
+      ],
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+});
+
+describe('maxIssues', () => {
+  it('should not show an error when the array length is less than max', () => {
+    const errors = { addError: sinon.spy() };
+    maxIssues(errors, []);
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should show not show an error when the array length is greater than max', () => {
+    const errors = { addError: sinon.spy() };
+    const validDate = getDate({ offset: { months: -2 } });
+    const template = {
+      issue: 'x',
+      decisionDate: validDate,
+      [SELECTED]: true,
+    };
+    maxIssues(errors, {
+      contestedIssues: new Array(MAX_LENGTH.SELECTIONS + 1).fill(template),
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+});
+
+describe('selectionRequired', () => {
+  const _ = null;
+  const getData = (selectContested = false, selectAdditional = false) => ({
+    contestedIssues: [
+      {
+        attributes: {
+          ratingIssueSubjectText: 'test',
+          approxDecisionDate: '2021-01-01',
+        },
+        [SELECTED]: selectContested,
+      },
+    ],
+    additionalIssues: [
+      {
+        issue: 'test 2',
+        decisionDate: '2021-01-01',
+        [SELECTED]: selectAdditional,
+      },
+    ],
+  });
+  it('should show an error when no issues are selected', () => {
+    const errors = { addError: sinon.spy() };
+    selectionRequired(errors, _, getData());
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show not show an error when a contested issue is selected', () => {
+    const errors = { addError: sinon.spy() };
+    selectionRequired(errors, _, getData(true));
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should show not show an error when an additional issue is selected', () => {
+    const errors = { addError: sinon.spy() };
+    selectionRequired(errors, _, getData(false, true));
+    expect(errors.addError.called).to.be.false;
+  });
+});
+
+describe('missingIssueName', () => {
+  it('should show an error when a name is missing', () => {
+    const errors = { addError: sinon.spy() };
+    missingIssueName(errors);
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error when a name is missing', () => {
+    const errors = { addError: sinon.spy() };
+    missingIssueName(errors, 'test');
+    expect(errors.addError.called).to.be.false;
+  });
+});
+
+describe('maxNameLength', () => {
+  it('should show an error when a name is too long', () => {
+    const errors = { addError: sinon.spy() };
+    maxNameLength(errors, 'ab '.repeat(MAX_LENGTH.ISSUE_NAME / 2));
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error when a name is not too long', () => {
+    const errors = { addError: sinon.spy() };
+    maxNameLength(errors, 'test');
+    expect(errors.addError.called).to.be.false;
+  });
+});

--- a/src/applications/appeals/995/tests/validations/validations.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/validations.unit.spec.js
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  requireRatedDisability,
+  contactInfoValidation,
+} from '../../validations';
+import { errorMessages, SELECTED } from '../../constants';
+
+describe('requireRatedDisability', () => {
+  it('should show an error if no disabilities are selected', () => {
+    const errors = { addError: sinon.spy() };
+    requireRatedDisability(errors, [{}, {}]);
+    expect(errors.addError.calledWith(errorMessages.contestedIssue)).to.be.true;
+  });
+  it('should not show an error if a disabilitiy is selected', () => {
+    const errors = { addError: sinon.spy() };
+    requireRatedDisability(errors, [{}, { [SELECTED]: true }]);
+    expect(errors.addError.notCalled).to.be.true;
+  });
+});
+
+describe('contactInfoValidation', () => {
+  const getData = ({
+    email = true,
+    phone = true,
+    address = true,
+    homeless = false,
+  } = {}) => ({
+    veteran: {
+      email: email ? 'placeholder' : '',
+      phone: phone ? { phoneNumber: 'placeholder' } : {},
+      address: address ? { addressLine1: 'placeholder' } : {},
+    },
+    homeless,
+  });
+  it('should not show an error when data is available', () => {
+    const addError = sinon.spy();
+    contactInfoValidation({ addError }, null, getData());
+    expect(addError.notCalled).to.be.true;
+  });
+  it('should have an error when email is missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation({ addError }, null, getData({ email: false }));
+    expect(addError.called).to.be.true;
+    expect(addError.args[0][0]).to.contain('add an email');
+  });
+  it('should have multiple errors when email & phone are missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ email: false, phone: false }),
+    );
+    expect(addError.called).to.be.true;
+    expect(addError.firstCall.args[0]).to.contain('add an email');
+    expect(addError.secondCall.args[0]).to.contain('add a phone');
+  });
+  it('should have multiple errors when everything is missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ email: false, phone: false, address: false }),
+    );
+    expect(addError.called).to.be.true;
+    expect(addError.firstCall.args[0]).to.contain('add an email');
+    expect(addError.secondCall.args[0]).to.contain('add a phone');
+    expect(addError.thirdCall.args[0]).to.contain('add an address');
+  });
+  it('should not include address when homeless is true', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ address: false, homeless: true }),
+    );
+    expect(addError.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Original Ticket

https://github.com/department-of-veterans-affairs/va.gov-team/issues/43627

## URL of change

- `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/contestable-issues`
- `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995//add-issue?index=1`
- `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/issue-summary`

## Background

We're building out the Supplemental Claims form and this PR is adding the contestable issues selection, addition and summary pages. 

```mermaid
 flowchart TB
  ContestableIssues .-> AddOrEdit[Add or edit issue] --> ContestableIssues
  IssueSummary -. go back and add more .-> ContestableIssues
  ContestableIssues --> IssueSummary[Issue Summary]
```

We don't have a backend in place, so we're reusing the Higher-Level Review contestable issues endpoint. And the 1 year limit is still applied to these contestable issues (on the frontend), but will eventually need to be removed once the proper endpoint is being used.

## Steps to test

1. Pull in branch or use review instance
2. Log into user 233 (Cara) - an HLR user
3. Go to `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995`, and then navigate through the form to the `/contestable-issues` page
4. Use the "Add a new issue" link to add entries
5. Skip the opt-in (empty) page to get to the issue summary page

## Code changes

Added API call action and updated App to make the call. We're likely going to add a psuedo-wizard to gather the benefit type, but right now it's defaulting to "compensation" since that'll be the only benefit type we'll support in phase 1. Added page components, styles and related tests

## How was your code tested

Added unit tests

## Screenshots

<details><summary>Contestable issues page</summary>

<!-- leave a blank line above -->
<img width="651" alt="Supplemental claim contestable issues page showing ankylosis of knee, a loaded issue, and test which is a typed-in issue. Both checked, but the test issues includes a change link and remove button" src="https://user-images.githubusercontent.com/136959/178762983-d5beea00-8f4a-4b17-94ab-e183225ecf39.png"></details>

<details><summary>Add issue page</summary>

<!-- leave a blank line above -->
<img width="648" alt="Add issue page showing a name of issue input and a decision date block with a select element for month and another for day, and a year input. A cancel and add issue button are below the elements" src="https://user-images.githubusercontent.com/136959/178762987-e9b35458-35ff-4b62-94d4-890e08bf29e7.png"></details>

<details><summary>Issue summary</summary>

<!-- leave a blank line above -->
<img width="650" alt="Issue summary page showing a list of both checked issues" src="https://user-images.githubusercontent.com/136959/178764049-688031ef-a726-446e-a4d2-3c1efe534270.png"></details>

## Acceptance criteria
- [x] Contestable issues retrieved & shown
- [x] Can add issues and view a summary 
- [x] All tests passing


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs