### PR TITLE
VACMS-9871: update cookieOnly to false to always display injected header

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -184,12 +184,12 @@
     {
       "hostname": "m.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.m.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     }
   ]
 }


### PR DESCRIPTION
## Description
This PR updates the cookieOnly for m.va.gov and www.m.va.gov to `false` to always display injected header

## Original issue(s)
[department-of-veterans-affairs/va.gov-cms/issues/9871](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9871)

## Testing done
- [x] locally
- [x] with cookieOnly set to `true`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
