### PR TITLE
[VA-9924] Use Driving Distance for Nearby Vet Centers

### DIFF
--- a/src/applications/facility-locator/utils/facilityDistance.js
+++ b/src/applications/facility-locator/utils/facilityDistance.js
@@ -1,4 +1,5 @@
 import { MIN_RADIUS } from '../constants';
+import { mapboxToken } from './mapboxToken';
 
 function toRadians(value) {
   return (value * Math.PI) / 180;
@@ -60,3 +61,25 @@ export function calculateBoundingBox(lat, long, radius) {
     toDegrees(maxLatitude).toFixed(3),
   ];
 }
+
+export const convertMetersToMiles = meters =>
+  Math.round(meters * 0.000621371192);
+
+export const distancesToNearbyVetCenters = (
+  originalVetCenterCoordinates,
+  nearbyVetCentersCoordinates,
+) => {
+  const originalVetCenterCoordinatesParam = originalVetCenterCoordinates.join(
+    ',',
+  );
+  const startingCoordinatesParam = nearbyVetCentersCoordinates
+    .map(loc => loc.join(','))
+    .join(';');
+  let sourcesParam = '';
+
+  for (let i = 1; i <= nearbyVetCentersCoordinates.length; i += 1) {
+    sourcesParam = `${sourcesParam}${i !== 1 ? ';' : ''}${i}`;
+  }
+
+  return `https://api.mapbox.com/directions-matrix/v1/mapbox/driving/${originalVetCenterCoordinatesParam};${startingCoordinatesParam}?sources=${sourcesParam}&destinations=0&annotations=distance,duration&access_token=${mapboxToken}`;
+};

--- a/src/applications/static-pages/facilities/vet-center/NearByVetCenters.jsx
+++ b/src/applications/static-pages/facilities/vet-center/NearByVetCenters.jsx
@@ -160,21 +160,37 @@ const NearByVetCenters = props => {
   };
 
   const normalizeFetchedVetCenters = vcs => {
-    return vcs.map(vc => ({
-      id: vc.id,
-      entityBundle: vc.attributes.facilityType,
-      fieldPhoneNumber: vc.attributes.phone.main,
-      title: vc.attributes.name,
-      fieldAddress: {
-        addressLine1: vc.attributes.address.physical.address1,
-        administrativeArea: vc.attributes.address.physical.state,
-        locality: vc.attributes.address.physical.city,
-        postalCode: vc.attributes.address.physical.zip,
-      },
-      fieldOperatingStatusFacility: vc.attributes.operatingStatus?.code.toLowerCase(),
-      fieldOperatingStatusMoreInfo:
-        vc.attributes.operatingStatus?.additionalInfo,
-    }));
+    return vcs
+      .map(vc => {
+        let centerDistance = false;
+
+        if (nearbyVetCenterDistances) {
+          const vetCenterDistance = nearbyVetCenterDistances.find(
+            distance => distance.id === vc.id,
+          );
+
+          centerDistance = vetCenterDistance.distance;
+        }
+
+        return {
+          id: vc.id,
+          entityBundle: vc.attributes.facilityType,
+          fieldPhoneNumber: vc.attributes.phone.main,
+          distance: centerDistance,
+          title: vc.attributes.name,
+          fieldAddress: {
+            addressLine1: vc.attributes.address.physical.address1,
+            administrativeArea: vc.attributes.address.physical.state,
+            locality: vc.attributes.address.physical.city,
+            postalCode: vc.attributes.address.physical.zip,
+          },
+          fieldOperatingStatusFacility: vc.attributes.operatingStatus?.code.toLowerCase(),
+          fieldOperatingStatusMoreInfo:
+            vc.attributes.operatingStatus?.additionalInfo,
+        };
+      })
+      .filter(center => center.distance < NEARBY_VET_CENTER_RADIUS_MILES)
+      .sort((a, b) => (a.distance < b.distance ? 1 : -1));
   };
 
   const renderNearbyVetCenterContainer = sortedVetCenters => (


### PR DESCRIPTION
## Description

"Other Nearby Vet Centers" don't properly organize and filter based on the distances from the first vet center.

[Mapbox has a matrix endpoint](https://docs.mapbox.com/api/navigation/matrix/#retrieve-a-matrix) that lets you measure the driving distances [from multiple points away from a single one (many to one).](https://docs.mapbox.com/help/getting-started/directions/#matrix-api-requests) This PR adds an additional request to that endpoint so each nearby Vet center has the driving distance away in miles. It then sorts the centers from closest to farthest and removes any further away than the original bounding box radius.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#9924

## Testing done

Visual, see below

## Screenshots

Taken from [the Myrtle Beach Vet Center page.](http://localhost:3002/preview?nodeId=28177)

### Data with new Endpoint

<img width="711" alt="Screen Shot 2022-08-23 at 9 44 05 AM" src="https://user-images.githubusercontent.com/10790736/186175147-08ed942a-796b-4a03-ab1c-933ca71a6ed5.png">

### Before and After

<img width="593" alt="Screen Shot 2022-08-23 at 9 48 03 AM" src="https://user-images.githubusercontent.com/10790736/186175243-fa49b4c9-7b05-4289-af73-fb2811c31409.png">

<img width="661" alt="Screen Shot 2022-08-23 at 9 35 37 AM" src="https://user-images.githubusercontent.com/10790736/186175199-f143bdaf-7836-4c79-b2d7-7e91db39d4df.png">

## Acceptance criteria

- [ ] Vet center distances are measured by driving distance, not "as the crow flies" distance
- [ ] Driving distances are validated by an external source or API (Mapbox)
- [ ] Nearby vet centers are organized by driving distance from closest to furthest.
- [ ] Vet centers further away from the bounding box radius aren't included

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
