### PR TITLE
Add validation to exclude caret in comment field

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -20,6 +20,23 @@ import {
 } from '../redux/actions';
 import { selectFeatureVAOSServiceRequests } from '../../redux/selectors';
 
+function isValidComment(value) {
+  // exclude the ^ since the caret is a delimiter for MUMPS (Vista)
+  if (value !== null) {
+    return /^[^^]+$/g.test(value);
+  }
+  return true;
+}
+
+function validComment(errors, input) {
+  if (input && !isValidComment(input)) {
+    errors.addError('following special character is not allowed: ^');
+  }
+  if (input && !/\S/.test(input)) {
+    errors.addError('Please provide a response');
+  }
+}
+
 const initialSchema = {
   default: {
     type: 'object',
@@ -56,7 +73,7 @@ const uiSchema = {
       'ui:options': {
         rows: 5,
       },
-      'ui:validations': [validateWhiteSpace],
+      'ui:validations': [validComment],
     },
   },
   cc: {

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -112,6 +112,25 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
     );
   });
 
+  it('should show error msg when ^ is entered in VA medical request', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
+
+    fireEvent.click(
+      await screen.findByLabelText(/Routine or follow-up visit/i),
+    );
+    const textBox = screen.getByRole('textbox');
+    fireEvent.change(textBox, { target: { value: '^' } });
+    expect(textBox.value).to.equal('^');
+    fireEvent.click(screen.getByText(/Continue/));
+
+    expect(await screen.findByRole('alert')).to.contain.text(
+      'following special character is not allowed: ^',
+    );
+  });
+
   it('should show alternate textbox char length if navigated via direct schedule flow', async () => {
     const store = createTestStore(initialState);
     store.dispatch(startDirectScheduleFlow());


### PR DESCRIPTION
## Description
When user types in a string containing the ^ character in the comment field, the comment does not get stored in Vista. The ^ character is the default delimiter in MUMPS code hence FE now has validation to exclude the caret character from the comment field.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44070


## Testing done
unit and local test

## Screenshots
![Screen Shot 2022-08-11 at 10 46 42 AM](https://user-images.githubusercontent.com/54327023/184208764-9263858e-d0be-4709-beca-9530b64f00a1.png)


## Acceptance criteria
- [ ] show error message when ^ is entered in the comment field

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
