### PR TITLE
Direct deposit down banner

### DIFF
--- a/src/platform/user/authentication/components/DowntimeBanner.js
+++ b/src/platform/user/authentication/components/DowntimeBanner.js
@@ -1,63 +1,45 @@
-import React from 'react';
-import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
 import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
+import { DOWNTIME_BANNER_CONFIG, AUTH_DEPENDENCIES } from '../constants';
 
-export const downtimeBannersConfig = [
-  {
-    dependencies: [EXTERNAL_SERVICES.idme, EXTERNAL_SERVICES.ssoe],
-    headline: 'Our sign in process isn’t working right now',
-    status: 'error',
-    message:
-      'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',
-  },
-  {
-    dependencies: [EXTERNAL_SERVICES.dslogon],
-    headline: 'You may have trouble signing in with DS Logon',
-    status: 'warning',
-    message:
-      'We’re sorry. We’re working to fix some problems with our DS Logon sign in process. If you’d like to sign in to VA.gov with your DS Logon account, please check back later.',
-  },
-  {
-    dependencies: [EXTERNAL_SERVICES.mhv],
-    headline: 'You may have trouble signing in with My HealtheVet',
-    status: 'warning',
-    message:
-      'We’re sorry. We’re working to fix some problems with our My HealtheVet sign in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
-  },
-  {
-    dependencies: [EXTERNAL_SERVICES.mvi],
-    headline: 'You may have trouble signing in or using some tools or services',
-    status: 'warning',
-    message:
-      'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
-  },
-  {
-    dependencies: [EXTERNAL_SERVICES.logingov],
-    headline: 'You may have trouble signing in with Login.gov',
-    status: 'warning',
-    message:
-      'We’re sorry. We’re working to fix some problems with our Login.gov sign in process. If you’d like to sign in to VA.gov with your Login.gov username and password, please check back later.',
-  },
-];
+export function DowntimeBanners({ statuses }) {
+  const [statusState, setStatusDown] = useState({});
 
-export const DowntimeBanner = ({ dependencies, headline, status, message }) => (
-  <ExternalServicesError dependencies={dependencies}>
-    <div className="downtime-notification row">
-      <div className="columns small-12">
-        <div className="form-warning-banner">
-          <va-alert visible status={status}>
-            <h2 slot="headline">{headline}</h2>
-            {message}
-          </va-alert>
-          <br />
+  useEffect(
+    () => {
+      if (statuses && statuses.length) {
+        const banner = statuses
+          .sort((a, b) => {
+            if (a.service < b.service) return 1;
+            if (a.service > b.service) return -1;
+            return 0;
+          })
+          .find(k => !['active'].includes(k.status));
+
+        setStatusDown(DOWNTIME_BANNER_CONFIG[(banner?.serviceId)] ?? {});
+      }
+    },
+    [statuses, setStatusDown],
+  );
+
+  const { status: errorStatus, headline, message } = statusState;
+
+  return (
+    <ExternalServicesError dependencies={AUTH_DEPENDENCIES}>
+      <div className="downtime-notification row">
+        <div className="columns small-12">
+          <div className="form-warning-banner fed-warning--v2">
+            <va-alert visible status={errorStatus}>
+              <h2 slot="headline">{headline}</h2>
+              {message}
+            </va-alert>
+          </div>
         </div>
       </div>
-    </div>
-  </ExternalServicesError>
-);
-
-export default function DowntimeBanners() {
-  return downtimeBannersConfig.map((props, i) => (
-    <DowntimeBanner {...props} key={`downtime-banner-${i}`} />
-  ));
+    </ExternalServicesError>
+  );
 }
+
+export const mapStateToProps = state => state.externalServiceStatuses;
+export default connect(mapStateToProps)(DowntimeBanners);

--- a/src/platform/user/authentication/components/DowntimeBanner.js
+++ b/src/platform/user/authentication/components/DowntimeBanner.js
@@ -1,45 +1,62 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
-import { DOWNTIME_BANNER_CONFIG, AUTH_DEPENDENCIES } from '../constants';
+import { getBackendStatuses as getBackendStatusAction } from 'platform/monitoring/external-services/actions';
+import { getStatusFromStatuses } from '../constants';
 
-export function DowntimeBanners({ statuses }) {
-  const [statusState, setStatusDown] = useState({});
+export function DowntimeBanners({
+  shouldGetBackendStatuses,
+  getBackendStatuses,
+  statuses,
+}) {
+  const [bannerStatus, setBannerStatus] = useState({});
 
   useEffect(
     () => {
-      if (statuses && statuses.length) {
-        const banner = statuses
-          .sort((a, b) => {
-            if (a.service < b.service) return 1;
-            if (a.service > b.service) return -1;
-            return 0;
-          })
-          .find(k => !['active'].includes(k.status));
-
-        setStatusDown(DOWNTIME_BANNER_CONFIG[(banner?.serviceId)] ?? {});
+      if (shouldGetBackendStatuses) {
+        getBackendStatuses();
       }
     },
-    [statuses, setStatusDown],
+    [shouldGetBackendStatuses, getBackendStatuses],
   );
 
-  const { status: errorStatus, headline, message } = statusState;
+  useEffect(
+    () => {
+      if (statuses !== null) {
+        const _sorted = getStatusFromStatuses(statuses);
+        setBannerStatus(_sorted);
+      }
+    },
+    [setBannerStatus, statuses],
+  );
+
+  const shouldRender = Object.keys(bannerStatus).length > 0;
+  const { headline, status: alertStatus, message } = bannerStatus;
 
   return (
-    <ExternalServicesError dependencies={AUTH_DEPENDENCIES}>
+    shouldRender && (
       <div className="downtime-notification row">
         <div className="columns small-12">
           <div className="form-warning-banner fed-warning--v2">
-            <va-alert visible status={errorStatus}>
+            <va-alert visible status={alertStatus}>
               <h2 slot="headline">{headline}</h2>
               {message}
             </va-alert>
           </div>
         </div>
       </div>
-    </ExternalServicesError>
+    )
   );
 }
 
-export const mapStateToProps = state => state.externalServiceStatuses;
-export default connect(mapStateToProps)(DowntimeBanners);
+export const mapStateToProps = state => {
+  const { loading, statuses } = state.externalServiceStatuses;
+  const shouldGetBackendStatuses = !loading && !statuses;
+  return { shouldGetBackendStatuses, statuses };
+};
+
+const mapDispatchToProps = { getBackendStatuses: getBackendStatusAction };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DowntimeBanners);

--- a/src/platform/user/authentication/components/DowntimeBanner.js
+++ b/src/platform/user/authentication/components/DowntimeBanner.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { getBackendStatuses as getBackendStatusAction } from 'platform/monitoring/external-services/actions';
+import environment from 'platform/utilities/environment';
 import { getStatusFromStatuses } from '../constants';
 
 export function DowntimeBanners({
@@ -12,7 +13,7 @@ export function DowntimeBanners({
 
   useEffect(
     () => {
-      if (shouldGetBackendStatuses) {
+      if (!environment.isLocalhost() && shouldGetBackendStatuses) {
         getBackendStatuses();
       }
     },

--- a/src/platform/user/authentication/components/LoginBanners.jsx
+++ b/src/platform/user/authentication/components/LoginBanners.jsx
@@ -4,45 +4,49 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/Tele
 export default function LoginBanners({
   headline = '',
   description = '',
+  bannerType = 'info',
   displayDifferentDevice,
+  displayAdditionalInfo = true,
   additionalInfoId = '',
 }) {
   return (
     <div className="downtime-notification row">
       <div className="columns small-12">
-        <div className="form-warning-banner">
-          <va-alert visible status="info">
+        <div className="form-warning-banner fed-warning--v2">
+          <va-alert visible status={bannerType}>
             <h2 slot="headline">{headline}</h2>
-            <p>{description}</p>
-            <va-additional-info
-              id={additionalInfoId}
-              trigger="Here's what you can do now"
-              disable-border
-            >
-              {displayDifferentDevice && (
-                <>
-                  <ul>
-                    <li>
-                      Try to sign in from a different browser or device. Use a
-                      browser other than Safari (like Edge, Chrome, or Firefox).
-                      If you're using an iPhone, iPad, or other Apple device,
-                      try a different device (like a laptop or desktop
-                      computer).
-                    </li>
-                    <li>
-                      If sign in fails, refresh the page in your browser.
-                      Refreshing the page may fix the problem.
-                    </li>
-                  </ul>
-                  <p>
-                    If you still have trouble signing in, try again later. Or
-                    call us at <va-telephone contact={CONTACTS.HELP_DESK} />{' '}
-                    (TTY: <va-telephone contact={CONTACTS['711']} />
-                    ). We’re here 24/7.
-                  </p>
-                </>
-              )}
-            </va-additional-info>
+            <p className="vads-u-margin-top--1">{description}</p>
+            {displayAdditionalInfo && (
+              <va-additional-info
+                id={additionalInfoId}
+                trigger="Here's what you can do now"
+                disable-border
+              >
+                {displayDifferentDevice && (
+                  <>
+                    <ul>
+                      <li>
+                        Try to sign in from a different browser or device. Use a
+                        browser other than Safari (like Edge, Chrome, or
+                        Firefox). If you're using an iPhone, iPad, or other
+                        Apple device, try a different device (like a laptop or
+                        desktop computer).
+                      </li>
+                      <li>
+                        If sign in fails, refresh the page in your browser.
+                        Refreshing the page may fix the problem.
+                      </li>
+                    </ul>
+                    <p>
+                      If you still have trouble signing in, try again later. Or
+                      call us at <va-telephone contact={CONTACTS.HELP_DESK} />{' '}
+                      (TTY: <va-telephone contact={CONTACTS['711']} />
+                      ). We’re here 24/7.
+                    </p>
+                  </>
+                )}
+              </va-additional-info>
+            )}
           </va-alert>
           <br />
         </div>

--- a/src/platform/user/authentication/components/LoginBanners.jsx
+++ b/src/platform/user/authentication/components/LoginBanners.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+
+export default function LoginBanners({
+  headline = '',
+  description = '',
+  displayDifferentDevice,
+  additionalInfoId = '',
+}) {
+  return (
+    <div className="downtime-notification row">
+      <div className="columns small-12">
+        <div className="form-warning-banner">
+          <va-alert visible status="info">
+            <h2 slot="headline">{headline}</h2>
+            <p>{description}</p>
+            <va-additional-info
+              id={additionalInfoId}
+              trigger="Here's what you can do now"
+              disable-border
+            >
+              {displayDifferentDevice && (
+                <>
+                  <ul>
+                    <li>
+                      Try to sign in from a different browser or device. Use a
+                      browser other than Safari (like Edge, Chrome, or Firefox).
+                      If you're using an iPhone, iPad, or other Apple device,
+                      try a different device (like a laptop or desktop
+                      computer).
+                    </li>
+                    <li>
+                      If sign in fails, refresh the page in your browser.
+                      Refreshing the page may fix the problem.
+                    </li>
+                  </ul>
+                  <p>
+                    If you still have trouble signing in, try again later. Or
+                    call us at <va-telephone contact={CONTACTS.HELP_DESK} />{' '}
+                    (TTY: <va-telephone contact={CONTACTS['711']} />
+                    ). We’re here 24/7.
+                  </p>
+                </>
+              )}
+            </va-additional-info>
+          </va-alert>
+          <br />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/platform/user/authentication/components/LoginBanners.jsx
+++ b/src/platform/user/authentication/components/LoginBanners.jsx
@@ -15,7 +15,7 @@ export default function LoginBanners({
         <div className="form-warning-banner fed-warning--v2">
           <va-alert visible status={bannerType}>
             <h2 slot="headline">{headline}</h2>
-            <p className="vads-u-margin-top--1">{description}</p>
+            <p className="vads-u-margin-top--2">{description}</p>
             {displayAdditionalInfo && (
               <va-additional-info
                 id={additionalInfoId}

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -67,7 +67,7 @@ export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
               isn’t available right now. We’re doing some maintenance work on
               this system.
               <br />
-              <span className="vads-u--margin-top--1 vads-u--display--block">
+              <span className="vads-u-margin-top--2 vads-u-display--block">
                 Check back on Monday, August 15, 2022, to review your
                 information
               </span>

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import LogoutAlert from 'platform/user/authentication/components/LogoutAlert';
-import DowntimeBanners from 'platform/user/authentication/components/DowntimeBanner';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import LogoutAlert from './LogoutAlert';
+import DowntimeBanners from './DowntimeBanner';
 
 function checkWebkit() {
   const ua = navigator.userAgent.toLowerCase();

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
 import LogoutAlert from './LogoutAlert';
 import DowntimeBanners from './DowntimeBanner';
 import LoginBanners from './LoginBanners';
@@ -26,6 +31,12 @@ function checkWebkit() {
   );
 }
 export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
+  const displayDirectDepositBanner = useSelector(
+    state =>
+      toggleValues(state)[
+        FEATURE_FLAG_NAMES.profileHideDirectDepositCompAndPen
+      ],
+  );
   return (
     <>
       <div className="row">
@@ -45,6 +56,25 @@ export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
               device, you may have trouble signing in right now. We’re working
               to fix this problem as fast as we can."
           displayDifferentDeviceContent
+        />
+      )}
+      {displayDirectDepositBanner && (
+        <LoginBanners
+          headline="Disability and direct deposit information isn’t available right now"
+          displayAdditionalInfo={false}
+          bannerType="warning"
+          description={
+            <>
+              We’re sorry. Disability and pension direct deposit information
+              isn’t available right now. We’re doing some maintenance work on
+              this system.
+              <br />
+              <span className="vads-u--margin-top--1 vads-u--display--block">
+                Check back on Monday, August 15, 2022, to review your
+                information
+              </span>
+            </>
+          }
         />
       )}
     </>

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import LogoutAlert from './LogoutAlert';
 import DowntimeBanners from './DowntimeBanner';
+import LoginBanners from './LoginBanners';
 
 function checkWebkit() {
   const ua = navigator.userAgent.toLowerCase();
@@ -38,48 +38,14 @@ export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
       </div>
       <DowntimeBanners />
       {isIOS() && (
-        <div className="downtime-notification row">
-          <div className="columns small-12">
-            <div className="form-warning-banner">
-              <va-alert visible status="info">
-                <h2 slot="headline">
-                  You may have trouble signing in right now
-                </h2>
-                <p>
-                  We’re sorry. If you're using the Safari browser or an Apple
-                  mobile device, you may have trouble signing in right now.
-                  We’re working to fix this problem as fast as we can.
-                </p>
-                <va-additional-info
-                  id="ios-bug"
-                  trigger="Here's what you can do now"
-                  disable-border
-                >
-                  <ul>
-                    <li>
-                      Try to sign in from a different browser or device. Use a
-                      browser other than Safari (like Edge, Chrome, or Firefox).
-                      If you're using an iPhone, iPad, or other Apple device,
-                      try a different device (like a laptop or desktop
-                      computer).
-                    </li>
-                    <li>
-                      If sign in fails, refresh the page in your browser.
-                      Refreshing the page may fix the problem.
-                    </li>
-                  </ul>
-                  <p>
-                    If you still have trouble signing in, try again later. Or
-                    call us at <va-telephone contact={CONTACTS.HELP_DESK} />{' '}
-                    (TTY: <va-telephone contact={CONTACTS['711']} />
-                    ). We’re here 24/7.
-                  </p>
-                </va-additional-info>
-              </va-alert>
-              <br />
-            </div>
-          </div>
-        </div>
+        <LoginBanners
+          additionalInfoId="ios-bug"
+          headline="You may have trouble signing in right now"
+          description="We’re sorry. If you're using the Safari browser or an Apple mobile
+              device, you may have trouble signing in right now. We’re working
+              to fix this problem as fast as we can."
+          displayDifferentDeviceContent
+        />
       )}
     </>
   );

--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -52,9 +52,7 @@ export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
         <LoginBanners
           additionalInfoId="ios-bug"
           headline="You may have trouble signing in right now"
-          description="We’re sorry. If you're using the Safari browser or an Apple mobile
-              device, you may have trouble signing in right now. We’re working
-              to fix this problem as fast as we can."
+          description="We’re sorry. If you’re using the Safari browser or an Apple mobile device, you may have trouble signing in right now. We’re working to fix this problem as fast as we can."
           displayDifferentDeviceContent
         />
       )}

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -210,3 +210,17 @@ export const DOWNTIME_BANNER_CONFIG = {
       'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
   },
 };
+
+export const getStatusFromStatuses = _status => {
+  const sorted = _status
+    .sort((a, b) => {
+      if (a.service < b.service) return 1;
+      if (a.service > b.service) return -1;
+      return 0;
+    })
+    .find(k => !['active'].includes(k.status));
+
+  return sorted && AUTH_DEPENDENCIES.some(id => id === sorted.serviceId)
+    ? DOWNTIME_BANNER_CONFIG[sorted.serviceId]
+    : {};
+};

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
 import LoginGovSVG from 'platform/user/authentication/components/LoginGovSVG';
 import IDMeSVG from 'platform/user/authentication/components/IDMeSVG';
 import environment from '../../utilities/environment';
@@ -163,4 +164,49 @@ export const AUTH_PARAMS = {
   codeChallengeMethod: 'code_challenge_method',
   clientId: 'client_id',
   to: 'to',
+};
+
+export const AUTH_DEPENDENCIES = [
+  EXTERNAL_SERVICES.idme,
+  EXTERNAL_SERVICES.ssoe,
+  EXTERNAL_SERVICES.dslogon,
+  EXTERNAL_SERVICES.mhv,
+  EXTERNAL_SERVICES.mvi,
+  EXTERNAL_SERVICES.logingov,
+];
+
+export const generateCSPBanner = ({ csp }) => {
+  return {
+    headline: `You may have trouble signing in with ${
+      SERVICE_PROVIDERS[csp].label
+    }`,
+    status: 'warning',
+    message: `We’re sorry. We’re working to fix some problems with our ${
+      SERVICE_PROVIDERS[csp].label
+    } sign in process. If you’d like to sign in to VA.gov with your ${
+      SERVICE_PROVIDERS[csp].label
+    } account, please check back later.`,
+  };
+};
+
+export const DOWNTIME_BANNER_CONFIG = {
+  ...Object.keys(SERVICE_PROVIDERS).reduce(
+    (acc, cv) => ({
+      ...acc,
+      [cv]: generateCSPBanner({ csp: cv }),
+    }),
+    {},
+  ),
+  ssoe: {
+    headline: 'Our sign in process isn’t working right now',
+    status: 'error',
+    message:
+      'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',
+  },
+  mvi: {
+    headline: 'You may have trouble signing in or using some tools or services',
+    status: 'warning',
+    message:
+      'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
+  },
 };

--- a/src/platform/user/tests/authentication/components/DowntimeBanner.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/DowntimeBanner.unit.spec.js
@@ -1,101 +1,62 @@
 import React from 'react';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
-import configureMockStore from 'redux-mock-store';
 import DowntimeBanners, {
-  downtimeBannersConfig,
-  DowntimeBanner,
+  mapStateToProps,
 } from 'platform/user/authentication/components/DowntimeBanner';
+import {
+  DOWNTIME_BANNER_CONFIG,
+  AUTH_DEPENDENCIES,
+} from 'platform/user/authentication/constants';
 
-const mockStore = configureMockStore();
-const generateState = ({
-  ssoeDown = false,
-  idmeDown = false,
-  dslogonDown = false,
-  mhvDown = false,
-  mviDown = false,
-  logingovDown = false,
-}) => ({
+const generateState = ({ serviceId = 'mvi', serviceDown = false }) => ({
   externalServiceStatuses: {
-    statuses: [
-      {
-        service: 'DS Logon',
-        serviceId: 'dslogon',
-        status: dslogonDown ? 'inactive' : 'active',
-      },
-      {
-        service: 'ID.me',
-        serviceId: 'idme',
-        status: idmeDown ? 'inactive' : 'active',
-      },
-      {
-        service: 'SSOe',
-        serviceId: 'ssoe',
-        status: ssoeDown ? 'inactive' : 'active',
-      },
-      {
-        service: 'Login.gov',
-        serviceId: 'logingov',
-        status: logingovDown ? 'inactive' : 'active',
-      },
-      {
-        service: 'MVI',
-        serviceId: 'mvi',
-        status: mviDown ? 'inactive' : 'active',
-      },
-      {
-        service: 'MHV',
-        serviceId: 'mhv',
-        status: mhvDown ? 'inactive' : 'active',
-      },
-    ],
+    loading: false,
+    statuses: AUTH_DEPENDENCIES.map(deps => ({
+      service: deps.toUpperCase(),
+      serviceId: deps,
+      status: serviceId === deps && serviceDown ? 'inactive' : 'active',
+    })),
   },
-});
-const filteredDowntimeConfig = deps => {
-  return downtimeBannersConfig.reduce((dependency, current) => {
-    return current.dependencies.includes(deps) ? current : dependency;
-  }, {});
-};
-
-describe('DowntimeBanners', () => {
-  it('should render a collection of `DowntimeBanner`', () => {
-    const initialState = generateState({});
-    const store = mockStore(initialState);
-    const wrapper = shallow(<DowntimeBanners store={store} />);
-
-    expect(wrapper.find('DowntimeBanner').length).to.eql(5);
-    wrapper.unmount();
-  });
 });
 
 describe('DowntimeBanner', () => {
-  const downtimeDeps = ['ssoe', 'mhv', 'idme', 'logingov', 'dslogon', 'mhv'];
-  let initialState;
-  let downtimeBannerProps;
-  let store;
+  it('should not display banner if statuses are active', () => {
+    const screen = renderInReduxProvider(<DowntimeBanners />, {
+      initialState: generateState({ serviceId: 'mvi', serviceDown: false }),
+    });
 
-  beforeEach(() => {
-    initialState = generateState({});
-    store = mockStore(initialState);
-    downtimeBannerProps = filteredDowntimeConfig();
+    expect(
+      screen.queryByText(
+        /You may have trouble signing in or using some tools or services/i,
+      ),
+    ).to.be.null;
   });
 
-  downtimeDeps.forEach(dependency => {
-    it(`should render if ${dependency} is down`, () => {
-      initialState = generateState({ [`${dependency}Down`]: true });
-      store = mockStore(initialState);
-      downtimeBannerProps = filteredDowntimeConfig(dependency);
+  AUTH_DEPENDENCIES.forEach(csp => {
+    it(`should display ${csp} banner when status is inactive`, () => {
+      const screen = renderInReduxProvider(<DowntimeBanners />, {
+        initialState: generateState({ serviceId: csp, serviceDown: true }),
+      });
 
-      const wrapper = shallow(
-        <DowntimeBanner store={store} {...downtimeBannerProps} />,
-      );
+      const { headline } = DOWNTIME_BANNER_CONFIG[csp];
 
-      expect(wrapper.find('h2').text()).to.eql(downtimeBannerProps.headline);
-      expect(wrapper.find('va-alert').prop('visible')).to.be.true;
-      expect(wrapper.find('va-alert').prop('status')).to.eql(
-        downtimeBannerProps.status,
-      );
-      wrapper.unmount();
+      expect(screen.queryByText(headline)).to.not.be.null;
+    });
+  });
+});
+
+describe('mapStateToProps', () => {
+  describe('externalServiceStatuses', () => {
+    it('should display props', () => {
+      expect(
+        mapStateToProps({
+          externalServiceStatuses: {
+            shouldGetBackendStatuses: true,
+            statuses: null,
+          },
+        }).shouldGetBackendStatuses,
+      ).to.be.true;
     });
   });
 });

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -25,12 +25,12 @@ describe('LoginHeader', () => {
     expect(wrapper.find('LogoutAlert').exists()).to.be.true;
   });
   it('should render `DowntimeBanners`', () => {
-    expect(wrapper.find('DowntimeBanners').exists()).to.be.true;
+    expect(wrapper.find('Connect(DowntimeBanners)').exists()).to.be.true;
   });
   it('should display an informational alert for iOS users', () => {
     const mutatedProps = { loggedOut: false, isIOS: () => true };
     wrapper = shallow(<LoginHeader {...mutatedProps} />);
-    expect(wrapper.find('#ios-bug').exists()).to.be.true;
+    expect(wrapper.find('LoginBanners').exists()).to.be.true;
     wrapper.unmount();
   });
 });

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -1,36 +1,50 @@
 import React from 'react';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
 import LoginHeader from 'platform/user/authentication/components/LoginHeader';
 
+const generateState = ({ toggledOn = false }) => ({
+  featureToggles: {
+    // eslint-disable-next-line camelcase
+    profile_hide_direct_deposit_comp_and_pen: toggledOn,
+  },
+});
+
 describe('LoginHeader', () => {
-  let wrapper;
-  const props = { loggedOut: false, isIOS: () => false };
-
-  beforeEach(() => {
-    wrapper = shallow(<LoginHeader {...props} />);
-  });
-
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   it('should render', () => {
-    expect(wrapper.exists()).to.be.true;
-    expect(wrapper.find('h1').text()).to.include('Sign in');
+    const screen = renderInReduxProvider(<LoginHeader />, {
+      initialState: generateState({}),
+    });
+
+    expect(screen.queryByText(/Sign in/i)).to.not.be.null;
   });
-  it('should render a `LogoutAlert` if loggedOut is true', () => {
-    expect(wrapper.find('LogoutAlert').exists()).to.be.false;
-    wrapper.setProps({ loggedOut: true });
-    expect(wrapper.find('LogoutAlert').exists()).to.be.true;
+
+  it('should display the LogoutAlert component when user is loggedIn', () => {
+    const screen = renderInReduxProvider(<LoginHeader loggedOut />, {
+      initialState: generateState({}),
+    });
+
+    expect(screen.queryByText(/You have successfully signed out/i)).to.not.be
+      .null;
   });
-  it('should render `DowntimeBanners`', () => {
-    expect(wrapper.find('Connect(DowntimeBanners)').exists()).to.be.true;
+
+  it('should show an alert for iOS users', () => {
+    const screen = renderInReduxProvider(<LoginHeader isIOS={() => true} />, {
+      initialState: generateState({}),
+    });
+
+    const iosDescription = /We’re sorry. If you’re using the Safari browser or an Apple mobile device, you may have trouble signing in right now. We’re working to fix this problem as fast as we can./i;
+
+    expect(screen.queryByText(iosDescription)).to.not.be.null;
   });
-  it('should display an informational alert for iOS users', () => {
-    const mutatedProps = { loggedOut: false, isIOS: () => true };
-    wrapper = shallow(<LoginHeader {...mutatedProps} />);
-    expect(wrapper.find('LoginBanners').exists()).to.be.true;
-    wrapper.unmount();
+
+  it('should display direct deposit error', () => {
+    const screen = renderInReduxProvider(<LoginHeader />, {
+      initialState: generateState({ toggledOn: true }),
+    });
+
+    const directDepositDesc = /We’re sorry. Disability and pension direct deposit information isn’t available right now. We’re doing some maintenance work on this system./i;
+
+    expect(screen.queryByText(directDepositDesc)).to.not.be.null;
   });
 });


### PR DESCRIPTION
## Description
This PR addresses the body of work for creating a banner on Sign in (Modal + Page) because Direct Deposit will be down for maintenance.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#45519


## Testing done
Unit

## Screenshots
![Screen Shot 2022-08-12 at 11 33 38 AM](https://user-images.githubusercontent.com/67602137/184389285-70d2c385-89d6-47d6-9ab9-20975bf283a7.png)


## Acceptance criteria
- [x] When the `profile_hide_direct_deposit_comp_and_pen` feature toggle is ON, a Banner with the appropriate Direct Deposit content will be displayed on Sign in (Modal + Page)
- [x] When the `profile_hide_direct_deposit_comp_and_pen` feature toggle is OFF, the Direct Deposit banner will not be displayed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
