### PR TITLE
(chore) add mock, add source to GA event

### DIFF
--- a/src/applications/personalization/profile/actions/index.js
+++ b/src/applications/personalization/profile/actions/index.js
@@ -55,7 +55,7 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
 
     const baseUrl = '/profile/service_history';
 
-    const apiEventName = `GET ${baseUrl}`;
+    let apiEventName = `GET ${baseUrl}`;
 
     try {
       recordAnalyticsEvent(
@@ -101,6 +101,10 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
         });
         return;
       }
+
+      apiEventName = `${apiEventName}${
+        response?.dataSource ? ` Source: ${response.dataSource}` : ''
+      }`;
 
       recordAnalyticsEvent(
         createApiEvent({

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -48,7 +48,7 @@ const responses = {
     return res.status(200).json(bankAccounts.defaultResponse);
   },
   'GET /v0/profile/service_history': (_req, res) => {
-    return res.status(200).json(serviceHistory.none);
+    return res.status(200).json(serviceHistory.airForce);
   },
   'GET /v0/disability_compensation_form/rating_info': {
     data: {

--- a/src/applications/personalization/profile/mocks/service-history/index.js
+++ b/src/applications/personalization/profile/mocks/service-history/index.js
@@ -8,12 +8,16 @@ const none = {
   },
 };
 
-const generateServiceHistory = ({ branchOfService = 'Air Force' }) => {
+const generateServiceHistory = ({
+  branchOfService = 'Air Force',
+  dataSource = 'api.va_profile',
+}) => {
   return {
     data: {
       id: '',
       type: 'arrays',
       attributes: {
+        dataSource,
         serviceHistory: [
           {
             branchOfService,


### PR DESCRIPTION
## Description
Adds a `Source` to the military information / service history api call GA events so that the source of truth for this information can be tracked as we roll out a migration to a new system.

Also added mock data to manually test the event payload

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44075

## Testing done
Manually tested

## Acceptance criteria
- [x] Source is sent within GA api request if there is a `dataSource` key in the response attributes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
