### PR TITLE
Fixes the logout functionality for Sign in Service

### DIFF
--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -20,9 +20,8 @@ import {
   logout as IAMLogout,
   verify,
   mfa,
-  createAndStoreReturnUrl,
 } from 'platform/user/authentication/utilities';
-import { logout as SISLogout } from 'platform/utilities/oauth/utilities';
+import { logoutUrlSiS } from 'platform/utilities/oauth/utilities';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { AUTH_EVENTS } from 'platform/user/authentication/constants';
 import MFA from './components/messages/DirectDeposit/MFA';
@@ -476,11 +475,7 @@ export class CallToActionWidget extends Component {
     if (this.props.authenticatedWithSSOe) {
       IAMLogout();
     } else {
-      const signInServiceName = this.props.profile?.session?.signInServiceName;
-      SISLogout({
-        signInServiceName,
-        storedLocation: createAndStoreReturnUrl(),
-      });
+      window.location = logoutUrlSiS();
     }
   };
 

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -7,7 +7,7 @@ import {
   signInServiceName,
 } from 'platform/user/authentication/selectors';
 import { logoutUrl } from 'platform/user/authentication/utilities';
-import { logout as SISLogout } from 'platform/utilities/oauth/utilities';
+import { logoutUrlSiS, logoutEvent } from 'platform/utilities/oauth/utilities';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -23,25 +23,14 @@ export function PersonalizationDropdown(props) {
   const { isSSOe, csp } = props;
 
   const createSignout = useCallback(
-    () => {
-      const label = 'Sign Out';
-      return isSSOe ? (
-        <a href={logoutUrl()}>{label}</a>
-      ) : (
-        <button
-          type="button"
-          className="button-styled-as-link"
-          onClick={() => {
-            SISLogout({
-              signInServiceName: csp,
-              storedLocation: window.location.href,
-            });
-          }}
-        >
-          {label}
-        </button>
-      );
-    },
+    () => (
+      <a
+        href={isSSOe ? logoutUrl() : logoutUrlSiS()}
+        onClick={() => logoutEvent(csp)}
+      >
+        Sign Out
+      </a>
+    ),
     [isSSOe, csp],
   );
 

--- a/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 
 import { logoutUrl } from 'platform/user/authentication/utilities';
+import { logoutUrlSiS } from 'platform/utilities/oauth/utilities';
 import { PersonalizationDropdown } from 'platform/site-wide/user-nav/components/PersonalizationDropdown';
 
 describe('<PersonalizationDropdown>', () => {
@@ -71,24 +71,11 @@ describe('<PersonalizationDropdown>', () => {
     wrapper.unmount();
   });
 
-  it('should use the logoutUrl if using SSOe', () => {
-    const wrapper = shallow(<PersonalizationDropdown isSSOe />);
+  it('should use the logoutUrlSiS if using OAuth', () => {
+    const wrapper = shallow(<PersonalizationDropdown />);
     const signoutLink = wrapper.find('a').at(3);
-    const expectedUrl = logoutUrl();
+    const expectedUrl = logoutUrlSiS();
     expect(signoutLink.prop('href')).to.equal(expectedUrl);
-    wrapper.unmount();
-  });
-
-  it('should use the the SISLogout if using OAuth', () => {
-    const SISLogout = sinon.spy();
-    const wrapper = shallow(
-      <PersonalizationDropdown isSSOe={false} csp="idme" />,
-    );
-    const signoutButton = wrapper.find('button');
-    signoutButton.simulate('click', {
-      event: { sis: SISLogout() },
-    });
-    expect(SISLogout.called).to.equal(true);
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/user-nav/tests/user-nav.cypress.spec.js
+++ b/src/platform/site-wide/user-nav/tests/user-nav.cypress.spec.js
@@ -3,36 +3,31 @@ import { generateMockUser } from './mocks/user';
 
 const selectors = {
   menu: '#login-root button[aria-controls="account-menu"]',
-  signOut: '#account-menu ul li:nth-child(4)',
+  signOut: '#account-menu ul li:nth-child(4) a',
 };
 
 describe('User Nav Test', () => {
   ['sis', 'iam'].forEach(authBroker => {
     it(`Displays the proper elements on the nav (${authBroker})`, () => {
       const mockUser = generateMockUser({ authBroker });
-      const signOutSelector = `${selectors.signOut} ${
-        authBroker === 'iam' ? 'a' : 'button'
-      }`;
       cy.login(mockUser);
       cy.visit('/my-va');
       cy.title().should('contain', 'My VA | Veterans Affairs');
-      Cypress.on('uncaught:exception', () => {
-        return false;
-        // Skip over an API call that results in a network error.
-      });
+      // Skip over an API call that results in a network error.
+      Cypress.on('uncaught:exception', () => false);
 
       cy.get(selectors.menu, { timeout: Timeouts.slow })
         .should('be.visible')
         .then(dropDownMenu => {
           cy.wrap(dropDownMenu).click();
-          cy.get(signOutSelector, { timeout: Timeouts.slow })
+          cy.get(selectors.signOut, { timeout: Timeouts.slow })
             .should('be.visible')
             .and('contain', 'Sign Out')
-            .then(signOutButton => {
-              cy.wrap(signOutButton).click();
+            .then(signoutLink => {
+              cy.wrap(signoutLink).click();
               cy.url().should(
                 'match',
-                /\/sessions\/slo\/new|\/my-va|chrome-error:\/\/chromewebdata\//,
+                /\/sessions\/slo\/new|\/my-va|\/sign_in\/logout|chrome-error:\/\/chromewebdata\//,
               );
             });
         });

--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -4,15 +4,8 @@ import differenceInSeconds from 'date-fns/differenceInSeconds';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import recordEvent from 'platform/monitoring/record-event';
-import {
-  logout as IAMLogout,
-  createAndStoreReturnUrl,
-} from 'platform/user/authentication/utilities';
-import {
-  refresh,
-  logout as SISLogout,
-  checkOrSetSessionExpiration,
-} from 'platform/utilities/oauth/utilities';
+import { logout as IAMLogout } from 'platform/user/authentication/utilities';
+import { refresh, logoutUrlSiS } from 'platform/utilities/oauth/utilities';
 import { teardownProfileSession } from 'platform/user/profile/utilities';
 import localStorage from 'platform/utilities/storage/localStorage';
 
@@ -59,7 +52,7 @@ class SessionTimeoutModal extends React.Component {
   expireSession = () => {
     recordEvent({ event: 'logout-session-expired' });
     teardownProfileSession();
-    window.location = '/session-expired';
+    window.location = logoutUrlSiS();
   };
 
   extendSession = () => {
@@ -71,7 +64,7 @@ class SessionTimeoutModal extends React.Component {
     localStorage.removeItem('sessionExpiration');
     this.setState({ countdown: null });
     if (this.props.authenticatedWithOAuth) {
-      refresh(checkOrSetSessionExpiration);
+      refresh();
     } else {
       this.props.onExtendSession();
     }
@@ -82,11 +75,7 @@ class SessionTimeoutModal extends React.Component {
     if (!this.props.authenticatedWithOAuth) {
       IAMLogout();
     } else {
-      const { signInServiceName } = this.props;
-      SISLogout({
-        signInServiceName,
-        storedLocation: createAndStoreReturnUrl(),
-      });
+      window.location = logoutUrlSiS();
     }
   };
 

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -345,33 +345,11 @@ describe('OAuth - Utilities', () => {
   });
 
   describe('logout', () => {
-    it('should redirect when Login.gov is CSP', () => {
-      const url = 'https://va.gov/?state=some_random_state';
-      window.location = new URL(url);
-      oAuthUtils.logout({ signInServiceName: 'logingov' });
-      expect(window.location.href).to.not.eql(url);
-    });
-    it('should make a GET request to `/logout` if using ID.me or any other CSP', () => {
-      mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), []);
-      ['mhv', 'dslogon', 'idme'].forEach(signInServiceName => {
-        oAuthUtils.logout({ signInServiceName });
-        expect(global.fetch.called).to.be.true;
-        expect(global.fetch.firstCall.args[1].method).to.equal('GET');
-        expect(global.fetch.firstCall.args[0].includes('/logout')).to.be.true;
-      });
-    });
-    it('should updated the loggedIn status, teardown profile, and redirect to the stored page if the response is ok', () => {
-      const url = 'https://dev.va.gov/education-benefits';
-      window.location = new URL(url);
-      mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), []);
-      oAuthUtils.logout({ signInServiceName: 'idme' });
-      expect(global.fetch.calledOnce).to.be.true;
-      expect(localStorage.getItem('hasSession')).to.be.null;
-      expect(localStorage.getItem('sessionExpiration')).to.be.null;
-      expect(localStorage.getItem('atExpires')).to.be.null;
-      expect(window.location.href).to.eql(url);
+    it('should redirect to backend for logout', () => {
+      window.location = new URL('https://va.gov/?state=some_random_state');
+      const url = oAuthUtils.logoutUrlSiS();
+      window.location = url;
+      expect(window.location).to.eql(url);
     });
   });
 });


### PR DESCRIPTION
## Description
This PR fixes the Sign in Service logout functionality to be a link rather than a button so that the appropriate redirects occur.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#45229


## Testing done
Unit / manual

## Screenshots
n/a

## Acceptance criteria
- [x] Signing in with the SiS using ID.me or Login.gov, I am redirected to `/v0/sign_in/logout` and I am logged out
- [x] Signing in with the SiS using ID.me or Login.gov, when the Session Timeout Modal pops up, clicking Sign out redirects a user to `v0/sign_in/logout` and I am logged out.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
