### PR TITLE
Use https instead of ssh in update-json-schema script

### DIFF
--- a/script/update-json-schema.sh
+++ b/script/update-json-schema.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-NEW_HASH=$(git ls-remote git://github.com/department-of-veterans-affairs/vets-json-schema/ refs/heads/master | awk '{print $1}')
+NEW_HASH=$(git ls-remote https://github.com/department-of-veterans-affairs/vets-json-schema/ refs/heads/master | awk '{print $1}')
 sed -i '' -e 's/\(vets-json-schema\.git#\)\(.*\)\(",$\)/\1'$NEW_HASH'\3/' package.json
 yarn install


### PR DESCRIPTION
## Description
The `update-json-schema.sh` script, which is run by `yarn update:schema`, has stopped working correctly. Specifically it removes the sha from the `vets-json-schema` package in `package.json` instead of updating the sha as it should. The root cause is that
```
git ls-remote git://github.com/department-of-veterans-affairs/vets-json-schema/
```

is timing out. Switching from the ssh protocol to https fixes the problem. There's no need to use ssh, especially since this is a public repo.

## Original issue(s)
N/A

## Testing done
Run `yarn update:schema` locally

## Screenshots


## Acceptance criteria
- [ ] `yarn update:schema` updates the package sha instead of removing it

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
