### PR TITLE
[cFSR] - Fixing debt selection issues

### DIFF
--- a/src/applications/financial-status-report/components/DebtCheckBox.jsx
+++ b/src/applications/financial-status-report/components/DebtCheckBox.jsx
@@ -52,7 +52,7 @@ const DebtCheckBox = ({ debt }) => {
 
     const newlySelectedDebtsAndCopays = selectedDebtsAndCopays?.length
       ? [...selectedDebtsAndCopays, selectedDebt]
-      : [selectedDebtsAndCopays];
+      : [selectedDebt];
 
     return dispatch(
       setData({

--- a/src/applications/financial-status-report/components/DebtCheckBox.jsx
+++ b/src/applications/financial-status-report/components/DebtCheckBox.jsx
@@ -50,9 +50,9 @@ const DebtCheckBox = ({ debt }) => {
       ? [...selectedDebts, selectedDebt]
       : [selectedDebt];
 
-    const newlySelectedDebtsAndCopays = selectedDebts?.length
-      ? [...selectedDebts, selectedDebt]
-      : [selectedDebt];
+    const newlySelectedDebtsAndCopays = selectedDebtsAndCopays?.length
+      ? [...selectedDebtsAndCopays, selectedDebt]
+      : [selectedDebtsAndCopays];
 
     return dispatch(
       setData({

--- a/src/applications/financial-status-report/pages/veteran/debts.js
+++ b/src/applications/financial-status-report/pages/veteran/debts.js
@@ -12,7 +12,13 @@ export const uiSchema = {
       </span>
     ),
     'ui:widget': AvailableDebts,
-    'ui:required': ({ selectedDebts }) => !selectedDebts.length,
+    'ui:required': formData => {
+      const { selectedDebts, selectedDebtsAndCopays = [] } = formData;
+
+      return formData['view:combinedFinancialStatusReport']
+        ? !selectedDebtsAndCopays.length
+        : !selectedDebts.length;
+    },
     'ui:options': {
       hideOnReview: true,
     },


### PR DESCRIPTION
## Description
Encountered a bug where a debt needed to be selected in order to continue from the selection page. 
 - Updated `required` field for debt selection page to reference new selected debts and copays array depending on the 
feature flag. 

Encountered a second bug where checking/unchecking debts would clear selected copays. 
 - Updated dispatch to use correct array


## Acceptance criteria
- [x] Debt/Copay selection working as intended

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
