### PR TITLE
COE | Download link has no `href`

### DIFF
--- a/src/applications/lgy/coe/shared/actions/index.js
+++ b/src/applications/lgy/coe/shared/actions/index.js
@@ -47,7 +47,7 @@ export const generateCoe = (skip = '') => async dispatch => {
         status === COE_ELIGIBILITY_STATUS.eligible
       ) {
         const res = await getCoeURL();
-        if (res.errors.length) {
+        if (res.errors?.length) {
           dispatch({ type: GET_COE_URL_FAILED, response: res });
         } else {
           dispatch({ type: GET_COE_URL_SUCCEEDED, response: res });


### PR DESCRIPTION
## Original Issue(s)
https://github.com/department-of-veterans-affairs/vets-website/issues/21864

## URL of fix
[COE Status Page](http://localhost:3001/housing-assistance/home-loans/check-coe-status/your-coe)

## Expected behavior
When the COE status is `AVAILABLE` or `ELIGIBLE` the veteran should be provided with a link to download their COE. This link should point to a URL to download the COE from.

## Current behavior
When the COE status is `AVAILABLE` or `ELIGIBLE` the veteran is provided with a link to download their COE. This link doesn't point to anything

## Your fix
The action creator that calls the `v0/coe/download_coe` endpoint checks for `response.errors.length`. If there are no issues, `response` should not have an `errors` object. Because `errors` is sometimes defined `.length` causes an error and neither the success or the failure actions can be called. Checking `response.errors?.length` instead fixes this .

## How has this been tested?
Tested manually. Tests still pass


## Acceptance criteria
- [x] COE Download link has a valid `href`
