### PR TITLE
Fix startApp reference for secure-messaging

### DIFF
--- a/src/applications/mhv/secure-messaging/app-entry.jsx
+++ b/src/applications/mhv/secure-messaging/app-entry.jsx
@@ -5,7 +5,7 @@ import './sass/message-list.scss';
 import './sass/search-messages.scss';
 import './sass/secure-messaging.scss';
 
-import startApp from 'platform/startup';
+import startApp from 'platform/startup/router';
 import routes from './routes';
 import reducer from './reducers';
 import manifest from './manifest.json';

--- a/src/applications/mhv/secure-messaging/routes.jsx
+++ b/src/applications/mhv/secure-messaging/routes.jsx
@@ -2,20 +2,36 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import App from './containers/App';
 import Compose from './containers/Compose';
-import MessageDetail from './containers/MessageDetails';
+import MessageDetails from './containers/MessageDetails';
 import MessageReply from './containers/MessageReply';
 import SearchMessages from './containers/SearchMessages';
 
 const routes = (
   <Switch>
-    <Route path="/" component={App} />
-    <Route path="/compose" component={Compose} />
-    <Route path="/message" component={MessageDetail} />
-    <Route path="/reply" component={MessageReply} />
-    <Route path="/search" component={SearchMessages} />
-    <Route path="/draft/:draftId" component={Compose} />
-    <Route path="/sent/:messageId" component={MessageDetail} />
-    <Route path="/trash/:messageId" component={MessageDetail} />
+    <Route exact path="/" key="App">
+      <App />
+    </Route>
+    <Route exact path="/compose" key="Compose">
+      <Compose />
+    </Route>
+    <Route exact path="/message" key="MessageDetails">
+      <MessageDetails />
+    </Route>
+    <Route exact path="/reply" key="MessageReply">
+      <MessageReply />
+    </Route>
+    <Route exact path="/search" key="SearchMessages">
+      <SearchMessages />
+    </Route>
+    <Route path="/draft/:draftId" key="Compose">
+      <Compose />
+    </Route>
+    <Route path="/sent/:messageId" key="MessageDetails">
+      <MessageDetails />
+    </Route>
+    <Route path="/trash/:messageId" key="MessageDetails">
+      <MessageDetails />
+    </Route>
   </Switch>
 );
 


### PR DESCRIPTION
## Description
app-entry.jsx for secure-messaging app was referencing the startApp() function to an incorrect source. As a result, app was using a wrong Router.

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
