### PR TITLE
Configure linter rule for no-cross-app-imports (#41208)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,15 @@ module.exports = {
   rules: {
     /* || Eslint main rules || */
     camelcase: [2, { properties: 'always' }], // Override airbnb style.
+    '@department-of-veterans-affairs/no-cross-app-imports': [
+      'warn', // Warn for now, but after cleanup of imports, change to error
+      {
+        // Aliases copied from babel.config.json
+        '~': './src',
+        '@@vap-svc': './src/platform/user/profile/vap-svc',
+        '@@profile': './src/applications/personalization/profile',
+      },
+    ],
     'deprecate/import': [
       'warn',
       {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.10.0",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.2.1",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.2.2",
     "@department-of-veterans-affairs/generator-vets-website": "^3.8.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,10 +2517,10 @@
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.2.1.tgz#98186933a21d3ef4a1790d1aa2585232849cd176"
-  integrity sha512-4QRsPsm5in1hTIS2RILjNYycICrbXWpGXXug+qhCDKfOK78hjgbzQXhyZ0KXh0NXB47NR4JA1H9jjy9oKemxwg==
+"@department-of-veterans-affairs/eslint-plugin@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.2.2.tgz#6a9668a2a7e40b755b31e36bc2daf95d62d87032"
+  integrity sha512-V97Ka7zXS+jdh4XN/VcCLXldubEvbH390JFslAmnqMD5b9er/kj585ndlI4p5WunaP3kIwJRY7A4CuunrVrO7w==
 
 "@department-of-veterans-affairs/formation@^7.0.2":
   version "7.0.2"


### PR DESCRIPTION
## Description
Configure our new linter rule to warn about cross-app imports. In the future this will error out and fail the build, but we can't do that yet because we have too many existing cross-app imports.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41208

## Testing done
- Run `yarn lint` locally

## Screenshots


## Acceptance criteria
- [x] Linter rule is in place and warns about cross-app imports in vets-website

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
