### PR TITLE
VAOS Staging: CC Requests Comments Being Truncated from 250 Characters to 100

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -12,10 +12,14 @@ import {
 import { getClinicId } from '../../../services/healthcare-service';
 import { getTimezoneByFacilityId } from '../../../utils/timezone';
 
-function getReasonCode(data) {
+function getReasonCode({ data, isCC }) {
   const code = PURPOSE_TEXT_V2.filter(purpose => purpose.id !== 'other').find(
     purpose => purpose.id === data.reasonForAppointment,
   )?.serviceName;
+
+  const reasonAdditionalInfo = isCC
+    ? data.reasonAdditionalInfo.slice(0, 250)
+    : data.reasonAdditionalInfo.slice(0, 100);
 
   return {
     // If the user selects one of the three preset radio selections
@@ -25,9 +29,7 @@ function getReasonCode(data) {
     // Per Brad - All comments should be sent in the reasonCode.text field and should should be
     // truncated to 100 char for both VA appointment types only. CC appointments will continue
     // to be truncated to 250 char
-    text: data.reasonAdditionalInfo
-      ? data.reasonAdditionalInfo.slice(0, 100)
-      : null,
+    text: data.reasonAdditionalInfo ? reasonAdditionalInfo : null,
   };
 }
 
@@ -84,7 +86,7 @@ export function transformFormToVAOSCCRequest(state) {
     locationId: data.communityCareSystemId,
     serviceType: typeOfCare.idV2 || typeOfCare.ccId,
     // comment: data.reasonAdditionalInfo,
-    reasonCode: getReasonCode(data),
+    reasonCode: getReasonCode({ data, isCC: true }),
     contact: {
       telecom: [
         {
@@ -131,7 +133,7 @@ export function transformFormToVAOSVARequest(state) {
     locationId: data.vaFacility,
     // This may need to change when we get the new service type ids
     serviceType: typeOfCare.idV2,
-    reasonCode: getReasonCode(data),
+    reasonCode: getReasonCode({ data, isCC: false }),
     // comment: data.reasonAdditionalInfo,
     contact: {
       telecom: [
@@ -180,6 +182,6 @@ export function transformFormToVAOSAppointment(state) {
     locationId: data.vaFacility,
     // removing this for now, it's preventing QA from testing, will re-introduce when the team figures out how we're handling the comment field
     // comment: getUserMessage(data),
-    reasonCode: getReasonCode(data),
+    reasonCode: getReasonCode({ data, isCC: false }),
   };
 }


### PR DESCRIPTION
## Description
Updated CC comments to 250. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44493


## Testing done


## Screenshots
<img width="746" alt="Screen Shot 2022-07-19 at 7 35 50 PM" src="https://user-images.githubusercontent.com/47654119/179865682-2bb8ebe5-c9fe-4665-98ce-27e02f02c15c.png">
<img width="746" alt="Screen Shot 2022-07-19 at 7 49 20 PM" src="https://user-images.githubusercontent.com/47654119/179866836-dfa60200-2b76-4c42-87d1-2c450265bada.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
