### PR TITLE
CST | Migrate `Telephone` to `va-telephone`

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -26,7 +26,7 @@ import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 import { mockApi } from '../tests/e2e/fixtures/mocks/mock-api';
 
 // This should make it a bit easier to turn mocks on and off manually
-const SHOULD_USE_MOCKS = false;
+const SHOULD_USE_MOCKS = true;
 // NOTE: This should only be TRUE when developing locally
 const CAN_USE_MOCKS = environment.isLocalhost() && !window.Cypress;
 const USE_MOCKS = CAN_USE_MOCKS && SHOULD_USE_MOCKS;

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -26,7 +26,7 @@ import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 import { mockApi } from '../tests/e2e/fixtures/mocks/mock-api';
 
 // This should make it a bit easier to turn mocks on and off manually
-const SHOULD_USE_MOCKS = true;
+const SHOULD_USE_MOCKS = false;
 // NOTE: This should only be TRUE when developing locally
 const CAN_USE_MOCKS = environment.isLocalhost() && !window.Cypress;
 const USE_MOCKS = CAN_USE_MOCKS && SHOULD_USE_MOCKS;

--- a/src/applications/claims-status/components/ConsolidatedClaims.jsx
+++ b/src/applications/claims-status/components/ConsolidatedClaims.jsx
@@ -9,6 +9,7 @@ export const consolidatedClaimsContent = (
   </div>
 );
 
+// TODO: Remove this component; it is no longer being used
 export default function ConsolidatedClaims({ onClose }) {
   return (
     <div>

--- a/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -21,7 +21,7 @@ const vhaVersion = (
 const AppealHelpSidebar = ({ aoj }) => {
   switch (aoj) {
     case AOJS.vba:
-      return AskVAQuestions;
+      return <AskVAQuestions />;
     case AOJS.vha:
       return vhaVersion;
     case AOJS.nca:

--- a/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -1,36 +1,27 @@
 import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import * as Sentry from '@sentry/browser';
-// remove this Telephone once the web component supports this pattern exception
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import PropTypes from 'prop-types';
 
 import { AOJS } from '../../utils/appeals-v2-helpers';
 import AskVAQuestions from '../AskVAQuestions';
 
 const vhaVersion = (
-  <div>
+  <>
     <h2 className="help-heading">Need help?</h2>
     <p>Call Health Care Benefits</p>
     <p className="help-phone-number">
-      <Telephone contact={CONTACTS['222_VETS']} pattern="###-###-VETS (####)" />
+      <va-telephone contact={CONTACTS['222_VETS']} vanity="VETS" />
     </p>
     <p>Monday through Friday, 8:00 a.m. to 8:00 p.m. ET</p>
-  </div>
+  </>
 );
 
-/**
- * Displays the "Need help?" sidebar content based on the appeal's location.
- *
- * @param {String} aoj       The Agency of Original Jurisdiction.
- *                            Used if the location is 'aoj'
- *                            Possible options:
- *                            ['vba', 'vha', 'nca', 'other']
- */
-export default function AppealHelpSidebar({ aoj }) {
+// NOTE: aoj stands for 'Agency of Original Jurisdiction'
+const AppealHelpSidebar = ({ aoj }) => {
   switch (aoj) {
     case AOJS.vba:
-      return <AskVAQuestions />;
+      return AskVAQuestions;
     case AOJS.vha:
       return vhaVersion;
     case AOJS.nca:
@@ -39,5 +30,12 @@ export default function AppealHelpSidebar({ aoj }) {
       return null;
     default:
       Sentry.captureMessage(`appeal-status-unexpected-aoj: ${aoj}`);
+      return null;
   }
-}
+};
+
+AppealHelpSidebar.propTypes = {
+  aoj: PropTypes.oneOf(['vba', 'vha', 'nca', 'other']),
+};
+
+export default AppealHelpSidebar;

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -1,5 +1,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+// TODO: Look at moving the .process-step css into this file
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
+// TODO: Determine if we are actually using any of these
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
@@ -302,12 +304,6 @@
 }
 
 .help-phone-number {
-  margin: 0.5em 0;
-}
-
-.help-phone-number-link {
-  font-weight: bold;
-  text-decoration: none;
   margin: 0.5em 0;
 }
 


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44400

## URL of change
[/track-claims/appeals/{appealId}/status](http:/localhost:3001/track-claims/appeals/1196201/status)

## Background
We are still using the `Telephone` react component in the Claims Status Tool codebase. This needs to be migrated to use the `va-telephone` web-component

## Steps to test
Before you can test in the browser, you will need to:
* Update `src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx` line 24 from:
```js
return <AskVAQuestions />;
```
to
```js
return vhaVersion;
```

To see it in the browser:
* Login with a staging user and navigate to: [/track-claims/appeals/1196201/status](http:/localhost:3001/track-claims/appeals/1196201/status)
* On the right hand side there is a sidebar with the heading "Need help?"
* The telephone component should look like this:
![Screen Shot 2022-07-14 at 3 00 39 PM](https://user-images.githubusercontent.com/13838621/179072867-9d794750-c017-40df-af9c-0a53aa8097f9.png)

## Code changes
* Added `propTypes` to the `AppealHelperSidebar` component
* Migrated the `Telephone` component to `va-telephone` via eslint helper, then manually added `vanity="VETS"`

## Screenshots
<details><summary>Before</summary>

![Screen Shot 2022-07-14 at 2 09 43 PM](https://user-images.githubusercontent.com/13838621/179074339-55b95547-a2a0-4fd3-b812-c18d0bd31aa0.png)</details>

<details><summary>After</summary>

![Screen Shot 2022-07-14 at 2 12 37 PM](https://user-images.githubusercontent.com/13838621/179074364-a67d18c2-e95b-4818-91cd-ac8edc2c00b9.png)</details>

## How was your code tested
Test still pass; tested visually

## Acceptance criteria
- [ ] `Telephone` component is replaced with `va-telephone`
- [ ] Vanity text is preserved

## Definition of done
- [ ] *
