### PR TITLE
[VA-21108] Remove locator tab indexes

### DIFF
--- a/src/applications/facility-locator/components/facility-details/OperationStatus.jsx
+++ b/src/applications/facility-locator/components/facility-details/OperationStatus.jsx
@@ -48,7 +48,7 @@ export default function OperationStatus(props) {
   return (
     <va-alert close-btn-aria-label="" status={alertClass} visible>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-      <h2 slot="headline" tabIndex={0} role="alert">
+      <h2 slot="headline" role="alert">
         {operationStatusTitle}
       </h2>
       <div data-testid="status-description">

--- a/src/applications/facility-locator/components/search-results-items/common/LocationOperationStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationOperationStatus.jsx
@@ -38,7 +38,7 @@ const LocationOperationStatus = ({ operatingStatus }) => {
       data-testid={`${operatingStatus.code.toLowerCase()}-message`}
       class="vads-u-margin-y--2"
     >
-      <div tabIndex={0}>
+      <div>
         <span className="sr-only">Alert: </span>
         {operationStatusTitle}
       </div>

--- a/src/applications/facility-locator/tests/components/search-results/LocationOperationStatus.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationOperationStatus.unit.spec.jsx
@@ -6,16 +6,6 @@ import LocationOperationStatus from '../../../components/search-results-items/co
 
 describe('facility-locator', () => {
   describe('LocationOperationStatus', () => {
-    it('should have tabIndex on the div', () => {
-      const operatingStatus = { code: 'CLOSED' };
-      const { container } = render(
-        <LocationOperationStatus operatingStatus={operatingStatus} />,
-      );
-      expect(container.querySelector('div').getAttribute('tabindex')).to.equal(
-        '0',
-      );
-    });
-
     it('check in button passes axeCheck', () => {
       const operatingStatus = { code: 'CLOSED' };
       axeCheck(<LocationOperationStatus operatingStatus={operatingStatus} />);


### PR DESCRIPTION
## Description

Some unneeded tab indexes are used in the facility locator alerts since they should only be added to interactive elements. This removes them to make the experience more aligned with screen reader tools' expectations.

`LocationCovidStatus` was already fixed in a separate follow-up PR, so the other two files are the only ones changed here.

Closes [#21108](https://github.com/department-of-veterans-affairs/vets-website/issues/21108)

## Original issue(s)

https://github.com/department-of-veterans-affairs/vets-website/issues/21108

## Testing done

Visual, keyboard

## Screenshots

None

## Acceptance criteria
- [ ] Alerts in the facility locator statuses don't let keyboard uses tab onto non-interactive text

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
