### PR TITLE
Fix Medallia modal on tablets

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -1,4 +1,4 @@
-// @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 /* Fonts */
 #liveForm .ng-binding,

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -51,7 +51,7 @@
   position: relative;
 }
 
-/* Very specific override that fixes an issue where the modal width is unreadable because it is constrained to the width of col-sm-1 on tablet screens */
+/* Very specific override that fixes an issue where the modal is unreadable because it is constrained to the width of col-sm-1 on tablet screens */
 @media (min-width: 576px) {
   #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
     max-width: 100% !important;

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -51,8 +51,7 @@
   position: relative;
 }
 
-/* Very specific override that fixes an issue where the modal width is unreadable 
-because it is constrained to the width of col-sm-1 on tablet screens */
+/* Very specific override that fixes an issue where the modal width is unreadable because it is constrained to the width of col-sm-1 on tablet screens */
 @media (min-width: 576px) {
   #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
     max-width: 100% !important;

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -51,8 +51,12 @@
   position: relative;
 }
 
-#liveForm > div > div.row.neb-form-close-btn-container.ng-hide > div.col-sm-offset-11.col-sm-1 {
-  max-width: 100% !important;
+/* Very specific override that fixes an issue where the modal width is unreadable 
+because it is constrained to the width of col-sm-1 on tablet screens */
+@media (min-width: 576px) {
+  #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
+    max-width: 100% !important;
+  }
 }
 
 /* https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706#issuecomment-769341669 */
@@ -113,9 +117,3 @@
   z-index: 9999999;
   color: $color-gray-light !important;
 }
-
-// @media (min-width: 576px) {
-//   #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
-//     max-width: 100% !important;
-//   }
-// }

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -1,4 +1,4 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+// @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 /* Fonts */
 #liveForm .ng-binding,
@@ -49,6 +49,10 @@
 
   /* Add `position: relative;` so `position: absolute;` can be applied to the child `button` element */
   position: relative;
+}
+
+#liveForm>div>div.row.neb-form-close-btn-container.ng-hide > div.col-sm-offset-11.col-sm-1 {
+  max-width: 100% !important;
 }
 
 /* https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706#issuecomment-769341669 */

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -51,7 +51,7 @@
   position: relative;
 }
 
-#liveForm>div>div.row.neb-form-close-btn-container.ng-hide > div.col-sm-offset-11.col-sm-1 {
+#liveForm > div > div.row.neb-form-close-btn-container.ng-hide > div.col-sm-offset-11.col-sm-1 {
   max-width: 100% !important;
 }
 
@@ -113,3 +113,9 @@
   z-index: 9999999;
   color: $color-gray-light !important;
 }
+
+// @media (min-width: 576px) {
+//   #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
+//     max-width: 100% !important;
+//   }
+// }


### PR DESCRIPTION
## Description
This ticket fixes the Medallia feedback modal on tablet-sized screens 


## Original issue(s)
https://app.zenhub.com/workspaces/contact-center-62cdd9546ec1530018209672/issues/department-of-veterans-affairs/va.gov-team/45346

## Testing done


## Screenshots
![medallia-tablet](https://user-images.githubusercontent.com/11021491/183477114-1dc6ce4c-7786-4987-b051-ca137a962956.gif)


## Acceptance criteria
- [X] Modal is readable on tablet screens

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
