### PR TITLE
Update eslint-plugin dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.10.0",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.3.0",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.4.0",
     "@department-of-veterans-affairs/generator-vets-website": "^3.8.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,10 +2517,10 @@
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.3.0.tgz#30d9da8775f7aa5fa18c6ff7bcb072248e31bf14"
-  integrity sha512-7FuNKVZjuO5zaBWJfpNKAgtqwI3SwvF9OQNu6+xpBwyBWj4u86XxDoXHIzLilgeQNAdphLvvKjiXp4HbHDlMcA==
+"@department-of-veterans-affairs/eslint-plugin@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.4.0.tgz#72d5ed8490bba9867c7c1a567b332a532bf7f233"
+  integrity sha512-Gd+x2clQXnCl4HeNIuLtQZ/kCfy3+8vFETpEZCDSKek6NeIus4edlO1UOlJIIamP2nwam53jTr8xt7Q2/3sAgA==
   dependencies:
     jsx-ast-utils "^3.3.3"
 


### PR DESCRIPTION
## Original issue(s)
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1049


## Testing done
<img width="283" alt="Screen Shot 2022-09-06 at 12 17 56 PM" src="https://user-images.githubusercontent.com/36863582/188688422-1027b315-edb2-4f76-9437-e35daf12ccf1.png">


## Screenshots
<img width="770" alt="Screen Shot 2022-09-06 at 12 31 12 PM" src="https://user-images.githubusercontent.com/36863582/188688395-0c3d54c8-1f46-45c8-bc01-e354ef20409b.png">


## Acceptance criteria
- [x] ESLint warning rule exists for the OMB info component
