### PR TITLE
Add tl language for pact

### DIFF
--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(11);
+    expect(result.length).to.equal(12);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(11);
+    expect(result.length).to.equal(12);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -32,5 +32,6 @@ export default {
   pact: {
     en: '/resources/the-pact-act-and-your-va-benefits',
     es: '/resources/the-pact-act-and-your-va-benefits-esp',
+    tl: 'resources/the-pact-act-and-your-va-benefits-tag/',
   },
 };

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -32,6 +32,6 @@ export default {
   pact: {
     en: '/resources/the-pact-act-and-your-va-benefits',
     es: '/resources/the-pact-act-and-your-va-benefits-esp',
-    tl: '/resources/the-pact-act-and-your-va-benefits-tag/',
+    tl: '/resources/the-pact-act-and-your-va-benefits-tag',
   },
 };

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -32,6 +32,6 @@ export default {
   pact: {
     en: '/resources/the-pact-act-and-your-va-benefits',
     es: '/resources/the-pact-act-and-your-va-benefits-esp',
-    tl: 'resources/the-pact-act-and-your-va-benefits-tag/',
+    tl: '/resources/the-pact-act-and-your-va-benefits-tag/',
   },
 };


### PR DESCRIPTION
## Description
added tl for pact act language URLs

## Original issue(s)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
