### PR TITLE
Adding combined debt portal and medical copays (back) to allow list

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -9,6 +9,10 @@
       "slackGroup": "@check-in-fe"
     },
     {
+      "rootFolder": "combined-debt-portal",
+      "slackGroup": "<@U0329KDCJ0Y> <@U031KTDNYEP>"
+    },
+    {
       "rootFolder": "coronavirus-research",
       "slackGroup": "@cto-health-products"
     },
@@ -43,6 +47,10 @@
     {
       "rootFolder": "login",
       "slackGroup": "@vsp-identity-group"
+    },
+    {
+      "rootFolder": "medical-copays",
+      "slackGroup": "<@U0329KDCJ0Y> <@U031KTDNYEP>"
     },
     {
       "rootFolder": "mhv-inherited-proofing",


### PR DESCRIPTION
## Description

- Adding `combined-debt-portal` to allow list after confirming no cross app references were found. 
- Re-adding `medical-copays` to allow list after removing all cross app references. 
  - [Previous ticket removing it for reference](https://github.com/department-of-veterans-affairs/vets-website/pull/21901) 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46079

## Acceptance criteria
- [ ] No cross app references found for `combined-debt-portal` or `medical-copays`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
