### PR TITLE
fix empty comment field

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -66,7 +66,7 @@ function VAFacilityName({ facility }) {
 }
 
 VAFacilityName.propTypes = {
-  facility: PropTypes.object.isRequired,
+  facility: PropTypes.object,
 };
 
 function handleClick({ history, link, idClickable }) {

--- a/src/applications/vaos/appointment-list/components/RequestedStatusAlert.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedStatusAlert.jsx
@@ -97,5 +97,5 @@ export default function RequestedStatusAlert({ appointment, facility }) {
 
 RequestedStatusAlert.propTypes = {
   appointment: PropTypes.object.isRequired,
-  facility: PropTypes.object.isRequired,
+  facility: PropTypes.object,
 };

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -737,7 +737,10 @@ export function getProviderInfoV2(appointment) {
     const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
       getState(),
     );
-    if (featureVAOSServiceCCAppointments && !!appointment.practitioners) {
+    if (
+      featureVAOSServiceCCAppointments &&
+      appointment.practitioners.length > 0
+    ) {
       const ProviderNpi = getPreferredCCProviderNPI(appointment);
 
       const providerData = await fetchPreferredProvider(ProviderNpi);
@@ -747,7 +750,10 @@ export function getProviderInfoV2(appointment) {
         providerData,
       });
     }
-    if (featureVAOSServiceCCAppointments && !appointment.practitioners) {
+    if (
+      featureVAOSServiceCCAppointments &&
+      appointment.practitioners.length === 0
+    ) {
       dispatch({
         type: FETCH_PROVIDER_SUCCEEDED,
         providerData: null,

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -729,19 +729,16 @@ export function fetchFacilitySettings() {
  * Function to retrieve provider information from the provider
  * endpoint when using the v2 api.
  *
- * @param {*} appointments
+ * @param {*} appointment
  */
-export function getProviderInfoV2(appointments) {
+export function getProviderInfoV2(appointment) {
   // Provider information included with v2 provider api call.
   return async (dispatch, getState) => {
     const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
       getState(),
     );
-    if (
-      featureVAOSServiceCCAppointments &&
-      appointments.practitioners.length > 0
-    ) {
-      const ProviderNpi = getPreferredCCProviderNPI(appointments);
+    if (featureVAOSServiceCCAppointments && !!appointment.practitioners) {
+      const ProviderNpi = getPreferredCCProviderNPI(appointment);
 
       const providerData = await fetchPreferredProvider(ProviderNpi);
 
@@ -750,10 +747,7 @@ export function getProviderInfoV2(appointments) {
         providerData,
       });
     }
-    if (
-      featureVAOSServiceCCAppointments &&
-      appointments.practitioners.length === 0
-    ) {
+    if (featureVAOSServiceCCAppointments && !appointment.practitioners) {
       dispatch({
         type: FETCH_PROVIDER_SUCCEEDED,
         providerData: null,

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -17,9 +17,13 @@ function getReasonCode({ data, isCC }) {
     purpose => purpose.id === data.reasonForAppointment,
   )?.serviceName;
 
-  const reasonAdditionalInfo = isCC
-    ? data.reasonAdditionalInfo.slice(0, 250)
-    : data.reasonAdditionalInfo.slice(0, 100);
+  let reasonText = null;
+  if (isCC && data.reasonAdditionalInfo) {
+    reasonText = data.reasonAdditionalInfo.slice(0, 250);
+  }
+  if (!isCC) {
+    reasonText = data.reasonAdditionalInfo.slice(0, 100);
+  }
 
   return {
     // If the user selects one of the three preset radio selections
@@ -29,7 +33,7 @@ function getReasonCode({ data, isCC }) {
     // Per Brad - All comments should be sent in the reasonCode.text field and should should be
     // truncated to 100 char for both VA appointment types only. CC appointments will continue
     // to be truncated to 250 char
-    text: data.reasonAdditionalInfo ? reasonAdditionalInfo : null,
+    text: data.reasonAdditionalInfo ? reasonText : null,
   };
 }
 
@@ -86,9 +90,7 @@ export function transformFormToVAOSCCRequest(state) {
     locationId: data.communityCareSystemId,
     serviceType: typeOfCare.idV2 || typeOfCare.ccId,
     // comment: data.reasonAdditionalInfo,
-    reasonCode: data.reasonAdditionalInfo
-      ? getReasonCode({ data, isCC: true })
-      : null,
+    reasonCode: getReasonCode({ data, isCC: true }),
     contact: {
       telecom: [
         {

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -17,13 +17,9 @@ function getReasonCode({ data, isCC }) {
     purpose => purpose.id === data.reasonForAppointment,
   )?.serviceName;
 
-  let reasonText = null;
-  if (isCC && data.reasonAdditionalInfo) {
-    reasonText = data.reasonAdditionalInfo.slice(0, 250);
-  }
-  if (!isCC) {
-    reasonText = data.reasonAdditionalInfo.slice(0, 100);
-  }
+  const reasonAdditionalInfo = isCC
+    ? data.reasonAdditionalInfo.slice(0, 250)
+    : data.reasonAdditionalInfo.slice(0, 100);
 
   return {
     // If the user selects one of the three preset radio selections
@@ -33,7 +29,7 @@ function getReasonCode({ data, isCC }) {
     // Per Brad - All comments should be sent in the reasonCode.text field and should should be
     // truncated to 100 char for both VA appointment types only. CC appointments will continue
     // to be truncated to 250 char
-    text: data.reasonAdditionalInfo ? reasonText : null,
+    text: data.reasonAdditionalInfo ? reasonAdditionalInfo : null,
   };
 }
 
@@ -90,7 +86,9 @@ export function transformFormToVAOSCCRequest(state) {
     locationId: data.communityCareSystemId,
     serviceType: typeOfCare.idV2 || typeOfCare.ccId,
     // comment: data.reasonAdditionalInfo,
-    reasonCode: getReasonCode({ data, isCC: true }),
+    reasonCode: data.reasonAdditionalInfo
+      ? getReasonCode({ data, isCC: true })
+      : null,
     contact: {
       telecom: [
         {

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -17,9 +17,13 @@ function getReasonCode({ data, isCC }) {
     purpose => purpose.id === data.reasonForAppointment,
   )?.serviceName;
 
-  const reasonAdditionalInfo = isCC
-    ? data.reasonAdditionalInfo.slice(0, 250)
-    : data.reasonAdditionalInfo.slice(0, 100);
+  let reasonText = null;
+  if (isCC && data.reasonAdditionalInfo) {
+    reasonText = data.reasonAdditionalInfo.slice(0, 250);
+  }
+  if (!isCC) {
+    reasonText = data.reasonAdditionalInfo.slice(0, 100);
+  }
 
   return {
     // If the user selects one of the three preset radio selections
@@ -29,7 +33,7 @@ function getReasonCode({ data, isCC }) {
     // Per Brad - All comments should be sent in the reasonCode.text field and should should be
     // truncated to 100 char for both VA appointment types only. CC appointments will continue
     // to be truncated to 250 char
-    text: data.reasonAdditionalInfo ? reasonAdditionalInfo : null,
+    text: data.reasonAdditionalInfo ? reasonText : null,
   };
 }
 


### PR DESCRIPTION
## Description
When the optional comment field is left blank, the user is unable to complete making a Community Care request

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44768


## Testing done
local test

## Screenshots

![Screen Shot 2022-07-21 at 6 00 51 PM](https://user-images.githubusercontent.com/54327023/180339935-0403a38d-b319-489b-9b5a-33ebd8af842f.png)

## Acceptance criteria
- [ ] User able to complete the CC appointment request
- [ ] Displays the pending details page upon making the appointment request

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
