### PR TITLE
[CDP] 43978 Updating icon styling for consistency 

### DIFF
--- a/src/applications/combined-debt-portal/combined/sass/combined-debt-portal.scss
+++ b/src/applications/combined-debt-portal/combined/sass/combined-debt-portal.scss
@@ -3,3 +3,7 @@
 .no-wrap {
     white-space: nowrap;
   }
+
+  .icon-right {
+    margin-right: 10px;
+  }

--- a/src/applications/combined-debt-portal/combined/sass/combined-debt-portal.scss
+++ b/src/applications/combined-debt-portal/combined/sass/combined-debt-portal.scss
@@ -5,5 +5,5 @@
   }
 
   .icon-right {
-    margin-right: 10px;
+    padding-right: 10px;
   }

--- a/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
+++ b/src/applications/combined-debt-portal/debt-letters/const/diary-codes/debtSummaryCardContent.js
@@ -3,16 +3,16 @@ import { addDays } from 'date-fns';
 import { formatDate } from '../../../combined/utils/helpers';
 
 const TriangleIcon = () => (
-  <div className="vads-u-margin-top--0p5 vads-u-margin-right--1">
-    <i aria-hidden="true" className="fas fa-exclamation-triangle" />
+  <>
+    <i aria-hidden="true" className="fas fa-exclamation-triangle icon-right" />
     <span className="sr-only">important</span>
-  </div>
+  </>
 );
 const CircleIcon = () => (
-  <div className="vads-u-margin-top--0p5 vads-u-margin-right--1">
-    <i aria-hidden="true" className="fas fa-info-circle" />
+  <>
+    <i aria-hidden="true" className="fas fa-info-circle icon-right" />
     <span className="sr-only">informational</span>
-  </div>
+  </>
 );
 
 export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
@@ -21,7 +21,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
   switch (diaryCode) {
     case '71':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Contact us to verify your military status
@@ -31,7 +31,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '655':
     case '817':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Submit a Financial Status Report so that we can make a decision on
@@ -41,7 +41,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '212':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Contact us to update your address
@@ -56,7 +56,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '448':
     case '453':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             We’ve paused collection on this debt as you requested
@@ -67,7 +67,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '449':
     case '459': // This one is 30 days
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your {balance} balance now or request help by{' '}
@@ -77,7 +77,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '109':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your {balance} balance now or request help by{' '}
@@ -91,7 +91,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '130':
     case '140':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your {balance} balance now or request help by{' '}
@@ -101,7 +101,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '117':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your {balance} past due balance in full or request help before{' '}
@@ -111,7 +111,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '123':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your {balance} past due balance now or request help by{' '}
@@ -121,7 +121,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '680':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your {balance} balance now or request help
@@ -131,7 +131,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '681':
     case '682':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             The U.S. Department of the Treasury is offsetting your federal
@@ -143,7 +143,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '600':
     case '601':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Continue making monthly payments until your balance is paid
@@ -153,7 +153,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '430':
     case '431':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             We’re offsetting your education benefits each month until your debt
@@ -172,7 +172,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '615':
     case '617':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             We’re offsetting your benefit payments each month until your debt is
@@ -183,7 +183,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '603': // TODO: Date Not Listed
     case '613':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Make a payment on your {balance} balance or request help by{' '}
@@ -198,7 +198,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '860':
     case '855':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Contact the U.S. Department of the Treasury to pay this debt
@@ -207,7 +207,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '811':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Continue making monthly payments while we review your compromise
@@ -217,7 +217,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '815': // TODO: Date Not Listed
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <TriangleIcon />
           <p className="vads-u-margin-y--0">
             Pay your one time payment as part of your compromise agreement by{' '}
@@ -227,7 +227,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '816':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             We’re processing your compromise offer payment
@@ -241,7 +241,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '809':
     case '820':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Continue making monthly payments while we review your waiver request
@@ -251,7 +251,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     // case '818', '819', '830', '842' Omitted
     case '822':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Continue making monthly payments while we review your dispute
@@ -260,7 +260,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '825':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Continue making monthly payments while we review your request for a
@@ -270,7 +270,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
       );
     case '821':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">
             Continue making monthly payments while we review your Notice of
@@ -289,7 +289,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '422':
     case '627':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">We’re updating your account</p>
         </div>
@@ -299,7 +299,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '483':
     case '484':
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">We’re reviewing your account</p>
         </div>
@@ -311,7 +311,7 @@ export const debtSummaryText = (diaryCode, dateOfLetter, balance) => {
     case '503':
     default:
       return (
-        <div className="vads-u-display--flex vads-u-align-items--flex-start">
+        <div className="vads-u-display--flex vads-u-align-items--baseline">
           <CircleIcon />
           <p className="vads-u-margin-y--0">We’re updating your account.</p>
         </div>

--- a/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
@@ -75,7 +75,7 @@ const BalanceCard = ({ id, amount, facility, city, date }) => {
         <i
           aria-hidden="true"
           role="img"
-          className="fa fa-exclamation-triangle"
+          className="fa fa-exclamation-triangle icon-right"
         />
         {isCurrentBalance ? (
           <CurrentContent id={id} date={date} />

--- a/src/applications/combined-debt-portal/medical-copays/sass/medical-copays.scss
+++ b/src/applications/combined-debt-portal/medical-copays/sass/medical-copays.scss
@@ -17,9 +17,6 @@
   align-items: baseline;
   margin-bottom: 16px;
   pointer-events: auto;
-  i {
-    padding-right: 10px;
-  }
   p {
     margin: 0;
   }


### PR DESCRIPTION
## Description
Updated icons to have `padding-right` value of 10px, and container flexbox item alignment for consistency across app. 

## Original issue(s)
"The icon should have no top padding and a right padding of 10px. See the copay card icons."

department-of-veterans-affairs/va.gov-team#43978

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25368370/180286268-47782b94-b49f-4fef-8d6e-58f0c0162ad7.png) | ![image](https://user-images.githubusercontent.com/25368370/180287790-12836cff-c0b3-469f-a433-4c5de3d02e78.png) |


## Acceptance criteria
- [ ] Styling for icons is consistent across the app

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
