### PR TITLE
[CDP] Updating local content page 

### DIFF
--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -1,27 +1,25 @@
 import React from 'react';
 import { getAppUrl } from 'platform/utilities/registry-helpers';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
-const debtLettersUrl = getAppUrl('your-debt');
+const cdpUrl = getAppUrl('combined-debt-portal');
 const fsrUrl = getAppUrl('request-debt-help-form-5655');
 
 const ManageVADebtCTA = () => (
   <>
-    <Breadcrumbs>
+    <va-breadcrumbs>
       <a href="/">Home</a>
       <a href="/manage-va-debt">Manage your VA debt</a>
-    </Breadcrumbs>
-    <h1>Manage your VA debt</h1>
+    </va-breadcrumbs>
+    <h1>Manage your VA debt for benefit overpayments and copay bills</h1>
     <p>
-      Check the status of debt related to VA disability compensation,
-      non-service-connected pension, or education benefits. And make payments or
-      request help now if you’d like.
+      Review your current VA benefit debt or copay bill balances online. And
+      find out how to make payments or request help now.
     </p>
-    <h3>Check the status of your VA benefit debt</h3>
+    <h3>Review your benefit debt and copay bills online</h3>
     <a
       className="usa-button-primary va-button-primary"
       target="_self"
-      href={debtLettersUrl}
+      href={cdpUrl}
     >
       Manage your VA debt
     </a>


### PR DESCRIPTION
## Description
`Manage your VA debt` button link now points to `/manage-va-debt/summary` on localhost:3001/manage-va-debt page, and text has been updated to reflect new content page. 

## Screenshots
|Before|After|
|---|---|
| ![image](https://user-images.githubusercontent.com/25368370/180469771-0765f0da-547f-4e89-abb4-dfb202f06348.png) | ![image](https://user-images.githubusercontent.com/25368370/180469287-4469cc81-da95-4c39-9dca-a5a92ca8bf2f.png) |

## Acceptance criteria
- [ ] Local content page has new text and links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
