### PR TITLE
HLR & NOD | Fix issue with infinite loop

### DIFF
--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -72,7 +72,7 @@ export const getEligibleContestableIssues = issues => {
       .join(' ')
       .includes('deferred');
     const date = moment(approxDecisionDate);
-    if (isDeferred || !date.isValid()) {
+    if (isDeferred || !date.isValid() || !ratingIssueSubjectText) {
       return false;
     }
     return date.add(1, 'years').isAfter(today);

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -10,6 +10,14 @@ import { SELECTED, LEGACY_TYPE } from '../constants';
 export const isVersion1Data = formData => !!formData?.zipCode5;
 
 /**
+ * Get issue name/title from either a manually added issue or issue loaded from
+ * the API
+ * @param {AdditionalIssueItem|ContestableIssueItem}
+ */
+export const getIssueName = (entry = {}) =>
+  entry.issue || entry.attributes?.ratingIssueSubjectText;
+
+/**
  * @typedef ContestableIssues
  * @type {Array<Object>}
  * @property {ContestableIssueItem|LegacyAppealsItem}
@@ -65,7 +73,8 @@ export const getEligibleContestableIssues = issues => {
       .join(' ')
       .includes('deferred');
     const date = moment(approxDecisionDate);
-    if (isDeferred || !date.isValid()) {
+    const issueName = getIssueName(issue);
+    if (isDeferred || !date.isValid() || !issueName) {
       return false;
     }
     return date.add(1, 'years').isAfter(today);
@@ -144,14 +153,6 @@ export const getSelected = formData => {
 // the formData is updated
 export const getSelectedCount = (formData, items) =>
   getSelected({ ...formData, additionalIssues: items }).length;
-
-/**
- * Get issue name/title from either a manually added issue or issue loaded from
- * the API
- * @param {AdditionalIssueItem|ContestableIssueItem}
- */
-export const getIssueName = (entry = {}) =>
-  entry.issue || entry.attributes?.ratingIssueSubjectText;
 
 export const getIssueDate = (entry = {}) =>
   entry.decisionDate || entry.attributes?.approxDecisionDate || '';

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -10,14 +10,6 @@ import { SELECTED, LEGACY_TYPE } from '../constants';
 export const isVersion1Data = formData => !!formData?.zipCode5;
 
 /**
- * Get issue name/title from either a manually added issue or issue loaded from
- * the API
- * @param {AdditionalIssueItem|ContestableIssueItem}
- */
-export const getIssueName = (entry = {}) =>
-  entry.issue || entry.attributes?.ratingIssueSubjectText;
-
-/**
  * @typedef ContestableIssues
  * @type {Array<Object>}
  * @property {ContestableIssueItem|LegacyAppealsItem}
@@ -73,8 +65,7 @@ export const getEligibleContestableIssues = issues => {
       .join(' ')
       .includes('deferred');
     const date = moment(approxDecisionDate);
-    const issueName = getIssueName(issue);
-    if (isDeferred || !date.isValid() || !issueName) {
+    if (isDeferred || !date.isValid() || !ratingIssueSubjectText) {
       return false;
     }
     return date.add(1, 'years').isAfter(today);
@@ -153,6 +144,14 @@ export const getSelected = formData => {
 // the formData is updated
 export const getSelectedCount = (formData, items) =>
   getSelected({ ...formData, additionalIssues: items }).length;
+
+/**
+ * Get issue name/title from either a manually added issue or issue loaded from
+ * the API
+ * @param {AdditionalIssueItem|ContestableIssueItem}
+ */
+export const getIssueName = (entry = {}) =>
+  entry.issue || entry.attributes?.ratingIssueSubjectText;
 
 export const getIssueDate = (entry = {}) =>
   entry.decisionDate || entry.attributes?.approxDecisionDate || '';


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44803

## URL(s) of fix
* [/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/introduction](http://localhost:3001/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/introduction)
* [/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction](http://localhost:3001/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction)

## Expected behavior
When the user accesses the HLR form, they are able to complete the form without the website locking up

## Current behavior
When veterans that have a contestable issue that has a `approxDecisionDate` within the last year and a `ratingIssueSubjectText` of null enter the HLR form, the form locks up and becomes unresponsive.

## Your fix
* Filter out any contestable issues that have a `approxDecsionDate` within the last year and `ratingIssueSubjectText` set to null before they are put into the Redux store

## How has this been tested?
Tested manually. Tests still pass

## Acceptance criteria
- [x] Veterans that access HLR or NOD are able to complete the form without the website becoming unresponsive and locking up