### PR TITLE
[CDP] 43979 - Fixing debt letter table formatting

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/const/diary-codes/index.js
+++ b/src/applications/combined-debt-portal/debt-letters/const/diary-codes/index.js
@@ -8,10 +8,10 @@ export const renderLetterHistory = diaryCode => {
     case '109':
       return (
         <>
-          <p className="vads-u-margin-bottom--0">
+          <p className="vads-u-margin--0">
             <strong>First demand letter</strong>
           </p>
-          <p className="vads-u-margin-top--0">
+          <p className="vads-u-margin--0">
             A letter was sent to notify you of your debt and provide information
             on how to resolve it.
           </p>
@@ -20,10 +20,10 @@ export const renderLetterHistory = diaryCode => {
     case '117':
       return (
         <>
-          <p className="vads-u-margin-bottom--0">
+          <p className="vads-u-margin--0">
             <strong>Second demand letter</strong>
           </p>
-          <p className="vads-u-margin-top--0">
+          <p className="vads-u-margin--0">
             A letter was sent to inform you that failure to pay or contact the
             DMC within 60 days would result in the debt being reported to Credit
             Reporting Agencies.
@@ -33,10 +33,10 @@ export const renderLetterHistory = diaryCode => {
     case '123':
       return (
         <>
-          <p className="vads-u-margin-bottom--0">
+          <p className="vads-u-margin--0">
             <strong>Third demand letter</strong>
           </p>
-          <p className="vads-u-margin-top--0">
+          <p className="vads-u-margin--0">
             A letter was sent to inform you that failure to pay or contact the
             DMC within 30 days would result in the debt being referred to the
             Department of Treasury for collection. This referral could result in
@@ -47,10 +47,10 @@ export const renderLetterHistory = diaryCode => {
     case '130':
       return (
         <>
-          <p className="vads-u-margin-bottom--0">
+          <p className="vads-u-margin--0">
             <strong>Debt increase letter</strong>
           </p>
-          <p className="vads-u-margin-top--0">
+          <p className="vads-u-margin--0">
             A letter was sent to inform you that your debt’s balance has
             increased due to additional benefit over payments being made to you.
           </p>


### PR DESCRIPTION
## Description
Debt letters table had misaligned content within the table caused by default `<p>` margins. 

## Original issue(s)
"The VA debt letter history table is misaligned in the second column"
department-of-veterans-affairs/va.gov-team#43979

## Screenshots

|Before|After|
|---|---|
| ![image](https://user-images.githubusercontent.com/25368370/180462039-6862e00a-2db0-4530-8ebc-b868e1eaecec.png) | ![image](https://user-images.githubusercontent.com/25368370/180462098-35042e64-23d5-49a0-b38f-92fb3ee3ce40.png) |
| ![image](https://user-images.githubusercontent.com/25368370/180461819-adbd56af-118e-4ce7-8444-a1870f3e5c60.png) | ![image](https://user-images.githubusercontent.com/25368370/180461920-dba91e5a-a8f7-4962-a7a1-1518019f46b9.png) |

## Acceptance criteria
- [ ] Table content is aligned properly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
