### PR TITLE
updated 1095B download widget to be able to select PDF or text form options

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -11,6 +11,13 @@ import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
 
+import {
+  lastUpdatedComponent,
+  notFoundComponent,
+  radioOptions,
+  radioOptionsAriaLabels,
+} from './utils';
+
 export const App = ({ loggedIn, toggleLoginModal }) => {
   const [lastUpdated, updateLastUpdated] = useState('');
   const [year, updateYear] = useState(0);
@@ -20,19 +27,6 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
     downloaded: false,
     timeStamp: '',
   });
-
-  const radioOptions = [
-    { label: 'Option 1: PDF document (best for printing)', value: 'pdf' },
-    {
-      label:
-        'Option 2: Text file (best for screen readers, screen enlargers, and refreshable Braille displays)',
-      value: 'txt',
-    },
-  ];
-  const radioOptionsAriaLabels = [
-    'Option 1: P D F Document (best for printing)',
-    'Option 2: Text File (best for screen readers, screen enlargers, and refreshable Braille displays)',
-  ];
 
   const getContent = () => {
     return apiRequest(`/form1095_bs/download_${formType}/${year}`)
@@ -141,17 +135,6 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
     />
   );
 
-  const lastUpdatedComponent = (
-    <p>
-      <span className="vads-u-line-height--3 vads-u-display--block">
-        <strong>Related to:</strong> Health care
-      </span>
-      <span className="vads-u-line-height--3 vads-u-display--block">
-        <strong>Document last updated:</strong> {lastUpdated}
-      </span>
-    </p>
-  );
-
   const downloadButton = (
     <p>
       <button
@@ -166,35 +149,9 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
     </p>
   );
 
-  const notFoundComponent = (
-    <va-alert close-btn-aria-label="Close notification" status="info" visible>
-      <h3 slot="headline">
-        You don’t have a 1095-B tax form available right now
-      </h3>
-      <div>
-        <p>
-          If you recently enrolled in VA health care, you may not have a 1095-B
-          form yet. We process 1095-B forms in early January each year, based on
-          your enrollment in VA health care during the past year.
-        </p>
-        <p>
-          If you think you should have a 1095-B form, call us at{' '}
-          <a href="tel:+18772228387" aria-label="1 8 7 7 2 2 2 8 3 8 7">
-            1-877-222-8387
-          </a>{' '}
-          (
-          <a href="tel:711" aria-label="TTY. 7 1 1">
-            TTY: 711
-          </a>
-          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-        </p>
-      </div>
-    </va-alert>
-  );
-
   const errorComponent = (
     <>
-      {lastUpdatedComponent}
+      {lastUpdatedComponent(lastUpdated)}
       <va-alert
         close-btn-aria-label="Close notification"
         status="warning"
@@ -223,7 +180,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
 
   const successComponent = (
     <>
-      {lastUpdatedComponent}
+      {lastUpdatedComponent(lastUpdated)}
       <va-alert
         close-btn-aria-label="Close notification"
         status="success"
@@ -244,7 +201,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
 
   const loggedInComponent = (
     <>
-      {lastUpdatedComponent}
+      {lastUpdatedComponent(lastUpdated)}
       {radioComponent}
       {downloadButton}
     </>
@@ -276,7 +233,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
   if (loggedIn) {
     if (formError.error) {
       if (formError.type === 'not found') {
-        return notFoundComponent;
+        return notFoundComponent();
       }
       if (formError.type === 'download error') {
         return errorComponent;

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -81,7 +81,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
         a.href = result;
         a.target = '_blank';
 
-        if (formType === 'txt') a.download = `1095B-${year}.txt`; // download text file directly, pdf opens in new window
+        if (formType === 'txt') a.download = `1095B-${year}.txt`; // download text file directly
 
         document.body.appendChild(a); // we need to append the element to the dom -> otherwise it will not work in firefox
         a.click();

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -80,10 +80,9 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
         const a = document.createElement('a');
         a.href = result;
         a.target = '_blank';
-        if (formType === 'txt') {
-          // download text file directly, pdf opens in new window
-          a.download = `1095B-${year}.txt`;
-        }
+
+        if (formType === 'txt') a.download = `1095B-${year}.txt`; // download text file directly, pdf opens in new window
+
         document.body.appendChild(a); // we need to append the element to the dom -> otherwise it will not work in firefox
         a.click();
         a.remove(); // removes element from the DOM

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -28,6 +28,15 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
     timeStamp: '',
   });
 
+  const dateOptions = {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true,
+  };
+
   const getContent = () => {
     return apiRequest(`/form1095_bs/download_${formType}/${year}`)
       .then(response => response.blob())
@@ -87,19 +96,11 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
         a.click();
         a.remove(); // removes element from the DOM
         const date = new Date();
-        const options = {
-          year: 'numeric',
-          month: 'numeric',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-          hour12: true,
-        };
         updateFormError({ error: false, type: '' });
         updateFormDownloaded({
           downloaded: true,
           timeStamp: formatTimeString(
-            date.toLocaleDateString(undefined, options),
+            date.toLocaleDateString(undefined, dateOptions),
           ),
         });
       }

--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+export const radioOptions = [
+  { label: 'Option 1: PDF document (best for printing)', value: 'pdf' },
+  {
+    label:
+      'Option 2: Text file (best for screen readers, screen enlargers, and refreshable Braille displays)',
+    value: 'txt',
+  },
+];
+
+export const radioOptionsAriaLabels = [
+  'Option 1: P D F Document (best for printing)',
+  'Option 2: Text File (best for screen readers, screen enlargers, and refreshable Braille displays)',
+];
+
+export const lastUpdatedComponent = ({ lastUpdated }) => {
+  return (
+    <p>
+      <span className="vads-u-line-height--3 vads-u-display--block">
+        <strong>Related to:</strong> Health care
+      </span>
+      <span className="vads-u-line-height--3 vads-u-display--block">
+        <strong>Document last updated:</strong> {lastUpdated}
+      </span>
+    </p>
+  );
+};
+
+export const notFoundComponent = () => {
+  return (
+    <va-alert close-btn-aria-label="Close notification" status="info" visible>
+      <h3 slot="headline">
+        You don’t have a 1095-B tax form available right now
+      </h3>
+      <div>
+        <p>
+          If you recently enrolled in VA health care, you may not have a 1095-B
+          form yet. We process 1095-B forms in early January each year, based on
+          your enrollment in VA health care during the past year.
+        </p>
+        <p>
+          If you think you should have a 1095-B form, call us at{' '}
+          <a href="tel:+18772228387" aria-label="1 8 7 7 2 2 2 8 3 8 7">
+            1-877-222-8387
+          </a>{' '}
+          (
+          <a href="tel:711" aria-label="TTY. 7 1 1">
+            TTY: 711
+          </a>
+          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+        </p>
+      </div>
+    </va-alert>
+  );
+};


### PR DESCRIPTION
## Description
This PR adds the ability to download the text version of the 1095B form, as well as the PDF version

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44334


## Testing done
extensively tested the radio selecting and form downloading manually to be sure they both work as expected.


## Screenshots
<img width="611" alt="Screen Shot 2022-07-20 at 5 22 45 PM" src="https://user-images.githubusercontent.com/47372929/180093256-7a2da2fb-0c5a-457f-8698-076dd3fd94af.png">

## Acceptance criteria
- [x] radio buttons allow the selection of either PDF or text forms (with PDF default)
- [x] both forms get correctly downloaded upon clicking the download button

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
