### PR TITLE
[Check-in] Consolidate mock appointment creation

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -26,7 +26,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - aboutToExpireUUID: `25165847-2c16-4c8b-8790-5de37a7f427f`
   - pacificTimezoneUUID: `6c72b801-74ac-47fe-82af-cfe59744b45f`
 ### Pre-check-in
-  - defaultUUID: `0429dda5-4165-46be-9ed1-1e652a8dfd83`
+  - defaultUUID: `46bebc0a-b99c-464f-a5c5-560bc9eae287`
   - phoneApptUUID: `258d753c-262a-4ab2-b618-64b645884daf`
   - alreadyPreCheckedInUUID: `4d523464-c450-49dc-9a18-c04b3f1642ee`
   - canceledAppointmentUUID: `9d7b7c15-d539-4624-8d15-b740b84e8548`

--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -16,7 +16,7 @@ Before you get started check [this page](https://depo-platform-documentation.scr
   - start app `yarn watch --env entry=check-in,pre-check-in`
   - visit the app:
     - check-in `http://localhost:3001/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287`
-    - pre-check-in `http://localhost:3001/health-care/appointment-pre-check-in/?id=0429dda5-4165-46be-9ed1-1e652a8dfd83`
+    - pre-check-in `http://localhost:3001/health-care/appointment-pre-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287`
   - Login using the mock user, Last name: `Smith` Last four: `1234` or DOB `03-15-1989`
 
 ## Mock UUIDs

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -1,6 +1,7 @@
 import session from '../mocks/v2/sessions';
 import preCheckInData from '../mocks/v2/pre-check-in-data';
 import checkInData from '../mocks/v2/check-in-data';
+import sharedData from '../mocks/v2/shared';
 import featureToggles from '../mocks/v2/feature-toggles';
 
 class ApiInitializer {
@@ -162,7 +163,7 @@ class ApiInitializer {
       nextOfKinConfirmedAt = null,
       emergencyContactNeedsUpdate = true,
       emergencyContactConfirmedAt = null,
-      uuid = preCheckInData.get.defaultUUID,
+      uuid = sharedData.get.defaultUUID,
     } = {}) => {
       cy.intercept('GET', '/check_in/v2/pre_check_ins/*', req => {
         if (extraValidation) {
@@ -272,7 +273,7 @@ class ApiInitializer {
     withSuccess: ({
       extraValidation = null,
       appointments = null,
-      token = checkInData.get.defaultUUID,
+      token = sharedData.get.defaultUUID,
       numberOfCheckInAbledAppointments = 2,
       demographicsNeedsUpdate = true,
       demographicsConfirmedAt = null,
@@ -320,7 +321,7 @@ class ApiInitializer {
     },
     withBadData: ({
       extraValidation = null,
-      token = checkInData.get.defaultUUID,
+      token = sharedData.get.defaultUUID,
       numberOfCheckInAbledAppointments = 2,
       demographicsNeedsUpdate = true,
       demographicsConfirmedAt = null,

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -284,7 +284,7 @@ class ApiInitializer {
       timezone = 'browser',
     } = {}) => {
       cy.intercept('GET', `/check_in/v2/patient_check_ins/*`, req => {
-        const rv = checkInData.get.createMultipleAppointments(
+        const rv = sharedData.get.createMultipleAppointments(
           token,
           numberOfCheckInAbledAppointments,
           demographicsNeedsUpdate,
@@ -298,7 +298,7 @@ class ApiInitializer {
         if (appointments && appointments.length) {
           const customAppointments = [];
           appointments.forEach((appointment, index) => {
-            const createdAppointment = checkInData.get.createAppointment(
+            const createdAppointment = sharedData.get.createAppointment(
               'ELIGIBLE',
               'some-facility',
               `000${index}`,
@@ -331,7 +331,7 @@ class ApiInitializer {
       emergencyContactConfirmedAt = null,
     } = {}) => {
       cy.intercept('GET', `/check_in/v2/patient_check_ins/*`, req => {
-        const rv = checkInData.get.createMultipleAppointments(
+        const rv = sharedData.get.createMultipleAppointments(
           token,
           numberOfCheckInAbledAppointments,
           demographicsNeedsUpdate,

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -4,6 +4,7 @@ const delay = require('mocker-api/lib/delay');
 const commonResponses = require('../../../../platform/testing/local-dev-mock-api/common');
 const checkInData = require('./mocks/v2/check-in-data/index');
 const preCheckInData = require('./mocks/v2/pre-check-in-data/index');
+const sharedData = require('./mocks/v2/shared/index');
 const sessions = require('./mocks/v2/sessions/index');
 
 const featureToggles = require('./mocks/v2/feature-toggles/index');
@@ -56,9 +57,9 @@ const responses = {
     const { uuid } = req.params;
     if (hasBeenValidated) {
       hasBeenValidated = false;
-      return res.json(checkInData.get.createMultipleAppointments(uuid, 3));
+      return res.json(sharedData.get.createMultipleAppointments(uuid, 3));
     }
-    return res.json(checkInData.get.createMultipleAppointments(uuid));
+    return res.json(sharedData.get.createMultipleAppointments(uuid));
   },
   'POST /check_in/v2/patient_check_ins/': (req, res) => {
     const { uuid, appointmentIen, facilityId } =

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
@@ -1,12 +1,4 @@
-const dateFns = require('date-fns');
-const { utcToZonedTime, format } = require('date-fns-tz');
-
-const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
-const pacificTimezoneUUID = '6c72b801-74ac-47fe-82af-cfe59744b45f';
-const aboutToExpireUUID = '25165847-2c16-4c8b-8790-5de37a7f427f';
-
-const isoDateWithoutTimezoneFormat = "yyyy-LL-dd'T'HH:mm:ss";
-const isoDateWithOffsetFormat = "yyyy-LL-dd'T'HH:mm:ss.SSSxxx";
+const { mockDemographics, defaultUUID } = require('../shared/get');
 
 const createMockSuccessResponse = (
   data,
@@ -22,23 +14,12 @@ const createMockSuccessResponse = (
     id: data.id || defaultUUID,
     payload: {
       demographics: {
-        mailingAddress: {
-          street1: '123 Turtle Trail',
-          city: 'Treetopper',
-          state: 'Tennessee',
-          zip: '101010',
-        },
-        homeAddress: {
-          street1: '445 Fine Finch Fairway',
-          street2: 'Apt 201',
-          city: 'Fairfence',
-          state: 'Florida',
-          zip: '445545',
-        },
-        homePhone: '5552223333',
-        mobilePhone: '5553334444',
-        workPhone: '5554445555',
-        emailAddress: 'kermit.frog@sesameenterprises.us',
+        mailingAddress: mockDemographics.mailingAddress,
+        homeAddress: mockDemographics.homeAddress,
+        homePhone: mockDemographics.homePhone,
+        mobilePhone: mockDemographics.mobilePhone,
+        workPhone: mockDemographics.workPhone,
+        emailAddress: mockDemographics,
       },
       appointments: [
         {
@@ -68,211 +49,6 @@ const createMockSuccessResponse = (
   return rv;
 };
 
-const getAppointmentStartTime = (
-  eligibility = 'ELIGIBLE',
-  preCheckInValid = false,
-  uuid = defaultUUID,
-) => {
-  let startTime = preCheckInValid ? dateFns.addDays(new Date(), 1) : new Date();
-
-  if (eligibility === 'INELIGIBLE_TOO_LATE') {
-    startTime = dateFns.subHours(startTime, 1);
-  } else if (eligibility === 'INELIGIBLE_TOO_EARLY') {
-    startTime = dateFns.addHours(startTime, 1);
-  } else if (uuid === aboutToExpireUUID) {
-    startTime = dateFns.subMinutes(startTime, 14);
-  } else {
-    startTime = dateFns.addMinutes(startTime, 15);
-  }
-
-  return startTime;
-};
-
-const createAppointment = (
-  eligibility = 'ELIGIBLE',
-  facilityId = 'some-facility',
-  appointmentIen = Math.floor(Math.random() * 100000),
-  clinicFriendlyName = 'TEST CLINIC',
-  preCheckInValid = false,
-  uuid = defaultUUID,
-  timezone = 'browser',
-  stationNo = '0001',
-  clinicLocation = 'Test location, room A',
-) => {
-  const startTime = getAppointmentStartTime(eligibility, preCheckInValid, uuid);
-  const formattedStartTime = dateFns.format(
-    startTime,
-    isoDateWithoutTimezoneFormat,
-  );
-
-  // C.f. CHECKIN_MINUTES_BEFORE in {chip repo}/infra/template.yml
-  let checkInWindowStart = dateFns.subMinutes(new Date(startTime), 30);
-  let formattedCheckInWindowStart = format(
-    checkInWindowStart,
-    isoDateWithOffsetFormat,
-  );
-  // C.f. CHECKIN_MINUTES_AFTER in {chip repo}/infra/template.yml
-  let checkInWindowEnd = dateFns.addMinutes(new Date(startTime), 15);
-  let formattedCheckInWindowEnd = dateFns.format(
-    checkInWindowEnd,
-    isoDateWithOffsetFormat,
-  );
-
-  if (timezone !== 'browser') {
-    checkInWindowStart = dateFns.subMinutes(
-      utcToZonedTime(new Date(startTime), timezone),
-      30,
-    );
-    formattedCheckInWindowStart = format(
-      checkInWindowStart,
-      isoDateWithOffsetFormat,
-      { timeZone: timezone },
-    );
-    checkInWindowEnd = dateFns.addMinutes(
-      utcToZonedTime(new Date(startTime), timezone),
-      15,
-    );
-    formattedCheckInWindowEnd = format(
-      checkInWindowEnd,
-      isoDateWithOffsetFormat,
-      { timeZone: timezone },
-    );
-  }
-
-  return {
-    facility: 'LOMA LINDA VA CLINIC',
-    checkInSteps: [],
-    clinicPhoneNumber: '5551234567',
-    clinicFriendlyName,
-    clinicName: 'LOM ACC CLINIC TEST',
-    appointmentIen,
-    startTime: formattedStartTime,
-    eligibility,
-    facilityId,
-    checkInWindowStart: formattedCheckInWindowStart,
-    checkInWindowEnd: formattedCheckInWindowEnd,
-    checkedInTime: '',
-    stationNo,
-    clinicLocation,
-  };
-};
-
-const createMultipleAppointments = (
-  token,
-  numberOfCheckInAbledAppointments = 2,
-  demographicsNeedsUpdate = false,
-  demographicsConfirmedAt = null,
-  nextOfKinNeedsUpdate = false,
-  nextOfKinConfirmedAt = null,
-  emergencyContactNeedsUpdate = false,
-  emergencyContactConfirmedAt = null,
-) => {
-  const rv = {
-    id: token || defaultUUID,
-    payload: {
-      demographics: {
-        emergencyContact: {
-          name: 'Bugs Bunny',
-          workPhone: '',
-          relationship: 'EXTENDED FAMILY MEMBER',
-          phone: '5558675309',
-          address: {
-            zip: '87102',
-            country: 'USA',
-            street3: '',
-            city: 'Albuquerque',
-            county: null,
-            street1: '123 fake street',
-            zip4: '',
-            street2: '',
-            state: 'New Mexico',
-          },
-        },
-        nextOfKin1: {
-          name: 'VETERAN,JONAH',
-          relationship: 'BROTHER',
-          phone: '1112223333',
-          workPhone: '4445556666',
-          address: {
-            street1: '123 Main St',
-            street2: 'Ste 234',
-            street3: '',
-            city: 'Los Angeles',
-            county: 'Los Angeles',
-            state: 'CA',
-            zip: '90089',
-            zip4: '',
-            country: 'USA',
-          },
-        },
-        mailingAddress: {
-          street1: '123 Turtle Trail',
-          street2: '',
-          street3: '',
-          city: 'Treetopper',
-          state: 'Tennessee',
-          zip: '101010',
-        },
-        homeAddress: {
-          street1: '445 Fine Finch Fairway',
-          street2: 'Apt 201',
-          city: 'Fairfence',
-          state: 'Florida',
-          zip: '445545',
-        },
-        homePhone: '5552223333',
-        mobilePhone: '5553334444',
-        workPhone: '5554445555',
-        emailAddress: 'kermit.frog@sesameenterprises.us',
-      },
-      appointments: [
-        createAppointment(
-          'INELIGIBLE_TOO_LATE',
-          'ABC_123',
-          '0000',
-          `TEST CLINIC-L`,
-        ),
-      ],
-      patientDemographicsStatus: {
-        demographicsNeedsUpdate,
-        demographicsConfirmedAt,
-        nextOfKinNeedsUpdate,
-        nextOfKinConfirmedAt,
-        emergencyContactNeedsUpdate,
-        emergencyContactConfirmedAt,
-      },
-    },
-  };
-
-  let timezone = 'browser';
-  if (token === pacificTimezoneUUID) {
-    timezone = 'America/Los_Angeles';
-  }
-  for (let i = 0; i < numberOfCheckInAbledAppointments; i += 1) {
-    rv.payload.appointments.push(
-      createAppointment(
-        'ELIGIBLE',
-        'ABC_123',
-        `000${i + 1}`,
-        `TEST CLINIC-${i}`,
-        false,
-        token,
-        timezone,
-      ),
-    );
-  }
-  rv.payload.appointments.push(
-    createAppointment(
-      'INELIGIBLE_TOO_EARLY',
-      'ABC_123',
-      `0050`,
-      `TEST CLINIC-E`,
-    ),
-  );
-
-  return rv;
-};
-
 const createMockFailedResponse = _data => {
   return {
     error: true,
@@ -280,10 +56,6 @@ const createMockFailedResponse = _data => {
 };
 
 module.exports = {
-  aboutToExpireUUID,
   createMockSuccessResponse,
   createMockFailedResponse,
-  createMultipleAppointments,
-  createAppointment,
-  defaultUUID,
 };

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -1,6 +1,10 @@
 const dateFns = require('date-fns');
+const {
+  mockDemographics,
+  defaultUUID,
+  createAppointment,
+} = require('../shared/get');
 
-const defaultUUID = '0429dda5-4165-46be-9ed1-1e652a8dfd83';
 const phoneApptUUID = '258d753c-262a-4ab2-b618-64b645884daf';
 
 const alreadyPreCheckedInUUID = '4d523464-c450-49dc-9a18-c04b3f1642ee';
@@ -12,7 +16,6 @@ const expiredUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
 const expiredPhoneUUID = '08ba56a7-68b7-4b9f-b779-53ba609140ef';
 
 const isoDateWithoutTimezoneFormat = "yyyy-LL-dd'T'HH:mm:ss";
-const isoDateWithOffsetFormat = "yyyy-LL-dd'T'HH:mm:ss.SSSxxx";
 
 const createMockSuccessResponse = (
   token,
@@ -71,121 +74,24 @@ const createMockSuccessResponse = (
     apptKind = 'phone';
   }
 
-  const formattedStartTime = dateFns.format(
-    mockTime,
-    isoDateWithoutTimezoneFormat,
-  );
-
-  const checkInWindowStart = dateFns.subMinutes(
-    new Date(mockTime.getTime()),
-    30,
-  );
-  const formattedCheckInWindowStart = dateFns.format(
-    checkInWindowStart,
-    isoDateWithOffsetFormat,
-  );
-
-  const checkInWindowEnd = dateFns.addMinutes(new Date(mockTime.getTime()), 15);
-  const formattedCheckInWindowEnd = dateFns.format(
-    checkInWindowEnd,
-    isoDateWithOffsetFormat,
-  );
-
   return {
     id: token || defaultUUID,
     payload: {
-      demographics: {
-        emergencyContact: {
-          name: 'Bugs Bunny',
-          workPhone: '',
-          relationship: 'EXTENDED FAMILY MEMBER',
-          phone: '5558675309',
-          address: {
-            zip: '87102',
-            country: 'USA',
-            street3: '',
-            city: 'Albuquerque',
-            county: null,
-            street1: '123 fake street',
-            zip4: '',
-            street2: '',
-            state: 'New Mexico',
-          },
-        },
-        nextOfKin1: {
-          name: 'VETERAN,JONAH',
-          relationship: 'BROTHER',
-          phone: '1112223333',
-          workPhone: '4445556666',
-          address: {
-            street1: '123 Main St',
-            street2: 'Ste 234',
-            street3: '',
-            city: 'Los Angeles',
-            county: 'Los Angeles',
-            state: 'CA',
-            zip: '90089',
-            zip4: '',
-            country: 'USA',
-          },
-        },
-        mailingAddress: {
-          street1: '123 Turtle Trail',
-          street2: '',
-          street3: '',
-          city: 'Treetopper',
-          state: 'Tennessee',
-          zip: '101010',
-        },
-        homeAddress: {
-          street1: '445 Fine Finch Fairway',
-          street2: 'Apt 201',
-          city: 'Fairfence',
-          state: 'Florida',
-          zip: '445545',
-        },
-        homePhone: '5552223333',
-        mobilePhone: '5553334444',
-        workPhone: '5554445555',
-        emailAddress: 'kermit.frog@sesameenterprises.us',
-      },
+      demographics: mockDemographics,
       appointments: [
-        {
-          facility: 'LOMA LINDA VA CLINIC',
-          kind: apptKind,
-          checkInSteps,
-          clinicPhoneNumber: '5551234567',
-          clinicFriendlyName: 'TEST CLINIC',
-          clinicName: 'LOM ACC CLINIC TEST',
-          appointmentIen: '0001',
-          startTime: formattedStartTime,
-          eligibility: 'ELIGIBLE',
-          facilityId: 'some-facility',
-          checkInWindowStart: formattedCheckInWindowStart,
-          checkInWindowEnd: formattedCheckInWindowEnd,
-          checkedInTime: '',
-          status,
-          stationNo: '0001',
+        createAppointment({
           clinicLocation: 'Test location, room B',
-        },
-        {
-          facility: 'LOMA LINDA VA CLINIC',
           kind: apptKind,
-          checkInSteps,
-          clinicPhoneNumber: '5551234567',
-          clinicFriendlyName: 'TEST CLINIC',
-          clinicName: 'LOM ACC CLINIC TEST',
-          appointmentIen: '0002',
-          startTime: formattedStartTime,
-          eligibility: 'ELIGIBLE',
-          facilityId: 'some-facility',
-          checkInWindowStart: formattedCheckInWindowStart,
-          checkInWindowEnd: formattedCheckInWindowEnd,
-          checkedInTime: '',
           status,
-          stationNo: '0001',
+          startTime: mockTime,
+          checkInSteps,
+        }),
+        createAppointment({
           clinicLocation: 'Test location, room C',
-        },
+          status,
+          startTime: mockTime,
+          checkInSteps,
+        }),
       ],
       patientDemographicsStatus: {
         demographicsNeedsUpdate,

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -85,12 +85,14 @@ const createMockSuccessResponse = (
           status,
           startTime: mockTime,
           checkInSteps,
+          preCheckInValid: true,
         }),
         createAppointment({
           clinicLocation: 'Test location, room C',
           status,
           startTime: mockTime,
           checkInSteps,
+          preCheckInValid: true,
         }),
       ],
       patientDemographicsStatus: {

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -89,6 +89,7 @@ const createMockSuccessResponse = (
         }),
         createAppointment({
           clinicLocation: 'Test location, room C',
+          kind: apptKind,
           status,
           startTime: mockTime,
           checkInSteps,

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -85,7 +85,7 @@ const getAppointmentStartTime = (
   return startTime;
 };
 
-const createAppointment = (
+const createAppointment = ({
   eligibility = 'ELIGIBLE',
   facilityId = 'some-facility',
   appointmentIen = Math.floor(Math.random() * 100000),
@@ -99,7 +99,7 @@ const createAppointment = (
   status = '',
   startTime = getAppointmentStartTime(eligibility, preCheckInValid, uuid),
   checkInSteps = [],
-) => {
+} = {}) => {
   const formattedStartTime = dateFns.format(
     startTime,
     isoDateWithoutTimezoneFormat,
@@ -174,12 +174,12 @@ const createMultipleAppointments = (
     payload: {
       demographics: mockDemographics,
       appointments: [
-        createAppointment(
-          'INELIGIBLE_TOO_LATE',
-          'ABC_123',
-          '0000',
-          `TEST CLINIC-L`,
-        ),
+        createAppointment({
+          eligibility: 'INELIGIBLE_TOO_LATE',
+          facilityId: 'ABC_123',
+          appointmentIen: '0000',
+          clinicFriendlyName: `TEST CLINIC-L`,
+        }),
       ],
       patientDemographicsStatus: {
         demographicsNeedsUpdate,
@@ -198,24 +198,23 @@ const createMultipleAppointments = (
   }
   for (let i = 0; i < numberOfCheckInAbledAppointments; i += 1) {
     rv.payload.appointments.push(
-      createAppointment(
-        'ELIGIBLE',
-        'ABC_123',
-        `000${i + 1}`,
-        `TEST CLINIC-${i}`,
-        false,
-        token,
+      createAppointment({
+        eligibility: 'ELIGIBLE',
+        facilityId: 'ABC_123',
+        appointmentIen: `000${i + 1}`,
+        clinicFriendlyName: `TEST CLINIC-${i}`,
+        uuid: token,
         timezone,
-      ),
+      }),
     );
   }
   rv.payload.appointments.push(
-    createAppointment(
-      'INELIGIBLE_TOO_EARLY',
-      'ABC_123',
-      `0050`,
-      `TEST CLINIC-E`,
-    ),
+    createAppointment({
+      eligibility: 'INELIGIBLE_TOO_EARLY',
+      facilityId: 'ABC_123',
+      appointmentIen: `0050`,
+      clinicFriendlyName: `TEST CLINIC-E`,
+    }),
   );
 
   return rv;

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -1,0 +1,230 @@
+const dateFns = require('date-fns');
+const { utcToZonedTime, format } = require('date-fns-tz');
+
+const isoDateWithoutTimezoneFormat = "yyyy-LL-dd'T'HH:mm:ss";
+const isoDateWithOffsetFormat = "yyyy-LL-dd'T'HH:mm:ss.SSSxxx";
+
+// check in UUIDS
+const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
+const aboutToExpireUUID = '25165847-2c16-4c8b-8790-5de37a7f427f';
+const pacificTimezoneUUID = '6c72b801-74ac-47fe-82af-cfe59744b45f';
+
+const mockDemographics = {
+  emergencyContact: {
+    name: 'Bugs Bunny',
+    workPhone: '',
+    relationship: 'EXTENDED FAMILY MEMBER',
+    phone: '5558675309',
+    address: {
+      zip: '87102',
+      country: 'USA',
+      street3: '',
+      city: 'Albuquerque',
+      county: null,
+      street1: '123 fake street',
+      zip4: '',
+      street2: '',
+      state: 'New Mexico',
+    },
+  },
+  nextOfKin1: {
+    name: 'VETERAN,JONAH',
+    relationship: 'BROTHER',
+    phone: '1112223333',
+    workPhone: '4445556666',
+    address: {
+      street1: '123 Main St',
+      street2: 'Ste 234',
+      street3: '',
+      city: 'Los Angeles',
+      county: 'Los Angeles',
+      state: 'CA',
+      zip: '90089',
+      zip4: '',
+      country: 'USA',
+    },
+  },
+  mailingAddress: {
+    street1: '123 Turtle Trail',
+    street2: '',
+    street3: '',
+    city: 'Treetopper',
+    state: 'Tennessee',
+    zip: '101010',
+  },
+  homeAddress: {
+    street1: '445 Fine Finch Fairway',
+    street2: 'Apt 201',
+    city: 'Fairfence',
+    state: 'Florida',
+    zip: '445545',
+  },
+  homePhone: '5552223333',
+  mobilePhone: '5553334444',
+  workPhone: '5554445555',
+  emailAddress: 'kermit.frog@sesameenterprises.us',
+};
+
+const getAppointmentStartTime = (
+  eligibility = 'ELIGIBLE',
+  preCheckInValid = false,
+  uuid = defaultUUID,
+) => {
+  let startTime = preCheckInValid ? dateFns.addDays(new Date(), 1) : new Date();
+
+  if (eligibility === 'INELIGIBLE_TOO_LATE') {
+    startTime = dateFns.subHours(startTime, 1);
+  } else if (eligibility === 'INELIGIBLE_TOO_EARLY') {
+    startTime = dateFns.addHours(startTime, 1);
+  } else if (uuid === aboutToExpireUUID) {
+    startTime = dateFns.subMinutes(startTime, 14);
+  } else {
+    startTime = dateFns.addMinutes(startTime, 15);
+  }
+
+  return startTime;
+};
+
+const createAppointment = (
+  eligibility = 'ELIGIBLE',
+  facilityId = 'some-facility',
+  appointmentIen = Math.floor(Math.random() * 100000),
+  clinicFriendlyName = 'TEST CLINIC',
+  preCheckInValid = false,
+  uuid = defaultUUID,
+  timezone = 'browser',
+  stationNo = '0001',
+  clinicLocation = 'Test location, room A',
+  kind = 'clinic',
+  status = '',
+  startTime = getAppointmentStartTime(eligibility, preCheckInValid, uuid),
+  checkInSteps = [],
+) => {
+  const formattedStartTime = dateFns.format(
+    startTime,
+    isoDateWithoutTimezoneFormat,
+  );
+
+  // C.f. CHECKIN_MINUTES_BEFORE in {chip repo}/infra/template.yml
+  let checkInWindowStart = dateFns.subMinutes(new Date(startTime), 30);
+  let formattedCheckInWindowStart = format(
+    checkInWindowStart,
+    isoDateWithOffsetFormat,
+  );
+  // C.f. CHECKIN_MINUTES_AFTER in {chip repo}/infra/template.yml
+  let checkInWindowEnd = dateFns.addMinutes(new Date(startTime), 15);
+  let formattedCheckInWindowEnd = dateFns.format(
+    checkInWindowEnd,
+    isoDateWithOffsetFormat,
+  );
+
+  if (timezone !== 'browser') {
+    checkInWindowStart = dateFns.subMinutes(
+      utcToZonedTime(new Date(startTime), timezone),
+      30,
+    );
+    formattedCheckInWindowStart = format(
+      checkInWindowStart,
+      isoDateWithOffsetFormat,
+      { timeZone: timezone },
+    );
+    checkInWindowEnd = dateFns.addMinutes(
+      utcToZonedTime(new Date(startTime), timezone),
+      15,
+    );
+    formattedCheckInWindowEnd = format(
+      checkInWindowEnd,
+      isoDateWithOffsetFormat,
+      { timeZone: timezone },
+    );
+  }
+
+  return {
+    facility: 'LOMA LINDA VA CLINIC',
+    kind,
+    checkInSteps,
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName,
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen,
+    startTime: formattedStartTime,
+    eligibility,
+    facilityId,
+    checkInWindowStart: formattedCheckInWindowStart,
+    checkInWindowEnd: formattedCheckInWindowEnd,
+    checkedInTime: '',
+    status,
+    stationNo,
+    clinicLocation,
+  };
+};
+
+const createMultipleAppointments = (
+  token,
+  numberOfCheckInAbledAppointments = 2,
+  demographicsNeedsUpdate = false,
+  demographicsConfirmedAt = null,
+  nextOfKinNeedsUpdate = false,
+  nextOfKinConfirmedAt = null,
+  emergencyContactNeedsUpdate = false,
+  emergencyContactConfirmedAt = null,
+) => {
+  const rv = {
+    id: token || defaultUUID,
+    payload: {
+      demographics: mockDemographics,
+      appointments: [
+        createAppointment(
+          'INELIGIBLE_TOO_LATE',
+          'ABC_123',
+          '0000',
+          `TEST CLINIC-L`,
+        ),
+      ],
+      patientDemographicsStatus: {
+        demographicsNeedsUpdate,
+        demographicsConfirmedAt,
+        nextOfKinNeedsUpdate,
+        nextOfKinConfirmedAt,
+        emergencyContactNeedsUpdate,
+        emergencyContactConfirmedAt,
+      },
+    },
+  };
+
+  let timezone = 'browser';
+  if (token === pacificTimezoneUUID) {
+    timezone = 'America/Los_Angeles';
+  }
+  for (let i = 0; i < numberOfCheckInAbledAppointments; i += 1) {
+    rv.payload.appointments.push(
+      createAppointment(
+        'ELIGIBLE',
+        'ABC_123',
+        `000${i + 1}`,
+        `TEST CLINIC-${i}`,
+        false,
+        token,
+        timezone,
+      ),
+    );
+  }
+  rv.payload.appointments.push(
+    createAppointment(
+      'INELIGIBLE_TOO_EARLY',
+      'ABC_123',
+      `0050`,
+      `TEST CLINIC-E`,
+    ),
+  );
+
+  return rv;
+};
+
+module.exports = {
+  aboutToExpireUUID,
+  createMultipleAppointments,
+  createAppointment,
+  defaultUUID,
+  mockDemographics,
+};

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/index.js
@@ -1,0 +1,5 @@
+const get = require('./get');
+
+module.exports = {
+  get: { ...get },
+};

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -7,22 +7,22 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 import Appointments from '../pages/Appointments';
 
-import checkInData from '../../../../api/local-mock-api/mocks/v2/check-in-data';
+import sharedData from '../../../../api/local-mock-api/mocks/v2/shared';
 
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
     beforeEach(() => {
-      const rv1 = checkInData.get.createMultipleAppointments();
-      const earliest = checkInData.get.createAppointment();
+      const rv1 = sharedData.get.createMultipleAppointments();
+      const earliest = sharedData.get.createAppointment();
       earliest.startTime = '2021-08-19T03:00:00';
-      const midday = checkInData.get.createAppointment();
+      const midday = sharedData.get.createAppointment();
       midday.startTime = '2021-08-19T13:00:00';
-      const latest = checkInData.get.createAppointment();
+      const latest = sharedData.get.createAppointment();
       latest.startTime = '2027-08-19T18:00:00';
       rv1.payload.appointments = [latest, earliest, midday];
 
-      const rv2 = checkInData.get.createMultipleAppointments();
-      const newLatest = checkInData.get.createAppointment();
+      const rv2 = sharedData.get.createMultipleAppointments();
+      const newLatest = sharedData.get.createAppointment();
       newLatest.startTime = '2027-08-19T17:00:00';
       rv2.payload.appointments = [newLatest, earliest, midday];
       const responses = [rv1, rv2];

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
@@ -7,7 +7,7 @@ import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
 import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 import Appointments from '../pages/Appointments';
 import Confirmation from '../pages/Confirmation';
-import checkInData from '../../../../api/local-mock-api/mocks/v2/check-in-data';
+import sharedData from '../../../../api/local-mock-api/mocks/v2/shared';
 
 describe('Check In Experience', () => {
   describe('everything path', () => {
@@ -25,17 +25,17 @@ describe('Check In Experience', () => {
       initializeCheckInDataPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
 
-      const rv1 = checkInData.get.createMultipleAppointments();
-      const earliest = checkInData.get.createAppointment();
+      const rv1 = sharedData.get.createMultipleAppointments();
+      const earliest = sharedData.get.createAppointment();
       earliest.startTime = '2021-08-19T03:00:00';
-      const midday = checkInData.get.createAppointment();
+      const midday = sharedData.get.createAppointment();
       midday.startTime = '2021-08-19T13:00:00';
-      const latest = checkInData.get.createAppointment();
+      const latest = sharedData.get.createAppointment();
       latest.startTime = '2027-08-19T18:00:00';
       rv1.payload.appointments = [latest, earliest, midday];
 
-      const rv2 = checkInData.get.createMultipleAppointments();
-      const newLatest = checkInData.get.createAppointment();
+      const rv2 = sharedData.get.createMultipleAppointments();
+      const newLatest = sharedData.get.createAppointment();
       newLatest.startTime = '2027-08-19T17:00:00';
       rv2.payload.appointments = [newLatest, earliest, midday];
       const responses = [rv1, rv2];

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Pre-Check In Experience ', () => {
 
     initializePreCheckInDataPost.withSuccess(req => {
       expect(req.body.preCheckIn.uuid).to.equal(
-        '0429dda5-4165-46be-9ed1-1e652a8dfd83',
+        '46bebc0a-b99c-464f-a5c5-560bc9eae287',
       );
       expect(req.body.preCheckIn.demographicsUpToDate).to.equal(false);
       expect(req.body.preCheckIn.nextOfKinUpToDate).to.equal(false);

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.yes.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.yes.to.three.questions.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Pre-Check In Experience ', () => {
 
     initializePreCheckInDataPost.withSuccess(req => {
       expect(req.body.preCheckIn.uuid).to.equal(
-        '0429dda5-4165-46be-9ed1-1e652a8dfd83',
+        '46bebc0a-b99c-464f-a5c5-560bc9eae287',
       );
       expect(req.body.preCheckIn.demographicsUpToDate).to.equal(true);
       expect(req.body.preCheckIn.nextOfKinUpToDate).to.equal(true);

--- a/src/applications/check-in/pre-check-in/tests/e2e/requires-form/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/requires-form/session.reloads.on.refresh.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Pre Check In Experience', () => {
 
       cy.reload();
       // redirected back to landing page to reload the data
-      cy.url().should('match', /id=0429dda5-4165-46be-9ed1-1e652a8dfd83/);
+      cy.url().should('match', /id=46bebc0a-b99c-464f-a5c5-560bc9eae287/);
 
       ValidateVeteran.validatePage.preCheckIn();
       ValidateVeteran.validateVeteran();

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/no.data.in.redux.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/no.data.in.redux.cypress.spec.js
@@ -18,7 +18,7 @@ describe('Pre Check In Experience', () => {
 
       cy.window().then(window => {
         const sample = JSON.stringify({
-          token: '0429dda5-4165-46be-9ed1-1e652a8dfd83',
+          token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
         });
         window.sessionStorage.setItem(
           'health.care.pre.check.in.current.uuid',

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.is.saved.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Pre Check In Experience', () => {
           'health.care.pre.check.in.current.uuid',
         );
         const sample = JSON.stringify({
-          token: '0429dda5-4165-46be-9ed1-1e652a8dfd83',
+          token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
         });
         expect(data).to.equal(sample);
         cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -36,12 +36,12 @@ describe('Pre Check In Experience', () => {
           'health.care.pre.check.in.current.uuid',
         );
         const sample = JSON.stringify({
-          token: '0429dda5-4165-46be-9ed1-1e652a8dfd83',
+          token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
         });
         expect(data).to.equal(sample);
         cy.reload();
         // redirected back to landing page to reload the data
-        cy.url().should('match', /id=0429dda5-4165-46be-9ed1-1e652a8dfd83/);
+        cy.url().should('match', /id=46bebc0a-b99c-464f-a5c5-560bc9eae287/);
 
         ValidateVeteran.validatePage.preCheckIn();
         cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/url.is.prioritized.over.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/url.is.prioritized.over.session.cypress.spec.js
@@ -50,7 +50,7 @@ describe('Pre Check In Experience', () => {
           'health.care.pre.check.in.current.uuid',
         );
         const sample = JSON.stringify({
-          token: '0429dda5-4165-46be-9ed1-1e652a8dfd83',
+          token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
         });
         expect(data).to.equal(sample);
       });

--- a/src/applications/check-in/tests/e2e/commands/index.js
+++ b/src/applications/check-in/tests/e2e/commands/index.js
@@ -1,8 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-import checkInData from '../../../api/local-mock-api/mocks/v2/check-in-data';
-import preCheckInData from '../../../api/local-mock-api/mocks/v2/pre-check-in-data';
+import sharedData from '../../../api/local-mock-api/mocks/v2/shared';
 
-const checkInUUID = checkInData.get.defaultUUID;
+const checkInUUID = sharedData.get.defaultUUID;
 
 Cypress.Commands.add('visitWithUUID', (uuid = checkInUUID, language = 'en') => {
   cy.visit(`/health-care/appointment-check-in/?id=${uuid}`, {
@@ -21,7 +20,7 @@ Cypress.Commands.add('visitWithUUID', (uuid = checkInUUID, language = 'en') => {
   });
 });
 
-const preCheckInUUID = preCheckInData.get.defaultUUID;
+const preCheckInUUID = sharedData.get.defaultUUID;
 
 Cypress.Commands.add('visitPreCheckInWithUUID', (uuid = preCheckInUUID) => {
   cy.visit(`/health-care/appointment-pre-check-in/?id=${uuid}`);

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -24,9 +24,9 @@ describe('check in', () => {
     describe('hasMoreAppointmentsToCheckInto', () => {
       it('returns false if selected Appointment is undefined and no more eligible appointments found', () => {
         const appointments = [
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
         ];
 
         expect(
@@ -56,9 +56,9 @@ describe('check in', () => {
           'TEST CLINIC',
         );
         const appointments = [
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
           selectedAppointment,
         ];
 
@@ -74,14 +74,14 @@ describe('check in', () => {
           'TEST CLINIC',
         );
         const appointments = [
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment(
-            'ELIGIBLE',
-            'some-facility',
-            'some-other-ien',
-            'TEST CLINIC',
-          ),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({
+            eligibility: 'ELIGIBLE',
+            facilityId: 'some-facility',
+            appointmentIen: 'some-other-ien',
+            clinicFriendlyName: 'TEST CLINIC',
+          }),
           selectedAppointment,
         ];
         expect(
@@ -89,36 +89,36 @@ describe('check in', () => {
         ).to.equal(true);
       });
       it('returns true if the selected appointment is not found and there are more eligible appointments', () => {
-        const selectedAppointment = createAppointment(
-          'ELIGIBLE',
-          'some-facility',
-          'some-ien',
-          'TEST CLINIC',
-        );
+        const selectedAppointment = createAppointment({
+          eligibility: 'ELIGIBLE',
+          facilityId: 'some-facility',
+          appointmentIen: 'some-ien',
+          clinicFriendlyName: 'TEST CLINIC',
+        });
         const appointments = [
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment(
-            'ELIGIBLE',
-            'some-facility',
-            'some-other-ien',
-            'TEST CLINIC',
-          ),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({
+            eligibility: 'ELIGIBLE',
+            facilityId: 'some-facility',
+            appointmentIen: 'some-other-ien',
+            clinicFriendlyName: 'TEST CLINIC',
+          }),
         ];
         expect(
           hasMoreAppointmentsToCheckInto(appointments, selectedAppointment),
         ).to.equal(true);
       });
       it('returns false if no more eligible appointments are found', () => {
-        const selectedAppointment = createAppointment(
-          'ELIGIBLE',
-          'some-facility',
-          'some-ien',
-          'TEST CLINIC',
-        );
+        const selectedAppointment = createAppointment({
+          eligibility: 'ELIGIBLE',
+          facilityId: 'some-facility',
+          appointmentIen: 'some-other-ien',
+          clinicFriendlyName: 'TEST CLINIC',
+        });
         const appointments = [
-          createAppointment('INELIGIBLE_TOO_EARLY'),
-          createAppointment('INELIGIBLE_TOO_EARLY'),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
+          createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
         ];
         expect(
           hasMoreAppointmentsToCheckInto(appointments, selectedAppointment),
@@ -325,15 +325,15 @@ describe('check in', () => {
     describe('preCheckinExpired', () => {
       it('identifies an expired pre-check-in appointment list', () => {
         const appointments = [
-          createAppointment(null, null, null, null, false),
-          createAppointment(null, null, null, null, false),
+          createAppointment({ preCheckInValid: false }),
+          createAppointment({ preCheckInValid: false }),
         ];
         expect(preCheckinExpired(appointments)).to.be.true;
       });
       it('identifies a valid pre-check-in appointment list', () => {
         const appointments = [
-          createAppointment(null, null, null, null, true),
-          createAppointment(null, null, null, null, true),
+          createAppointment({ preCheckInValid: true }),
+          createAppointment({ preCheckInValid: true }),
         ];
         expect(preCheckinExpired(appointments)).to.be.false;
       });

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -10,7 +10,7 @@ import {
   preCheckinExpired,
 } from './index';
 
-import { get } from '../../api/local-mock-api/mocks/v2/check-in-data';
+import { get } from '../../api/local-mock-api/mocks/v2/shared';
 import { ELIGIBILITY } from './eligibility';
 
 describe('check in', () => {


### PR DESCRIPTION
## Description
This PR moves mock appointment creation into a shared file, to cut down on duplicate code maintenance. It also migrates the function arguments to an object type, so that you can more easily specify custom appointment attributes (without having to put a dozen 'nulls' and remember that the attribute you want is the 8th one).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45089


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
