### PR TITLE
VA-9318: Use Search URL that matches environment for results

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -581,7 +581,7 @@ class SearchApp extends React.Component {
             bestBet: isBestBet,
             title: strippedTitle,
             index,
-            url: result.url,
+            url: replaceWithStagingDomain(result.url),
           })}
         >
           <h4

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -582,6 +582,7 @@ class SearchApp extends React.Component {
             title: strippedTitle,
             index,
             url: replaceWithStagingDomain(result.url),
+            // Trigger a new build
           })}
         >
           <h4


### PR DESCRIPTION
## Description

Search results, when clicked, always go to the Prod URL. This change makes it consistent with the environment in question.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9310

## Testing done

Visual, in testing

[See a page with the bug here by clicking on the first search result.](http://9df5b1adc1ad806bb40bca569123e366.review.vetsgov-internal:3001/search/?query=center&t=false)
[See the local environment with the fix here.](http://31290c022b357d4a8e6588f15f7523e9.review.vetsgov-internal:3001/search/?query=center&t=false)

## Screenshots


## Acceptance criteria

- [ ] Search result URLs, when clicked, go to the expected environment URL

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
