### PR TITLE
[Check-in] Add params to common errors for analytics

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
@@ -46,10 +46,10 @@ const AppointmentAction = props => {
           setSelectedAppointment(appointment);
           goToNextPage();
         } else {
-          goToErrorPage();
+          goToErrorPage('?error=check-in-post-error');
         }
       } catch (error) {
-        goToErrorPage();
+        goToErrorPage('?error=error-completing-check-in');
       }
     },
     [appointment, goToErrorPage, goToNextPage, setSelectedAppointment, token],

--- a/src/applications/check-in/containers/withAuthorization.jsx
+++ b/src/applications/check-in/containers/withAuthorization.jsx
@@ -26,7 +26,7 @@ const withAuthorization = (Component, options) => {
           const sessionToken = getCurrentToken(window)?.token;
           if (!sessionToken) {
             // @TODO: Add a friendlier message when the UUID is not found
-            goToErrorPage();
+            goToErrorPage('?error=no-token');
           } else {
             jumpToPage(URLS.LANDING, { params: { url: { id: sessionToken } } });
           }

--- a/src/applications/check-in/containers/withForm.jsx
+++ b/src/applications/check-in/containers/withForm.jsx
@@ -25,7 +25,7 @@ const withForm = (Component, options = {}) => {
           if (token) {
             jumpToPage(URLS.LANDING, { params: { url: { id: token } } });
           } else {
-            goToErrorPage();
+            goToErrorPage('?error=no-token');
           }
         }
       },

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -56,7 +56,7 @@ const DisplayMultipleAppointments = props => {
       }
 
       if (checkInDataError) {
-        goToErrorPage();
+        goToErrorPage('?error=cant-retrieve-check-in-data');
       }
     },
     [appointments, checkInDataError, goToErrorPage, refreshCheckInData],

--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -75,7 +75,7 @@ const Demographics = props => {
   );
 
   if (!demographics) {
-    goToErrorPage();
+    goToErrorPage('?error=no-demographics');
     return <></>;
   }
   return (

--- a/src/applications/check-in/day-of/pages/EmergencyContact.jsx
+++ b/src/applications/check-in/day-of/pages/EmergencyContact.jsx
@@ -76,7 +76,7 @@ const EmergencyContact = props => {
   );
 
   if (!emergencyContact) {
-    goToErrorPage();
+    goToErrorPage('?error=no-emergency-contact');
     return <></>;
   }
   return (

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -67,14 +67,14 @@ const Landing = props => {
         recordEvent({
           event: createAnalyticsSlug('landing-page-launched-no-token'),
         });
-        goToErrorPage();
+        goToErrorPage('?error=no=token');
       }
 
       if (!isUUID(token)) {
         recordEvent({
           event: createAnalyticsSlug('malformed-token'),
         });
-        goToErrorPage();
+        goToErrorPage('?error=bad-token');
       }
 
       if (token && !sessionCallMade) {
@@ -87,7 +87,7 @@ const Landing = props => {
           .then(session => {
             if (session.errors || session.error) {
               clearCurrentSession(window);
-              goToErrorPage();
+              goToErrorPage('?error=session-error');
             } else {
               // if session with read.full exists, go to check in page
               setShouldSendDemographicsFlags(window, true);

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -106,7 +106,7 @@ const Landing = props => {
           })
           .catch(() => {
             clearCurrentSession(window);
-            goToErrorPage();
+            goToErrorPage('?error=error-fromlocation-landing');
           });
       }
     },

--- a/src/applications/check-in/day-of/pages/LoadingPage/index.jsx
+++ b/src/applications/check-in/day-of/pages/LoadingPage/index.jsx
@@ -21,10 +21,10 @@ const LoadingPage = props => {
   useEffect(
     () => {
       if (checkInDataError) {
-        goToErrorPage();
+        goToErrorPage('?error=cant-retrieve-check-in-data');
       }
       if (!isEmpty(demographics)) {
-        goToNextPage();
+        goToNextPage('?error=no-demographics');
       }
     },
     [checkInDataError, demographics, goToErrorPage, goToNextPage],

--- a/src/applications/check-in/day-of/pages/NextOfKin.jsx
+++ b/src/applications/check-in/day-of/pages/NextOfKin.jsx
@@ -75,7 +75,7 @@ const NextOfKin = props => {
   );
 
   if (!nextOfKin) {
-    goToErrorPage();
+    goToErrorPage('?error=no-next-of-kin');
     return <></>;
   }
   return (

--- a/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/TestComponent.jsx
@@ -17,7 +17,7 @@ export default function TestComponent({ router }) {
 
   const errorTest = () => {
     // strip out button click event stuff from being sent as a param to the function
-    goToErrorPage();
+    goToErrorPage('?error=test-error');
   };
 
   return (

--- a/src/applications/check-in/hooks/tests/useFormRouting/useFormRouting.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useFormRouting/useFormRouting.unit.spec.jsx
@@ -226,7 +226,7 @@ describe('check-in', () => {
 
         const button = component.getByTestId('error-button');
         fireEvent.click(button);
-        expect(push.calledWith(URLS.ERROR)).to.be.true;
+        expect(push.calledWith(`${URLS.ERROR}?error=test-error`)).to.be.true;
       });
     });
     describe('jumpToPage', () => {

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -36,7 +36,7 @@ const useFormRouting = (router = {}) => {
         }
         router.push(query);
       } else {
-        goToErrorPage();
+        goToErrorPage('?error=routing-error');
       }
     },
     [goToErrorPage, router],

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -57,7 +57,7 @@ const Confirmation = props => {
         try {
           const resp = await api.v2.postPreCheckInData({ ...preCheckInData });
           if (resp.data.error || resp.data.errors) {
-            goToErrorPage();
+            goToErrorPage('?error=pre-check-in-post-error');
           } else {
             setPreCheckinComplete(window, true);
             // hide loading screen
@@ -65,7 +65,7 @@ const Confirmation = props => {
             focusElement('h1');
           }
         } catch (error) {
-          goToErrorPage();
+          goToErrorPage('?error=error-completing-pre-check-in');
         }
       }
 

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -57,7 +57,7 @@ const Introduction = props => {
           .getPreCheckInData(token)
           .then(json => {
             if (json.error) {
-              goToErrorPage();
+              goToErrorPage('?error=error-getting-pre-check-in-data');
               return; // prevent a react no-op on an unmounted component
             }
             const { payload } = json;
@@ -89,7 +89,7 @@ const Introduction = props => {
             setIsLoading(false);
           })
           .catch(() => {
-            goToErrorPage();
+            goToErrorPage('?error=error-fromlocation-precheckin-introduction');
           });
     },
     [

--- a/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/index.jsx
@@ -73,11 +73,11 @@ const Introduction = props => {
               payload.appointments.length > 0 &&
               preCheckinExpired(payload.appointments)
             ) {
-              goToErrorPage();
+              goToErrorPage('?error=pre-check-in-expired');
             }
 
             if (appointmentWasCanceled(payload.appointments)) {
-              goToErrorPage();
+              goToErrorPage('?error=appointment-canceled');
             }
 
             if (preCheckinAlreadyCompleted(payload.appointments)) {

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -71,14 +71,14 @@ const Index = props => {
         recordEvent({
           event: createAnalyticsSlug('landing-page-launched-no-token'),
         });
-        goToErrorPage();
+        goToErrorPage('?error=no-token');
       }
 
       if (!isUUID(token)) {
         recordEvent({
           event: createAnalyticsSlug('malformed-token'),
         });
-        goToErrorPage();
+        goToErrorPage('?error=bad-token');
       }
       if (token && isUUID(token)) {
         // call the sessions api
@@ -93,7 +93,7 @@ const Index = props => {
 
               if (session.error || session.errors) {
                 clearCurrentSession(window);
-                goToErrorPage();
+                goToErrorPage('?error=session-error');
               } else {
                 setCurrentToken(window, token);
                 setPreCheckinComplete(window, false);

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -100,7 +100,7 @@ const validateLogin = async (
     });
     if (resp.errors || resp.error) {
       setIsLoading(false);
-      goToErrorPage();
+      goToErrorPage('?error=session-error');
     } else {
       setSession(token, resp.permissions);
       if (!isLorotaDeletionEnabled) {


### PR DESCRIPTION
## Description
This PR passes some URL params to the error page with many common (and easy to code discern) errors to assist with analytics understanding until we are able to better refactor how our error pages work.

I would appreciate a sanity check on all of these to make sure I correctly interpreted the error from the code. All calls should now have a param passed with them. ~~Also, I didn't add params to all the `goToErrorPage()` calls, as some (mostly around request errors) felt like there isn't one specific reason we could point to in a param there. If you think I missed any calls that *should* have a param, let me know.~~

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45777


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
