### PR TITLE
fix for practitioner length

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
@@ -37,7 +37,7 @@ export default function RequestListItem({ appointment, facility }) {
     'MMMM D, YYYY',
   );
   const link = `requests/${appointment.id}`;
-  const idClickable = `id-${appointment.id.replace('.', '\\.')}`;
+  const idClickable = `id-${appointment.id?.replace('.', '\\.')}`;
   const featureStatusImprovement = useSelector(state =>
     selectFeatureStatusImprovement(state),
   );

--- a/src/applications/vaos/appointment-list/components/cancel/CancelAppointmentConfirmationModal.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelAppointmentConfirmationModal.jsx
@@ -63,5 +63,5 @@ CancelAppointmentConfirmationModal.propTypes = {
   status: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   isConfirmed: PropTypes.bool,
-  onConfirm: PropTypes.bool,
+  onConfirm: PropTypes.func,
 };

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -737,10 +737,7 @@ export function getProviderInfoV2(appointment) {
     const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
       getState(),
     );
-    if (
-      featureVAOSServiceCCAppointments &&
-      appointment.practitioners.length > 0
-    ) {
+    if (featureVAOSServiceCCAppointments && appointment.practitioners?.length) {
       const ProviderNpi = getPreferredCCProviderNPI(appointment);
 
       const providerData = await fetchPreferredProvider(ProviderNpi);
@@ -752,7 +749,7 @@ export function getProviderInfoV2(appointment) {
     }
     if (
       featureVAOSServiceCCAppointments &&
-      appointment.practitioners.length === 0
+      !appointment.practitioners?.length
     ) {
       dispatch({
         type: FETCH_PROVIDER_SUCCEEDED,


### PR DESCRIPTION
## Description
This ticket corrects for 2 bugs 

Error 1: Message appears when clicking the browser back button to view the requested queue after user just canceled a CC request
Error 2: A preferred provider name displays on the confirmation page even though none was selected.  Background: User create two CC requests back to back. The first request, user selects CC provider from list and completes the request.  User makes a second CC request immediately after the first. The second request user does NOT select a CC provider. The review page correctly displays "No Provider Selected", however on confirmation page, Preferred Provider section now shows the selected provider from first request.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43756


## Testing done
Steps to test fix for error 1:

1. create an CC appointment request
2. click "View Appointments" link
3. use dropdown to select "Requested"
4. select the recently requested appointment and cancel it
5. use the browser back button to view the requested queue list

Steps to test fix for error 2:

1. User create two CC requests back to back. The first request, user selects CC provider from list and completes the request.  
2. Make a second request immediately after the first. This time do not select a CC provider and complete the request. The review and confirmation page should say "No provider selected"


## Screenshots
n/a

## Acceptance criteria
- [ ] displays the request appointment list queue when clicking the back button after having canceled a CC request
- [ ] When making a request with no provider selected, the confirmation page should day "No provide selected"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
