### PR TITLE
ownship always displays, if there is no onwership value display defau…

### DIFF
--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -99,7 +99,6 @@ const ProfilePageHeader = ({
   };
 
   const main = facilityMap.main.institution;
-
   const stars = convertRatingToStars(ratingAverage);
   const displayStars =
     gibctSchoolRatings && stars && ratingCount >= MINIMUM_RATING_COUNT;
@@ -172,13 +171,9 @@ const ProfilePageHeader = ({
                 buttonId="typeAccredited-button"
               />
             </IconWithInfo>
-            <IconWithInfo
-              icon="building"
-              present={!environment.isProduction() ?? ownershipName}
-            >
+            <IconWithInfo icon="building" present={!environment.isProduction()}>
               {'   '}
-              Institutional Ownership:
-              {ownershipName}
+              Institutional Ownership: {ownershipName || 'N/A'}
             </IconWithInfo>
           </div>
         )}


### PR DESCRIPTION
## Description
EDU would like for the institution Ownership to be displayed on all cards. If institution cards does not have an Ownership name, please add "N/A" after ALL Intuitions ownership. SAMPLE -Institution Ownership: N/A

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#46348](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/46348)


## Testing done
local Env/staging


## Acceptance criteria
- [ ] Ownership name is displayed, if no ownership info say N/A

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
