### PR TITLE
Upgrade component-library to 11.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.17.7",
-    "@department-of-veterans-affairs/component-library": "^11.0.0",
+    "@department-of-veterans-affairs/component-library": "^11.2.1",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "0.0.2",

--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -193,7 +193,7 @@ class ValidateVeteran {
   getDobError = () => {
     cy.get('[label="Date of birth"]')
       .shadow()
-      .find('.error-message')
+      .find('#error-message')
       .contains('Your date of birth can not be in the future');
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,13 +2512,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.0.0.tgz#c9364124d06dd02db036c4e22fed93a6ffd1e09e"
-  integrity sha512-RQg3BG4Qnaj3QBuUSNQalGBTtNx8DrGV0ktF4xRdqsVFCBjmpvhWL0mOlanNXD0075ETWSlIKQXnlt4heV9RWQ==
+"@department-of-veterans-affairs/component-library@^11.2.1":
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.2.1.tgz#a38b66fef717cc3b94f4a3149d3d3359fdc950de"
+  integrity sha512-3QzZuDursC7dy+vT8t8LNoGnVVj3YzCB4Up/SmZ8WLZXcfnI43Vt6SUC0gYdW+Qdz61zeBIRaJyC0wJNyOGDhw==
   dependencies:
     "@department-of-veterans-affairs/react-components" "7.0.0"
-    "@department-of-veterans-affairs/web-components" "4.7.0"
+    "@department-of-veterans-affairs/web-components" "4.9.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2625,10 +2625,10 @@
     intersection-observer "^0.12.0"
     postcss-url "^10.1.1"
 
-"@department-of-veterans-affairs/web-components@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.7.0.tgz#02cc91e2eb012dfdd0c069ac26a066c195a158d7"
-  integrity sha512-ef3bbOqctcfBXiATvvXPAOsZR7G7sazvARGFH4z1dHUzOEtoOB0KxwfmYZcYTmhGTg3twAOfEdGsjTmON0kNDQ==
+"@department-of-veterans-affairs/web-components@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.9.1.tgz#f7e8135a0123d21eea190410e36e21caf051b404"
+  integrity sha512-G5l4HXX4s/pK0W4kSrB9sEGEbbUw+0MN7lnDe8HxM9djPYU4BLpM3RkiZhwviaCPdG2Ep+LvUu7BdFQEpxL68Q==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description

This bumps the `component-library` version. The main reason for doing this now is so that teams can use the new `tty` prop on `<va-telephone>`. This should close https://github.com/department-of-veterans-affairs/va.gov-team/issues/43969

### Release notes

#### [v11.1.0](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.1.0)

##### New Features & Components :tada: 

- Add va-link component by @andresriveratoro in https://github.com/department-of-veterans-affairs/component-library/pull/481
- Add aria-invalid to most form components by @bkjohnson in https://github.com/department-of-veterans-affairs/component-library/pull/489

##### Fixes

- va-button uses aria-label only when a value is given by @andresriveratoro in https://github.com/department-of-veterans-affairs/component-library/pull/483
- Remove unneeded aria-live when errors occur by @bkjohnson in https://github.com/department-of-veterans-affairs/component-library/pull/485
- Remove aria-labelledby in form controls by @bkjohnson in https://github.com/department-of-veterans-affairs/component-library/pull/484
- Associate date errors with sub components by @bkjohnson in https://github.com/department-of-veterans-affairs/component-library/pull/486

#### [v11.2.0](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.2.0)

##### New Features & Components :tada: 

- Add tty prop to telephone component by @bkjohnson in https://github.com/department-of-veterans-affairs/component-library/pull/492

#### [v11.2.1](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.2.1)

##### Fixes

- style: update va-breadcrumbs padding by @andresriveratoro in https://github.com/department-of-veterans-affairs/component-library/pull/496

## Original issue(s)
N/A

## Testing done

None

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
