### PR TITLE
Remove address autofill feature flag from Caregivers application

### DIFF
--- a/src/applications/caregivers/components/AdditionalInfo/PrimaryCaregiverInfo.jsx
+++ b/src/applications/caregivers/components/AdditionalInfo/PrimaryCaregiverInfo.jsx
@@ -15,7 +15,6 @@ export const PrimaryCaregiverInfo = ({
 }) => {
   const formData = formContext?.formData || {};
   const { veteranFullName: name, veteranAddress: address } = formData;
-  const canAutofillAddress = formData['view:canAutofill1010cgAddress'];
 
   return (
     <>
@@ -25,22 +24,21 @@ export const PrimaryCaregiverInfo = ({
         <p className="vads-u-margin-top--2">{primaryPageIntro}</p>
       )}
 
-      {showContactIntro &&
-        canAutofillAddress && (
-          <>
-            <p className="vads-u-margin-top--2">{primaryContactIntro}</p>
-            <p className="vads-u-font-size--h4 vads-u-margin-bottom--1">
-              <strong>Veteran address</strong>
-            </p>
-            <p className="va-address-block vads-u-margin-left--0">
-              {name.first} {name.middle} {name.last}
-              <br />
-              {address.street} {address.street2}
-              <br />
-              {address.city}, {address.state} {address.postalCode}
-            </p>
-          </>
-        )}
+      {showContactIntro && (
+        <>
+          <p className="vads-u-margin-top--2">{primaryContactIntro}</p>
+          <p className="vads-u-font-size--h4 vads-u-margin-bottom--1">
+            <strong>Veteran address</strong>
+          </p>
+          <p className="va-address-block vads-u-margin-left--0">
+            {name.first} {name.middle} {name.last}
+            <br />
+            {address.street} {address.street2}
+            <br />
+            {address.city}, {address.state} {address.postalCode}
+          </p>
+        </>
+      )}
 
       {additionalInfo && (
         <section className="vads-u-margin-y--2p5">

--- a/src/applications/caregivers/components/AdditionalInfo/SecondaryCaregiverInfo.jsx
+++ b/src/applications/caregivers/components/AdditionalInfo/SecondaryCaregiverInfo.jsx
@@ -11,7 +11,6 @@ export const SecondaryCaregiverInfo = ({
 }) => {
   const formData = formContext?.formData || {};
   const { veteranFullName: name, veteranAddress: address } = formData;
-  const canAutofillAddress = formData['view:canAutofill1010cgAddress'];
 
   return (
     <>
@@ -19,22 +18,21 @@ export const SecondaryCaregiverInfo = ({
 
       {showPageIntro && <p className="vads-u-margin-top--2">{introText}</p>}
 
-      {showContactIntro &&
-        canAutofillAddress && (
-          <>
-            <p className="vads-u-margin-top--2">{introText}</p>
-            <p className="vads-u-font-size--h4 vads-u-margin-bottom--1">
-              <strong>Veteran address</strong>
-            </p>
-            <p className="va-address-block vads-u-margin-left--0">
-              {name.first} {name.middle} {name.last}
-              <br />
-              {address.street} {address.street2}
-              <br />
-              {address.city}, {address.state} {address.postalCode}
-            </p>
-          </>
-        )}
+      {showContactIntro && (
+        <>
+          <p className="vads-u-margin-top--2">{introText}</p>
+          <p className="vads-u-font-size--h4 vads-u-margin-bottom--1">
+            <strong>Veteran address</strong>
+          </p>
+          <p className="va-address-block vads-u-margin-left--0">
+            {name.first} {name.middle} {name.last}
+            <br />
+            {address.street} {address.street2}
+            <br />
+            {address.city}, {address.state} {address.postalCode}
+          </p>
+        </>
+      )}
 
       {additionalInfo && (
         <section className="vads-u-margin-y--1p5">

--- a/src/applications/caregivers/components/FormFieldsets/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFieldsets/AddressWithAutofill.jsx
@@ -129,16 +129,14 @@ const PrimaryAddressWithAutofill = props => {
         {inputLabelMap[props.name]} current address
       </legend>
 
-      {canAutofillAddress && (
-        <VaCheckbox
-          id="root_primaryAddress_autofill"
-          checked={formData['view:autofill']}
-          label="Use the same address as the Veteran"
-          className="vads-u-margin-left--neg3"
-          style={{ marginLeft: '-24px' }}
-          onVaChange={handleCheck}
-        />
-      )}
+      <VaCheckbox
+        id="root_primaryAddress_autofill"
+        checked={formData['view:autofill']}
+        label="Use the same address as the Veteran"
+        className="vads-u-margin-left--neg3"
+        style={{ marginLeft: '-24px' }}
+        onVaChange={handleCheck}
+      />
 
       <VaTextInput
         id={idSchema.street.$id}
@@ -222,7 +220,6 @@ PrimaryAddressWithAutofill.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  canAutofillAddress: state.featureToggles?.canAutofill1010cgAddress,
   veteranAddress: state.form.data.veteranAddress,
 });
 

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -19,27 +19,10 @@ import {
 } from 'platform/monitoring/DowntimeNotification';
 import { setData } from 'platform/forms-system/src/js/actions';
 
-export const IntroductionPage = ({
-  route,
-  router,
-  formData,
-  setFormData,
-  canAutofill1010cgAddress,
-}) => {
+export const IntroductionPage = ({ route, router }) => {
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
   }, []);
-
-  useEffect(
-    () => {
-      setFormData({
-        ...formData,
-        'view:canAutofill1010cgAddress': canAutofill1010cgAddress,
-      });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [canAutofill1010cgAddress],
-  );
 
   const startForm = useCallback(
     () => {
@@ -275,7 +258,6 @@ export const IntroductionPage = ({
 
 const mapStateToProps = state => ({
   formData: state.form.data,
-  canAutofill1010cgAddress: state.featureToggles?.canAutofill1010cgAddress,
 });
 
 const mapDispatchToProps = {
@@ -283,7 +265,6 @@ const mapDispatchToProps = {
 };
 
 IntroductionPage.propTypes = {
-  canAutofill1010cgAddress: PropTypes.bool,
   formData: PropTypes.object,
   route: PropTypes.object,
   router: PropTypes.object,

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -113,14 +113,6 @@
       {
         "name": "gibctCh33BenefitRateUpdate",
         "value": true
-      },
-      {
-        "name": "canAutofill1010cgAddress",
-        "value": true
-      },
-      {
-        "name": "can_autofill_10_10cg_address",
-        "value": true
       }
     ]
   }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,7 +1,6 @@
 // prettier-ignore
 
 export default Object.freeze({
-  canAutofill1010cgAddress: 'can_autofill_10_10cg_address',
   cernerOverride463: 'cerner_override_463',
   cernerOverride531: 'cerner_override_531',
   cernerOverride648: 'cerner_override_648',


### PR DESCRIPTION
## Description
The caregivers application was utilizing a feature flag for a controlled rollout of an address autofill feature in the form. Now that we have had released this feature to 100% of users and verified we have zero issues with this feature, we no longer need this feature flag. This PR removes all the conditional logic associated with the feature flag.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44954

## Testing done
- [x] e2e testing

## Acceptance criteria
- [ ] Address autofill content and form fields render as expected without use of flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
