### PR TITLE
Added, removed, and updated GA events.

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { parseISO } from 'date-fns';
-import recordEvent from 'platform/monitoring/record-event';
 import { api } from '../../api';
 
 import { useFormRouting } from '../../hooks/useFormRouting';
@@ -31,10 +30,6 @@ const AppointmentAction = props => {
   const { goToNextPage, goToErrorPage } = useFormRouting(router);
   const onClick = useCallback(
     async () => {
-      recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'check in now',
-      });
       try {
         const json = await api.v2.postCheckInData({
           uuid: token,

--- a/src/applications/check-in/components/BackButton.jsx
+++ b/src/applications/check-in/components/BackButton.jsx
@@ -23,7 +23,7 @@ const BackButton = props => {
     e => {
       e.preventDefault();
       recordEvent({
-        event: createAnalyticsSlug('back-button-clicked'),
+        event: createAnalyticsSlug('back-button-clicked', 'nav'),
         fromPage: currentPage,
       });
       action();

--- a/src/applications/check-in/components/BackToAppointments.jsx
+++ b/src/applications/check-in/components/BackToAppointments.jsx
@@ -18,7 +18,7 @@ const BackToAppointments = ({ router }) => {
     e => {
       e.preventDefault();
       recordEvent({
-        event: createAnalyticsSlug('back-button-clicked'),
+        event: createAnalyticsSlug('go-to-appointments-clicked', 'nav'),
       });
       jumpToPage(URLS.DETAILS);
     },

--- a/src/applications/check-in/components/ExternalLink.jsx
+++ b/src/applications/check-in/components/ExternalLink.jsx
@@ -20,7 +20,7 @@ function ExternalLink({
         event: createAnalyticsSlug(eventId, eventPrefix),
       });
     },
-    [eventId],
+    [eventId, eventPrefix],
   );
 
   return (
@@ -37,6 +37,7 @@ function ExternalLink({
 ExternalLink.propTypes = {
   children: PropTypes.node,
   eventId: PropTypes.string,
+  eventPrefix: PropTypes.string,
   href: PropTypes.string,
   hrefLang: PropTypes.string,
 };

--- a/src/applications/check-in/components/ExternalLink.jsx
+++ b/src/applications/check-in/components/ExternalLink.jsx
@@ -5,13 +5,19 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import { createAnalyticsSlug } from '../utils/analytics';
 
-function ExternalLink({ children, href, hrefLang, eventId = null }) {
+function ExternalLink({
+  children,
+  href,
+  hrefLang,
+  eventId = null,
+  eventPrefix = '',
+}) {
   const { t, i18n } = useTranslation();
 
   const handleClick = useCallback(
     () => {
       recordEvent({
-        event: createAnalyticsSlug(eventId),
+        event: createAnalyticsSlug(eventId, eventPrefix),
       });
     },
     [eventId],

--- a/src/applications/check-in/components/PreCheckInAccordionBlock.jsx
+++ b/src/applications/check-in/components/PreCheckInAccordionBlock.jsx
@@ -73,7 +73,7 @@ const PreCheckInAccordionBlock = ({
               <Trans
                 i18nKey="or-you-can-call"
                 components={[
-                  <va-telephone key="or-you-can-call" contact="800-698-2411">
+                  <va-telephone key="or-you-can-call" contact="8006982411">
                     link
                   </va-telephone>,
                 ]}
@@ -106,7 +106,7 @@ const PreCheckInAccordionBlock = ({
             <Trans
               i18nKey="please-call"
               components={[
-                <va-telephone key="please call" contact="800-698-2411">
+                <va-telephone key="please call" contact="8006982411">
                   link
                 </va-telephone>,
               ]}

--- a/src/applications/check-in/components/PreCheckInAccordionBlock.jsx
+++ b/src/applications/check-in/components/PreCheckInAccordionBlock.jsx
@@ -42,6 +42,8 @@ const PreCheckInAccordionBlock = ({
                     key="link"
                     href="https://www.va.gov/profile/personal-information"
                     hrefLang="en"
+                    eventId="sign-in-from-accordion-clicked"
+                    eventPrefix="nav"
                   >
                     link
                   </ExternalLink>,

--- a/src/applications/check-in/components/TravelPayReimbursementLink.jsx
+++ b/src/applications/check-in/components/TravelPayReimbursementLink.jsx
@@ -11,6 +11,7 @@ function TravelPayReimbursementLink() {
         href="/health-care/get-reimbursed-for-travel-pay/"
         hrefLang="en"
         eventId="request-travel-pay-reimbursement--link-clicked"
+        eventPrefix="nav"
       >
         {t('find-out-how-to-request-travel-pay-reimbursement')}
       </ExternalLink>

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
+import recordEvent from 'platform/monitoring/record-event';
+
+import { createAnalyticsSlug } from '../../../utils/analytics';
+
 import DemographicItem from '../../DemographicItem';
 import Wrapper from '../../layout/Wrapper';
 
@@ -15,6 +19,7 @@ const ConfirmablePage = ({
   loadingMessageOverride = null,
   withBackButton = false,
   Footer,
+  pageType,
 }) => {
   const { t } = useTranslation();
   const defaultLoadingMessage = () => (
@@ -22,6 +27,19 @@ const ConfirmablePage = ({
   );
   const LoadingMessage = loadingMessageOverride ?? defaultLoadingMessage;
 
+  const onYesClick = () => {
+    recordEvent({
+      event: createAnalyticsSlug(`yes-to-${pageType}-clicked`, 'nav'),
+    });
+    yesAction();
+  };
+
+  const onNoClick = () => {
+    recordEvent({
+      event: createAnalyticsSlug(`no-to-${pageType}-clicked`, 'nav'),
+    });
+    noAction();
+  };
   return (
     <Wrapper
       pageTitle={header}
@@ -71,7 +89,7 @@ const ConfirmablePage = ({
       ) : (
         <>
           <button
-            onClick={yesAction}
+            onClick={onYesClick}
             className="usa-button-primary usa-button-big"
             data-testid="yes-button"
             type="button"
@@ -79,7 +97,7 @@ const ConfirmablePage = ({
             {t('yes')}
           </button>
           <button
-            onClick={noAction}
+            onClick={onNoClick}
             className="usa-button-secondary vads-u-margin-top--2 usa-button-big"
             data-testid="no-button"
             type="button"
@@ -106,6 +124,7 @@ ConfirmablePage.propTypes = {
   Footer: PropTypes.func,
   isLoading: PropTypes.bool,
   loadingMessageOverride: PropTypes.func,
+  pageType: PropTypes.string,
   subtitle: PropTypes.string,
   withBackButton: PropTypes.bool,
 };

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
@@ -52,6 +52,7 @@ export default function DemographicsDisplay({
         yesAction={yesAction}
         noAction={noAction}
         Footer={Footer}
+        pageType="demographic-information"
       />
     </>
   );

--- a/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.jsx
+++ b/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.jsx
@@ -44,6 +44,7 @@ export default function EmergencyContactDisplay({
         Footer={Footer}
         isLoading={isLoading}
         withBackButton
+        pageType="emergency-contact"
       />
     </>
   );

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -62,6 +62,7 @@ export default function NextOfKinDisplay({
         loadingMessageOverride={loadingMessage}
         Footer={Footer}
         withBackButton
+        pageType="next-of-kin"
       />
     </>
   );

--- a/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/DisplayMultipleAppointments.jsx
@@ -65,7 +65,10 @@ const DisplayMultipleAppointments = props => {
   const handleClick = useCallback(
     () => {
       recordEvent({
-        event: createAnalyticsSlug('refresh-appointments-button-clicked'),
+        event: createAnalyticsSlug(
+          'refresh-appointments-button-clicked',
+          'nav',
+        ),
       });
 
       refreshCheckInData();

--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
+import { createAnalyticsSlug } from '../../utils/analytics';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import BackToHome from '../../components/BackToHome';
 import Footer from '../../components/layout/Footer';
@@ -32,8 +33,7 @@ const Demographics = props => {
   const yesClick = useCallback(
     () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'yes-to-demographic-information',
+        event: createAnalyticsSlug('yes-to-demographic-information', 'nav'),
       });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ demographicsUpToDate: 'yes' }));
@@ -46,8 +46,7 @@ const Demographics = props => {
   const noClick = useCallback(
     () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'no-to-demographic-information',
+        event: createAnalyticsSlug('no-to-demographic-information', 'nav'),
       });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ demographicsUpToDate: 'no' }));

--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -2,8 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
-import recordEvent from 'platform/monitoring/record-event';
-import { createAnalyticsSlug } from '../../utils/analytics';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import BackToHome from '../../components/BackToHome';
 import Footer from '../../components/layout/Footer';
@@ -32,9 +30,6 @@ const Demographics = props => {
 
   const yesClick = useCallback(
     () => {
-      recordEvent({
-        event: createAnalyticsSlug('yes-to-demographic-information', 'nav'),
-      });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ demographicsUpToDate: 'yes' }));
       }
@@ -45,9 +40,6 @@ const Demographics = props => {
 
   const noClick = useCallback(
     () => {
-      recordEvent({
-        event: createAnalyticsSlug('no-to-demographic-information', 'nav'),
-      });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ demographicsUpToDate: 'no' }));
       }

--- a/src/applications/check-in/day-of/pages/EmergencyContact.jsx
+++ b/src/applications/check-in/day-of/pages/EmergencyContact.jsx
@@ -3,8 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
-import recordEvent from 'platform/monitoring/record-event';
-import { createAnalyticsSlug } from '../../utils/analytics';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import BackButton from '../../components/BackButton';
 import BackToHome from '../../components/BackToHome';
@@ -43,9 +41,6 @@ const EmergencyContact = props => {
 
   const yesClick = useCallback(
     () => {
-      recordEvent({
-        event: createAnalyticsSlug('yes-to-emergency-contact', 'nav'),
-      });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ emergencyContactUpToDate: 'yes' }));
       }
@@ -56,9 +51,6 @@ const EmergencyContact = props => {
 
   const noClick = useCallback(
     () => {
-      recordEvent({
-        event: createAnalyticsSlug('no-to-emergency-contact', 'nav'),
-      });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ emergencyContactUpToDate: 'no' }));
       }

--- a/src/applications/check-in/day-of/pages/EmergencyContact.jsx
+++ b/src/applications/check-in/day-of/pages/EmergencyContact.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
+import { createAnalyticsSlug } from '../../utils/analytics';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import BackButton from '../../components/BackButton';
 import BackToHome from '../../components/BackToHome';
@@ -43,8 +44,7 @@ const EmergencyContact = props => {
   const yesClick = useCallback(
     () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'yes-to-emergency-contact-information',
+        event: createAnalyticsSlug('yes-to-emergency-contact', 'nav'),
       });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ emergencyContactUpToDate: 'yes' }));
@@ -57,8 +57,7 @@ const EmergencyContact = props => {
   const noClick = useCallback(
     () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'no-to-emergency-contact-information',
+        event: createAnalyticsSlug('no-to-emergency-contact', 'nav'),
       });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ emergencyContactUpToDate: 'no' }));

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import recordEvent from 'platform/monitoring/record-event';
 import { makeSelectFeatureToggles } from '../../utils/selectors/feature-toggles';
 import { api } from '../../api';
 import {
@@ -15,7 +14,6 @@ import { URLS } from '../../utils/navigation';
 import { createInitFormAction } from '../../actions/navigation';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
-import { createAnalyticsSlug } from '../../utils/analytics';
 import { isUUID, SCOPES } from '../../utils/token-format-validator';
 
 import { createSetSession } from '../../actions/authentication';
@@ -64,16 +62,10 @@ const Landing = props => {
     () => {
       const token = getTokenFromLocation(location);
       if (!token) {
-        recordEvent({
-          event: createAnalyticsSlug('landing-page-launched-no-token'),
-        });
         goToErrorPage('?error=no=token');
       }
 
       if (!isUUID(token)) {
-        recordEvent({
-          event: createAnalyticsSlug('malformed-token'),
-        });
         goToErrorPage('?error=bad-token');
       }
 

--- a/src/applications/check-in/day-of/pages/NextOfKin.jsx
+++ b/src/applications/check-in/day-of/pages/NextOfKin.jsx
@@ -3,8 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
-import recordEvent from 'platform/monitoring/record-event';
-import { createAnalyticsSlug } from '../../utils/analytics';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import BackButton from '../../components/BackButton';
 import BackToHome from '../../components/BackToHome';
@@ -42,9 +40,6 @@ const NextOfKin = props => {
 
   const yesClick = useCallback(
     () => {
-      recordEvent({
-        event: createAnalyticsSlug('yes-to-next-of-kin', 'nav'),
-      });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ nextOfKinUpToDate: 'yes' }));
       }
@@ -55,9 +50,6 @@ const NextOfKin = props => {
 
   const noClick = useCallback(
     () => {
-      recordEvent({
-        event: createAnalyticsSlug('no-to-next-of-kin', 'nav'),
-      });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ nextOfKinUpToDate: 'no' }));
       }

--- a/src/applications/check-in/day-of/pages/NextOfKin.jsx
+++ b/src/applications/check-in/day-of/pages/NextOfKin.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
+import { createAnalyticsSlug } from '../../utils/analytics';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import BackButton from '../../components/BackButton';
 import BackToHome from '../../components/BackToHome';
@@ -42,8 +43,7 @@ const NextOfKin = props => {
   const yesClick = useCallback(
     () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'yes-to-next-of-kin-information',
+        event: createAnalyticsSlug('yes-to-next-of-kin', 'nav'),
       });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ nextOfKinUpToDate: 'yes' }));
@@ -56,8 +56,7 @@ const NextOfKin = props => {
   const noClick = useCallback(
     () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'no-to-next-of-kin-information',
+        event: createAnalyticsSlug('no-to-next-of-kin', 'nav'),
       });
       if (isDayOfDemographicsFlagsEnabled) {
         dispatch(recordAnswer({ nextOfKinUpToDate: 'no' }));

--- a/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
@@ -2,9 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
-import recordEvent from 'platform/monitoring/record-event';
 
-import { createAnalyticsSlug } from '../../../utils/analytics';
 import BackToHome from '../../../components/BackToHome';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import Footer from '../../../components/layout/Footer';
@@ -30,9 +28,6 @@ const Demographics = props => {
 
   const yesClick = useCallback(
     async () => {
-      recordEvent({
-        event: createAnalyticsSlug('yes-to-demographic-information', 'nav'),
-      });
       dispatch(recordAnswer({ demographicsUpToDate: 'yes' }));
       goToNextPage();
     },
@@ -40,9 +35,6 @@ const Demographics = props => {
   );
   const noClick = useCallback(
     async () => {
-      recordEvent({
-        event: createAnalyticsSlug('no-to-demographic-information', 'nav'),
-      });
       dispatch(recordAnswer({ demographicsUpToDate: 'no' }));
       goToNextPage();
     },

--- a/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/index.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
+import { createAnalyticsSlug } from '../../../utils/analytics';
 import BackToHome from '../../../components/BackToHome';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import Footer from '../../../components/layout/Footer';
@@ -30,8 +31,7 @@ const Demographics = props => {
   const yesClick = useCallback(
     async () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'yes-to-demographic-information',
+        event: createAnalyticsSlug('yes-to-demographic-information', 'nav'),
       });
       dispatch(recordAnswer({ demographicsUpToDate: 'yes' }));
       goToNextPage();
@@ -41,8 +41,7 @@ const Demographics = props => {
   const noClick = useCallback(
     async () => {
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': 'no-to-demographic-information',
+        event: createAnalyticsSlug('no-to-demographic-information', 'nav'),
       });
       dispatch(recordAnswer({ demographicsUpToDate: 'no' }));
       goToNextPage();

--- a/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
@@ -2,9 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import recordEvent from 'platform/monitoring/record-event';
-
-import { createAnalyticsSlug } from '../../../utils/analytics';
 import { recordAnswer } from '../../../actions/universal';
 
 import BackButton from '../../../components/BackButton';
@@ -31,10 +28,6 @@ const EmergencyContact = props => {
   const buttonClick = useCallback(
     async answer => {
       setIsLoading(true);
-      recordEvent({
-        event: createAnalyticsSlug(`${answer}-to-emergency-contact`, 'nav'),
-      });
-
       dispatch(recordAnswer({ emergencyContactUpToDate: `${answer}` }));
       goToNextPage();
     },

--- a/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/EmergencyContact/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import recordEvent from 'platform/monitoring/record-event';
 
+import { createAnalyticsSlug } from '../../../utils/analytics';
 import { recordAnswer } from '../../../actions/universal';
 
 import BackButton from '../../../components/BackButton';
@@ -31,8 +32,7 @@ const EmergencyContact = props => {
     async answer => {
       setIsLoading(true);
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': `${answer}-to-emergency-contact`,
+        event: createAnalyticsSlug(`${answer}-to-emergency-contact`, 'nav'),
       });
 
       dispatch(recordAnswer({ emergencyContactUpToDate: `${answer}` }));

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import propTypes from 'prop-types';
 
 import { useTranslation } from 'react-i18next';
-import recordEvent from 'platform/monitoring/record-event';
 
 import { api } from '../../../api';
 
@@ -13,7 +12,6 @@ import { createSetSession } from '../../../actions/authentication';
 import { useSessionStorage } from '../../../hooks/useSessionStorage';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 
-import { createAnalyticsSlug } from '../../../utils/analytics';
 import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
 import {
   createForm,
@@ -68,16 +66,10 @@ const Index = props => {
     () => {
       const token = getTokenFromLocation(router.location);
       if (!token) {
-        recordEvent({
-          event: createAnalyticsSlug('landing-page-launched-no-token'),
-        });
         goToErrorPage('?error=no-token');
       }
 
       if (!isUUID(token)) {
-        recordEvent({
-          event: createAnalyticsSlug('malformed-token'),
-        });
         goToErrorPage('?error=bad-token');
       }
       if (token && isUUID(token)) {

--- a/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
@@ -3,10 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
-import recordEvent from 'platform/monitoring/record-event';
-
 import { recordAnswer } from '../../../actions/universal';
-import { createAnalyticsSlug } from '../../../utils/analytics';
 
 import BackButton from '../../../components/BackButton';
 import BackToHome from '../../../components/BackToHome';
@@ -34,9 +31,6 @@ const NextOfKin = props => {
   const buttonClick = useCallback(
     async answer => {
       setIsLoading(true);
-      recordEvent({
-        event: createAnalyticsSlug(`${answer}-to-next-of-kin`, 'nav'),
-      });
       dispatch(recordAnswer({ nextOfKinUpToDate: `${answer}` }));
       goToNextPage();
     },

--- a/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/NextOfKin/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { recordAnswer } from '../../../actions/universal';
+import { createAnalyticsSlug } from '../../../utils/analytics';
 
 import BackButton from '../../../components/BackButton';
 import BackToHome from '../../../components/BackToHome';
@@ -34,8 +35,7 @@ const NextOfKin = props => {
     async answer => {
       setIsLoading(true);
       recordEvent({
-        event: 'cta-button-click',
-        'button-click-label': `${answer}-to-next-of-kin`,
+        event: createAnalyticsSlug(`${answer}-to-next-of-kin`, 'nav'),
       });
       dispatch(recordAnswer({ nextOfKinUpToDate: `${answer}` }));
       goToNextPage();


### PR DESCRIPTION
## Description
Updates GA events that we want to keep to use the nav prefix as outlined by Ben's notes in the ticket.

To test use this extension: https://chrome.google.com/webstore/detail/adswerve-datalayer-inspec/kmcbdogdandhihllalknlcjfpdjcleom/related?hl=en-US

See instructions here: https://depo-platform-documentation.scrollhelp.site/analytics-monitoring/frequently-asked-questions -> under the `How can I tell if an interaction is being tracked (i.e. button clicks, pageviews, PDF downloads, etc.)?` accordion. All events should start with `nav-`
## Original issue(s)
department-of-veterans-affairs/va.gov-team#46171



## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
