### PR TITLE
Remove unused Cypress scripts from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "build:webpack:local": "yarn build:webpack --env buildtype=localhost",
     "check-app-imports": "node script/check-cross-app-imports.js",
     "cy:count": "node ./script/count-cy-specs",
-    "cy:my-testrail-helper": "node ./script/cypress-testrail-helper",
-    "cy:my-testrail-run": "cypress run --config-file config/my-cypress-testrail.json",
     "cy:open": "cypress open --config-file config/cypress.json",
     "cy:run": "cypress run --config-file config/cypress.json",
     "cy:test:docker": "node script/run-cypress-tests-docker.js",


### PR DESCRIPTION
## Description
PR to remove two unused Cypress scripts from the `package.json`.`cy:my-testrail-helper` references a script that does not work with Cypress 10, and `cy:my-testrail-run` references a Cypress configuration file that does not exist.

## Acceptance criteria
- [ ] CI passes.