### PR TITLE
[check-in] Add aria-hidden to <br/> to prevent duplicate readout of addresses

### DIFF
--- a/src/applications/check-in/components/AddressBlock.jsx
+++ b/src/applications/check-in/components/AddressBlock.jsx
@@ -30,7 +30,7 @@ const AddressBlock = ({ address }) => {
       <span data-testid="address-line-street1">{address.street1}</span>
       {lineTwo}
       {lineThree}
-      <br />
+      <br aria-hidden="true" />
       <span data-testid="address-city-state-and-zip">
         {`${address.city}, ${address.state} ${address.zip.substring(0, 5)}`}
       </span>


### PR DESCRIPTION
## Description
As best I can tell through testing, for whatever reason the <br/> separating lines in the address blocks is what was causing the first line to be read out twice. I've added "aria-hidden" to these elements, and the screenreader now reads the address lines only once, as expected.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44418


## Testing done
Manual testing using VoiceOver on Mac.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
