### PR TITLE
VACMS-9477: updated copy if there are no results for a custom date range

### DIFF
--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -25,10 +25,7 @@ export const Results = ({
     return (
       <p className="vads-u-margin--0 vads-u-margin-top--2 vads-u-margin-bottom--1">
         {queryId === 'custom-date-range' ? (
-          <span>
-            No events listed because filters are applied that exclude events
-            from view
-          </span>
+          <span>No results found for Custom date range</span>
         ) : (
           <span>
             No results found for <strong>{query}</strong>


### PR DESCRIPTION
## Description
Currently `No Events listed because filters are applied that exclude events from view` appears when no events meet the Custom date range filter criteria. This PR updates the copy to `No results found for Custom date range` for better user experience.

## Original issue(s)
[department-of-veterans-affairs/va.gov-cms/issues/9477](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9477)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
