### PR TITLE
adds bug fix for verify for both OAuth + SAML

### DIFF
--- a/src/applications/verify/components/verifyButton.jsx
+++ b/src/applications/verify/components/verifyButton.jsx
@@ -1,15 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { updateStateAndVerifier } from 'platform/utilities/oauth/utilities';
+
+import { defaultWebOAuthOptions } from 'platform/user/authentication/config/constants';
 import { verify } from 'platform/user/authentication/utilities';
 
 export const VerifyButton = ({ className, label, image, policy, useOAuth }) => {
+  const verifyHandler = () => {
+    if (useOAuth) {
+      updateStateAndVerifier(policy);
+    }
+    verify({
+      policy,
+      useOAuth,
+      acr: defaultWebOAuthOptions.acrVerify[policy],
+    });
+  };
+
   return (
     <button
       key={policy}
       type="button"
       className={`usa-button ${className}`}
-      onClick={() => verify({ policy, useOAuth })}
+      onClick={() => verifyHandler()}
     >
       <strong>
         Verify with <span className="sr-only">{label}</span>

--- a/src/platform/user/authentication/config/constants.js
+++ b/src/platform/user/authentication/config/constants.js
@@ -27,4 +27,5 @@ export const defaultWebOAuthOptions = {
   clientId: 'web',
   acr: { idme: 'min', dslogon: 'min', mhv: 'min', logingov: 'min' },
   acrSignup: { idme_signup: 'min', logingov_signup: 'min' },
+  acrVerify: { idme: 'loa3', logingov: 'ial2' },
 };

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -149,6 +149,7 @@ export function sessionTypeUrl({
   version = API_VERSION,
   allowVerification = false,
   useOauth = false,
+  acr = null,
 }) {
   if (!type) {
     return null;
@@ -200,6 +201,7 @@ export function sessionTypeUrl({
 
   if (useOAuth && (isLogin || isSignup)) {
     return createOAuthRequest({
+      acr,
       application,
       clientId,
       type,
@@ -294,13 +296,15 @@ export async function verify({
   clickedEvent = AUTH_EVENTS.VERIFY,
   isLink = false,
   useOAuth = false,
+  acr = null,
 }) {
   const type = SIGNUP_TYPES[policy];
   const url = await sessionTypeUrl({
     type,
     version,
-    allowVerification: true,
     useOauth: useOAuth,
+    ...(!useOAuth && { allowVerification: true }),
+    acr,
   });
 
   return isLink ? url : redirect(url, `${type}-${clickedEvent}`);

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -97,6 +97,7 @@ export async function createOAuthRequest({
   passedQueryParams = {},
   passedOptions = {},
   type = '',
+  acr,
 }) {
   const isDefaultOAuth = !application || clientId === CLIENT_IDS.WEB;
   const isMobileOAuth =
@@ -130,9 +131,11 @@ export async function createOAuthRequest({
     [OAUTH_KEYS.CLIENT_ID]: encodeURIComponent(
       clientId || oAuthOptions.clientId,
     ),
-    [OAUTH_KEYS.ACR]: passedOptions.isSignup
-      ? oAuthOptions.acrSignup[type]
-      : oAuthOptions.acr[type],
+    [OAUTH_KEYS.ACR]:
+      acr ||
+      (passedOptions.isSignup
+        ? oAuthOptions.acrSignup[type]
+        : oAuthOptions.acr[type]),
     [OAUTH_KEYS.RESPONSE_TYPE]: OAUTH_ALLOWED_PARAMS.CODE,
     ...(isDefaultOAuth && { [OAUTH_KEYS.STATE]: state }),
     ...(passedQueryParams.gaClientId && {


### PR DESCRIPTION
## Description
This PR fixes the `acr` value in OAuth and ensures the SAML format is unaffected.  Additionally it updates the `state` and `code_verifier`

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#46170


## Testing done
Unit

## Screenshots
n/a

## Acceptance criteria
- [x] OAuth - ACR - ID.me `loa3`, Login.gov `ial2`
- [x] SAML - ID.me `idme_signup_verified`, Login.gov `logingov_signup_verified`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
