### PR TITLE
Check in/44335/text input error state

### DIFF
--- a/src/applications/check-in/components/TextInputErrorWrapper.jsx
+++ b/src/applications/check-in/components/TextInputErrorWrapper.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TextInputErrorWrapper = ({ error, children }) =>
+  error ? <div className="vads-u-padding-left--2">{children}</div> : children;
+
+TextInputErrorWrapper.propTypes = {
+  error: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default TextInputErrorWrapper;

--- a/src/applications/check-in/components/TextInputErrorWrapper.jsx
+++ b/src/applications/check-in/components/TextInputErrorWrapper.jsx
@@ -5,8 +5,8 @@ const TextInputErrorWrapper = ({ error, children }) =>
   error ? <div className="vads-u-padding-left--2p5">{children}</div> : children;
 
 TextInputErrorWrapper.propTypes = {
-  error: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
+  error: PropTypes.bool.isRequired,
 };
 
 export default TextInputErrorWrapper;

--- a/src/applications/check-in/components/TextInputErrorWrapper.jsx
+++ b/src/applications/check-in/components/TextInputErrorWrapper.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+// This component can be removed once DS fixes error state, evaluate during next audit.
 const TextInputErrorWrapper = ({ error, children }) =>
-  error ? <div className="vads-u-padding-left--2">{children}</div> : children;
+  error ? <div className="vads-u-padding-left--2p5">{children}</div> : children;
 
 TextInputErrorWrapper.propTypes = {
   error: PropTypes.bool.isRequired,

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -7,6 +7,7 @@ import { VaTextInput } from '@department-of-veterans-affairs/component-library/d
 import { Date } from '@department-of-veterans-affairs/component-library';
 import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
 import Wrapper from '../../layout/Wrapper';
+import TextInputErrorWrapper from '../../TextInputErrorWrapper';
 
 export default function ValidateDisplay({
   header = '',
@@ -85,18 +86,22 @@ export default function ValidateDisplay({
         <></>
       )}
       <form className="vads-u-margin-bottom--2p5" onSubmit={handleFormSubmit}>
-        <VaTextInput
-          autoCorrect="false"
-          error={lastNameErrorMessage}
-          label={t('your-last-name')}
-          name="last-name"
-          onInput={updateField}
-          required
-          spellCheck="false"
-          value={lastName}
-          data-testid="last-name-input"
-          onKeyDown={handleEnter}
-        />
+        <TextInputErrorWrapper
+          error={lastNameErrorMessage && lastNameErrorMessage.length}
+        >
+          <VaTextInput
+            autoCorrect="false"
+            error={lastNameErrorMessage}
+            label={t('your-last-name')}
+            name="last-name"
+            onInput={updateField}
+            required
+            spellCheck="false"
+            value={lastName}
+            data-testid="last-name-input"
+            onKeyDown={handleEnter}
+          />
+        </TextInputErrorWrapper>
         {isLorotaSecurityUpdatesEnabled ? (
           <div data-testid="dob-input" className="vads-u-margin-top--3">
             <Date
@@ -112,18 +117,22 @@ export default function ValidateDisplay({
             />
           </div>
         ) : (
-          <VaTextInput
-            error={last4ErrorMessage}
-            inputmode="numeric"
-            label={t('last-4-digits-of-your-social-security-number')}
-            maxlength="4"
-            onInput={updateField}
-            name="last-4-ssn"
-            required
-            value={last4Ssn}
-            data-testid="last-4-input"
-            onKeyDown={handleEnter}
-          />
+          <TextInputErrorWrapper
+            error={last4ErrorMessage && last4ErrorMessage.length}
+          >
+            <VaTextInput
+              error={last4ErrorMessage}
+              inputmode="numeric"
+              label={t('last-4-digits-of-your-social-security-number')}
+              maxlength="4"
+              onInput={updateField}
+              name="last-4-ssn"
+              required
+              value={last4Ssn}
+              data-testid="last-4-input"
+              onKeyDown={handleEnter}
+            />
+          </TextInputErrorWrapper>
         )}
         <button
           type="button"

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -86,6 +86,7 @@ export default function ValidateDisplay({
         <></>
       )}
       <form className="vads-u-margin-bottom--2p5" onSubmit={handleFormSubmit}>
+        {/* @TODO This error wrapper can go away once fixed in DS. Evaluate during next audit */}
         <TextInputErrorWrapper
           error={lastNameErrorMessage && lastNameErrorMessage.length}
         >

--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -78,3 +78,9 @@ ol.appointment-list{
     }
   }
 }
+
+// Missing styles from the DS. Evaluate if still needed when auditing sass.
+va-text-input[error]:not([error=""])::part(label) ,
+va-text-input[error]:not([error=""])::part(span)  {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Description
Adds a couple of bandaid fixes for the error state of the `va-text-input` component.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44335

## Screenshots
![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (24)](https://user-images.githubusercontent.com/13967174/179268528-eb4dea02-44fe-4053-9174-1e89e6398a4b.png)


