### PR TITLE
updates to 1095B widget based on staging review suggestions

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -155,7 +155,7 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
       <LastUpdatedComponent lastUpdated={lastUpdated} />
       <va-alert
         close-btn-aria-label="Close notification"
-        status="warning"
+        status="error"
         visible
       >
         <h2 slot="headline">We couldn’t download your form</h2>

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -107,7 +107,7 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
 
   const radioComponent = (
     <>
-      <h3>Choose your file format and download your document</h3>
+      <h2>Choose your file format and download your document</h2>
       <VaRadio
         id="1095-download-options"
         label="We offer two file format options for this form. Choose the option that best meets your needs."

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -158,7 +158,7 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
         status="warning"
         visible
       >
-        <h3 slot="headline">We couldn’t download your form</h3>
+        <h2 slot="headline">We couldn’t download your form</h2>
         <div>
           <p>
             We’re sorry. Something went wrong when we tried to download your
@@ -186,7 +186,7 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
         status="success"
         visible
       >
-        <h3 slot="headline">Download Complete</h3>
+        <h2 slot="headline">Download Complete</h2>
         <div>
           <p>
             You successfully downloaded your 1095-B tax form. Please check your
@@ -213,9 +213,9 @@ export const App = ({ loggedIn, toggleLoginModal, displayToggle }) => {
       status="continue"
       visible
     >
-      <h3 slot="headline">
+      <h2 slot="headline">
         Please sign in to download your 1095-B tax document
-      </h3>
+      </h2>
       <div>
         Sign in with your existing <ServiceProvidersText isBold /> account.{' '}
         <ServiceProvidersTextCreateAcct />

--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -52,9 +52,9 @@ export const LastUpdatedComponent = props => {
 export const notFoundComponent = () => {
   return (
     <va-alert close-btn-aria-label="Close notification" status="info" visible>
-      <h3 slot="headline">
+      <h2 slot="headline">
         You don’t have a 1095-B tax form available right now
-      </h3>
+      </h2>
       <div>
         <p>
           If you recently enrolled in VA health care, you may not have a 1095-B
@@ -78,9 +78,9 @@ export const unavailableComponent = () => {
       status="warning"
       visible
     >
-      <h3 slot="headline">
+      <h2 slot="headline">
         Your 1095-B form isn’t available to download right now
-      </h3>
+      </h2>
       <div>
         <p>
           Check back later. Or, if you need help with this form now, call us at{' '}

--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -73,11 +73,7 @@ export const notFoundComponent = () => {
 
 export const unavailableComponent = () => {
   return (
-    <va-alert
-      close-btn-aria-label="Close notification"
-      status="warning"
-      visible
-    >
+    <va-alert close-btn-aria-label="Close notification" status="info" visible>
       <h2 slot="headline">
         Your 1095-B form isn’t available to download right now
       </h2>

--- a/src/applications/static-pages/download-1095b/tests/01-1095b-authed.cypress.spec.js
+++ b/src/applications/static-pages/download-1095b/tests/01-1095b-authed.cypress.spec.js
@@ -1,7 +1,7 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 import { form, featureToggles } from './e2e/fixtures/mocks/mocks';
 
-describe.skip('Authed 1095-B Form Download PDF', () => {
+describe('Authed 1095-B Form Download PDF', () => {
   beforeEach(() => {
     cy.intercept('GET', 'v0/feature_toggles?*', featureToggles).as(
       'featureToggles',
@@ -25,13 +25,13 @@ describe.skip('Authed 1095-B Form Download PDF', () => {
 
     cy.axeCheck();
 
-    cy.get('#1095-download-options-0').should('be.checked');
-    cy.get('#1095-download-options-1').should('not.be.checked');
+    cy.get('#pdf').should('be.visible');
+    cy.get('#txt').should('be.visible');
 
     cy.get('#download-url')
       .click()
       .then(() => {
-        cy.get('.usa-content div va-alert h3').should(
+        cy.get('.usa-content div va-alert h2').should(
           'have.text',
           'Download Complete',
         );

--- a/src/applications/static-pages/download-1095b/tests/02-1095b-no-form-available.cypress.spec.js
+++ b/src/applications/static-pages/download-1095b/tests/02-1095b-no-form-available.cypress.spec.js
@@ -24,7 +24,7 @@ describe('No 1095-B Form Available for Download', () => {
 
     cy.axeCheck();
 
-    cy.get('.usa-content div va-alert h3').should(
+    cy.get('.usa-content div va-alert h2').should(
       'have.text',
       'You don’t have a 1095-B tax form available right now',
     );


### PR DESCRIPTION
## Description
This PR updates the header for the 1095B download widget in order to maintain the header hierarchy. It also changes a couple warning alerts to more appropriate alerts. This also fixes the 1095B failing Cypress test that others were experiencing with their PRs

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46639
department-of-veterans-affairs/va.gov-team#46636


## Testing done
local testing to make sure its still rendering properly


## Screenshots
<img width="841" alt="Screen Shot 2022-09-07 at 3 48 15 PM" src="https://user-images.githubusercontent.com/47372929/188964343-bd3203cd-34e2-40c9-a78f-92d54d741b28.png">

<img width="736" alt="Screen Shot 2022-09-07 at 4 33 59 PM" src="https://user-images.githubusercontent.com/47372929/188973013-d33b30a0-caa1-4af7-bcca-9a4c476afbb1.png">

<img width="789" alt="Screen Shot 2022-09-07 at 4 41 13 PM" src="https://user-images.githubusercontent.com/47372929/188973557-219cf871-47e4-4a86-a821-1895bc5ce710.png">

