### PR TITLE
Don't allow already checked-in appointments to be checked in again

### DIFF
--- a/src/applications/check-in/components/BackToAppointments.jsx
+++ b/src/applications/check-in/components/BackToAppointments.jsx
@@ -44,7 +44,6 @@ const BackToAppointments = ({ router }) => {
 
 BackToAppointments.propTypes = {
   router: PropTypes.object,
-  triggerRefresh: PropTypes.func,
 };
 
 export default withRouter(BackToAppointments);

--- a/src/applications/check-in/components/BackToAppointments.jsx
+++ b/src/applications/check-in/components/BackToAppointments.jsx
@@ -11,7 +11,7 @@ import { useFormRouting } from '../hooks/useFormRouting';
 
 import { URLS } from '../utils/navigation';
 
-const BackToAppointments = ({ router, triggerRefresh }) => {
+const BackToAppointments = ({ router }) => {
   const { jumpToPage } = useFormRouting(router);
   const { t } = useTranslation();
   const handleClick = useCallback(
@@ -20,10 +20,9 @@ const BackToAppointments = ({ router, triggerRefresh }) => {
       recordEvent({
         event: createAnalyticsSlug('back-button-clicked'),
       });
-      triggerRefresh();
       jumpToPage(URLS.DETAILS);
     },
-    [jumpToPage, triggerRefresh],
+    [jumpToPage],
   );
   return (
     <>

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -18,9 +18,13 @@ const CheckInConfirmation = props => {
   const appointment = selectedAppointment;
   const appointmentDateTime = new Date(appointment.startTime);
 
-  useEffect(() => {
-    scrollToTop('topScrollElement');
-  }, []);
+  useEffect(
+    () => {
+      scrollToTop('topScrollElement');
+      triggerRefresh();
+    },
+    [triggerRefresh],
+  );
 
   const pageTitle = t('youre-checked-in', {
     date: appointmentDateTime,
@@ -44,10 +48,7 @@ const CheckInConfirmation = props => {
         </div>
       </va-alert>
       <TravelPayReimbursementLink />
-      <BackToAppointments
-        appointments={appointments}
-        triggerRefresh={triggerRefresh}
-      />
+      <BackToAppointments appointments={appointments} />
       <Footer />
       <BackToHome />
     </Wrapper>

--- a/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
@@ -52,5 +52,16 @@ describe('Check In Experience -- ', () => {
       Confirmation.validateBackButton();
       cy.injectAxeThenAxeCheck();
     });
+    it('refreshes appointment data when pressing the browser back button', () => {
+      cy.intercept(
+        '/check_in/v2/patient_check_ins/*',
+        cy.spy().as('apptRefresh'),
+      );
+      cy.go('back');
+      cy.get('@apptRefresh')
+        .its('callCount')
+        .should('equal', 1);
+      cy.injectAxeThenAxeCheck();
+    });
   });
 });

--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector, batch } from 'react-redux';
 import { api } from '../api';
 import { makeSelectCurrentContext } from '../selectors';
@@ -47,7 +47,7 @@ const useGetCheckInData = (refreshNeeded, appointmentsOnly = false) => {
     [appointmentsOnly, dispatch, token],
   );
 
-  useEffect(
+  useLayoutEffect(
     () => {
       if (isStale) {
         setIsLoading(true);


### PR DESCRIPTION
## Description
This PR forces an appointment refresh upon making it to the confirmation page. Previously, an appointment refresh was only triggered if the "Go to another appointment" button was clicked. This did not cover the case of a user clicking their browser back button. Now, an appointment refresh should be triggered through all ways of navigating back to the appointment list, which should update the checked-in appointment and disallow a duplicate checkin.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#38166


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
