### PR TITLE
Fix Dashboard Notifications E2E tests

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
@@ -20,10 +20,6 @@ import {
 import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
 
 describe('The My VA Dashboard - Notifications', () => {
-  // Skipping in CI due to flakes; passes fine locally.
-  before(function() {
-    if (Cypress.env('CI')) this.skip();
-  });
   // TODO: Fix for CI (try local headless)
   describe('when the feature is hidden', () => {
     beforeEach(() => {
@@ -85,7 +81,7 @@ describe('The My VA Dashboard - Notifications', () => {
     it('and they have a notification - C13025', () => {
       cy.intercept(
         '/v0/onsite_notifications',
-        notificationSuccessNotDismissed(),
+        notificationSuccessNotDismissed(Cypress.env('CI')),
       ).as('notifications2');
       cy.login(mockUser);
       cy.visit('my-va/');
@@ -101,7 +97,7 @@ describe('The My VA Dashboard - Notifications', () => {
     it('and they have multiple notifications - C16720', () => {
       cy.intercept(
         '/v0/onsite_notifications',
-        multipleNotificationSuccess(),
+        multipleNotificationSuccess(Cypress.env('CI')),
       ).as('notifications3');
       cy.login(mockUser);
       cy.visit('my-va/');
@@ -117,7 +113,7 @@ describe('The My VA Dashboard - Notifications', () => {
     it('and they have dismissed notifications - C16721', () => {
       cy.intercept(
         '/v0/onsite_notifications',
-        notificationSuccessDismissed(),
+        notificationSuccessDismissed(Cypress.env('CI')),
       ).as('notifications4');
       cy.login(mockUser);
       cy.visit('my-va/');
@@ -142,7 +138,7 @@ describe('The My VA Dashboard - Notifications', () => {
     it('and they dismiss a notification - C16723', () => {
       cy.intercept(
         '/v0/onsite_notifications',
-        notificationSuccessNotDismissed(),
+        notificationSuccessNotDismissed(Cypress.env('CI')),
       ).as('notifications6');
       cy.intercept(
         'PATCH',

--- a/src/applications/personalization/dashboard/tests/fixtures/test-notifications-response.js
+++ b/src/applications/personalization/dashboard/tests/fixtures/test-notifications-response.js
@@ -1,13 +1,16 @@
 import { addDays } from 'date-fns';
 
-export const notificationSuccessNotDismissed = () => {
+export const notificationSuccessNotDismissed = ci => {
+  let templateId = 'f9947b27-df3b-4b09-875c-7f76594d766d';
+  if (ci) templateId = '7efc2b8b-e59a-4571-a2ff-0fd70253e973';
+
   return {
     data: [
       {
         id: 'e4213b12-eb44-4b2f-bac5-3384fbde0b7a',
         type: 'onsite_notifications',
         attributes: {
-          templateId: 'f9947b27-df3b-4b09-875c-7f76594d766d',
+          templateId,
           vaProfileId: '1273780',
           dismissed: false,
           createdAt: addDays(new Date(), -3),
@@ -18,14 +21,17 @@ export const notificationSuccessNotDismissed = () => {
   };
 };
 
-export const notificationSuccessDismissed = () => {
+export const notificationSuccessDismissed = ci => {
+  let templateId = 'f9947b27-df3b-4b09-875c-7f76594d766d';
+  if (ci) templateId = '7efc2b8b-e59a-4571-a2ff-0fd70253e973';
+
   return {
     data: [
       {
         id: 'e4213b12-eb44-4b2f-bac5-3384fbde0b7a',
         type: 'onsite_notifications',
         attributes: {
-          templateId: 'f9947b27-df3b-4b09-875c-7f76594d766d',
+          templateId,
           vaProfileId: '1273780',
           dismissed: true,
           createdAt: addDays(new Date(), -3),
@@ -36,13 +42,16 @@ export const notificationSuccessDismissed = () => {
   };
 };
 
-export const notificationDismissedSuccess = () => {
+export const notificationDismissedSuccess = ci => {
+  let templateId = 'f9947b27-df3b-4b09-875c-7f76594d766d';
+  if (ci) templateId = '7efc2b8b-e59a-4571-a2ff-0fd70253e973';
+
   return {
     data: {
       id: 'e4213b12-eb44-4b2f-bac5-3384fbde0b7a',
       type: 'onsite_notifications',
       attributes: {
-        templateId: 'f9947b27-df3b-4b09-875c-7f76594d766d',
+        templateId,
         vaProfileId: '1273780',
         dismissed: true,
         createdAt: addDays(new Date(), -3),
@@ -52,14 +61,17 @@ export const notificationDismissedSuccess = () => {
   };
 };
 
-export const multipleNotificationSuccess = () => {
+export const multipleNotificationSuccess = ci => {
+  let templateId = 'f9947b27-df3b-4b09-875c-7f76594d766d';
+  if (ci) templateId = '7efc2b8b-e59a-4571-a2ff-0fd70253e973';
+
   return {
     data: [
       {
         id: 'e4213b12-eb44-4b2f-bac5-3384fbde0b7a',
         type: 'onsite_notifications',
         attributes: {
-          templateId: 'f9947b27-df3b-4b09-875c-7f76594d766d',
+          templateId,
           vaProfileId: '1273780',
           dismissed: false,
           createdAt: addDays(new Date(), -3),
@@ -70,7 +82,7 @@ export const multipleNotificationSuccess = () => {
         id: '700a1a99-5736-49ca-945e-7feb7fe79216',
         type: 'onsite_notifications',
         attributes: {
-          templateId: 'f9947b27-df3b-4b09-875c-7f76594d766d',
+          templateId,
           vaProfileId: '1273780',
           dismissed: false,
           createdAt: addDays(new Date(), -5),


### PR DESCRIPTION
## Description
This PR fixes an issue with these E2E tests where the Notifications component was not rendering due to an invalid `templateId` for the production build, causing these tests to fail in CI.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/41688

## Testing done
Ran tests locally.

## Acceptance criteria
- [x] CI passes.