### PR TITLE
Profile/45512/fix alert on navigation direct deposit

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -108,6 +108,17 @@ const DirectDeposit = ({
     ],
   );
 
+  // fix for when the TemporaryOutage is displayed
+  // prevents alert from showing when navigating away from DD page and no edits have been made
+  useEffect(
+    () => {
+      if (hideDirectDepositCompAndPen) {
+        setCnpFormIsDirty(true);
+      }
+    },
+    [hideDirectDepositCompAndPen, setCnpFormIsDirty],
+  );
+
   useEffect(
     () => {
       // Show alert when navigating away

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
@@ -8,14 +8,15 @@ const TemporaryOutage = () => (
       visible
     >
       <h2 slot="headline">
-        Disability compensation and pension benefits is temporarily unavailable
+        Disability and pension information isn’t available right now
       </h2>
 
       <p>
-        We’re sorry, but disability compensation and pension benefits
-        information is currently unavailable due to system maintenance. We’ll
-        have this system back online as soon as possible. Please check back
-        Monday, August 15th.
+        We’re sorry. Disability and pension direct deposit information isn’t
+        available right now. We’re doing some maintenance work on this system.
+      </p>
+      <p className="vads-u-margin-bottom--0">
+        Check back on Monday, August 15, 2022, to review your information.
       </p>
     </va-alert>
   </div>


### PR DESCRIPTION
## Description
2 part PR

- fix for an 'you have unsaved edits' alert that would display if edits weren't performed and the hiding direct deposit feature toggle was true.
- update of approved final content for the alert

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/45512


## Testing done
All e2e and unit tests still passing.
Manually tested minor alert logic change

## Screenshots
![Screen Shot 2022-08-11 at 11.59.57 AM.png](https://images.zenhubusercontent.com/60ddebd504ce2452d0e0fa92/e0f447ef-d264-4bad-ac49-acb86ef91408)

## Acceptance criteria
- [x] Content updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
