### PR TITLE
VACMS-10272: updated relative image paths for legacy sites

### DIFF
--- a/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
+++ b/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
@@ -25,7 +25,7 @@ export const OfficialGovtWebsite = () => {
         <img
           alt="U.S. flag"
           className="header-us-flag vads-u-margin-right--1"
-          src="/img/tiny-usa-flag.png"
+          src="https://www.va.gov/img/tiny-usa-flag.png"
         />
         <button
           aria-controls="official-govt-site-explanation"
@@ -52,7 +52,7 @@ export const OfficialGovtWebsite = () => {
             <img
               alt="Dot gov"
               className="usa-banner-icon usa-media_block-img"
-              src="/img/icon-dot-gov.svg"
+              src="https://www.va.gov/img/icon-dot-gov.svg"
             />
             <p className="vads-u-margin-top--0">
               <strong>The .gov means it’s official.</strong>
@@ -66,7 +66,7 @@ export const OfficialGovtWebsite = () => {
             <img
               alt="SSL"
               className="usa-banner-icon usa-media_block-img"
-              src="/img/icon-https.svg"
+              src="https://www.va.gov/img/icon-https.svg"
             />
             <p className="vads-u-margin-top--0">
               <strong>The site is secure.</strong>


### PR DESCRIPTION
## Description
This PR updates relative image paths (which are broken for legacy sites) to absolute so they point to image paths on production. 


## Original issue(s)
[department-of-veterans-affairs/va.gov-cms/issues/10272](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10272)

## Testing done


## Screenshots
### before
![Screen Shot 2022-08-25 at 10 56 43 AM](https://user-images.githubusercontent.com/8542413/186699548-113c5a19-a30d-4182-8a4a-5e67e3da8f20.png)

### after
![Screen Shot 2022-08-25 at 10 57 12 AM](https://user-images.githubusercontent.com/8542413/186699520-1f7ff016-ffc5-4edb-af97-611ad596c094.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
