### PR TITLE
Updated to yarn lock file and resetting aliases in babel config

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -49,18 +49,18 @@
           "~": "./src",
           "@@vap-svc": "./src/platform/user/profile/vap-svc",
           "@@profile": "./src/applications/personalization/profile",
-          "@department-of-veterans-affairs/component-library/LoadingIndicator": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/LoadingIndicator",
-          "@department-of-veterans-affairs/component-library/AlertBox": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/AlertBox",
-          "@department-of-veterans-affairs/component-library/ProgressButton": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/ProgressButton",
-          "@department-of-veterans-affairs/component-library/RadioButtons": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/RadioButtons",
-          "@department-of-veterans-affairs/component-library/Breadcrumbs": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/Breadcrumbs",
-          "@department-of-veterans-affairs/component-library/Modal": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/Modal",
-          "@department-of-veterans-affairs/component-library/FileInput": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/FileInput",
-          "@department-of-veterans-affairs/component-library/SystemDownView": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/SystemDownView",
-          "@department-of-veterans-affairs/component-library/Pagination": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/Pagination",
-          "@department-of-veterans-affairs/component-library/Checkbox": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/Checkbox",
-          "@department-of-veterans-affairs/component-library/DropDownPanel": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/DropDownPanel",
-          "@department-of-veterans-affairs/component-library/AdditionalInfo": "@department-of-veterans-affairs/component-library/node_modules/@department-of-veterans-affairs/react-components/AdditionalInfo"
+          "@department-of-veterans-affairs/component-library/LoadingIndicator": "@department-of-veterans-affairs/react-components/LoadingIndicator",
+          "@department-of-veterans-affairs/component-library/AlertBox": "@department-of-veterans-affairs/react-components/AlertBox",
+          "@department-of-veterans-affairs/component-library/ProgressButton": "@department-of-veterans-affairs/react-components/ProgressButton",
+          "@department-of-veterans-affairs/component-library/RadioButtons": "@department-of-veterans-affairs/react-components/RadioButtons",
+          "@department-of-veterans-affairs/component-library/Breadcrumbs": "@department-of-veterans-affairs/react-components/Breadcrumbs",
+          "@department-of-veterans-affairs/component-library/Modal": "@department-of-veterans-affairs/react-components/Modal",
+          "@department-of-veterans-affairs/component-library/FileInput": "@department-of-veterans-affairs/react-components/FileInput",
+          "@department-of-veterans-affairs/component-library/SystemDownView": "@department-of-veterans-affairs/react-components/SystemDownView",
+          "@department-of-veterans-affairs/component-library/Pagination": "@department-of-veterans-affairs/react-components/Pagination",
+          "@department-of-veterans-affairs/component-library/Checkbox": "@department-of-veterans-affairs/react-components/Checkbox",
+          "@department-of-veterans-affairs/component-library/DropDownPanel": "@department-of-veterans-affairs/react-components/DropDownPanel",
+          "@department-of-veterans-affairs/component-library/AdditionalInfo": "@department-of-veterans-affairs/react-components/AdditionalInfo"
         }
       }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10891,14 +10891,7 @@ husky@>=6:
   resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
   integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
-i18next-browser-languagedetector@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.3.tgz#9bc47fb4a5db86d567318895df343d2d1b9692f3"
-  integrity sha512-T+oGXHXtrur14CGnZZ7qQ07X38XJQEI00b/4ILrtO6xPbwTlQ1wtMZC2H+tBULixHuVUXv8LKbxfjyITJkezUg==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-
-i18next-browser-languagedetector@^6.1.4:
+i18next-browser-languagedetector@^6.1.3, i18next-browser-languagedetector@^6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.4.tgz#7b087c5edb6f6acd38ef54ede2160ab9cde0108f"
   integrity sha512-wukWnFeU7rKIWT66VU5i8I+3Zc4wReGcuDK2+kuFhtoxBRGWGdvYI9UQmqNL/yQH1KogWwh+xGEaIPH8V/i2Zg==


### PR DESCRIPTION
## Description
Resetting aliases in babelrc. Aliases were updated in a previous PR (outlined in the attached issue). We think the lock file just need to be cleared out, so this PR does that, and resets the aliases.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45219

## Testing

This was originally a problem with CI and unit tests, so the testing is just in CI