### PR TITLE
10-10EZ HCA application - added feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -148,6 +148,7 @@ export default Object.freeze({
   caregiverSIGIEnabled: 'caregiver_sigi_enabled',
   hcaAmericanIndianEnabled: 'hca_american_indian_enabled',
   hcaShortFormEnabled: 'hca_short_form_enabled',
+  hcaEnrollmentStatusOverrideEnabled: 'hca_enrollment_status_override_enabled',
   checkVAInboxEnabled: 'check_va_inbox_enabled',
   ratedDisabilitiesSortAbTest: 'rated_disabilities_sort_ab_test',
   showExpandableVamcAlert: 'show_expandable_vamc_alert'


### PR DESCRIPTION
## Description of change
Added feature flag to override hca enrollment status, so users can have multiple submissions; will be used in staging.
https://github.com/department-of-veterans-affairs/vets-api/pull/10370

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44665
