### PR TITLE
Fixes State Mismatch bug

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -271,8 +271,8 @@ export default function RenderErrorContainer({
     case AUTH_ERROR.OAUTH_STATE_MISMATCH:
       alertContent = (
         <p className="vads-u-margin-top--0">
-          We’re having trouble signing you in to VA.gov right now because the
-          browser state is different.
+          We’re having trouble signing you in to VA.gov right now because your
+          browser information is different from the initial sign in.
         </p>
       );
       troubleshootingContent = (
@@ -297,6 +297,9 @@ export default function RenderErrorContainer({
           <Helpdesk>
             If you’ve taken the steps above and still can’t sign in,
           </Helpdesk>
+          <button type="button" onClick={openLoginModal}>
+            Try signing in again
+          </button>
         </>
       );
       break;

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -144,8 +144,8 @@ export class AuthApp extends React.Component {
   handleTokenRequest = async ({ code, state, csp }) => {
     // Verify the state matches in storage
     if (
-      !sessionStorage.getItem(OAUTH_KEYS.STATE) ||
-      sessionStorage.getItem(OAUTH_KEYS.STATE) !== state
+      !localStorage.getItem(OAUTH_KEYS.STATE) ||
+      localStorage.getItem(OAUTH_KEYS.STATE) !== state
     ) {
       this.generateOAuthError({
         code: AUTH_ERROR.OAUTH_STATE_MISMATCH,

--- a/src/platform/user/tests/authentication/components/DowntimeBanner.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/DowntimeBanner.unit.spec.js
@@ -12,6 +12,7 @@ import {
 const generateState = ({ serviceId = 'mvi', serviceDown = false }) => ({
   externalServiceStatuses: {
     loading: false,
+    shouldGetBackendStatuses: false,
     statuses: AUTH_DEPENDENCIES.map(deps => ({
       service: deps.toUpperCase(),
       serviceId: deps,

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -32,7 +32,7 @@ export const saveStateAndVerifier = type => {
     Ensures saved state is not overwritten if location has state parameter.
   */
   if (window.location.search.includes(OAUTH_KEYS.STATE)) return null;
-  const storage = window.localStorage;
+  const storage = localStorage;
 
   // Create and store a random "state" value
   const state = oauthCrypto.generateRandomString(28);
@@ -54,7 +54,7 @@ export const saveStateAndVerifier = type => {
 };
 
 export const removeStateAndVerifier = () => {
-  const storage = window.localStorage;
+  const storage = localStorage;
 
   Object.keys(storage)
     .filter(key => ALL_STATE_AND_VERIFIERS.includes(key))
@@ -64,7 +64,7 @@ export const removeStateAndVerifier = () => {
 };
 
 export const updateStateAndVerifier = csp => {
-  const storage = window.localStorage;
+  const storage = localStorage;
 
   storage.setItem(OAUTH_KEYS.STATE, storage.getItem(`${csp}_signup_state`));
   storage.setItem(
@@ -149,7 +149,8 @@ export async function createOAuthRequest({
 }
 
 export const getCV = () => {
-  const codeVerifier = sessionStorage.getItem(OAUTH_KEYS.CODE_VERIFIER);
+  const storage = localStorage;
+  const codeVerifier = storage.getItem(OAUTH_KEYS.CODE_VERIFIER);
   return { codeVerifier };
 };
 

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -32,7 +32,7 @@ export const saveStateAndVerifier = type => {
     Ensures saved state is not overwritten if location has state parameter.
   */
   if (window.location.search.includes(OAUTH_KEYS.STATE)) return null;
-  const storage = window.sessionStorage;
+  const storage = window.localStorage;
 
   // Create and store a random "state" value
   const state = oauthCrypto.generateRandomString(28);
@@ -54,7 +54,7 @@ export const saveStateAndVerifier = type => {
 };
 
 export const removeStateAndVerifier = () => {
-  const storage = window.sessionStorage;
+  const storage = window.localStorage;
 
   Object.keys(storage)
     .filter(key => ALL_STATE_AND_VERIFIERS.includes(key))
@@ -64,7 +64,7 @@ export const removeStateAndVerifier = () => {
 };
 
 export const updateStateAndVerifier = csp => {
-  const storage = window.sessionStorage;
+  const storage = window.localStorage;
 
   storage.setItem(OAUTH_KEYS.STATE, storage.getItem(`${csp}_signup_state`));
   storage.setItem(

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -70,15 +70,13 @@ describe('OAuth - Utilities', () => {
     });
     it('should set sessionStorage', () => {
       oAuthUtils.saveStateAndVerifier();
-      expect(!!window.sessionStorage.getItem('state')).to.be.true;
-      expect(!!window.sessionStorage.getItem('code_verifier')).to.be.true;
+      expect(!!localStorage.getItem('state')).to.be.true;
+      expect(!!localStorage.getItem('code_verifier')).to.be.true;
     });
     it('should return an object with state and codeVerifier', () => {
       const { state, codeVerifier } = oAuthUtils.saveStateAndVerifier();
-      expect(window.sessionStorage.getItem('state')).to.eql(state);
-      expect(window.sessionStorage.getItem('code_verifier')).to.eql(
-        codeVerifier,
-      );
+      expect(localStorage.getItem('state')).to.eql(state);
+      expect(localStorage.getItem('code_verifier')).to.eql(codeVerifier);
     });
   });
 
@@ -136,15 +134,20 @@ describe('OAuth - Utilities', () => {
 
   describe('getCV', () => {
     it('should return null when empty', () => {
+      const storage = localStorage;
+      storage.clear();
       expect(oAuthUtils.getCV()).to.eql({ codeVerifier: null });
+      storage.clear();
     });
     it('should return code_verifier when in session storage', () => {
       const cvValue = 'success_getCV';
-      window.sessionStorage.setItem('code_verifier', cvValue);
+      const storage = localStorage;
+      storage.clear();
+      storage.setItem('code_verifier', cvValue);
       expect(oAuthUtils.getCV()).to.eql({
         codeVerifier: cvValue,
       });
-      window.sessionStorage.clear();
+      storage.clear();
     });
   });
 
@@ -157,23 +160,29 @@ describe('OAuth - Utilities', () => {
     });
     it('should generate a proper url with appropriate query params', async () => {
       const cvValue = 'success_buildTokenRequest';
-      window.sessionStorage.setItem('code_verifier', cvValue);
+      const storage = localStorage;
+      storage.clear();
+      storage.setItem('code_verifier', cvValue);
       const tokenPath = `https://dev-api.va.gov/v0/sign_in/token?grant_type=authorization_code&client_id=web&redirect_uri=https%253A%252F%252Fdev.va.gov&code=hello&code_verifier=${cvValue}`;
       const btr = await oAuthUtils.buildTokenRequest({ code: 'hello' });
       expect(btr.href).to.eql(tokenPath);
       expect(btr.href).includes('code=');
       expect(btr.href).includes('code_verifier=');
+      storage.clear();
     });
   });
 
   describe('requestToken', () => {
     it('should fail if url is not generated', async () => {
+      localStorage.clear();
       const req2 = await oAuthUtils.requestToken({ code: 'test' });
       expect(req2).to.eql(null);
     });
     it('should POST successfully to `/token` endpoint', async () => {
       const cvValue = 'tst';
-      global.sessionStorage.setItem('code_verifier', cvValue);
+      const storage = localStorage;
+      storage.clear();
+      storage.setItem('code_verifier', cvValue);
       mockFetch();
       setFetchResponse(global.fetch.onFirstCall(), []);
       const tokenOptions = await oAuthUtils.requestToken({ code: 'success' });
@@ -181,10 +190,13 @@ describe('OAuth - Utilities', () => {
       expect(global.fetch.calledOnce).to.be.true;
       expect(global.fetch.firstCall.args[1].method).to.equal('POST');
       expect(global.fetch.firstCall.args[0].includes('/token')).to.be.true;
+      storage.clear();
     });
     it('should return an error if `/token` endpoint unsuccessful', async () => {
       const cvValue = 'tst';
-      global.sessionStorage.setItem('code_verifier', cvValue);
+      const storage = localStorage;
+      storage.clear();
+      storage.setItem('code_verifier', cvValue);
       mockFetch();
       setFetchFailure(global.fetch.onFirstCall(), []);
       const tokenOptions = await oAuthUtils.requestToken({
@@ -194,6 +206,7 @@ describe('OAuth - Utilities', () => {
       expect(global.fetch.firstCall.args[1].method).to.equal('POST');
       expect(global.fetch.firstCall.args[0].includes('/token')).to.be.true;
       expect(tokenOptions.ok).to.be.false;
+      storage.clear();
     });
   });
 
@@ -292,7 +305,8 @@ describe('OAuth - Utilities', () => {
     ];
 
     it('should get the generated sessionStorage state & code verifier', () => {
-      const storage = window.sessionStorage;
+      const storage = localStorage;
+      storage.clear();
       expect(storage.getItem('state')).to.be.null;
       expect(storage.getItem('code_verifier')).to.be.null;
       signupKeys.forEach(key =>
@@ -307,8 +321,9 @@ describe('OAuth - Utilities', () => {
       expect(storage.length).to.eql(2);
       storage.clear();
     });
-    it('it should remove only those items from sessionStorage', () => {
-      const storage = window.sessionStorage;
+    it('it should remove only those items from localStorage', () => {
+      const storage = localStorage;
+      storage.clear();
       expect(storage.getItem('state')).to.be.null;
       expect(storage.getItem('code_verifier')).to.be.null;
       signupKeys.forEach(key =>
@@ -322,17 +337,20 @@ describe('OAuth - Utilities', () => {
   });
 
   describe('removeStateAndVerifier', () => {
-    it('should remove all state & verifiers from sessionStorage', () => {
-      const storage = window.sessionStorage;
+    it('should remove all state & verifiers from localStorage', () => {
+      const storage = localStorage;
+      storage.clear();
       ALL_STATE_AND_VERIFIERS.forEach(storageKey => {
         storage.setItem(storageKey, 'randomValue');
       });
 
       oAuthUtils.removeStateAndVerifier();
       expect(Object.keys(storage).length).to.eql(0);
+      storage.clear();
     });
-    it('should not remove any other item from sessionStorage', () => {
-      const storage = window.sessionStorage;
+    it('should not remove any other item from localStorage', () => {
+      const storage = localStorage;
+      storage.clear();
       ALL_STATE_AND_VERIFIERS.forEach(storageKey => {
         storage.setItem(storageKey, 'randomValue');
       });
@@ -341,6 +359,7 @@ describe('OAuth - Utilities', () => {
       oAuthUtils.removeStateAndVerifier();
       expect(Object.keys(storage).length).to.eql(1);
       expect(storage.getItem('otherKey')).to.eql('otherValue');
+      storage.clear();
     });
   });
 

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -153,10 +153,13 @@ describe('OAuth - Utilities', () => {
 
   describe('buildTokenRequest', () => {
     it('should not generate url if no `code` is provider or `code_verifier` is null', async () => {
+      const storage = localStorage;
+      storage.clear();
       const btr = await oAuthUtils.buildTokenRequest();
       expect(btr).to.be.null;
       const btr2 = oAuthUtils.buildTokenRequest({ code: 'hello' });
       expect(btr2).to.be.null;
+      storage.clear();
     });
     it('should generate a proper url with appropriate query params', async () => {
       const cvValue = 'success_buildTokenRequest';


### PR DESCRIPTION
## Description
This PR does 2 things
1. On the AuthApp for error code 202 (State mismatch OAuth) adds a button to reattempt login
2. Changes the `state` and `code_verifier` to use localStorage instead of sessionStorage (allowing access of storage between tabs)

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#45827


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] The Sign in Service authentication process works as expected
- [x] When opening up the Sign in Modal (or on the Sign in Page) the `state` and `code_verifier` are saved to local storage

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
