### PR TITLE
Add logging to HCA for future discharge dates

### DIFF
--- a/src/applications/hca/helpers.js
+++ b/src/applications/hca/helpers.js
@@ -1,9 +1,10 @@
 import mapValues from 'lodash/mapValues';
 import * as Sentry from '@sentry/browser';
-import set from 'platform/utilities/data/set';
 import moment from 'moment';
 import vaMedicalFacilities from 'vets-json-schema/dist/vaMedicalFacilities.json';
 
+import set from 'platform/utilities/data/set';
+import recordEvent from 'platform/monitoring/record-event';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import {
@@ -239,6 +240,18 @@ export function transform(formConfig, form) {
   // Log, using Sentry, when user is not logged in and is missing veteran name, ssn or dob
   if (form.data['view:isLoggedIn'] === false) {
     LogToSentry(withoutViewFields);
+  }
+
+  // use logging to track volume of forms submitted with future discharge dates
+  if (
+    form.data.lastDischargeDate &&
+    moment(form.data.lastDischargeDate, 'YYYY-MM-DD').isAfter(
+      moment().endOf('day'),
+    )
+  ) {
+    recordEvent({
+      event: 'hca-future-discharge-date-submission',
+    });
   }
 
   return JSON.stringify({


### PR DESCRIPTION
## Description
Our product owners have requested, for the Health care application, we start logging how many veterans are applying for health care with a future discharge date. There is stakeholder request for functionality down the line that will directly affect those who are putting in that value and our product owner would like to gauge how often that is currently happening. This PR adds in GA logging for such cases.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43544

## Acceptance criteria
- [ ] GA successfully logs this event when the discharge date is listed past the current date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
