### PR TITLE
40139 fix appointment list link

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -179,6 +179,7 @@ export default function AppointmentListItem({ appointment, facility }) {
     </li>
   );
 }
+
 AppointmentListItem.propTypes = {
   appointment: PropTypes.object.isRequired,
   facility: PropTypes.object,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -162,14 +162,14 @@ export default function AppointmentListItem({ appointment, facility }) {
           )}
         </div>
         <div className="vads-u-flex--auto vads-u-padding-top--0p5 medium-screen:vads-u-padding-top--0 vaos-hide-for-print">
-          <button
-            type="button"
-            role="link"
-            className="va-button-link vaos-appts__focus--hide-outline"
+          <Link
+            className="vaos-appts__focus--hide-outline"
             aria-label={label}
+            to={link}
+            onClick={e => e.preventDefault()}
           >
             Details
-          </button>
+          </Link>
 
           <i
             aria-hidden="true"

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory, Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { focusElement } from 'platform/utilities/ui';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -170,7 +170,6 @@ export default function AppointmentListItem({ appointment, facility }) {
           >
             Details
           </Link>
-
           <i
             aria-hidden="true"
             className="fas fa-chevron-right vads-u-color--link-default vads-u-margin-left--1"

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import { focusElement } from 'platform/utilities/ui';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -162,13 +162,15 @@ export default function AppointmentListItem({ appointment, facility }) {
           )}
         </div>
         <div className="vads-u-flex--auto vads-u-padding-top--0p5 medium-screen:vads-u-padding-top--0 vaos-hide-for-print">
-          <Link
-            className="vaos-appts__focus--hide-outline"
+          <button
+            type="button"
+            role="link"
+            className="va-button-link vaos-appts__focus--hide-outline"
             aria-label={label}
-            to={link}
           >
             Details
-          </Link>
+          </button>
+
           <i
             aria-hidden="true"
             className="fas fa-chevron-right vads-u-color--link-default vads-u-margin-left--1"
@@ -178,7 +180,6 @@ export default function AppointmentListItem({ appointment, facility }) {
     </li>
   );
 }
-
 AppointmentListItem.propTypes = {
   appointment: PropTypes.object.isRequired,
   facility: PropTypes.object,


### PR DESCRIPTION
## Description
This fixes and issue with the "Details" link on the appointment list page. It was incorrectly adding either an additional `/va` or `/cc` to the path when clicked.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team/issues/40139](https://github.com/department-of-veterans-affairs/va.gov-team/issues/40139)

## Testing done
- Local testing
- e2e testing
- unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
