### PR TITLE
Upgrade generator-vets-website to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.10.0",
     "@department-of-veterans-affairs/eslint-plugin": "^1.2.1",
-    "@department-of-veterans-affairs/generator-vets-website": "^3.7.0",
+    "@department-of-veterans-affairs/generator-vets-website": "^3.8.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",
     "@sentry/browser": "^6.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,10 +2544,10 @@
     element-closest "^3.0.1"
     foundation-sites "5"
 
-"@department-of-veterans-affairs/generator-vets-website@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.7.0.tgz#f6fca9a158406956a17bf7fcb76a765aab2d2f9f"
-  integrity sha512-CHTyurvi6gYls2OCGuQ2ygLJK60XfCVlBlH/KgwD53M3jTMKJMsyTsehTNSZL6+qJJZqYhIaOO4uVgCIpai5xQ==
+"@department-of-veterans-affairs/generator-vets-website@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.8.0.tgz#078f11543acb0fa315115ed95d195b4cb2dd801d"
+  integrity sha512-w3g6qF8TiGDeepxHCY+jwq+qeEqJKdb3Rpw0e93hcekNliQliMcf1jVDpmkNysQUIrl163U+corwb1nMcpFaOA==
   dependencies:
     chalk "^4.1.0"
     yeoman-generator "^5.6.1"


### PR DESCRIPTION
## Description
Upgrade generator-vets-website to incorporate changes from https://github.com/department-of-veterans-affairs/generator-vets-website/pull/268 and https://github.com/department-of-veterans-affairs/generator-vets-website/pull/271

## Original issue(s)
None

## Testing done
- Run `npx yo` locally and confirm app is created

## Screenshots


## Acceptance criteria
- [ ] Package is upgraded

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
