### PR TITLE
fix: updating burial-poc-v6 Intro page to use web-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.4.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "1.3.3",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.4.3",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@mapbox/mapbox-sdk": "^0.13.2",

--- a/src/applications/burial-poc-v6/pages/BurialIntroduction.jsx
+++ b/src/applications/burial-poc-v6/pages/BurialIntroduction.jsx
@@ -1,14 +1,114 @@
 import React from 'react';
 import {
   Page,
-  IntroductionPage,
+  FormTitle,
 } from '@department-of-veterans-affairs/va-forms-system-core';
 
 export default function BurialIntroduction(props) {
   return (
     <>
       <Page {...props}>
-        <IntroductionPage />
+        <div className="schemaform-intro">
+          <FormTitle title="Apply for burial benefits" />
+          <p>Equal to VA Form 21P-530 (Application for Burial Benefits).</p>
+          <h2 className="vads-u-font-size--h4">
+            Follow the steps below to apply for burial benefits.
+          </h2>
+          <va-process-list>
+            <li>
+              <div>
+                <h3>Prepare</h3>
+              </div>
+              <div>
+                <h4>
+                  <a href="/burials-memorials/veterans-burial-allowance/">
+                    Find out if you qualify for a burial allowance
+                  </a>
+                  .
+                </h4>
+              </div>
+              <br />
+              <div>
+                <h4>
+                  To fill out this application, you’ll need information about
+                  the deceased Veteran, including their:
+                </h4>
+              </div>
+              <ul>
+                <li>Social Security number or VA file number (required)</li>
+                <li>Date and place of birth (required)</li>
+                <li>Date and place of death (required)</li>
+                <li>Military status and history</li>
+              </ul>
+              <div>
+                <h4>You may need to upload:</h4>
+              </div>
+              <ul>
+                <li>
+                  A copy of the deceased Veteran’s DD214 or other separation
+                  documents
+                </li>
+                <li>A copy of the Veteran’s death certificate</li>
+                <li>
+                  Documentation for transportation costs (if you’re claiming
+                  costs for the transportation of the Veteran’s remains)
+                </li>
+              </ul>
+              <p>
+                <strong>What if I need help filling out my application?</strong>{' '}
+                An accredited representative, like a Veterans Service Officer
+                (VSO), can help you fill out your claim.{' '}
+                <a href="/disability/get-help-filing-claim/">
+                  Get help filing your claim
+                </a>
+                .
+              </p>
+              <h4>Learn about other survivor and dependent benefits</h4>
+              <p>
+                If you’re the survivor or dependent of a Veteran who died in the
+                line of duty or from a service-related illness, you may be able
+                to get a benefit called{' '}
+                <a href="/burials-memorials/dependency-indemnity-compensation/">
+                  Dependency and Indemnity Compensation
+                </a>
+                .
+              </p>
+            </li>
+            <li>
+              <div>
+                <h3>Apply</h3>
+              </div>
+              <div>
+                <p>Complete this burial benefits form.</p>
+                <p>
+                  After submitting the form, you’ll get a confirmation message.
+                  You can print this for your records.
+                </p>
+              </div>
+            </li>
+            <li>
+              <div>
+                <h3>VA Review</h3>
+              </div>
+              <p>We process claims in the order we receive them.</p>
+              <p>We’ll let you know by mail if we need more information.</p>
+            </li>
+            <li>
+              <div>
+                <h3>Decision</h3>
+              </div>
+              <p>
+                After we process your claim, you’ll get a notice in the mail
+                about the decision.
+              </p>
+            </li>
+          </va-process-list>
+          <va-omb-info
+            exp-date="12/31/2077"
+            omb-number="12-3456"
+            res-burden={120}
+          />
+        </div>
       </Page>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,10 +2563,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.3.3.tgz#d7a5843ffb3a6aec3484993e41085bfca121a01b"
-  integrity sha512-im9vI/P5FhZg23CaHY8S4avDhtuT1DtlnZxXIR2TtTyv+RBmYzvfQFJt5JUKoLqMaNH4coH+H9AmDCnmPkrHFg==
+"@department-of-veterans-affairs/va-forms-system-core@1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.3.tgz#76acd24c468ffdd9509415e65854094b075ccbcb"
+  integrity sha512-c1Ry/aNeTTOLrOPoBQdt9R8IzE/zebUBkcFwcli5rjkD/nzekbM10hdx677XuiqTNtmLNYZ/Udm88OwwccmY1g==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"


### PR DESCRIPTION
## Description

In this PR, I have updated the `burial-poc-v6` application to use `va-omb-info` and `va-process-list` on the IntroductionPage, and updated the version of VAFSC to `1.4.3` to include new changes (removal of IntroductionPage component and OMBInfo updates).

## Original issue(s)

[department-of-veterans-affairs/va.gov-team#288](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/288)

## Testing done

- [ ] All Unit Tests Pass

## Screenshots

<img width="800" alt="image" src="https://user-images.githubusercontent.com/22844722/186719364-21e9e000-66c9-4b67-ae0c-5aed260ac2c7.png">

## Acceptance criteria
- [ ] OMBInfo shows up properly when using `va-omb-info`
- [ ] All Tests Pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
