### PR TITLE
VACMS-10335: Removes VSO link from footer

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -99,43 +99,36 @@
     },
     {
       "column": 2,
-      "href": "https://www.va.gov/vso/",
-      "order": 5,
-      "target": null,
-      "title": "Veterans Service Organizations (VSOs)"
-    },
-    {
-      "column": 2,
       "href": "https://www.va.gov/statedva.htm",
-      "order": 6,
+      "order": 5,
       "target": null,
       "title": "State Veterans Affairs offices"
     },
     {
       "column": 2,
       "href": "https://www.va.gov/landing2_business.htm",
-      "order": 7,
+      "order": 6,
       "target": null,
       "title": "Doing business with VA"
     },
     {
       "column": 2,
       "href": "https://www.va.gov/jobs/",
-      "order": 8,
+      "order": 7,
       "target": null,
       "title": "Careers at VA"
     },
     {
       "column": 2,
       "href": "https://www.va.gov/outreach-and-events/outreach-materials/",
-      "order": 9,
+      "order": 8,
       "target": null,
       "title": "VA outreach materials"
     },
     {
       "column": 2,
       "href": "https://www.va.gov/welcome-kit/",
-      "order": 10,
+      "order": 9,
       "target": null,
       "title": "Your VA welcome kit"
     },


### PR DESCRIPTION
## Description
Removes link from footer.

Note: There is a [related (and more important) PR on content-build](https://github.com/department-of-veterans-affairs/content-build/pull/1272). This vets-website PR only changes the footer when vets-website is run locally in standalone mode (i.e. localhost:3001).  The related content-build PR is the important piece that changes this on the actual production website.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10335


## Testing done
Tested locally. Confirms link is gone when running vets-website in standalone mode (i.e. localhost:3001).
