### PR TITLE
DHP-372: change 'go back' button to 'cancel' in disconnect modal

### DIFF
--- a/src/applications/dhp-connected-devices/components/DisconnectModal.jsx
+++ b/src/applications/dhp-connected-devices/components/DisconnectModal.jsx
@@ -16,7 +16,7 @@ export const DisconnectModal = ({
         onPrimaryButtonClick={handleDisconnect}
         onSecondaryButtonClick={handleClose}
         primaryButtonText="Disconnect device"
-        secondaryButtonText="Go back"
+        secondaryButtonText="Cancel"
         data-testid="disconnect-modal"
         visible
       >

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -42,9 +42,9 @@ describe('Device disconnection card modal', () => {
       ),
     ).to.exist;
     expect(modal.getAttribute('primaryButtonText')).to.eq('Disconnect device');
-    expect(modal.getAttribute('secondaryButtonText')).to.eq('Go back');
+    expect(modal.getAttribute('secondaryButtonText')).to.eq('Cancel');
   });
-  it("Should close modal when 'Go back' button is clicked", async () => {
+  it("Should close modal when 'Cancel' button is clicked", async () => {
     const goBackBtn = modal.__events.secondaryButtonClick;
     await goBackBtn();
     expect(screen.queryByTestId('disconnect-modal')).to.not.exist;


### PR DESCRIPTION
Update "Go back" button text in Disconnect Modal to "Cancel"

Co-authored-by: Lex Joseph <lex.joseph@thoughtworks.com
Co-authored-by: Rebecca Green <rebecca.green@thoughtworks.com>

## Description
Implements Collaboration Cycle feedback to change disconnect modal 'go back' button text from 'go back' to 'cancel'

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
[Original issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/44207)

## Acceptance criteria

Given A Veteran is logged in and has a device connected 
When the Veteran selects the Disconnect button for a connected device 
Then the Disconnect modal is displayed with the following buttons:Disconnect DeviceCancel

Given A Veteran has navigated to the Disconnect modal 
When the Veteran selects the Cancel button 
Then  the Disconnect modal closes and the Device Connection page is displayed AND the device is still connected.

