### PR TITLE
Update vets-website to be a system

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,6 +1,7 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: System
 metadata:
+  title: VA.gov
   name: vets-website
   description: This is the front end for VA.gov.
   annotations:
@@ -9,6 +10,5 @@ metadata:
     - javascript
     - sass
 spec:
-  type: website
   owner: platform-release-tools
-  lifecycle: production
+  domain: vfs


### PR DESCRIPTION
## Description

Updates the vets-website `catalog-info.yaml` file to be a System entity in the `vfs` domain.

## Original issue(s)

https://github.com/department-of-veterans-affairs/platform-pst-console-ui-configuration/issues/89
