### PR TITLE
Profile limit phone extension to 6

### DIFF
--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -58,7 +58,7 @@ function editPhoneNumber(numberName) {
     `${numberName} (U.S. numbers only)`,
     { exact: false },
   );
-  const extensionInput = view.getByLabelText(/Extension/);
+  const extensionInput = view.getByLabelText(/Extension (6 digits maximum)/);
   expect(phoneNumberInput).to.exist;
 
   // enter a new phone number in the form

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -58,7 +58,7 @@ function editPhoneNumber(numberName) {
     `${numberName} (U.S. numbers only)`,
     { exact: false },
   );
-  const extensionInput = view.getByLabelText(/Extension (6 digits maximum)/);
+  const extensionInput = view.getByLabelText('Extension (6 digits maximum)');
   expect(phoneNumberInput).to.exist;
 
   // enter a new phone number in the form

--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -15,7 +15,8 @@ export const phoneFormSchema = {
     },
     extension: {
       type: 'string',
-      pattern: '^\\s*[a-zA-Z0-9]{0,10}\\s*$',
+      pattern: '^\\s*[a-zA-Z0-9]{0,6}\\s*$',
+      maxLength: 6,
     },
   },
   required: ['inputPhoneNumber'],
@@ -34,7 +35,7 @@ export const phoneUiSchema = fieldName => {
       },
     },
     extension: {
-      'ui:title': 'Extension',
+      'ui:title': 'Extension (6 digits maximum)',
       'ui:errorMessages': {
         pattern: 'Please enter a valid extension.',
       },


### PR DESCRIPTION
## Description
Updates phone extension field to only allow a maximum of 6 numbers in it.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/45263

## Testing done
Updated tests for new label

## Acceptance criteria
- [x] Extension for phone limited to 6 numbers

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
