### PR TITLE
VACMS-9387: update content Get Medical Records page - Aug 18 target merge

### DIFF
--- a/src/applications/static-pages/cta-widget/components/messages/OpenMyHealtheVet.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/OpenMyHealtheVet.jsx
@@ -12,9 +12,9 @@ const OpenMyHealtheVet = ({
     alertText: (
       <p>
         You may need to sign in again on My HealtheVet to use the site’s{' '}
-        {toolName} tool. If you do, sign in with the same account you here on
-        VA.gov. You also may need to disable your browser’s pop-up blocker so
-        that My HealtheVet will be able to open.
+        {toolName} tool. If you do, sign in with the same account you used to
+        sign in here on VA.gov. You also may need to disable your browser’s
+        pop-up blocker so that My HealtheVet will be able to open.
       </p>
     ),
     primaryButtonText: 'Go to My HealtheVet',

--- a/src/applications/static-pages/cta-widget/components/messages/OpenMyHealtheVet.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/OpenMyHealtheVet.jsx
@@ -13,8 +13,8 @@ const OpenMyHealtheVet = ({
       <p>
         You may need to sign in again on My HealtheVet to use the site’s{' '}
         {toolName} tool. If you do, sign in with the same account you here on
-        VA.gov. You also may need to disable your browser’s pop-up pop-up
-        blocker so that My HealtheVet will be able to open.
+        VA.gov. You also may need to disable your browser’s pop-up blocker so
+        that My HealtheVet will be able to open.
       </p>
     ),
     primaryButtonText: 'Go to My HealtheVet',

--- a/src/applications/static-pages/cta-widget/components/messages/OpenMyHealtheVet.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/OpenMyHealtheVet.jsx
@@ -12,9 +12,9 @@ const OpenMyHealtheVet = ({
     alertText: (
       <p>
         You may need to sign in again on My HealtheVet to use the site’s{' '}
-        {toolName} tool. If you do, please sign in with the same account you
-        used to sign in here on VA.gov. You also may need to disable your
-        browser’s pop-up blocker so that My HealtheVet will be able to open.
+        {toolName} tool. If you do, sign in with the same account you here on
+        VA.gov. You also may need to disable your browser’s pop-up pop-up
+        blocker so that My HealtheVet will be able to open.
       </p>
     ),
     primaryButtonText: 'Go to My HealtheVet',

--- a/src/applications/static-pages/cta-widget/components/messages/SignIn.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/SignIn.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CallToActionAlert from '../CallToActionAlert';
-
 import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
+import CallToActionAlert from '../CallToActionAlert';
 
 const SignIn = ({
   serviceDescription,
@@ -14,7 +13,7 @@ const SignIn = ({
   ariaDescribedby = null,
 }) => {
   const content = {
-    heading: `Please sign in to ${serviceDescription}`,
+    heading: `Sign in to ${serviceDescription}`,
     headerLevel,
     alertText: (
       <p>

--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -148,7 +148,7 @@ export const ctaWidgetsLookup = {
     isHealthTool: true,
     mhvToolName: 'VA Blue Button',
     requiredServices: backendServices.HEALTH_RECORDS,
-    serviceDescription: 'view your VA medical records',
+    serviceDescription: 'manage your VA medical records',
   },
   [CTA_WIDGET_TYPES.HEARING_AID_SUPPLIES]: {
     id: CTA_WIDGET_TYPES.HEARING_AID_SUPPLIES,

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -165,11 +165,10 @@ export class CernerCallToAction extends Component {
           })}
 
           <p className="usa-alert-text">
-            Please choose a health management portal below, depending on your
-            provider&apos;s facility. You may need to disable your
-            browser&apos;s pop-up blocker to open the portal. If you&apos;re
-            prompted to sign in again, use the same account you used to sign in
-            on VA.gov.
+            Choose a health management portal, depending on your provider&apos;s
+            facility. You may need to disable your browser&apos;s pop-up blocker
+            to open the portal. If you&apos;re prompted to sign in again, use
+            the same account you used to sign in on VA.gov.
           </p>
 
           <h4 className="vads-u-margin-y--3">{linksHeaderText}</h4>

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.unit.spec.js
@@ -47,7 +47,7 @@ describe('<CernerCallToAction>', () => {
 
     const text = wrapper.text();
     expect(text).to.include(
-      'Please choose a health management portal below, depending on your provider',
+      'Choose a health management portal, depending on your provider',
     );
 
     wrapper.unmount();

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -53,7 +53,7 @@ const AuthContent = ({
         </li>
         <li>
           Download a Health Summary that includes specific information from your
-          VA medical records (like your known allergies, medications, and recent
+          VA medical records (like your known allergies, medicines, and recent
           lab results)
         </li>
         <li>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -6,7 +6,6 @@ import Telephone, {
 // Relative imports.
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
-import ServiceProvidersList from 'platform/user/authentication/components/ServiceProvidersList';
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import {
   authenticatedWithSSOePropType,
@@ -20,303 +19,242 @@ const AuthContent = ({
   cernerFacilities,
   otherFacilities,
   ehrDataByVhaId,
-}) => (
-  <>
-    <h2 className="vads-u-margin-bottom--2 vads-u-font-size--lg">
-      On this page:
-    </h2>
-    <ul>
-      <li>
-        <a href="#va-blue-button">
-          My HealtheVet (VA Blue Button) and My VA Health{' '}
-        </a>
-      </li>
-      <li>
-        <a href="#vhie">The Veterans Health Information Exchange (VHIE)</a>
-      </li>
-    </ul>
-    <h2 id="va-blue-button">My HealtheVet (VA Blue Button) and My VA Health</h2>
-    <CernerCallToAction
-      cernerFacilities={cernerFacilities}
-      otherFacilities={otherFacilities}
-      ehrDataByVhaId={ehrDataByVhaId}
-      linksHeaderText="Get your medical records from:"
-      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'download-my-data')}
-      myVAHealthLink={getCernerURL(
-        '/pages/health_record/clinical_documents/sharing',
-      )}
-    />
-    <h3>What are My HealtheVet and My VA Health, and which will I use?</h3>
-    <p>
-      My HealtheVet and My VA Health are both VA health management portals
-      designed to help you manage your care. My VA Health is our new portal that
-      providers at select facilities have started to use.
-    </p>
-    <p>
-      Each portal offers a tool to help you manage your medical records. The
-      portal you’ll use will depend on where you receive care. If you receive
-      care at both Mann-Grandstaff VA Medical Center and another VA facility,
-      you may need to use both portals.
-    </p>
-    <h3>How can My HealtheVet’s VA Blue Button tool help me manage my care?</h3>
-    <p>
-      This tool lets you review, print, save, download, and share information
-      from your VA medical records and personal health record. With this tool,
-      you can better manage your health needs and communicate with your health
-      care team.
-    </p>
-    <p>
-      <strong>With My HealtheVet’s VA Blue Button tool, you can:</strong>
-    </p>
-    <ul>
-      <li>
-        Download a customized Blue Button report with information from your VA
-        medical records, personal health record, and in some cases your military
-        service record
-      </li>
-      <li>
-        Download a Health Summary that includes specific information from your
-        VA medical records (like your known allergies, medications, and recent
-        lab results)
-      </li>
-      <li>
-        Build your own personal health record that includes information like
-        your self-entered medical history, emergency contacts, and medicines
-      </li>
-      <li>
-        Monitor your vital signs and track your diet and exercise with our
-        online journals
-      </li>
-      <li>
-        Share a digital copy of the personal health information you entered
-        yourself with your VA health care team through secure messaging
-      </li>
-    </ul>
-    <h3>How can My VA Health’s Health Records tool help me manage my care?</h3>
-    <p>
-      This tool lets you review and print information from your VA medical
-      records at Mann-Grandstaff VA Medical Center.
-    </p>
-    <p>
-      <strong>With My VA Health’s Health Records tool, you can:</strong>
-    </p>
-    <ul>
-      <li>
-        Review and print your health profile, lab and test results, health
-        conditions, and procedures
-      </li>
-      <li>Review, download, and share clinical documents</li>
-    </ul>
-    <h3>Am I eligible to use these tools?</h3>
-    <p>
-      You can use these tools to get your VA medical records if you meet all of
-      the requirements listed below.
-    </p>
-    <p>
-      <strong>Both of these must be true. You’re:</strong>
-    </p>
-    <ul>
-      <li>
-        Enrolled in VA health care, <strong>and</strong>
-      </li>
-      <li>Registered as a patient in a VA health facility</li>
-    </ul>
-    <p>
-      <a href="/health-care/how-to-apply/">
+}) => {
+  return (
+    <>
+      <h2 id="va-blue-button">
+        Use My HealtheVet or My VA Health to manage your records online
+      </h2>
+      <CernerCallToAction
+        cernerFacilities={cernerFacilities}
+        otherFacilities={otherFacilities}
+        ehrDataByVhaId={ehrDataByVhaId}
+        linksHeaderText="Get your medical records from:"
+        myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'download-my-data')}
+        myVAHealthLink={getCernerURL(
+          '/pages/health_record/clinical_documents/sharing',
+        )}
+      />
+      <h3>What are My HealtheVet and My VA Health, and which will I use?</h3>
+      <p>
+        My HealtheVet and My VA Health are both VA health management portals
+        designed to help you manage your care. My VA Health is our new portal
+        that providers at select facilities have started to use.
+      </p>
+      <p>
+        Each portal offers a tool to help you manage your medical records. The
+        portal you’ll use will depend on where you receive care. If you receive
+        care at more than one VA facility, you may need to use both portals.
+      </p>
+      <h3>What you can do in My HealtheVet’s VA Blue Button</h3>
+      <ul>
+        <li>
+          Download a customized Blue Button report with information from your VA
+          medical records, personal health record, and in some cases your
+          military service record
+        </li>
+        <li>
+          Download a Health Summary that includes specific information from your
+          VA medical records (like your known allergies, medications, and recent
+          lab results)
+        </li>
+        <li>
+          Build your own personal health record that includes information like
+          your self-entered medical history, emergency contacts, and medicines
+        </li>
+        <li>
+          Monitor your vital signs and track your diet and exercise with our
+          online journals
+        </li>
+        <li>
+          Share a digital copy of the personal health information you entered
+          yourself with your VA health care team through secure messaging
+        </li>
+      </ul>
+      <h3>What you can do in My VA Health’s Health Records</h3>
+      <ul>
+        <li>
+          Review and print your VA medical records—including your health
+          profile, lab and test results, health conditions, and procedures
+        </li>
+        <li>Review, download, and share clinical documents</li>
+      </ul>
+      <h3>Who can manage VA medical records online</h3>
+      <p>
+        You can use these tools to get your VA medical records if you meet all
+        of these requirements.
+      </p>
+      <p>
+        <strong>All of these must be true:</strong>
+      </p>
+      <ul>
+        <li>
+          You’re enrolled in VA health care, <strong>and</strong>
+        </li>
+        <li>
+          You’re registered as a patient in a VA health facility,{' '}
+          <strong>and</strong>
+        </li>
+        <li>
+          You have a verified <strong>Login.gov</strong> or{' '}
+          <strong>ID.me</strong> account or a Premium <strong>DS Logon</strong>{' '}
+          or <strong>My HealtheVet</strong> account
+        </li>
+      </ul>
+      <a href="/health-care/how-to-apply">
         Find out how to apply for VA health care
       </a>
-    </p>
-    <p>
-      <strong>And you must have one of these free accounts:</strong>
-    </p>
-    <ServiceProvidersList />
-    <a
-      href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
-      rel="noreferrer noopener"
-    >
-      Learn about the 2 different My HealtheVet account types
-    </a>
-    <h3>Once I’m signed in, how do I access my medical records?</h3>
-    <h4>If you’re accessing your records on My HealtheVet</h4>
-    <p>
-      Go to your welcome page dashboard, and click on{' '}
-      <strong>Health Records</strong>. You’ll go to a new page.
-    </p>
-    <p>From here, you can choose to access your VA:</p>
-    <ul>
-      <li>Blue Button report</li>
-      <li>
-        Health summary, <strong>or</strong>
-      </li>
-      <li>Medical images and reports</li>
-    </ul>
-    <h5>If you’d like to add information to your personal health record</h5>
-    <p>
-      Go the blue navigation menu at the top of the page, and click on{' '}
-      <strong>Track Health</strong>. You’ll go to a new page where you can
-      choose to record information like your vital signs, health history, goals,
-      and food and exercise efforts.
-    </p>
-    <h4>If you’re accessing your records on My VA Health</h4>
-    <p>
-      In the navigation panel, click on <strong>Health Record</strong> You’ll go
-      to a new page.
-    </p>
-    <p>From here, you can choose to access your:</p>
-    <ul>
-      <li>Health profile</li>
-      <li>Lab and test results</li>
-      <li>Health conditions</li>
-      <li>Procedures</li>
-      <li>Clinical documents</li>
-    </ul>
-    <h3>Will my personal health information be protected?</h3>
-    <p>
-      Yes. Our health management portals are secure websites. We follow strict
-      security policies and practices to protect your personal health
-      information.
-    </p>
-    <p>
-      If you print or download anything from the website, you’ll need to take
-      responsibility for protecting that information.
-    </p>
-    <h3>What if I have more questions?</h3>
-    <h4>For My HealtheVet questions</h4>
-    <p>You can:</p>
-    <ul>
-      <li>
-        Read the FAQs pages on the My HealtheVet web portal
-        <br />
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#bbtop">
-          VA Blue Button FAQs
-        </a>
-        <br />
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/faqs#CCD">
-          VA health summary FAQs
-        </a>
-        <br />
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/faqs#VAMIR">
-          VA medical images and reports FAQs
-        </a>
-      </li>
-      <li>
-        Call the My HealtheVet help desk at{' '}
-        <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
-          877-327-0022
-        </a>{' '}
-        (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
-        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-      </li>
-      <li>
-        Or{' '}
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv">
-          contact us online
-        </a>
-      </li>
-    </ul>
-    <h4>For My VA Health questions</h4>
-    <p>
-      Call My VA Health support anytime at{' '}
-      <a href="tel:18009621024" aria-label="8 0 0. 9 6 2. 1 0 2 4.">
-        {' '}
-        800-962-1024
-      </a>
-      .
-    </p>
-    <h2>The Veterans Health Information Exchange</h2>
-    <p>
-      The Veterans Health Information Exchange (VHIE) program lets us
-      automatically and securely share your health information with
-      participating community care providers as well as the Department of
-      Defense.
-    </p>
-    <h3>What’s VHIE, and how can it help me manage my health?</h3>
-    <p>
-      VHIE gives your health care providers a more complete view of your health
-      record to help them make more informed treatment decisions. Through VHIE,
-      community providers who are a part of your care team can safely and
-      securely receive your VA health information electronically.
-    </p>
-    <p>
-      VHIE helps improve continuity of your care, reduce test duplication, and
-      avoid clinical error. That’s because you can see all your health care
-      providers from different practices or networks in one place. Our secure
-      system also eliminates the need to send paper medical records by mail, and
-      to carry your records to appointments with community providers.
-    </p>
-    <p>
-      We share your health information only with participating community
-      providers via VHIE when they’re treating you. Visit the{' '}
-      <a href="/VHIE/">VHIE page</a> to learn more about how the program helps
-      your providers better understand your health history and develop safer,
-      more effective treatment plans.
-    </p>
-    <h4>VHIE sharing options</h4>
-    <p>
-      If you don’t want your community providers to receive your information via
-      VHIE, you may opt out of electronic sharing at any time. And if you
-      previously opted out but want to resume secure, seamless sharing, you may
-      opt back in. Visit the{' '}
-      <a href="/VHIE/VHIE_Sharing_Options.asp">VHIE Sharing Options page</a> to
-      learn more.
-    </p>
-    <h3>How do I opt out?</h3>
-    <p>
-      If you would prefer to opt out of sharing your health information
-      electronically, you can do so at any time. You must complete and submit{' '}
-      <a href="/vaforms/medical/pdf/10-10164-fill.pdf">
-        VA Form 10-10164 (PDF)
-      </a>{' '}
-      to your facility’s Release of Information Office (ROI). You may also opt
-      out via{' '}
-      <a
-        rel="noreferrer noopener"
-        href="https://www.myhealth.va.gov/mhv-portal-web/home"
-      >
-        My HealtheVet
-      </a>
-      .
-    </p>
-    <p>
-      <strong>Note:</strong> If you haven’t already done so, you’ll need to
-      upgrade your My HealtheVet account to Premium status to opt out. Visit{' '}
-      <a href="https://www.myhealth.va.gov/mhv-portal-web/home">
-        My HealtheVet
-      </a>{' '}
-      to learn more.
-    </p>
-    <p>
-      Choosing to opt out will not affect your access to care from community
-      providers. However, if you opt out, your community providers may not
-      receive your medical records before you receive treatment. This may put
-      you at risk. Also, if you visit any emergency room, your information may
-      still be shared via VHIE so that you can receive the care you need.
-    </p>
-    <h3>If I opt out, how can I opt back in?</h3>
-    <p>
-      If you previously opted out, but want to resume secure, seamless sharing,
-      you may do so at any time. Simply complete{' '}
-      <a href="/vaforms/medical/pdf/10-10163-fill.pdf">
-        VA Form 10-10163 (PDF)
-      </a>{' '}
-      and return it to your VA facility’s ROI office, or submit it online
-      through{' '}
-      <a
-        rel="noreferrrer noopener"
-        href="https://www.myhealth.va.gov/mhv-portal-web/home"
-      >
-        My HealtheVet
-      </a>
-      .
-    </p>
-    <h3>Can I check my sharing preference status?</h3>
-    <p>
-      Yes. Please contact your VA facility’s ROI office. If you’ve already
-      submitted your form to opt out, or to opt back in, to the electronic
-      sharing program, your request may be in process.
-    </p>
-  </>
-);
+      <h3>Questions about managing your VA medical records</h3>
+      <va-accordion>
+        <va-accordion-item id="first">
+          <h4 slot="headline">
+            Once I’m signed in, how do I access my medical records?
+          </h4>
+          <h5>If you’re accessing your records on My HealtheVet</h5>
+          <p>
+            Go to your welcome page dashboard. Then select{' '}
+            <strong>Health Records</strong>. You’ll go to a new page.
+          </p>
+          <p>From here, you can choose to access these items:</p>
+          <ul>
+            <li>Your VA Blue Button report</li>
+            <li>Your VA health summary</li>
+            <li>Your VA medical images and reports</li>
+          </ul>
+          <strong>
+            How can I add information to my personal health record in My
+            HealtheVet?
+          </strong>
+          <p>
+            Go to the main navigation menu at the top of the page, and click on{' '}
+            <strong>Track Health</strong>. You’ll go to a new page.
+          </p>
+          <p>
+            From here, you can choose to record different types of information
+            like these:
+          </p>
+          <ul>
+            <li>Vital signs</li>
+            <li>Health history</li>
+            <li>Health goals</li>
+            <li>Food and exercise efforts</li>
+          </ul>
+          <h5>If you’re accessing your records on My VA Health</h5>
+          <p>
+            Go to the main navigation menu. Then select{' '}
+            <strong>Health Record</strong>. You’ll go to a new page.
+          </p>
+          <p>From here, you can choose to access these items:</p>
+          <ul>
+            <li>Your VA health profile</li>
+            <li>Your VA lab and test results</li>
+            <li>Your health conditions and procedures</li>
+            <li>Your VA clinical documents</li>
+          </ul>
+        </va-accordion-item>
+        <va-accordion-item
+          header="What if I can’t access all of my medical records in My HealtheVet or My VA Health?"
+          id="second"
+        >
+          <p>
+            You can request a complete copy of your medical records from your VA
+            health facility or the Department of Defense (DoD), depending on
+            where you received care.
+          </p>
+          <a href="/resources/how-to-get-your-medical-records-from-your-va-health-facility">
+            Learn how to request medical records from your VA health facility
+          </a>
+          <br />
+          <br />
+          <a href="https://www.tricare.mil/resources/medicalrecords">
+            Learn how to get DoD Health Records on the TRICARE website
+          </a>
+        </va-accordion-item>
+        <va-accordion-item
+          header="Will VA protect my personal health information?"
+          id="third"
+        >
+          <p>
+            Yes. My HealtheVet and My VA Health are secure websites. We follow
+            strict security policies and practices to protect your personal
+            health information.
+          </p>
+          <p>
+            If you print or download anything from either website, you’ll need
+            to take responsibility for protecting that information.
+          </p>
+        </va-accordion-item>
+        <va-accordion-item
+          header="How does VA share my health information with providers outside VA?"
+          id="fourth"
+        >
+          <p>
+            The Veterans Health Information Exchange (VHIE) program lets us
+            securely share your health information with participating community
+            care providers in our network. VHIE also lets us share your
+            information with the Department of Defense.
+          </p>
+          <p>
+            VHIE gives your health care providers a more complete understanding
+            of your health record. This more complete understanding can help
+            your providers make more informed treatment decisions. We share your
+            health information with participating community providers only when
+            they’re treating you.
+          </p>
+          <p>
+            If you don’t want us to share your information through VHIE, you can
+            opt out at any time.
+          </p>
+          <a href="/resources/the-veterans-health-information-exchange-vhie">
+            Learn more about VHIE
+          </a>
+        </va-accordion-item>
+        <va-accordion-item header="What if I have more questions?" id="fifth">
+          <h4>For My HealtheVet questions</h4>
+          <p>You can get more information in any of these ways:</p>
+          <ul>
+            <li>
+              Read the FAQs pages on the My HealtheVet web portal
+              <br />
+              <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs-blue-button">
+                VA Blue Button FAQs
+              </a>
+              <br />
+              <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs-health-summary">
+                VA health summary FAQs
+              </a>
+              <br />
+              <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/what-are-va-medical-images-and-reports-faqs">
+                VA medical images and reports FAQs
+              </a>
+            </li>
+            <li>
+              Call the My HealtheVet help desk at{' '}
+              <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
+                877-327-0022
+              </a>{' '}
+              (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
+              ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            </li>
+            <li>
+              <a href="https://www.myhealth.va.gov/contact-us">
+                Contact us online through My HealtheVet
+              </a>
+            </li>
+          </ul>
+          <h4>For My VA Health questions</h4>
+          <p>
+            Call My VA Health support anytime at{' '}
+            <a href="tel:18773270022" aria-label="8 0 0. 9 6 2. 1 0 2 4.">
+              800-962-1024
+            </a>
+            .
+          </p>
+        </va-accordion-item>
+      </va-accordion>
+    </>
+  );
+};
 
 AuthContent.propTypes = {
   authenticatedWithSSOe: authenticatedWithSSOePropType,

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -228,11 +228,9 @@ const AuthContent = ({
             </li>
             <li>
               Call the My HealtheVet help desk at{' '}
-              <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
-                877-327-0022
-              </a>{' '}
-              (<va-telephone contact={CONTACTS.HELP_TTY} tty />
-              ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              <va-telephone contact="8773270022" /> (
+              <va-telephone contact={CONTACTS.HELP_TTY} tty />) Monday through
+              Friday, 8:00 a.m. to 8:00 p.m. ET.
             </li>
             <li>
               <a href="https://www.myhealth.va.gov/contact-us">
@@ -243,10 +241,7 @@ const AuthContent = ({
           <h4>For My VA Health questions</h4>
           <p>
             Call My VA Health support anytime at{' '}
-            <a href="tel:18773270022" aria-label="8 0 0. 9 6 2. 1 0 2 4.">
-              800-962-1024
-            </a>
-            .
+            <va-telephone contact="8773270022" />.
           </p>
         </va-accordion-item>
       </va-accordion>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -1,8 +1,6 @@
 // Node modules.
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 // Relative imports.
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
@@ -233,7 +231,7 @@ const AuthContent = ({
               <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
                 877-327-0022
               </a>{' '}
-              (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
+              (<va-telephone contact={CONTACTS.HELP_TTY} tty />
               ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
             </li>
             <li>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -126,7 +126,7 @@ const AuthContent = ({
             HealtheVet?
           </strong>
           <p>
-            Go to the main navigation menu at the top of the page, and click on{' '}
+            Go to the main navigation menu. Then select{' '}
             <strong>Track Health</strong>. You’ll go to a new page.
           </p>
           <p>
@@ -162,7 +162,7 @@ const AuthContent = ({
             where you received care.
           </p>
           <a href="/resources/how-to-get-your-medical-records-from-your-va-health-facility">
-            Learn how to request medical records from your VA health facility
+            Learn how to get medical records from your VA health facility
           </a>
           <br />
           <br />

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.unit.spec.js
@@ -11,31 +11,15 @@ describe('Get Medical Records Page <AuthContent>', () => {
 
     const text = wrapper.text();
     expect(text).to.include('CernerCallToAction');
-    expect(text).to.include('My HealtheVet (VA Blue Button) and My VA Health');
-    expect(text).to.include('My HealtheVet (VA Blue Button) and My VA Health');
     expect(text).to.include(
       'What are My HealtheVet and My VA Health, and which will I use?',
     );
     expect(text).to.include(
-      'How can My HealtheVet’s VA Blue Button tool help me manage my care?',
+      'What you can do in My HealtheVet’s VA Blue Button',
     );
-    expect(text).to.include(
-      'How can My VA Health’s Health Records tool help me manage my care?',
-    );
-    expect(text).to.include('Am I eligible to use these tools?');
-    expect(text).to.include(
-      'Once I’m signed in, how do I access my medical records?',
-    );
-    expect(text).to.include(
-      'Will my personal health information be protected?',
-    );
-    expect(text).to.include('What if I have more questions?');
-    expect(text).to.include(
-      'What’s VHIE, and how can it help me manage my health?',
-    );
-    expect(text).to.include('How do I opt out?');
-    expect(text).to.include('If I opt out, how can I opt back in?');
-    expect(text).to.include('Can I check my sharing preference status?');
+    expect(text).to.include('What you can do in My VA Health’s Health Records');
+    expect(text).to.include('Who can manage VA medical records online');
+    expect(text).to.include('Questions about managing your VA medical records');
 
     wrapper.unmount();
   });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -1,8 +1,6 @@
 // Node modules.
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 // Relative imports.
 import CallToActionWidget from 'applications/static-pages/cta-widget';
 
@@ -206,7 +204,7 @@ const UnauthContent = () => (
             <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
               877-327-0022
             </a>{' '}
-            (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
+            (<va-telephone contact={CONTACTS.HELP_TTY} tty />
             ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
           </li>
           <li>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -87,7 +87,7 @@ const UnauthContent = () => (
         id="second"
       >
         <p>
-          Go to the main navigation menu at the top of the page, and click on{' '}
+          Go to the main navigation menu. Then select{' '}
           <strong>Track Health</strong>. You’ll go to a new page.
         </p>
         <p>
@@ -114,23 +114,21 @@ const UnauthContent = () => (
           <strong>If you’re signing up for a My HealtheVet account</strong>, go
           to “Notifications and Settings” on the registration page. Select{' '}
           <strong>On</strong> for “VA medical images and report available
-          notification”.
-          <br />
-          <a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">
-            Sign up for an account on the My HealtheVet website
-          </a>
+          notification.”
         </p>
+        <a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">
+          Sign up for an account on the My HealtheVet website
+        </a>
         <p>
           <strong>If you already have a My HealtheVet account</strong>, go to
           your profile page to update your notification settings.
-          <br />
-          <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">
-            Sign in to your account on the My HealtheVet website
-          </a>
         </p>
+        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">
+          Sign in to your account on the My HealtheVet website
+        </a>
       </va-accordion-item>
       <va-accordion-item
-        header="What if some of my medical records are missing online?"
+        header="What if I can’t access all of my medical records through VA Blue Button?"
         id="fourth"
       >
         <p>
@@ -139,7 +137,7 @@ const UnauthContent = () => (
           you received care.
         </p>
         <a href="/resources/how-to-get-your-medical-records-from-your-va-health-facility">
-          Learn how to request medical records from your VA health facility
+          Learn how to get medical records from your VA health facility
         </a>
         <br />
         <br />

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -201,11 +201,9 @@ const UnauthContent = () => (
           </li>
           <li>
             Call the My HealtheVet help desk at{' '}
-            <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
-              877-327-0022
-            </a>{' '}
-            (<va-telephone contact={CONTACTS.HELP_TTY} tty />
-            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            <va-telephone contact="8773270022" /> (
+            <va-telephone contact={CONTACTS.HELP_TTY} tty />) Monday through
+            Friday, 8:00 a.m. to 8:00 p.m. ET.
           </li>
           <li>
             <a href="https://www.myhealth.va.gov/contact-us">

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -121,7 +121,7 @@ const UnauthContent = () => (
           <strong>If you already have a My HealtheVet account</strong>, go to
           your profile page to update your notification settings.
         </p>
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">
+        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login">
           Sign in to your account on the My HealtheVet website
         </a>
       </va-accordion-item>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -5,36 +5,14 @@ import Telephone, {
 } from '@department-of-veterans-affairs/component-library/Telephone';
 // Relative imports.
 import CallToActionWidget from 'applications/static-pages/cta-widget';
-import ServiceProvidersList from 'platform/user/authentication/components/ServiceProvidersList';
 
 const UnauthContent = () => (
   <>
-    <h2 className="vads-u-margin-bottom--2 vads-u-font-size--lg">
-      On this page:
+    <h2 id="va-blue-button">
+      Use VA Blue Button to manage your records online
     </h2>
-    <ul>
-      <li>
-        <a href="#va-blue-button">VA Blue Button</a>
-      </li>
-      <li>
-        <a href="#vhie">The Veterans Health Information Exchange (VHIE)</a>
-      </li>
-    </ul>
-    <h2 id="va-blue-button">VA Blue Button</h2>
     <CallToActionWidget appId="health-records" setFocus={false} />
-    <h3>
-      What is VA Blue Button, and how can it help me manage my health care?
-    </h3>
-    <p>
-      VA Blue Button is a feature of the My HealtheVet health management portal.
-      It lets you review, print, save, download, and share information from your
-      VA medical record and personal health record. With this tool, you can
-      better manage your health needs and communicate with your health care
-      team.
-    </p>
-    <p>
-      <strong>With VA Blue Button, you can:</strong>
-    </p>
+    <h3>What you can do when you sign in</h3>
     <ul>
       <li>
         Download a customized Blue Button report with information from your VA
@@ -43,8 +21,8 @@ const UnauthContent = () => (
       </li>
       <li>
         Download a Health Summary that includes specific information from your
-        VA medical records (like your known allergies, medications, and recent
-        lab results)
+        VA medical records (like your known allergies, medicines, and recent lab
+        results)
       </li>
       <li>
         Build your own personal health record that includes information like
@@ -59,194 +37,188 @@ const UnauthContent = () => (
         yourself with your VA health care team through secure messaging
       </li>
     </ul>
-    <h3>Am I eligible to use all the features of VA Blue Button?</h3>
+    <h3>Who can manage VA medical records online</h3>
     <p>
-      You can use all the features of this tool if you meet all of the
-      requirements listed below.
+      You can use all the features of VA Blue Button if you meet all of these
+      requirements.
     </p>
     <p>
-      <strong>Both of these must be true. You’re:</strong>
+      <strong>All of these must be true:</strong>
     </p>
     <ul>
       <li>
-        Enrolled in VA health care, <strong>and</strong>
+        You’re enrolled in VA health care, <strong>and</strong>
       </li>
-      <li>Registered as a patient in a VA health facility</li>
+      <li>
+        You’re registered as a patient in a VA health facility,{' '}
+        <strong>and</strong>
+      </li>
+      <li>
+        You have a verified <strong>Login.gov</strong> or <strong>ID.me</strong>{' '}
+        account or a Premium <strong>DS Logon</strong> or{' '}
+        <strong>My HealtheVet</strong> account
+      </li>
     </ul>
     <p>
       <a href="/health-care/how-to-apply">
         Find out how to apply for VA health care
       </a>
     </p>
-    <p>
-      <strong>And you must have one of these free accounts:</strong>
-    </p>
-    <ServiceProvidersList />
-    <a
-      href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
-      rel="noreferrer noopener"
-    >
-      Learn about the 2 different My HealtheVet account types
-    </a>
-    <h3>Once I’m signed in, how do I access my medical records?</h3>
 
-    <p>
-      Go to your welcome page dashboard, and click on{' '}
-      <strong>Health Records</strong>. You’ll go to a new page.
-    </p>
-    <p>From here, you can choose to access your VA:</p>
-    <ul>
-      <li>Blue Button report</li>
-      <li>Health summary</li>
-      <li>Medical images and reports</li>
-    </ul>
-    <h4>If you’d like to add information to your personal health record</h4>
-    <p>
-      Go to the blue navigation menu at the top of the page, and click on{' '}
-      <strong>Track Health</strong>. You’ll go to a new page where you can
-      choose to record information like your vital signs, health history, goals,
-      and food and exercise efforts.
-    </p>
-    <h3>Will my personal health information be protected?</h3>
-    <p>
-      Yes. This is a secure website. We follow strict security policies and
-      practices to protect your personal health information.
-    </p>
-    <p>
-      If you print or download anything from the website, you’ll need to take
-      responsibility for protecting that information.
-    </p>
-    <h3>What if I have more questions?</h3>
-    <p>You can:</p>
-    <ul>
-      <li>
-        Read the FAQs pages on the My HealtheVet web portal
-        <br />
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#bbtop">
-          VA Blue Button FAQs
-        </a>
-        <br />
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/faqs#CCD">
-          VA health summary FAQs
-        </a>
-        <br />
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/faqs#VAMIR">
-          VA medical images and reports FAQs
-        </a>
-      </li>
-      <li>
-        Call the My HealtheVet help desk at{' '}
-        <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
-          877-327-0022
-        </a>{' '}
-        (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
-        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-      </li>
-      <li>
-        Or{' '}
-        <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv">
-          contact us online
-        </a>
-      </li>
-    </ul>
-
-    <h2 id="vhie">The Veterans Health Information Exchange</h2>
-    <p>
-      The Veterans Health Information Exchange (VHIE) program lets us
-      automatically and securely share your health information with
-      participating community care providers as well as the Department of
-      Defense.
-    </p>
-    <h3>What’s VHIE, and how can it help me manage my health?</h3>
-    <p>
-      VHIE gives your health care providers a more complete view of your health
-      record to help them make more informed treatment decisions. Through VHIE,
-      community providers who are a part of your care team can safely and
-      securely receive your VA health information electronically.
-    </p>
-
-    <p>
-      VHIE helps improve continuity of your care, reduce test duplication, and
-      avoid clinical error. That’s because you can see all your health care
-      providers from different practices or networks in one place. Our secure
-      system also eliminates the need to send paper medical records by mail, and
-      to carry your records to appointments with community providers.
-    </p>
-
-    <p>
-      We share your health information only with participating community
-      providers via VHIE when they’re treating you. Visit the{' '}
-      <a href="/VHIE/">VHIE page</a> to learn more about how the program helps
-      your providers better understand your health history and develop safer,
-      more effective treatment plans.
-    </p>
-    <h4>VHIE sharing options</h4>
-    <p>
-      If you don’t want your community providers to receive your information via
-      VHIE, you may opt out of electronic sharing at any time. And if you
-      previously opted out but want to resume secure, seamless sharing, you may
-      opt back in. Visit the{' '}
-      <a href="/VHIE/VHIE_Sharing_Options.asp">VHIE Sharing Options page</a> to
-      learn more.
-    </p>
-    <h3>How do I opt out?</h3>
-    <p>
-      If you would prefer to opt out of sharing your health information
-      electronically, you can do so at any time. You must complete and submit{' '}
-      <a href="/vaforms/medical/pdf/10-10164-fill.pdf">
-        VA Form 10-10164 (PDF)
-      </a>{' '}
-      to your facility’s Release of Information Office (ROI). You may also opt
-      out via{' '}
-      <a
-        href="https://www.myhealth.va.gov/mhv-portal-web/home"
-        rel="noreferrer noopener"
+    <h3>Questions about managing your VA medical records</h3>
+    <va-accordion>
+      <va-accordion-item id="first">
+        <h4 slot="headline">
+          Once I’m signed in, how do I access my medical records?
+        </h4>
+        <p>
+          Go to your welcome page dashboard. Then select{' '}
+          <strong>Health Records</strong>. You’ll go to a new page.
+        </p>
+        <p>From here, you can choose to access these items:</p>
+        <ul>
+          <li>Your VA Blue Button report</li>
+          <li>Your VA health summary</li>
+          <li>Your VA medical images and reports</li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item
+        header="How can I add information to my personal health record?"
+        id="second"
       >
-        My HealtheVet
-      </a>
-      .
-    </p>
-    <p>
-      <strong>Note:</strong> If you haven’t already done so, you’ll need to
-      upgrade your My HealtheVet account to Premium status to opt out. Visit{' '}
-      <a
-        href="https://www.myhealth.va.gov/mhv-portal-web/home"
-        rel="noreferrer noopener"
+        <p>
+          Go to the main navigation menu at the top of the page, and click on{' '}
+          <strong>Track Health</strong>. You’ll go to a new page.
+        </p>
+        <p>
+          From here, you can choose to record different types of information
+          like these:
+        </p>
+        <ul>
+          <li>Vital signs</li>
+          <li>Health history</li>
+          <li>Health goals</li>
+          <li>Food and exercise efforts</li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item
+        header="Can I get notifications when my medical images and reports are ready?"
+        id="third"
       >
-        My HealtheVet
-      </a>{' '}
-      to learn more.
-    </p>
-    <p>
-      Choosing to opt out will not affect your access to care from community
-      providers. However, if you opt out, your community providers may not
-      receive your medical records before you receive treatment. This may put
-      you at risk. Also, if you visit any emergency room, your information may
-      still be shared via VHIE so that you can receive the care you need.
-    </p>
-    <h3>If I opt out, how can I opt back in?</h3>
-    <p>
-      If you previously opted out, but want to resume secure, seamless sharing,
-      you may do so at any time. Simply complete{' '}
-      <a href="/vaforms/medical/pdf/10-10163-fill.pdf">
-        VA Form 10-10163 (PDF)
-      </a>{' '}
-      and return it to your VA facility’s ROI office, or submit it online
-      through{' '}
-      <a
-        href="https://www.myhealth.va.gov/mhv-portal-web/home"
-        rel="noreferrer noopener"
+        <p>
+          Yes. You can sign up to get notifications by email on the{' '}
+          <strong>My HealtheVet</strong> website. You can get notifications with
+          a Basic or Premium <strong>My HealtheVet</strong> account.
+        </p>
+        <p>
+          <strong>If you’re signing up for a My HealtheVet account</strong>, go
+          to “Notifications and Settings” on the registration page. Select{' '}
+          <strong>On</strong> for “VA medical images and report available
+          notification”.
+          <br />
+          <a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">
+            Sign up for an account on the My HealtheVet website
+          </a>
+        </p>
+        <p>
+          <strong>If you already have a My HealtheVet account</strong>, go to
+          your profile page to update your notification settings.
+          <br />
+          <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">
+            Sign in to your account on the My HealtheVet website
+          </a>
+        </p>
+      </va-accordion-item>
+      <va-accordion-item
+        header="What if some of my medical records are missing online?"
+        id="fourth"
       >
-        My HealtheVet
-      </a>
-      .
-    </p>
-    <h3>Can I check my sharing preference status?</h3>
-    <p>
-      Yes. Please contact your VA facility’s ROI office. If you’ve already
-      submitted your form to opt out, or to opt back in, to the electronic
-      sharing program, your request may be in process.
-    </p>
+        <p>
+          You can request a complete copy of your medical records from your VA
+          health facility or the Department of Defense (DoD), depending on where
+          you received care.
+        </p>
+        <a href="/resources/how-to-get-your-medical-records-from-your-va-health-facility">
+          Learn how to request medical records from your VA health facility
+        </a>
+        <br />
+        <br />
+        <a href="https://www.tricare.mil/resources/medicalrecords">
+          Learn how to get DoD Health Records on the TRICARE website
+        </a>
+      </va-accordion-item>
+      <va-accordion-item
+        header="Will VA protect my personal health information?"
+        id="fifth"
+      >
+        <p>
+          Yes. This is a secure website. We follow strict security policies and
+          practices to protect your personal health information.
+        </p>
+        <p>
+          If you print or download anything from the website, you’ll need to
+          take responsibility for protecting that information.
+        </p>
+      </va-accordion-item>
+      <va-accordion-item
+        header="How does VA share my health information with providers outside VA?"
+        id="sixth"
+      >
+        <p>
+          The Veterans Health Information Exchange (VHIE) program lets us
+          securely share your health information with participating community
+          care providers in our network. VHIE also lets us share your
+          information with the Department of Defense.
+        </p>
+        <p>
+          VHIE gives your health care providers a more complete understanding of
+          your health record. This more complete understanding can help your
+          providers make more informed treatment decisions. We share your health
+          information with participating community providers only when they’re
+          treating you.
+        </p>
+        <p>
+          If you don’t want us to share your information through VHIE, you can
+          opt out at any time.
+        </p>
+        <a href="/resources/the-veterans-health-information-exchange-vhie">
+          Learn more about VHIE
+        </a>
+      </va-accordion-item>
+      <va-accordion-item header="What if I have more questions?" id="seventh">
+        <p>You can get more information in any of these ways:</p>
+        <ul>
+          <li>
+            Read the FAQs pages on the My HealtheVet web portal
+            <br />
+            <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs-blue-button">
+              VA Blue Button FAQs
+            </a>
+            <br />
+            <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs-health-summary">
+              VA health summary FAQs
+            </a>
+            <br />
+            <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/what-are-va-medical-images-and-reports-faqs">
+              VA medical images and reports FAQs
+            </a>
+          </li>
+          <li>
+            Call the My HealtheVet help desk at{' '}
+            <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
+              877-327-0022
+            </a>{' '}
+            (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
+            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          </li>
+          <li>
+            <a href="https://www.myhealth.va.gov/contact-us">
+              Contact us online through My HealtheVet
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+    </va-accordion>
   </>
 );
 

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.unit.spec.js
@@ -10,27 +10,10 @@ describe('Get Medical Records Page <UnauthContent>', () => {
     const wrapper = shallow(<UnauthContent />);
 
     const text = wrapper.text();
-    expect(text).to.include('On this page:');
     expect(text).to.include('VA Blue Button');
-    expect(text).to.include(
-      'What is VA Blue Button, and how can it help me manage my health care?',
-    );
-    expect(text).to.include(
-      'Am I eligible to use all the features of VA Blue Button?',
-    );
-    expect(text).to.include(
-      'Once I’m signed in, how do I access my medical records?',
-    );
-    expect(text).to.include(
-      'Will my personal health information be protected?',
-    );
-    expect(text).to.include('What if I have more questions?');
-    expect(text).to.include(
-      'What’s VHIE, and how can it help me manage my health?',
-    );
-    expect(text).to.include('How do I opt out?');
-    expect(text).to.include('If I opt out, how can I opt back in?');
-    expect(text).to.include('Can I check my sharing preference status?');
+    expect(text).to.include('What you can do when you sign in');
+    expect(text).to.include('Who can manage VA medical records online');
+    expect(text).to.include('Questions about managing your VA medical records');
 
     wrapper.unmount();
   });


### PR DESCRIPTION
trying this again... ([scrapped the previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/21510) due to something weird that happened when I merged `main` in)

**TARGET MERGE**: August 18th, for deploy on the 19th.

## Description
Updated FAQ copy on /health-care/get-medical-records/ with new content to reflect new Research & Support pages:

- [Get.your.medical.records_Cerner.version_for PW (1).docx](https://github.com/department-of-veterans-affairs/va.gov-cms/files/8970419/Get.your.medical.records_Cerner.version_for.PW.1.docx)
- [Get.your.medical.records_Non-Cerner.version_for.SME.team.docx](https://github.com/department-of-veterans-affairs/va.gov-cms/files/8970472/Get.your.medical.records_Non-Cerner.version_for.SME.team.docx)

## Original issue(s)
[/department-of-veterans-affairs/va.gov-cms/issues/9387](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9387)

## Testing done
- [x] locally
- [ ] Get QA reviews from @RLHecht and @laurwill from Sitewide Content
- [ ] @jilladams to get test user for Cerner/authenticated content

## Screenshots

### Non-Cerner
![Screenshot of changes for Non-Cerner Get Medical Records page](https://user-images.githubusercontent.com/8542413/185462876-c7dc70b1-6671-4dfa-ad6d-ed6bf7cc26bb.png)

### Cerner
![Screenshot of changes for Non-Cerner Get Medical Records page](https://user-images.githubusercontent.com/8542413/185462990-7b933dc2-e786-4d43-bc20-105096784885.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
