### PR TITLE
feat: bumping vafsc version to latest 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.2.2",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "0.0.8",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.1.1",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@formatjs/intl-datetimeformat": "^4.2.3",
     "@formatjs/intl-getcanonicallocales": "^1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,10 +2563,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-0.0.8.tgz#8ebc24177410cdae18d7b93afecd5c16cd46e2c5"
-  integrity sha512-atwnMJuat2rzX0DyFqVI43aUEc/jaodoKoAb6WSRC5LIVNo8dWa3uPa6d71NlTky2kB7umqHVuoc7gLocqwCBw==
+"@department-of-veterans-affairs/va-forms-system-core@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.1.1.tgz#c6376899f19f054edd63f6ee9de076009c10187e"
+  integrity sha512-fnbwHYUDsQIM7TXdsRYr/AsMdrdmulmD72gq6OT+DFrHDfmMG2n6YAH8LhomOMpdZh2aDJa5tNChIV9r5TgZyg==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"


### PR DESCRIPTION
## Description
Upgrade version to the latest version of the va-forms-system-core@1.1.1.

## Testing done
- [x] All Unit Tests Pass

## Acceptance criteria
- [x] All Tests passing as expected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
