### PR TITLE
9909 show facility location name when no address is provided by cms

### DIFF
--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
@@ -2,6 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { deriveEventLocations } from '../../helpers';
 
+const WhereContent = ({ fieldLocation, fieldType, derivedLocations }) => {
+  if (fieldType === 'online') return 'This is an online event.';
+  return (
+    <>
+      <a href={fieldLocation?.entity?.entityUrl.path}>
+        {fieldLocation?.entity?.title}
+      </a>
+      {derivedLocations?.length > 0 && (
+        <div>
+          {derivedLocations?.map(location => (
+            <p className="vads-u-margin--0" key={location}>
+              {location}
+            </p>
+          ))}
+        </div>
+      )}
+    </>
+  );
+};
+
 export const ResultsWhereContent = ({ event }) => {
   const fieldFacilityLocation = event?.fieldFacilityLocation;
   const fieldLocationType = event?.fieldLocationType;
@@ -12,26 +32,6 @@ export const ResultsWhereContent = ({ event }) => {
     locations.length === 0
   )
     return <></>;
-
-  const WhereContent = ({ fieldLocation, fieldType, derivedLocations }) => {
-    if (fieldType === 'online') return 'This is an online event.';
-    return (
-      <>
-        <a href={fieldLocation?.entity?.entityUrl.path}>
-          {fieldLocation?.entity?.title}
-        </a>
-        {derivedLocations?.length > 0 && (
-          <div>
-            {derivedLocations?.map(location => (
-              <p className="vads-u-margin--0" key={location}>
-                {location}
-              </p>
-            ))}
-          </div>
-        )}
-      </>
-    );
-  };
 
   return (
     <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
@@ -55,7 +55,7 @@ ResultsWhereContent.propTypes = {
   event: PropTypes.object,
 };
 
-ResultsWhereContent.propTypes = {
+WhereContent.propTypes = {
   derivedLocations: PropTypes.object,
   fieldLocation: PropTypes.object,
   fieldType: PropTypes.object,

--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
@@ -1,21 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deriveEventLocations } from '../../helpers';
 
-export const ResultsWhereContent = ({
-  fieldFacilityLocation,
-  fieldLocationType,
-  locations,
-}) => {
-  function whereContent() {
-    if (fieldLocationType === 'online') return 'This is an online event.';
+export const ResultsWhereContent = ({ event }) => {
+  const fieldFacilityLocation = event?.fieldFacilityLocation;
+  const fieldLocationType = event?.fieldLocationType;
+  const locations = deriveEventLocations(event);
+  if (
+    fieldFacilityLocation === null &&
+    fieldLocationType !== 'online' &&
+    locations.length === 0
+  )
+    return <></>;
+
+  const WhereContent = ({ fieldLocation, fieldType, derivedLocations }) => {
+    if (fieldType === 'online') return 'This is an online event.';
     return (
       <>
-        <a href={fieldFacilityLocation?.entity?.entityUrl.path}>
-          {fieldFacilityLocation?.entity?.title}
+        <a href={fieldLocation?.entity?.entityUrl.path}>
+          {fieldLocation?.entity?.title}
         </a>
-        {locations?.length > 0 && (
+        {derivedLocations?.length > 0 && (
           <div>
-            {locations?.map(location => (
+            {derivedLocations?.map(location => (
               <p className="vads-u-margin--0" key={location}>
                 {location}
               </p>
@@ -24,14 +31,7 @@ export const ResultsWhereContent = ({
         )}
       </>
     );
-  }
-
-  if (
-    fieldFacilityLocation === null &&
-    fieldLocationType !== 'online' &&
-    locations.length === 0
-  )
-    return <></>;
+  };
 
   return (
     <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
@@ -39,16 +39,27 @@ export const ResultsWhereContent = ({
         <strong>Where:</strong>
       </p>
       <div className="vads-u-display--flex vads-u-flex-direction--column">
-        <p className="vads-u-margin--0">{whereContent()}</p>
+        <p className="vads-u-margin--0">
+          <WhereContent
+            fieldLocation={fieldFacilityLocation}
+            fieldType={fieldLocationType}
+            derivedLocations={locations}
+          />
+          {/* {WhereContent(fieldFacilityLocation, fieldLocationType, locations)} */}
+        </p>
       </div>
     </div>
   );
 };
 
 ResultsWhereContent.propTypes = {
-  fieldFacilityLocation: PropTypes.object,
-  fieldLocationType: PropTypes.string,
-  locations: PropTypes.array,
+  event: PropTypes.object,
+};
+
+ResultsWhereContent.propTypes = {
+  derivedLocations: PropTypes.object,
+  fieldLocation: PropTypes.object,
+  fieldType: PropTypes.object,
 };
 
 export default ResultsWhereContent;

--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const ResultsWhereContent = ({
+  fieldFacilityLocation,
+  fieldLocationType,
+  locations,
+}) => {
+  function whereContent() {
+    if (fieldLocationType === 'online') return 'This is an online event.';
+    return (
+      <>
+        <a href={fieldFacilityLocation?.entity?.entityUrl.path}>
+          {fieldFacilityLocation?.entity?.title}
+        </a>
+        {locations?.length > 0 && (
+          <div>
+            {locations?.map(location => (
+              <p className="vads-u-margin--0" key={location}>
+                {location}
+              </p>
+            ))}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  if (
+    fieldFacilityLocation === null &&
+    fieldLocationType !== 'online' &&
+    locations.length === 0
+  )
+    return <></>;
+
+  return (
+    <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
+      <p className="vads-u-margin--0 vads-u-margin-right--0p5">
+        <strong>Where:</strong>
+      </p>
+      <div className="vads-u-display--flex vads-u-flex-direction--column">
+        <p className="vads-u-margin--0">{whereContent()}</p>
+      </div>
+    </div>
+  );
+};
+
+ResultsWhereContent.propTypes = {
+  fieldFacilityLocation: PropTypes.object,
+  fieldLocationType: PropTypes.string,
+  locations: PropTypes.array,
+};
+
+export default ResultsWhereContent;

--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
@@ -45,7 +45,6 @@ export const ResultsWhereContent = ({ event }) => {
             fieldType={fieldLocationType}
             derivedLocations={locations}
           />
-          {/* {WhereContent(fieldFacilityLocation, fieldLocationType, locations)} */}
         </p>
       </div>
     </div>

--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -6,7 +6,6 @@ import moment from 'moment-timezone';
 // Relative imports.
 import ResultsWhereContent from './ResultsWhereContent';
 import {
-  deriveEventLocations,
   deriveMostRecentDate,
   deriveResultsEndNumber,
   deriveResultsStartNumber,
@@ -84,9 +83,6 @@ export const Results = ({
               .format('z')
               .replace(/S|D/i, '');
 
-            // Derive the event locations.
-            const locations = deriveEventLocations(event);
-
             return (
               <div
                 className="vads-u-display--flex vads-u-flex-direction--column vads-u-border-top--1px vads-u-border-color--gray-light vads-u-padding-y--4"
@@ -126,11 +122,7 @@ export const Results = ({
                 </div>
 
                 {/* Where */}
-                <ResultsWhereContent
-                  fieldFacilityLocation={event?.fieldFacilityLocation}
-                  fieldLocationType={event?.fieldLocationType}
-                  locations={locations}
-                />
+                <ResultsWhereContent event={event} />
               </div>
             );
           })}

--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -167,6 +167,25 @@ export const Results = ({
                     </div>
                   </div>
                 )}
+
+                {/* shows field facility location when no address is provided  */}
+                {locations?.length === 0 &&
+                  event.fieldFacilityLocation?.entity?.title && (
+                    <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
+                      <p className="vads-u-margin--0 vads-u-margin-right--0p5">
+                        <strong>Where:</strong>
+                      </p>
+                      <p className="vads-u-margin--0">
+                        <a
+                          href={
+                            event.fieldFacilityLocation.entity.entityUrl.path
+                          }
+                        >
+                          {event.fieldFacilityLocation.entity.title}
+                        </a>
+                      </p>
+                    </div>
+                  )}
               </div>
             );
           })}

--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import VaPagination from '@department-of-veterans-affairs/component-library/Pagination';
 import moment from 'moment-timezone';
 // Relative imports.
+import ResultsWhereContent from './ResultsWhereContent';
 import {
   deriveEventLocations,
   deriveMostRecentDate,
@@ -125,67 +126,11 @@ export const Results = ({
                 </div>
 
                 {/* Where */}
-                {event?.fieldLocationType === 'online' && (
-                  <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
-                    <p className="vads-u-margin--0 vads-u-margin-right--0p5">
-                      <strong>Where:</strong>
-                    </p>
-
-                    <div className="vads-u-display--flex vads-u-flex-direction--column">
-                      <p className="vads-u-margin--0">
-                        This is an online event.
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                {locations?.length > 0 && (
-                  <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
-                    <p className="vads-u-margin--0 vads-u-margin-right--0p5">
-                      <strong>Where:</strong>
-                    </p>
-
-                    <div className="vads-u-display--flex vads-u-flex-direction--column">
-                      {event.fieldFacilityLocation?.entity?.entityUrl?.path &&
-                        event.fieldFacilityLocation?.entity?.title && (
-                          <p className="vads-u-margin--0">
-                            <a
-                              href={
-                                event.fieldFacilityLocation.entity.entityUrl
-                                  .path
-                              }
-                            >
-                              {event.fieldFacilityLocation.entity.title}
-                            </a>
-                          </p>
-                        )}
-                      {locations?.map(location => (
-                        <p className="vads-u-margin--0" key={location}>
-                          {location}
-                        </p>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* shows field facility location when no address is provided  */}
-                {locations?.length === 0 &&
-                  event.fieldFacilityLocation?.entity?.title && (
-                    <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
-                      <p className="vads-u-margin--0 vads-u-margin-right--0p5">
-                        <strong>Where:</strong>
-                      </p>
-                      <p className="vads-u-margin--0">
-                        <a
-                          href={
-                            event.fieldFacilityLocation.entity.entityUrl.path
-                          }
-                        >
-                          {event.fieldFacilityLocation.entity.title}
-                        </a>
-                      </p>
-                    </div>
-                  )}
+                <ResultsWhereContent
+                  fieldFacilityLocation={event?.fieldFacilityLocation}
+                  fieldLocationType={event?.fieldLocationType}
+                  locations={locations}
+                />
               </div>
             );
           })}

--- a/src/applications/static-pages/events/components/Results/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/Results/index.unit.spec.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 // Relative imports.
 import { Results } from '.';
 import { ResultsWhereContent } from './ResultsWhereContent';
@@ -20,25 +21,30 @@ describe('Events <Results>', () => {
 });
 
 describe('Events <ResultsWhereContent>', () => {
-  function getProps(locationObj, locationString, locationArray) {
-    return {
+  function getProps(locationObj, locationString, locationReadable) {
+    // eslint-disable-next-line sonarjs/prefer-immediate-return
+    const event = {
       fieldFacilityLocation: locationObj,
       fieldLocationType: locationString,
-      locations: locationArray,
+      fieldLocationHumanreadable: locationReadable,
     };
+    return event;
   }
+
   it('renders online event prompt when event location type is online', () => {
-    const onlineProps = getProps({}, 'online', []);
-    const wrapper = shallow(<ResultsWhereContent {...onlineProps} />);
-    expect(wrapper.text()).includes('This is an online event.');
-    wrapper.unmount();
+    const onlineEvent = getProps({}, 'online', null);
+    const component = render(<ResultsWhereContent event={onlineEvent} />);
+    expect(component.getByText('This is an online event.')).to.exist;
   });
+
   it('render given location when included in location array', () => {
-    const locationArrayProps = getProps({}, '', ['pittsburgh']);
-    const wrapper = shallow(<ResultsWhereContent {...locationArrayProps} />);
-    expect(wrapper.text()).includes('pittsburgh');
-    wrapper.unmount();
+    const locationArrayEvent = getProps({}, '', 'pittsburgh');
+    const component = render(
+      <ResultsWhereContent event={locationArrayEvent} />,
+    );
+    expect(component.getByText('pittsburgh')).to.exist;
   });
+
   it('renders location name when given in location object', () => {
     const fieldLocationExample = {
       entity: {
@@ -46,9 +52,10 @@ describe('Events <ResultsWhereContent>', () => {
         entityUrl: {},
       },
     };
-    const locationObjectProps = getProps(fieldLocationExample, '', []);
-    const wrapper = shallow(<ResultsWhereContent {...locationObjectProps} />);
-    expect(wrapper.text()).includes('test location');
-    wrapper.unmount();
+    const locationObjectEvent = getProps(fieldLocationExample, '', null);
+    const component = render(
+      <ResultsWhereContent event={locationObjectEvent} />,
+    );
+    expect(component.getByText('test location')).to.exist;
   });
 });

--- a/src/applications/static-pages/events/components/Results/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/Results/index.unit.spec.js
@@ -22,13 +22,11 @@ describe('Events <Results>', () => {
 
 describe('Events <ResultsWhereContent>', () => {
   function getProps(locationObj, locationString, locationReadable) {
-    // eslint-disable-next-line sonarjs/prefer-immediate-return
-    const event = {
+    return {
       fieldFacilityLocation: locationObj,
       fieldLocationType: locationString,
       fieldLocationHumanreadable: locationReadable,
     };
-    return event;
   }
 
   it('renders online event prompt when event location type is online', () => {

--- a/src/applications/static-pages/events/components/Results/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/Results/index.unit.spec.js
@@ -4,6 +4,28 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
 import { Results } from '.';
+import { ResultsWhereContent } from './ResultsWhereContent';
+
+// page: PropTypes.number.isRequired,
+// perPage: PropTypes.number.isRequired,
+// query: PropTypes.string.isRequired,
+// results: PropTypes.arrayOf(
+//   PropTypes.shape({
+//     entityUrl: PropTypes.object.isRequired,
+//     fieldDatetimeRangeTimezone: PropTypes.arrayOf(
+//       PropTypes.shape({
+//         endValue: PropTypes.number.isRequired,
+//         timezone: PropTypes.string,
+//         value: PropTypes.number.isRequired,
+//       }),
+//     ).isRequired,
+//     fieldDescription: PropTypes.string,
+//     title: PropTypes.string.isRequired,
+//   }),
+// ).isRequired,
+// totalResults: PropTypes.number.isRequired,
+// onPageSelect: PropTypes.func.isRequired,
+// queryId: PropTypes.string,
 
 describe('Events <Results>', () => {
   it('renders what we expect', () => {
@@ -14,6 +36,22 @@ describe('Events <Results>', () => {
     expect(wrapper.text()).includes('No results found');
 
     // Clean up.
+    wrapper.unmount();
+  });
+});
+
+describe('Events <ResultsWhereContent>', () => {
+  function getProps(locationObj, locationString, locationArray) {
+    return {
+      fieldFacilityLocation: locationObj,
+      fieldLocationType: locationString,
+      locations: locationArray,
+    };
+  }
+  it('renders online event prompt when event location type is online', () => {
+    const onlineProps = getProps({}, 'online', []);
+    const wrapper = shallow(<ResultsWhereContent {...onlineProps} />);
+    expect(wrapper.text()).includes('This is an online event.');
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/events/components/Results/index.unit.spec.js
+++ b/src/applications/static-pages/events/components/Results/index.unit.spec.js
@@ -6,27 +6,6 @@ import { shallow } from 'enzyme';
 import { Results } from '.';
 import { ResultsWhereContent } from './ResultsWhereContent';
 
-// page: PropTypes.number.isRequired,
-// perPage: PropTypes.number.isRequired,
-// query: PropTypes.string.isRequired,
-// results: PropTypes.arrayOf(
-//   PropTypes.shape({
-//     entityUrl: PropTypes.object.isRequired,
-//     fieldDatetimeRangeTimezone: PropTypes.arrayOf(
-//       PropTypes.shape({
-//         endValue: PropTypes.number.isRequired,
-//         timezone: PropTypes.string,
-//         value: PropTypes.number.isRequired,
-//       }),
-//     ).isRequired,
-//     fieldDescription: PropTypes.string,
-//     title: PropTypes.string.isRequired,
-//   }),
-// ).isRequired,
-// totalResults: PropTypes.number.isRequired,
-// onPageSelect: PropTypes.func.isRequired,
-// queryId: PropTypes.string,
-
 describe('Events <Results>', () => {
   it('renders what we expect', () => {
     // Set up.
@@ -52,6 +31,24 @@ describe('Events <ResultsWhereContent>', () => {
     const onlineProps = getProps({}, 'online', []);
     const wrapper = shallow(<ResultsWhereContent {...onlineProps} />);
     expect(wrapper.text()).includes('This is an online event.');
+    wrapper.unmount();
+  });
+  it('render given location when included in location array', () => {
+    const locationArrayProps = getProps({}, '', ['pittsburgh']);
+    const wrapper = shallow(<ResultsWhereContent {...locationArrayProps} />);
+    expect(wrapper.text()).includes('pittsburgh');
+    wrapper.unmount();
+  });
+  it('renders location name when given in location object', () => {
+    const fieldLocationExample = {
+      entity: {
+        title: 'test location',
+        entityUrl: {},
+      },
+    };
+    const locationObjectProps = getProps(fieldLocationExample, '', []);
+    const wrapper = shallow(<ResultsWhereContent {...locationObjectProps} />);
+    expect(wrapper.text()).includes('test location');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
#9909.   Where was not showing for events on the event list when an address wasn't being provided. This adds logic to show the facility location if there is no address given.


## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9909)


## Testing done
Local testing.  To test, start vets-website and preview the event page bedford-health-care/events/ . Observer that "The wall that heals" has a location rendered.

## Screenshots
<img width="821" alt="Screen Shot 2022-08-18 at 9 47 59 AM" src="https://user-images.githubusercontent.com/61624970/185410991-4a3bfb35-fb3f-4f0e-bdc8-32a7b2b78b82.png">
<img width="821" alt="Screen Shot 2022-08-18 at 9 44 56 AM" src="https://user-images.githubusercontent.com/61624970/185410995-b1d892ac-0569-4b39-a682-7dd2e8781eb5.png">



## Acceptance criteria
- [ ] Location shows on all events

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
