### PR TITLE
Certificate of Eligibility: remove confirm email address field

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/contact-information/additional-information.js
+++ b/src/applications/lgy/coe/form/config/chapters/contact-information/additional-information.js
@@ -10,12 +10,7 @@ const { additionalInformation } = contactInformation;
 export const schema = {
   ...additionalInformation,
   title,
-  properties: {
-    ...additionalInformation.properties,
-    'view:confirmContactEmail': {
-      $ref: '#/definitions/email',
-    },
-  },
+  properties: additionalInformation.properties,
 };
 
 export const uiSchema = {
@@ -24,23 +19,4 @@ export const uiSchema = {
     'ui:title': 'Phone number',
   },
   contactEmail: emailUI(),
-  'view:confirmContactEmail': {
-    ...emailUI(),
-    'ui:title': 'Confirm email address',
-    'ui:required': () => true,
-    'ui:validations': [
-      {
-        validator: (errors, _fieldData, formData) => {
-          if (
-            formData.contactEmail?.toLowerCase() !==
-            formData['view:confirmContactEmail']?.toLowerCase()
-          ) {
-            errors.addError(
-              'This email does not match your previously entered email',
-            );
-          }
-        },
-      },
-    ],
-  },
 };

--- a/src/applications/lgy/coe/form/tests/config/applicantCommunicationPreferences.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/config/applicantCommunicationPreferences.unit.spec.jsx
@@ -6,9 +6,9 @@ import { Provider } from 'react-redux';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import createCommonStore from 'platform/startup/store';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 const defaultStore = createCommonStore();
 
@@ -31,7 +31,7 @@ describe('COE applicant communication preferences', () => {
     );
     const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input').length).to.equal(3);
+    expect(formDOM.querySelectorAll('input').length).to.equal(2);
   });
 
   it('Should not submit without required fields', () => {
@@ -51,7 +51,7 @@ describe('COE applicant communication preferences', () => {
 
     formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -66,7 +66,6 @@ describe('COE applicant communication preferences', () => {
           data={{
             contactPhone: '5555555555',
             contactEmail: 'test@test.com',
-            'view:confirmContactEmail': 'test@test.com',
           }}
           onSubmit={onSubmit}
         />

--- a/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
@@ -15,7 +15,6 @@
   },
   "contactPhone": "4445551212",
   "contactEmail": "test2@test1.net",
-  "view:confirmContactEmail": "test2@test1.net",
   "identity": "VETERAN",
   "periodsOfService": [
     {

--- a/src/applications/lgy/coe/form/tests/fixtures/data/minimal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/minimal-test.json
@@ -15,7 +15,6 @@
   },
   "contactPhone": "4445551212",
   "contactEmail": "test2@test1.net",
-  "view:confirmContactEmail": "test2@test1.net",
   "identity": "VETERAN",
   "periodsOfService": [
     {


### PR DESCRIPTION
## Description

This removes the _Confirm Email_ field from the Certificate of Eligibility form as they are not required to confirm it by entering it twice in separate fields.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#45020](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45020)

## Testing done
Existing tests have been updated


## Screenshots
<img width="896" alt="COE Example" src="https://user-images.githubusercontent.com/969752/184904470-60150ab9-0699-44ca-84cb-9ad0063adcaf.png">
