### PR TITLE
Increase parallelization for Cypress in CI when more than 200 tests are selected

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ on:
       - '**'
 
 env:
-  NUM_CONTAINERS: '8'
+  NUM_CONTAINERS: '12'
 
 concurrency:
   group: ${{ github.ref != 'refs/heads/main' && github.ref || github.sha }}
@@ -481,9 +481,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix:
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
     env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,9 +7,6 @@ on:
     tags-ignore:
       - '**'
 
-env:
-  NUM_CONTAINERS: '12'
-
 concurrency:
   group: ${{ github.ref != 'refs/heads/main' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -431,6 +428,8 @@ jobs:
     outputs:
       tests: ${{ steps.tests.outputs.selected }}
       app_urls: ${{ steps.get-changed-apps.outputs.urls }}
+      num_containers: ${{ steps.containers.outputs.num }}
+      ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
 
     steps:
       - name: Checkout
@@ -455,7 +454,7 @@ jobs:
           delimiter: ','
           output-type: 'entry_name, url'
 
-      - name: Set TESTS variable
+      - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
         run: node script/github-actions/select-cypress-tests.js
         env:
           RUN_FULL_SUITE: false
@@ -466,6 +465,14 @@ jobs:
       - name: Set output of TESTS
         id: tests
         run: echo ::set-output name=selected::$TESTS
+
+      - name: Set output of NUM_CONTAINERS
+        id: containers
+        run: echo ::set-output name=num::$NUM_CONTAINERS
+
+      - name: Set output of CI_NODE_INDEX
+        id: matrix
+        run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
 
   cypress-tests:
     name: Cypress E2E Tests
@@ -483,7 +490,7 @@ jobs:
       fail-fast: false
       max-parallel: 12
       matrix:
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        ci_node_index: ${{ fromJson(needs.cypress-tests-prep.outputs.ci_node_index) }}
 
     env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
@@ -548,6 +555,7 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
           APP_URLS: ${{ needs.cypress-tests-prep.outputs.app_urls }}
+          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Archive test videos
         if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
@@ -959,6 +967,7 @@ jobs:
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports
           TEST_RETRIES_TABLE_NAME: cypress_retry_records
+          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
           # env.MOCHAWESOME_REPORT_RESULTS is set and exported during the above step when the mochawesome report is generated.  It contains the output string for the publish step at the end of the job with the numbers from the Mochawesome report.
 
       - name: Upload Cypress E2E test videos to s3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,9 +62,9 @@ jobs:
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
-      # - name: Cancel workflow if commit has full build
-      #   if: ${{ github.event_name == 'workflow_run' && steps.get-changed-apps.outputs.app_entries == '' }}
-      #   uses: andymckay/cancel-action@0.2
+      - name: Cancel workflow if commit has full build
+        if: ${{ github.event_name == 'workflow_run' && steps.get-changed-apps.outputs.app_entries == '' }}
+        uses: andymckay/cancel-action@0.2
 
   build:
     name: Build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Run the full E2E test suite on a specific commit
-        required: true
-  workflow_run:
-    workflows: [Continuous Integration]
-    types: [completed]
-    branches: [main]
+on: [push]
+  # workflow_dispatch:
+  #   inputs:
+  #     commit_sha:
+  #       description: Run the full E2E test suite on a specific commit
+  #       required: true
+  # workflow_run:
+  #   workflows: [Continuous Integration]
+  #   types: [completed]
+  #   branches: [main]
 
 env:
   NUM_CONTAINERS: '8'
@@ -62,9 +62,9 @@ jobs:
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Cancel workflow if commit has full build
-        if: ${{ github.event_name == 'workflow_run' && steps.get-changed-apps.outputs.app_entries == '' }}
-        uses: andymckay/cancel-action@0.2
+      # - name: Cancel workflow if commit has full build
+      #   if: ${{ github.event_name == 'workflow_run' && steps.get-changed-apps.outputs.app_entries == '' }}
+      #   uses: andymckay/cancel-action@0.2
 
   build:
     name: Build
@@ -167,9 +167,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix:
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
     env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
@@ -224,6 +224,7 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
           APP_URLS: ''
+          NUM_CONTAINERS: 12
 
       # Temporarily disabled due to apparent memory issues caused by code coverage tools
       # - name: View code coverage summary
@@ -393,6 +394,7 @@ jobs:
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports
           TEST_RETRIES_TABLE_NAME: cypress_retry_records
+          NUM_CONTAINERS: 12
 
       - name: Upload Cypress E2E test videos to s3
         if: ${{ needs.cypress-tests.result == 'failure' }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
-on: [push]
-  # workflow_dispatch:
-  #   inputs:
-  #     commit_sha:
-  #       description: Run the full E2E test suite on a specific commit
-  #       required: true
-  # workflow_run:
-  #   workflows: [Continuous Integration]
-  #   types: [completed]
-  #   branches: [main]
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Run the full E2E test suite on a specific commit
+        required: true
+  workflow_run:
+    workflows: [Continuous Integration]
+    types: [completed]
+    branches: [main]
 
 env:
   NUM_CONTAINERS: '8'

--- a/.github/workflows/get-changed-apps/action.yml
+++ b/.github/workflows/get-changed-apps/action.yml
@@ -43,7 +43,7 @@ runs:
         if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
             echo ::set-output name=changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
         else
-          echo ::set-output name=changed_files::$(git diff --name-only origin/main...)
+          echo ::set-output name=changed_files::$(git diff --name-only origin/cypress-parallel-12...)
         fi
 
     - name: Get entry names

--- a/.github/workflows/get-changed-apps/action.yml
+++ b/.github/workflows/get-changed-apps/action.yml
@@ -43,7 +43,7 @@ runs:
         if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
             echo ::set-output name=changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
         else
-          echo ::set-output name=changed_files::$(git diff --name-only origin/cypress-parallel-12...)
+          echo ::set-output name=changed_files::$(git diff --name-only origin/main...)
         fi
 
     - name: Get entry names

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -2,7 +2,7 @@ const { runCommandSync } = require('../utils');
 
 const tests = JSON.parse(process.env.TESTS);
 const step = Number(process.env.STEP);
-const numContainers = Number(process.env.NUM_CONTAINERS);
+const numContainers = Number(process.env.NUM_CONTAINERS) - 1;
 const divider = Math.ceil(tests.length / numContainers);
 const appUrl = process.env.APP_URLS.split(',')[0];
 
@@ -20,10 +20,12 @@ if (tests.join(',').includes('all-claims.cypress.spec.js') && step === 11) {
 
 if (batch.includes('all-claims.cypress.spec.js') && step !== 11) {
   const status = runCommandSync(
-    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch.replace(
-      '/__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js',
-      '',
-    )}' --env app_url=${appUrl}`,
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch
+      .replace(
+        '/__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js',
+        '',
+      )
+      .replace(',,', ',')}' --env app_url=${appUrl}`,
   );
   process.exit(status);
 }

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -14,7 +14,7 @@ const lastStep = numContainers - 1;
 
 if (tests.some(test => test.match(longestTest))) {
   longestTestIsPresent = true;
-  divider = Math.ceil(tests.length / numContainers - 1);
+  divider = Math.ceil(tests.length / (numContainers - 1));
   tests = tests.filter(test => !test.match(longestTest));
 } else {
   divider = Math.ceil(tests.length / numContainers);

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -11,6 +11,23 @@ const batch = tests
   .slice(step * divider, (step + 1) * divider)
   .join(',');
 
+if (tests.includes('all-claims.cypress.spec.js') && step === 11) {
+  const status = runCommandSync(
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec /__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js --env app_url=${appUrl}`,
+  );
+  process.exit(status);
+}
+
+if (batch.includes('all-claims.cypress.spec.js') && step !== 11) {
+  const status = runCommandSync(
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch.replace(
+      '/__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js',
+      '',
+    )}' --env app_url=${appUrl}`,
+  );
+  process.exit(status);
+}
+
 if (batch !== '') {
   const status = runCommandSync(
     `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}' --env app_url=${appUrl}`,

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -1,31 +1,33 @@
 const { runCommandSync } = require('../utils');
 
-const tests = JSON.parse(process.env.TESTS);
+let tests = JSON.parse(process.env.TESTS);
 const step = Number(process.env.STEP);
-const numContainers = Number(process.env.NUM_CONTAINERS) - 1;
-const divider = Math.ceil(tests.length / numContainers);
+const numContainers = Number(process.env.NUM_CONTAINERS);
 const appUrl = process.env.APP_URLS.split(',')[0];
+
+// The following logic checks if the longest-running test has been selected.
+// If it has been selected, it is run in its own container in the last parallel container.
+let divider;
+let longestTestIsPresent = false;
+const longestTest = /all-claims.cypress.spec.js/g;
+const lastStep = step - 1;
+
+if (tests.some(test => test.match(longestTest))) {
+  longestTestIsPresent = true;
+  divider = Math.ceil(tests.length / numContainers - 1);
+  tests = tests.filter(test => !test.match(longestTest));
+} else {
+  divider = Math.ceil(tests.length / numContainers);
+}
 
 const batch = tests
   .map(test => test.replace('/home/runner/work', '/__w'))
   .slice(step * divider, (step + 1) * divider)
   .join(',');
 
-if (tests.join(',').includes('all-claims.cypress.spec.js') && step === 11) {
+if (longestTestIsPresent && step === lastStep) {
   const status = runCommandSync(
-    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec /__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js --env app_url=${appUrl}`,
-  );
-  process.exit(status);
-}
-
-if (batch.includes('all-claims.cypress.spec.js') && step !== 11) {
-  const status = runCommandSync(
-    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch
-      .replace(
-        '/__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js',
-        '',
-      )
-      .replace(',,', ',')}' --env app_url=${appUrl}`,
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec 'src/applications/**/all-claims.cypress.spec.js' --env app_url=${appUrl}`,
   );
   process.exit(status);
 }

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -11,11 +11,7 @@ const batch = tests
   .slice(step * divider, (step + 1) * divider)
   .join(',');
 
-if (batch === '') {
-  process.exit(0);
-}
-
-if (tests.includes('all-claims.cypress.spec.js') && step === 11) {
+if (tests.join(',').includes('all-claims.cypress.spec.js') && step === 11) {
   const status = runCommandSync(
     `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec /__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js --env app_url=${appUrl}`,
   );
@@ -32,7 +28,11 @@ if (batch.includes('all-claims.cypress.spec.js') && step !== 11) {
   process.exit(status);
 }
 
-const status = runCommandSync(
-  `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}' --env app_url=${appUrl}`,
-);
-process.exit(status);
+if (batch !== '') {
+  const status = runCommandSync(
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}' --env app_url=${appUrl}`,
+  );
+  process.exit(status);
+} else {
+  process.exit(0);
+}

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -20,6 +20,7 @@ if (tests.some(test => test.match(longestTest))) {
   divider = Math.ceil(tests.length / numContainers);
 }
 
+// Split up the array of tests for each container.
 const batch = tests
   .map(test => test.replace('/home/runner/work', '/__w'))
   .slice(step * divider, (step + 1) * divider)
@@ -30,9 +31,7 @@ if (longestTestIsPresent && step === lastStep) {
     `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec 'src/applications/**/all-claims.cypress.spec.js' --env app_url=${appUrl}`,
   );
   process.exit(status);
-}
-
-if (batch !== '') {
+} else if (batch !== '') {
   const status = runCommandSync(
     `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}' --env app_url=${appUrl}`,
   );

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -11,6 +11,10 @@ const batch = tests
   .slice(step * divider, (step + 1) * divider)
   .join(',');
 
+if (batch === '') {
+  process.exit(0);
+}
+
 if (tests.includes('all-claims.cypress.spec.js') && step === 11) {
   const status = runCommandSync(
     `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec /__w/vets-website/vets-website/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js --env app_url=${appUrl}`,
@@ -28,11 +32,7 @@ if (batch.includes('all-claims.cypress.spec.js') && step !== 11) {
   process.exit(status);
 }
 
-if (batch !== '') {
-  const status = runCommandSync(
-    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}' --env app_url=${appUrl}`,
-  );
-  process.exit(status);
-} else {
-  process.exit(0);
-}
+const status = runCommandSync(
+  `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}' --env app_url=${appUrl}`,
+);
+process.exit(status);

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -10,7 +10,7 @@ const appUrl = process.env.APP_URLS.split(',')[0];
 let divider;
 let longestTestIsPresent = false;
 const longestTest = /all-claims.cypress.spec.js/g;
-const lastStep = step - 1;
+const lastStep = numContainers - 1;
 
 if (tests.some(test => test.match(longestTest))) {
   longestTestIsPresent = true;

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -219,6 +219,28 @@ function selectTests(graph, pathsOfChangedFiles) {
 }
 
 function exportVariables(tests) {
+  const numTests = tests.length;
+
+  if (numTests <= 200) {
+    core.exportVariable('NUM_CONTAINERS', 8);
+    core.exportVariable('CI_NODE_INDEX', [0, 1, 2, 3, 4, 5, 6, 7]);
+  } else {
+    core.exportVariable('NUM_CONTAINERS', 12);
+    core.exportVariable('CI_NODE_INDEX', [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+    ]);
+  }
   core.exportVariable('TESTS', tests);
 }
 


### PR DESCRIPTION
## Description
This PR modifies the CI workflow so that 12 parallel containers are used for Cypress tests when more than 200 tests are selected. Eight containers will be used when less than 201 are selected. This should reduce CI times by a few minutes on average.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/45520


## Testing done
Tested test selection script locally.
Tested parallelization with multiple test commits.
Tested dispatched E2E workflow.

## Acceptance criteria
- [ ] CI passes.