### PR TITLE
46079 - Removed cross app references to debt-letters

### DIFF
--- a/src/applications/personalization/dashboard/actions/debts.js
+++ b/src/applications/personalization/dashboard/actions/debts.js
@@ -1,11 +1,20 @@
 import recordEvent from 'platform/monitoring/record-event';
 import { apiRequest } from '~/platform/utilities/api';
 import environment from '~/platform/utilities/environment';
-import { deductionCodes } from '~/applications/debt-letters/const/deduction-codes';
 
 export const DEBTS_FETCH_SUCCESS = 'DEBTS_FETCH_SUCCESS';
 export const DEBTS_FETCH_FAILURE = 'DEBTS_FETCH_FAILURE';
 export const DEBTS_FETCH_INITIATED = 'DEBTS_FETCH_INITIATED';
+
+export const deductionCodes = Object.freeze({
+  '30': 'Disability compensation and pension debt',
+  '41': 'Chapter 34 education debt',
+  '44': 'Chapter 35 education debt',
+  '71': 'Post-9/11 GI Bill debt for books and supplies',
+  '72': 'Post-9/11 GI Bill debt for housing',
+  '74': 'Post-9/11 GI Bill debt for tuition',
+  '75': 'Post-9/11 GI Bill debt for tuition (school liable)',
+});
 
 export const fetchDebts = () => async dispatch => {
   dispatch({ type: DEBTS_FETCH_INITIATED });


### PR DESCRIPTION
## Description
Removed cross app reference to `debt-letters`
`debt-letters` is eventually being deprecated as the functionality has been moved to the `combined-debt-portal` which we'd like to keep isolated so it can be on the allow list for continuous deploy. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46079

## Acceptance criteria
- [x] No longer referencing across apps to `debt-letters`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
