### PR TITLE
Revert "Revert `actions/setup-node` version to fix CI"

### DIFF
--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -122,7 +122,7 @@ jobs:
         working-directory: qa-standards-dashboard-data
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 

--- a/.github/workflows/init-data-repo/action.yml
+++ b/.github/workflows/init-data-repo/action.yml
@@ -18,7 +18,7 @@ runs:
       working-directory: qa-standards-dashboard-data
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -28,7 +28,7 @@ runs:
       run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -78,7 +78,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -191,7 +191,7 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#21651

`actions/setup-node` was downgraded to `v2`  to see if it would fix issues with this action. [According to this comment](https://github.com/actions/setup-node/issues/544#issuecomment-1185505820), the issue has been resolved, so we can switch back to `v3`.