### PR TITLE
Update HCA OMB Privacy Act Statement modal close events

### DIFF
--- a/src/applications/hca/components/HcaOMBInfo.jsx
+++ b/src/applications/hca/components/HcaOMBInfo.jsx
@@ -31,7 +31,12 @@ const HcaOMBInfo = () => {
           Privacy Act Statement
         </button>
       </div>
-      <VaModal id="omb-modal" visible={modalOpen} closeEvent={closeModal}>
+      <VaModal
+        id="omb-modal"
+        visible={modalOpen}
+        onCloseEvent={closeModal}
+        clickToClose
+      >
         <HCAPrivacyActStatement />
       </VaModal>
     </div>


### PR DESCRIPTION
## Description
During a recent update, a typo was introduced to the `VaModal` close event inside the OMB info at the start of the Health care application. The typo doesn't allow the modal to close after opening. This PR fixes the the close event and adds the ability to click outside the modal to close.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44698

## Acceptance criteria
- [ ] Modal properly closes by either click the close button or clicking elsewhere on the screen

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
