### PR TITLE
Fix flaky Profile E2E test

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/post-delete-mobile-phone-alert.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-delete-mobile-phone-alert.cypress.spec.js
@@ -37,7 +37,7 @@ describe('Contact info update success alert', () => {
   });
   it('should be shown after deleting mobile phone number', () => {
     cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-    cy.findByRole('link', { name: /update mobile phone/i }).click({
+    cy.contains('Update mobile phone').click({
       waitForAnimations: true,
     });
     cy.findByRole('button', { name: /remove mobile phone/i }).click({


### PR DESCRIPTION
## Description
PR to fix flakiness in this test. Using `cy.contains()` instead of `cy.findByRole()` fixed a race condition with interacting with this element.

## Testing done
Ran test 30 times locally.

## Acceptance criteria
- [ ] CI passes.