### PR TITLE
43976 - CDP - [Other - Accessibility] Almost-match between visible text and screen reader only text. (00.00.2)

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/HTMLStatementLink.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/HTMLStatementLink.jsx
@@ -14,13 +14,7 @@ const HTMLStatementLink = ({ id, statementDate }) => {
         to={`/copay-balances/${id}/detail/statement`}
         data-testid={`balance-details-${id}-statement-view`}
       >
-        <span aria-hidden="true">
-          {formattedStatementDate(statementDate)} statement{' '}
-        </span>
-        <span className="sr-only">
-          Download {formattedStatementDate(statementDate)} dated medical copay
-          statement
-        </span>
+        <span>{formattedStatementDate(statementDate)} statement </span>
       </Link>
     </div>
   );


### PR DESCRIPTION
## Description
Followed platform guidance to reorganize and ultimately lead to removal of unnecessary aria elements. Rendering link this way reaches desired behavior. Of note, the 'Download' info that was there seemed to be entirely inaccurate, this is not the spot the download is available.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43976


## Testing done
Used NVDA to determine how text sounded when read by screenreader.


## Acceptance criteria
- [ X ] Unnecessary elements removed and component is read successfully.

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
 