### PR TITLE
Upgrade `actions/cache` to `v3` in dependency caching in CI

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -3,11 +3,11 @@ description: Install dependencies
 
 inputs:
   key:
-    description: keys for actions/cache@v2
+    description: keys for actions/cache@v3
     required: false
     default: ''
   restore-keys:
-    description: restore-keys for actions/cache@v2
+    description: restore-keys for actions/cache@v3
     required: false
     default: ''
   yarn_cache_folder:
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ''
   path:
-    description: path for actions/cache@v2
+    description: path for actions/cache@v3
     required: false
     default: ''
 
@@ -38,7 +38,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}


### PR DESCRIPTION
## Description
Quick PR to upgrade `actions/cache` to the latest version.

## Acceptance criteria
- [ ] CI passes.