### PR TITLE
updated display for when 1095b feature toggle is off

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -72,11 +72,12 @@ export const unavailableComponent = () => {
       status="warning"
       visible
     >
-      <h3 slot="headline">1095-B download unavailable at this time</h3>
+      <h3 slot="headline">
+        Your 1095-B form isn’t available to download right now
+      </h3>
       <div>
         <p>
-          Please check back later or if you need immediate assistance with this
-          tax form, call the Enrollment Center at{' '}
+          Check back later. Or, if you need help with this form now, call us at{' '}
           {phoneComponent(CONTACTS['222_VETS'])}. We’re here Monday through
           Friday, 8:00 a.m. to 8:00 p.m. ET.
         </p>


### PR DESCRIPTION
## Description
This PR updates the display that the user sees if the 1095B feature toggle is off

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44334


## Testing done
Tested display locally to make sure it appears as desired

## Screenshots
<img width="733" alt="Screen Shot 2022-08-26 at 12 57 21 PM" src="https://user-images.githubusercontent.com/47372929/186956150-a8dc61cb-f8ce-4469-94cb-464c8d9752f5.png">



## Acceptance criteria
- [x] looks like image below:
![image](https://user-images.githubusercontent.com/47372929/186956408-e3934f50-13f6-47bb-a514-b108065b29d0.png)


