### PR TITLE
Fix missing day-of label

### DIFF
--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -10,7 +10,7 @@ const v2 = {
   }) => {
     const url = `/check_in/v2/sessions/`;
     const checkInTypeSlug = checkInType ? `?checkInType=${checkInType}` : '';
-    const eventLabel = `${checkInType ?? 'day-of'}-get-current-session-${
+    const eventLabel = `${checkInType || 'day-of'}-get-current-session-${
       isLorotaSecurityUpdatesEnabled ? 'dob' : 'ssn4'
     }`;
 
@@ -60,7 +60,7 @@ const v2 = {
       mode: 'cors',
     };
 
-    const eventLabel = `${checkInType ?? 'day-of'}-validating-user-${
+    const eventLabel = `${checkInType || 'day-of'}-validating-user-${
       isLorotaSecurityUpdatesEnabled ? 'dob' : 'ssn4'
     }`;
 


### PR DESCRIPTION
## Description

Corrects logic error that meant `day-of` is not being added to the GA event label.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44383


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
