### PR TITLE
Remove the "Update browserslist" build step (flaky, not needed)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,9 +121,6 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Update browserslist
-        run: npx browserslist@latest --update-db
-
       - name: Create test results folder
         run: mkdir -p test-results
 
@@ -351,9 +348,6 @@ jobs:
           path: |
             .cache/yarn
             node_modules
-
-      - name: Update browserslist
-        run: npx browserslist@latest --update-db
 
       - name: Get changed applications
         id: get-changed-apps


### PR DESCRIPTION
## Description
Remove the "Update browserslist" build step. It sometimes caused builds to fail, and it was not needed.

## Original issue(s)
None

## Testing done
Successful CI run

## Screenshots


## Acceptance criteria
- [ ] "Update browserlist" step is removed from the build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
