### PR TITLE
replaced IRIS with Ask VA and changed url

### DIFF
--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -96,15 +96,11 @@ export const bslHelpInstructions = (
   <div>
     <p>
       If your service period or disability status information is incorrect,
-      please send us a message through VA’s{' '}
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://iris.custhelp.com/app/ask"
-      >
-        Inquiry Routing & Information System (IRIS)
+      please send us a message through
+      <a target="_blank" rel="noopener noreferrer" href="https://ask.va.gov/">
+        Ask VA
       </a>
-      . VA will respond within 5 business days.
+      . We will respond within 5 business days.
     </p>
   </div>
 );


### PR DESCRIPTION
## Description
This PR updates the IRIS URL on `https://www.va.gov/records/download-va-letters/letters/letter-list` since IRIS has been replaced by Ask VA

## Original issue(s)
n/a

## Testing done
n/a

## Screenshots
n/a

## Acceptance criteria
- [X] Link points to Ask VA

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
