### PR TITLE
Update last full deploy check

### DIFF
--- a/script/github-actions/check-deployability.js
+++ b/script/github-actions/check-deployability.js
@@ -96,7 +96,7 @@ const isAncestor = (commitA, commitB) => {
  */
 const isAheadOfLastFullDeploy = async (commitSha, env) => {
   const lastFullDeployCommitSha = await getLastFullDeployCommit(env);
-  return isAncestor(commitSha, lastFullDeployCommitSha);
+  return isAncestor(lastFullDeployCommitSha, commitSha);
 };
 
 /**
@@ -108,8 +108,9 @@ const isAheadOfLastFullDeploy = async (commitSha, env) => {
  */
 const isDeployableToEnv = async (commitSha, env) => {
   const TIMEOUT = 5; // Number of minutes to wait before checking again
+  const isNewerCommit = await isAheadOfLastFullDeploy(commitSha, env);
 
-  if (!(await isAheadOfLastFullDeploy(commitSha, env))) {
+  if (!isNewerCommit) {
     console.log(
       `Commit is older than the last full deploy of ${env}. Skipping deploy.`,
     );
@@ -143,8 +144,12 @@ const isDeployableToEnv = async (commitSha, env) => {
  */
 const isDeployableToProd = async commitSha => {
   const TIMEOUT = 10; // Number of minutes to wait before checking again
+  const isNewerCommit = await isAheadOfLastFullDeploy(
+    commitSha,
+    ENVIRONMENTS.VAGOVPROD,
+  );
 
-  if (!(await isAheadOfLastFullDeploy(commitSha, ENVIRONMENTS.VAGOVPROD))) {
+  if (!isNewerCommit) {
     console.log(
       `Commit is older than the last full deploy of ${
         ENVIRONMENTS.VAGOVPROD

--- a/script/github-actions/check-deployability.js
+++ b/script/github-actions/check-deployability.js
@@ -169,7 +169,7 @@ const isDeployableToProd = async commitSha => {
 
   // Don't deploy isolated app commits that are older than the daily deploy
   // commit. The daily deploy will include the changes from the older commit.
-  const isAheadOfDailyDeploy = isAncestor(commitSha, dailyDeploySha);
+  const isAheadOfDailyDeploy = isAncestor(dailyDeploySha, commitSha);
 
   if (!isAheadOfDailyDeploy) {
     console.log(

--- a/script/github-actions/check-deployability.js
+++ b/script/github-actions/check-deployability.js
@@ -173,7 +173,7 @@ const isDeployableToProd = async commitSha => {
 
   if (!isAheadOfDailyDeploy) {
     console.log(
-      'Daily Production Deploy is already running with a newer commit. Skipping isolated app deploy.',
+      `Daily Production Deploy is currently deploying a newer commit (${dailyDeploySha}). Skipping isolated app deploy.`,
     );
     return false;
   }


### PR DESCRIPTION
## Description
The check for the last full deploy commit needs to be updated to correctly check if the right sha is an ancestor.

## Acceptance criteria
- [x] `isAheadOfLastFullDeploy` correctly checks if the commit to be deployed is a descendant of the last full deploy commit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
