### PR TITLE
Fix/burial poc v6 previous names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,8 @@
 
 # VSP
 *       @department-of-veterans-affairs/platform-release-tools
-src/application/_mock-form @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
+src/applications/_mock-form @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
+src/applications/burial-poc-v6 @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
 src/platform/forms        @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
 src/platform/forms-system @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
 script/component-migration @department-of-veterans-affairs/platform-design-system-fe

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.2.2",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "1.1.1",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.2.1",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@formatjs/intl-datetimeformat": "^4.2.3",
     "@formatjs/intl-getcanonicallocales": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.2.2",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "1.2.1",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.2.2",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@formatjs/intl-datetimeformat": "^4.2.3",
     "@formatjs/intl-getcanonicallocales": "^1.7.3",

--- a/src/applications/burial-poc-v6/pages/PreviousNames.jsx
+++ b/src/applications/burial-poc-v6/pages/PreviousNames.jsx
@@ -16,7 +16,14 @@ export default function PreviousNames(props) {
         values?.previousNames &&
         values?.veteranServedUnderAnotherName === 'false'
       ) {
-        setFieldValue(`previousNames`, []);
+        setFieldValue(`previousNames`, [
+          {
+            first: '',
+            middle: '',
+            last: '',
+            suffix: '',
+          },
+        ]);
       }
     },
     [values?.veteranServedUnderAnotherName],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,10 +2563,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.1.1.tgz#c6376899f19f054edd63f6ee9de076009c10187e"
-  integrity sha512-fnbwHYUDsQIM7TXdsRYr/AsMdrdmulmD72gq6OT+DFrHDfmMG2n6YAH8LhomOMpdZh2aDJa5tNChIV9r5TgZyg==
+"@department-of-veterans-affairs/va-forms-system-core@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.2.1.tgz#76801291af308e03133a8a3d0f10eb5b7bf37ec9"
+  integrity sha512-W4Bs6nIuCLbe2GskV58rXsj2ed9GxiAlrStvoaMzf4Y8tATATDnOx/bif0l8iOH/Sll0k64gkAHlZTZgyXaEIQ==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,10 +2563,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.2.1.tgz#76801291af308e03133a8a3d0f10eb5b7bf37ec9"
-  integrity sha512-W4Bs6nIuCLbe2GskV58rXsj2ed9GxiAlrStvoaMzf4Y8tATATDnOx/bif0l8iOH/Sll0k64gkAHlZTZgyXaEIQ==
+"@department-of-veterans-affairs/va-forms-system-core@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.2.2.tgz#7802e2fc19f1dfe07de0ead55baf9f0dd53098a2"
+  integrity sha512-mZApqHbPL37g2mUWIRxCEka890yNp48rI8HPo3RIXk0lx/adoKHwfBEqIf2D2/2tiIbYnqYKWhtaoUeGRQFaaA==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"


### PR DESCRIPTION
## Description

This PR fixes a validation error on the PreviousNames page inside of the burial-poc-v6 application. 

Also bumps the version of va-forms-system-core to the current working version.

## Original issue(s)

[department-of-veterans-affairs/va.gov-team#479](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/479)

## Testing done

- [x] Unit tests passing

## Screenshots

https://user-images.githubusercontent.com/22844722/183976518-c59c72ff-4d09-483e-8c31-91c60e280951.mov

## Acceptance criteria

- [x] Prevent navigation when previous name radio is set to `true` and name required fields are empty
- [x] Prevent navigation back to Review Page when when previous name radio is set to `true` and name required fields are empty

## Definition of done

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
