### PR TITLE
MEB: Add Unverified Claimant Alert

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: self-hosted
     outputs:
       entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
+      continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
 
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
@@ -47,7 +48,7 @@ jobs:
         uses: ./.github/workflows/get-changed-apps
         with:
           delimiter: ','
-          output-type: 'entry_name'
+          output-type: 'entry_name, continuous_deployment'
 
       - name: Configure AWS Credentials
         if: ${{ matrix.buildtype == 'vagovprod' }}
@@ -1090,7 +1091,7 @@ jobs:
           aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
 
   set-deploy-environments:
-    name: Set environments to deploy
+    name: Set Environments to Deploy
     needs: [archive, build]
     if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
     runs-on: ubuntu-latest
@@ -1098,7 +1099,6 @@ jobs:
       environments: ${{ steps.set-environments.outputs.environments }}
     env:
       DEPLOY_TO_PRODUCTION: false # Enables production deployments for apps on the allowlist when set to true
-      IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
       DEV: "{
           \\\"environment\\\": \\\"vagovdev\\\", 
           \\\"bucket\\\": \\\"dev.va.gov\\\", 
@@ -1121,7 +1121,7 @@ jobs:
       - name: Set environments for deploy matrix
         id: set-environments
         run: |
-          if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ env.IS_ISOLATED_APP_BUILD }} == true ]]; then
+          if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ needs.build.outputs.continuous_deployment }} == true ]]; then
             echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}},${{env.PROD}}]}
           else
             echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}}]}
@@ -1152,7 +1152,7 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Check commit deployability
+      - name: Check if commit can be deployed
         id: check-deployability
         run: node ./script/github-actions/check-deployability.js
         env:

--- a/.github/workflows/get-changed-apps/action.yml
+++ b/.github/workflows/get-changed-apps/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: ' '
 
   output-type:
-    description: 'Comma delimited list of changed application details to retrieve. Output types include: `entry_name`, `folder`, `slack_group`, `url`.'
+    description: 'Comma delimited list of changed application details to retrieve. Output types include: `entry_name`, `folder`, `slack_group`, `url`, `continuous_deployment`.'
     required: false
     default: ''
 
@@ -16,6 +16,10 @@ outputs:
   changed_files:
     description: 'Space delimited list of paths for changed files that differ from `main` branch.'
     value: ${{ steps.get-changed-files.outputs.changed_files }}
+  
+  continuous_deployment:
+    description: 'Whether all changed applications have continuous deployment enabled.'
+    value: ${{ steps.check-continuous-deployment.outputs.is_enabled }}
 
   entry_names:
     description: 'Entry names of changed applications.'
@@ -75,5 +79,13 @@ runs:
       if: contains(inputs.output-type, 'url')
       shell: bash
       run: echo ::set-output name=urls::$(node script/github-actions/get-changed-apps.js --output-type url -d "${{ inputs.delimiter }}")
+      env:
+        CHANGED_FILE_PATHS: ${{ steps.get-changed-files.outputs.changed_files }}
+
+    - name: Check if continuous deployment is enabled
+      id: check-continuous-deployment
+      if: contains(inputs.output-type, 'continuous_deployment')
+      shell: bash
+      run: echo ::set-output name=is_enabled::$(node script/github-actions/get-changed-apps.js --continuous-deployment)
       env:
         CHANGED_FILE_PATHS: ${{ steps.get-changed-files.outputs.changed_files }}

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@department-of-veterans-affairs/component-library": "^11.4.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
-    "@department-of-veterans-affairs/va-forms-system-core": "1.4.3",
+    "@department-of-veterans-affairs/va-forms-system-core": "1.4.6",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@mapbox/mapbox-sdk": "^0.13.2",

--- a/script/github-actions/get-changed-apps.unit.spec.js
+++ b/script/github-actions/get-changed-apps.unit.spec.js
@@ -1,22 +1,25 @@
 import { expect } from 'chai';
 import mockFs from 'mock-fs';
 
-import { getChangedAppsString } from './get-changed-apps';
+import {
+  getChangedAppsString,
+  isContinuousDeploymentEnabled,
+} from './get-changed-apps';
+
+const createManifest = name => {
+  return JSON.stringify({
+    appName: name.toUpperCase(),
+    entryFile: `./${name}-entry.jsx`,
+    entryName: name,
+    rootUrl: `/${name}`,
+  });
+};
+
+const createChangedAppsConfig = (apps = []) => {
+  return { apps };
+};
 
 describe('getChangedAppsString', () => {
-  const createManifest = name => {
-    return JSON.stringify({
-      appName: name.toUpperCase(),
-      entryFile: `./${name}-entry.jsx`,
-      entryName: name,
-      rootUrl: `/${name}`,
-    });
-  };
-
-  const createChangedAppsConfig = (apps = []) => {
-    return { apps };
-  };
-
   before(() => {
     mockFs({
       'src/applications/app1': {
@@ -307,6 +310,107 @@ describe('getChangedAppsString', () => {
       const appString = getChangedAppsString(changedFiles, config, 'folder');
       expect(appString).to.be.empty;
     });
+  });
+
+  after(() => mockFs.restore());
+});
+
+describe('isContinuousDeploymentEnabled', () => {
+  before(() => {
+    mockFs({
+      'src/applications/app1': {
+        'manifest.json': createManifest('app1'),
+        'some-file.js': '',
+        'other-file.js': '',
+      },
+      'src/applications/app2': {
+        'manifest.json': createManifest('app2'),
+        'some-file.js': '',
+        'other-file.js': '',
+      },
+    });
+  });
+
+  it('should return true when an app does not specify continuous deployment option', () => {
+    const config = createChangedAppsConfig([{ rootFolder: 'app1' }]);
+    const changedFiles = ['src/applications/app1/some-file.js'];
+
+    const continuousDeployment = isContinuousDeploymentEnabled(
+      changedFiles,
+      config,
+    );
+    expect(continuousDeployment).to.be.true;
+  });
+
+  it('should return false when an app sets continuous deployment to false', () => {
+    const config = createChangedAppsConfig([
+      { rootFolder: 'app1', continuousDeployment: false },
+    ]);
+    const changedFiles = ['src/applications/app1/some-file.js'];
+
+    const continuousDeployment = isContinuousDeploymentEnabled(
+      changedFiles,
+      config,
+    );
+    expect(continuousDeployment).to.be.false;
+  });
+
+  it('should return false when at least one app sets continuous deployment to false', () => {
+    const config = createChangedAppsConfig([
+      { rootFolder: 'app1', continuousDeployment: false },
+      { rootFolder: 'app2' },
+    ]);
+    const changedFiles = [
+      'src/applications/app1/some-file.js',
+      'src/applications/app2/some-file.js',
+    ];
+
+    const continuousDeployment = isContinuousDeploymentEnabled(
+      changedFiles,
+      config,
+    );
+    expect(continuousDeployment).to.be.false;
+  });
+
+  it('should return true when no apps set continuous deployment to false', () => {
+    const config = createChangedAppsConfig([
+      { rootFolder: 'app1' },
+      { rootFolder: 'app2', continuousDeployment: true },
+    ]);
+    const changedFiles = [
+      'src/applications/app1/some-file.js',
+      'src/applications/app2/some-file.js',
+    ];
+
+    const continuousDeployment = isContinuousDeploymentEnabled(
+      changedFiles,
+      config,
+    );
+    expect(continuousDeployment).to.be.true;
+  });
+
+  it('should throw an when an app has an invalid data type in `continuousDeployment`', () => {
+    const config = createChangedAppsConfig([
+      { rootFolder: 'app1', continuousDeployment: 'on' },
+    ]);
+    const changedFiles = ['src/applications/app1/some-file.js'];
+
+    expect(() => {
+      isContinuousDeploymentEnabled(changedFiles, config);
+    }).to.throw(Error);
+  });
+
+  it('should return false when there are no changed file paths', () => {
+    const config = createChangedAppsConfig([
+      { rootFolder: 'app1', continuousDeployment: true },
+    ]);
+    const changedFiles = [];
+
+    const continuousDeployment = isContinuousDeploymentEnabled(
+      changedFiles,
+      config,
+    );
+    expect(continuousDeployment).to.be.false;
   });
 
   after(() => mockFs.restore());

--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -41,12 +41,12 @@ const ONE_MINUTE_IN_THE_FUTURE = () => {
   return new Date(new Date().getTime() + 60000);
 };
 
-export function fetchPersonalInformation() {
+export function fetchPersonalInformation(showUnverifiedUserAlert) {
   return async dispatch => {
     dispatch({ type: FETCH_PERSONAL_INFORMATION });
     return apiRequest(CLAIMANT_INFO_ENDPOINT)
       .then(response => {
-        if (!response?.data?.attributes?.claimant) {
+        if (!response?.data?.attributes?.claimant && !showUnverifiedUserAlert) {
           window.location.href =
             '/education/apply-for-education-benefits/application/1990/';
         } else {
@@ -61,8 +61,10 @@ export function fetchPersonalInformation() {
           type: FETCH_PERSONAL_INFORMATION_FAILED,
           errors,
         });
-        window.location.href =
-          '/education/apply-for-education-benefits/application/1990/';
+        if (!showUnverifiedUserAlert) {
+          window.location.href =
+            '/education/apply-for-education-benefits/application/1990/';
+        }
       });
   };
 }

--- a/src/applications/my-education-benefits/components/IntroductionLoginV1.jsx
+++ b/src/applications/my-education-benefits/components/IntroductionLoginV1.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { VA_FORM_IDS } from 'platform/forms/constants';
+
+import LoadingIndicator from './LoadingIndicator';
+import { getAppData } from '../selectors';
+
+function IntroductionLoginV1({ firstName, eligibility, route, user }) {
+  return (
+    <>
+      {user?.login?.currentlyLoggedIn &&
+        firstName &&
+        eligibility &&
+        !user.profile.savedForms.some(
+          p => p.form === VA_FORM_IDS.FORM_22_1990EZ,
+        ) && <h2>Begin your application for education benefits</h2>}
+
+      {!user.login.currentlyLoggedIn || (firstName && eligibility) ? (
+        <SaveInProgressIntro
+          testActionLink
+          user={user}
+          prefillEnabled={route.formConfig.prefillEnabled}
+          messages={route.formConfig.savedFormMessages}
+          pageList={route.pageList}
+          hideUnauthedStartLink
+          headingLevel={2}
+          startText="Start your application"
+        />
+      ) : (
+        <LoadingIndicator />
+      )}
+
+      {!user?.login?.currentlyLoggedIn && (
+        <a href="/education/apply-for-education-benefits/application/1990/applicant/information">
+          Start your application without signing in
+        </a>
+      )}
+    </>
+  );
+}
+
+IntroductionLoginV1.propTypes = {
+  route: PropTypes.object.isRequired,
+  eligibility: PropTypes.arrayOf(PropTypes.string),
+  firstName: PropTypes.string,
+  user: PropTypes.object,
+};
+
+const mapStateToProps = state => ({
+  ...getAppData(state),
+  firstName: state.data?.formData?.data?.attributes?.claimant?.firstName,
+});
+
+export default connect(mapStateToProps)(IntroductionLoginV1);

--- a/src/applications/my-education-benefits/components/IntroductionLoginV2.jsx
+++ b/src/applications/my-education-benefits/components/IntroductionLoginV2.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { getIntroState } from 'platform/forms/save-in-progress/selectors';
+import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { UNAUTH_SIGN_IN_DEFAULT_MESSAGE } from 'platform/forms-system/src/js/constants';
@@ -14,7 +15,7 @@ function IntroductionLoginV2({
   isClaimantCallComplete,
   isEligibilityCallComplete,
   isLoggedIn,
-  loa3,
+  isLOA3,
   route,
   showHideLoginModal,
   user,
@@ -90,7 +91,7 @@ function IntroductionLoginV2({
 
       {apiCallsComplete &&
         isLoggedIn &&
-        loa3 && (
+        isLOA3 && (
           <SaveInProgressIntro
             headingLevel={2}
             hideUnauthedStartLink
@@ -105,7 +106,7 @@ function IntroductionLoginV2({
 
       {apiCallsComplete &&
         isLoggedIn &&
-        !loa3 && (
+        !isLOA3 && (
           <va-alert
             close-btn-aria-label="Close notification"
             status="continue"
@@ -150,8 +151,8 @@ IntroductionLoginV2.propTypes = {
   eligibility: PropTypes.arrayOf(PropTypes.string),
   isClaimantCallComplete: PropTypes.bool,
   isEligibilityCallComplete: PropTypes.bool,
+  isLOA3: PropTypes.bool,
   isLoggedIn: PropTypes.bool,
-  loa3: PropTypes.bool,
   showHideLoginModal: PropTypes.func,
   user: PropTypes.object,
 };
@@ -159,7 +160,7 @@ IntroductionLoginV2.propTypes = {
 const mapStateToProps = state => ({
   ...getIntroState(state),
   ...getAppData(state),
-  loa3: false, // isLOA3(state),
+  isLOA3: isLOA3Selector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/applications/my-education-benefits/components/IntroductionLoginV2.jsx
+++ b/src/applications/my-education-benefits/components/IntroductionLoginV2.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { getIntroState } from 'platform/forms/save-in-progress/selectors';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import { UNAUTH_SIGN_IN_DEFAULT_MESSAGE } from 'platform/forms-system/src/js/constants';
+
+import { getAppData } from '../selectors';
+import LoadingIndicator from './LoadingIndicator';
+
+function IntroductionLoginV2({
+  isClaimantCallComplete,
+  isEligibilityCallComplete,
+  isLoggedIn,
+  loa3,
+  route,
+  showHideLoginModal,
+  user,
+}) {
+  const apiCallsComplete = isClaimantCallComplete && isEligibilityCallComplete;
+
+  const openLoginModal = () => {
+    showHideLoginModal(true, 'cta-form');
+  };
+
+  return (
+    <>
+      {isLoggedIn !== false && !apiCallsComplete && <LoadingIndicator />}
+
+      {isLoggedIn !== undefined && (
+        <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--3">
+          Begin your application for education benefits
+        </h2>
+      )}
+
+      {!isLoggedIn && (
+        <>
+          <va-alert
+            close-btn-aria-label="Close notification"
+            status="continue"
+            visible
+          >
+            <h2 slot="headline">
+              Save time—and save your work in progress—by signing in before
+              starting your application
+            </h2>
+            <div>
+              <p className="vads-u-margin-top--0">
+                When you’re signed in to your verified VA.gov account:
+              </p>
+              <ul>
+                <li>
+                  We can prefill part of your application based on your account
+                  details.
+                </li>
+                <li>We may be able to give you an instant decision.</li>
+                <li>
+                  You can save your application in progress, and come back later
+                  to finish filling it out. You have 60 days from the date you
+                  start or update your application to submit it. After 60 days
+                  we’ll delete the application and you’ll have to start over.
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you sign in after you’ve started your
+                application, you won’t be able to save the information you’ve
+                already filled in.
+              </p>
+
+              <button
+                className="usa-button-primary"
+                onClick={openLoginModal}
+                // aria-label={ariaLabel}
+                // aria-describedby={ariaDescribedby}
+                type="button"
+              >
+                {UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
+              </button>
+              <p>
+                <a href="https://www.va.gov/education/apply-for-education-benefits/application/1990/applicant/information">
+                  Start your application without signing in
+                </a>
+              </p>
+            </div>
+          </va-alert>
+        </>
+      )}
+
+      {apiCallsComplete &&
+        isLoggedIn &&
+        loa3 && (
+          <SaveInProgressIntro
+            headingLevel={2}
+            hideUnauthedStartLink
+            messages={route?.formConfig.savedFormMessages}
+            pageList={route.pageList}
+            prefillEnabled={route?.formConfig?.prefillEnabled}
+            startText="Start your application"
+            testActionLink
+            user={user}
+          />
+        )}
+
+      {apiCallsComplete &&
+        isLoggedIn &&
+        !loa3 && (
+          <va-alert
+            close-btn-aria-label="Close notification"
+            status="continue"
+            visible
+          >
+            <h2 slot="headline">When you verify your VA.gov account:</h2>
+            <div>
+              <p className="vads-u-margin-top--0">
+                When you’re signed in to your verified VA.gov account:
+              </p>
+              <ul>
+                <li>
+                  We can prefill part of your application based on your account
+                  details.
+                </li>
+                <li>We may be able to give you an instant decision.</li>
+              </ul>
+              <p>
+                Verifying your VA.gov account is a one-time process that will
+                take <strong>5-10 minutes</strong> to complete. Once your
+                account is verified, you can continue to this application.
+              </p>
+              <p className="vads-u-margin-bottom--2p5">
+                <a
+                  className="vads-c-action-link--green"
+                  href="/profile"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Verify your identity before starting your application
+                </a>
+              </p>
+            </div>
+          </va-alert>
+        )}
+    </>
+  );
+}
+
+IntroductionLoginV2.propTypes = {
+  route: PropTypes.object.isRequired,
+  eligibility: PropTypes.arrayOf(PropTypes.string),
+  isClaimantCallComplete: PropTypes.bool,
+  isEligibilityCallComplete: PropTypes.bool,
+  isLoggedIn: PropTypes.bool,
+  loa3: PropTypes.bool,
+  showHideLoginModal: PropTypes.func,
+  user: PropTypes.object,
+};
+
+const mapStateToProps = state => ({
+  ...getIntroState(state),
+  ...getAppData(state),
+  loa3: false, // isLOA3(state),
+});
+
+const mapDispatchToProps = {
+  showHideLoginModal: toggleLoginModal,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(IntroductionLoginV2);

--- a/src/applications/my-education-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/my-education-benefits/containers/IntroductionPage.jsx
@@ -1,17 +1,16 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { connect } from 'react-redux';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import { VA_FORM_IDS } from 'platform/forms/constants';
 
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 
 import HowToApplyPost911GiBill from '../components/HowToApplyPost911GiBill';
-import { fetchUser } from '../selectors/userDispatch';
-import LoadingIndicator from '../components/LoadingIndicator';
+import IntroductionLoginV1 from '../components/IntroductionLoginV1';
+import IntroductionLoginV2 from '../components/IntroductionLoginV2';
+import { getAppData } from '../selectors';
 
-export const IntroductionPage = ({ firstName, eligibility, user, route }) => {
+export const IntroductionPage = ({ route, showUnverifiedUserAlert }) => {
   return (
     <div className="schemaform-intro">
       <FormTitle title="Apply for VA education benefits" />
@@ -86,32 +85,10 @@ export const IntroductionPage = ({ firstName, eligibility, user, route }) => {
         </ol>
       </div>
 
-      {user?.login?.currentlyLoggedIn &&
-        firstName &&
-        eligibility &&
-        !user.profile.savedForms.some(
-          p => p.form === VA_FORM_IDS.FORM_22_1990EZ,
-        ) && <h2>Begin your application for education benefits</h2>}
-
-      {!user.login.currentlyLoggedIn || (firstName && eligibility) ? (
-        <SaveInProgressIntro
-          testActionLink
-          user={user}
-          prefillEnabled={route.formConfig.prefillEnabled}
-          messages={route.formConfig.savedFormMessages}
-          pageList={route.pageList}
-          hideUnauthedStartLink
-          headingLevel={2}
-          startText="Start your application"
-        />
+      {showUnverifiedUserAlert ? (
+        <IntroductionLoginV2 route={route} />
       ) : (
-        <LoadingIndicator />
-      )}
-
-      {!user?.login?.currentlyLoggedIn && (
-        <a href="https://www.va.gov/education/apply-for-education-benefits/application/1990/applicant/information">
-          Start your application without signing in
-        </a>
+        <IntroductionLoginV1 route={route} />
       )}
 
       <OMBInfo resBurden={15} ombNumber="2900-0154" expDate="02/28/2023" />
@@ -120,9 +97,7 @@ export const IntroductionPage = ({ firstName, eligibility, user, route }) => {
 };
 
 const mapStateToProps = state => ({
-  firstName: state.data?.formData?.data?.attributes?.claimant?.firstName,
-  eligibility: state.data?.eligibility,
-  user: fetchUser(state),
+  ...getAppData(state),
 });
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/my-education-benefits/reducers/index.js
+++ b/src/applications/my-education-benefits/reducers/index.js
@@ -26,13 +26,12 @@ export default {
       case FETCH_PERSONAL_INFORMATION:
         return {
           ...state,
-          personalInfoFetchInProgress: true,
         };
       case FETCH_PERSONAL_INFORMATION_SUCCESS:
       case FETCH_PERSONAL_INFORMATION_FAILED:
         return {
           ...state,
-          personalInfoFetchInProgress: false,
+          personalInfoFetchComplete: true,
           formData: action?.response || {},
         };
       case FETCH_CLAIM_STATUS_SUCCESS:
@@ -45,6 +44,7 @@ export default {
       case FETCH_ELIGIBILITY_FAILURE:
         return {
           ...state,
+          eligibilityFetchComplete: true,
           eligibility:
             action?.response?.data?.attributes?.eligibility
               ?.filter(

--- a/src/applications/my-education-benefits/selectors.js
+++ b/src/applications/my-education-benefits/selectors.js
@@ -1,0 +1,12 @@
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+
+export const getAppData = state => ({
+  eligibility: state.data?.eligibility,
+  isClaimantCallComplete: state.data?.personalInfoFetchComplete,
+  isEligibilityCallComplete: state.data?.eligibilityFetchComplete,
+  showUnverifiedUserAlert: toggleValues(state)[
+    FEATURE_FLAG_NAMES.showMebUnverifiedUserAlert
+  ],
+  user: state.user || {},
+});

--- a/src/applications/my-education-benefits/selectors/userDispatch.js
+++ b/src/applications/my-education-benefits/selectors/userDispatch.js
@@ -1,1 +1,0 @@
-export const fetchUser = state => state.user || {};

--- a/src/applications/toe-benefits/containers/App.jsx
+++ b/src/applications/toe-benefits/containers/App.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { format } from 'date-fns';
-import { fetchUser } from '../../my-education-benefits/selectors/userDispatch';
 import Layout from '../../education-letters/components/Layout';
 import FormFooter from '../../my-education-benefits/components/FormFooter';
 // import ApprovedUI from '../components/approvedUI';
@@ -100,7 +99,7 @@ App.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  user: fetchUser(state),
+  user: state.user || {},
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -111,6 +111,7 @@ export default Object.freeze({
   showFinancialStatusReportWizard: 'show_financial_status_report_wizard',
   showFormI18n: 'show_form_i18n',
   showMebMockEndpoints: 'show_meb_mock_endpoints',
+  showMebUnverifiedUserAlert: 'show_meb_unverified_user_alert',
   showUpdatedToeApp: 'show_updated_toe_app',
   showMedicalCopays: 'show_medical_copays',
   showHealthcareExperienceQuestionnaire:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,10 +2565,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/va-forms-system-core@1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.3.tgz#76acd24c468ffdd9509415e65854094b075ccbcb"
-  integrity sha512-c1Ry/aNeTTOLrOPoBQdt9R8IzE/zebUBkcFwcli5rjkD/nzekbM10hdx677XuiqTNtmLNYZ/Udm88OwwccmY1g==
+"@department-of-veterans-affairs/va-forms-system-core@1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/va-forms-system-core/-/va-forms-system-core-1.4.6.tgz#3eb5ab717c87a12f3957c8e42554865672609d45"
+  integrity sha512-+mLGkvma3bFkIOQFBoWrK5r4XrOZylUgSr/97XVvCrua+ih63l8EuCIY3IdQ5bUcWj/qe7KU0AMuDWsqoeT4LA==
   dependencies:
     connect-history-api-fallback "^1.6.0"
     date-fns "^2.28.0"


### PR DESCRIPTION
## Description
Add an alert on the My Education Benefits Introduction page when a claimant doesn't have a verified ID.me account. This change is hidden behind a new feature flag (`show_meb_unverified_user_alert`) added in https://github.com/department-of-veterans-affairs/vets-website/pull/22072.

## Testing done
Tested verified and unverified users (mocked) with the `show_meb_unverified_user_alert` feature flag turned on and off. Verified that the old functionality remains with the feature flag turned off and the user is show the alerts and not redirected when the feature flag is on and the account isn't verified.