### PR TITLE
Fix/on this page burial poc v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.4.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "1.4.3",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.4.5",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@mapbox/mapbox-sdk": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.4.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "1.4.5",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.4.6",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@mapbox/mapbox-sdk": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,10 +2565,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.3.tgz#76acd24c468ffdd9509415e65854094b075ccbcb"
-  integrity sha512-c1Ry/aNeTTOLrOPoBQdt9R8IzE/zebUBkcFwcli5rjkD/nzekbM10hdx677XuiqTNtmLNYZ/Udm88OwwccmY1g==
+"@department-of-veterans-affairs/va-forms-system-core@1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.5.tgz#857ec384741f32ea66a50fed2596a545512f9809"
+  integrity sha512-v9u90RxUruKlbRbG1oa8qgRMPlaYVbshlv04N0uMUj1z1CjSkZWA9mvtn3QfWlnh9r5rqX0RYA+12G0suHyDAQ==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,10 +2565,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.5.tgz#857ec384741f32ea66a50fed2596a545512f9809"
-  integrity sha512-v9u90RxUruKlbRbG1oa8qgRMPlaYVbshlv04N0uMUj1z1CjSkZWA9mvtn3QfWlnh9r5rqX0RYA+12G0suHyDAQ==
+"@department-of-veterans-affairs/va-forms-system-core@1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.6.tgz#3eb5ab717c87a12f3957c8e42554865672609d45"
+  integrity sha512-+mLGkvma3bFkIOQFBoWrK5r4XrOZylUgSr/97XVvCrua+ih63l8EuCIY3IdQ5bUcWj/qe7KU0AMuDWsqoeT4LA==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"


### PR DESCRIPTION
## Description

In this PR, FLT has updated the `va-forms-system-core` to version `1.4.6`. This change includes updates to the `ReviewPage` component and also allows for custom `onChange` for all form components to be passed through.

This change also updates a bug in staging where the `On This Page` table of contents view on the `ReviewPage` component was not showing properly.

## Original issue(s)

- [department-of-veterans-affairs/va-forms-system-core#531](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/531)
- On this page bug in ReviewPage for `burial-poc-v6`

## Testing done

- [x] All Unit Tests Pass

## Acceptance criteria
- [x] ReviewPage "On This Page" section shows as normal
- [x] Ability to pass through custom `onChange` events to Form Components

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
