### PR TITLE
add tests fix missing phoneType, remove unused phone fields

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
@@ -38,7 +38,6 @@ import {
   selectVAPContactInfoField,
   selectVAPServiceTransaction,
   selectEditViewData,
-  selectTransactionIntervalId,
 } from '@@vap-svc/selectors';
 
 import { transformInitialFormValues } from '@@profile/util/contact-information/formValues';
@@ -413,7 +412,6 @@ export const mapStateToProps = (state, ownProps) => {
     transactionRequest,
     editViewData: selectEditViewData(state),
     emptyMailingAddress: isEmptyAddress(mailingAddress),
-    transactionId: selectTransactionIntervalId(state),
   };
 };
 

--- a/src/applications/personalization/profile/hooks/useProfileTransaction.js
+++ b/src/applications/personalization/profile/hooks/useProfileTransaction.js
@@ -123,7 +123,7 @@ const useProfileTransaction = fieldName => {
     let payload = value;
 
     if (convertCleanDataToPayload) {
-      payload = convertCleanDataToPayload(payload);
+      payload = convertCleanDataToPayload(payload, fieldName);
     }
 
     const method = payload?.id ? 'PUT' : 'POST';

--- a/src/applications/personalization/profile/tests/hooks/useProfileTransaction.spec.js
+++ b/src/applications/personalization/profile/tests/hooks/useProfileTransaction.spec.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { expect } from 'chai';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
+
+import * as VAP_SERVICE from 'platform/user/profile/vap-svc/constants';
+import {
+  phoneFormSchema,
+  phoneUiSchema,
+} from '../../util/contact-information/phoneUtils';
+
+import { renderWithProfileReducers as render } from '../unit-test-helpers';
+import useProfileTransaction from '../../hooks/useProfileTransaction';
+
+const initialState = {
+  vapService: {
+    hasUnsavedEdits: true,
+    modal: 'homePhone',
+    modalData: null,
+    formFields: {
+      homePhone: {
+        value: {
+          areaCode: '',
+          countryCode: '',
+          extension: '',
+          inputPhoneNumber: '',
+          isInternational: false,
+          phoneNumber: '',
+        },
+      },
+    },
+    transactions: [],
+    fieldTransactionMap: {
+      homePhone: {
+        isPending: false,
+        method: 'POST',
+        isFailed: true,
+        error: {},
+      },
+    },
+    transactionsAwaitingUpdate: [],
+  },
+};
+
+const setup = () => {
+  mockFetch();
+  setFetchJSONResponse(global.fetch.onFirstCall(), {
+    data: {
+      attributes: {},
+    },
+  });
+};
+
+function setupTestComponent(...args) {
+  const returnVal = {};
+  function TestComponent() {
+    Object.assign(returnVal, useProfileTransaction(...args));
+    return null;
+  }
+  render(<TestComponent />, { initialState });
+  return returnVal;
+}
+
+describe('useProfileTransaction hook', () => {
+  beforeEach(() => {
+    setup();
+  });
+
+  describe('basic state and field info for each VAP_SERVICE field', () => {
+    Object.values(VAP_SERVICE.FIELD_NAMES).forEach(fieldName => {
+      it(`should return loading, analyticsSectionName, and title for ${fieldName}`, () => {
+        const result = setupTestComponent(fieldName);
+
+        expect(result.isLoading).to.be.false;
+        expect(result.analyticsSectionName).to.be.equal(
+          VAP_SERVICE.ANALYTICS_FIELD_MAP[fieldName],
+        );
+        expect(result.title).to.be.equal(VAP_SERVICE.FIELD_TITLES[fieldName]);
+      });
+    });
+  });
+
+  describe('Home Phone specific tests', () => {
+    it('should return appropriate formSchema and uiSchema for legacy form system', () => {
+      const fieldName = VAP_SERVICE.FIELD_NAMES.HOME_PHONE;
+      const result = setupTestComponent(fieldName);
+
+      expect(result.formSchema).to.deep.equal(phoneFormSchema);
+      expect(result.uiSchema).to.deep.equal(
+        phoneUiSchema(VAP_SERVICE.FIELD_TITLES[fieldName]),
+      );
+    });
+
+    it('should POST when existing record id is not present', () => {
+      const fieldName = VAP_SERVICE.FIELD_NAMES.HOME_PHONE;
+      const result = setupTestComponent(fieldName);
+
+      expect(result.isLoading).to.be.false;
+
+      act(() => {
+        result.startTransaction({
+          inputPhoneNumber: '123456789',
+          extension: '000',
+        });
+      });
+
+      expect(result.isLoading).to.be.true;
+      expect(global.fetch.firstCall.args[1].method).to.equal('POST');
+    });
+
+    it('should PUT when existing record id is present anbd include id in fetch', () => {
+      const fieldName = VAP_SERVICE.FIELD_NAMES.HOME_PHONE;
+      const result = setupTestComponent(fieldName);
+
+      expect(result.isLoading).to.be.false;
+
+      act(() => {
+        result.startTransaction({
+          inputPhoneNumber: '123456789',
+          extension: '000',
+          id: '111',
+        });
+      });
+
+      expect(result.isLoading).to.be.true;
+
+      const fetchOptions = global.fetch.firstCall.args[1];
+      const body = JSON.parse(fetchOptions.body);
+
+      expect(fetchOptions.method).to.equal('PUT');
+      expect(body.id).to.equal('111');
+    });
+
+    it('should fetch with correct request body data to correct endpoint', () => {
+      const fieldName = VAP_SERVICE.FIELD_NAMES.HOME_PHONE;
+      const result = setupTestComponent(fieldName);
+
+      expect(result.isLoading).to.be.false;
+
+      act(() => {
+        result.startTransaction({
+          inputPhoneNumber: '123456789',
+          extension: '000',
+        });
+      });
+
+      expect(result.isLoading).to.be.true;
+
+      const [url, fetchOptions] = global.fetch.firstCall.args;
+      const body = JSON.parse(fetchOptions.body);
+
+      expect(url.endsWith('profile/telephones')).to.be.true;
+      expect(body.areaCode).to.equal('123');
+      expect(body.extension).to.equal('000');
+      expect(body.phoneNumber).to.equal('456789');
+      expect(body.phoneType).to.equal(VAP_SERVICE.PHONE_TYPE[fieldName]);
+    });
+  });
+});

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -10,9 +10,8 @@ import {
   USA,
 } from '@@vap-svc/constants';
 
-import PhoneNumberWidget from '~/platform/forms-system/src/js/widgets/PhoneNumberWidget';
-
 import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
+import PhoneNumberWidget from '~/platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
 import PhoneEditModal from './PhoneEditModal';
 import PhoneView from './PhoneView';
@@ -61,7 +60,6 @@ export default class PhoneField extends React.Component {
     fieldName: PropTypes.oneOf([
       FIELD_NAMES.HOME_PHONE,
       FIELD_NAMES.MOBILE_PHONE,
-      FIELD_NAMES.TEMP_PHONE,
       FIELD_NAMES.WORK_PHONE,
       FIELD_NAMES.FAX_NUMBER,
     ]).isRequired,

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -90,8 +90,6 @@ export const FIELD_NAMES = {
   HOME_PHONE: 'homePhone',
   MOBILE_PHONE: 'mobilePhone',
   WORK_PHONE: 'workPhone',
-  TEMP_PHONE: 'temporaryPhone',
-  FAX_NUMBER: 'faxNumber',
   EMAIL: 'email',
   MAILING_ADDRESS: 'mailingAddress',
   RESIDENTIAL_ADDRESS: 'residentialAddress',
@@ -105,8 +103,6 @@ export const FIELD_TITLES = {
   [FIELD_NAMES.HOME_PHONE]: 'Home phone number',
   [FIELD_NAMES.MOBILE_PHONE]: 'Mobile phone number',
   [FIELD_NAMES.WORK_PHONE]: 'Work phone number',
-  [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
-  [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
   [FIELD_NAMES.EMAIL]: 'Contact email address',
   [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',
@@ -129,8 +125,6 @@ export const FIELD_IDS = {
   [FIELD_NAMES.HOME_PHONE]: 'home-phone-number',
   [FIELD_NAMES.MOBILE_PHONE]: 'mobile-phone-number',
   [FIELD_NAMES.WORK_PHONE]: 'work-phone-number',
-  [FIELD_NAMES.TEMP_PHONE]: 'temporary-phone-number',
-  [FIELD_NAMES.FAX_NUMBER]: 'fax-number',
   [FIELD_NAMES.EMAIL]: 'contact-email-address',
   [FIELD_NAMES.MAILING_ADDRESS]: 'mailing-address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'home-address',
@@ -140,8 +134,6 @@ export const FIELD_IDS = {
 export const PHONE_TYPE = {
   [FIELD_NAMES.MOBILE_PHONE]: 'MOBILE',
   [FIELD_NAMES.WORK_PHONE]: 'WORK',
-  [FIELD_NAMES.TEMP_PHONE]: 'TEMPORARY',
-  [FIELD_NAMES.FAX_NUMBER]: 'FAX',
   [FIELD_NAMES.HOME_PHONE]: 'HOME',
 };
 
@@ -156,7 +148,6 @@ export const ANALYTICS_FIELD_MAP = {
   [FIELD_NAMES.HOME_PHONE]: 'home-telephone',
   [FIELD_NAMES.MOBILE_PHONE]: 'mobile-telephone',
   [FIELD_NAMES.WORK_PHONE]: 'work-telephone',
-  [FIELD_NAMES.FAX_NUMBER]: 'fax-telephone',
   [FIELD_NAMES.EMAIL]: 'email',
   [FIELD_NAMES.MAILING_ADDRESS]: 'mailing-address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'home-address',


### PR DESCRIPTION
## Description

- Adds a small fix to the useProfileTransaction -> startTransaction usage to include the fieldName. Not doing this was making the transactions requests fail due to the request payload not including a field type.
- Adds unit tests for the useProfileTransaction
- Removes some unneeded code for fields that are no longer use in the Profile

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43727

## Testing done

Unit tests added

