### PR TITLE
ToE and Fry/DEA: Fix Phone Validation and Logic

### DIFF
--- a/src/applications/fry-dea/config/form.js
+++ b/src/applications/fry-dea/config/form.js
@@ -53,7 +53,7 @@ import RelatedVeterans from '../components/RelatedVeterans';
 import { phoneSchema, phoneUISchema } from '../schema';
 import EmailViewField from '../components/EmailViewField';
 import {
-  isValidPhone,
+  isValidPhoneField,
   validateEmail,
   validateReMarriageDate,
 } from '../validation';
@@ -1127,10 +1127,10 @@ const formConfig = {
                     ]
                       .slice(0, 4)
                       .includes('Yes')) ||
-                  isValidPhone(
+                  isValidPhoneField(
                     formData[formFields.viewPhoneNumbers][
                       formFields.mobilePhoneNumber
-                    ].phone,
+                    ],
                   ),
               },
             },
@@ -1155,10 +1155,10 @@ const formConfig = {
                     ]
                       .slice(0, 4)
                       .includes('Yes')) ||
-                  !isValidPhone(
+                  !isValidPhoneField(
                     formData[formFields.viewPhoneNumbers][
                       formFields.mobilePhoneNumber
-                    ].phone,
+                    ],
                   ) ||
                   !formData[formFields.viewPhoneNumbers][
                     formFields.mobilePhoneNumber

--- a/src/applications/fry-dea/validation.js
+++ b/src/applications/fry-dea/validation.js
@@ -2,7 +2,7 @@ import { isValidEmail } from 'platform/forms/validations';
 import { compareAsc } from 'date-fns';
 import { formFields } from './constants';
 
-export const isValidPhone = (phone, isInternational) => {
+const isValidPhone = (phone, isInternational) => {
   let stripped;
   try {
     stripped = phone.replace(/[^\d]/g, '');
@@ -12,6 +12,11 @@ export const isValidPhone = (phone, isInternational) => {
   return isInternational
     ? /^\d{10,15}$/.test(stripped)
     : /^\d{10}$/.test(stripped);
+};
+
+export const isValidPhoneField = phoneField => {
+  const { isInternational } = phoneField;
+  return isValidPhone(phoneField.phone, isInternational);
 };
 
 const validatePhone = (errors, phone, isInternational) => {

--- a/src/applications/toe/constants.js
+++ b/src/applications/toe/constants.js
@@ -51,4 +51,5 @@ export const formFields = {
   sponsorFullName: 'sponsorFullName',
   userFullName: 'userFullName',
   viewPhoneNumbers: 'view:phoneNumbers',
+  viewReceiveTextMessages: 'view:receiveTextMessages',
 };

--- a/src/applications/toe/schema.js
+++ b/src/applications/toe/schema.js
@@ -23,7 +23,7 @@ export function phoneUISchema(category) {
       ],
     },
     isInternational: {
-      'ui:title': `This ${category} phone number is international`,
+      'ui:title': `This ${category} phone number is international.`,
       'ui:reviewField': YesNoReviewField,
       'ui:options': {
         hideIf: formData => {

--- a/src/applications/toe/schema.js
+++ b/src/applications/toe/schema.js
@@ -1,0 +1,63 @@
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import commonDefinitions from 'vets-json-schema/dist/definitions.json';
+
+const { usaPhone } = commonDefinitions;
+
+import PhoneReviewField from './components/PhoneReviewField';
+import YesNoReviewField from './components/YesNoReviewField';
+import { formFields } from './constants';
+import { titleCase } from './helpers';
+import { validateHomePhone, validateMobilePhone } from './utils/validation';
+
+export function phoneUISchema(category) {
+  return {
+    'ui:options': {
+      hideLabelText: true,
+      showFieldLabel: false,
+    },
+    'ui:objectViewField': PhoneReviewField,
+    phone: {
+      ...phoneUI(`${titleCase(category)} phone number`),
+      'ui:validations': [
+        category === 'mobile' ? validateMobilePhone : validateHomePhone,
+      ],
+    },
+    isInternational: {
+      'ui:title': `This ${category} phone number is international`,
+      'ui:reviewField': YesNoReviewField,
+      'ui:options': {
+        hideIf: formData => {
+          if (category === 'mobile') {
+            if (
+              !formData[formFields.viewPhoneNumbers][
+                formFields.mobilePhoneNumber
+              ].phone
+            ) {
+              return true;
+            }
+          } else if (
+            !formData[formFields.viewPhoneNumbers][formFields.phoneNumber].phone
+          ) {
+            return true;
+          }
+          return false;
+        },
+      },
+    },
+  };
+}
+
+export function phoneSchema() {
+  return {
+    type: 'object',
+    properties: {
+      phone: {
+        ...usaPhone,
+        pattern: '^\\d[-]?\\d(?:[0-9-]*\\d)?$',
+      },
+      isInternational: {
+        type: 'boolean',
+      },
+    },
+  };
+}

--- a/src/applications/toe/utils/validation.js
+++ b/src/applications/toe/utils/validation.js
@@ -1,23 +1,47 @@
 import { isValidEmail } from 'platform/forms/validations';
 import moment from 'moment';
 import { formatReadableDate } from '../helpers';
+import { formFields } from '../constants';
 
-export const isValidPhone = value => {
+const isValidPhone = (phone, isInternational) => {
   let stripped;
   try {
-    stripped = value.replace(/[^\d]/g, '');
+    stripped = phone.replace(/[^\d]/g, '');
   } catch (err) {
-    stripped = value;
+    stripped = phone;
   }
-  return /^\d{10}$/.test(stripped);
+  return isInternational
+    ? /^\d{10,15}$/.test(stripped)
+    : /^\d{10}$/.test(stripped);
 };
 
-export const validatePhone = (errors, phone) => {
-  if (phone && !isValidPhone(phone)) {
+export const isValidPhoneField = phoneField => {
+  const { isInternational } = phoneField;
+  return isValidPhone(phoneField.phone, isInternational);
+};
+
+const validatePhone = (errors, phone, isInternational) => {
+  if (phone && !isValidPhone(phone, isInternational)) {
+    const numDigits = isInternational ? '10 to 15' : '10';
     errors.addError(
-      'Please enter a 10-digit phone number (with or without dashes)',
+      `Please enter a ${numDigits}-digit phone number (with or without dashes)`,
     );
   }
+};
+
+export const validateHomePhone = (errors, phone, formData) => {
+  const { isInternational } = formData[formFields.viewPhoneNumbers][
+    formFields.phoneNumber
+  ];
+
+  validatePhone(errors, phone, isInternational);
+};
+
+export const validateMobilePhone = (errors, phone, formData) => {
+  const { isInternational } = formData[formFields.viewPhoneNumbers][
+    formFields.mobilePhoneNumber
+  ];
+  validatePhone(errors, phone, isInternational);
 };
 
 export const validateEmail = (errors, email) => {


### PR DESCRIPTION
## Description
This fixes phone number validation and logic in both ToE and Fry/DEA. Unify schema and validation code to correctly show the international checkbox in ToE and fix the logic/validation for the text message on the contact preferences for both apps.

## Screenshots
### International Checkbox Displayed When Field is Not Empty
<img width="320" alt="image" src="https://user-images.githubusercontent.com/112403/186002337-c3b9efcc-179b-419c-a112-233ab1a906e8.png">

### Text Message Warnings and Errors
The warning messages are displayed when the applicant selects to receive text messages and the error messages are only displayed after they click Continue.

#### No Mobile Phone Number is Entered
<img width="542" alt="image" src="https://user-images.githubusercontent.com/112403/186001088-824658bc-1f3a-4285-8e10-1d2878012c96.png">

#### Mobile Phone Number is International
<img width="541" alt="image" src="https://user-images.githubusercontent.com/112403/186002799-3b908748-41e5-4d67-8351-fda4cf9aa847.png">