### PR TITLE
Create new VFS app: last test

### DIFF
--- a/src/applications/last-folder/app-entry.jsx
+++ b/src/applications/last-folder/app-entry.jsx
@@ -1,0 +1,14 @@
+import 'platform/polyfills';
+import './sass/last-bundle.scss';
+
+import startApp from 'platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+});

--- a/src/applications/last-folder/containers/App.jsx
+++ b/src/applications/last-folder/containers/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App({ children }) {
+  return <div>{children}</div>;
+}

--- a/src/applications/last-folder/manifest.json
+++ b/src/applications/last-folder/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "last test",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "last-bundle",
+  "rootUrl": "/my-url",
+  "productId": "a6fbf4b5-5265-4098-b3d3-eb6f076d9bb3"
+}

--- a/src/applications/last-folder/reducers/index.js
+++ b/src/applications/last-folder/reducers/index.js
@@ -1,0 +1,3 @@
+export default {
+
+};

--- a/src/applications/last-folder/routes.jsx
+++ b/src/applications/last-folder/routes.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Route } from 'react-router';
+import App from './containers/App.jsx';
+
+const routes = (
+  <Route path="/" component={App}>
+  </Route>
+);
+
+export default routes;

--- a/src/applications/last-folder/sass/last-bundle.scss
+++ b/src/applications/last-folder/sass/last-bundle.scss
@@ -1,0 +1,1 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/src/applications/last-folder/tests/last-bundle.cypress.spec.js
+++ b/src/applications/last-folder/tests/last-bundle.cypress.spec.js
@@ -1,0 +1,15 @@
+import manifest from '../manifest.json';
+
+describe(manifest.appName, () => {
+  // Skip tests in CI until the app is released.
+  // Remove this block when the app has a content page in production.
+  before(function() {
+    if (Cypress.env('CI')) this.skip();
+  });
+
+  it('is accessible', () => {
+    cy.visit(manifest.rootUrl)
+      .injectAxe()
+      .axeCheck();
+  });
+});


### PR DESCRIPTION
# Auto-generated new app: last test
This PR and branch create a skeleton of a new VFS app, last test.  They were created from the Console UI, using the `vfs-create-app` template, to invoke the [vets-website app generator](https://github.com/department-of-veterans-affairs/generator-vets-website) script.

## Checklist
- [ ] - Review contents of PR
- [ ] - Make a markdown file in the [vagov-content repo](https://github.com/department-of-veterans-affairs/vagov-content) at `pages//my-url.md`
- [ ] - Update `content-build` registry file with an entry for this new app:
```json
{
  "appName": "last test",
  "entryName": "last-bundle",
  "rootUrl": "/my-url",
  "productId":  "PRODUCT_ID"
  "template": {
    "vagovprod": false
    "layout": "page-react.html"
  }
}
```
