### PR TITLE
[CDP] - 46078 - Update and Add Google Analytics to Events

### DIFF
--- a/src/applications/combined-debt-portal/combined/routes.jsx
+++ b/src/applications/combined-debt-portal/combined/routes.jsx
@@ -8,12 +8,20 @@ import MCPOverview from '../medical-copays/containers/OverviewPage';
 import DebtDetails from '../debt-letters/containers/DebtDetails';
 import DebtLettersDownload from '../debt-letters/containers/DebtLettersDownload';
 import DebtLettersSummary from '../debt-letters/containers/DebtLettersSummary';
+import recordEvent from '~/platform/monitoring/record-event';
 
 const Routes = () => (
   <CombinedPortalApp>
     <Switch>
       <Route exact path="/" component={OverviewPage} />
-      <Route exact path="/copay-balances" component={MCPOverview} />
+      <Route
+        exact
+        path="/copay-balances"
+        component={MCPOverview}
+        onClick={() => {
+          recordEvent({ event: 'cta-link-click-enter-mcp' });
+        }}
+      />
       <Route exact path="/copay-balances/:id/detail" component={DetailPage} />
       <Route
         exact
@@ -25,6 +33,9 @@ const Routes = () => (
         exact
         path="/debt-balances/letters"
         component={DebtLettersDownload}
+        onClick={() => {
+          recordEvent({ event: 'cta-link-click-enter-ltr' });
+        }}
       />
       <Route exact path="/debt-balances/details/:id" component={DebtDetails} />
       <Route>

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { format, isValid } from 'date-fns';
 import { getDebtDetailsCardContent } from '../const/diary-codes/debtDetailsCardContent';
 import { currency } from '../utils/page';
+import recordEvent from '~/platform/monitoring/record-event';
 
 const DebtDetailsCard = ({ debt }) => {
   // TODO: currently we do not have a debtID so we need to make one by combining fileNumber and diaryCode
@@ -49,6 +50,9 @@ const DebtDetailsCard = ({ debt }) => {
                 className="vads-c-action-link--blue"
                 data-testid="link-make-payment"
                 href="https://www.pay.va.gov/"
+                onClick={() => {
+                  recordEvent({ event: 'cta-link-click-debt-make-payment' });
+                }}
               >
                 Make a payment
               </a>
@@ -61,6 +65,9 @@ const DebtDetailsCard = ({ debt }) => {
                 className="vads-c-action-link--blue"
                 data-testid="link-request-help"
                 href="/manage-va-debt/request-debt-help-form-5655"
+                onClick={() => {
+                  recordEvent({ event: 'cta-link-click-debt-request-help' });
+                }}
               >
                 Request help with your debt
               </a>

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -6,6 +6,7 @@ import { deductionCodes } from '../const/deduction-codes';
 import { setActiveDebt } from '../../combined/actions/debts';
 import { currency } from '../utils/page';
 import { debtSummaryText } from '../const/diary-codes/debtSummaryCardContent';
+import recordEvent from '~/platform/monitoring/record-event';
 
 const DebtSummaryCard = ({ debt }) => {
   // TODO: currently we do not have a debtID so we need to make one by combining fileNumber and diaryCode
@@ -33,7 +34,10 @@ const DebtSummaryCard = ({ debt }) => {
       <div className="vads-u-margin-right--5 vads-u-margin-top--2 vads-u-font-weight--bold">
         <Link
           data-testid="debt-details-button"
-          onClick={() => setActiveDebt(debt)}
+          onClick={() => {
+            recordEvent({ event: 'cta-link-click-debt-summary-card' });
+            setActiveDebt(debt);
+          }}
           to={`/debt-balances/details/${debt.fileNumber + debt.deductionCode}`}
           aria-label={`Check details and resolve this ${debtCardHeading}`}
         >

--- a/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/BalanceCard.jsx
@@ -8,6 +8,7 @@ import {
   formatDate,
   verifyCurrentBalance,
 } from '../../combined/utils/helpers';
+import recordEvent from '~/platform/monitoring/record-event';
 
 const CurrentContent = ({ id, date }) => (
   <p>
@@ -88,6 +89,9 @@ const BalanceCard = ({ id, amount, facility, city, date }) => {
         to={`/copay-balances/${id}/detail`}
         data-testid={`detail-link-${id}`}
         aria-label={`Check details and resolve this debt for ${facility}`}
+        onClick={() => {
+          recordEvent({ event: 'cta-link-click-copay-balance-card' });
+        }}
       >
         {linkText}
         <i

--- a/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/DownloadStatement.jsx
@@ -30,7 +30,10 @@ const DownloadStatement = ({ statementId, statementDate, fullName }) => {
       <div className="vads-u-margin-top--2">
         <a
           className="vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--flex-start"
-          onClick={() => handleDownloadClick(statementDate)}
+          onClick={() => {
+            recordEvent({ event: 'cta-link-click-copay-statement-download' });
+            handleDownloadClick(statementDate);
+          }}
           download={downloadFileName}
           href={pdfStatementUri}
           type="application/pdf"

--- a/src/applications/combined-debt-portal/medical-copays/components/HTMLStatementLink.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/HTMLStatementLink.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import recordEvent from '~/platform/monitoring/record-event';
 
 const HTMLStatementLink = ({ id, statementDate }) => {
   const formattedStatementDate = date => {
@@ -13,6 +14,9 @@ const HTMLStatementLink = ({ id, statementDate }) => {
       <Link
         to={`/copay-balances/${id}/detail/statement`}
         data-testid={`balance-details-${id}-statement-view`}
+        onClick={() => {
+          recordEvent({ event: 'cta-link-click-copay-statement-link' });
+        }}
       >
         <span>{formattedStatementDate(statementDate)} statement </span>
       </Link>


### PR DESCRIPTION
## Description
Added google analytics recordEvent calls to actions that missed them and updated corresponding spreadsheet for analytics team.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46078 

https://docs.google.com/spreadsheets/d/1uShRq2no_W37foQ7QiBZ9M_tOhszI-lfjqM_KjnCm4E/edit#gid=0

## Acceptance criteria
- [ X ] Analytics events added and corresponding document for team updated.

## Definition of done
- [ X ] Events are logged appropriately
- [ X ] Documentation has been updated, if applicable
- [ X ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
