### PR TITLE
Added new event record on language toggle.

### DIFF
--- a/src/applications/check-in/components/LanguagePicker.jsx
+++ b/src/applications/check-in/components/LanguagePicker.jsx
@@ -1,7 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import recordEvent from 'platform/monitoring/record-event';
 
+import { createAnalyticsSlug } from '../utils/analytics';
 import withTranslationEnabled from '../containers/withTranslationEnabled';
 
 function LanguagePicker(props) {
@@ -10,6 +12,9 @@ function LanguagePicker(props) {
   const { language } = i18n;
   function changeLanguage(e) {
     e.preventDefault();
+    recordEvent({
+      event: createAnalyticsSlug(`language-switch-${e.target.lang}`),
+    });
     i18n.changeLanguage(e.target.getAttribute('lang'));
   }
 


### PR DESCRIPTION
## Description
Adds an event recorder for the lang toggle. This alone will not register in GA. An issue with the analytics team has been opened to add the events.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45230


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
