### PR TITLE
(chore) fix wording for cta, remove 'personal'

### DIFF
--- a/src/applications/static-pages/cta-widget/components/messages/ChangeAddress.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/ChangeAddress.jsx
@@ -9,7 +9,7 @@ const ChangeAddress = ({ serviceDescription, primaryButtonHandler }) => {
     alertText: (
       <p>
         You’ll find your mailing and home address in your profile’s{' '}
-        <strong>Personal and contact information</strong> section.
+        <strong>Contact information</strong> section.
       </p>
     ),
     primaryButtonText: 'Go to your VA.gov profile',
@@ -21,8 +21,8 @@ const ChangeAddress = ({ serviceDescription, primaryButtonHandler }) => {
 };
 
 ChangeAddress.propTypes = {
-  serviceDescription: PropTypes.string.isRequired,
   primaryButtonHandler: PropTypes.func.isRequired,
+  serviceDescription: PropTypes.string.isRequired,
 };
 
 export default ChangeAddress;


### PR DESCRIPTION
## Description
Update wording on ChangeAddress CTA. Removed the word 'Personal' since the page is now just 'Contact Information'

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34290


## Testing done
Manually tested

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
