### PR TITLE
Ensure that the FieldTemplate text description appears first

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -104,8 +104,8 @@ export default function FieldTemplate(props) {
 
   const content = (
     <>
-      {showLabel && labelElement}
       {textDescription && <p>{textDescription}</p>}
+      {showLabel && labelElement}
       {DescriptionField && (
         <DescriptionField
           options={uiSchema['ui:options']}


### PR DESCRIPTION
## Description
This will allow the text input and its label to be visually closer together, which improves accessibility.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/315


## Testing done
Yes

## Screenshots
![image.png](https://images.zenhubusercontent.com/6283eaffdea4c21364d67e5a/890f1ae2-a2a5-41af-ace8-59ef67824e2f)

## Acceptance criteria
- [ ] Ensure that the input and its label are visually closer together

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
