### PR TITLE
Implement retry action on e2e injection test workflow

### DIFF
--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -36,8 +36,12 @@ jobs:
         run: node src/platform/testing/e2e/test-server.js --buildtype=${{ env.BUILDTYPE }} --port=3001 &
 
       - name: Run Cypress tests
-        run: yarn cy:run --spec "src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js"
-        timeout-minutes: 30
+        uses: nick-fields/retry@v2
+        with:
+          command: yarn cy:run --spec "src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js"
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 180
         env:
           CYPRESS_CI: false
           CYPRESS_RUN_INJECTION: true

--- a/src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js
+++ b/src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js
@@ -1,8 +1,10 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
 import manifest from '../../manifest.json';
 import { proxyRewriteWhitelist as allowList } from '../../proxy-rewrite-whitelist.json';
 
 describe(manifest.appName, () => {
   // Skip tests unless we are running the daily workflow job
+  // eslint-disable-next-line func-names
   before(function() {
     if (Cypress.env('RUN_INJECTION') !== true) this.skip();
   });


### PR DESCRIPTION
## Description
We are seeing an uptick in failures from the proxy rewrite e2e tests for the sitewide header/footer injection. The test failures are due to timeout in reaching out to the external sites that we are injecting the VA.gov header & footer into. This PR implements retry logic onto the github workflow that controls the run of the injection testing in an attempt to allow the test to connect to the external site. 

## Acceptance criteria
- [ ] Cypress test is able to run multiple times before we ultimately fail it

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
