### PR TITLE
[DHP-369] Changes DeviceConnectionCard link to a va active link

### DIFF
--- a/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
@@ -7,14 +7,14 @@ export const DeviceConnectionCard = ({ device }) => {
     <div className="connect-device">
       <h3 className="vads-u-margin-y--0">{device.name}</h3>
       <p className="vads-u-margin-y--0">
-        <a
+        <va-link
+          active
           data-testid={`${device.key}-connect-link`}
           id={`${device.key}-connect-link`}
           className="connect-button"
           href={`${environment.API_URL}/dhp_connected_devices${device.authUrl}`}
-        >
-          Connect
-        </a>
+          text="Connect"
+        />
       </p>
     </div>
   );


### PR DESCRIPTION
## Description
Changes DeviceConnectionCard component  link to be a va-link instead of an <a> tag.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44227

## Testing done
Unit
