### PR TITLE
Check in/45786/server side attempts

### DIFF
--- a/src/applications/check-in/actions/universal/index.js
+++ b/src/applications/check-in/actions/universal/index.js
@@ -15,3 +15,12 @@ export const recordAnswer = answer => {
     payload: answer,
   };
 };
+
+export const SET_ERROR = 'SET_ERROR';
+
+export const setError = errorString => {
+  return {
+    type: SET_ERROR,
+    payload: { error: errorString },
+  };
+};

--- a/src/applications/check-in/actions/universal/universal.actions.unit.spec.js
+++ b/src/applications/check-in/actions/universal/universal.actions.unit.spec.js
@@ -1,6 +1,13 @@
 import { expect } from 'chai';
 
-import { setApp, SET_APP, recordAnswer, RECORD_ANSWER } from './index';
+import {
+  setApp,
+  SET_APP,
+  recordAnswer,
+  RECORD_ANSWER,
+  setError,
+  SET_ERROR,
+} from './index';
 
 describe('check-in', () => {
   describe('universal actions', () => {
@@ -24,6 +31,16 @@ describe('check-in', () => {
           demographicsUpToDate: 'yes',
         });
         expect(action.payload.demographicsUpToDate).equal('yes');
+      });
+    });
+    describe('setError', () => {
+      it('should return correct action', () => {
+        const action = setError({});
+        expect(action.type).to.equal(SET_ERROR);
+      });
+      it('should return correct structure', () => {
+        const action = setError('max-validation');
+        expect(action.payload.error).equal('max-validation');
       });
     });
   });

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -147,6 +147,11 @@ class ApiInitializer {
         }
       });
     },
+    withValidationMaxAttempts: () => {
+      cy.intercept('POST', '/check_in/v2/sessions', req => {
+        req.reply(410, session.post.createMockMaxValidateErrorResponse());
+      });
+    },
     withFailure: (errorCode = 401) => {
       cy.intercept('POST', '/check_in/v2/sessions', req => {
         req.reply(errorCode, session.post.createMockFailedResponse());

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -8,7 +8,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceDayOfDemographicsFlagsEnabled = true,
     checkInExperienceLorotaSecurityUpdatesEnabled = false,
     checkInExperiencePhoneAppointmentsEnabled = false,
-    checkInExperienceLorotaDeletionEnabled = true,
+    checkInExperienceLorotaDeletionEnabled = false,
   } = toggles;
 
   return {

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -8,6 +8,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceDayOfDemographicsFlagsEnabled = true,
     checkInExperienceLorotaSecurityUpdatesEnabled = false,
     checkInExperiencePhoneAppointmentsEnabled = false,
+    checkInExperienceLorotaDeletionEnabled = true,
   } = toggles;
 
   return {
@@ -45,6 +46,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'check_in_experience_phone_appointments_enabled',
           value: checkInExperiencePhoneAppointmentsEnabled,
+        },
+        {
+          name: 'check_in_experience_lorota_deletion_enabled',
+          value: checkInExperienceLorotaDeletionEnabled,
         },
       ],
     },

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
@@ -45,6 +45,18 @@ const mocks = {
         ],
       };
     },
+    createMockMaxValidateErrorResponse: () => {
+      return {
+        errors: [
+          {
+            title: 'Authentication Error',
+            detail: 'Authentication Error',
+            code: 'LOROTA-MAPPED-API_401',
+            status: '410',
+          },
+        ],
+      };
+    },
     createMockFailedResponse,
   },
 };

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -147,6 +147,7 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
 - `check_in_experience_phone_appointments_enabled` : Enables or disables telephone appointments as an alternate type to in-person
   - when to sunset: once we have successfully tested this feature in production with users
+- `check_in_experience_lorota_deletion_enabled`: Enables tracking validation attempts on the server side. When toggle is on, the backend will count the attempts, then delete the entry in LoRota when it reaches the max amount of attempts, and send the frontend a status 410. When it is off, attempts are tracked in local storage.
 
 ### How to test this?
 

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -1,26 +1,27 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import BackToHome from '../../components/BackToHome';
 import Footer from '../../components/layout/Footer';
 
+import { makeSelectError } from '../../selectors';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
 import Wrapper from '../../components/layout/Wrapper';
 
 const Error = () => {
   const { t } = useTranslation();
   const { getValidateAttempts } = useSessionStorage(false);
-  let { isMaxValidateAttempts } = getValidateAttempts(window);
-  const queryString = window.location.search;
-  const urlParams = new URLSearchParams(queryString);
-  const error = urlParams.get('error');
-  if (error === 'validation') {
-    isMaxValidateAttempts = true;
-  }
+  const selectError = useMemo(makeSelectError, []);
+  const { error } = useSelector(selectError);
+  const { isMaxValidateAttempts } = getValidateAttempts(window);
+
+  const validationError = isMaxValidateAttempts || error === 'max-validation';
+
   const maxValidateMessage = t(
     'were-sorry-we-couldnt-match-your-information-to-our-records-please-ask-a-staff-member-for-help',
   );
-  const message = isMaxValidateAttempts
+  const message = validationError
     ? maxValidateMessage
     : t(
         'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
@@ -31,7 +32,7 @@ const Error = () => {
       <va-alert
         background-only
         show-icon
-        status={isMaxValidateAttempts ? 'error' : 'info'}
+        status={validationError ? 'error' : 'info'}
         data-testid="error-message"
       >
         <div>{message}</div>

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -10,7 +10,13 @@ import Wrapper from '../../components/layout/Wrapper';
 const Error = () => {
   const { t } = useTranslation();
   const { getValidateAttempts } = useSessionStorage(false);
-  const { isMaxValidateAttempts } = getValidateAttempts(window);
+  let { isMaxValidateAttempts } = getValidateAttempts(window);
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+  const error = urlParams.get('error');
+  if (error === 'validation') {
+    isMaxValidateAttempts = true;
+  }
   const maxValidateMessage = t(
     'were-sorry-we-couldnt-match-your-information-to-our-records-please-ask-a-staff-member-for-help',
   );

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -37,7 +37,6 @@ const Landing = props => {
     clearCurrentSession,
     setShouldSendDemographicsFlags,
     setCurrentToken,
-    resetAttempts,
   } = useSessionStorage(false);
   const dispatch = useDispatch();
 
@@ -121,7 +120,6 @@ const Landing = props => {
       sessionCallMade,
       setSession,
       setShouldSendDemographicsFlags,
-      resetAttempts,
       isLorotaSecurityUpdatesEnabled,
     ],
   );

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -44,7 +44,10 @@ const ValidateVeteran = props => {
   const { token } = useSelector(selectCurrentContext);
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const { isLorotaSecurityUpdatesEnabled } = useSelector(selectFeatureToggles);
+  const {
+    isLorotaSecurityUpdatesEnabled,
+    isLorotaDeletionEnabled,
+  } = useSelector(selectFeatureToggles);
 
   const {
     getValidateAttempts,
@@ -75,6 +78,7 @@ const ValidateVeteran = props => {
         setSession,
         app,
         resetAttempts,
+        isLorotaDeletionEnabled,
       );
     },
     [
@@ -89,6 +93,7 @@ const ValidateVeteran = props => {
       resetAttempts,
       setSession,
       token,
+      isLorotaDeletionEnabled,
       isLorotaSecurityUpdatesEnabled,
     ],
   );

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { createSetSession } from '../../actions/authentication';
+import { setError } from '../../actions/universal';
 
 import { useFormRouting } from '../../hooks/useFormRouting';
 
@@ -20,6 +21,13 @@ const ValidateVeteran = props => {
   const { router } = props;
   const { t } = useTranslation();
   const dispatch = useDispatch();
+
+  const updateError = useCallback(
+    error => {
+      dispatch(setError(error));
+    },
+    [dispatch],
+  );
 
   const setSession = useCallback(
     (token, permissions) => {
@@ -79,6 +87,7 @@ const ValidateVeteran = props => {
         app,
         resetAttempts,
         isLorotaDeletionEnabled,
+        updateError,
       );
     },
     [

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -104,6 +104,7 @@ const ValidateVeteran = props => {
       token,
       isLorotaDeletionEnabled,
       isLorotaSecurityUpdatesEnabled,
+      updateError,
     ],
   );
   return (

--- a/src/applications/check-in/day-of/tests/e2e/errors/max.validation.failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/max.validation.failed.cypress.spec.js
@@ -1,0 +1,35 @@
+import '../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
+import Error from '../pages/Error';
+
+describe('Check In Experience -- ', () => {
+  describe('max validation attempts -- ', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+      } = ApiInitializer;
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
+      initializeSessionPost.withValidationMaxAttempts();
+      cy.visitWithUUID();
+      ValidateVeteran.validatePage.dayOf();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('validation failed with failed response from server. redirect to error page after max validate limit reached', () => {
+      cy.injectAxeThenAxeCheck();
+      ValidateVeteran.validateVeteran('Sith', '4321');
+      ValidateVeteran.attemptToGoToNextPage();
+
+      Error.validatePageLoaded(true);
+      cy.createScreenshots('Day-of-check-in--validation-error');
+    });
+  });
+});

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -3,7 +3,6 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Demographics from '../../../../tests/e2e/pages/Demographics';
-import Error from '../pages/Error';
 
 describe('Check In Experience -- ', () => {
   describe('extra validation -- ', () => {
@@ -26,7 +25,7 @@ describe('Check In Experience -- ', () => {
         window.sessionStorage.clear();
       });
     });
-    it('validation failed with failed response from server. redirect to error page after max validate limit reached', () => {
+    it('validation failed with failed response from server', () => {
       cy.injectAxeThenAxeCheck();
       // First Attempt
       ValidateVeteran.validateVeteran('Sith', '4321');
@@ -38,13 +37,6 @@ describe('Check In Experience -- ', () => {
       ValidateVeteran.attemptToGoToNextPage();
       ValidateVeteran.validateErrorAlert();
       cy.createScreenshots('Day-of-check-in--inline-validation-error');
-      // Third/Final attempt
-      ValidateVeteran.validateVeteran('Sith', '4321');
-      ValidateVeteran.validateErrorAlert();
-      ValidateVeteran.attemptToGoToNextPage();
-
-      Error.validatePageLoaded(true);
-      cy.createScreenshots('Day-of-check-in--validation-error');
     });
     it('fails validation once and then succeeds on the second attempt', () => {
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/pre-check-in/README.md
+++ b/src/applications/check-in/pre-check-in/README.md
@@ -99,6 +99,7 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
 - `check_in_experience_phone_appointments_enabled` : Enables or disables telephone appointments as an alternate type to in-person
   - when to sunset: once we have successfully tested this feature in production with users
+- `check_in_experience_lorota_deletion_enabled`: Enables tracking validation attempts on the server side. When toggle is on, the backend will count the attempts, then delete the entry in LoRota when it reaches the max amount of attempts, and send the frontend a status 410. When it is off, attempts are tracked in local storage.
 
 ### How to test this?
 

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -36,8 +36,13 @@ const Error = () => {
   const { isPhoneAppointmentsEnabled } = useSelector(selectFeatureToggles);
 
   const { getValidateAttempts } = useSessionStorage(true);
-  const { isMaxValidateAttempts } = getValidateAttempts(window);
-
+  let { isMaxValidateAttempts } = getValidateAttempts(window);
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+  const error = urlParams.get('error');
+  if (error === 'validation') {
+    isMaxValidateAttempts = true;
+  }
   // Get appointment dates if available.
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { appointments } = useSelector(selectVeteranData);

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -5,6 +5,7 @@ import propTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
 import { createSetSession } from '../../../actions/authentication';
+import { setError } from '../../../actions/universal';
 
 import BackToHome from '../../../components/BackToHome';
 import ValidateDisplay from '../../../components/pages/validate/ValidateDisplay';
@@ -22,6 +23,14 @@ const Index = ({ router }) => {
   const { goToNextPage, goToErrorPage } = useFormRouting(router);
   const { t } = useTranslation();
   const dispatch = useDispatch();
+
+  const updateError = useCallback(
+    error => {
+      dispatch(setError(error));
+    },
+    [dispatch],
+  );
+
   const setSession = useCallback(
     (token, permissions) => {
       dispatch(createSetSession({ token, permissions }));
@@ -79,6 +88,7 @@ const Index = ({ router }) => {
         app,
         resetAttempts,
         isLorotaDeletionEnabled,
+        updateError,
       );
     },
     [

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -105,6 +105,7 @@ const Index = ({ router }) => {
       token,
       isLorotaDeletionEnabled,
       isLorotaSecurityUpdatesEnabled,
+      updateError,
     ],
   );
 

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -36,7 +36,10 @@ const Index = ({ router }) => {
   const { app } = useSelector(selectApp);
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const { isLorotaSecurityUpdatesEnabled } = useSelector(selectFeatureToggles);
+  const {
+    isLorotaSecurityUpdatesEnabled,
+    isLorotaDeletionEnabled,
+  } = useSelector(selectFeatureToggles);
 
   const [isLoading, setIsLoading] = useState(false);
   const [lastName, setLastName] = useState('');
@@ -75,6 +78,7 @@ const Index = ({ router }) => {
         setSession,
         app,
         resetAttempts,
+        isLorotaDeletionEnabled,
       );
     },
     [
@@ -89,6 +93,7 @@ const Index = ({ router }) => {
       resetAttempts,
       setSession,
       token,
+      isLorotaDeletionEnabled,
       isLorotaSecurityUpdatesEnabled,
     ],
   );

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/max.validation.failed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/max.validation.failed.cypress.spec.js
@@ -1,0 +1,36 @@
+import '../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
+import Error from '../pages/Error';
+
+describe('Pre-Check In Experience', () => {
+  describe('max validation attempts -- ', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+      } = ApiInitializer;
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
+      initializeSessionPost.withValidationMaxAttempts();
+      cy.visitPreCheckInWithUUID();
+      ValidateVeteran.validatePage.preCheckIn();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('validation failed with failed response from server. redirect to error page after max validate limit reached', () => {
+      cy.injectAxeThenAxeCheck();
+      // Third/Final attempt
+      ValidateVeteran.validateVeteran('Sith', '4321');
+      ValidateVeteran.attemptToGoToNextPage();
+
+      Error.validatePageLoaded(true);
+      cy.createScreenshots('Pre-check-in--validation-error');
+    });
+  });
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -3,7 +3,6 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
-import Error from '../pages/Error';
 
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
@@ -26,7 +25,7 @@ describe('Pre-Check In Experience', () => {
         window.sessionStorage.clear();
       });
     });
-    it('validation failed with failed response from server. redirect to error page after max validate limit reached', () => {
+    it('validation failed with failed response from server', () => {
       cy.injectAxeThenAxeCheck();
       // First Attempt
       ValidateVeteran.validateVeteran('Sith', '4321');
@@ -37,14 +36,6 @@ describe('Pre-Check In Experience', () => {
       ValidateVeteran.validateVeteran('Sith', '4321');
       ValidateVeteran.attemptToGoToNextPage();
       ValidateVeteran.validateErrorAlert();
-
-      // Third/Final attempt
-      ValidateVeteran.validateVeteran('Sith', '4321');
-      ValidateVeteran.validateErrorAlert();
-      ValidateVeteran.attemptToGoToNextPage();
-
-      Error.validatePageLoaded(true);
-      cy.createScreenshots('Pre-check-in--validation-error');
     });
     it('fails validation once and then succeeds on the second attempt', () => {
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
@@ -3,7 +3,6 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
-import Error from '../pages/Error';
 
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
@@ -30,7 +29,7 @@ describe('Pre-Check In Experience', () => {
         window.sessionStorage.clear();
       });
     });
-    it('validation failed with failed response from server. redirect to error page after max validate limit reached', () => {
+    it('validation failed with failed response from server', () => {
       cy.injectAxeThenAxeCheck();
       // First Attempt
       ValidateVeteran.validateVeteranDobWithFailure();
@@ -41,11 +40,6 @@ describe('Pre-Check In Experience', () => {
       ValidateVeteran.validateVeteranDobWithFailure();
       ValidateVeteran.attemptToGoToNextPage();
       ValidateVeteran.validateErrorAlert(true);
-
-      // Third/Final attempt
-      ValidateVeteran.validateVeteranDobWithFailure();
-      ValidateVeteran.attemptToGoToNextPage();
-      Error.validatePageLoaded(true);
     });
     it('fails validation once and then succeeds on the second attempt', () => {
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -9,6 +9,7 @@ const initialState = {
     data: {},
   },
   app: '',
+  error: '',
 };
 
 import {
@@ -35,7 +36,7 @@ import {
   seeStaffMessageUpdatedHandler,
 } from './day-of';
 
-import { setAppHandler } from './universal';
+import { setAppHandler, setErrorHandler } from './universal';
 
 import { INIT_FORM } from '../actions/navigation';
 
@@ -45,7 +46,7 @@ import { SET_SESSION } from '../actions/authentication';
 
 import { setSessionHandler } from './authentication';
 
-import { SET_APP, RECORD_ANSWER } from '../actions/universal';
+import { SET_APP, RECORD_ANSWER, SET_ERROR } from '../actions/universal';
 
 const handler = Object.freeze({
   [INIT_FORM]: initFormHandler,
@@ -60,6 +61,7 @@ const handler = Object.freeze({
   [UPDATE_PRE_CHECK_IN_FORM]: updateFormHandler,
   [UPDATE_DAY_OF_CHECK_IN_FORM]: updateFormHandler,
   [SET_APP]: setAppHandler,
+  [SET_ERROR]: setErrorHandler,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/reducers/reducer.unit.spec.js
+++ b/src/applications/check-in/reducers/reducer.unit.spec.js
@@ -18,6 +18,7 @@ describe('check in', () => {
             pages: [],
             data: {},
           },
+          error: '',
         });
       });
       it('should return the state if action is not found', () => {

--- a/src/applications/check-in/reducers/universal/index.js
+++ b/src/applications/check-in/reducers/universal/index.js
@@ -2,4 +2,7 @@ const setAppHandler = (state, action) => {
   return { ...state, ...action.payload };
 };
 
-export { setAppHandler };
+const setErrorHandler = (state, action) => {
+  return { ...state, ...action.payload };
+};
+export { setAppHandler, setErrorHandler };

--- a/src/applications/check-in/reducers/universal/universal.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/universal/universal.reducers.unit.spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { setAppHandler } from './index';
+import { setAppHandler, setErrorHandler } from './index';
 
-import { setApp } from '../../actions/universal';
+import { setApp, setError } from '../../actions/universal';
 
 import appReducer from '../index';
 
@@ -22,6 +22,23 @@ describe('check in', () => {
           const action = setApp('preCheckIn');
           state = appReducer.checkInData(undefined, action);
           expect(state.app).to.equal('preCheckIn');
+        });
+      });
+    });
+    describe('setError', () => {
+      describe('setErrorHandler', () => {
+        it('should return form structure', () => {
+          const action = setError('');
+          const state = setErrorHandler({ error: '' }, action);
+          expect(state).haveOwnProperty('error');
+        });
+      });
+      describe('reducer is called; finds the correct handler', () => {
+        it('should set the error string', () => {
+          let state = {};
+          const action = setError('max-validation');
+          state = appReducer.checkInData(undefined, action);
+          expect(state.error).to.equal('max-validation');
         });
       });
     });

--- a/src/applications/check-in/selectors/index.js
+++ b/src/applications/check-in/selectors/index.js
@@ -58,6 +58,17 @@ const selectApp = createSelector(
 
 const makeSelectApp = () => selectApp;
 
+const selectError = createSelector(
+  state => {
+    return {
+      error: state?.checkInData?.error,
+    };
+  },
+  app => app,
+);
+
+const makeSelectError = () => selectError;
+
 export {
   makeSelectCurrentContext,
   makeSelectForm,
@@ -65,4 +76,5 @@ export {
   makeSelectConfirmationData,
   makeSelectSeeStaffMessage,
   makeSelectApp,
+  makeSelectError,
 };

--- a/src/applications/check-in/selectors/selector.unit.spec.js
+++ b/src/applications/check-in/selectors/selector.unit.spec.js
@@ -8,6 +8,7 @@ import {
   makeSelectConfirmationData,
   makeSelectSeeStaffMessage,
   makeSelectApp,
+  makeSelectError,
 } from './index';
 
 describe('check-in', () => {
@@ -145,6 +146,19 @@ describe('check-in', () => {
         const selectApp = makeSelectApp();
         expect(selectApp(state)).to.eql({
           app: 'preCheckIn',
+        });
+      });
+    });
+    describe('makeSelectError', () => {
+      const state = {
+        checkInData: {
+          error: 'max-validation',
+        },
+      };
+      it('returns error string', () => {
+        const selectError = makeSelectError();
+        expect(selectError(state)).to.eql({
+          error: 'max-validation',
         });
       });
     });

--- a/src/applications/check-in/utils/selectors/feature-toggles.js
+++ b/src/applications/check-in/utils/selectors/feature-toggles.js
@@ -30,6 +30,9 @@ const selectFeatureToggles = createSelector(
     isPhoneAppointmentsEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.checkInExperiencePhoneAppointmentsEnabled
     ],
+    isLorotaDeletionEnabled: toggleValues(state)[
+      FEATURE_FLAG_NAMES.checkInExperienceLorotaDeletionEnabled
+    ],
   }),
   toggles => toggles,
 );

--- a/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
+++ b/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
@@ -18,7 +18,7 @@ describe('check-in', () => {
         check_in_experience_day_of_demographics_flags_enabled: false,
         check_in_experience_lorota_security_updates_enabled: false,
         check_in_experience_phone_appointments_enabled: false,
-        checkInExperienceLorotaDeletionEnabled: false,
+        check_in_experience_lorota_deletion_enabled: false,
         loading: false,
       },
     };
@@ -36,7 +36,7 @@ describe('check-in', () => {
           isDayOfDemographicsFlagsEnabled: false,
           isLorotaSecurityUpdatesEnabled: false,
           isPhoneAppointmentsEnabled: false,
-          checkInExperienceLorotaDeletionEnabled: false,
+          isLorotaDeletionEnabled: false,
         });
       });
     });

--- a/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
+++ b/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
@@ -18,6 +18,7 @@ describe('check-in', () => {
         check_in_experience_day_of_demographics_flags_enabled: false,
         check_in_experience_lorota_security_updates_enabled: false,
         check_in_experience_phone_appointments_enabled: false,
+        checkInExperienceLorotaDeletionEnabled: false,
         loading: false,
       },
     };
@@ -35,6 +36,7 @@ describe('check-in', () => {
           isDayOfDemographicsFlagsEnabled: false,
           isLorotaSecurityUpdatesEnabled: false,
           isPhoneAppointmentsEnabled: false,
+          checkInExperienceLorotaDeletionEnabled: false,
         });
       });
     });

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -21,6 +21,8 @@ import { api } from '../../api';
  * @param {string} [token]
  * @param {function} [setSession]
  * @param {string} [app]
+ * @param {function} [resetAttempts]
+ * @param {boolean} [isLorotaDeletionEnabled]
  */
 
 const validateLogin = async (
@@ -41,6 +43,7 @@ const validateLogin = async (
   setSession,
   app,
   resetAttempts,
+  isLorotaDeletionEnabled,
 ) => {
   setLastNameErrorMessage();
   setLast4ErrorMessage();
@@ -98,16 +101,21 @@ const validateLogin = async (
       goToErrorPage();
     } else {
       setSession(token, resp.permissions);
-      resetAttempts(window, token, true);
+      if (!isLorotaDeletionEnabled) {
+        resetAttempts(window, token, true);
+      }
       goToNextPage();
     }
   } catch (e) {
     setIsLoading(false);
     if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
-      goToErrorPage();
+      const params = e?.errors[0]?.status === '410' ? '?error=validation' : '';
+      goToErrorPage(params);
     } else {
       setShowValidateError(true);
-      incrementValidateAttempts(window);
+      if (!isLorotaDeletionEnabled) {
+        incrementValidateAttempts(window);
+      }
     }
   }
 };

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -112,7 +112,7 @@ const validateLogin = async (
     setIsLoading(false);
     if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
       let params = '';
-      if (e?.errors[0]?.status === '410') {
+      if (e?.errors[0]?.status === '410' || isMaxValidateAttempts) {
         params = '?error=validation';
         updateError('max-validation');
       }

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -111,8 +111,11 @@ const validateLogin = async (
   } catch (e) {
     setIsLoading(false);
     if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
-      const params = e?.errors[0]?.status === '410' ? '?error=validation' : '';
-      updateError('max-validation');
+      let params = '';
+      if (e?.errors[0]?.status === '410') {
+        params = '?error=validation';
+        updateError('max-validation');
+      }
       goToErrorPage(params);
     } else {
       setShowValidateError(true);

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -23,6 +23,7 @@ import { api } from '../../api';
  * @param {string} [app]
  * @param {function} [resetAttempts]
  * @param {boolean} [isLorotaDeletionEnabled]
+ * @param {function} [updateError]
  */
 
 const validateLogin = async (
@@ -44,6 +45,7 @@ const validateLogin = async (
   app,
   resetAttempts,
   isLorotaDeletionEnabled,
+  updateError,
 ) => {
   setLastNameErrorMessage();
   setLast4ErrorMessage();
@@ -110,6 +112,7 @@ const validateLogin = async (
     setIsLoading(false);
     if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
       const params = e?.errors[0]?.status === '410' ? '?error=validation' : '';
+      updateError('max-validation');
       goToErrorPage(params);
     } else {
       setShowValidateError(true);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -20,6 +20,7 @@ export default Object.freeze({
   checkInExperienceDayOfDemographicsFlagsEnabled: 'check_in_experience_day_of_demographics_flags_enabled',
   checkInExperienceLorotaSecurityUpdatesEnabled: 'check_in_experience_lorota_security_updates_enabled',
   checkInExperiencePhoneAppointmentsEnabled: 'check_in_experience_phone_appointments_enabled',
+  checkInExperienceLorotaDeletionEnabled: 'check_in_experience_lorota_deletion_enabled',
   checkVAInboxEnabled: 'check_va_inbox_enabled',
   coeAccess: 'coe_access',
   combinedDebtPortalAccess: 'combined_debt_portal_access',


### PR DESCRIPTION
## Description
Moves max validation handling to server side response if flag flipped. Adds error string to reducer. Error page selects the error but only handles max validation attempts. Further error refactoring can pick this pattern up.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45786


## Testing done
updated cypress tests and unit tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
