### PR TITLE
Update JSON Schema for ToE (1990EMEB) Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c1bfa4b045d3801808b435db56f204dba48018da",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#9e40f2e7eb92b5fddb0ce3b2fb809305abbadf3c",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19615,9 +19615,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#c1bfa4b045d3801808b435db56f204dba48018da":
-  version "20.20.9"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c1bfa4b045d3801808b435db56f204dba48018da"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#9e40f2e7eb92b5fddb0ce3b2fb809305abbadf3c":
+  version "20.20.10"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#9e40f2e7eb92b5fddb0ce3b2fb809305abbadf3c"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
This is a follow-up to #21803 to correctly add the ToE (1990EMEB form ID). Update the JSON schema for the latest vets-json-schema update.

vets-json-schema PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/710