### PR TITLE
[cFSR] Fixing required field breaking cFSR submission. 

### DIFF
--- a/src/applications/financial-status-report/pages/resolution/resolutionComment.js
+++ b/src/applications/financial-status-report/pages/resolution/resolutionComment.js
@@ -19,6 +19,13 @@ export const uiSchema = {
           classNames: 'schemaform-currency-input',
           widgetClassNames: 'input-size-3',
         },
+        'ui:required': (formData, index) => {
+          return (
+            formData.selectedDebtsAndCopays[index]?.resolutionOption &&
+            formData.selectedDebtsAndCopays[index]?.resolutionOption !==
+              'waiver'
+          );
+        },
         'ui:validations': [validateCurrency, validateResolutionAmount],
       },
     },
@@ -32,7 +39,6 @@ export const schema = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['resolutionComment'],
         properties: {
           resolutionComment: {
             type: 'string',


### PR DESCRIPTION
## Description
Updating `resolutionComment` required field to match depends for that page more closely, so submission won't break when waiver option is selected and there is no comment. 

## Acceptance criteria
- [ ] Submission is working again for combined fsr

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
