### PR TITLE
Certificate of Eligibility | Prevent empty other document description submission

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
+++ b/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import environment from 'platform/utilities/environment';
 import { validateFileField } from 'platform/forms-system/src/js/validation';
+
 import FileField from './FileField';
 import UploadRequirements from './UploadRequirements';
-import { updateFilesSchema } from '../../helpers';
+import { validateDocumentDescription } from '../../helpers';
 import { DOCUMENT_TYPES } from '../../../../status/constants';
 
 const DocumentUploadDescription = () => (
@@ -85,11 +86,11 @@ export const uiSchema = {
     'ui:field': FileField,
     'ui:options': {
       addAnotherLabel: 'Upload another document',
+      attachmentType: {
+        'ui:title': 'Document type',
+      },
       attachmentDescription: {
         'ui:title': 'Document description',
-      },
-      attachmentType: {
-        'ui:title': 'Select a document to upload',
       },
       buttonText: 'Upload document',
       classNames: 'schemaform-file-upload',
@@ -116,13 +117,12 @@ export const uiSchema = {
         confirmationCode: fileInfo.data.attributes.confirmationCode,
       }),
       showFieldLabel: true,
-      updateSchema: updateFilesSchema,
     },
     'ui:errorMessages': {
       required: 'Please upload a file',
       minItems: 'Please upload at least one file',
     },
-    'ui:validations': [validateFileField],
+    'ui:validations': [validateFileField, validateDocumentDescription],
   },
   'view:documentUploadDescription': {
     'ui:title': ' ',

--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -6,6 +6,16 @@ export const customCOEsubmit = (formConfig, form) => {
 
   const { periodsOfService = [], relevantPriorLoans = [] } = formCopy.data;
 
+  const isoDateString = (dateString = '') => {
+    const [year, month, setDay = ''] = dateString.split('-');
+    // set day to the 1st when not set
+    const day = setDay === 'XX' ? '01' : setDay.padStart(2, '0');
+    // using new Date().toISOString() includes the timezone offset, so we're building it
+    return dateString
+      ? `${year}-${month.padStart(2, '0')}-${day}T00:00:00.000Z`
+      : '';
+  };
+
   const formattedForm = {
     ...formCopy,
     data: {
@@ -13,26 +23,22 @@ export const customCOEsubmit = (formConfig, form) => {
       periodsOfService: periodsOfService.map(period => ({
         ...period,
         dateRange: {
-          from: new Date(period.dateRange.from).toISOString(),
-          to: new Date(period.dateRange.to).toISOString(),
+          from: isoDateString(period.dateRange.from),
+          to: isoDateString(period.dateRange.to),
         },
       })),
-      relevantPriorLoans: relevantPriorLoans.map(loan => {
-        const [fromYear, fromMonth] = loan.dateRange.from.split('-');
-        const [toYear, toMonth] = loan.dateRange.to.split('-');
-        return {
-          ...loan,
-          dateRange: {
-            //  our form months are 1-12 (Jan-Dec) but a Date() month starts 0
-            from: new Date(fromYear, fromMonth - 1).toISOString(),
-            to: new Date(toYear, toMonth - 1).toISOString(),
-          },
-        };
-      }),
+      relevantPriorLoans: relevantPriorLoans.map(loan => ({
+        ...loan,
+        dateRange: {
+          from: isoDateString(loan.dateRange.from),
+          to: isoDateString(loan.dateRange.to),
+        },
+      })),
     },
   };
 
-  const formData = transformForSubmit(formConfig, formattedForm);
+  // transformForSubmit returns a JSON string
+  const formData = JSON.parse(transformForSubmit(formConfig, formattedForm));
 
   return JSON.stringify({
     lgyCoeClaim: {

--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -41,14 +41,26 @@ export const customCOEsubmit = (formConfig, form) => {
   });
 };
 
-export const updateFilesSchema = (formData, filesSchema) => {
-  const schemaCopy = { ...filesSchema };
-  const files = formData.files || [];
-  files.forEach((file, index) => {
-    schemaCopy.items[index].required = ['attachmentType'];
-    if (file.attachmentType === 'Other') {
-      schemaCopy.items[index].required.push('attachmentDescription');
+export const validateDocumentDescription = (errors, fileList) => {
+  fileList.forEach((file, index) => {
+    const error =
+      file.attachmentType === 'Other' && !file.attachmentDescription
+        ? 'Please provide a description'
+        : null;
+    if (error && !errors[index]) {
+      /* eslint-disable no-param-reassign */
+      errors[index] = {
+        attachmentDescription: {
+          __errors: [],
+          addError(msg) {
+            this.__errors.push(msg);
+          },
+        },
+      };
+      /* eslint-enable no-param-reassign */
+    }
+    if (error) {
+      errors[index].attachmentDescription.addError(error);
     }
   });
-  return schemaCopy;
 };

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import * as helpers from 'platform/forms-system/src/js/helpers';
-import { customCOEsubmit, updateFilesSchema } from '../../config/helpers';
+import {
+  customCOEsubmit,
+  validateDocumentDescription,
+} from '../../config/helpers';
 
 const form = {
   data: {
@@ -40,44 +43,36 @@ const result = JSON.stringify({
   },
 });
 
-describe.skip('coe helpers', () => {
-  describe('customCOEsubmit', () => {
+describe('coe helpers', () => {
+  describe.skip('customCOEsubmit', () => {
     it('should correctly format the form data', () => {
       sinon.stub(helpers, 'transformForSubmit').returns(formattedProperties);
       expect(customCOEsubmit({}, form)).to.equal(result);
     });
   });
-  describe('updateFilesSchema', () => {
-    it('should return an empty object when no files are present', () => {
-      expect(updateFilesSchema({}, {})).to.deep.equal({});
+  describe('validateDocumentDescription', () => {
+    const errors = addError => [{ attachmentDescription: { addError } }];
+    const fileList = (type, descrip) => [
+      {
+        attachmentType: type,
+        attachmentDescription: descrip,
+      },
+    ];
+    it('should not add an error for non-other type', () => {
+      const spy = sinon.spy();
+      validateDocumentDescription(errors(spy), fileList('ALTA statement', ''));
+      expect(spy.called).to.be.false;
     });
-    it('should return a single item not requiring an attachmentDescription', () => {
-      expect(
-        updateFilesSchema(
-          { files: [{ attachmentType: 'Test' }] },
-          { items: [{ required: ['attachmentType'] }] },
-        ),
-      ).to.deep.equal({
-        items: [
-          {
-            required: ['attachmentType'],
-          },
-        ],
-      });
+    it('should not add an error for Other-type with description', () => {
+      const spy = sinon.spy();
+      validateDocumentDescription(errors(spy), fileList('Other', 'ok'));
+      expect(spy.called).to.be.false;
     });
-    it('should return a single item requiring an attachmentDescription', () => {
-      expect(
-        updateFilesSchema(
-          { files: [{ attachmentType: 'Other' }] },
-          { items: [{ required: ['attachmentType'] }] },
-        ),
-      ).to.deep.equal({
-        items: [
-          {
-            required: ['attachmentType', 'attachmentDescription'],
-          },
-        ],
-      });
+    it('should add an error for a missing attachmentDescription', () => {
+      const spy = sinon.spy();
+      validateDocumentDescription(errors(spy), fileList('Other', ''));
+      expect(spy.called).to.be.true;
+      expect(spy.calledWith('Please provide a description'));
     });
   });
 });

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -1,53 +1,21 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import * as helpers from 'platform/forms-system/src/js/helpers';
+import formConfig from '../../config/form';
 import {
   customCOEsubmit,
   validateDocumentDescription,
 } from '../../config/helpers';
-
-const form = {
-  data: {
-    periodsOfService: [{ dateRange: { from: '2010-10-10', to: '2012-12-12' } }],
-    relevantPriorLoans: [
-      { dateRange: { from: '1990-01-XX', to: '1992-02-XX' } },
-    ],
-  },
-};
-
-const formattedProperties = {
-  periodsOfService: [
-    {
-      dateRange: {
-        from: '2010-10-10T00:00:00.000Z',
-        to: '2012-12-12T00:00:00.000Z',
-      },
-    },
-  ],
-  relevantPriorLoans: [
-    {
-      dateRange: {
-        from: '1990-01-01T05:00:00.000Z',
-        to: '1992-02-01T05:00:00.000Z',
-      },
-    },
-  ],
-};
-
-const result = JSON.stringify({
-  lgyCoeClaim: {
-    form: {
-      ...formattedProperties,
-    },
-  },
-});
+import maximalTest from '../fixtures/data/maximal-test.json';
+import maximalTestResult from '../fixtures/data/transformed-maximal-test.json';
 
 describe('coe helpers', () => {
-  describe.skip('customCOEsubmit', () => {
+  describe('customCOEsubmit', () => {
     it('should correctly format the form data', () => {
-      sinon.stub(helpers, 'transformForSubmit').returns(formattedProperties);
-      expect(customCOEsubmit({}, form)).to.equal(result);
+      const submitting = JSON.parse(
+        customCOEsubmit(formConfig, { data: maximalTest }),
+      );
+      expect(submitting).to.deep.equal(maximalTestResult);
     });
   });
   describe('validateDocumentDescription', () => {

--- a/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
@@ -72,7 +72,16 @@
       "name": "Test.pdf",
       "size": 33016,
       "confirmationCode": "some-UUID",
-      "isEncrypted": false
+      "isEncrypted": false,
+      "attachmentType": "Other",
+      "attachmentDescription": "Other description"
+    },
+    {
+      "name": "Test2.pdf",
+      "size": 35016,
+      "confirmationCode": "some-UUID2",
+      "isEncrypted": false,
+      "attachmentType": "ALTA statement"
     }
   ],
   "privacyAgreementAccepted": true

--- a/src/applications/lgy/coe/form/tests/fixtures/data/minimal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/minimal-test.json
@@ -15,7 +15,8 @@
   },
   "contactPhone": "4445551212",
   "contactEmail": "test2@test1.net",
-  "identity": "VETERAN",
+  "intent": "REFI",
+  "identity": "DNANA",
   "periodsOfService": [
     {
       "serviceBranch": "Air Force",
@@ -25,6 +26,6 @@
       }
     }
   ],
-  "vaLoanIndicator": true,
+  "vaLoanIndicator": false,
   "privacyAgreementAccepted": true
 }

--- a/src/applications/lgy/coe/form/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/transformed-maximal-test.json
@@ -1,0 +1,92 @@
+{
+  "lgyCoeClaim": {
+    "form": {
+      "fullName": {
+        "first": "Mark",
+        "last": "Webb",
+        "suffix": "Jr."
+      },
+      "dateOfBirth": "1950-10-04",
+      "applicantAddress": {
+        "country": "USA",
+        "street": "123 Faker Street",
+        "city": "Bogusville",
+        "state": "GA",
+        "postalCode": "30058"
+      },
+      "contactPhone": "4445551212",
+      "contactEmail": "test2@test1.net",
+      "identity": "VETERAN",
+      "periodsOfService": [
+        {
+          "serviceBranch": "Air Force",
+          "dateRange": {
+            "from": "2001-03-21T00:00:00.000Z",
+            "to": "2014-07-21T00:00:00.000Z"
+          }
+        },
+        {
+          "serviceBranch": "Air Force Reserve",
+          "dateRange": {
+            "from": "2014-07-22T00:00:00.000Z",
+            "to": "2016-07-22T00:00:00.000Z"
+          }
+        }
+      ],
+      "vaLoanIndicator": true,
+      "intent": "ONETIMERESTORATION",
+      "relevantPriorLoans": [
+        {
+          "dateRange": {
+            "from": "2015-01-01T00:00:00.000Z",
+            "to": "2020-01-01T00:00:00.000Z"
+          },
+          "propertyAddress": {
+            "propertyAddress1": "345 Main St",
+            "propertyAddress2": "Apt 3",
+            "propertyCity": "Blank",
+            "propertyState": "AK",
+            "propertyZip": "85274"
+          },
+          "vaLoanNumber": "123-45",
+          "propertyOwned": true,
+          "willRefinance": false
+        },
+        {
+          "dateRange": {
+            "from": "2020-01-01T00:00:00.000Z",
+            "to": ""
+          },
+          "propertyAddress": {
+            "propertyAddress1": "346 Main St",
+            "propertyAddress2": "Apt 4",
+            "propertyCity": "Blank",
+            "propertyState": "AK",
+            "propertyZip": "85274"
+          },
+          "vaLoanNumber": "100 23",
+          "propertyOwned": true,
+          "willRefinance": false
+        }
+      ],
+      "files": [
+        {
+          "name": "Test.pdf",
+          "size": 33016,
+          "confirmationCode": "some-UUID",
+          "isEncrypted": false,
+          "attachmentType": "Other",
+          "attachmentDescription": "Other description"
+        },
+        {
+          "name": "Test2.pdf",
+          "size": 35016,
+          "confirmationCode": "some-UUID2",
+          "isEncrypted": false,
+          "attachmentType": "ALTA statement"
+        }
+      ],
+      "privacyAgreementAccepted": true
+    }
+  }
+}


### PR DESCRIPTION
## Original Ticket

[#45409](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45409)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/upload-supporting-documents`

## Background

When the Veteran sets the document type to "Other" a document description input is revealed. But if left blank and another file is uploaded, the validation of the document description is lost. And the Veteran is allowed to proceed with the form when a blank document description value.

This PR adds validation errors when the document description is missing. Unit tests has been added.

This PR also addresses an out of scope issue with the submit COE unit test. 

## Steps to test

1. Pull this branch locally or test in a review instance
2. Go to the URL of change
3. Log in to user 228 (Mark)
4. Get to the upload page (choose Veteran and "No" previous loan)
5. Upload a document
6. Choose "Other" document type
7. **Leave the document description blank**
8. Upload a second document
9. Choose a type that isn't "Other"
10. Use the "Continue" form button
11. An error for the document description will appear

## Code changes

- Changed "Document type" label text
- Added a new `ui:validation` rule with unit tests
- Updated maximal & minimal test data
- Out of scope, but needed work:
  - Fixed `customCOEsubmit` stringifying the JSON twice
  - Built ISO date as a string instead of using the date method (bypasses timezone time issue)
  - Added transformed maximal test data & fixed `customCOEsubmit` unit test

## How was your code tested

Unit tests & e2e tests

## Acceptance criteria
- [x] Empty document descriptions now always show an error
- [x] Add & updated unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
