### PR TITLE
Certificate of Eligibility | Fix upload page headers

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/documents/FileField.jsx
+++ b/src/applications/lgy/coe/form/config/chapters/documents/FileField.jsx
@@ -302,6 +302,9 @@ class FileField extends React.Component {
           formContext.reviewMode ? 'schemaform-file-upload-review' : undefined
         }
       >
+        <legend className="vads-u-font-size--base">
+          Your uploaded documents
+        </legend>
         {files.length > 0 && (
           <ul className="schemaform-file-list">
             {files.map((file, index) => {

--- a/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
+++ b/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
@@ -28,7 +28,9 @@ const UploadRequirements = ({ formData }) => {
 
   return (
     <div>
-      <h2 className="vads-u-font-size--h4">Upload your documents</h2>
+      <h3 className="vads-u-font-size--h4 vads-u-margin-top--1">
+        Upload your documents
+      </h3>
       {identity && (
         <p className="vads-u-font-weight--bold">Please upload the following</p>
       )}

--- a/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
+++ b/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
@@ -8,6 +8,9 @@ import { DOCUMENT_TYPES } from '../../../../status/constants';
 
 const DocumentUploadDescription = () => (
   <div>
+    <h3 className="vads-u-font-size--h4">
+      Having problems uploading your document?
+    </h3>
     <p>
       You can upload your document in a .pdf, .jpg, .jpeg, or .png file format.
       You’ll first need to scan a copy of your document onto your computer or
@@ -70,13 +73,15 @@ export const schema = {
 
 export const uiSchema = {
   'view:documentRequirements': {
-    'ui:field': UploadRequirements,
+    'ui:title': ' ',
+    'ui:description': UploadRequirements,
     'ui:options': {
       classNames: 'schemaform-block-override',
+      forceDivWrapper: true,
     },
   },
   files: {
-    'ui:title': 'Your uploaded documents',
+    'ui:title': ' ',
     'ui:field': FileField,
     'ui:options': {
       addAnotherLabel: 'Upload another document',
@@ -120,11 +125,10 @@ export const uiSchema = {
     'ui:validations': [validateFileField],
   },
   'view:documentUploadDescription': {
-    'ui:title': () => (
-      <legend className="schemaform-block-title">
-        Having problems uploading your document?
-      </legend>
-    ),
+    'ui:title': ' ',
     'ui:description': DocumentUploadDescription,
+    'ui:options': {
+      forceDivWrapper: true,
+    },
   },
 };


### PR DESCRIPTION
## Original Ticket

[#45029](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45029)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/upload-supporting-documents`

## Background

An accessibility audit of the COE upload page discovered some headings that needed to be adjusted.  Changing an `H2` to an `H3` and changing a non-header into an `H3`

## Steps to test

1. Pull this branch or test in a review instance
2. Log in to user 228 (Colder/Mark)
3. Enable the [save-in-progress menu](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-use-the-save-in-progress-m) (add `#dev-on` to the URL)
4. Open [`maximal-test.json` data in your browser](https://raw.githubusercontent.com/department-of-veterans-affairs/vets-website/main/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json)
5.  Select all (<kbd>Command (⌘)</kbd> + <kbd>A</kbd>, then Copy (<kbd>Command (⌘)</kbd> + <kbd>C</kbd>) the data
6. Click the "Open the save-in-progress menu" link to open the modal
7. Paste the `maximal-test.json` into the "Form data" text area 
8. Set the "Return url" to the URL of change
9. Use "Replace" to save and restart the form
10. On the "Upload your documents" page, use the [HeadingsMap](https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi?hl=en) extension to check the heading levels
    <details><summary>HeadingsMap screenshot</summary>

    <!-- leave a blank line above -->
    <img width="1150" alt="Headings map side bar showing an h1 for request a VA home loan COE, an h2 for the step 5 of 6 heading, an h3 for upload your documents and another h3 for the having problems uploading your document? headers. A bunch of h2s are below these that are all in the footer" src="https://user-images.githubusercontent.com/136959/185232692-70a5b9b4-6e25-454d-b832-3255d4dd4ae3.png"></details>

11. Run [axe DevTools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en) (ignore color contrast & same link name issue in the page header)
12. Run [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en) - there should now only be one `fieldset` with an associated `legend`

## Code changes

- Changed `H2` to an `H3`
- Switched a `legend` to an `H3`
- Removed unnecessary `fieldsets` (using `forceDivWrapper` & setting `ui:title` to a single space)

## How was your code tested

A11y testing tools, manual testing for `fieldsets` & `legends` (only analyzed by WAVE)

## Acceptance criteria
- [x] Headers on the COE upload page are appropriately set
- [x] Only one `fieldset` & `legend` pair on the page 
- [x] A11y tests passing
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs