### PR TITLE
Ensure that the item name in the ArrayField heading does not render `undefined`

### DIFF
--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -300,7 +300,7 @@ class ArrayField extends React.Component {
                           tabIndex="-1"
                           ref={focusElement}
                         >
-                          New {itemName}
+                          New {uiOptions.itemName ?? ''}
                         </h4>
                       ) : null}
                       <SchemaForm


### PR DESCRIPTION
## Description
For example, when on the review page of the Health Care Application form, adding "Other coverage" shows `undefined` in the heading. Please see original issue for more details.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/447


## Testing done
Yes

## Screenshots
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/5934582/180327717-9543d2e3-e3d1-4501-a3e1-518a79820a58.png">


## Acceptance criteria
- [x] Ensure that the item name in the ArrayField heading does not render `undefined`

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
