### PR TITLE
[cFSR] 46643 - Confirmation page resolution options display

### DIFF
--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -8,10 +8,15 @@ import { focusElement } from 'platform/utilities/ui';
 import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
+import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
 import GetFormHelp from '../components/GetFormHelp';
 import { deductionCodes } from '../constants/deduction-codes';
 import DownloadFormPDF from '../components/DownloadFormPDF';
-import { fsrConfirmationEmailToggle } from '../utils/helpers';
+import {
+  fsrConfirmationEmailToggle,
+  DEBT_TYPES,
+  fsrReasonDisplay,
+} from '../utils/helpers';
 
 const { scroller } = Scroll;
 const scrollToTop = () => {
@@ -24,9 +29,39 @@ const scrollToTop = () => {
 
 const RequestDetailsCard = ({ data, response }) => {
   const name = data.personalData?.veteranFullName;
+  const combinedFSR = data['view:combinedFinancialStatusReport'];
   const windowPrint = useCallback(() => {
     window.print();
   }, []);
+
+  const debtListItem = (debt, index) => {
+    const debtFor =
+      debt.debtType === DEBT_TYPES.DEBT
+        ? deductionCodes[debt.deductionCode]
+        : debt.station.facilityName ||
+          getMedicalCenterNameByID(debt.station.facilitYNum);
+    const resolution = fsrReasonDisplay(debt.resolutionOption);
+
+    return (
+      <li key={index}>
+        {resolution}
+        <span className="vads-u-margin--0p5">for</span>
+        {debtFor}
+      </li>
+    );
+  };
+
+  const reliefList = combinedFSR
+    ? data.selectedDebtsAndCopays?.map((debt, index) =>
+        debtListItem(debt, index),
+      )
+    : data.selectedDebts?.map((debt, index) => (
+        <li key={index}>
+          {debt.resolution?.resolutionType}
+          <span className="vads-u-margin--0p5">for</span>
+          {deductionCodes[debt.deductionCode]}
+        </li>
+      ));
 
   return (
     <div className="inset">
@@ -42,15 +77,7 @@ const RequestDetailsCard = ({ data, response }) => {
         <p>
           <strong>Requested repayment or relief options</strong>
         </p>
-        <ul>
-          {data.selectedDebts?.map((debt, index) => (
-            <li key={index}>
-              {debt.resolution?.resolutionType}
-              <span className="vads-u-margin--0p5">for</span>
-              {deductionCodes[debt.deductionCode]}
-            </li>
-          ))}
-        </ul>
+        <ul>{reliefList}</ul>
         <p className="vads-u-margin-bottom--0">
           <strong>Date submitted</strong>
         </p>

--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -201,7 +201,7 @@ const ConfirmationPage = ({ form, download }) => {
         </p>
 
         <a
-          className="usa-button-primary va-button-primary vads-u-margin-top--1p5 vads-u-margin-bottom--2p5"
+          className="vads-c-action-link--green vads-u-margin-top--1p5 vads-u-margin-bottom--2p5"
           href={`${environment.BASE_URL}`}
         >
           Go back to VA.gov

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -103,20 +103,22 @@ export const nameStr = (socialSecurity, compensation, education, addlInc) => {
   return otherIncNames?.map(item => item).join(', ') ?? '';
 };
 
+export const fsrReasonDisplay = resolutionOption => {
+  switch (resolutionOption) {
+    case 'monthly':
+      return 'Extended monthly payments';
+    case 'waiver':
+      return 'Waiver';
+    case 'compromise':
+      return 'Compromise';
+    default:
+      return '';
+  }
+};
+
 export const getFsrReason = (debts, combinedFSR) => {
   const reasons = combinedFSR
-    ? debts.map(({ resolutionOption }) => {
-        switch (resolutionOption) {
-          case 'monthly':
-            return 'Extended monthly payments';
-          case 'waiver':
-            return 'Waiver';
-          case 'compromise':
-            return 'Compromise';
-          default:
-            return '';
-        }
-      })
+    ? debts.map(({ resolutionOption }) => fsrReasonDisplay(resolutionOption))
     : debts.map(({ resolution }) => resolution.resolutionType);
   const uniqReasons = [...new Set(reasons)];
 


### PR DESCRIPTION
## Description
Updated confirmation page to display debts and copays behind feature flag. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46643


## Screenshots
![image](https://user-images.githubusercontent.com/25368370/188677863-cc4699f1-e985-4fac-9327-7130e31dd9a3.png)

## Acceptance criteria
- [ ] Combined confirmation page shows debts AND copays
- [ ] Existing confirmation page functions correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
