### PR TITLE
update past months

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
@@ -19,6 +19,7 @@ import {
 } from '../../redux/selectors';
 import useClinicFormState from './useClinicFormState';
 import { MENTAL_HEALTH, PRIMARY_CARE } from '../../../utils/constants';
+import { selectFeatureVaosV2Next } from '../../../redux/selectors';
 
 function formatTypeOfCare(careLabel) {
   if (careLabel.startsWith('MOVE') || careLabel.startsWith('CPAP')) {
@@ -45,6 +46,10 @@ function getPageTitle(schema, typeOfCare, usingPastClinics) {
 
 const pageKey = 'clinicChoice';
 export default function ClinicChoicePage() {
+  const featureVaosV2Next = useSelector(state =>
+    selectFeatureVaosV2Next(state),
+  );
+
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -66,6 +71,7 @@ export default function ClinicChoicePage() {
     data.clinicId === 'NONE' && !eligibility?.request;
   const usingPastClinics =
     typeOfCare.id !== PRIMARY_CARE && typeOfCare.id !== MENTAL_HEALTH;
+  const pastMonths = featureVaosV2Next ? 36 : 24;
 
   useEffect(() => {
     scrollAndFocus();
@@ -106,7 +112,7 @@ export default function ClinicChoicePage() {
           </h1>
           {usingPastClinics && (
             <p>
-              In the last 24 months you’ve had{' '}
+              In the last {pastMonths} months you’ve had{' '}
               {vowelCheck(typeOfCareLabel) ? 'an' : 'a'} {typeOfCareLabel}{' '}
               appointment at the following {facility.name} clinics:
             </p>

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -575,7 +575,7 @@ const responses = {
         { name: 'vaOnlineSchedulingPocHealthApt', value: true },
         { name: 'vaOnlineSchedulingStatusImprovement', value: true },
         { name: 'vaOnlineFilter36Vats', value: true },
-        { name: 'vaOnlineSchedulingVaosV2Next', value: true },
+        { name: 'vaOnlineSchedulingVAOSV2Next', value: true },
         { name: 'edu_section_103', value: true },
         { name: 'vaViewDependentsAccess', value: false },
         { name: 'gibctEybBottomSheet', value: true },


### PR DESCRIPTION
## Description
Since we changed the logic to expand the filter from 24 to 36 past appointment month check for eligibility, the Choose a VA Clinic Choose page should reflect the same message in the text under the `vaos-v2-next` toggle. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44688


## Testing done
local test

## Screenshots
`vaos-v2-next` toggle

![Screen Shot 2022-08-15 at 6 13 16 PM](https://user-images.githubusercontent.com/54327023/184961839-f6141020-4538-4478-bafc-8328c0ed66e7.png)

without toggle
![Screen Shot 2022-08-15 at 6 12 30 PM](https://user-images.githubusercontent.com/54327023/184961944-044dfed4-48d6-471c-b6e0-ac6004e084fa.png)


## Acceptance criteria
- [ ] when `vaos-v2-next` toggle is on, have the description say 36 months
- [ ] when  `vaos-v2-next` toggle is off, have the description say 24 months

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
