### PR TITLE
added analytics tracking for 1095B form option radio buttons

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -18,6 +18,7 @@ import {
   radioOptions,
   radioOptionsAriaLabels,
   radioLabel,
+  dateOptions,
 } from './utils';
 
 export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
@@ -29,15 +30,6 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
     downloaded: false,
     timeStamp: '',
   });
-
-  const dateOptions = {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    hour12: true,
-  };
 
   const getContent = () => {
     return apiRequest(`/form1095_bs/download_${formType}/${year}`)

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -113,15 +113,7 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
       name="1095-download-options"
       label={radioLabel}
       options={radioOptions}
-      onValueChange={({ value }) => {
-        updateFormType(value);
-        recordEvent({
-          event: 'int-radio-button-option-click',
-          'radio-button-label':
-            'Choose your file format and download your document',
-          'radio-button-option-click-label': value,
-        });
-      }}
+      onValueChange={({ value }) => updateFormType(value)}
       value={{ value: formType }}
       ariaDescribedby={radioOptionsAriaLabels}
       additionalFieldsetClass="vads-u-margin-top--0"
@@ -133,6 +125,12 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
       <button
         className="usa-button-primary va-button"
         onClick={function() {
+          recordEvent({
+            event: 'int-radio-button-option-click',
+            'radio-button-label':
+              'Choose your file format and download your document',
+            'radio-button-option-click-label': `${formType} 1095B downloaded`,
+          });
           callGetContent();
         }}
         id="download-url"

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -8,10 +8,10 @@ import { connect } from 'react-redux';
 import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
 import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
+import recordEvent from '~/platform/monitoring/record-event';
 
 import {
   notFoundComponent,
@@ -121,7 +121,15 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
       name="1095-download-options"
       label={radioLabel}
       options={radioOptions}
-      onValueChange={({ value }) => updateFormType(value)}
+      onValueChange={({ value }) => {
+        updateFormType(value);
+        recordEvent({
+          event: 'int-radio-button-option-click',
+          'radio-button-label':
+            'Choose your file format and download your document',
+          'radio-button-option-click-label': value,
+        });
+      }}
       value={{ value: formType }}
       ariaDescribedby={radioOptionsAriaLabels}
       additionalFieldsetClass="vads-u-margin-top--0"

--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -1,5 +1,14 @@
 import React from 'react';
 
+export const dateOptions = {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  hour12: true,
+};
+
 export const radioOptions = [
   { label: 'Option 1: PDF document (best for printing)', value: 'pdf' },
   {


### PR DESCRIPTION
## Description
Added event recording for the 1095-B form option selection radio button


## Original issue(s)
department-of-veterans-affairs/va.gov-team#44810


## Testing done


## Acceptance criteria
- [x] changes in the radio button selection are recorded in analytics

## Definition of done
- [x] Events are logged appropriately
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
