### PR TITLE
Certificate of Eligibility | Allow same closing & paid off date, and fix date formatting

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -73,6 +73,7 @@ export const uiSchema = {
         'Closing date of your loan',
         'Date you paid off your loan (Leave this blank if it’s not paid off)',
         'Date loan ended must be after the start of the loan',
+        true, // allow start & end to be the same month/year
       ),
       propertyAddress: {
         'ui:title': 'Property address',

--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -22,8 +22,9 @@ const PreviousLoanView = ({ formData }) => {
   let from = '';
   let to = '';
   if (formData.dateRange) {
-    from = formatReviewDate(formData.dateRange.from);
-    to = formatReviewDate(formData.dateRange.to);
+    // formatReviewDate('YYYMMDD', monthYearFlag)
+    from = formatReviewDate(formData.dateRange.from, true);
+    to = formatReviewDate(formData.dateRange.to, true);
   }
 
   return (

--- a/src/applications/lgy/coe/form/tests/config/loanHistory.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/config/loanHistory.unit.spec.jsx
@@ -166,4 +166,87 @@ describe('COE applicant loan history', () => {
     expect(error).to.exist;
     expect(error.textContent).to.contain('numbers only');
   });
+
+  it('Should allow same month/year closing & paid off dates', () => {
+    const onSubmit = sinon.spy();
+    const form = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            relevantPriorLoans: [
+              {
+                dateRange: {
+                  from: '2019-02-XX',
+                  to: '2019-02-XX',
+                },
+                propertyAddress: {
+                  propertyAddress1: '412 Crooks Road',
+                  propertyCity: 'Clawson',
+                  propertyState: 'AK',
+                  propertyZip: '48017',
+                },
+              },
+            ],
+          }}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('Should render only month & year in date range (no XX for day)', () => {
+    const onSubmit = sinon.spy();
+    const form = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            relevantPriorLoans: [
+              {
+                dateRange: {
+                  from: '2019-02-XX',
+                  to: '2019-03-XX',
+                },
+                propertyAddress: {
+                  propertyAddress1: '412 Crooks Road',
+                  propertyCity: 'Clawson',
+                  propertyState: 'AK',
+                  propertyZip: '48017',
+                },
+              },
+              {
+                dateRange: {
+                  from: '2019-04-XX',
+                  to: '2019-05-XX',
+                },
+                propertyAddress: {
+                  propertyAddress1: '414 Crooks Road',
+                  propertyCity: 'Clawson',
+                  propertyState: 'AK',
+                  propertyZip: '48017',
+                },
+              },
+            ],
+          }}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    expect(formDOM.querySelector('.small-collapse').textContent).to.contain(
+      '02/2019 - 03/2019',
+    );
+  });
 });


### PR DESCRIPTION
## Original Tickets

[#45028](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45028)
[#42488](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42488)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/loan-history`

## Background

Previous VA loans have the potential to have the same month & year for both the closing date and the paid off date. This PR allows the same date per the discussion in the original ticket

Additionally, the collapsed card date range format has been fixed to only show the month/year (and not `XX` for a day that wasn't set)

<details><summary>VA Loan history result</summary>

<!-- leave a blank line above -->
<img width="572" alt="COE loan page showing a collapsed card with a date range of 01/2022 - 01/2022 and an open card showing February 2022 in both the closing date and paid off date form elements" src="https://user-images.githubusercontent.com/136959/185443832-410a5b87-b165-4124-be3e-3ba957679114.png"></details>

## Steps to test

1. Pull this branch locally or test in a review instance
2. Go to the URL of change without needing to log in
3. Enter same month/year into closing date &  paid off date entries
4. Note no error message
5. Add a street address, city, state and postal code
6. Activate "Update" button
7. The collapsed card should only display the month & year in the date range

## Code changes

- Add `true` parameter flag to date range function to allow same month/year date range
- Add `true` to `formatReviewDate` functions to properly format the date using only month and year
- Add unit tests

## How was your code tested

Unit tests

## Acceptance criteria
- [x] Allow same date in closing date & paid off date
- [x] Fix date formatting in collapsed card 
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs