### PR TITLE
added pact translation urls

### DIFF
--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(10);
+    expect(result.length).to.equal(11);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(10);
+    expect(result.length).to.equal(11);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {
@@ -29,6 +29,6 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(tag)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(10);
+    expect(result.length).to.equal(12);
   });
 });

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -29,4 +29,9 @@ export default {
     es: '/health-care/covid-19-vaccine-esp/about-covid-19-vaccine-esp',
     tl: '/health-care/covid-19-vaccine-tag/about-covid-19-vaccine-tag',
   },
+  pact: {
+    en: '/resources/the-pact-act-and-your-va-benefits',
+    es: '/resources/the-pact-act-and-your-va-benefits-esp',
+    tl: '/resources/the-pact-act-and-your-va-benefits-tag',
+  },
 };

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -32,6 +32,5 @@ export default {
   pact: {
     en: '/resources/the-pact-act-and-your-va-benefits',
     es: '/resources/the-pact-act-and-your-va-benefits-esp',
-    tl: '/resources/the-pact-act-and-your-va-benefits-tag',
   },
 };


### PR DESCRIPTION
## Description
Added urls for PACT translation pages.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9918)


## Testing done
local testing

## Screenshots


## Acceptance criteria
- [ ] translation component renders and links to appropriate urls

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
