### PR TITLE
Removes iOS banner from LoginHeader

### DIFF
--- a/src/platform/user/authentication/components/LoginHeader.jsx
+++ b/src/platform/user/authentication/components/LoginHeader.jsx
@@ -9,28 +9,7 @@ import LogoutAlert from './LogoutAlert';
 import DowntimeBanners from './DowntimeBanner';
 import LoginBanners from './LoginBanners';
 
-function checkWebkit() {
-  const ua = navigator.userAgent.toLowerCase();
-
-  if (
-    ua.indexOf('chrome') === ua.indexOf('android') &&
-    ua.indexOf('safari') !== -1
-  ) {
-    // accessed via a WebKit-based browser
-    return true;
-  }
-
-  if (ua.includes('crios') || ua.includes('fxios')) {
-    return true;
-  }
-  // check if accessed via a WebKit-based webview
-  return (
-    ua.indexOf('ipad') !== -1 ||
-    ua.indexOf('iphone') !== -1 ||
-    ua.indexOf('ipod') !== -1
-  );
-}
-export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
+export default function LoginHeader({ loggedOut }) {
   const displayDirectDepositBanner = useSelector(
     state =>
       toggleValues(state)[
@@ -48,14 +27,6 @@ export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
         </div>
       </div>
       <DowntimeBanners />
-      {isIOS() && (
-        <LoginBanners
-          additionalInfoId="ios-bug"
-          headline="You may have trouble signing in right now"
-          description="We’re sorry. If you’re using the Safari browser or an Apple mobile device, you may have trouble signing in right now. We’re working to fix this problem as fast as we can."
-          displayDifferentDeviceContent
-        />
-      )}
       {displayDirectDepositBanner && (
         <LoginBanners
           headline="Disability and direct deposit information isn’t available right now"
@@ -80,6 +51,5 @@ export default function LoginHeader({ loggedOut, isIOS = checkWebkit }) {
 }
 
 LoginHeader.propTypes = {
-  isIOS: PropTypes.bool,
   loggedOut: PropTypes.bool,
 };

--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.js
@@ -28,16 +28,6 @@ describe('LoginHeader', () => {
       .null;
   });
 
-  it('should show an alert for iOS users', () => {
-    const screen = renderInReduxProvider(<LoginHeader isIOS={() => true} />, {
-      initialState: generateState({}),
-    });
-
-    const iosDescription = /We’re sorry. If you’re using the Safari browser or an Apple mobile device, you may have trouble signing in right now. We’re working to fix this problem as fast as we can./i;
-
-    expect(screen.queryByText(iosDescription)).to.not.be.null;
-  });
-
   it('should display direct deposit error', () => {
     const screen = renderInReduxProvider(<LoginHeader />, {
       initialState: generateState({ toggledOn: true }),


### PR DESCRIPTION
## Description
This PR removes an iOS informational banner that displays on the LoginHeader component.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#45637


## Testing done
Unit & manual

## Screenshots
Original
<img width="1186" alt="Screen Shot 2022-08-30 at 10 21 35 AM" src="https://user-images.githubusercontent.com/67602137/187464525-fcd5cf00-4125-4f13-afa8-d13c45686b50.png">

Changing to
<img width="1186" alt="Screen Shot 2022-08-30 at 10 22 57 AM" src="https://user-images.githubusercontent.com/67602137/187464568-b751770e-7d80-42bf-82bd-203b14674dd5.png">


## Acceptance criteria
- [x] Using any iOS device, I do NOT see the information banner on the Sign in Modal or the Sign in page (`/sign-in`)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
