### PR TITLE
SM to VA.gov:  Compose - Reply to functionality

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { capitalize } from 'lodash';
+import { useHistory } from 'react-router-dom';
 import MessageActionButtons from './MessageActionsButtons';
 import AttachmentsList from './AttachmentsList';
 
@@ -16,7 +17,15 @@ const MessageDetailBlock = props => {
     subject,
   } = props.message;
 
+  const history = useHistory();
   const casedCategory = capitalize(category);
+
+  const handleReplyButton = useCallback(
+    () => {
+      history.push('/reply');
+    },
+    [history],
+  );
 
   return (
     <section className="message-detail-block">
@@ -29,6 +38,7 @@ const MessageDetailBlock = props => {
         </h2>
         <button
           type="button"
+          onClick={handleReplyButton}
           className="send-button-top medium-screen:vads-u-padding-right--2"
         >
           <i className="fas fa-reply" />


### PR DESCRIPTION
## Description
**GIVEN** a user is on Message Detail view at `/my-health/secure-messaging/message`
**WHEN** a user clicks on **Reply button** in the header next to the Message Subject 
**THEN** a user should be redirected to Reply view at  `/my-health/secure-messaging/reply`

## Original issue(s)
[Jira - SM to VA.gov:  Compose - Reply to functionality](https://vajira.max.gov/browse/MHV-33553)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
