### PR TITLE
Veteran ID Page Verify Button Bug Fix 

### DIFF
--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -18,7 +18,6 @@ import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors'
 import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import {
   logout as IAMLogout,
-  verify,
   mfa,
 } from 'platform/user/authentication/utilities';
 import { logoutUrlSiS } from 'platform/utilities/oauth/utilities';
@@ -485,7 +484,7 @@ export class CallToActionWidget extends Component {
   };
 
   verifyHandler = () => {
-    verify();
+    window.location.href = '/verify';
   };
 
   render() {


### PR DESCRIPTION
## Description
Redirects users to verify page when they click verify link on Veteran ID card page. 

## Original issue(s)
closes ["Verify your Identity" button not functional on Veteran ID Card Page #46297
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46297)

## Testing done
unit

## Acceptance criteria
- [x] user is redirected to `/verify` page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
