### PR TITLE
Add TTY attribute to va-telephone components in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -35,8 +35,8 @@ const NeedHelpFooter = () => {
         If this form isn’t working right for you, please call us at{' '}
         <va-telephone contact={CONTACTS.HELP_DESK} />.<br />
         <span>
-          If you have hearing loss, call TTY:{' '}
-          <va-telephone contact={CONTACTS['711']} />.
+          If you have hearing loss, call{' '}
+          <va-telephone contact={CONTACTS['711']} tty />.
         </span>
       </p>
     </>

--- a/src/applications/caregivers/components/SubmitError/index.jsx
+++ b/src/applications/caregivers/components/SubmitError/index.jsx
@@ -46,8 +46,9 @@ const SubmitError = ({ form }) => {
         <div>
           If you have trouble downloading your application, call our{' '}
           <a href="https://www.va.gov/">VA.gov</a> help desk at{' '}
-          <va-telephone contact={CONTACTS.HELP_DESK} /> (TTY: 711). We’re here
-          Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          <va-telephone contact={CONTACTS.HELP_DESK} /> (
+          <va-telephone contact={CONTACTS['711']} tty />
+          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </div>
 
         <DownLoadLink form={form} />


### PR DESCRIPTION
## Description
The design system team recently released an update to the va-telephone component to allow for support of TTY numbers. This PR updates any components that need the TTY support offered within the Caregivers application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45041

## Acceptance criteria
- [ ] All `va-telephone` component are utilized correctly for the phone type

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
