### PR TITLE
42013 - [CDP] - Debt letter download page updates due to VBMS endpoint being back up

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -6,7 +6,7 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/Tele
 export const DownloadLettersAlert = () => (
   <va-alert status="warning">
     <h3 slot="headline">
-      Letters sent after December 9th, 2021 are unavailable for download
+      Downloadable letters have incorrect repayment plan terms
     </h3>
     <p className="vads-u-font-size--base vads-u-font-family--sans">
       We’re sorry. The length of time listed for repayment plans in these

--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -9,9 +9,9 @@ export const DownloadLettersAlert = () => (
       Letters sent after December 9th, 2021 are unavailable for download
     </h3>
     <p className="vads-u-font-size--base vads-u-font-family--sans">
-      We’re sorry. Because the letters sent after this date are unavailable for
-      download right now, we need to refer you to the letters you receive by
-      mail.
+      We’re sorry. The length of time listed for repayment plans in these
+      letters is too short. Use the letters you get in the mail to find the
+      correct repayment plan terms.
     </p>
     <p className="vads-u-font-size--base vads-u-font-family--sans">
       If you have any questions, call us at{' '}


### PR DESCRIPTION
## Description
Updated alert content to match current status of download availability per convo with Jill and Denise.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#42013 

## Screenshots
![42013_Working](https://user-images.githubusercontent.com/29178824/181010891-145372ec-ca82-489d-9baf-cc9aa9262085.png)

## Acceptance criteria
- [ X ] Content updated to match new uxpin in ticket

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
