### PR TITLE
Update analytics session events to include app & auth type info

### DIFF
--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -3,12 +3,20 @@ import environment from 'platform/utilities/environment';
 import { makeApiCallWithSentry } from '../utils';
 
 const v2 = {
-  getSession: async ({ token, checkInType }) => {
+  getSession: async ({
+    token,
+    checkInType,
+    isLorotaSecurityUpdatesEnabled = false,
+  }) => {
     const url = `/check_in/v2/sessions/`;
     const checkInTypeSlug = checkInType ? `?checkInType=${checkInType}` : '';
+    const eventLabel = `${checkInType ?? 'day-of'}-get-current-session-${
+      isLorotaSecurityUpdatesEnabled ? 'dob' : 'ssn4'
+    }`;
+
     const json = await makeApiCallWithSentry(
       apiRequest(`${environment.API_URL}${url}${token}${checkInTypeSlug}`),
-      'get-current-session',
+      eventLabel,
       token,
     );
     return {
@@ -52,9 +60,13 @@ const v2 = {
       mode: 'cors',
     };
 
+    const eventLabel = `${checkInType ?? 'day-of'}-validating-user-${
+      isLorotaSecurityUpdatesEnabled ? 'dob' : 'ssn4'
+    }`;
+
     const json = await makeApiCallWithSentry(
       apiRequest(`${environment.API_URL}${url}`, settings),
-      'validating-user',
+      eventLabel,
       token,
     );
     return {

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import recordEvent from 'platform/monitoring/record-event';
+import { makeSelectFeatureToggles } from '../../utils/selectors/feature-toggles';
 import { api } from '../../api';
 import {
   getTokenFromLocation,
@@ -25,6 +26,9 @@ const Landing = props => {
   const { location, router } = props;
   const { jumpToPage, goToErrorPage } = useFormRouting(router);
   const { t } = useTranslation();
+
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isLorotaSecurityUpdatesEnabled } = useSelector(selectFeatureToggles);
 
   const [loadMessage] = useState(t('finding-your-appointment-information'));
   const {
@@ -74,7 +78,10 @@ const Landing = props => {
 
       if (token) {
         api.v2
-          .getSession({ token })
+          .getSession({
+            token,
+            isLorotaSecurityUpdatesEnabled,
+          })
           .then(session => {
             if (session.errors || session.error) {
               clearCurrentSession(window);
@@ -111,6 +118,7 @@ const Landing = props => {
       setSession,
       setShouldSendDemographicsFlags,
       resetAttempts,
+      isLorotaSecurityUpdatesEnabled,
     ],
   );
   return (

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -117,6 +117,7 @@ const Index = props => {
       clearCurrentSession,
       goToErrorPage,
       initForm,
+      isLorotaSecurityUpdatesEnabled,
       jumpToPage,
       router,
       setCurrentToken,

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import propTypes from 'prop-types';
 
 import { useTranslation } from 'react-i18next';
@@ -14,6 +14,7 @@ import { useSessionStorage } from '../../../hooks/useSessionStorage';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 
 import { createAnalyticsSlug } from '../../../utils/analytics';
+import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
 import {
   createForm,
   getTokenFromLocation,
@@ -27,6 +28,9 @@ import { APP_NAMES } from '../../../utils/appConstants';
 const Index = props => {
   const { router } = props;
   const { t } = useTranslation();
+
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isLorotaSecurityUpdatesEnabled } = useSelector(selectFeatureToggles);
 
   const { goToErrorPage, jumpToPage } = useFormRouting(router);
   const {
@@ -80,7 +84,7 @@ const Index = props => {
         const checkInType = APP_NAMES.PRE_CHECK_IN;
 
         api.v2
-          .getSession({ token, checkInType })
+          .getSession({ token, checkInType, isLorotaSecurityUpdatesEnabled })
           .then(session => {
             // if successful, dispatch session data  into redux and current window
 


### PR DESCRIPTION
## Description

We need to be able to track session authentication success with SSN4 & DOB validation. This PR updates the API analytics event labels to include the app name and auth type.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44383

## Acceptance criteria
- [ ] event labels include day-of/precheckin and ssn4/dob

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
