### PR TITLE
Update catalog-info.yaml to add Domo Links

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,5 +22,3 @@ metadata:
 spec:
   owner: platform-release-tools
   domain: vfs
-
-

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,18 @@ metadata:
   tags:
     - javascript
     - sass
+  links:
+    - url: https://va-gov.domo.com/page/426422632
+      title: Content KPIs (Domo)
+      icon: dashboard
+    - url: https://va-gov.domo.com/page/447193050
+      title: Forms KPIs (Domo)
+      icon: dashboard
+    - url: https://va-gov.domo.com/page/1964748112
+      title: Search KPIs (Domo)
+      icon: dashboard
 spec:
   owner: platform-release-tools
   domain: vfs
+
+


### PR DESCRIPTION
## Description

Adding Console UI links to dashboards maintained in Platform Analytics and Insights in Domo.

## Original issue(s)

N/A

## Testing done

Tested links go to valid dashboards within Domo.

## Screenshots

https://va-gov.domo.com/page/426422632

Goes to:

![Screen Shot 2022-07-28 at 3 44 21 PM](https://user-images.githubusercontent.com/116142/181624100-43c474d7-8813-45fb-945e-4698418ca1d4.png)

https://va-gov.domo.com/page/447193050 to:

![Screen Shot 2022-07-28 at 3 46 25 PM](https://user-images.githubusercontent.com/116142/181624426-6a6d227c-bd12-412c-bcd2-3a0b9566b774.png)

https://va-gov.domo.com/page/1964748112 to:

![Screen Shot 2022-07-28 at 3 47 04 PM](https://user-images.githubusercontent.com/116142/181624516-11859850-95a4-4f3c-b1cb-13462c0cbb5a.png)

