### PR TITLE
Signup bug

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -316,16 +316,15 @@ export function logout(
 
 export async function signup({
   version = API_VERSION,
-  csp = CSP_IDS.ID_ME,
+  policy = CSP_IDS.ID_ME,
+  isLink = false,
 } = {}) {
-  return redirect(
-    await sessionTypeUrl({
-      type: `${csp}_signup`,
-      version,
-      ...(csp === CSP_IDS.ID_ME && { queryParams: { op: 'signup' } }),
-    }),
-    `${csp}-${AUTH_EVENTS.REGISTER}`,
-  );
+  const url = await sessionTypeUrl({
+    type: `${policy}_signup`,
+    version,
+    ...(policy === CSP_IDS.ID_ME && { queryParams: { op: 'signup' } }),
+  });
+  return isLink ? url : redirect(url, `${policy}-${AUTH_EVENTS.REGISTER}`);
 }
 
 export const signupUrl = type => {

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -547,7 +547,7 @@ describe('Authentication Utilities', () => {
 
     it('should redirect to the provided CSPs signup session url', async () => {
       setup({ path: nonUsipPath });
-      await authUtilities.signup({ csp: CSP_IDS.LOGIN_GOV });
+      await authUtilities.signup({ policy: CSP_IDS.LOGIN_GOV });
       expect(global.window.location).to.equal(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.LOGIN_GOV] }),
       );
@@ -556,28 +556,30 @@ describe('Authentication Utilities', () => {
 
   describe('signupUrl', () => {
     it('should generate an ID.me session signup url by default', async () => {
-      expect(await authUtilities.signupUrl()).to.include(
-        API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
-      );
+      expect(
+        await authUtilities.signup({ policy: CSP_IDS.ID_ME, isLink: true }),
+      ).to.include(API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }));
     });
 
     it('should append op=signup param for ID.me signups', async () => {
-      expect(await authUtilities.signupUrl(CSP_IDS.ID_ME)).to.contain.all(
+      expect(
+        await authUtilities.signup({ policy: CSP_IDS.ID_ME, isLink: true }),
+      ).to.contain.all(
         API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
         'op=signup',
       );
     });
 
     it('should generate a session signup url for the given type', async () => {
-      expect(await authUtilities.signupUrl(CSP_IDS.LOGIN_GOV)).to.include(
-        API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.LOGIN_GOV] }),
-      );
+      expect(
+        await authUtilities.signup({ policy: CSP_IDS.LOGIN_GOV, isLink: true }),
+      ).to.include(API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.LOGIN_GOV] }));
     });
 
     it('should generate an ID.me session signup url if the given type is not valid', async () => {
-      expect(await authUtilities.signupUrl('test')).to.include(
-        API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }),
-      );
+      expect(
+        await authUtilities.signup({ type: 'test', isLink: true }),
+      ).to.include(API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.ID_ME] }));
     });
   });
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -546,11 +546,13 @@ describe('Authentication Utilities', () => {
     });
 
     it('should redirect to the provided CSPs signup session url', async () => {
-      setup({ path: nonUsipPath });
-      await authUtilities.signup({ policy: CSP_IDS.LOGIN_GOV });
-      expect(global.window.location).to.equal(
-        API_SESSION_URL({ type: SIGNUP_TYPES[CSP_IDS.LOGIN_GOV] }),
-      );
+      setup({ path: normalPathWithParams });
+      const expectedUrl = await authUtilities.signup({
+        policy: CSP_IDS.LOGIN_GOV,
+        isLink: true,
+      });
+      authUtilities.redirect(expectedUrl);
+      expect(global.window.location).to.contain(expectedUrl);
     });
   });
 

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -105,6 +105,9 @@ export async function createOAuthRequest({
     config ??
     (externalApplicationsConfig[application] ||
       externalApplicationsConfig.default);
+  const useType = passedOptions.isSignup
+    ? type.slice(0, type.indexOf('_'))
+    : type;
 
   /*
     Web - Generate state & codeVerifier if default oAuth
@@ -137,7 +140,7 @@ export async function createOAuthRequest({
     [OAUTH_KEYS.CODE_CHALLENGE_METHOD]: OAUTH_ALLOWED_PARAMS.S256,
   };
 
-  const url = new URL(API_SIGN_IN_SERVICE_URL({ type }));
+  const url = new URL(API_SIGN_IN_SERVICE_URL({ type: useType }));
 
   Object.keys(oAuthParams).forEach(param =>
     url.searchParams.append(param, oAuthParams[param]),

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -128,7 +128,8 @@ describe('OAuth - Utilities', () => {
           },
         });
         const { oAuthOptions } = externalApplicationsConfig.default;
-        expect(url).to.include(`type=${csp}`);
+        const expectedType = csp.slice(0, csp.indexOf('_'));
+        expect(url).to.include(`type=${expectedType}`);
         expect(url).to.include(`acr=${oAuthOptions.acrSignup[csp]}`);
       });
     });


### PR DESCRIPTION
## Description
This PR changes the way the `signup` function is used to authenticate a user for signup.
Original Sign in Service URL:
`/v0/sign_in/authorize?type=idme_signup|logingov_signup`

Intended Sign in Service URL:
`/v0/sign_in/authorize?type=idme|logingov`

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#45907

## Testing done
Unit testing + E2E

## Screenshots
n/a

## Acceptance criteria
- [x] The `signup` function should be able to generate a URL or do a redirect by passing a parameter
- [x] The `signup` function for SiS should result in a URL like this: `v0/sign_in/authorize?type={csp}` for both Login.gov and ID.me respectively
- [x] The `signup` function for IAM should remain unchanged and be `v1/sessions/{csp}_signup/new` for both Login.gov and ID.me respectively 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
