### PR TITLE
VACMS-9767 add VA Formulary Advisor paths to allowlist

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -67,6 +67,21 @@
       "cookieOnly": true
     },
     {
+      "hostname": "va.gov/formularyadvisor",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "www.va.gov/formularyadvisor",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "vaww.internet.staging.va.gov/formularyadvisor",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
       "hostname": "www.healthquality.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": true


### PR DESCRIPTION
## Description
This PR adds paths for the VA Formulary Advisor team (currently using TeamSite) to the injected header allowlist. This will allow these domains to grab the modernized VA header and footer:

- `va.gov/formularyadvisor`
- `www.va.gov/formularyadvisor`
- `vaww.internet.staging.va.gov/formularyadvisor`

## Original issue(s)
[department-of-veterans-affairs/va.gov-cms/issues/9767](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9767)

## Testing done
[ ] injected header will be checked on staging: vaww.internet.staging.va.gov/formularyadvisor by setting cookie to false

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
