### PR TITLE
Add va-promo-banner to analyticsEvents dictionary

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -166,6 +166,13 @@ const analyticsEvents = {
       prefix: 'modal',
     },
   ],
+  'va-promo-banner': [
+    {
+      action: 'linkClick',
+      event: 'nav-promo-banner-link-click',
+      prefix: 'promo-banner',
+    },
+  ],
   'va-radio': [
     {
       action: 'change',

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -62,13 +62,6 @@ const analyticsEvents = {
       prefix: 'loading-indicator',
     },
   ],
-  PromoBanner: [
-    {
-      action: 'linkClick',
-      event: 'nav-promo-banner-link-click',
-      prefix: 'promo-banner',
-    },
-  ],
   RadioButtons: [
     {
       action: 'change',


### PR DESCRIPTION
## Description

This adds configuration for the `<va-promo-banner>` web component to be tracked in Google Analytics. It follows the same pattern that the React component did.

## Original issue(s)
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1105


## Testing done

None


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
