### PR TITLE
[41718] Include individual value of expenses for FSR

### DIFF
--- a/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
@@ -1043,7 +1043,7 @@ describe('fsr transform information', () => {
     it('has valid data', () => {
       const submissionObj = JSON.parse(transform(null, inputObject));
       expect(submissionObj.additionalData.additionalComments).to.equal(
-        'Supporting personal statement...',
+        'Supporting personal statement...\nIndividual expense amount: Pool service ($200), Lawn service ($100.54)',
       );
     });
     describe('bankruptcy', () => {

--- a/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
@@ -1043,7 +1043,7 @@ describe('fsr transform information', () => {
     it('has valid data', () => {
       const submissionObj = JSON.parse(transform(null, inputObject));
       expect(submissionObj.additionalData.additionalComments).to.equal(
-        'Supporting personal statement...\nIndividual expense amount: Pool service ($200), Lawn service ($100.54)',
+        'Supporting personal statement...\nIndividual expense amount: Pool service ($200.00), Lawn service ($100.54)',
       );
     });
     describe('bankruptcy', () => {

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -141,6 +141,16 @@ export const getAmountCanBePaidTowardDebt = (debts, combinedFSR) => {
         );
 };
 
+export const mergeAdditionalComments = (additionalComments, expenses) => {
+  const individualExpenses = expenses
+    .map(expense => `${expense.name} ($${expense.amount})`)
+    .join(', ');
+
+  const individualExpensesStr = `Individual expense amount: ${individualExpenses}`;
+
+  return `${additionalComments}\n${individualExpensesStr}`;
+};
+
 export const getMonthlyIncome = ({
   additionalIncome: {
     addlIncRecords,

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -143,12 +143,14 @@ export const getAmountCanBePaidTowardDebt = (debts, combinedFSR) => {
 
 export const mergeAdditionalComments = (additionalComments, expenses) => {
   const individualExpenses = expenses
-    .map(expense => `${expense.name} ($${expense.amount})`)
+    ?.map(expense => `${expense.name} (${currency(expense.amount)})`)
     .join(', ');
 
   const individualExpensesStr = `Individual expense amount: ${individualExpenses}`;
 
-  return `${additionalComments}\n${individualExpensesStr}`;
+  return individualExpenses
+    ? `${additionalComments}\n${individualExpensesStr}`
+    : additionalComments;
 };
 
 export const getMonthlyIncome = ({

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -12,6 +12,7 @@ import {
   otherDeductionsAmt,
   nameStr,
   getAmountCanBePaidTowardDebt,
+  mergeAdditionalComments,
 } from './helpers';
 
 export const transform = (formConfig, form) => {
@@ -259,7 +260,10 @@ export const transform = (formConfig, form) => {
         courtLocation: additionalData.bankruptcy.courtLocation,
         docketNumber: additionalData.bankruptcy.docketNumber,
       },
-      additionalComments: additionalData.additionalComments,
+      additionalComments: mergeAdditionalComments(
+        additionalData.additionalComments,
+        otherExpenses,
+      ),
     },
     applicantCertifications: {
       veteranSignature: `${vetFirst} ${vetMiddle} ${vetLast}`,


### PR DESCRIPTION
## Description
Itemize other expenses in additional comments to display value

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#41718](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41718)


## Screenshots
![image](https://user-images.githubusercontent.com/20892803/188728218-8f221dfd-9905-4cad-9547-d423728932df.png)


## Acceptance criteria
- [ ] Individual expense amounts available in field 36
- [ ] Does not conflict with current additional comments

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
