### PR TITLE
Fixes issue with view:confirmContactEmail crashing the app

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/contact-information/additional-information.js
+++ b/src/applications/lgy/coe/form/config/chapters/contact-information/additional-information.js
@@ -32,8 +32,8 @@ export const uiSchema = {
       {
         validator: (errors, _fieldData, formData) => {
           if (
-            formData.contactEmail.toLowerCase() !==
-            formData['view:confirmContactEmail'].toLowerCase()
+            formData.contactEmail?.toLowerCase() !==
+            formData['view:confirmContactEmail']?.toLowerCase()
           ) {
             errors.addError(
               'This email does not match your previously entered email',


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/45020

## URL of fix
[Additional contact information page](http://localhost:3001/housing-assistance/home-loans/request-coe-form-26-1880/additional-contact-information)

# Expected behavior
When a user clicks the 'Continue' button on the 'Additional contact information' step of the form with all of the form inputs empty, they should see errors on all of the inputs. If they then start entering text into the 'Confirm email address' field, the form should not crash

## Current behavior
When a user clicks the 'Continue' button on the 'Additional contact information' step of the form with all of the form inputs empty, they see errors on all of the inputs. If they then start entering text into the 'Confirm email address' field, the form completely disappears

## Your fix
The `view:confirmContactEmail` input has a custom validator. This validator checks the values of `formData.contactEmail` and `formData['view:confirmContactEmail']`. It is assuming that bot of these values are undefined, and if `formData.contactEmail` is `undefined` then the validator function errors, which causes a chain of other errors to occur.
* Using `?` with both `formData.contactEmail` and `formData['view:confirmContactEmail']`

## How has this been tested?
Tested manually by running through the crash scenario and confirming that it no longer causes a crash. Also tried inputting into the other fields after hitting 'Continue' and they don't crash the form either.

## Acceptance criteria
- [x] Form no longer crashes when entering input into the 'Confirm email address' field from an errored state
