### PR TITLE
bump moment to 2.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "mapbox-gl": "^1.12.0",
     "markdown-it": "^12.3.2",
     "markdown-it-link-attributes": "^4.0.0",
-    "moment": "~2.24.0",
+    "moment": "~2.29.4",
     "moment-timezone": "^0.5.34",
     "octokit": "^1.7.1",
     "octokit-plugin-create-pull-request": "^3.11.0",

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
@@ -73,7 +73,7 @@ describe('Unemployability affective Dates', () => {
     fillDate(
       form,
       'root_unemployability_disabilityAffectedEmploymentFullTimeDate',
-      '2017-03-04"',
+      '2017-03-04',
     );
 
     form.find('form').simulate('submit');

--- a/src/platform/forms-system/test/js/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/helpers.unit.spec.js
@@ -37,17 +37,17 @@ describe('Schemaform helpers:', () => {
       });
       expect(parseISODate('2003-02-XX')).to.eql({
         month: '2',
-        day: '',
+        day: null,
         year: '2003',
       });
       expect(parseISODate('2003-02')).to.eql({
         month: '2',
-        day: '',
+        day: null,
         year: '2003',
       });
       expect(parseISODate('2003')).to.eql({
         month: '',
-        day: '',
+        day: null,
         year: '2003',
       });
     });

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -403,8 +403,8 @@ describe('Schemaform validations', () => {
       const errors = { to: { addError: sinon.spy() } };
       validateDateRangeAllowSameMonth(errors, {
         // the difference from validateDateRange
-        from: '2014-01-XX',
-        to: '2014-01-XX',
+        from: '2014-01-01',
+        to: '2014-01-01',
       });
 
       expect(errors.to.addError.called).to.be.false;

--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -172,7 +172,7 @@ describe('Validations unit tests', () => {
       };
       const toDate = {
         day: {
-          value: '',
+          value: null,
           dirty: true,
         },
         month: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13695,15 +13695,10 @@ moment-timezone@^0.5.34:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.22.1:
+"moment@>= 2.9.0", moment@^2.22.1, moment@~2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
-moment@~2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
## Description
This PR bumps moment to 2.29.4 in response to a high severity security vulnerability.

**Please note**: Moment `2.29.4` introduces a change whereby if a day with the value of an empty string is passed to the `moment()` function an invalid moment instance is returned. This breaks some tests. I have modified the tests to work but need help verifying that the applications will still function as designed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
