### PR TITLE
Detect encryption in a wider variety of PDFs

### DIFF
--- a/src/platform/forms-system/src/js/utilities/file/readAndCheckFile.js
+++ b/src/platform/forms-system/src/js/utilities/file/readAndCheckFile.js
@@ -29,8 +29,12 @@ export default function readAndCheckFile(file, checks) {
           reject(new Error('Unable to get file'));
         }
       };
-      // The content we need _should_ be within the first 256 bytes of the file
-      const blob = file.slice(0, 256);
+      // The PDF flags we care about should only show up at the beginning and
+      // end of the PDF. Using 512 for the end because one example we used had
+      // flags showing up more than 256 bytes before the end of the file
+      const fileStart = file.slice(0, 256);
+      const fileEnd = file.slice(-512);
+      const blob = new Blob([fileStart, fileEnd]);
       // TODO: once we stop supporting IE11, update this and replace the
       // readAsArrayBuffer and Int8Array conversion in the code with a string
       // compare using readAsBinaryString (which isn't supported by IE11)


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44849

## URL of fix
Since this is platform code, this PR applies to most form apps, but to test with CST:
[/track-claims/your-claims/{claimId}/files](http://localhost:3001/track-claims/your-claims/claim-received/files)

NOD: This URL will take you straight to the upload page, you don't have to be signed in either
[NOD Upload page](http://localhost:3001/decision-reviews/board-appeal/request-board-appeal-form-10182/evidence-submission/upload)

## Files
[TestPDF_AES256.pdf](https://github.com/department-of-veterans-affairs/vets-website/files/9213267/TestPDF_AES256.pdf)

## Expected behavior
The PDF file above is encrypted (password is password123). When attempting to upload this file via the 'Add files' button under 'Select files to upload', the UI should prompt the veteran to enter a password to decrypt the PDF

## Current behavior
When attempting to upload the encrypted PDF file above, users are not prompted to enter a password to decrypt the PDF. This PDF fails to be flagged by our encryption check.

## Your fix
### The issue
The issue with the current code is that it expects that the `Encrypt` flag will always be located at the beginning of the file. This is not always the case, as demonstrated by the PDF listed in the Files section.

### The fix
* Grab 512 bytes from the end of the file so that we can check for the `Encrypt` flag there as well

## How has this been tested?
I'm able to test this through manual interaction with the UI. This is not a bulletproof fix though

## Screenshots
<details><summary>Before</summary>

<img width="754" alt="Screen Shot 2022-07-28 at 1 40 13 PM" src="https://user-images.githubusercontent.com/13838621/181613661-fba61d6b-f812-45e4-9d78-9b72d2b3c4ce.png"></details>

<details><summary>After</summary>

<img width="699" alt="Screen Shot 2022-07-28 at 1 36 48 PM" src="https://user-images.githubusercontent.com/13838621/181613805-c8db8c5e-8e9d-4910-b261-4eb75ee6eb21.png">
</details>

## Acceptance criteria
- [x] PDFs like the example in the Files section are detected as encrypted