### PR TITLE
VACMS-9525 Update cookie to always activate injected header on VA Enterprise Architecture Home

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -59,12 +59,12 @@
     {
       "hostname": "ea.oit.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.ea.oit.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.healthquality.va.gov",


### PR DESCRIPTION
## Description
This PR sets the injected header cookie `cookieOnly` to false on http://ea.oit.va.gov/, so that the injected header **always** shows.

## Original issue(s)
[department-of-veterans-affairs/va.gov-cms/issues/9525](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9525)

## Testing done
[x] with `cookieOnly` set to true

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
