### PR TITLE
Burials | Added missing parameters to validateDate function

### DIFF
--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -1,9 +1,9 @@
 import find from 'lodash/find';
+import { Validator } from 'jsonschema';
 import get from '../../../utilities/data/get';
 import omit from '../../../utilities/data/omit';
 import set from '../../../utilities/data/set';
 import unset from '../../../utilities/data/unset';
-import { Validator } from 'jsonschema';
 
 import { isActivePage, parseISODate, minYear, maxYear } from './helpers';
 import {
@@ -348,6 +348,11 @@ export function validateSSN(errors, ssn) {
 export function validateDate(
   errors,
   dateString,
+  formData,
+  schema,
+  errorMessages,
+  currentIndex,
+  appStateData,
   customMinYear = minYear,
   customMaxYear = maxYear,
 ) {
@@ -520,11 +525,14 @@ export function validateDateRangeAllowSameMonth(
 export function getFileError(file) {
   if (file.errorMessage) {
     return file.errorMessage;
-  } else if (file.uploading) {
+  }
+  if (file.uploading) {
     return 'Uploading file...';
-  } else if (file.isEncrypted && !file.password) {
+  }
+  if (file.isEncrypted && !file.password) {
     return null; // still awaiting password entry
-  } else if (!file.confirmationCode) {
+  }
+  if (!file.confirmationCode) {
     return 'Something went wrong...';
   }
 

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -388,7 +388,17 @@ export function validateCurrentOrPastDate(
   const {
     futureDate = 'Please provide a valid current or past date',
   } = errorMessages;
-  validateDate(errors, dateString, minYear, new Date().getFullYear());
+  validateDate(
+    errors,
+    dateString,
+    formData,
+    schema,
+    errorMessages,
+    undefined,
+    undefined,
+    minYear,
+    new Date().getFullYear(),
+  );
   const { day, month, year } = parseISODate(dateString);
   if (!isValidCurrentOrPastDate(day, month, year)) {
     errors.addError(futureDate);


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43344

## URL of fix
[/burials-and-memorials/application/530/military-history/service-periods](http://localhost:3001/burials-and-memorials/application/530/military-history/service-periods)

## Expected behavior
When a user inputs a date whose year field is outside of the allowed range (1900-2122), they receive the error message:
`Please enter a year between 1900 and 2122`

## Current behavior
When a user inputs a date whose year field is outside of the allowed range (1900-2122), they receive the error message:
`Please enter a year between [object Object] and [object Object]`

## Your fix
### Notes
* `ui:validations` accepts an array of functions (or objects, though this is not as common)
* every function in the array [gets called with the following arguments](https://github.com/department-of-veterans-affairs/vets-website/blob/680826e/src/platform/forms-system/src/js/validation.js#L205-L213):
    * pathErrors
    * currentData
    * formData
    * schema
    * uiSchema['errorMessages']
    * currentIndex
    * appStateData
* [validateDate](https://github.com/department-of-veterans-affairs/vets-website/blob/680826e/src/platform/forms-system/src/js/validation.js#L348-L369) is a platform-provided validator that we are using with our date fields in the burials form
* `validateDate` is only anticipating the first 2 arguments, and includes a few extra arguments that have default values for the min and max year allowed
* `customMinYear` and `customMaxYear` are used to generate the error message
* They are currently being set to the values of `formData` and `schema`

### My fix
* Added the extra parameters to the function parameters list so that `customMinYear` and `customMaxYear` can be set properly

## How has this been tested?
Visually tested. Tests still pass

## Screenshots
<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/13838621/181112751-974fd0f5-c194-4120-b385-509610242e71.png)</details>

<details><summary>After</summary>

![Screen Shot 2022-07-26 at 4 12 17 PM](https://user-images.githubusercontent.com/13838621/181112931-890c087b-a85b-430a-afbc-ec57492fd461.png)</details>

## Acceptance criteria
- [ ] When entering dates, inputting a year that is not between 1900 and 2122 should result in an error
- [ ] The error should be human readable and indicate which years the year input needs to be between
