### PR TITLE
Fixes minor bug in SessionTimeoutModal

### DIFF
--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -52,7 +52,11 @@ class SessionTimeoutModal extends React.Component {
   expireSession = () => {
     recordEvent({ event: 'logout-session-expired' });
     teardownProfileSession();
-    window.location = logoutUrlSiS();
+    if (!this.props.authenticatedWithOAuth) {
+      IAMLogout();
+    } else {
+      window.location = logoutUrlSiS();
+    }
   };
 
   extendSession = () => {


### PR DESCRIPTION
## Description
This PR addresses and fixes a minor bug found in the `expireSession` method in which the redirect is not conditionalized and essentially redirects to the wrong URL causing Sentry to freak out because of "missing tokens" that were never issued to it.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#45471

## Testing done
Unit

## Screenshots
N/a

## Acceptance criteria
- [ ] The `expireSession` method is called conditionally depending on the `authBroker`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
