### PR TITLE
[CDP] 44003 - Updated breadcrumbs across app for accuracy consistency

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -36,7 +36,7 @@ const OverviewPage = () => {
     <>
       <va-breadcrumbs className="vads-u-font-family--sans" label="Breadcrumb">
         <a href="/">Home</a>
-        <a href="/manage-va-debt">Review and manage VA debt and bills</a>
+        <a href="/manage-va-debt">Manage your VA debt</a>
         <a href="/manage-va-debt/summary">Your VA debt and bills</a>
       </va-breadcrumbs>
       <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
@@ -56,9 +56,9 @@ const DebtDetails = () => {
       <div className="vads-l-col--9 small-desktop-screen:vads-l-col--12">
         <va-breadcrumbs label="Breadcrumb">
           <a href="/">Home</a>
-          <a href="/manage-va-debt/">Manage your VA debt and bills</a>
-          <Link to="/manage-va-debt/summary/">Your debt and bills summary</Link>
-          <Link to="/debt-balances/">Benefit debt balances</Link>
+          <a href="/manage-va-debt/">Manage your VA debt</a>
+          <Link to="/manage-va-debt/summary/">Your VA debt and bills</Link>
+          <Link to="/debt-balances/">Current VA debt</Link>
           <Link
             to={`/debt-balances/details/${selectedDebt.fileNumber +
               selectedDebt.deductionCode}`}

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
@@ -21,9 +21,9 @@ const DebtLettersDownload = () => {
       <div className="vads-l-col--9 small-desktop-screen:vads-l-col--12">
         <va-breadcrumbs label="Breadcrumb">
           <a href="/">Home</a>
-          <a href="/manage-va-debt/">Manage your VA debt and bills</a>
-          <a href="/manage-va-debt/summary/">Your debt and bills summary</a>
-          <Link to="/debt-balances/">Benefit debt balances</Link>
+          <a href="/manage-va-debt/">Manage your VA debt</a>
+          <a href="/manage-va-debt/summary/">Your VA debt and bills</a>
+          <Link to="/debt-balances/">Current VA debt</Link>
           <Link to="/debt-balances/letters">Debt letters</Link>
         </va-breadcrumbs>
       </div>

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -91,9 +91,9 @@ const DebtLettersSummary = () => {
     <>
       <va-breadcrumbs label="Breadcrumb">
         <a href="/">Home</a>
-        <a href="/manage-va-debt/">Manage your VA debt and bills</a>
-        <a href="/manage-va-debt/summary/">Your debt and bills summary</a>
-        <Link to="/debt-balances">Benefit debt balances</Link>
+        <a href="/manage-va-debt/">Manage your VA debt</a>
+        <a href="/manage-va-debt/summary/">Your VA debt and bills</a>
+        <Link to="/debt-balances">Current VA debt</Link>
       </va-breadcrumbs>
       <div
         className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8"

--- a/src/applications/combined-debt-portal/medical-copays/containers/DetailPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/DetailPage.jsx
@@ -46,8 +46,8 @@ const DetailPage = ({ match }) => {
     <>
       <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
         <a href="/">Home</a>
-        <a href="/manage-va-debt">Manage your VA debt and bills</a>
-        <a href="/manage-va-debt/summary/">Your debt and bills summary</a>
+        <a href="/manage-va-debt">Manage your VA debt</a>
+        <a href="/manage-va-debt/summary/">Your VA debt and bills</a>
         <a href="/manage-va-debt/summary/copay-balances">
           Current copay balances
         </a>

--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -35,8 +35,8 @@ const HTMLStatementPage = ({ match }) => {
       <div className="vads-l-col--12 small-desktop-screen:vads-l-col--10">
         <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
           <a href="/">Home</a>
-          <a href="/manage-va-debt">Manage your VA debt and bills</a>
-          <a href="/manage-va-debt/summary/">Your debt and bills summary</a>
+          <a href="/manage-va-debt">Manage your VA debt</a>
+          <a href="/manage-va-debt/summary/">Your VA debt and bills</a>
           <a href="/manage-va-debt/summary/copay-balances">
             Current copay balances
           </a>

--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -98,8 +98,8 @@ const OverviewPage = () => {
     <>
       <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
         <a href="/">Home</a>
-        <a href="/manage-va-debt">Manage your VA debt and bills</a>
-        <a href="/manage-va-debt/summary/">Your debt and bills summary</a>
+        <a href="/manage-va-debt">Manage your VA debt</a>
+        <a href="/manage-va-debt/summary/">Your VA debt and bills</a>
         <a href="/manage-va-debt/summary/copay-balances">
           {' '}
           Current copay balances


### PR DESCRIPTION
## Description
Updated Breadcrumbs across CDP for consistency. 
Content page is `Manage your VA debt` 
Summary page (react entry point) is `Your VA debt and bills` 
Debt Overview (balances) page is `Current VA debt`

## Original issue(s)
"Change breadcrumb to match page H1 or vice-versa."
department-of-veterans-affairs/va.gov-team#44003

## Screenshot(s)
`Current VA debt` example:

![image](https://user-images.githubusercontent.com/25368370/180299745-2a98123a-b4c1-4fc1-b5ad-e2d99efb15ba.png)

## Acceptance criteria
- [ ] Breadcrumbs are consistent with `h1` tags across the application. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
