### PR TITLE
Profile/hide direct deposit behind toggle

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import {
   cnpDirectDepositUiState,
   eduDirectDepositUiState,
+  selectHideDirectDepositCompAndPen,
 } from '@@profile/selectors';
 import { Prompt } from 'react-router-dom';
 import { CSP_IDS } from 'platform/user/authentication/constants';
@@ -30,10 +31,16 @@ import BankInfo from './BankInfo';
 import { benefitTypes } from '~/applications/personalization/common/constants';
 
 import DirectDepositWrapper from './DirectDepositWrapper';
+import TemporaryOutage from './alerts/TemporaryOutage';
 
 import { BANK_INFO_UPDATED_ALERT_SETTINGS } from '../../constants';
 
-const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
+const DirectDeposit = ({
+  cnpUiState,
+  eduUiState,
+  isVerifiedUser,
+  hideDirectDepositCompAndPen,
+}) => {
   const [showCNPSuccessMessage, setShowCNPSuccessMessage] = useState(false);
   const [showEDUSuccessMessage, setShowEDUSuccessMessage] = useState(false);
 
@@ -116,6 +123,7 @@ const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
   return (
     <>
       <Headline>Direct deposit information</Headline>
+
       <DirectDepositWrapper setViewingIsRestricted={setViewingIsRestricted}>
         <Prompt
           message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
@@ -129,12 +137,16 @@ const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
             )}
             dependencies={[externalServices.evss]}
           >
-            <BankInfo
-              type={benefitTypes.CNP}
-              setFormIsDirty={setCnpFormIsDirty}
-              setViewingPayments={setViewingPayments}
-              showSuccessMessage={showCNPSuccessMessage}
-            />
+            {hideDirectDepositCompAndPen ? (
+              <TemporaryOutage />
+            ) : (
+              <BankInfo
+                type={benefitTypes.CNP}
+                setFormIsDirty={setCnpFormIsDirty}
+                setViewingPayments={setViewingPayments}
+                showSuccessMessage={showCNPSuccessMessage}
+              />
+            )}
           </DowntimeNotification>
         ) : (
           <VerifyIdentiy />
@@ -166,6 +178,7 @@ DirectDeposit.propTypes = {
     isSaving: PropTypes.bool.isRequired,
     responseError: PropTypes.object,
   }).isRequired,
+  hideDirectDepositCompAndPen: PropTypes.bool.isRequired,
   isVerifiedUser: PropTypes.bool.isRequired,
 };
 
@@ -181,6 +194,7 @@ const mapStateToProps = state => {
     isVerifiedUser: isLOA3 && isUsingEligibleSignInService && is2faEnabled,
     cnpUiState: cnpDirectDepositUiState(state),
     eduUiState: eduDirectDepositUiState(state),
+    hideDirectDepositCompAndPen: selectHideDirectDepositCompAndPen(state),
   };
 };
 

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
@@ -1,8 +1,4 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
 
 const TemporaryOutage = () => (
   <div className="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--4">
@@ -11,35 +7,16 @@ const TemporaryOutage = () => (
       status="warning"
       visible
     >
-      <h2 slot="headline">Direct deposit isn’t available right now</h2>
-      <>
-        <p>
-          We’re sorry. Direct deposit isn’t available right now. We’re working
-          to fix the issue as soon as possible. Please check back after 5 p.m.
-          ET, Monday, August 16 for an update.
-        </p>
-        <h4>What you can do</h4>
-        <p>
-          If you have questions or concerns related to your direct deposit, call
-          us at{' '}
-          <a
-            href="tel:1-800-827-1000"
-            aria-label="800. 8 2 7. 1000."
-            title="Dial the telephone number 800-827-1000"
-            className="no-wrap"
-          >
-            800-827-1000
-          </a>{' '}
-          (TTY:{' '}
-          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-          ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. Or go
-          to your{' '}
-          <a href="/find-locations/?facilityType=benefits">
-            nearest VA regional office
-          </a>
-          .
-        </p>
-      </>
+      <h2 slot="headline">
+        Disability compensation and pension benefits is temporarily unavailable
+      </h2>
+
+      <p>
+        We’re sorry, but disability compensation and pension benefits
+        information is currently unavailable due to system maintenance. We’ll
+        have this system back online as soon as possible. Please check back
+        Monday, August 15th.
+      </p>
     </va-alert>
   </div>
 );

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Telephone, {
+  CONTACTS,
+  PATTERNS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
+
+const TemporaryOutage = () => (
+  <div className="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--4">
+    <va-alert
+      close-btn-aria-label="Close notification"
+      status="warning"
+      visible
+    >
+      <h2 slot="headline">Direct deposit isn’t available right now</h2>
+      <>
+        <p>
+          We’re sorry. Direct deposit isn’t available right now. We’re working
+          to fix the issue as soon as possible. Please check back after 5 p.m.
+          ET, Monday, August 16 for an update.
+        </p>
+        <h4>What you can do</h4>
+        <p>
+          If you have questions or concerns related to your direct deposit, call
+          us at{' '}
+          <a
+            href="tel:1-800-827-1000"
+            aria-label="800. 8 2 7. 1000."
+            title="Dial the telephone number 800-827-1000"
+            className="no-wrap"
+          >
+            800-827-1000
+          </a>{' '}
+          (TTY:{' '}
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+          ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. Or go
+          to your{' '}
+          <a href="/find-locations/?facilityType=benefits">
+            nearest VA regional office
+          </a>
+          .
+        </p>
+      </>
+    </va-alert>
+  </div>
+);
+
+export default TemporaryOutage;

--- a/src/applications/personalization/profile/mocks/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/feature-toggles/index.js
@@ -12,6 +12,7 @@ const generateFeatureToggles = (toggles = {}) => {
     profileShowPronounsAndSexualOrientation = false,
     profileShowReceiveTextNotifications = true,
     profileUseVAFSC = false,
+    profileHideDirectDepositCompAndPen = false,
   } = toggles;
 
   return {
@@ -53,6 +54,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'profile_use_vafsc',
           value: profileUseVAFSC,
+        },
+        {
+          name: 'profile_hide_direct_deposit_comp_and_pen',
+          value: profileHideDirectDepositCompAndPen,
         },
       ],
     },

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -34,7 +34,9 @@ const responses = {
   'GET /v0/profile/status': status,
   'OPTIONS /v0/maintenance_windows': 'OK',
   'GET /v0/maintenance_windows': { data: [] },
-  'GET /v0/feature_toggles': generateFeatureToggles(),
+  'GET /v0/feature_toggles': generateFeatureToggles({
+    profileHideDirectDepositCompAndPen: true,
+  }),
   'GET /v0/ppiu/payment_information': (_req, res) => {
     return res.status(200).json(payments.paymentHistory.simplePaymentHistory);
   },

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -125,3 +125,6 @@ export function selectVAProfilePersonalInformation(state, fieldName) {
     ? set(result, notListedTextKey, notListedTextValue)
     : result;
 }
+
+export const selectHideDirectDepositCompAndPen = state =>
+  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileHideDirectDepositCompAndPen];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -77,6 +77,7 @@ export default Object.freeze({
   omniChannelLink: 'omni_channel_link',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',
   profileNotificationSettings: 'profile_notification_settings',
+  profileHideDirectDepositCompAndPen: 'profile_hide_direct_deposit_comp_and_pen',
   profileDoNotRequireInternationalZipCode: 'profile_do_not_require_international_zip_code',
   profileForceBadAddressIndicator: 'profile_force_bad_address_indicator',
   profileShowAddressChangeModal: 'profile_show_address_change_modal',


### PR DESCRIPTION
## Description
Adds an alert for the Direct Deposit page based on a feature toggle. This is required just for a periodic maintenance period.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/45512


## Testing done
Unit tests and E2E tests passing


## Acceptance criteria
- [x] Alert added behind feature toggle

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
