### PR TITLE
Check in/45344/hide location for telephone appts

### DIFF
--- a/src/applications/check-in/components/AppointmentBlockWithIcons.jsx
+++ b/src/applications/check-in/components/AppointmentBlockWithIcons.jsx
@@ -78,19 +78,20 @@ const AppointmentBlock = props => {
                 >
                   {clinic}
                 </div>
-                {appointment.clinicLocation && (
-                  <>
-                    <div className="check-in--label vads-u-margin-right--1">
-                      {t('location')}:
-                    </div>
-                    <div
-                      className="check-in--value"
-                      data-testid="clinic-location"
-                    >
-                      {appointment.clinicLocation}
-                    </div>
-                  </>
-                )}
+                {appointment?.kind === 'clinic' &&
+                  appointment.clinicLocation && (
+                    <>
+                      <div className="check-in--label vads-u-margin-right--1">
+                        {t('location')}:
+                      </div>
+                      <div
+                        className="check-in--value"
+                        data-testid="clinic-location"
+                      >
+                        {appointment.clinicLocation}
+                      </div>
+                    </>
+                  )}
               </div>
               {page === 'confirmation' || appointment?.kind === 'phone' ? (
                 <va-alert

--- a/src/applications/check-in/components/AppointmentBlockWithIcons.jsx
+++ b/src/applications/check-in/components/AppointmentBlockWithIcons.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { locationShouldBeDisplayed } from '../utils/appointment';
 
 const AppointmentBlock = props => {
   const { appointments, page } = props;
@@ -78,20 +79,19 @@ const AppointmentBlock = props => {
                 >
                   {clinic}
                 </div>
-                {appointment?.kind === 'clinic' &&
-                  appointment.clinicLocation && (
-                    <>
-                      <div className="check-in--label vads-u-margin-right--1">
-                        {t('location')}:
-                      </div>
-                      <div
-                        className="check-in--value"
-                        data-testid="clinic-location"
-                      >
-                        {appointment.clinicLocation}
-                      </div>
-                    </>
-                  )}
+                {locationShouldBeDisplayed(appointment) && (
+                  <>
+                    <div className="check-in--label vads-u-margin-right--1">
+                      {t('location')}:
+                    </div>
+                    <div
+                      className="check-in--value"
+                      data-testid="clinic-location"
+                    >
+                      {appointment.clinicLocation}
+                    </div>
+                  </>
+                )}
               </div>
               {page === 'confirmation' || appointment?.kind === 'phone' ? (
                 <va-alert

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentConfirmationListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentConfirmationListItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { locationShouldBeDisplayed } from '../../utils/appointment';
 
 const AppointmentConfirmationListItem = props => {
   const { appointment, index = 0 } = props;
@@ -30,17 +31,16 @@ const AppointmentConfirmationListItem = props => {
         <div className="check-in--value" data-testid="appointment-clinic">
           {clinic}
         </div>
-        {appointment.kind === 'clinic' &&
-          appointment.clinicLocation && (
-            <>
-              <div className="check-in--label vads-u-margin-right--1">
-                {t('location')}:
-              </div>
-              <div className="check-in--value" data-testid="clinic-location">
-                {appointment.clinicLocation}
-              </div>
-            </>
-          )}
+        {locationShouldBeDisplayed(appointment) && (
+          <>
+            <div className="check-in--label vads-u-margin-right--1">
+              {t('location')}:
+            </div>
+            <div className="check-in--value" data-testid="clinic-location">
+              {appointment.clinicLocation}
+            </div>
+          </>
+        )}
       </div>
     </li>
   );

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentConfirmationListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentConfirmationListItem.jsx
@@ -30,16 +30,17 @@ const AppointmentConfirmationListItem = props => {
         <div className="check-in--value" data-testid="appointment-clinic">
           {clinic}
         </div>
-        {appointment.clinicLocation && (
-          <>
-            <div className="check-in--label vads-u-margin-right--1">
-              {t('location')}:
-            </div>
-            <div className="check-in--value" data-testid="clinic-location">
-              {appointment.clinicLocation}
-            </div>
-          </>
-        )}
+        {appointment.kind === 'clinic' &&
+          appointment.clinicLocation && (
+            <>
+              <div className="check-in--label vads-u-margin-right--1">
+                {t('location')}:
+              </div>
+              <div className="check-in--value" data-testid="clinic-location">
+                {appointment.clinicLocation}
+              </div>
+            </>
+          )}
       </div>
     </li>
   );

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { locationShouldBeDisplayed } from '../../utils/appointment';
 import AppointmentLocation from './AppointmentLocation';
 
 import AppointmentAction from './AppointmentAction';
@@ -32,15 +33,14 @@ const AppointmentListItem = props => {
             <span className="item-value" data-testid="clinic-name">
               <AppointmentLocation appointment={appointment} />
             </span>
-            {appointment.kind === 'clinic' &&
-              appointment.clinicLocation && (
-                <>
-                  <span className="item-label">{t('location')}: </span>
-                  <span className="item-value" data-testid="clinic-location">
-                    {appointment.clinicLocation}
-                  </span>
-                </>
-              )}
+            {locationShouldBeDisplayed(appointment) && (
+              <>
+                <span className="item-label">{t('location')}: </span>
+                <span className="item-value" data-testid="clinic-location">
+                  {appointment.clinicLocation}
+                </span>
+              </>
+            )}
           </p>
         </div>
       </div>

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -32,14 +32,15 @@ const AppointmentListItem = props => {
             <span className="item-value" data-testid="clinic-name">
               <AppointmentLocation appointment={appointment} />
             </span>
-            {appointment.clinicLocation && (
-              <>
-                <span className="item-label">{t('location')}: </span>
-                <span className="item-value" data-testid="clinic-location">
-                  {appointment.clinicLocation}
-                </span>
-              </>
-            )}
+            {appointment.kind === 'clinic' &&
+              appointment.clinicLocation && (
+                <>
+                  <span className="item-label">{t('location')}: </span>
+                  <span className="item-value" data-testid="clinic-location">
+                    {appointment.clinicLocation}
+                  </span>
+                </>
+              )}
           </p>
         </div>
       </div>

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
@@ -55,7 +55,7 @@ describe('check-in', () => {
         'Green Team facility',
       );
     });
-    it('should render the appointment location when available', () => {
+    it('should render the appointment location for in-person appointments when available', () => {
       const listItem = render(
         <Provider store={store}>
           <AppointmentListItem
@@ -64,6 +64,7 @@ describe('check-in', () => {
               clinicFriendlyName: 'Green Team Clinic1',
               facility: 'Green Team facility',
               clinicLocation: 'Green Team location',
+              kind: 'clinic',
             }}
           />
         </Provider>,
@@ -74,6 +75,23 @@ describe('check-in', () => {
         'Green Team location',
       );
     });
+    it('should not render the appointment location for phone appointments even if available', () => {
+      const listItem = render(
+        <Provider store={store}>
+          <AppointmentListItem
+            appointment={{
+              startTime: '2021-07-19T13:56:31',
+              clinicFriendlyName: 'Green Team Clinic1',
+              facility: 'Green Team facility',
+              clinicLocation: 'Green Team location',
+              kind: 'phone',
+            }}
+          />
+        </Provider>,
+      );
+
+      expect(listItem.queryByTestId('clinic-location')).to.not.exist;
+    });
     it('should not render the appointment location when not available', () => {
       const listItem = render(
         <Provider store={store}>
@@ -82,6 +100,7 @@ describe('check-in', () => {
               startTime: '2021-07-19T13:56:31',
               clinicFriendlyName: 'Green Team Clinic1',
               facility: 'Green Team facility',
+              kind: 'clinic',
             }}
           />
         </Provider>,

--- a/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import cloneDeep from 'platform/utilities/data/cloneDeep';
 import AppointmentBlock from '../AppointmentBlock';
 import i18n from '../../utils/i18n/i18n';
 
@@ -14,6 +15,7 @@ const appointments = [
     clinicName: 'LOM ACC CLINIC TEST',
     appointmentIen: 'some-ien',
     startTime: '2021-11-16T21:39:36',
+    kind: 'clinic',
   },
   {
     facility: 'LOMA LINDA VA CLINIC',
@@ -22,6 +24,7 @@ const appointments = [
     clinicName: 'LOM ACC CLINIC TEST',
     appointmentIen: 'some-ien2',
     startTime: '2021-11-16T23:00:00',
+    kind: 'clinic',
   },
 ];
 describe('pre-check-in', () => {
@@ -79,8 +82,8 @@ describe('pre-check-in', () => {
       ).to.have.text('LOM ACC CLINIC TEST');
     });
 
-    it('should render the appointment location when available', () => {
-      const locationAppointments = [...appointments];
+    it('should render the appointment location for in person appointments when available', () => {
+      const locationAppointments = cloneDeep(appointments);
       locationAppointments[0].clinicLocation = 'Test location';
       const screen = render(
         <I18nextProvider i18n={i18n}>
@@ -92,6 +95,28 @@ describe('pre-check-in', () => {
           .getAllByTestId('appointment-list-item')[0]
           .querySelector('[data-testid="clinic-location"]'),
       ).to.have.text('Test location');
+      expect(
+        screen
+          .getAllByTestId('appointment-list-item')[1]
+          .querySelector('[data-testid="clinic-location"]'),
+      ).to.not.exist;
+    });
+
+    it('should not render the appointment location for phone appointments even if available', () => {
+      const phoneLocationAppointments = cloneDeep(appointments);
+      phoneLocationAppointments[0].clinicLocation = 'Test location';
+      phoneLocationAppointments[0].kind = 'phone';
+      phoneLocationAppointments[1].kind = 'phone';
+      const screen = render(
+        <I18nextProvider i18n={i18n}>
+          <AppointmentBlock appointments={phoneLocationAppointments} />
+        </I18nextProvider>,
+      );
+      expect(
+        screen
+          .getAllByTestId('appointment-list-item')[0]
+          .querySelector('[data-testid="clinic-location"]'),
+      ).to.not.exist;
       expect(
         screen
           .getAllByTestId('appointment-list-item')[1]

--- a/src/applications/check-in/components/tests/AppointmentBlockWithIcons.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlockWithIcons.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import cloneDeep from 'platform/utilities/data/cloneDeep';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../../utils/i18n/i18n';
 import AppointmentBlockWithIcons from '../AppointmentBlockWithIcons';
@@ -14,6 +15,7 @@ const appointments = [
     clinicName: 'LOM ACC CLINIC TEST',
     appointmentIen: 'some-ien',
     startTime: '2021-11-16T21:39:36',
+    kind: 'clinic',
   },
   {
     facility: 'LOMA LINDA VA CLINIC',
@@ -22,6 +24,7 @@ const appointments = [
     clinicName: 'LOM ACC CLINIC TEST',
     appointmentIen: 'some-ien2',
     startTime: '2021-11-16T23:00:00',
+    kind: 'clinic',
   },
 ];
 describe('pre-check-in', () => {
@@ -216,8 +219,8 @@ describe('pre-check-in', () => {
         );
         expect(screen.queryByTestId('facility-name')).to.not.exist;
       });
-      it('should render the appointment location when available', () => {
-        const locationAppointments = [...appointments];
+      it('should render the appointment location for in person appointments when available', () => {
+        const locationAppointments = cloneDeep(appointments);
         locationAppointments[0].clinicLocation = 'Test location';
         const screen = render(
           <I18nextProvider i18n={i18n}>
@@ -229,6 +232,29 @@ describe('pre-check-in', () => {
             .getAllByTestId('appointment-list-item')[0]
             .querySelector('[data-testid="clinic-location"]'),
         ).to.have.text('Test location');
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[1]
+            .querySelector('[data-testid="clinic-location"]'),
+        ).to.not.exist;
+      });
+      it('should not render the appointment location for phone appointments even when available', () => {
+        const phoneLocationAppointments = cloneDeep(appointments);
+        phoneLocationAppointments[0].clinicLocation = 'Test location';
+        phoneLocationAppointments[0].kind = 'phone';
+        phoneLocationAppointments[1].kind = 'phone';
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlockWithIcons
+              appointments={phoneLocationAppointments}
+            />
+          </I18nextProvider>,
+        );
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="clinic-location"]'),
+        ).to.not.exist;
         expect(
           screen
             .getAllByTestId('appointment-list-item')[1]

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -8,6 +8,7 @@ import {
   sortAppointmentsByStartTime,
   removeTimeZone,
   preCheckinExpired,
+  locationShouldBeDisplayed,
 } from './index';
 
 import { get } from '../../api/local-mock-api/mocks/v2/shared';
@@ -248,6 +249,39 @@ describe('check in', () => {
           delete appointments[idx].checkInSteps;
         });
         expect(preCheckinAlreadyCompleted(appointments)).to.deep.equal(false);
+      });
+    });
+    describe('locationShouldBeDisplayed', () => {
+      it('returns true for in-person appointments with content in the location field', () => {
+        const appointment = createAppointment();
+        expect(locationShouldBeDisplayed(appointment)).to.deep.equal(true);
+      });
+      it('returns false for in-person appointments without content in the location field', () => {
+        const appointment = createAppointment();
+        appointment.clinicLocation = '';
+        expect(locationShouldBeDisplayed(appointment)).to.deep.equal(false);
+      });
+      it('returns false for in-person appointments without the location field', () => {
+        const appointment = createAppointment();
+        delete appointment.clinicLocation;
+        expect(locationShouldBeDisplayed(appointment)).to.deep.equal(false);
+      });
+      it('returns false for phone appointments with the location field', () => {
+        const appointment = createAppointment();
+        appointment.kind = 'phone';
+        expect(locationShouldBeDisplayed(appointment)).to.deep.equal(false);
+      });
+      it('returns false for phone appointments without content in the location field', () => {
+        const appointment = createAppointment();
+        appointment.kind = 'phone';
+        appointment.clinicLocation = '';
+        expect(locationShouldBeDisplayed(appointment)).to.deep.equal(false);
+      });
+      it('returns false for phone appointments without the location field', () => {
+        const appointment = createAppointment();
+        appointment.kind = 'phone';
+        delete appointment.clinicLocation;
+        expect(locationShouldBeDisplayed(appointment)).to.deep.equal(false);
       });
     });
     describe('sortAppointmentsByStartTime', () => {

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -44,6 +44,7 @@ const appointmentWasCanceled = appointments => {
 
   return Array.isArray(appointments) && appointments.some(statusIsCanceled);
 };
+
 /**
  * Return the first cancelled appointment.
  *
@@ -117,7 +118,11 @@ const preCheckinAlreadyCompleted = appointments => {
  * @returns {boolean}
  */
 const locationShouldBeDisplayed = appointment => {
-  return appointment.kind === 'clinic' && Boolean(appointment.clinicLocation);
+  const notEmpty = location => {
+    return typeof location === 'string' && location.length > 0;
+  };
+
+  return appointment.kind === 'clinic' && notEmpty(appointment.clinicLocation);
 };
 
 /**

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -111,6 +111,16 @@ const preCheckinAlreadyCompleted = appointments => {
 };
 
 /**
+ * Determine whether the physical location should be displayed for the given appointment.
+ *
+ * @param {Appointment} appointment
+ * @returns {boolean}
+ */
+const locationShouldBeDisplayed = appointment => {
+  return appointment.kind === 'clinic' && Boolean(appointment.clinicLocation);
+};
+
+/**
  * @param {Array<Appointment>} appointments
  */
 const sortAppointmentsByStartTime = appointments => {
@@ -173,6 +183,7 @@ export {
   getFirstCanceledAppointment,
   hasMoreAppointmentsToCheckInto,
   intervalUntilNextAppointmentIneligibleForCheckin,
+  locationShouldBeDisplayed,
   sortAppointmentsByStartTime,
   preCheckinAlreadyCompleted,
   removeTimeZone,


### PR DESCRIPTION
## Description

The location field should not be shown for phone appointments. This PR limits the location to only be shown when the appointment kind is "clinic".

## Original issue(s)

department-of-veterans-affairs/va.gov-team#54344


## Testing done
- manual testing
- added unit tests

## Screenshots

day-of checkin:

![Screen Shot 2022-08-05 at 13 47 24](https://user-images.githubusercontent.com/101649/183150360-bc5c8031-ddbd-4fcb-a6be-c3cc0011fc03.png)

pre-checkin, phone appointment:

![Screen Shot 2022-08-05 at 13 48 06](https://user-images.githubusercontent.com/101649/183150400-7c2850fc-5d44-45b8-ac0e-49f33673a14d.png)
![Screen Shot 2022-08-05 at 13 47 52](https://user-images.githubusercontent.com/101649/183150404-206f8d43-d953-4857-9970-30bd5d60672c.png)

pre-checkin, in-person appointment:

![Screen Shot 2022-08-05 at 13 48 44](https://user-images.githubusercontent.com/101649/183150438-d483aa4b-2310-4400-8401-7488c4484529.png)
![Screen Shot 2022-08-05 at 13 48 33](https://user-images.githubusercontent.com/101649/183150439-6f49322a-2d41-4073-a6a7-814366331b74.png)


## Acceptance criteria
- [ ] location field is not shown for phone appointments
- [ ] location field is still shown for in-person appointments

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
