### PR TITLE
Certificate of Eligibility | Update VA loan number input

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,8 +333,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a1dea4255d9d9f5383ce2ac7749ba9194abff53a",
-    "whatwg-fetch": "^3.6.2"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a1dea4255d9d9f5383ce2ac7749ba9194abff53a"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -333,7 +333,8 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7543eac2cbeeb338d2c43bc9e931c66f5982f551"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a1dea4255d9d9f5383ce2ac7749ba9194abff53a",
+    "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   createUSAStateLabels,
@@ -35,6 +36,21 @@ const PreviousLoanView = ({ formData }) => {
       <div>{to ? `${from} - ${to}` : `${from} - present`}</div>
     </div>
   );
+};
+
+PreviousLoanView.propTypes = {
+  formData: PropTypes.shape({
+    dateRange: PropTypes.shape({
+      from: PropTypes.string,
+      to: PropTypes.string,
+    }),
+    propertyAddress: PropTypes.shape({
+      propertyAddress1: PropTypes.string,
+      propertyCity: PropTypes.string,
+      propertyState: PropTypes.string,
+      propertyZip: PropTypes.string,
+    }),
+  }),
 };
 
 export const schema = loanHistory;
@@ -101,6 +117,9 @@ export const uiSchema = {
       vaLoanNumber: {
         'ui:title': 'VA loan number',
         'ui:options': { widgetClassNames: 'usa-input-medium' },
+        'ui:errorMessages': {
+          pattern: 'Please enter numbers only (dashes allowed)',
+        },
       },
       propertyOwned: {
         'ui:title': 'Do you still own this property?',

--- a/src/applications/lgy/coe/form/routes.jsx
+++ b/src/applications/lgy/coe/form/routes.jsx
@@ -1,6 +1,6 @@
 import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 import formConfig from './config/form';
-import App from './containers/App.jsx';
+import App from './containers/App';
 
 const routes = [
   {

--- a/src/applications/lgy/coe/form/tests/config/loanHistory.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/config/loanHistory.unit.spec.jsx
@@ -92,4 +92,78 @@ describe('COE applicant loan history', () => {
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
   });
+  it('Should allow loan number with numbers, dashes and spaces', () => {
+    const form = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            relevantPriorLoans: [
+              {
+                vaLoanNumber: '1-234 5',
+              },
+            ],
+          }}
+          onSubmit={() => {}}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+  });
+  it('Should not allow loan number with a leading dash', () => {
+    const form = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            relevantPriorLoans: [
+              {
+                vaLoanNumber: '-1-234-5',
+              },
+            ],
+          }}
+          onSubmit={() => {}}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+    const error = formDOM.querySelectorAll('.usa-input-error')?.[0];
+    expect(error).to.exist;
+    expect(error.textContent).to.contain('numbers only');
+  });
+  it('Should not allow non-digits in loan number', () => {
+    const form = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            relevantPriorLoans: [
+              {
+                vaLoanNumber: '1-234-5a',
+              },
+            ],
+          }}
+          onSubmit={() => {}}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+    const error = formDOM.querySelectorAll('.usa-input-error')?.[0];
+    expect(error).to.exist;
+    expect(error.textContent).to.contain('numbers only');
+  });
 });

--- a/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
@@ -47,7 +47,7 @@
         "propertyState": "AK",
         "propertyZip": "85274"
       },
-      "vaLoanNumber": 99,
+      "vaLoanNumber": "123-45",
       "propertyOwned": true,
       "willRefinance": false
     },

--- a/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
@@ -62,7 +62,7 @@
         "propertyState": "AK",
         "propertyZip": "85274"
       },
-      "vaLoanNumber": 100,
+      "vaLoanNumber": "100 23",
       "propertyOwned": true,
       "willRefinance": false
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19471,9 +19471,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#7543eac2cbeeb338d2c43bc9e931c66f5982f551":
-  version "20.20.12"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7543eac2cbeeb338d2c43bc9e931c66f5982f551"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#a1dea4255d9d9f5383ce2ac7749ba9194abff53a":
+  version "20.20.13"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a1dea4255d9d9f5383ce2ac7749ba9194abff53a"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Original Ticket

[#45026](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45026)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/loan-history`

## Background

Currently, the VA Loan ID Number (LIN) is set as a number-type input, and allows negative numbers. From the discussions in #45026, we plan to change this input to a text-type and allow Veterans to enter numbers, dashes and spaces only. An error message will show otherwise

## Steps to test

1. Pull this branch or test in a review instance
2. Go to URL of change (no need to log in to test)
3. Enter "-12345" in the VA loan number input
4. Upon blur, an error message should display
5. Add non-numeric characters to see that the error persists
6. Replace the value with `123-45 67` to see that this is acceptable

## Code changes

- Updated & merged the VA loan number schema in the vets-json-schema in [#714](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/714)
- Update package.json for latest vets-json-schema version
- Added PropTypes (fix eslint issues)
- Add pattern error message
- Add pattern unit tests
- Update maximal-test data

## How was your code tested

Unit tests

## Acceptance criteria
- [x] COE VA loan ID number is now a text input that only accepts numbers, dashes & spaces
- [x] Added error message (needs content review)
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs