### PR TITLE
Update global references to vets-api to point to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you're developing a feature that requires the API, but can't or don't want to
 run it locally, you can specify `--env api`:
 
 ```sh
-yarn watch --env api=https://dev-api.va.gov
+yarn watch --env api=https://dev-platform-api.va.gov
 ```
 
 You will need to disable CORS in your browser when using a non-local API. Here are some helpful links that explain how to do this:

--- a/script/build-help.js
+++ b/script/build-help.js
@@ -21,7 +21,7 @@ const helpSections = [
         name: 'env api',
         typeLabel: '{underline string}',
         description:
-          'Point vets-website to a running api.\nE.g. {bold https://dev-api.va.gov}. Defaults to {bold http://localhost:3000}.',
+          'Point vets-website to a running api.\nE.g. {bold https://dev-platform-api.va.gov}. Defaults to {bold http://localhost:3000}.',
       },
       {
         name: 'env host',

--- a/src/site/constants/environments-configs.js
+++ b/src/site/constants/environments-configs.js
@@ -14,19 +14,19 @@ module.exports = {
   [ENVIRONMENTS.VAGOVPROD]: {
     BUILDTYPE: ENVIRONMENTS.VAGOVPROD,
     BASE_URL: 'https://www.va.gov',
-    API_URL: 'https://api.va.gov',
+    API_URL: 'https://platform-api.va.gov',
   },
 
   [ENVIRONMENTS.VAGOVSTAGING]: {
     BUILDTYPE: ENVIRONMENTS.VAGOVSTAGING,
     BASE_URL: 'https://staging.va.gov',
-    API_URL: 'https://staging-api.va.gov',
+    API_URL: 'https://staging-platform-api.va.gov',
   },
 
   [ENVIRONMENTS.VAGOVDEV]: {
     BUILDTYPE: ENVIRONMENTS.VAGOVDEV,
     BASE_URL: 'https://dev.va.gov',
-    API_URL: 'https://dev-api.va.gov',
+    API_URL: 'https://dev-platform-api.va.gov',
   },
 
   [ENVIRONMENTS.LOCALHOST]: {


### PR DESCRIPTION
## Description

Updating global vets-api references per the CIT rollout plan.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45248


## Testing done
We do local and deployed spot checks for QA to make sure general functionality is all working in combination with passing automated tests. [View test plan](https://docs.google.com/spreadsheets/d/1gSMJO8mV2dgU8CAwX0Zo3wnB7Pgv9Y6h7wDEfvhTrQA/edit?usp=sharing)

We had to update the `web_origins` for vets-api to enable testing for this ([view PR](https://github.com/department-of-veterans-affairs/devops/pull/11863)).
