### PR TITLE
[cFSR] Fixing edge case for comma values

### DIFF
--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -45,7 +45,9 @@ export const currency = amount => {
     minimumFractionDigits: 2,
   });
   const value =
-    typeof amount === 'number' ? amount : parseFloat(amount.replace(',', ''));
+    typeof amount === 'number'
+      ? amount
+      : parseFloat(amount.replaceAll(',', ''));
   return formatter.format(value);
 };
 
@@ -57,7 +59,7 @@ export const sumValues = (arr, key) => {
   const isArrValid = Array.isArray(arr) && arr.length && hasProperty(arr, key);
   if (!isArrValid) return 0;
   return arr.reduce(
-    (acc, item) => acc + (Number(item[key]?.replace(',', '')) ?? 0),
+    (acc, item) => acc + (Number(item[key]?.replaceAll(',', '')) ?? 0),
     0,
   );
 };
@@ -66,7 +68,7 @@ export const filterDeductions = (deductions, filters) => {
   if (!deductions.length) return 0;
   return deductions
     .filter(({ name }) => filters.includes(name))
-    .reduce((acc, curr) => acc + Number(curr.amount.replace(',', '')), 0);
+    .reduce((acc, curr) => acc + Number(curr.amount.replaceAll(',', '')), 0);
 };
 
 export const otherDeductionsName = (deductions, filters) => {
@@ -81,7 +83,7 @@ export const otherDeductionsAmt = (deductions, filters) => {
   if (!deductions.length) return 0;
   return deductions
     .filter(({ name }) => name && !filters.includes(name))
-    .reduce((acc, curr) => acc + Number(curr.amount.replace(',', '')), 0);
+    .reduce((acc, curr) => acc + Number(curr.amount.replaceAll(',', '')), 0);
 };
 
 export const nameStr = (socialSecurity, compensation, education, addlInc) => {
@@ -126,14 +128,15 @@ export const getAmountCanBePaidTowardDebt = (debts, combinedFSR) => {
     ? debts
         .filter(item => item.resolutionComment !== undefined)
         .reduce(
-          (acc, debt) => acc + Number(debt.resolutionComment.replace(',', '')),
+          (acc, debt) =>
+            acc + Number(debt.resolutionComment.replaceAll(',', '')),
           0,
         )
     : debts
         .filter(item => item.resolution.offerToPay !== undefined)
         .reduce(
           (acc, debt) =>
-            acc + Number(debt.resolution?.offerToPay.replace(',', '')),
+            acc + Number(debt.resolution?.offerToPay.replaceAll(',', '')),
           0,
         );
 };
@@ -159,7 +162,7 @@ export const getMonthlyIncome = ({
   const vetGrossSalary = sumValues(currEmployment, 'veteranGrossSalary');
   const vetAddlInc = sumValues(addlIncRecords, 'amount');
   const vetSocSecAmt = Number(
-    socialSecurity.socialSecAmt?.replace(',', '') ?? 0,
+    socialSecurity.socialSecAmt?.replaceAll(',', '') ?? 0,
   );
   const vetComp = sumValues(income, 'compensationAndPension');
   const vetEdu = sumValues(income, 'education');
@@ -177,13 +180,13 @@ export const getMonthlyIncome = ({
   const spGrossSalary = sumValues(spCurrEmployment, 'spouseGrossSalary');
   const spAddlInc = sumValues(spAddlIncome, 'amount');
   const spSocialSecAmt = Number(
-    socialSecurity.socialSecAmt?.replace(',', '') ?? 0,
+    socialSecurity.socialSecAmt?.replaceAll(',', '') ?? 0,
   );
   const spComp = Number(
-    benefits.spouseBenefits.compensationAndPension?.replace(',', '') ?? 0,
+    benefits.spouseBenefits.compensationAndPension?.replaceAll(',', '') ?? 0,
   );
   const spEdu = Number(
-    benefits.spouseBenefits.education?.replace(',', '') ?? 0,
+    benefits.spouseBenefits.education?.replaceAll(',', '') ?? 0,
   );
   const spBenefits = spComp + spEdu;
   const spDeductions = spCurrEmployment?.map(emp => emp.deductions).flat() ?? 0;
@@ -209,7 +212,7 @@ export const getMonthlyExpenses = ({
   const otherExp = sumValues(otherExpenses, 'amount');
   const expVals = Object.values(expenses).filter(Boolean);
   const totalExp = expVals.reduce(
-    (acc, expense) => acc + Number(expense.replace(',', '')),
+    (acc, expense) => acc + Number(expense.replaceAll(',', '')),
     0,
   );
 
@@ -223,7 +226,7 @@ export const getTotalAssets = ({ assets, realEstateRecords }) => {
   const realEstate = sumValues(realEstateRecords, 'realEstateAmount');
   const totAssets = Object.values(assets)
     .filter(item => item && !Array.isArray(item))
-    .reduce((acc, amount) => acc + Number(amount.replace(',', '')), 0);
+    .reduce((acc, amount) => acc + Number(amount.replaceAll(',', '')), 0);
 
   return totVehicles + totRecVehicles + totOtherAssets + realEstate + totAssets;
 };

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -72,7 +72,7 @@ export const transform = (formConfig, form) => {
   const vetGrossSalary = sumValues(currEmployment, 'veteranGrossSalary');
   const vetAddlInc = sumValues(addlIncRecords, 'amount');
   const vetSocSecAmt = Number(
-    socialSecurity.socialSecAmt?.replace(',', '') ?? 0,
+    socialSecurity.socialSecAmt?.replaceAll(',', '') ?? 0,
   );
   const vetComp = sumValues(income, 'compensationAndPension');
   const vetEdu = sumValues(income, 'education');
@@ -90,13 +90,13 @@ export const transform = (formConfig, form) => {
   const spGrossSalary = sumValues(spCurrEmployment, 'spouseGrossSalary');
   const spAddlInc = sumValues(spAddlIncome, 'amount');
   const spSocialSecAmt = Number(
-    socialSecurity.socialSecAmt?.replace(',', '') ?? 0,
+    socialSecurity.socialSecAmt?.replaceAll(',', '') ?? 0,
   );
   const spComp = Number(
-    benefits.spouseBenefits.compensationAndPension?.replace(',', '') ?? 0,
+    benefits.spouseBenefits.compensationAndPension?.replaceAll(',', '') ?? 0,
   );
   const spEdu = Number(
-    benefits.spouseBenefits.education?.replace(',', '') ?? 0,
+    benefits.spouseBenefits.education?.replaceAll(',', '') ?? 0,
   );
   const spBenefits = spComp + spEdu;
   const spDeductions = spCurrEmployment?.map(emp => emp.deductions).flat() ?? 0;


### PR DESCRIPTION
## Description
Using `replaceAll` to cover edge case of multiple commas in dollar amounts. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#41721
Sister ticket - #22046 

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/25368370/187265936-9ce910a7-0f67-457b-bfd5-d83059cffd2a.png)

### After
![image](https://user-images.githubusercontent.com/25368370/187264801-df1b0f66-7f35-4af4-b346-f2697b3a765d.png)


## Acceptance criteria
- [x] Multiple comma dollar values rendering appropriately 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
