### PR TITLE
Create new VFS app: My New APp

### DIFF
--- a/src/applications/my-app/app-entry.jsx
+++ b/src/applications/my-app/app-entry.jsx
@@ -1,0 +1,14 @@
+import 'platform/polyfills';
+import './sass/my-app.scss';
+
+import startApp from 'platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+});

--- a/src/applications/my-app/containers/App.jsx
+++ b/src/applications/my-app/containers/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App({ children }) {
+  return <div>{children}</div>;
+}

--- a/src/applications/my-app/manifest.json
+++ b/src/applications/my-app/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "My New APp",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "my-app",
+  "rootUrl": "/my-app",
+  "productId": "e726d697-0b44-45d5-8a30-05820d5ab6a1"
+}

--- a/src/applications/my-app/reducers/index.js
+++ b/src/applications/my-app/reducers/index.js
@@ -1,0 +1,3 @@
+export default {
+
+};

--- a/src/applications/my-app/routes.jsx
+++ b/src/applications/my-app/routes.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Route } from 'react-router';
+import App from './containers/App.jsx';
+
+const routes = (
+  <Route path="/" component={App}>
+  </Route>
+);
+
+export default routes;

--- a/src/applications/my-app/sass/my-app.scss
+++ b/src/applications/my-app/sass/my-app.scss
@@ -1,0 +1,1 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/src/applications/my-app/tests/my-app.cypress.spec.js
+++ b/src/applications/my-app/tests/my-app.cypress.spec.js
@@ -1,0 +1,15 @@
+import manifest from '../manifest.json';
+
+describe(manifest.appName, () => {
+  // Skip tests in CI until the app is released.
+  // Remove this block when the app has a content page in production.
+  before(function() {
+    if (Cypress.env('CI')) this.skip();
+  });
+
+  it('is accessible', () => {
+    cy.visit(manifest.rootUrl)
+      .injectAxe()
+      .axeCheck();
+  });
+});


### PR DESCRIPTION
# Auto-generated new app: My New APp
This PR and branch create a skeleton of a new VFS app, My New APp.  They were created from the Console UI, using the `vfs-create-app` template, to invoke the [vets-website app generator](https://github.com/department-of-veterans-affairs/generator-vets-website) script.

## Checklist
- [ ] - Review contents of PR, address any failed checks
- [ ] - Make a markdown file in the [vagov-content repo](https://github.com/department-of-veterans-affairs/vagov-content) at `pages//my-app.md`
- [ ] - Update `content-build` registry file with an entry for this new app (replace `PRODUCT_ID` with actual id):
```json
{
  "appName": "My New APp",
  "entryName": "my-app",
  "rootUrl": "/my-app",
  "productId":  "PRODUCT_ID"
  "template": {
    "vagovprod": false
    "layout": "page-react.html"
  }
}
```
