### PR TITLE
Fixed some accessibility issues with the megamenu

### DIFF
--- a/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
@@ -145,8 +145,8 @@ export default class MegaMenu extends React.Component {
           }}
         >
           <div id="vetnav" role="navigation">
-            <ul id="vetnav-menu" role="menubar">
-              <li role="menuitem">
+            <ul id="vetnav-menu">
+              <li>
                 <a
                   className="vetnav-level1"
                   data-testid="mobile-home-nav-link"
@@ -164,13 +164,13 @@ export default class MegaMenu extends React.Component {
                       ? 'current-page medium-screen:vads-u-margin-right--0'
                       : ''
                   }`}
-                  role="menuitem"
-                  aria-haspopup={!!item.menuSections}
                 >
                   {item.menuSections ? (
                     <button
+                      type="button"
                       aria-expanded={currentDropdown === item.title}
                       aria-controls={`vetnav-${_.kebabCase(item.title)}`}
+                      aria-haspopup={!!item.menuSections}
                       className="vetnav-level1"
                       data-e2e-id={`${_.kebabCase(item.title)}-${i}`}
                       onClick={() => this.toggleDropDown(item.title)}
@@ -205,7 +205,7 @@ export default class MegaMenu extends React.Component {
                   >
                     {item.title === currentDropdown &&
                       item.menuSections && (
-                        <ul aria-label={item.title} role="menu">
+                        <ul aria-label={item.title}>
                           {Array.isArray(item.menuSections)
                             ? item.menuSections.map((section, j) => (
                                 <MenuSection


### PR DESCRIPTION
## Description

Removed `role="menu"` and `role="menuitem"` from the megamenu as it was incorrectly added. The `menu` role requires a lot of keyboard bindings that are not present and is supposed to be reserved for application menus (like a file menu) rather than navigation. [Read more about the menu role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role). `menuitem` was removed, as it is a required child of `menu`.

Also moved `aria-haspopup` to the trigger button instead of the parent as it is supposed to be place on the clickable item. Read more about [aria-haspopup](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup).
