### PR TITLE
Adding vfs-mhv-secure-messaging team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,6 +101,10 @@ src/applications/education-letters @department-of-veterans-affairs/my-education-
 src/applications/fry-dea @department-of-veterans-affairs/my-education-benefits
 src/applications/toe @department-of-veterans-affairs/my-education-benefits
 
+# My HealtheVet Secure Messaging
+
+src/applications/mhv/secure-messaging @department-of-veterans-affairs/vfs-mhv-secure-messaging
+
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe
 src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-health-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,7 +102,6 @@ src/applications/fry-dea @department-of-veterans-affairs/my-education-benefits
 src/applications/toe @department-of-veterans-affairs/my-education-benefits
 
 # My HealtheVet Secure Messaging
-
 src/applications/mhv/secure-messaging @department-of-veterans-affairs/vfs-mhv-secure-messaging
 
 # Other


### PR DESCRIPTION
## Description
As a brand new team in the VA.gov space, we were requested to add our GitHub Team label name to CODEOWNERS file prior to submitting future pull requests. Please refer to the [thread on slack](https://dsva.slack.com/archives/CBU0KDSB1/p1661352080853779)   
Directory structure for src/spplications/mhv/secure-messaging is pending for submission on the following [pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/21981) which is dependent upon this pull request. 

## Original issue(s)
N/A

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
N/A

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
