### PR TITLE
Convert Introduction e2e page hook logic to an After Hook

### DIFF
--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -85,11 +85,13 @@ const testSecondaryTwo = createTestConfig(
       cy.intercept('POST', 'v0/form1010cg/attachments', mockUpload);
     },
     pageHooks: {
-      introduction: () => {
-        // Hit the start button
-        cy.findAllByText(/start/i, { selector: 'a' })
-          .first()
-          .click();
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          // Hit the start button
+          cy.findAllByText(/start/i, { selector: 'a' })
+            .first()
+            .click();
+        });
       },
       'primary-3': ({ afterHook }) => {
         afterHook(() => {
@@ -287,7 +289,6 @@ const testSecondaryTwo = createTestConfig(
         });
       },
     },
-    skip: true,
   },
   manifest,
   formConfig,


### PR DESCRIPTION
## Description
We are seeing increasing failures in the Cypress test for the caregivers application. This PR converts the "Start the application" button click on form introduction page hook to an "after" hook to ensure the route has resolved and application has successfully loaded before attempting to click the button to start the form.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44389

## Testing done
- [x] e2e testing

## Acceptance criteria
- [ ] Test consistently passes all checks without timeout

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
