### PR TITLE
domain added to whitelist

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -180,6 +180,16 @@
       "hostname": "www.volunteer.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": true
+    },
+    {
+      "hostname": "m.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "www.m.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
     }
   ]
 }


### PR DESCRIPTION
## Description
Added m.va.gov domains to allow lists

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9870

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
