### PR TITLE
CST | Add new appeal status type

### DIFF
--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -109,41 +109,41 @@ export function getAojDescription(aoj) {
 
 // TO DO: Replace these properties and content with real versions once finalized.
 export const STATUS_TYPES = {
-  pendingSoc: 'pending_soc',
-  pendingForm9: 'pending_form9',
-  pendingCertification: 'pending_certification',
-  pendingCertificationSsoc: 'pending_certification_ssoc',
-  remandSsoc: 'remand_ssoc',
-  pendingHearingScheduling: 'pending_hearing_scheduling',
-  scheduledHearing: 'scheduled_hearing',
-  onDocket: 'on_docket',
-  atVso: 'at_vso',
-  decisionInProgress: 'decision_in_progress',
-  bvaDevelopment: 'bva_development',
-  stayed: 'stayed',
-  remand: 'remand',
-  merged: 'merged',
-  bvaDecision: 'bva_decision',
-  fieldGrant: 'field_grant',
-  withdrawn: 'withdrawn',
-  ftr: 'ftr',
-  ramp: 'ramp',
-  reconsideration: 'reconsideration',
-  death: 'death',
-  otherClose: 'other_close',
-  evidentiaryPeriod: 'evidentiary_period',
   amaRemand: 'ama_remand',
-  postBvaDtaDecision: 'post_bva_dta_decision',
+  atVso: 'at_vso',
+  bvaDecision: 'bva_decision',
   bvaDecisionEffectuation: 'bva_decision_effectuation',
-  scReceived: 'sc_received',
-  scDecision: 'sc_decision',
-  scClosed: 'sc_closed',
-  hlrReceived: 'hlr_received',
+  bvaDevelopment: 'bva_development',
+  death: 'death',
+  decisionInProgress: 'decision_in_progress',
+  evidentiaryPeriod: 'evidentiary_period',
+  fieldGrant: 'field_grant',
+  ftr: 'ftr',
+  hlrClosed: 'hlr_closed',
   hlrDtaError: 'hlr_dta_error',
   hlrDecision: 'hlr_decision',
-  hlrClosed: 'hlr_closed',
-  statutoryOptIn: 'statutory_opt_in',
+  hlrReceived: 'hlr_received',
+  merged: 'merged',
+  onDocket: 'on_docket',
+  otherClose: 'other_close',
+  pendingCertification: 'pending_certification',
+  pendingCertificationSsoc: 'pending_certification_ssoc',
+  pendingForm9: 'pending_form9',
+  pendingHearingScheduling: 'pending_hearing_scheduling',
+  pendingSoc: 'pending_soc',
+  postBvaDtaDecision: 'post_bva_dta_decision',
+  ramp: 'ramp',
+  reconsideration: 'reconsideration',
+  remand: 'remand',
   remandReturn: 'remand_return',
+  remandSsoc: 'remand_ssoc',
+  scClosed: 'sc_closed',
+  scDecision: 'sc_decision',
+  scReceived: 'sc_received',
+  scheduledHearing: 'scheduled_hearing',
+  statutoryOptIn: 'statutory_opt_in',
+  stayed: 'stayed',
+  withdrawn: 'withdrawn',
 };
 
 export const ISSUE_STATUS = {
@@ -718,6 +718,8 @@ export function getStatusContents(appeal, name = {}) {
       );
       break;
     }
+    // TODO: Remove this if Caseflow fixes the issue on their end
+    case 'sc_recieved':
     case STATUS_TYPES.scReceived:
       contents.title = 'A reviewer is examining your new evidence';
       contents.description = (
@@ -853,6 +855,11 @@ export function getStatusContents(appeal, name = {}) {
       contents.description = (
         <p>We’re sorry, VA.gov will soon be updated to show your status.</p>
       );
+
+      Sentry.withScope(scope => {
+        scope.setExtra('statusType', statusType);
+        Sentry.captureMessage('appeals-unknown-status-type');
+      });
   }
 
   return contents;


### PR DESCRIPTION
Adding status type 'sc_recieved' to STATUS_TYPES map; Adding Sentry logging for when we encounter unknown status types

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44685

## URL of fix
[/track-claims/your-claims](http://localhost:3001/track-claims/your-claims)

## Expected behavior
When viewing the list of claims and appeals in the Claim Status Tool, each appeal in the list should display a status that is not `We don't know your status`

## Current behavior
When viewing the list of claims and appeals in the Claim Status Tool, appeals in the list that have a status type of `sc_recieved` display a status of `We don't know your status`

## Your fix
* Added case for status type 'sc_recieved' to the switch statement in [appeals-v2-helpers.jsx](https://github.com/department-of-veterans-affairs/vets-website/pull/21724/files#diff-9829e66ccbee3374bb1c27ecfe033ede7e4af9ae972e19665b72084a08b7c8beR722)
* Added Sentry logging in the default case with a message of `appeal-unknown-status-type`

## How has this been tested?
Tested this visually, unit tests / e2e tests still passing

## Screenshots
<details><summary>Before</summary>

![Screen Shot 2022-07-21 at 11 38 52 AM](https://user-images.githubusercontent.com/13838621/180268377-1f586fb7-cc2d-47c9-9d90-1a0f83b06b04.png)</details>

<details><summary>After</summary>

![Screen Shot 2022-07-21 at 10 55 39 AM](https://user-images.githubusercontent.com/13838621/180268466-6fa53b55-3aa2-45d5-a0f6-477d4e972920.png)
</details>

## Acceptance criteria
- [x] When the appeal status type is `sc_recieved` the `Status` text does not read `We don't know your status`
