### PR TITLE
ArrayField component - Ensures that focus is set on “Add another xyz” button once “xyz” is removed

### DIFF
--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -11,7 +11,7 @@ import {
 
 import scrollTo from 'platform/utilities/ui/scrollTo';
 import set from 'platform/utilities/data/set';
-import { scrollToFirstError } from '../utilities/ui';
+import { scrollToFirstError, focusElement } from '../utilities/ui';
 import { setArrayRecordTouched } from '../helpers';
 import { errorSchemaIsValid } from '../validation';
 import { getScrollOptions, isReactComponent } from '../../../../utilities/ui';
@@ -188,6 +188,8 @@ export default class ArrayField extends React.Component {
     this.props.onChange(newItems);
     this.setState(newState, () => {
       this.scrollToTop();
+      // Focus on "Add Another xyz" button after removing
+      focusElement('.va-growable-add-btn');
     });
   }
 


### PR DESCRIPTION
## Description
This improves accessibility by ensuring focus is set to an appropriate element after removing an item.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/89


## Testing done
Yes

## Screenshots

https://user-images.githubusercontent.com/5934582/179096203-80c4d27f-0c60-4947-87f3-53736ac4a770.mov



## Acceptance criteria
- [ ] Ensures that focus is set on “Add another xyz” button once “xyz” is removed

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
