### PR TITLE
Bump component-library version to 11.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "11.2.6",
+    "@department-of-veterans-affairs/component-library": "^11.4.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.2.2",

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -330,7 +330,7 @@ describe('VAOS community care flow', () => {
     cy.findByText(/Choose provider/i).click();
     cy.findByText(/remove/i).click();
     cy.axeCheckBestPractice();
-    cy.findByText(/cancel/i).click();
+    cy.findByText(/cancel/i).click({ force: true });
     // Click continue button
     cy.get('.usa-button').click();
 
@@ -634,7 +634,7 @@ describe('VAOS community care flow using VAOS service', () => {
     cy.findByText(/Choose provider/i).click();
     cy.findByText(/remove/i).click();
     cy.axeCheckBestPractice();
-    cy.findByText(/cancel/i).click();
+    cy.findByText(/cancel/i).click({ force: true });
     // Click continue button
     cy.get('.usa-button').click();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,13 +2505,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@11.2.6":
-  version "11.2.6"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.2.6.tgz#5bbd51427fbd41642e55e40ba6dbddb0d90485bd"
-  integrity sha512-lvapxOrGDZ1AcnD5BW4yBielJq6Wn6Nkxhyaa2mHGmNPOwv6m+ZECbwT9RqJHAqlnnjf7CofkbzRDfEvVh3nEw==
+"@department-of-veterans-affairs/component-library@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.4.0.tgz#6566a83b12c5c57cf2da69bad41dba8411491f49"
+  integrity sha512-YpIW/GWuPWKYMXBO164TtDmKfB+uGqfkV73xL3MFJ4UiFApOuIjuf01SvBpjKoTk3EUIVZ2lCf/iXlQ6t7QLQQ==
   dependencies:
     "@department-of-veterans-affairs/react-components" "7.0.1"
-    "@department-of-veterans-affairs/web-components" "4.9.6"
+    "@department-of-veterans-affairs/web-components" "4.11.0"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2582,10 +2582,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.9.6.tgz#16e9f057c0dbef33aa4342fc4d6ea94cdfd07c41"
-  integrity sha512-VJQq4VY8OQ0ZD32BacCjnnBeHyrJ9OoRmlBKZ7bR4LTLQwUWBDNYgSnLh8LQMO1h2gLnXdeeuMOz8xKEqT/Jig==
+"@department-of-veterans-affairs/web-components@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.11.0.tgz#94486e70e3ac7640820c0ddda4dce6c055710ab3"
+  integrity sha512-6egB77pWbf3FIMnirIrWfm/QqoKblgYWsiYxEq3UNDlYWMzCpA/82+5614gguXq58kLXLWHdDVY/BOINACiuqw==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description

The [failing Cypress test](https://github.com/department-of-veterans-affairs/vets-website/runs/7813824263?check_suite_focus=true#step:9:832) appears to be due to the combination of Cypress & Chrome. Locally if I tell Cypress to use Firefox, the test does not fail.

The `component-library` changes are:

- [11.3.0 - Add OMB Info component](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.3.0)
- [11.3.1 - Update form control error styles](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.3.1)
- [11.3.2 - Move aria attributes for `<va-modal>` to host element](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.3.2)
- [11.3.3 - Styling fixes for `<va-alert-expandable>`](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.3.3)
- [ 11.4.0 - Rework date component validation](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.4.0)


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done

E2E tests


## Screenshots

Cypress test failing in Chrome:

![A screenshot of the Cypress test runner in Chrome. The test is the VAOS community-care E2E test and Cypress is trying to click a Cancel button inside the modal but says that it is not visible, despite it being visible to sighted users](https://user-images.githubusercontent.com/2008881/184449878-fc6cd170-d699-4adb-af9f-808edf47ee5c.png)


Cypress test passing in firefox:

![A screenshot of the Cypress test runner in firefox. The test is the VAOS community-care E2E test and everything passes.](https://user-images.githubusercontent.com/2008881/184449722-6429c3e0-d476-4d2b-8a46-9b9f1d4e696f.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
