### PR TITLE
Supplemental Claims | Add supporting evidence upload & summary pages

### DIFF
--- a/src/applications/appeals/995/components/LocationField.jsx
+++ b/src/applications/appeals/995/components/LocationField.jsx
@@ -212,7 +212,6 @@ const LocationField = ({
             itemIdPrefix,
             definitions,
           );
-          const updateText = index === 0 ? 'Save' : 'Update';
           const isLast = itemsLength === index + 1;
           const isEditing = editing[index];
           const ariaLabel = uiOptions.itemAriaLabel;
@@ -262,10 +261,10 @@ const LocationField = ({
                           <button
                             type="button"
                             className="float-right"
-                            aria-label={`${updateText} ${itemName}`}
+                            aria-label={`Save ${itemName}`}
                             onClick={() => handleUpdate(index)}
                           >
-                            {updateText}
+                            Save
                           </button>
                           {itemsLength > 1 ? (
                             <button

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -16,8 +16,8 @@ import {
 import AddIssue from '../components/AddIssue';
 
 import addIssue from '../pages/addIssue';
-import benefitType from '../pages/benefitType';
-import certifcationAndSignature from '../pages/certifcationAndSignature';
+// import benefitType from '../pages/benefitType';
+// import certifcationAndSignature from '../pages/certifcationAndSignature';
 // import claimantName from '../pages/claimantName';
 // import claimantType from '../pages/claimantType';
 import contactInfo from '../pages/contactInformation';
@@ -87,12 +87,12 @@ const formConfig = {
     infoPages: {
       title: 'Veteran Details',
       pages: {
-        benefitType: {
-          title: 'Benefit Type',
-          path: 'benefit-type',
-          uiSchema: benefitType.uiSchema,
-          schema: benefitType.schema,
-        },
+        // benefitType: {
+        //   title: 'Benefit Type',
+        //   path: 'benefit-type',
+        //   uiSchema: benefitType.uiSchema,
+        //   schema: benefitType.schema,
+        // },
         veteranInfo: {
           title: 'Veteran Information',
           path: 'veteran-information',
@@ -258,17 +258,17 @@ const formConfig = {
       },
     },
 
-    signature: {
-      title: 'Certification & Signature',
-      pages: {
-        sign: {
-          title: 'Certification & Signature',
-          path: 'certification-and-signature',
-          uiSchema: certifcationAndSignature.uiSchema,
-          schema: certifcationAndSignature.schema,
-        },
-      },
-    },
+    // signature: {
+    //   title: 'Certification & Signature',
+    //   pages: {
+    //     sign: {
+    //       title: 'Certification & Signature',
+    //       path: 'certification-and-signature',
+    //       uiSchema: certifcationAndSignature.uiSchema,
+    //       schema: certifcationAndSignature.schema,
+    //     },
+    //   },
+    // },
   },
   footerContent: FormFooter,
   getHelp: GetFormHelp,

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -93,6 +93,45 @@ export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 export const MAX_FILE_SIZE_MB = 100;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
+export const ATTACHMENTS_PRIVATE = {
+  L049: 'Medical Treatment Record - Non-Government Facility',
+  L107: 'VA 21-4142 Authorization for Release of Information',
+  L023: 'Other',
+};
+
+export const ATTACHMENTS_OTHER = {
+  L015: 'Buddy/Lay Statement',
+  L018: 'Civilian Police Reports',
+  L029: 'Copy of a DD214',
+  L702: 'Disability Benefits Questionnaire (DBQ)',
+  L703: 'Goldmann Perimetry Chart/Field Of Vision Chart',
+  L034: 'Military Personnel Record',
+  L478: 'Medical Treatment Records - Furnished by SSA',
+  L048: 'Medical Treatment Record - Government Facility',
+  L049: 'Medical Treatment Record - Non-Government Facility',
+  L023: 'Other Correspondence',
+  L070: 'Photographs',
+  L222:
+    'VA Form 21-0779 - Request for Nursing Home Information in Connection with Claim for Aid & Attendance',
+  L228: 'VA Form 21-0781 - Statement in Support of Claim for PTSD',
+  L229:
+    'VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault',
+  L102:
+    'VA Form 21-2680 - Examination for Housebound Status or Permanent Need for Regular Aid & Attendance',
+  L107: 'VA Form 21-4142 - Authorization To Disclose Information',
+  L827: 'VA Form 21-4142a - General Release for Medical Provider Information',
+  L115:
+    'VA Form 21-4192 - Request for Employment Information in Connection with Claim for Disability',
+  L117:
+    'VA Form 21-4502 - Application for Automobile or Other Conveyance and Adaptive Equipment Under 38 U.S.C. 3901-3904',
+  L159:
+    'VA Form 26-4555 - Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant',
+  L133: 'VA Form 21-674 - Request for Approval of School Attendance',
+  L139: 'VA Form 21-686c - Declaration of Status of Dependents',
+  L149:
+    'VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability',
+};
+
 // Values from Lighthouse maintained schema
 // see ./config/form-0995-schema.json
 export const MAX_LENGTH = {

--- a/src/applications/appeals/995/content/evidenceSummary.jsx
+++ b/src/applications/appeals/995/content/evidenceSummary.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  hasVAEvidence,
+  hasPrivateEvidence,
+  hasOtherEvidence,
+  hasPrivateEvidenceToUpload,
+} from '../utils/helpers';
+
+export const evidenceSummaryDescription = ({ formData }) => {
+  const vaEvidence = hasVAEvidence(formData) ? formData.locations : [];
+  const privateEvidence = hasPrivateEvidence(formData)
+    ? formData.providerFacility
+    : [];
+  const privateEvidenceUploads = hasPrivateEvidenceToUpload(formData)
+    ? formData.privateMedicalRecordAttachments
+    : [];
+  const layEvidenceUploads = hasOtherEvidence(formData)
+    ? formData.additionalDocuments
+    : [];
+
+  const evidenceLength = !!vaEvidence.concat(
+    privateEvidence,
+    privateEvidenceUploads,
+    layEvidenceUploads,
+  ).length;
+
+  // Evidence isn't always properly cleared out from form data if removed
+  if (!evidenceLength) {
+    return (
+      <va-alert status="error">
+        <h2 slot="headline">You haven’t uploaded any evidence</h2>
+        Providing evidence is a requirement for filing a Supplemental Claim
+      </va-alert>
+    );
+  }
+
+  let vaContent = null;
+  let privateContent = null;
+  let layContent = null;
+  let privateEvidenceContent = null;
+
+  if (vaEvidence.length) {
+    const facilitiesList = vaEvidence.map(({ locationAndName }) => (
+      <li key={locationAndName}>{locationAndName}</li>
+    ));
+    vaContent = (
+      <div>
+        <p>We’ll get your VA medical records from:</p>
+        <ul>{facilitiesList}</ul>
+      </div>
+    );
+  }
+
+  if (privateEvidenceUploads.length) {
+    const privateEvidenceUploadsList = privateEvidenceUploads.map(upload => (
+      <li key={upload.name}>{upload.name}</li>
+    ));
+    privateContent = (
+      <div>
+        <p>We’ll submit the below private medical records you uploaded:</p>
+        <ul>{privateEvidenceUploadsList}</ul>
+      </div>
+    );
+  }
+
+  if (privateEvidence.length) {
+    const privateEvidenceList = privateEvidence.map(facility => (
+      <li key={facility.providerFacilityName}>
+        {facility.providerFacilityName}
+      </li>
+    ));
+    privateEvidenceContent = (
+      <div>
+        <p>We’ll get your private medical records from:</p>
+        <ul>{privateEvidenceList}</ul>
+      </div>
+    );
+  }
+
+  if (layEvidenceUploads.length) {
+    const layEvidenceUploadsList = layEvidenceUploads.map(upload => (
+      <li key={upload.name}>{upload.name}</li>
+    ));
+    layContent = (
+      <div>
+        <p>We’ll submit the below supporting evidence you uploaded:</p>
+        <ul>{layEvidenceUploadsList}</ul>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {vaContent}
+      {privateContent}
+      {privateEvidenceContent}
+      {layContent}
+    </div>
+  );
+};

--- a/src/applications/appeals/995/content/evidenceSummary.jsx
+++ b/src/applications/appeals/995/content/evidenceSummary.jsx
@@ -7,13 +7,16 @@ import {
 } from '../utils/helpers';
 
 export const evidenceSummaryDescription = ({ formData }) => {
+  const hasPrivateUpload = hasPrivateEvidenceToUpload(formData);
   const vaEvidence = hasVAEvidence(formData) ? formData.locations : [];
-  const privateEvidence = hasPrivateEvidence(formData)
-    ? formData.providerFacility
-    : [];
-  const privateEvidenceUploads = hasPrivateEvidenceToUpload(formData)
-    ? formData.privateMedicalRecordAttachments
-    : [];
+  const privateEvidence =
+    hasPrivateEvidence(formData) && !hasPrivateUpload
+      ? formData.providerFacility
+      : [];
+  const privateEvidenceUploads =
+    hasPrivateEvidence(formData) && hasPrivateUpload
+      ? formData.privateMedicalRecordAttachments
+      : [];
   const layEvidenceUploads = hasOtherEvidence(formData)
     ? formData.additionalDocuments
     : [];

--- a/src/applications/appeals/995/content/evidenceUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceUpload.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { MAX_FILE_SIZE_MB, SUPPORTED_UPLOAD_TYPES } from '../constants';
+import { readableList } from '../utils/helpers';
+/**
+ * Generic description added to file upload pages
+ * @param {String|ReactComponent} uploadTitle - page title
+ */
+export const UploadDescription = ({ uploadTitle }) => {
+  const types = readableList(SUPPORTED_UPLOAD_TYPES, 'or');
+  return (
+    <div>
+      {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
+      <p>
+        {`You can upload your document in a ${types} file format.`} You’ll first
+        need to scan a copy of your document onto your computer or mobile phone.
+        You can then upload the document from there.
+      </p>
+      <p>Guidelines for uploading a file:</p>
+      <ul>
+        <li>{`File types you can upload: ${types}`}</li>
+        <li>{`Maximum file size: ${MAX_FILE_SIZE_MB}MB`}</li>
+      </ul>
+      <p>
+        <em>
+          A 1MB file equals about 500 pages of text. A photo is usually about
+          6MB. Large files can take longer to upload with a slow Internet
+          connection.
+        </em>
+      </p>
+    </div>
+  );
+};
+
+UploadDescription.propTypes = {
+  uploadTitle: PropTypes.string,
+};
+
+export const evidencePrivateText = {
+  label: 'Upload your private medical records',
+  description: ' ',
+};
+
+export const evidenceOtherText = {
+  label: 'Supporting (lay) statements or other evidence',
+  description: 'Adding additional evidence:',
+};

--- a/src/applications/appeals/995/pages/evidencePrivateUpload.js
+++ b/src/applications/appeals/995/pages/evidencePrivateUpload.js
@@ -1,27 +1,17 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-
-import { UploadDescription } from '../content/evidencePrivateUpload';
+import {
+  UploadDescription,
+  evidencePrivateText,
+} from '../content/evidenceUpload';
 import { ancillaryFormUploadUi } from '../utils/upload';
 import { hasPrivateEvidenceToUpload } from '../utils/helpers';
+import { ATTACHMENTS_PRIVATE } from '../constants';
 
-const { privateMedicalRecordAttachments } = fullSchema.properties;
-
-const fileUploadUi = ancillaryFormUploadUi(
-  'Upload your private medical records',
-  ' ',
-  {
-    attachmentId: '',
-    addAnotherLabel: 'Add another document',
-  },
-);
+const fileUploadUi = ancillaryFormUploadUi(evidencePrivateText);
 
 export default {
   uiSchema: {
     privateMedicalRecordAttachments: {
       ...fileUploadUi,
-      'ui:options': {
-        ...fileUploadUi['ui:options'],
-      },
       'ui:description': UploadDescription,
       'ui:required': hasPrivateEvidenceToUpload,
     },
@@ -30,7 +20,26 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      privateMedicalRecordAttachments,
+      privateMedicalRecordAttachments: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['name', 'attachmentId'],
+          properties: {
+            name: {
+              type: 'string',
+            },
+            confirmationCode: {
+              type: 'string',
+            },
+            attachmentId: {
+              type: 'string',
+              enum: Object.keys(ATTACHMENTS_PRIVATE),
+              enumNames: Object.values(ATTACHMENTS_PRIVATE),
+            },
+          },
+        },
+      },
     },
   },
 };

--- a/src/applications/appeals/995/pages/evidenceSummary.js
+++ b/src/applications/appeals/995/pages/evidenceSummary.js
@@ -1,5 +1,10 @@
+import { evidenceSummaryDescription } from '../content/evidenceSummary';
+
 export default {
-  uiSchema: {},
+  uiSchema: {
+    'ui:title': 'Summary of evidence',
+    'ui:description': evidenceSummaryDescription,
+  },
 
   schema: {
     type: 'object',

--- a/src/applications/appeals/995/pages/evidenceUpload.js
+++ b/src/applications/appeals/995/pages/evidenceUpload.js
@@ -1,8 +1,39 @@
+import {
+  UploadDescription,
+  evidenceOtherText,
+} from '../content/evidenceUpload';
+import { ancillaryFormUploadUi } from '../utils/upload';
+import { ATTACHMENTS_OTHER } from '../constants';
+
 export default {
-  uiSchema: {},
+  uiSchema: {
+    additionalDocuments: {
+      ...ancillaryFormUploadUi(evidenceOtherText),
+      'ui:description': UploadDescription,
+    },
+  },
 
   schema: {
     type: 'object',
-    properties: {},
+    required: ['additionalDocuments'],
+    properties: {
+      additionalDocuments: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['name', 'attachmentId'],
+          properties: {
+            name: {
+              type: 'string',
+            },
+            attachmentId: {
+              type: 'string',
+              enum: Object.keys(ATTACHMENTS_OTHER),
+              enumNames: Object.values(ATTACHMENTS_OTHER),
+            },
+          },
+        },
+      },
+    },
   },
 };

--- a/src/applications/appeals/995/tests/fixtures/data/test-data.json
+++ b/src/applications/appeals/995/tests/fixtures/data/test-data.json
@@ -1,4 +1,169 @@
 {
   "data": {
+    "veteran": {
+      "ssnLastFour": "7821",
+      "vaFileLastFour": "8765",
+      "address": {
+        "addressLine1": "123 Main St",
+        "addressLine2": "Suite #1200",
+        "addressLine3": "Box 45678901234",
+        "city": "New York",
+        "countryName": "United States",
+        "countryCodeIso2": "US",
+        "stateCode": "NY",
+        "zipCode": "30012"
+      },
+      "phone": {
+        "countryCode": "6",
+        "areaCode": "555",
+        "phoneNumber": "8001111",
+        "phoneNumberExt": "2"
+      },
+      "email": "user@example.com"
+    },
+    "benefitType": "compensation",
+    "contestedIssues": [
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Headaches",
+          "description": "Acute chronic head pain",
+          "ratingIssuePercentNumber": "20",
+          "approxDecisionDate": "2021-06-10",
+          "decisionIssueId": 44,
+          "ratingIssueReferenceId": "66",
+          "ratingDecisionReferenceId": null
+        },
+        "view:selected": true
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Being green",
+          "description": "Chronic greenness",
+          "ratingIssuePercentNumber": "50",
+          "approxDecisionDate": "2021-06-01",
+          "decisionIssueId": 42,
+          "ratingIssueReferenceId": "52",
+          "ratingDecisionReferenceId": "999"
+        },
+        "view:selected": true
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Monocular vision",
+          "ratingIssuePercentNumber": "5",
+          "approxDecisionDate": "2021-06-04",
+          "decisionIssueId": 1,
+          "ratingIssueReferenceId": "2",
+          "ratingDecisionReferenceId": ""
+        }
+      }
+    ],
+    "legacyCount": 0,
+    "additionalIssues": [
+      {
+        "issue": "Test",
+        "decisionDate": "2022-01-01",
+        "view:selected": true
+      }
+    ],
+    "locations": [
+      {
+        "locationAndName": "VAMC Location 1",
+        "evidenceDates": [
+          {
+            "from": "2022-01-01",
+            "to": "2022-01-02"
+          },
+          {
+            "from": "2022-02-01",
+            "to": "2022-02-02"
+          },
+          {
+            "from": "2022-03-01",
+            "to": "2022-03-02"
+          },
+          {
+            "from": "2022-04-01",
+            "to": "2022-04-02"
+          }
+        ]
+      },
+      {
+        "locationAndName": "VA facility",
+        "evidenceDates": [
+          {
+            "from": "2022-02-03",
+            "to": "2022-02-08"
+          }
+        ]
+      }
+    ],
+    "providerFacility": [
+      {
+        "treatmentDateRange": {
+          "from": "2022-01-01",
+          "to": "2022-02-01"
+        },
+        "providerFacilityAddress": {
+          "country": "USA",
+          "street": "123 main",
+          "city": "city",
+          "state": "AK",
+          "postalCode": "90210"
+        },
+        "providerFacilityName": "Private Hospital"
+      }
+    ],
+    "view:limitedConsent": true,
+    "limitedConsent": "Pizza addiction",
+    "view:uploadPrivateRecordsChoice": {
+      "view:hasPrivateRecordsToUpload": false
+    },
+    "view:patientAcknowledgement": {
+      "view:acknowledgement": true
+    },
+    "view:selectableEvidenceTypes": {
+      "view:hasVaEvidence": true,
+      "view:hasPrivateEvidence": true,
+      "view:hasOtherEvidence": true
+    },
+    "privateMedicalRecordAttachments": [
+      {
+        "name": "private-medical-records.pdf",
+        "confirmationCode": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "attachmentId": "L049",
+        "size": 20000,
+        "isEncrypted": false
+      },
+      {
+        "name": "x-rays.pdf",
+        "confirmationCode": "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj",
+        "attachmentId": "L023",
+        "size": 30000,
+        "isEncrypted": false
+      }
+    ],
+    "additionalDocuments": [
+      {
+        "name": "buddy-statement.pdf",
+        "confirmationCode": "kkkkkkkk-llll-mmmm-nnnn-oooooooooooo",
+        "attachmentId": "L015",
+        "size": 40000,
+        "isEncrypted": false
+      },
+      {
+        "name": "photos.pdf",
+        "confirmationCode": "pppppppp-qqqql-rrrr-ssss-ttttttttttt",
+        "attachmentId": "L070",
+        "size": 40000,
+        "isEncrypted": false
+      }
+    ],
+    "socOptIn": true,
+    "form5103Acknowledged": true,
+    "privacyAgreementAccepted": true
   }
 }

--- a/src/applications/appeals/995/utils/helpers.js
+++ b/src/applications/appeals/995/utils/helpers.js
@@ -306,3 +306,4 @@ export const hasPrivateEvidenceToUpload = formData =>
   formData?.['view:uploadPrivateRecordsChoice']?.[
     'view:hasPrivateRecordsToUpload'
   ];
+// export const hasPrivateEvidenceUploads = formData =>

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -7,17 +7,7 @@ import fullSchema from '../config/form-0995-schema.json';
 
 import { MAX_FILE_SIZE_BYTES, SUPPORTED_UPLOAD_TYPES } from '../constants';
 
-export const ancillaryFormUploadUi = (
-  label,
-  itemDescription,
-  {
-    attachmentId = '',
-    widgetType = 'select',
-    customClasses = '',
-    isDisabled = false,
-    addAnotherLabel = 'Add Another',
-  } = {},
-) => {
+export const ancillaryFormUploadUi = content => {
   // a11y focus management. Move focus to select after upload
   // see va.gov-team/issues/19688
   const findAndFocusLastSelect = () => {
@@ -27,9 +17,11 @@ export const ancillaryFormUploadUi = (
       focusElement(lastSelect[0]);
     }
   };
-  return fileUploadUI(label, {
-    itemDescription,
-    hideLabelText: !label,
+  const addAnotherLabel = 'Add another document';
+
+  return fileUploadUI(content.label, {
+    itemDescription: content.description,
+    hideLabelText: !content.label,
     fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
     addAnotherLabel,
     fileTypes: SUPPORTED_UPLOAD_TYPES,
@@ -52,20 +44,19 @@ export const ancillaryFormUploadUi = (
       return {
         name: file.name,
         confirmationCode: response.data.attributes.guid,
-        attachmentId,
+        attachmentId: '',
       };
     },
     attachmentSchema: ({ fileId }) => ({
       'ui:title': 'Document type',
-      'ui:disabled': isDisabled,
-      'ui:widget': widgetType,
+      'ui:disabled': false,
+      'ui:widget': 'select',
       'ui:options': {
         widgetProps: {
           'aria-describedby': fileId,
         },
       },
     }),
-    classNames: customClasses,
     attachmentName: false,
   });
 };


### PR DESCRIPTION
## Original Ticket

https://github.com/department-of-veterans-affairs/va.gov-team/issues/43628

## URL of change

- `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995//supporting-evidence/additional-evidence`
    <details><summary>Supporting statements or other evidence page</summary>

    <!-- leave a blank line above -->
    <img width="708" alt="evidence upload page showing a buddy statement upload and a photos PDF file - note only PDFs are accepted" src="https://user-images.githubusercontent.com/136959/181373851-0ffb9296-8954-4b95-a738-65b1fbee9970.png"></details>

- `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/supporting-evidence/summary`
    <details><summary>Evidence summary page</summary>
    
    <!-- leave a blank line above -->
    <img width="739" alt="Summary of evidence page showing all possibilities - VA medical record locations, private medical record uploads, private medical record locations to obtain records and additional supporting evidence uploads" src="https://user-images.githubusercontent.com/136959/181373825-206d78c5-9ca5-4bec-a20a-4bb6461531cf.png"></details>

## Background

These supplemental claims pages were copied from Form 526

```mermaid
flowchart TB
    EvidenceTypes -. VA .-> VAMR[VA medical records]
    EvidenceTypes -. Private<br>only .-> PrivateMrUploadQuestion{Private medical<br>records upload}
    EvidenceTypes -. Supporting<br>only .-> StatementsUploadQuestion{Supporting statements<br>and evidence upload}

    EvidenceSummary[Summary of evidence]
    VAMR -. done .-> EvidenceSummary
    PrivateMrUpload -. done .-> EvidenceSummary
    PrivateProvider -. done - this files<br>form 4142 .-> EvidenceSummary
    StatementsUpload -. done .-> EvidenceSummary

    VAMR -. Supporting<br>selected .-> StatementsUploadQuestion
    VAMR -. Private<br>selected .-> PrivateMrUploadQuestion
    VAMR -. Add facility .-> VAMR

    PrivateMrUploadQuestion -. yes .-> PrivateMrUpload[Upload]
    PrivateMrUpload -. upload another .-> PrivateMrUpload
    PrivateMrUploadQuestion -. no .-> PrivateProvider[Add provider]
    PrivateProvider -. add another .-> PrivateProvider

    StatementsUploadQuestion -. yes .-> StatementsUpload[Upload]
    StatementsUpload -. upload another .-> StatementsUpload

    PrivateMrUpload -. Supporting<br>selected .-> StatementsUploadQuestion
    PrivateProvider -. Supporting<br>selected .-> StatementsUploadQuestion
```

This PR adds the additional evidence upload page and evidence summary pages

## Steps to test

1. Pull in this branch locally or use the review instance
2. Go to `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/` to start the form
3. Step through the form

## Code changes

- Added supporting statements & other evidence upload page
- Added evidence summary page
- VA records page will only show the "save" button text ("update" is no longer conditionally shown)
- Removed pages that will not (yet) be implemented
- Code cleanup

## How was your code tested

No unit tests added - awaiting final design and results of the design intent

## Acceptance criteria
- [x] Add supporting statements & other evidence upload page
- [x] Added evidence summary page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs