### PR TITLE
fix(): updating vafsc to 1.3.3 for privacy checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "11.2.6",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "~1.3.0",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.3.3",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@mapbox/mapbox-sdk": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,10 +2563,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@~1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.3.0.tgz#c8e38bf80e20e03e528a7791c33dc7839d9b5bcc"
-  integrity sha512-71bvBPDRNl4zabc8TLwmDHcHQK0kWySvr3EwTh6TzW8KQ5mtOSqPLneDyMQQr0FFuP0kSY7KQZLt+gteT6K+pg==
+"@department-of-veterans-affairs/va-forms-system-core@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.3.3.tgz#d7a5843ffb3a6aec3484993e41085bfca121a01b"
+  integrity sha512-im9vI/P5FhZg23CaHY8S4avDhtuT1DtlnZxXIR2TtTyv+RBmYzvfQFJt5JUKoLqMaNH4coH+H9AmDCnmPkrHFg==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"


### PR DESCRIPTION
## Description
Updating VAFSC to version 1.3.3 to include the privacy checkbox on the `ReviewPage` component in `burial-poc-v6`.

## Testing done
- [ ] All Tests Passing

## Screenshots
<img width="711" alt="image" src="https://user-images.githubusercontent.com/22844722/185980556-8762ca46-035f-4071-8133-b5887041f493.png">

## Acceptance criteria
- [ ] Privacy Checkbox is present and required on ReviewPage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
