### PR TITLE
Force scroll to top for loading pages

### DIFF
--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -77,6 +77,9 @@ const DisplayMultipleAppointments = props => {
   const { goToPreviousPage } = useFormRouting(router);
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
+
+  if (isLoading) window.scrollTo(0, 0);
+
   return isLoading ? (
     <va-loading-indicator message={t('loading-your-appointments-for-today')} />
   ) : (

--- a/src/applications/check-in/day-of/pages/CheckIn/index.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/index.jsx
@@ -24,6 +24,7 @@ const CheckIn = props => {
   const { token } = context;
 
   if (!appointment) {
+    window.scrollTo(0, 0);
     return (
       <va-loading-indicator
         message={t('loading-your-appointments-for-today')}

--- a/src/applications/check-in/day-of/pages/LoadingPage/index.jsx
+++ b/src/applications/check-in/day-of/pages/LoadingPage/index.jsx
@@ -30,6 +30,8 @@ const LoadingPage = props => {
     [checkInDataError, demographics, goToErrorPage, goToNextPage],
   );
 
+  window.scrollTo(0, 0);
+
   return (
     <va-loading-indicator message={t('loading-your-appointments-for-today')} />
   );

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -100,6 +100,7 @@ const Introduction = props => {
     ],
   );
   if (isLoading) {
+    window.scrollTo(0, 0);
     return (
       <va-loading-indicator message={t('loading-your-appointment-details')} />
     );


### PR DESCRIPTION
## Description
Unless we have more information about this ticket, the only time I can see this behaviour is during loading screens. This PR adds a quick force scroll to top on the main loading screens, particularly immediately after authentication, to avoid this issue.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42684


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
