### PR TITLE
Add ESLint rules for telephone contact

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -6,7 +6,5 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 2,
     'jsx-a11y/label-has-associated-control': 1,
     'jsx-a11y/no-static-element-interactions': 2,
-    '@department-of-veterans-affairs/prefer-telephone-component': 2,
-    '@department-of-veterans-affairs/telephone-contact-3-or-10-digits': 2,
   },
 };

--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -6,5 +6,7 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 2,
     'jsx-a11y/label-has-associated-control': 1,
     'jsx-a11y/no-static-element-interactions': 2,
+    '@department-of-veterans-affairs/prefer-telephone-component': 2,
+    '@department-of-veterans-affairs/telephone-contact-3-or-10-digits': 2,
   },
 };

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.10.0",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.2.2",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.3.0",
     "@department-of-veterans-affairs/generator-vets-website": "^3.8.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,10 +2517,12 @@
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.2.2.tgz#6a9668a2a7e40b755b31e36bc2daf95d62d87032"
-  integrity sha512-V97Ka7zXS+jdh4XN/VcCLXldubEvbH390JFslAmnqMD5b9er/kj585ndlI4p5WunaP3kIwJRY7A4CuunrVrO7w==
+"@department-of-veterans-affairs/eslint-plugin@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.3.0.tgz#30d9da8775f7aa5fa18c6ff7bcb072248e31bf14"
+  integrity sha512-7FuNKVZjuO5zaBWJfpNKAgtqwI3SwvF9OQNu6+xpBwyBWj4u86XxDoXHIzLilgeQNAdphLvvKjiXp4HbHDlMcA==
+  dependencies:
+    jsx-ast-utils "^3.3.3"
 
 "@department-of-veterans-affairs/formation@^7.0.2":
   version "7.0.2"
@@ -4873,6 +4875,17 @@ array-includes@^3.1.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
+array-includes@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.5.tgz#2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb"
+  integrity sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
@@ -7617,6 +7630,14 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+define-properties@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
@@ -8345,6 +8366,35 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
+
+es-abstract@^1.19.5:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
+  integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    regexp.prototype.flags "^1.4.3"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
 
 es-module-lexer@^0.9.0:
   version "0.9.3"
@@ -9896,7 +9946,7 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-function.prototype.name@^1.1.0:
+function.prototype.name@^1.1.0, function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
   integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
@@ -10476,6 +10526,11 @@ has-bigints@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
+has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
@@ -10491,6 +10546,13 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz"
@@ -10500,6 +10562,11 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -11553,6 +11620,11 @@ is-negative-zero@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
 
+is-negative-zero@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
 is-node-process@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
@@ -11728,6 +11800,13 @@ is-shared-array-buffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
   integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -11796,7 +11875,7 @@ is-utf8@^0.2.0, is-utf8@^0.2.1:
   resolved "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-weakref@^1.0.1:
+is-weakref@^1.0.1, is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
@@ -12274,6 +12353,14 @@ jsx-ast-utils@^3.2.1:
   dependencies:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
+
+jsx-ast-utils@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  dependencies:
+    array-includes "^3.1.5"
+    object.assign "^4.1.3"
 
 just-diff-apply@^3.0.0:
   version "3.0.0"
@@ -14324,6 +14411,11 @@ object-inspect@^1.11.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
+object-inspect@^1.12.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
 object-inspect@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz"
@@ -14378,6 +14470,16 @@ object.assign@^4.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.0"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.1:
@@ -16604,6 +16706,15 @@ regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+regexp.prototype.flags@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
+
 regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz"
@@ -18037,6 +18148,15 @@ string.prototype.trimend@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
+  integrity sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+
 string.prototype.trimleft@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz"
@@ -18078,6 +18198,15 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
+  integrity sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
 
 string_decoder@^1.1.1:
   version "1.2.0"
@@ -19027,6 +19156,16 @@ unbox-primitive@^1.0.1:
     function-bind "^1.1.1"
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 unbzip2-stream@^1.3.3:


### PR DESCRIPTION
## Description

New ESLint rules were added in https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/863. This bumps the package version to bring them in. They will be included here as warnings due to the recommended config:

https://github.com/department-of-veterans-affairs/vets-website/blob/c9ad501e5eee2bb753719ed2ded1b05bf43a4c5d/.eslintrc.js#L8

I'm setting them to be errors in the `.eslintrc.changed.js` file because the ESLint npm scripts in `package.json` all have `--quiet` on them which means that [the autofix functionality won't work by default](https://github.com/eslint/eslint/pull/8858).

---

To get an idea of how many times this would trigger, I changed these rules to be errors in the default ESLint config and ran `yarn lint:js` after removing the `--quiet` option.

<details>

<summary>Diff</summary>

```diff
diff --git a/.eslintrc.js b/.eslintrc.js
index 0d6d9881f3..a9aee8fef5 100644
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,6 +69,8 @@ module.exports = {
     'jsx-a11y/control-has-associated-label': 1, // 2
     'jsx-a11y/click-events-have-key-events': 1, // 24
     'jsx-a11y/anchor-is-valid': 1, // 51
+    '@department-of-veterans-affairs/prefer-telephone-component': 2,
+    '@department-of-veterans-affairs/telephone-contact-3-or-10-digits': 2,
     'jsx-a11y/label-has-associated-control': [
       1,
       {
diff --git a/package.json b/package.json
index 8b62cacf68..9df7f30b1e 100644
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jsdoc": "jsdoc",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:changed": "npm run lint:js:changed && npm run lint:sass:changed",
-    "lint:js": "eslint --quiet --ext .js --ext .jsx .",
+    "lint:js": "eslint --ext .js --ext .jsx .",
     "lint:js:changed": "LIST=`git diff-index --diff-filter=d --name-only --cached HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet $LIST; fi",
     "lint:js:changed:fix": "LIST=`git diff-index --diff-filter=d --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
     "lint:js:fix": "eslint --fix --quiet --ext .js --ext .jsx .",
```

</details>

This was the output:

![8959 problems (171 errors, 8788 warnings). 171 errors and 1224 warnings potentially fixable with the --fix option.](https://user-images.githubusercontent.com/2008881/186949168-0aa0cc49-e39d-45a9-8153-0dcf0b73f50a.png)

And when I run `yarn lint:js:fix` we see that number reduced to 101 errors, many of which are `prettier` errors since the `telephone-contact-3-or-10-digits` rule is trying to autofix some numbers but unable to finish.

![101 errors, 98 errors potentially fixable.](https://user-images.githubusercontent.com/2008881/186951804-7fb3f230-a6f2-4421-a48d-bdf499911ce0.png)


## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/864

## Testing done

Local testing. I did find some edge cases where disabling one of the rules seems appropriate:

https://github.com/department-of-veterans-affairs/vets-website/blob/4655850977fe08bf5e11fe55f46988bf3d034582/src/applications/virtual-agent/components/page/Disclaimer.jsx#L82-L85

There are also cases where these rules will be able to eliminate inconsistencies between the `tel` number and the user-facing number:

https://github.com/department-of-veterans-affairs/vets-website/blob/4655850977fe08bf5e11fe55f46988bf3d034582/src/applications/edu-benefits/10203/content/directDeposit.jsx#L68-L70

## Screenshots

### Developer intervention required

I'm working in the `CallNCACenter.jsx` file which has an `<a href="tel:"` in it:

https://github.com/department-of-veterans-affairs/vets-website/blob/c9ad501e5eee2bb753719ed2ded1b05bf43a4c5d/src/platform/static-data/CallNCACenter.jsx#L11

The steps taken are:

1. Observe the ESLint warning for `prefer-telephone-component`
1. Modify the file as if I was going to add the changes to a commit
1. Stage the changes
1. Try to commit the changes
1. pre-commit hook blocks me with an ESLint failure for the `telephone-contact-3-or-10-digits` rule
    - This means that the autofix for `prefer-telephone-component` happened, but these changes were undone to to the second rule failing
1. **Remove the leading 1 from the 11 digit contact number**
1. Stage the changes
1. Try to commit - no block happens
1. Switch over to the text editor to notice that the autofixes have been applied and we see a `<va-telephone>`.

[A recording of the session described above](https://user-images.githubusercontent.com/2008881/186790736-6822a059-9bf3-4642-ba69-a31d8ae15cca.webm)

### Easy autofix - prefer-telephone-component

For this recording I'm working in a helpers file:

https://github.com/department-of-veterans-affairs/vets-website/blob/c9ad501e5eee2bb753719ed2ded1b05bf43a4c5d/src/applications/sah/sahg/helpers.js#L17-L20

The tel number in the `href` has exactly 10 digits, so autofixing works without any extra effort.

1. Observe the ESLint warning for `prefer-telephone-component`
2. Stage the changes to the file (adding a comment)
3. Try to commit the changes
    - The pre-commit hook passes
4. Notice that the autofixed changes have been applied and the file uses `<va-telephone>`

[Recording of the session described above](https://user-images.githubusercontent.com/2008881/186792414-9142d0e0-4f49-475a-b9ae-1c12ba1369ba.webm)

### Easy autofix - telephone-contact-3-or-10-digits

This example uses a file which uses `<va-telephone>` components but the `contact` prop has hyphens in it:

https://github.com/department-of-veterans-affairs/vets-website/blob/dc13676aa2bc219326361e16a908fa6365720249/src/applications/medical-copays/components/Alerts.jsx#L29

Similar to the example above, when this changed file is staged for commit, the pre-commit hook will autofix these errors.

[A recording similar toe the one above, but the autofix is stripping hyphens rather than rewriting an anchor link to a telephone component.](https://user-images.githubusercontent.com/2008881/186945803-82f0109d-632d-4b16-a93b-826ea01febf4.webm)


## Acceptance criteria
- [x] Linting rule in `vets-website` can warn on the `<a href="tel:..."` pattern and guide users to the `<va-telephone>` web component
