### PR TITLE
Error 202 language 46291

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -271,34 +271,16 @@ export default function RenderErrorContainer({
     case AUTH_ERROR.OAUTH_STATE_MISMATCH:
       alertContent = (
         <p className="vads-u-margin-top--0">
-          We’re having trouble signing you in to VA.gov right now because your
-          browser information is different from the initial sign in.
+          We’re having trouble signing you in to VA.gov right now because of a
+          network error.
         </p>
       );
       troubleshootingContent = (
         <>
           <h2>What you can do:</h2>
-          <p>
-            <strong>Try taking these steps to fix the problem:</strong>
-          </p>
-          <ul>
-            <li>
-              Clear your Internet browser’s cookies and cache. Depending on
-              which browser you’re using, you’ll usually find this information
-              referred to as “Browsing Data,”, “Browsing History,” or “Website
-              Data.”
-            </li>
-            <li>
-              Make sure you have cookies enabled in your browser settings.
-              Depending on which browser you’re using, you’ll usually find this
-              information in the “Tools,” “Settings,” or “Preferences” menu.
-            </li>
-          </ul>
-          <Helpdesk>
-            If you’ve taken the steps above and still can’t sign in,
-          </Helpdesk>
+          <p>Please sign in again.</p>
           <button type="button" onClick={openLoginModal}>
-            Try signing in again
+            Sign in
           </button>
         </>
       );

--- a/src/applications/auth/tests/RenderErrorContainer.unit.spec.js
+++ b/src/applications/auth/tests/RenderErrorContainer.unit.spec.js
@@ -54,8 +54,8 @@ describe('RenderErrorContainer', () => {
     });
   });
 
-  it('should trigger the `openModalLogin` on certain error codes `001 | 003 | 004 | 005 | 009`', () => {
-    ['001', '003', '004', '005', '009'].forEach(CODE => {
+  it('should trigger the `openModalLogin` on certain error codes `001 | 003 | 004 | 005 | 009 | 202`', () => {
+    ['001', '003', '004', '005', '009', '202'].forEach(CODE => {
       const wrapper = mount(
         <RenderErrorContainer
           auth="fail"


### PR DESCRIPTION
## Description
This PR updates the language/content for Error 202: State Mismatch and prompts the user to Sign in again.  Additionally it updates the associated unit tests in the RenderErrorContainer.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#46291


## Testing done
Unit testing

## Screenshots
Original
<img width="1103" alt="Screen Shot 2022-08-30 at 11 25 57 AM" src="https://user-images.githubusercontent.com/67602137/187477628-b91afea0-60e9-41e0-ac9b-33b9c977d8a6.png">

New
<img width="1103" alt="Screen Shot 2022-08-30 at 11 27 01 AM" src="https://user-images.githubusercontent.com/67602137/187477688-cd90503e-fac7-4afb-ae4c-9845849f0dbb.png">


## Acceptance criteria
- [x] Navigating to the `http://localhost:3001/auth/login/callback/?code=202&auth=fail` page renders with a Network Error warning to the user and  re-prompts them to try signing in again.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
