### PR TITLE
[CDP] 44004 - Fixing Margin issues

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/CombinedPortalApp.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/CombinedPortalApp.jsx
@@ -78,7 +78,7 @@ const CombinedPortalApp = ({ children }) => {
 
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0 vads-u-margin-bottom--5">
-      <div className="vads-l-row medium-screen:vads-u-margin-x--neg2p5">
+      <div className="vads-l-row">
         <DowntimeNotification
           appTitle="Debts and bills application"
           dependencies={[externalServices.mvi, externalServices.vbs]}


### PR DESCRIPTION
## Description
The margins for the breadcrumbs on the debt details page were not offset to match the rest of the app. After investigation, removing a higher level `vads` margin setting gave a more consistent appearance for the breadcrumbs and fixed an issues where headers were also at an inconsistent offset. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44004


## Screenshots
Pre Change
![image](https://user-images.githubusercontent.com/25368370/179532566-47d306dd-80cc-44bc-9735-a1114f939557.png)


Post Change
![image](https://user-images.githubusercontent.com/25368370/179531895-30115349-0d51-4344-a581-e194abe3a048.png)


## Acceptance criteria
- [ ] Heading and breadcrumb margins are consistent throughout the application

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
