### PR TITLE
Ensure error message associated with the ReviewCollapsibleChapter component's accordion button is described by the button's text

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -377,6 +377,7 @@ class ReviewCollapsibleChapter extends React.Component {
                 className="vads-u-color--secondary vads-u-border-left--10px vads-u-border-color--secondary vads-u-display--flex vads-u-padding-left--1p5 vads-u-align-items--center vads-u-font-weight--bold"
                 role="alert"
                 style={{ minHeight: '50px' }}
+                aria-describedby={`collapsibleButton${this.id}`}
               >
                 <span className="sr-only">Error</span>
                 {chapterTitle} needs to be updated


### PR DESCRIPTION
## Description
Error messages within each accordion item will now be described by the accordion item button text.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/474


## Testing done
Yes

## Screenshots
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/5934582/179579457-950bcf27-a4a5-41ca-9b70-e29cc7affe4d.png">

## Acceptance criteria
- [x] Ensure that the error message associated with the ReviewCollapsibleChapter component's accordion button is described by the button's text using the `aria-describedby` attribute.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
