### PR TITLE
Fixes the state mismatch bug on the verify button

### DIFF
--- a/src/applications/verify/components/verifyButton.jsx
+++ b/src/applications/verify/components/verifyButton.jsx
@@ -8,14 +8,15 @@ import { verify } from 'platform/user/authentication/utilities';
 
 export const VerifyButton = ({ className, label, image, policy, useOAuth }) => {
   const verifyHandler = () => {
-    if (useOAuth) {
-      updateStateAndVerifier(policy);
-    }
     verify({
       policy,
       useOAuth,
       acr: defaultWebOAuthOptions.acrVerify[policy],
     });
+
+    if (useOAuth) {
+      updateStateAndVerifier(policy);
+    }
   };
 
   return (


### PR DESCRIPTION
## Description
This PR switches the `updateStateAndVerifier` call to occur after the `verify` call to ensure the `state` and `code_verifier` in local storage.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit testing

## Screenshots
n/a

## Acceptance criteria
- [x] Clicking on the ID.me or Login.gov verify button removes the individual `state` and `code_verifier`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
