### PR TITLE
revert va-select to Select component

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -2,10 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
-
+import Select from '@department-of-veterans-affairs/component-library/Select';
 import {
   VaModal,
-  VaSelect,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
@@ -261,29 +260,22 @@ class AddFilesForm extends React.Component {
                   </>
                 )}
                 <div className="clearfix" />
-                <VaSelect
+                <Select
                   required
-                  error={
+                  errorMessage={
                     validateIfDirty(docType, isNotBlank)
                       ? undefined
                       : 'Please provide a response'
                   }
                   name="docType"
                   label="What type of document is this?"
+                  options={DOC_TYPES}
                   value={docType}
-                  onVaSelect={e =>
-                    this.handleDocTypeChange(e.target.value, index)
+                  emptyDescription="Select a description"
+                  onValueChange={update =>
+                    this.props.onFieldChange(`files[${index}].docType`, update)
                   }
-                >
-                  <option disabled value="">
-                    Select a description
-                  </option>
-                  {DOC_TYPES.map(({ label, value }, i) => (
-                    <option key={i} value={value}>
-                      {label}
-                    </option>
-                  ))}
-                </VaSelect>
+                />
               </div>
             </div>
           ),


### PR DESCRIPTION
## Original issue(s)
department-of-veterans-affairs/va.gov-team#41813

# Expected behavior
When uploading a file, if the user leaves the document type field blank and attempts to submit the form without making a selection, the focus should be transferred back to the select box.

## Current behavior
Described in comment: https://app.zenhub.com/workspaces/benefits-team-1-6138d7b57a2631001a4b7562/issues/department-of-veterans-affairs/va.gov-team/41813#issuecomment-1181999456

## Your fix
Reverts `va-select` to `Select` because the Shadow DOM is blocking the component from the `errors` array, and therefore excluding it from the `ScrollToError` functionality which also transfers focus.

## How has this been tested?
- Sign in and go to http://localhost:3001/track-claims/your-claims/1196201/files
- Select a file to upload, but leave the select box for document type blank. You can leave the checkbox blank if you want
- Attempt to submit the form
- Focus should be transferred to the select box.

## Screenshots
![Screen Recording 2022-07-15 at 04 20 27 PM](https://user-images.githubusercontent.com/1094951/179305045-b6e44a4b-a26b-4051-a958-f189805103b1.gif)


## Definition of done
- [ ] Tests continue to pass
- [ ] Focus is transferred to the select box if the select box empty


## Acceptance criteria
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)