### PR TITLE
Update required declaration for HCA Medicare Claim Number field

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/medicarePartAEffectiveDate.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/medicarePartAEffectiveDate.js
@@ -18,22 +18,23 @@ export default {
       ...currentOrPastDateUI('What is your Medicare Part A effective date?'),
       'ui:description': MedicareEffectiveDateDescription,
       'ui:reviewField': CustomDateReviewField,
+      'ui:required': () => true,
     },
     medicareClaimNumber: {
       'ui:title': 'What is your Medicare claim number?',
       'ui:description': MedicareClaimNumberDescription,
       'ui:reviewField': CustomReviewField,
+      'ui:required': formData => formData['view:hcaMedicareClaimNumberEnabled'],
       'ui:errorMessages': {
         required: 'Please enter a valid 11-character Medicare claim number',
       },
       'ui:options': {
-        hideIf: form => !form['view:hcaMedicareClaimNumberEnabled'],
+        hideIf: formData => !formData['view:hcaMedicareClaimNumberEnabled'],
       },
     },
   },
   schema: {
     type: 'object',
-    required: ['medicarePartAEffectiveDate', 'medicareClaimNumber'],
     properties: {
       medicarePartAEffectiveDate,
       medicareClaimNumber,


### PR DESCRIPTION
## Description
A phased rollout of a new form field created an issue with continuing in the form due to the conditional field being a declared required field in the JSON schema. When the field wasn't present due to the feature flag, the schema still expected the value to exist to allow the form to progress. This PR moves the required declaration out of the JSON schema and into the UI Schema.  

## Acceptance criteria
- [ ] Users with and without the medicare claim number field can progress through the form as expected. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
