### PR TITLE
Add screen reader announcement to transportation note

### DIFF
--- a/src/applications/burials/helpers.jsx
+++ b/src/applications/burials/helpers.jsx
@@ -154,7 +154,10 @@ export const serviceRecordWarning = (
 );
 
 export const transportationWarning = (
-  <div className="usa-alert usa-alert-warning background-color-only">
+  <div
+    className="usa-alert usa-alert-warning background-color-only"
+    aria-live="polite"
+  >
     <span>
       <strong>Note:</strong> At the end of the application, you will be asked to
       upload documentation for the expenses you incurred for transporting the


### PR DESCRIPTION
# Original issue(s)
department-of-veterans-affairs/va.gov-team#43318

## URL of Fix:
[Apply for burial benefits | Step 4 of 6: Benefits selection](http://localhost:3001/burials-and-memorials/application/530/benefits/selection)

# Expected behavior
Blind users are notified when text content is added after making form selection.

## Current behavior
Blind users are not alerted to new text added to screen if they are tabbing through the form and might not know they will be asked to upload documentation at the end.

## Your fix
Two options were provided in the ticket. Adding `aria-live="polite"` to instruct the screen reader to read the new content when it is added to the screen seemed the more appropriate option for two reasons:
1) Informs users of additional required documentation when making selection, so the feedback is more immediate
2) Embedding the content within the `<label>` does not describe the information to be entered into the field.

## How has this been tested?
VoiceOver on MacOS

## Screenshots
Shows that the note now uses `aria-live`
<img width="635" alt="Screen Shot 2022-08-16 at 11 51 50 AM" src="https://user-images.githubusercontent.com/1094951/184927730-25040224-f4a4-4dfc-8a25-a89159dab6d2.png">


## Acceptance criteria
- [x] Tests continue to pass
- [x] Transportation note uses `aria-live="polite"`
- [x] Transportation note is announced when the user clicks the last checkbox.
