### PR TITLE
CDP - Statement Charges - Add Regex Replace for &NBSP

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/StatementCharges.jsx
@@ -17,7 +17,7 @@ const StatementCharges = ({ copay }) => {
           .replace('-', '')
           .replace(/[^\d.-]/g, '')}`}
       >
-        <span>{item.pDTransDescOutput.replace('&nbsp', '')}</span>
+        <span>{item.pDTransDescOutput.replace(/&nbsp;/g, '')}</span>
         <span>{item.pDRefNo}</span>
         <span>
           $


### PR DESCRIPTION
## Description
Fix pesky &nbsp bug once and for all per convo with Megan by adding regex replace for specific breakage.
![image](https://user-images.githubusercontent.com/29178824/183479371-03032815-0e4f-4360-be0d-b6e0681df4d6.png)

## Screenshots
![image](https://user-images.githubusercontent.com/29178824/183479130-1f86fe44-d50b-4808-93c7-d8c694b854e2.png)

## Acceptance criteria
- [ X ] No longer rendering nonbreaking space character.

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
