### PR TITLE
Fry/DEA: Update Logic and Text for Eligibility Cards

### DIFF
--- a/src/applications/fry-dea/components/FryDeaEligibilityCards.jsx
+++ b/src/applications/fry-dea/components/FryDeaEligibilityCards.jsx
@@ -1,10 +1,33 @@
 import React from 'react';
 import { connect } from 'react-redux';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
-// import { VETERANS_TYPE , VETERAN_NOT_LISTED_VALUE } from '../constants';
+import {
+  formFields,
+  VETERANS_TYPE,
+  VETERAN_NOT_LISTED_VALUE,
+} from '../constants';
 
-function FryDeaEligibilityCards(/* { selectedVeteran, veterans } */) {
+const eligibleMessage = (
+  <p>
+    <i
+      className="fas fa-check-circle fry-dea-benefit-selection-icon"
+      aria-hidden="true"
+    />{' '}
+    You may be eligible for this benefit
+  </p>
+);
+const notEligibleMessage = (
+  <p>
+    <i
+      className="fas fa-exclamation-circle vads-u-margin-right--1"
+      aria-hidden="true"
+    />{' '}
+    You’re not eligible for this benefit
+  </p>
+);
+
+function FryDeaEligibilityCards({ selectedVeteran, veterans }) {
   // if (
   //   !veterans ||
   //   !selectedVeteran ||
@@ -13,7 +36,10 @@ function FryDeaEligibilityCards(/* { selectedVeteran, veterans } */) {
   //   return <></>;
   // }
 
-  // const veteran = veterans.find(v => v.id === selectedVeteran);
+  const veteran =
+    selectedVeteran && selectedVeteran !== VETERAN_NOT_LISTED_VALUE
+      ? veterans.find(v => v.id === selectedVeteran)
+      : null;
 
   return (
     <>
@@ -33,13 +59,8 @@ function FryDeaEligibilityCards(/* { selectedVeteran, veterans } */) {
           Fry Scholarship
         </h4>
 
-        <p>
-          <i
-            className="fas fa-check-circle fry-dea-benefit-selection-icon"
-            aria-hidden="true"
-          />
-          You may be eligible for this benefit
-        </p>
+        {veteran &&
+          (veteran.fryEligibility ? eligibleMessage : notEligibleMessage)}
 
         <h4 className="vads-u-font-size--h5 vads-u-margin-top--0 vads-u-margin-bottom--2">
           Receive up to 36 months of benefits, including:
@@ -92,13 +113,8 @@ function FryDeaEligibilityCards(/* { selectedVeteran, veterans } */) {
           Survivors’ and Dependents’ Educational Assistance
         </h4>
 
-        <p>
-          <i
-            className="fas fa-check-circle vads-u-margin-right--1"
-            aria-hidden="true"
-          />
-          You may be eligible for this benefit
-        </p>
+        {veteran &&
+          (veteran.deaEligibility ? eligibleMessage : notEligibleMessage)}
 
         <h4 className="vads-u-font-size--h5 vads-u-margin-bottom--2">
           Receive up to 36 months of benefits, including:
@@ -125,8 +141,14 @@ function FryDeaEligibilityCards(/* { selectedVeteran, veterans } */) {
 }
 
 FryDeaEligibilityCards.propTypes = {
-  // selectedVeteran: PropTypes.string,
-  // veterans: VETERANS_TYPE,
+  selectedVeteran: PropTypes.string,
+  veterans: VETERANS_TYPE,
 };
 
-export default connect()(FryDeaEligibilityCards);
+const mapStateToProps = state => ({
+  selectedVeteran: state.form?.data[formFields.selectedVeteran],
+  formData: state.form?.data || {},
+  veterans: state.form?.data?.veterans,
+});
+
+export default connect(mapStateToProps)(FryDeaEligibilityCards);

--- a/src/applications/fry-dea/config/form.js
+++ b/src/applications/fry-dea/config/form.js
@@ -42,7 +42,7 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
 import {
-  ELIGIBILITY,
+  // ELIGIBILITY,
   formFields,
   RELATIONSHIP,
   VETERAN_NOT_LISTED_VALUE,
@@ -72,7 +72,7 @@ const checkImageSrc = environment.isStaging()
   ? `${VAGOVSTAGING}/img/check-sample.png`
   : `${vagovprod}/img/check-sample.png`;
 
-const BENEFITS = [ELIGIBILITY.FRY, ELIGIBILITY.DEA];
+// const BENEFITS = [ELIGIBILITY.FRY, ELIGIBILITY.DEA];
 
 function isValidName(str) {
   return str && /^[A-Za-z][A-Za-z ']*$/.test(str);
@@ -438,9 +438,9 @@ const formConfig = {
         benefitSelection: {
           title: 'Benefit Selection',
           path: 'benefit-selection',
-          depends: formData =>
-            formData.veterans?.length &&
-            formData[formFields.selectedVeteran] !== VETERAN_NOT_LISTED_VALUE,
+          // depends: formData =>
+          //   formData.veterans?.length &&
+          //   formData[formFields.selectedVeteran] !== VETERAN_NOT_LISTED_VALUE,
           uiSchema: {
             'view:benefitSelectionHeaderInfo': {
               'ui:description': (
@@ -509,27 +509,27 @@ const formConfig = {
                   fry: { 'aria-describedby': 'fry' },
                   dea: { 'aria-describedby': 'dea' },
                 },
-                updateSchema: (() => {
-                  const filterBenefits = createSelector(
-                    state => state,
-                    formData => {
-                      const veteran = formData?.veterans?.find(
-                        v => v.id === formData[formFields.selectedVeteran],
-                      );
+                // updateSchema: (() => {
+                //   const filterBenefits = createSelector(
+                //     state => state,
+                //     formData => {
+                //       const veteran = formData?.veterans?.find(
+                //         v => v.id === formData[formFields.selectedVeteran],
+                //       );
 
-                      return {
-                        enum: BENEFITS.filter(
-                          benefit =>
-                            (benefit === ELIGIBILITY.FRY &&
-                              veteran?.fryEligibility) ||
-                            (benefit === ELIGIBILITY.DEA &&
-                              veteran?.deaEligibility),
-                        ),
-                      };
-                    },
-                  );
-                  return (form, state) => filterBenefits(form, state);
-                })(),
+                //       return {
+                //         enum: BENEFITS.filter(
+                //           benefit =>
+                //             (benefit === ELIGIBILITY.FRY &&
+                //               veteran?.fryEligibility) ||
+                //             (benefit === ELIGIBILITY.DEA &&
+                //               veteran?.deaEligibility),
+                //         ),
+                //       };
+                //     },
+                //   );
+                //   return (form, state) => filterBenefits(form, state);
+                // })(),
               },
             },
           },


### PR DESCRIPTION
## Description
Update the logic for when the Fry/DEA Eligibility Cards should be displayed, always display both benefits to select even if we don't think they're eligible, and conditionally show (not) eligible text.

## Screenshots
![image](https://user-images.githubusercontent.com/112403/183515472-63edf489-7454-4bc1-a89a-24dbfc1255e0.png)
