### PR TITLE
Update proxy rewrite e2e testing for stability

### DIFF
--- a/src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js
+++ b/src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js
@@ -6,7 +6,7 @@ describe(manifest.appName, () => {
   // Skip tests unless we are running the daily workflow job
   // eslint-disable-next-line func-names
   before(function() {
-    // if (Cypress.env('RUN_INJECTION') !== true) this.skip();
+    if (Cypress.env('RUN_INJECTION') !== true) this.skip();
   });
 
   it('Should not inject header & footer on non-allowed host', () => {

--- a/src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js
+++ b/src/applications/proxy-rewrite/tests/e2e/proxy-rewrite-entry.cypress.spec.js
@@ -6,7 +6,7 @@ describe(manifest.appName, () => {
   // Skip tests unless we are running the daily workflow job
   // eslint-disable-next-line func-names
   before(function() {
-    if (Cypress.env('RUN_INJECTION') !== true) this.skip();
+    // if (Cypress.env('RUN_INJECTION') !== true) this.skip();
   });
 
   it('Should not inject header & footer on non-allowed host', () => {
@@ -39,7 +39,7 @@ describe(manifest.appName, () => {
   });
 
   it('Should inject header & footer on allowed hosts that are not cookie-only', () => {
-    const hostToEval = 'www.benefits.va.gov';
+    const hostToEval = 'www.ea.oit.va.gov';
     const listItem = allowList.find(item => item.hostname === hostToEval);
     const { cookieOnly } = listItem;
 


### PR DESCRIPTION
## Description
We have a ton of flakiness when it comes to evaluating the current hosted site for proxy injection. This PR updates the host to evaluate to hopefully find a more stable site that we can connect to for this test.

## Testing done
- [x] Cypress testing

## Acceptance criteria
- [ ] Host provides for successful pass of test

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
