### PR TITLE
bump component library version to 11.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^11.3.1",
+    "@department-of-veterans-affairs/component-library": "^11.3.2",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^11.3.2",
+    "@department-of-veterans-affairs/component-library": "11.2.6",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^11.2.2",
+    "@department-of-veterans-affairs/component-library": "^11.3.1",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,13 +2505,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^11.3.2":
-  version "11.3.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.3.2.tgz#536a12f447d9332f169dfaec7c02205232ca0ad6"
-  integrity sha512-08qv9Gl7p/q7PHsMHLttARLZyaQnav7+nrdXlW6mj5MVmUAMcgvFKJWlEn+cg8zczI5r4GwS7U5kyziDUNEFmA==
+"@department-of-veterans-affairs/component-library@11.2.6":
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.2.6.tgz#5bbd51427fbd41642e55e40ba6dbddb0d90485bd"
+  integrity sha512-lvapxOrGDZ1AcnD5BW4yBielJq6Wn6Nkxhyaa2mHGmNPOwv6m+ZECbwT9RqJHAqlnnjf7CofkbzRDfEvVh3nEw==
   dependencies:
     "@department-of-veterans-affairs/react-components" "7.0.1"
-    "@department-of-veterans-affairs/web-components" "4.10.2"
+    "@department-of-veterans-affairs/web-components" "4.9.6"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2582,10 +2582,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.10.2":
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.10.2.tgz#401fe40ae17b41fc15f25837444304ac45aee153"
-  integrity sha512-NeHglh8xmqrhaT5ubiB/vxJC9LngMyEKyqVYPc5180NXfV9tkhFIv4IxyJh0TFaYaMaL7yomy+1fxepAGgBWaQ==
+"@department-of-veterans-affairs/web-components@4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.9.6.tgz#16e9f057c0dbef33aa4342fc4d6ea94cdfd07c41"
+  integrity sha512-VJQq4VY8OQ0ZD32BacCjnnBeHyrJ9OoRmlBKZ7bR4LTLQwUWBDNYgSnLh8LQMO1h2gLnXdeeuMOz8xKEqT/Jig==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,13 +2505,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^11.3.1":
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.3.1.tgz#1943aec5df2d5ca86e323bb9f23b8fe9b15a0d01"
-  integrity sha512-rw48QOLbaN8o3360YeWcCnj5YI0Q7frQ731BXERzJbF3OmBSo6NWoNFGdCNzENGFb+4yp/1f2cgpQj//7axgqA==
+"@department-of-veterans-affairs/component-library@^11.3.2":
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.3.2.tgz#536a12f447d9332f169dfaec7c02205232ca0ad6"
+  integrity sha512-08qv9Gl7p/q7PHsMHLttARLZyaQnav7+nrdXlW6mj5MVmUAMcgvFKJWlEn+cg8zczI5r4GwS7U5kyziDUNEFmA==
   dependencies:
     "@department-of-veterans-affairs/react-components" "7.0.1"
-    "@department-of-veterans-affairs/web-components" "4.10.1"
+    "@department-of-veterans-affairs/web-components" "4.10.2"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2582,10 +2582,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.10.1":
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.10.1.tgz#2d7039cf70f7a6153679340f6ed039bd97667a25"
-  integrity sha512-wDewRvQHvIbTkU/YSLN3PDo9XvBiQXyHDCX7KDx98j9znZPodi/2J5i1MSrJaW8W27ILw9EnOSxYnNybASHYAA==
+"@department-of-veterans-affairs/web-components@4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.10.2.tgz#401fe40ae17b41fc15f25837444304ac45aee153"
+  integrity sha512-NeHglh8xmqrhaT5ubiB/vxJC9LngMyEKyqVYPc5180NXfV9tkhFIv4IxyJh0TFaYaMaL7yomy+1fxepAGgBWaQ==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,13 +2505,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.2.2.tgz#9acceaf448ccd6f5c978042bc397558a52f20a55"
-  integrity sha512-n/5XBxAADEZs96/jR+Q9ReLEtQZ20fLEh2uImpJjCMBQn1A1BncW7j4/K37B37avs2scQ3DqU5lYVagX8alwhw==
+"@department-of-veterans-affairs/component-library@^11.3.1":
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.3.1.tgz#1943aec5df2d5ca86e323bb9f23b8fe9b15a0d01"
+  integrity sha512-rw48QOLbaN8o3360YeWcCnj5YI0Q7frQ731BXERzJbF3OmBSo6NWoNFGdCNzENGFb+4yp/1f2cgpQj//7axgqA==
   dependencies:
     "@department-of-veterans-affairs/react-components" "7.0.1"
-    "@department-of-veterans-affairs/web-components" "4.9.2"
+    "@department-of-veterans-affairs/web-components" "4.10.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2582,10 +2582,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.9.2":
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.9.2.tgz#fef1ffcf69afecbabae1f2ef4dc557e8ce0cbba3"
-  integrity sha512-QG78EtJLS+XxdyrPF6pw42t+ZuyDGqMVPq9HWFw2WiyIVpaPQ+JpNYGzfVEb5JVUlSV+jc1Wib0JWyWgew3SYw==
+"@department-of-veterans-affairs/web-components@4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.10.1.tgz#2d7039cf70f7a6153679340f6ed039bd97667a25"
+  integrity sha512-wDewRvQHvIbTkU/YSLN3PDo9XvBiQXyHDCX7KDx98j9znZPodi/2J5i1MSrJaW8W27ILw9EnOSxYnNybASHYAA==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description
Changes included in this bump:
- style: add active styling for secondary and back va-button variants
- Add nowrap to telephone component CSS
- fix: text does not overlap icon in alerts
- fix: web components announce alerts

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
