### PR TITLE
1095-B Download Form E2E Tests

### DIFF
--- a/src/applications/static-pages/download-1095b/tests/01-1095b-authed.cypress.spec.js
+++ b/src/applications/static-pages/download-1095b/tests/01-1095b-authed.cypress.spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import Timeouts from 'platform/testing/e2e/timeouts';
 import { form, featureToggles } from './e2e/fixtures/mocks/mocks';
 

--- a/src/applications/static-pages/download-1095b/tests/01-1095b-authed.cypress.spec.js
+++ b/src/applications/static-pages/download-1095b/tests/01-1095b-authed.cypress.spec.js
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+import Timeouts from 'platform/testing/e2e/timeouts';
+import { form, featureToggles } from './e2e/fixtures/mocks/mocks';
+
+describe('Authed 1095-B Form Download PDF', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'v0/feature_toggles?*', featureToggles).as(
+      'featureToggles',
+    );
+    cy.intercept('GET', 'v0/form1095_bs/available_forms', form).as('form');
+    cy.intercept('GET', 'v0/form1095_bs/download_pdf/*', {
+      statusCode: 200,
+    });
+    cy.login();
+    cy.visit('/health-care/download-1095b/');
+    cy.wait(['@featureToggles', '@form']);
+  });
+
+  it('downloads the 1095-B PDF form', () => {
+    cy.get('body').should('be.visible');
+    cy.injectAxeThenAxeCheck();
+    cy.title().should('contain', '1095B Download | Veterans Affairs');
+    cy.get('.usa-content', {
+      timeout: Timeouts.slow,
+    }).should('be.visible');
+
+    cy.axeCheck();
+
+    cy.get('#1095-download-options-0').should('be.checked');
+    cy.get('#1095-download-options-1').should('not.be.checked');
+
+    cy.get('#download-url')
+      .click()
+      .then(() => {
+        cy.get('.usa-content div va-alert h3').should(
+          'have.text',
+          'Download Complete',
+        );
+        cy.get('#download-url').should('be.visible');
+      });
+
+    cy.axeCheck();
+  });
+});

--- a/src/applications/static-pages/download-1095b/tests/02-1095b-no-form-available.cypress.spec.js
+++ b/src/applications/static-pages/download-1095b/tests/02-1095b-no-form-available.cypress.spec.js
@@ -1,0 +1,34 @@
+import Timeouts from 'platform/testing/e2e/timeouts';
+import { formUnavailable, featureToggles } from './e2e/fixtures/mocks/mocks';
+
+describe('No 1095-B Form Available for Download', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'v0/feature_toggles?*', featureToggles).as(
+      'featureToggles',
+    );
+    cy.intercept('GET', '/v0/form1095_bs/available_forms', formUnavailable).as(
+      'formUnavailable',
+    );
+    cy.login();
+    cy.visit('/health-care/download-1095b/');
+    cy.wait(['@featureToggles', '@formUnavailable']);
+  });
+
+  it('correctly displays that no form is available for downloading', () => {
+    cy.get('body').should('be.visible');
+    cy.injectAxeThenAxeCheck();
+    cy.title().should('contain', '1095B Download | Veterans Affairs');
+    cy.get('.usa-content', {
+      timeout: Timeouts.slow,
+    }).should('be.visible');
+
+    cy.axeCheck();
+
+    cy.get('.usa-content div va-alert h3').should(
+      'have.text',
+      'You don’t have a 1095-B tax form available right now',
+    );
+
+    cy.axeCheck();
+  });
+});

--- a/src/applications/static-pages/download-1095b/tests/e2e/fixtures/mocks/mocks.js
+++ b/src/applications/static-pages/download-1095b/tests/e2e/fixtures/mocks/mocks.js
@@ -1,0 +1,26 @@
+const featureToggles = {
+  data: {
+    type: 'feature_toggles',
+    features: [{ name: 'show_digital_form_1095b', value: true }],
+  },
+};
+
+const form = {
+  availableForms: [
+    {
+      year: 2021,
+      lastUpdated: '2022-08-03T20:38:29.382Z',
+    },
+  ],
+};
+
+const formUnavailable = {
+  // eslint-disable-next-line camelcase
+  availableForms: [],
+};
+
+module.exports = {
+  featureToggles,
+  form,
+  formUnavailable,
+};

--- a/src/applications/static-pages/download-1095b/tests/e2e/fixtures/mocks/mocks.js
+++ b/src/applications/static-pages/download-1095b/tests/e2e/fixtures/mocks/mocks.js
@@ -15,7 +15,6 @@ const form = {
 };
 
 const formUnavailable = {
-  // eslint-disable-next-line camelcase
   availableForms: [],
 };
 


### PR DESCRIPTION
## Description
Adding E2E Tests for the 1095-B Widget for Accessibility Axe Checks.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44811

## Testing done
- Local Testing with Cypress and Axe Checks Enabled. 

## Screenshots


## Acceptance criteria
- [x] Ensure end-to-end tests - including the axe check, pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
