### PR TITLE
Deprecate RadioButtons React component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,10 @@ module.exports = {
         name: '@department-of-veterans-affairs/component-library/TextArea',
         use: '<va-textarea>',
       },
+      {
+        name: '@department-of-veterans-affairs/component-library/RadioButtons',
+        use: '<va-radio>',
+      },
     ],
     'jsx-a11y/control-has-associated-label': 1, // 2
     'jsx-a11y/click-events-have-key-events': 1, // 24


### PR DESCRIPTION
## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1046

## Acceptance criteria
- [x] ESLint warns about deprecation of RadioButtons React component

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
