### PR TITLE
Update HCA state of birth options to be 50 states + DC + Other

### DIFF
--- a/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
@@ -6,13 +6,7 @@ import { BirthInfoDescription } from '../../../components/FormDescriptions';
 import { HIGH_DISABILITY, emptyObjectSchema } from '../../../helpers';
 
 const { cityOfBirth } = fullSchemaHca.properties;
-const states = [
-  ...new Set(
-    Object.values(constants.states)
-      .reverse()
-      .flat(),
-  ),
-];
+const { states50AndDC } = constants;
 
 export default {
   uiSchema: {
@@ -48,8 +42,8 @@ export default {
           cityOfBirth,
           stateOfBirth: {
             type: 'string',
-            enum: [...states.map(object => object.value), 'Other'],
-            enumNames: [...states.map(object => object.label), 'Other'],
+            enum: [...states50AndDC.map(object => object.value), 'Other'],
+            enumNames: [...states50AndDC.map(object => object.label), 'Other'],
           },
         },
       },


### PR DESCRIPTION
## Description
For the Place of Birth question on the Health Care application, the HCA enrollment system cannot accept a state value that is not within the US 50 states + DC. They can accept an "Other" value but not state/province values from Mexico or Canada. This PR adjusts the state of birth dropdown to limit to only the accepted values.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45076

## Acceptance criteria
- [ ] Dropdown displays only US 50 States + DC + Other

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
