### PR TITLE
Filter clinics with direct scheduling enabled

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/useClinicFormState.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/useClinicFormState.jsx
@@ -67,7 +67,8 @@ export default function useClinicFormState() {
             pastAppointmentDateMap.set(clinicId, apptTime);
           }
         });
-
+        // filter the clinic where past appointment contains the clinicId
+        // and the clinic configuration has direct scheduling set to true
         if (featureVaosV2Next) {
           filteredClinics = clinics.filter(
             clinic =>

--- a/src/applications/vaos/services/healthcare-service/transformers.v2.js
+++ b/src/applications/vaos/services/healthcare-service/transformers.v2.js
@@ -19,6 +19,8 @@ export function transformClinicV2(clinic) {
     stationName: clinic.stationName,
     // Description of service as presented to a consumer while searching
     serviceName: clinic.serviceName,
+    // Allow direct scheduling by patient
+    patientDirectScheduling: clinic.patientDirectScheduling,
   };
 }
 

--- a/src/applications/vaos/services/mocks/v2/clinics.json
+++ b/src/applications/vaos/services/mocks/v2/clinics.json
@@ -15,7 +15,7 @@
         "primaryStopCodeName": "PRIMARY CARE/MEDICINE",
         "secondaryStopCode": null,
         "secondaryStopCodeName": "*Missing*",
-        "patientDirectScheduling": null,
+        "patientDirectScheduling": true,
         "patientDisplay": null,
         "char4": null
       }
@@ -35,7 +35,7 @@
         "primaryStopCodeName": "PRIMARY CARE/MEDICINE",
         "secondaryStopCode": null,
         "secondaryStopCodeName": "*Missing*",
-        "patientDirectScheduling": null,
+        "patientDirectScheduling": true,
         "patientDisplay": null,
         "char4": null
       }
@@ -55,7 +55,7 @@
         "primaryStopCodeName": "PRIMARY CARE/MEDICINE",
         "secondaryStopCode": 117,
         "secondaryStopCodeName": "NURSING (2ND ONLY)",
-        "patientDirectScheduling": null,
+        "patientDirectScheduling": true,
         "patientDisplay": null,
         "char4": null
       }
@@ -75,7 +75,7 @@
         "primaryStopCodeName": "PRIMARY CARE/MEDICINE",
         "secondaryStopCode": null,
         "secondaryStopCodeName": "*Missing*",
-        "patientDirectScheduling": null,
+        "patientDirectScheduling": true,
         "patientDisplay": null,
         "char4": null
       }

--- a/src/applications/vaos/tests/services/patient/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/patient/index.v2.unit.spec.js
@@ -157,7 +157,14 @@ describe('VAOS Patient service v0/v2 comparison', () => {
 
       const differences = diff(v0Result, v2Result);
 
-      expect(differences).to.be.empty;
+      // Then the results have the following differences
+      expect(differences).to.have.deep.members([
+        {
+          op: 'add',
+          path: ['clinics', 0, 'patientDirectScheduling'],
+          value: null,
+        },
+      ]);
     });
 
     it('should match when using primary care', async () => {
@@ -236,8 +243,14 @@ describe('VAOS Patient service v0/v2 comparison', () => {
       ]);
       const differences = diff(v0Result, v2Result);
 
-      // Then both results are the same
-      expect(differences).to.be.empty;
+      // Then the results have the following differences
+      expect(differences).to.have.deep.members([
+        {
+          op: 'add',
+          path: ['clinics', 0, 'patientDirectScheduling'],
+          value: null,
+        },
+      ]);
     });
 
     it('should match when requests and direct scheduling are disabled', async () => {
@@ -418,8 +431,14 @@ describe('VAOS Patient service v0/v2 comparison', () => {
 
       const differences = diff(v0Result, v2Result);
 
-      // Then both results are the same
-      expect(differences).to.be.empty;
+      // Then the results have the following differences
+      expect(differences).to.have.deep.members([
+        {
+          op: 'add',
+          path: ['clinics', 0, 'patientDirectScheduling'],
+          value: null,
+        },
+      ]);
     });
 
     it('should match when passing past clinic check', async () => {
@@ -506,8 +525,14 @@ describe('VAOS Patient service v0/v2 comparison', () => {
 
       const differences = diff(v0Result, v2Result);
 
-      // Then both results are the same
-      expect(differences).to.be.empty;
+      // Then the results have the following differences
+      expect(differences).to.have.deep.members([
+        {
+          op: 'add',
+          path: ['clinics', 0, 'patientDirectScheduling'],
+          value: null,
+        },
+      ]);
     });
 
     it('should match when DS is disabled by toggle', async () => {
@@ -679,8 +704,14 @@ describe('VAOS Patient service v0/v2 comparison', () => {
 
       const differences = diff(v0Result, v2Result);
 
-      // Then both results are the same
-      expect(differences).to.be.empty;
+      // Then the results have the following differences
+      expect(differences).to.have.deep.members([
+        {
+          op: 'add',
+          path: ['clinics', 0, 'patientDirectScheduling'],
+          value: null,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Description
Clinics with Direct Scheduling Flag = null are displayed to Veteran in the Direct Scheduling flow. Added a filter to display only when Direct Scheduling Flag = true

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46281


## Testing done
unit and local test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/188684163-382ff72e-35b6-4388-a27d-60459e8999e7.png)


## Acceptance criteria
- [ ] When clinic direct schedule flag is set to true then display the clinic
- [ ] make the change under the `VaosV2Next` toggle flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
