### PR TITLE
Dhp 358 unique identifiers

### DIFF
--- a/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
@@ -9,10 +9,12 @@ export const DeviceConnectionCard = ({ device }) => {
       <p className="vads-u-margin-y--0">
         <va-link
           active
+          role="link"
           data-testid={`${device.key}-connect-link`}
           id={`${device.key}-connect-link`}
           className="connect-button"
           href={`${environment.API_URL}/dhp_connected_devices${device.authUrl}`}
+          aria-label={`Connect ${device.name}`}
           text="Connect"
         />
       </p>

--- a/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
@@ -39,6 +39,7 @@ export const DeviceDisconnectionCard = ({ device }) => {
             id={`${device.key}-disconnect-link`}
             onKeyDown={() => setModalVisible(true)}
             className="usa-button-secondary"
+            aria-label={`Disconnect ${device.name}`}
           >
             Disconnect
           </button>

--- a/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { mount } from 'enzyme';
 import { DeviceConnectionCard } from '../../components/DeviceConnectionCard';
 
 describe('Device connection card', () => {
@@ -13,5 +14,16 @@ describe('Device connection card', () => {
     );
 
     expect(card.getByText(/Test Vendor/)).to.exist;
+  });
+  it('Has aria label for screen reader users', () => {
+    const card = mount(
+      <DeviceConnectionCard
+        device={{ key: 'test-vendor', name: 'Test Vendor' }}
+      />,
+    );
+    expect(
+      card.find('[data-testid="test-vendor-connect-link"]').prop('aria-label'),
+    ).to.equal('Connect Test Vendor');
+    card.unmount();
   });
 });

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import environment from 'platform/utilities/environment';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import { render, fireEvent } from '@testing-library/react';
+import { mount } from 'enzyme';
 import { DeviceDisconnectionCard } from '../../components/DeviceDisconnectionCard';
 
 describe('Device disconnection card', () => {
@@ -16,6 +17,19 @@ describe('Device disconnection card', () => {
 
     expect(card.getByText(/Test Vendor/)).to.exist;
   });
+  it('Has aria label for screen reader users', () => {
+    const card = mount(
+      <DeviceDisconnectionCard
+        device={{ key: 'test-vendor', name: 'Test Vendor' }}
+      />,
+    );
+    expect(
+      card
+        .find('[data-testid="test-vendor-disconnect-link"]')
+        .prop('aria-label'),
+    ).to.equal('Disconnect Test Vendor');
+    card.unmount();
+  });
 });
 
 describe('Device disconnection card modal', () => {
@@ -28,7 +42,9 @@ describe('Device disconnection card modal', () => {
   };
   beforeEach(async () => {
     screen = render(<DeviceDisconnectionCard device={device} />);
-    const disconnectBtn = screen.getByRole('button', { name: 'Disconnect' });
+    const disconnectBtn = screen.getByRole('button', {
+      name: 'Disconnect Test Vendor',
+    });
     fireEvent.click(disconnectBtn);
     modal = screen.getByTestId('disconnect-modal');
   });


### PR DESCRIPTION
## Description
This is an accessibility feature based on "Must" feedback from our Midpoint Review. This adds unique identifiers to links and buttons in the connection and disconnection flows in the form of aria labels, which are read by screen reader software.

## Original issue(s)
[Midpoint Review - Accessibility Feedback - Digital Health Platform, MVP](https://github.com/department-of-veterans-affairs/va.gov-team/issues/44231)

## Testing done
- Automated unit tests
- Manual QA with VoiceOver screen reader

## Screenshots
N/A

## Acceptance criteria
- [x] Given a Veteran is using a screen reader to navigate through the Device Connection flow, when the screen reader gets to a button, the button text is displayed with a unique accessible name for the screen reader
- [x] Given a Veteran is using a screen reader to navigate through the Device Connection flow, when the screen reader gets to a link, the link text is displayed with a unique accessible name for the screen reader

## Definition of done
- [ ] ~~Events are logged appropriately~~ N/A
- [ ] ~~Documentation has been updated, if applicable~~ N/A
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
