### PR TITLE
Update catalog-info.yaml to add Test User Dashboard to Config

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -19,6 +19,9 @@ metadata:
     - url: https://va-gov.domo.com/page/1964748112
       title: Search KPIs (Domo)
       icon: dashboard
+    - url: https://tud.vfs.va.gov
+      title: Test User Dashboard
+      icon: dashboard
 spec:
   owner: platform-release-tools
   domain: vfs


### PR DESCRIPTION
## Description

Adding a link to the VA.gov Test User Dashboard.

It is used for manual testing of the front end of vets-website in staging, so needs to be linked on the System page in Console UI.

## Original issue(s)

https://github.com/department-of-veterans-affairs/platform-console-ui/issues/638

## Testing done

Tested the validity of the link in browser, manually.

## Screenshots

![Screen Shot 2022-08-02 at 12 10 56 PM](https://user-images.githubusercontent.com/116142/182422116-90a51d1a-f3d7-4dc9-9a6e-bac33e32be8f.png)