### PR TITLE
Use run number to check for previous workflow runs

### DIFF
--- a/script/github-actions/check-deployability.js
+++ b/script/github-actions/check-deployability.js
@@ -109,7 +109,7 @@ const isAheadOfLastFullDeploy = async (commitSha, env) => {
  * Determines if the given commit sha can be deployed to non production environments.
  *
  * @param {string} commitSha - Commit sha
- * @param {string} runNumber - Run number of the workflow run
+ * @param {number} runNumber - Run number of the workflow run
  * @param {string} env - Environment name
  * @returns {Boolean} Whether or not the commit can be deployed to the environment.
  */

--- a/script/github-actions/check-deployability.js
+++ b/script/github-actions/check-deployability.js
@@ -9,8 +9,12 @@ const { runCommandSync, sleep } = require('../utils');
 const BUCKETS = require('../../src/site/constants/buckets');
 const ENVIRONMENTS = require('../../src/site/constants/environments');
 
-const { GITHUB_TOKEN: auth, GITHUB_REPOSITORY, GITHUB_SHA } = process.env;
-const [owner, repo] = GITHUB_REPOSITORY.split('/');
+const {
+  GITHUB_TOKEN: auth,
+  GITHUB_REPOSITORY,
+  GITHUB_SHA,
+  GITHUB_RUN_NUMBER,
+} = process.env;
 
 const octokit = new Octokit({ auth });
 
@@ -21,6 +25,8 @@ const octokit = new Octokit({ auth });
  * @returns {Array} List of in progress workflow runs.
  */
 const getInProgressWorkflowRuns = workflow_id => {
+  const [owner, repo] = GITHUB_REPOSITORY.split('/');
+
   const params = {
     owner,
     repo,
@@ -122,8 +128,8 @@ const isDeployableToEnv = async (commitSha, env) => {
   );
   if (inProgressWorkflowRuns.length === 1) return true;
 
-  const previousCommitsInProgress = inProgressWorkflowRuns.find(workflowRun =>
-    isAncestor(workflowRun.head_sha, commitSha),
+  const previousCommitsInProgress = inProgressWorkflowRuns.find(
+    workflowRun => workflowRun.run_number < GITHUB_RUN_NUMBER,
   );
 
   if (!previousCommitsInProgress) return true;


### PR DESCRIPTION
## Description
 
When determining if a commit can be deployed to dev & staging, the commit is compared to the commits of all in progress CI workflow runs in `main` to see if there's a workflow run with an older commit in progress. If there is, this lets CI know to wait until the older workflow runs complete before deploying. If the timing is right, the runner may not have later commits in it's local git history, which causes failures when comparing commits, because the local repo isn't aware of later commits. [Example CI failure](https://github.com/department-of-veterans-affairs/vets-website/runs/7752011979?check_suite_focus=true)

This PR resolves this issue by comparing the run number of the workflows rather than the commits. Workflow run numbers are auto incremented, so prior workflow runs will always have a smaller run number.

## Acceptance criteria
- [x] The run number is used to check for older CI workflow runs

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
