### PR TITLE
[department-of-veterans-affairs/va-virtual-agent#491] Fix flaky test

### DIFF
--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -879,7 +879,7 @@ describe('App', () => {
       },
     };
 
-    it.skip('when message activity is fired, then utterances should be stored in sessionStorage', () => {
+    it('when message activity is fired, then utterances should be stored in sessionStorage', done => {
       loadWebChat();
       mockApiRequest({ token: 'FAKETOKEN', apiSession: 'FAKEAPISESSION' });
 
@@ -905,23 +905,42 @@ describe('App', () => {
 
       expect(messageActivityHandlerSpy.callCount).to.equal(1);
       expect(messageActivityHandlerSpy.calledWith(event));
+
+      done();
+
       expect(sessionStorage.getItem(RECENT_UTTERANCES)).to.not.be.null;
       expect(
         JSON.parse(sessionStorage.getItem(RECENT_UTTERANCES)),
       ).to.have.members(['', 'first']);
+    });
 
-      event.data.text = 'second';
+    it('when message activity is fired and sessionStorage is already holding two utterances, then the oldest utterance should be removed', done => {
+      loadWebChat();
+      mockApiRequest({ token: 'FAKETOKEN', apiSession: 'FAKEAPISESSION' });
+
+      const messageActivityHandlerSpy = sinon.spy();
+      window.addEventListener(
+        'webchat-message-activity',
+        messageActivityHandlerSpy,
+      );
+
+      renderInReduxProvider(<Chatbox {...defaultProps} />, {
+        initialState: notLoggedInUser,
+        reducers: virtualAgentReducer,
+      });
+
+      sessionStorage.setItem(
+        RECENT_UTTERANCES,
+        JSON.stringify(['first', 'second']),
+      );
+
+      const event = new Event('webchat-message-activity');
+      event.data = { type: 'message', text: 'third', from: { role: 'user' } };
       window.dispatchEvent(event);
 
-      expect(messageActivityHandlerSpy.callCount).to.equal(2);
-      expect(
-        JSON.parse(sessionStorage.getItem(RECENT_UTTERANCES)),
-      ).to.have.members(['first', 'second']);
+      done();
 
-      event.data.text = 'third';
-      window.dispatchEvent(event);
-
-      expect(messageActivityHandlerSpy.callCount).to.equal(3);
+      expect(messageActivityHandlerSpy.callCount).to.equal(1);
       expect(
         JSON.parse(sessionStorage.getItem(RECENT_UTTERANCES)),
       ).to.have.members(['second', 'third']);


### PR DESCRIPTION
## Description
There was a flaky test in our test suite which we have since marked as skipped to prevent disruption to the platform pipeline (see [here](https://github.com/department-of-veterans-affairs/vets-website/pull/21098)).

This PR fixes the flakiness by invoking a jest `done()` callback pattern to ensure all expected components are available at time of expectation, as implemented across the test suite.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/491


## Testing done
Manual testing done with failing `CHOMA_SEED` from previous platform pipeline runs and with randomized seeds. All tests passing with consistency. 