### PR TITLE
(chore) update api urls

### DIFF
--- a/src/applications/personalization/appointments/actions/index.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/index.unit.spec.js
@@ -385,13 +385,13 @@ const mockFacilityData = {
   },
   links: {
     self:
-      'https://staging-api.va.gov/v1/facilities/va?ids=vha_442&page=1&per_page=10',
+      'https://staging-platform-api.va.gov/v1/facilities/va?ids=vha_442&page=1&per_page=10',
     first:
-      'https://staging-api.va.gov/v1/facilities/va?ids=vha_442&per_page=10',
+      'https://staging-platform-api.va.gov/v1/facilities/va?ids=vha_442&per_page=10',
     prev: null,
     next: null,
     last:
-      'https://staging-api.va.gov/v1/facilities/va?ids=vha_442&page=1&per_page=10',
+      'https://staging-platform-api.va.gov/v1/facilities/va?ids=vha_442&page=1&per_page=10',
   },
 };
 

--- a/src/applications/personalization/dashboard/utils/mocks/appointments/MOCK_FACILITIES.json
+++ b/src/applications/personalization/dashboard/utils/mocks/appointments/MOCK_FACILITIES.json
@@ -261,10 +261,10 @@
     }
   },
   "links": {
-    "self": "https://api.va.gov/v1/facilities/va?ids=vha_442GC%2Cvha_442&page=1&per_page=10",
-    "first": "https://api.va.gov/v1/facilities/va?ids=vha_442GC%2Cvha_442&per_page=10",
+    "self": "https://platform-api.va.gov/v1/facilities/va?ids=vha_442GC%2Cvha_442&page=1&per_page=10",
+    "first": "https://platform-api.va.gov/v1/facilities/va?ids=vha_442GC%2Cvha_442&per_page=10",
     "prev": null,
     "next": null,
-    "last": "https://api.va.gov/v1/facilities/va?ids=vha_442GC%2Cvha_442&page=1&per_page=10"
+    "last": "https://platform-api.va.gov/v1/facilities/va?ids=vha_442GC%2Cvha_442&page=1&per_page=10"
   }
 }

--- a/src/applications/personalization/dashboard/utils/mocks/messaging/folder.js
+++ b/src/applications/personalization/dashboard/utils/mocks/messaging/folder.js
@@ -9,6 +9,8 @@ export const mockFolderResponse = {
       unreadCount: 3,
       systemFolder: false,
     },
-    links: { self: 'https://staging-api.va.gov/v0/messaging/health/folders/0' },
+    links: {
+      self: 'https://staging-platform-api.va.gov/v0/messaging/health/folders/0',
+    },
   },
 };

--- a/src/applications/personalization/dashboard/utils/mocks/messaging/messages.js
+++ b/src/applications/personalization/dashboard/utils/mocks/messaging/messages.js
@@ -17,7 +17,8 @@ export const mockMessagesResponse = {
         readReceipt: null,
       },
       links: {
-        self: 'https://staging-api.va.gov/v0/messaging/health/messages/1412070',
+        self:
+          'https://staging-platform-api.va.gov/v0/messaging/health/messages/1412070',
       },
     },
     {
@@ -37,7 +38,8 @@ export const mockMessagesResponse = {
         readReceipt: null,
       },
       links: {
-        self: 'https://staging-api.va.gov/v0/messaging/health/messages/1412061',
+        self:
+          'https://staging-platform-api.va.gov/v0/messaging/health/messages/1412061',
       },
     },
     {
@@ -57,19 +59,20 @@ export const mockMessagesResponse = {
         readReceipt: null,
       },
       links: {
-        self: 'https://staging-api.va.gov/v0/messaging/health/messages/1412052',
+        self:
+          'https://staging-platform-api.va.gov/v0/messaging/health/messages/1412052',
       },
     },
   ],
   links: {
     self:
-      'https://staging-api.va.gov/v0/messaging/health/folders/0/messages?page=1&sort=-sent_date',
+      'https://staging-platform-api.va.gov/v0/messaging/health/folders/0/messages?page=1&sort=-sent_date',
     first:
-      'https://staging-api.va.gov/v0/messaging/health/folders/0/messages?page=1&per_page=10&sort=-sent_date',
+      'https://staging-platform-api.va.gov/v0/messaging/health/folders/0/messages?page=1&per_page=10&sort=-sent_date',
     prev: null,
     next: null,
     last:
-      'https://staging-api.va.gov/v0/messaging/health/folders/0/messages?page=1&per_page=10&sort=-sent_date',
+      'https://staging-platform-api.va.gov/v0/messaging/health/folders/0/messages?page=1&per_page=10&sort=-sent_date',
   },
   meta: {
     sort: { sentDate: 'DESC' },


### PR DESCRIPTION
## Description
Updates some minor mock data objects to use the upcoming api url naming. This isn't really used for any particular test assertions, but want to make sure that in the future any possible tests would still work if needing this data.

## Original issue(s)
N/A basically just a hotfix

## Testing done
All unit and E2E tests passing

## Acceptance criteria
- [x] urls updated

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
