### PR TITLE
Update notify-start job in daily deploy workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1264,7 +1264,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get release wait time (scheduled release)
-        run: echo 'RELEASE_WAIT=0' >> $GITHUB_ENV
+        run: echo 'RELEASE_WAIT=10' >> $GITHUB_ENV
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,1241 +12,1261 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build:
-    name: Build
-    runs-on: self-hosted
-    outputs:
-      entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
-      continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
-
-    env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-
-    strategy:
-      fail-fast: false
-      matrix:
-        buildtype: [vagovdev, vagovstaging, vagovprod]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Get changed applications
-        id: get-changed-apps
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          delimiter: ','
-          output-type: 'entry_name, continuous_deployment'
-
-      - name: Configure AWS Credentials
-        if: ${{ matrix.buildtype == 'vagovprod' }}
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get Mapbox Token
-        if: ${{ matrix.buildtype == 'vagovprod' }}
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token
-          env_variable_name: MAPBOX_TOKEN
-
-      - name: Build
-        run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
-        timeout-minutes: 30
-        env:
-          ENTRY: ${{ steps.get-changed-apps.outputs.entry_names }}
-
-      - name: Generate build details
-        run: |
-          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
-          BUILDTYPE=${{ matrix.buildtype }}
-          NODE_ENV=production
-          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-          CHANGE_TARGET=null
-          RUN_ID=${{ github.run_id }}
-          RUN_NUMBER=${{ github.run_number }}
-          REF=${{ github.sha }}
-          BUILDTIME=$(date +%s)
-          EOF
-
-      - name: Compress and archive build
-        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.buildtype }}.tar.bz2
-          path: ${{ matrix.buildtype }}.tar.bz2
-          retention-days: 1
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: self-hosted
-    outputs:
-      app_folders: ${{ steps.get-changed-apps.outputs.folders }}
-
-    env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Create test results folder
-        run: mkdir -p test-results
-
-      - name: Get changed applications
-        id: get-changed-apps
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          delimiter: ','
-          output-type: 'folder'
-
-      - name: Run unit tests
-        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} --coverage
-        env:
-          MOCHA_FILE: test-results/unit-tests.xml
-          APP_FOLDERS: ${{ steps.get-changed-apps.outputs.folders }}
-
-      - name: Archive unit test results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: unit-test-report
-          path: mochawesome-report
-
-      - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > test-results/coverage_report.txt
-
-      - name: Upload Coverage Report Artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: unit-test-coverage-report
-          path: coverage/test-coverage-report.json
-
-      - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/main' && steps.get-changed-apps.outputs.folders == '' }}
-        run: aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-
-      - name: Get code coverage
-        if: ${{ always() }}
-        id: code-coverage
-        run: echo ::set-output name=MARKDOWN::$(node ./script/github-actions/code-coverage-format-report.js)
-
-      - name: Publish test results
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: mikepenz/action-junit-report@v2.8.4
-        with:
-          check_name: 'Unit Tests Summary'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'test-results/unit-tests.xml'
-          summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
-          fail_on_failure: 'true'
-
-  contract-tests:
-    name: Contract Tests
-    runs-on: ubuntu-latest
-    outputs:
-      tests: ${{ steps.get-tests.outputs.tests }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get Pact Broker password
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /dsva-vagov/pact-broker/utility/PACT_BROKER_BASIC_AUTH_PASSWORD
-          env_variable_name: PACT_BROKER_BASIC_AUTH_PASSWORD
-
-      - name: Get GitHub token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Create test results folder
-        run: mkdir -p test-results
-
-      - name: Get changed applications
-        id: get-changed-apps
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          output-type: 'folder'
-
-      - name: Get contract tests
-        id: get-tests
-        run: |
-          if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
-            echo ::set-output name=tests::$(find src -name "*.pact.spec.js")
-          else
-            echo ::set-output name=tests::$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.pact.spec.js")
-          fi
-
-      - name: Run contract tests
-        if: steps.get-tests.outputs.tests != ''
-        run: yarn test:unit-pact-config ${{ steps.get-tests.outputs.tests }}
-        env:
-          MOCHA_FILE: ./test-results/test-results.xml
-
-      - name: Print Pact failures
-        if: steps.get-tests.outputs.tests != '' && failure()
-        run: cat test-results/test-results.xml
-
-      - name: Run Pact publish
-        if: steps.get-tests.outputs.tests != ''
-        run: yarn pact:publish
-        env:
-          PACT_BROKER_BASIC_AUTH_USERNAME: pact-broker
-          PACT_BROKER_BASE_URL: https://dev.va.gov/_vfs/pact-broker/
-
-      - name: Run Pact verify
-        if: steps.get-tests.outputs.tests != ''
-        run: |
-          curl -v -X POST \
-          -H 'Authorization: token ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}' \
-          -H 'Accept: application/vnd.github.v3+json' \
-          https://api.github.com/repos/department-of-veterans-affairs/vets-api/actions/workflows/8289333/dispatches \
-          -d '{"ref": "master"}' \
-          --fail
-
-      - name: Archive contract test results
-        if: steps.get-tests.outputs.tests != ''
-        uses: actions/upload-artifact@v3
-        with:
-          name: contract-test-report
-          path: mochawesome-report
-
-      - name: Archive contract test log
-        uses: actions/upload-artifact@v3
-        if: steps.get-tests.outputs.tests != '' && failure()
-        with:
-          name: contract-test-log
-          path: logs/pact.log
-
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Get changed applications
-        id: get-changed-apps
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          output-type: 'entry_name'
-
-      - name: Audit dependencies
-        if: steps.get-changed-apps.outputs.entry_names == ''
-        run: yarn security-check
-
-  linting:
-    name: Linting (All)
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Get changed applications
-        id: get-changed-apps
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          output-type: 'folder'
-
-      - name: Annotate ESLint results
-        run: |
-          if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
-            yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
-          else
-            yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js \
-            ${{ steps.get-changed-apps.outputs.folders }}
-          fi
-
-      - name: Run Stylelint
-        if: ${{ always() }}
-        run: |
-          if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
-            yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
-          else
-            files=$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.scss")
-            if [[ -n "$files" ]]; then yarn run stylelint verbose --output-file stylelint-report.json --formatter json $(echo $files); fi
-          fi
-
-      - name: Annotate Stylelint results
-        if: ${{ always() }}
-        run: node ./script/github-actions/stylelint-annotation-format.js
-
-  testing-reports-prep:
-    name: Testing Reports Prep
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    outputs:
-      app_list: ${{ env.APPLICATION_LIST }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Generate new application list
-        run: yarn generate-app-list
-      # exports app list and assigns to environmental variable at this step
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get va-vsp-bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
-
-      - name: Upload app list to BigQuery
-        run: yarn generate-app-list
-        working-directory: qa-standards-dashboard-data
-
-  cypress-tests-prep:
-    name: Prep for Cypress Tests
-    runs-on: ubuntu-latest
-    outputs:
-      tests: ${{ steps.tests.outputs.selected }}
-      app_urls: ${{ steps.get-changed-apps.outputs.urls }}
-      num_containers: ${{ steps.containers.outputs.num }}
-      ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Get changed applications
-        id: get-changed-apps
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          delimiter: ','
-          output-type: 'entry_name, url'
-
-      - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
-        run: node script/github-actions/select-cypress-tests.js
-        env:
-          RUN_FULL_SUITE: false
-          CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
-          APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
-          APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}
-
-      - name: Set output of TESTS
-        id: tests
-        run: echo ::set-output name=selected::$TESTS
-
-      - name: Set output of NUM_CONTAINERS
-        id: containers
-        run: echo ::set-output name=num::$NUM_CONTAINERS
-
-      - name: Set output of CI_NODE_INDEX
-        id: matrix
-        run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
-
-  cypress-tests:
-    name: Cypress E2E Tests
-    runs-on: self-hosted
-    timeout-minutes: 60
-    needs: [build, cypress-tests-prep]
-    if: |
-      needs.build.result == 'success' &&
-      needs.cypress-tests-prep.result == 'success'
-    container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
-      options: -u 1001:1001 -v /usr/local/share:/share
-
-    strategy:
-      fail-fast: false
-      max-parallel: 12
-      matrix:
-        ci_node_index: ${{ fromJson(needs.cypress-tests-prep.outputs.ci_node_index) }}
-
-    env:
-      CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
-      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
-
-    steps:
-      # The following statement is included in each step because of a bug in
-      # GitHub's branch protection:
-      #
-      # if: needs.cypress-tests-prep.outputs.tests != '[]'
-      #
-      # Previously, if no tests were selected, the branch protection check that
-      # requires the cypress-tests job to run was not satisfied. This update forces
-      # the job to always run, and skips each step if no tests are selected.
-      # Previously, the above conditional was included in the job's if statement.
-      - name: Configure AWS credentials
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Checkout vets-website
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        uses: actions/checkout@v3
-
-      - name: Download production build artifact
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        uses: actions/download-artifact@v3
-        with:
-          name: vagovprod.tar.bz2
-
-      - name: Unpack build
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        run: |
-          mkdir -p build/vagovprod
-          tar -C build/vagovprod -xjf vagovprod.tar.bz2
-
-      - name: Install dependencies
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        uses: ./.github/workflows/install
-        timeout-minutes: 20
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            /github/home/.cache/Cypress
-            node_modules
-
-      - name: Start server
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
-
-      - name: Run Cypress tests
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
-        run: node script/github-actions/run-cypress-tests.js
-        timeout-minutes: 40
-        env:
-          CYPRESS_CI: true
-          STEP: ${{ matrix.ci_node_index }}
-          TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
-          APP_URLS: ${{ needs.cypress-tests-prep.outputs.app_urls }}
-          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
-
-      - name: Archive test videos
-        if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-video-artifacts
-          path: cypress/videos
-
-      - name: Archive test screenshots
-        if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-screenshot-artifacts
-          path: cypress/screenshots
-
-      - name: Archive Mochawesome test results
-        if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-mochawesome-test-results
-          path: cypress/results
-          retention-days: 1
-
-  testing-reports-contract-tests:
-    name: Testing Reports - Contract Tests
-    runs-on: ubuntu-latest
-    needs: [testing-reports-prep, contract-tests]
-    if: |
-      always() &&
-      needs.contract-tests.outputs.tests != '' &&
-      (needs.contract-tests.result == 'success' || needs.contract-tests.result == 'failure')
-    continue-on-error: true
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-    steps:
-      - name: Set IS_MASTER_BUILD
-        run: |
-          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-              echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
-          else
-              echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # ----------------
-      # | Notify Slack |
-      # ----------------
-
-      - name: Notify Slack about Contract test failures
-        if: ${{ github.ref == 'refs/heads/main' && needs.contract-tests.result == 'failure' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-        continue-on-error: true
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-        with:
-          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Contract tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
-          channel_id: C026PD47Z19 #gha-test-status
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      # ------------------------
-      # | Upload BigQuery Data |
-      # ------------------------
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get va-vsp-bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
-
-      - name: Get AWS IAM role
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Set UUID for Mochawesome reports
-        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      # ------------------------------------------------------
-      # | Publish Contract Test Report and Upload to BigQuery |
-      # ------------------------------------------------------
-
-      - name: Download Contract Test Mochawesome test results
-        uses: actions/download-artifact@v3
-        with:
-          name: contract-test-report
-          path: qa-standards-dashboard-data/src/testing-reports/data
-
-      - name: Create Contract Test report and post results to BigQuery
-        run: yarn contract-mochawesome-to-bigquery
-        working-directory: qa-standards-dashboard-data
-        env:
-          TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
-          TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
-          TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
-
-      - name: Upload Contract Test report to s3
-        run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-contract-test-reports --acl public-read --region us-gov-west-1 --recursive
-
-      # -------------------------
-      # | Contract Tests Summary |
-      # -------------------------
-
-      - name: Publish Contract test results
-        if: ${{ always() }}
-        uses: LouisBrunner/checks-action@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Contract Tests Summary
-          conclusion: ${{ needs.contract-tests.result }}
-          output: |
-            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-
-  testing-reports-unit-tests:
-    name: Testing Reports - Unit Tests
-    runs-on: ubuntu-latest
-    needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() }}
-    continue-on-error: true
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-    steps:
-      - name: Set IS_MASTER_BUILD
-        run: |
-          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-              echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
-          else
-              echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
-          fi
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # ----------------
-      # | Notify Slack |
-      # ----------------
-
-      - name: Notify Slack about Unit test failures
-        if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.result == 'failure' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-        continue-on-error: true
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-        with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-          channel_id: C026PD47Z19 #gha-test-status
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      # ------------------------
-      # | Upload BigQuery Data |
-      # ------------------------
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get va-vsp-bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
-
-      - name: Get AWS IAM role
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Set UUID for Mochawesome reports
-        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      # --------------------------------------------------
-      # | Publish Unit Test Report and Upload to BigQuery |
-      # --------------------------------------------------
-
-      - name: Download Unit Test Mochawesome test results
-        uses: actions/download-artifact@v3
-        with:
-          name: unit-test-report
-          path: qa-standards-dashboard-data/src/testing-reports/data
-
-      - name: Create Unit Test report and post results to BigQuery
-        run: yarn unit-mochawesome-to-bigquery
-        working-directory: qa-standards-dashboard-data
-        env:
-          UNIT_TEST_RESULTS_TABLE_NAME: vets_website_unit_test_results
-          UNIT_TEST_EXECUTIONS_TABLE_NAME: unit_test_suite_executions
-          TEST_REPORTS_FOLDER_NAME: vets-website-unit-test-reports
-
-      - name: Upload Unit Test report to s3
-        run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
-
-      # -------------------------
-      # | Unit Tests Summary |
-      # -------------------------
-
-      - name: Unit test results
-        if: ${{ always() }}
-        uses: LouisBrunner/checks-action@v1.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Unit Tests Summary
-          conclusion: ${{ needs.unit-tests.result }}
-          output: |
-            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-
-  testing-reports-unit-tests-coverage:
-    name: Testing Reports - Unit Tests Coverage
-    runs-on: ubuntu-latest
-    needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
-    continue-on-error: true
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # ------------------------
-      # | Upload BigQuery Data |
-      # ------------------------
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get va-vsp-bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
-
-      - name: Get AWS IAM role
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Set UUID for Mochawesome reports
-        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      # --------------------------------------
-      # | Publish Unit Test Coverage Report       |
-      # -------------------------------------
-
-      - name: Download Unit Test Coverage Report
-        uses: actions/download-artifact@v3
-        with:
-          name: unit-test-coverage-report
-          path: qa-standards-dashboard-data/src/testing-reports/data
-
-      - name: Process Coverage Report and post results to BigQuery
-        run: yarn unit-coverage-to-bigquery
-        working-directory: qa-standards-dashboard-data
-
-  testing-reports-cypress:
-    name: Testing Reports - Cypress E2E Tests
-    runs-on: ubuntu-latest
-    needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
-    if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Notify Slack about Cypress test failures
-        if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-        continue-on-error: true
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-        with:
-          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
-          channel_id: C026PD47Z19 #gha-test-status
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-        # ------------------------
-        # | Upload BigQuery Data |
-        # ------------------------
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get va-vsp-bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
-
-      - name: Get AWS IAM role
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Set UUID for Mochawesome reports
-        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-        # --------------------------------------
-        # | Publish Cypress E2E Testing Report |
-        # -------------------------------------
-
-      - name: Download Cypress E2E Mochawesome test results
-        uses: actions/download-artifact@v3
-        with:
-          name: cypress-mochawesome-test-results
-          path: qa-standards-dashboard-data/src/testing-reports/data
-
-      - name: Download Cypress E2E video artifacts
-        if: ${{ needs.cypress-tests.result == 'failure' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: cypress-video-artifacts
-          path: qa-standards-dashboard-data/videos/${{ env.UUID }}
-
-      - name: Create Cypress E2E report and post results to BigQuery
-        run: yarn cypress-mochawesome-to-bigquery
-        working-directory: qa-standards-dashboard-data
-        env:
-          IS_MASTER_BUILD: false
-          TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
-          TEST_RESULTS_TABLE_NAME: cypress_test_results
-          TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports
-          TEST_RETRIES_TABLE_NAME: cypress_retry_records
-          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
-          # env.MOCHAWESOME_REPORT_RESULTS is set and exported during the above step when the mochawesome report is generated.  It contains the output string for the publish step at the end of the job with the numbers from the Mochawesome report.
-
-      - name: Upload Cypress E2E test videos to s3
-        if: ${{ needs.cypress-tests.result == 'failure' }}
-        run: aws s3 cp qa-standards-dashboard-data/videos/${{ env.UUID }} s3://testing-tools-testing-reports/vets-website-cypress-reports/videos/${{ env.UUID }} --acl public-read --region us-gov-west-1 --recursive
-
-      - name: Upload Cypress E2E test report to s3
-        run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-cypress-reports --acl public-read --region us-gov-west-1 --recursive
-
-        # -------------------------
-        # | Cypress Tests Summary |
-        # -------------------------
-
-      - name: Publish Cypress test results
-        if: ${{ always() }}
-        uses: LouisBrunner/checks-action@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Cypress Tests Summary
-          conclusion: ${{ needs.cypress-tests.result }}
-          output: |
-            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-
-  archive:
-    name: Archive
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        buildtype: [vagovdev, vagovstaging, vagovprod]
-
-    needs:
-      [
-        build,
-        cypress-tests,
-        unit-tests,
-        contract-tests,
-        security-audit,
-        linting,
-      ]
-
-    env:
-      IS_SINGLE_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
-
-    # Archive should still run even when linting is skipped (as in PRs).
-    # This if overrides the dependency on linting success to include skipped.
-    # Because of always(), the rest of the needed jobs have to be checked too.
-    # By doing this, later jobs that need this job require similar overrides
-    # or else they will also be skipped when linting is skipped.
-    if: |
-      always() &&
-      (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'skipped') &&
-      needs.build.result == 'success' &&
-      needs.unit-tests.result == 'success' &&
-      needs.contract-tests.result == 'success' &&
-      needs.security-audit.result == 'success' &&
-      (needs.linting.result == 'success' || needs.linting.result == 'skipped')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.buildtype }}.tar.bz2
-
-      - name: Extract build artifact
-        if: env.IS_SINGLE_APP_BUILD == 'true'
-        run: |
-          mkdir -p build/${{ matrix.buildtype }}
-          tar -C build/${{ matrix.buildtype }} -xjvf ${{ matrix.buildtype }}.tar.bz2
-          rm ${{ matrix.buildtype }}.tar.bz2
-
-      - name: Remove global assets from build
-        if: env.IS_SINGLE_APP_BUILD == 'true'
-        run: ./script/github-actions/remove-global-assets.sh
-        env:
-          ENTRY_NAMES: ${{ needs.build.outputs.entry_names }}
-          APP_DIRS: ${{ needs.unit-tests.outputs.app_folders }}
-          BUILD_DIR: build/${{ matrix.buildtype }}
-
-      - name: Generate build details
-        run: |
-          cat > BUILD_ARTIFACT.txt << EOF
-          IS_SINGLE_APP_BUILD=${{ env.IS_SINGLE_APP_BUILD }}
-          REF=${{ github.sha }}
-          EOF
-
-      - name: Compress and archive single/grouped app build
-        if: env.IS_SINGLE_APP_BUILD == 'true'
-        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
-
-      - name: Configure AWS credentials (1)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get AWS IAM role
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Upload build
-        run: |
-          aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
-          aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
-
-  set-deploy-environments:
-    name: Set Environments to Deploy
-    needs: [archive, build]
-    if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
-    runs-on: ubuntu-latest
-    outputs:
-      environments: ${{ steps.set-environments.outputs.environments }}
-    env:
-      DEPLOY_TO_PRODUCTION: false # Enables production deployments for apps on the allowlist when set to true
-      DEV: "{
-          \\\"environment\\\": \\\"vagovdev\\\", 
-          \\\"bucket\\\": \\\"dev.va.gov\\\", 
-          \\\"asset_bucket\\\": \\\"dev-va-gov-assets\\\",
-          \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
-        }"
-      STAGING: "{
-          \\\"environment\\\": \\\"vagovstaging\\\", 
-          \\\"bucket\\\": \\\"staging.va.gov\\\", 
-          \\\"asset_bucket\\\": \\\"staging-va-gov-assets\\\",
-          \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
-        }"
-      PROD: "{
-          \\\"environment\\\": \\\"vagovprod\\\", 
-          \\\"bucket\\\": \\\"www.va.gov\\\", 
-          \\\"asset_bucket\\\": \\\"prod-va-gov-assets\\\",
-          \\\"iam_role\\\": \\\"AWS_FRONTEND_PROD_ROLE\\\"
-        }"
-    steps:
-      - name: Set environments for deploy matrix
-        id: set-environments
-        run: |
-          if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ needs.build.outputs.continuous_deployment }} == true ]]; then
-            echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}},${{env.PROD}}]}
-          else
-            echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}}]}
-          fi
+  # build:
+  #   name: Build
+  #   runs-on: self-hosted
+  #   outputs:
+  #     entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
+  #     continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
+
+  #   env:
+  #     NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       buildtype: [vagovdev, vagovstaging, vagovprod]
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         delimiter: ','
+  #         output-type: 'entry_name, continuous_deployment'
+
+  #     - name: Configure AWS Credentials
+  #       if: ${{ matrix.buildtype == 'vagovprod' }}
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get Mapbox Token
+  #       if: ${{ matrix.buildtype == 'vagovprod' }}
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token
+  #         env_variable_name: MAPBOX_TOKEN
+
+  #     - name: Build
+  #       run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
+  #       timeout-minutes: 30
+  #       env:
+  #         ENTRY: ${{ steps.get-changed-apps.outputs.entry_names }}
+
+  #     - name: Generate build details
+  #       run: |
+  #         cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
+  #         BUILDTYPE=${{ matrix.buildtype }}
+  #         NODE_ENV=production
+  #         BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+  #         CHANGE_TARGET=null
+  #         RUN_ID=${{ github.run_id }}
+  #         RUN_NUMBER=${{ github.run_number }}
+  #         REF=${{ github.sha }}
+  #         BUILDTIME=$(date +%s)
+  #         EOF
+
+  #     - name: Compress and archive build
+  #       run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+
+  #     - name: Upload build artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{ matrix.buildtype }}.tar.bz2
+  #         path: ${{ matrix.buildtype }}.tar.bz2
+  #         retention-days: 1
+
+  # unit-tests:
+  #   name: Unit Tests
+  #   runs-on: self-hosted
+  #   outputs:
+  #     app_folders: ${{ steps.get-changed-apps.outputs.folders }}
+
+  #   env:
+  #     NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Create test results folder
+  #       run: mkdir -p test-results
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         delimiter: ','
+  #         output-type: 'folder'
+
+  #     - name: Run unit tests
+  #       run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} --coverage
+  #       env:
+  #         MOCHA_FILE: test-results/unit-tests.xml
+  #         APP_FOLDERS: ${{ steps.get-changed-apps.outputs.folders }}
+
+  #     - name: Archive unit test results
+  #       if: ${{ always() }}
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: unit-test-report
+  #         path: mochawesome-report
+
+  #     - name: Generate coverage report by app
+  #       run: node script/app-coverage-report.js > test-results/coverage_report.txt
+
+  #     - name: Upload Coverage Report Artifact
+  #       uses: actions/upload-artifact@v3
+  #       if: ${{ always() }}
+  #       with:
+  #         name: unit-test-coverage-report
+  #         path: coverage/test-coverage-report.json
+
+  #     - name: Configure AWS credentials (1)
+  #       if: ${{ github.ref == 'refs/heads/main' }}
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get AWS IAM role
+  #       if: ${{ github.ref == 'refs/heads/main' }}
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+  #     - name: Configure AWS Credentials (2)
+  #       if: ${{ github.ref == 'refs/heads/main' }}
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #     - name: Upload coverage report to S3
+  #       if: ${{ github.ref == 'refs/heads/main' && steps.get-changed-apps.outputs.folders == '' }}
+  #       run: aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+
+  #     - name: Get code coverage
+  #       if: ${{ always() }}
+  #       id: code-coverage
+  #       run: echo ::set-output name=MARKDOWN::$(node ./script/github-actions/code-coverage-format-report.js)
+
+  #     - name: Publish test results
+  #       if: ${{ always() }}
+  #       continue-on-error: true
+  #       uses: mikepenz/action-junit-report@v2.8.4
+  #       with:
+  #         check_name: 'Unit Tests Summary'
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         report_paths: 'test-results/unit-tests.xml'
+  #         summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
+  #         fail_on_failure: 'true'
+
+  # contract-tests:
+  #   name: Contract Tests
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     tests: ${{ steps.get-tests.outputs.tests }}
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get Pact Broker password
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /dsva-vagov/pact-broker/utility/PACT_BROKER_BASIC_AUTH_PASSWORD
+  #         env_variable_name: PACT_BROKER_BASIC_AUTH_PASSWORD
+
+  #     - name: Get GitHub token
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Create test results folder
+  #       run: mkdir -p test-results
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         output-type: 'folder'
+
+  #     - name: Get contract tests
+  #       id: get-tests
+  #       run: |
+  #         if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
+  #           echo ::set-output name=tests::$(find src -name "*.pact.spec.js")
+  #         else
+  #           echo ::set-output name=tests::$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.pact.spec.js")
+  #         fi
+
+  #     - name: Run contract tests
+  #       if: steps.get-tests.outputs.tests != ''
+  #       run: yarn test:unit-pact-config ${{ steps.get-tests.outputs.tests }}
+  #       env:
+  #         MOCHA_FILE: ./test-results/test-results.xml
+
+  #     - name: Print Pact failures
+  #       if: steps.get-tests.outputs.tests != '' && failure()
+  #       run: cat test-results/test-results.xml
+
+  #     - name: Run Pact publish
+  #       if: steps.get-tests.outputs.tests != ''
+  #       run: yarn pact:publish
+  #       env:
+  #         PACT_BROKER_BASIC_AUTH_USERNAME: pact-broker
+  #         PACT_BROKER_BASE_URL: https://dev.va.gov/_vfs/pact-broker/
+
+  #     - name: Run Pact verify
+  #       if: steps.get-tests.outputs.tests != ''
+  #       run: |
+  #         curl -v -X POST \
+  #         -H 'Authorization: token ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}' \
+  #         -H 'Accept: application/vnd.github.v3+json' \
+  #         https://api.github.com/repos/department-of-veterans-affairs/vets-api/actions/workflows/8289333/dispatches \
+  #         -d '{"ref": "master"}' \
+  #         --fail
+
+  #     - name: Archive contract test results
+  #       if: steps.get-tests.outputs.tests != ''
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: contract-test-report
+  #         path: mochawesome-report
+
+  #     - name: Archive contract test log
+  #       uses: actions/upload-artifact@v3
+  #       if: steps.get-tests.outputs.tests != '' && failure()
+  #       with:
+  #         name: contract-test-log
+  #         path: logs/pact.log
+
+  # security-audit:
+  #   name: Security Audit
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         output-type: 'entry_name'
+
+  #     - name: Audit dependencies
+  #       if: steps.get-changed-apps.outputs.entry_names == ''
+  #       run: yarn security-check
+
+  # linting:
+  #   name: Linting (All)
+  #   if: ${{ github.ref == 'refs/heads/main' }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         output-type: 'folder'
+
+  #     - name: Annotate ESLint results
+  #       run: |
+  #         if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
+  #           yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
+  #         else
+  #           yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js \
+  #           ${{ steps.get-changed-apps.outputs.folders }}
+  #         fi
+
+  #     - name: Run Stylelint
+  #       if: ${{ always() }}
+  #       run: |
+  #         if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
+  #           yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
+  #         else
+  #           files=$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.scss")
+  #           if [[ -n "$files" ]]; then yarn run stylelint verbose --output-file stylelint-report.json --formatter json $(echo $files); fi
+  #         fi
+
+  #     - name: Annotate Stylelint results
+  #       if: ${{ always() }}
+  #       run: node ./script/github-actions/stylelint-annotation-format.js
+
+  # testing-reports-prep:
+  #   name: Testing Reports Prep
+  #   runs-on: ubuntu-latest
+  #   continue-on-error: true
+  #   outputs:
+  #     app_list: ${{ env.APPLICATION_LIST }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Generate new application list
+  #       run: yarn generate-app-list
+  #     # exports app list and assigns to environmental variable at this step
+
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get va-vsp-bot token
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+  #     - name: Init Dashboard Data Repo
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+  #     - name: Set Up BigQuery Creds
+  #       uses: ./.github/workflows/configure-bigquery
+
+  #     - name: Upload app list to BigQuery
+  #       run: yarn generate-app-list
+  #       working-directory: qa-standards-dashboard-data
+
+  # cypress-tests-prep:
+  #   name: Prep for Cypress Tests
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     tests: ${{ steps.tests.outputs.selected }}
+  #     app_urls: ${{ steps.get-changed-apps.outputs.urls }}
+  #     num_containers: ${{ steps.containers.outputs.num }}
+  #     ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         delimiter: ','
+  #         output-type: 'entry_name, url'
+
+  #     - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
+  #       run: node script/github-actions/select-cypress-tests.js
+  #       env:
+  #         RUN_FULL_SUITE: false
+  #         CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
+  #         APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
+  #         APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}
+
+  #     - name: Set output of TESTS
+  #       id: tests
+  #       run: echo ::set-output name=selected::$TESTS
+
+  #     - name: Set output of NUM_CONTAINERS
+  #       id: containers
+  #       run: echo ::set-output name=num::$NUM_CONTAINERS
+
+  #     - name: Set output of CI_NODE_INDEX
+  #       id: matrix
+  #       run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
+
+  # cypress-tests:
+  #   name: Cypress E2E Tests
+  #   runs-on: self-hosted
+  #   timeout-minutes: 60
+  #   needs: [build, cypress-tests-prep]
+  #   if: |
+  #     needs.build.result == 'success' &&
+  #     needs.cypress-tests-prep.result == 'success'
+  #   container:
+  #     image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
+  #     options: -u 1001:1001 -v /usr/local/share:/share
+
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 12
+  #     matrix:
+  #       ci_node_index: ${{ fromJson(needs.cypress-tests-prep.outputs.ci_node_index) }}
+
+  #   env:
+  #     CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
+  #     NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
+
+  #   steps:
+  #     # The following statement is included in each step because of a bug in
+  #     # GitHub's branch protection:
+  #     #
+  #     # if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #     #
+  #     # Previously, if no tests were selected, the branch protection check that
+  #     # requires the cypress-tests job to run was not satisfied. This update forces
+  #     # the job to always run, and skips each step if no tests are selected.
+  #     # Previously, the above conditional was included in the job's if statement.
+  #     - name: Configure AWS credentials
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Checkout vets-website
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       uses: actions/checkout@v3
+
+  #     - name: Download production build artifact
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: vagovprod.tar.bz2
+
+  #     - name: Unpack build
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       run: |
+  #         mkdir -p build/vagovprod
+  #         tar -C build/vagovprod -xjf vagovprod.tar.bz2
+
+  #     - name: Install dependencies
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 20
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           /github/home/.cache/Cypress
+  #           node_modules
+
+  #     - name: Start server
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+
+  #     - name: Run Cypress tests
+  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
+  #       run: node script/github-actions/run-cypress-tests.js
+  #       timeout-minutes: 40
+  #       env:
+  #         CYPRESS_CI: true
+  #         STEP: ${{ matrix.ci_node_index }}
+  #         TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
+  #         APP_URLS: ${{ needs.cypress-tests-prep.outputs.app_urls }}
+  #         NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+
+  #     - name: Archive test videos
+  #       if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: cypress-video-artifacts
+  #         path: cypress/videos
+
+  #     - name: Archive test screenshots
+  #       if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: cypress-screenshot-artifacts
+  #         path: cypress/screenshots
+
+  #     - name: Archive Mochawesome test results
+  #       if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && always() }}
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: cypress-mochawesome-test-results
+  #         path: cypress/results
+  #         retention-days: 1
+
+  # testing-reports-contract-tests:
+  #   name: Testing Reports - Contract Tests
+  #   runs-on: ubuntu-latest
+  #   needs: [testing-reports-prep, contract-tests]
+  #   if: |
+  #     always() &&
+  #     needs.contract-tests.outputs.tests != '' &&
+  #     (needs.contract-tests.result == 'success' || needs.contract-tests.result == 'failure')
+  #   continue-on-error: true
+  #   env:
+  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+  #   steps:
+  #     - name: Set IS_MASTER_BUILD
+  #       run: |
+  #         if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
+  #             echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
+  #         else
+  #             echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
+  #         fi
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     # ----------------
+  #     # | Notify Slack |
+  #     # ----------------
+
+  #     - name: Notify Slack about Contract test failures
+  #       if: ${{ github.ref == 'refs/heads/main' && needs.contract-tests.result == 'failure' }}
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+  #       continue-on-error: true
+  #       env:
+  #         SSL_CERT_DIR: /etc/ssl/certs
+  #       with:
+  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Contract tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+  #         channel_id: C026PD47Z19 #gha-test-status
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  #     # ------------------------
+  #     # | Upload BigQuery Data |
+  #     # ------------------------
+
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get va-vsp-bot token
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+  #     - name: Init Dashboard Data Repo
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+  #     - name: Set Up BigQuery Creds
+  #       uses: ./.github/workflows/configure-bigquery
+
+  #     - name: Get AWS IAM role
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+  #     - name: Set UUID for Mochawesome reports
+  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+  #     - name: Configure AWS Credentials (2)
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #     # ------------------------------------------------------
+  #     # | Publish Contract Test Report and Upload to BigQuery |
+  #     # ------------------------------------------------------
+
+  #     - name: Download Contract Test Mochawesome test results
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: contract-test-report
+  #         path: qa-standards-dashboard-data/src/testing-reports/data
+
+  #     - name: Create Contract Test report and post results to BigQuery
+  #       run: yarn contract-mochawesome-to-bigquery
+  #       working-directory: qa-standards-dashboard-data
+  #       env:
+  #         TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
+  #         TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
+  #         TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
+
+  #     - name: Upload Contract Test report to s3
+  #       run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-contract-test-reports --acl public-read --region us-gov-west-1 --recursive
+
+  #     # -------------------------
+  #     # | Contract Tests Summary |
+  #     # -------------------------
+
+  #     - name: Publish Contract test results
+  #       if: ${{ always() }}
+  #       uses: LouisBrunner/checks-action@v1.2.0
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         name: Contract Tests Summary
+  #         conclusion: ${{ needs.contract-tests.result }}
+  #         output: |
+  #           {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+  # testing-reports-unit-tests:
+  #   name: Testing Reports - Unit Tests
+  #   runs-on: ubuntu-latest
+  #   needs: [testing-reports-prep, unit-tests]
+  #   if: ${{ always() }}
+  #   continue-on-error: true
+  #   env:
+  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+  #   steps:
+  #     - name: Set IS_MASTER_BUILD
+  #       run: |
+  #         if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
+  #             echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
+  #         else
+  #             echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
+  #         fi
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     # ----------------
+  #     # | Notify Slack |
+  #     # ----------------
+
+  #     - name: Notify Slack about Unit test failures
+  #       if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.result == 'failure' }}
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+  #       continue-on-error: true
+  #       env:
+  #         SSL_CERT_DIR: /etc/ssl/certs
+  #       with:
+  #         attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+  #         channel_id: C026PD47Z19 #gha-test-status
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  #     # ------------------------
+  #     # | Upload BigQuery Data |
+  #     # ------------------------
+
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get va-vsp-bot token
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+  #     - name: Init Dashboard Data Repo
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+  #     - name: Set Up BigQuery Creds
+  #       uses: ./.github/workflows/configure-bigquery
+
+  #     - name: Get AWS IAM role
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+  #     - name: Set UUID for Mochawesome reports
+  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+  #     - name: Configure AWS Credentials (2)
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #     # --------------------------------------------------
+  #     # | Publish Unit Test Report and Upload to BigQuery |
+  #     # --------------------------------------------------
+
+  #     - name: Download Unit Test Mochawesome test results
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: unit-test-report
+  #         path: qa-standards-dashboard-data/src/testing-reports/data
+
+  #     - name: Create Unit Test report and post results to BigQuery
+  #       run: yarn unit-mochawesome-to-bigquery
+  #       working-directory: qa-standards-dashboard-data
+  #       env:
+  #         UNIT_TEST_RESULTS_TABLE_NAME: vets_website_unit_test_results
+  #         UNIT_TEST_EXECUTIONS_TABLE_NAME: unit_test_suite_executions
+  #         TEST_REPORTS_FOLDER_NAME: vets-website-unit-test-reports
+
+  #     - name: Upload Unit Test report to s3
+  #       run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
+
+  #     # -------------------------
+  #     # | Unit Tests Summary |
+  #     # -------------------------
+
+  #     - name: Unit test results
+  #       if: ${{ always() }}
+  #       uses: LouisBrunner/checks-action@v1.1.1
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         name: Unit Tests Summary
+  #         conclusion: ${{ needs.unit-tests.result }}
+  #         output: |
+  #           {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+  # testing-reports-unit-tests-coverage:
+  #   name: Testing Reports - Unit Tests Coverage
+  #   runs-on: ubuntu-latest
+  #   needs: [testing-reports-prep, unit-tests]
+  #   if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
+  #   continue-on-error: true
+  #   env:
+  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     # ------------------------
+  #     # | Upload BigQuery Data |
+  #     # ------------------------
+
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get va-vsp-bot token
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+  #     - name: Init Dashboard Data Repo
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+  #     - name: Set Up BigQuery Creds
+  #       uses: ./.github/workflows/configure-bigquery
+
+  #     - name: Get AWS IAM role
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+  #     - name: Set UUID for Mochawesome reports
+  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+  #     - name: Configure AWS Credentials (2)
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #     # --------------------------------------
+  #     # | Publish Unit Test Coverage Report       |
+  #     # -------------------------------------
+
+  #     - name: Download Unit Test Coverage Report
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: unit-test-coverage-report
+  #         path: qa-standards-dashboard-data/src/testing-reports/data
+
+  #     - name: Process Coverage Report and post results to BigQuery
+  #       run: yarn unit-coverage-to-bigquery
+  #       working-directory: qa-standards-dashboard-data
+
+  # testing-reports-cypress:
+  #   name: Testing Reports - Cypress E2E Tests
+  #   runs-on: ubuntu-latest
+  #   needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
+  #   if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+  #   env:
+  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+  #   continue-on-error: true
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Notify Slack about Cypress test failures
+  #       if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+  #       continue-on-error: true
+  #       env:
+  #         SSL_CERT_DIR: /etc/ssl/certs
+  #       with:
+  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+  #         channel_id: C026PD47Z19 #gha-test-status
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  #       # ------------------------
+  #       # | Upload BigQuery Data |
+  #       # ------------------------
+
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get va-vsp-bot token
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+  #     - name: Init Dashboard Data Repo
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+  #     - name: Set Up BigQuery Creds
+  #       uses: ./.github/workflows/configure-bigquery
+
+  #     - name: Get AWS IAM role
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+  #     - name: Set UUID for Mochawesome reports
+  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+  #     - name: Configure AWS Credentials (2)
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #       # --------------------------------------
+  #       # | Publish Cypress E2E Testing Report |
+  #       # -------------------------------------
+
+  #     - name: Download Cypress E2E Mochawesome test results
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: cypress-mochawesome-test-results
+  #         path: qa-standards-dashboard-data/src/testing-reports/data
+
+  #     - name: Download Cypress E2E video artifacts
+  #       if: ${{ needs.cypress-tests.result == 'failure' }}
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: cypress-video-artifacts
+  #         path: qa-standards-dashboard-data/videos/${{ env.UUID }}
+
+  #     - name: Create Cypress E2E report and post results to BigQuery
+  #       run: yarn cypress-mochawesome-to-bigquery
+  #       working-directory: qa-standards-dashboard-data
+  #       env:
+  #         IS_MASTER_BUILD: false
+  #         TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
+  #         TEST_RESULTS_TABLE_NAME: cypress_test_results
+  #         TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports
+  #         TEST_RETRIES_TABLE_NAME: cypress_retry_records
+  #         NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+  #         # env.MOCHAWESOME_REPORT_RESULTS is set and exported during the above step when the mochawesome report is generated.  It contains the output string for the publish step at the end of the job with the numbers from the Mochawesome report.
+
+  #     - name: Upload Cypress E2E test videos to s3
+  #       if: ${{ needs.cypress-tests.result == 'failure' }}
+  #       run: aws s3 cp qa-standards-dashboard-data/videos/${{ env.UUID }} s3://testing-tools-testing-reports/vets-website-cypress-reports/videos/${{ env.UUID }} --acl public-read --region us-gov-west-1 --recursive
+
+  #     - name: Upload Cypress E2E test report to s3
+  #       run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-cypress-reports --acl public-read --region us-gov-west-1 --recursive
+
+  #       # -------------------------
+  #       # | Cypress Tests Summary |
+  #       # -------------------------
+
+  #     - name: Publish Cypress test results
+  #       if: ${{ always() }}
+  #       uses: LouisBrunner/checks-action@v1.2.0
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         name: Cypress Tests Summary
+  #         conclusion: ${{ needs.cypress-tests.result }}
+  #         output: |
+  #           {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+  # archive:
+  #   name: Archive
+  #   runs-on: ubuntu-latest
+
+  #   strategy:
+  #     matrix:
+  #       buildtype: [vagovdev, vagovstaging, vagovprod]
+
+  #   needs:
+  #     [
+  #       build,
+  #       cypress-tests,
+  #       unit-tests,
+  #       contract-tests,
+  #       security-audit,
+  #       linting,
+  #     ]
+
+  #   env:
+  #     IS_SINGLE_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
+
+  #   # Archive should still run even when linting is skipped (as in PRs).
+  #   # This if overrides the dependency on linting success to include skipped.
+  #   # Because of always(), the rest of the needed jobs have to be checked too.
+  #   # By doing this, later jobs that need this job require similar overrides
+  #   # or else they will also be skipped when linting is skipped.
+  #   if: |
+  #     always() &&
+  #     (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'skipped') &&
+  #     needs.build.result == 'success' &&
+  #     needs.unit-tests.result == 'success' &&
+  #     needs.contract-tests.result == 'success' &&
+  #     needs.security-audit.result == 'success' &&
+  #     (needs.linting.result == 'success' || needs.linting.result == 'skipped')
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Download build artifact
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: ${{ matrix.buildtype }}.tar.bz2
+
+  #     - name: Extract build artifact
+  #       if: env.IS_SINGLE_APP_BUILD == 'true'
+  #       run: |
+  #         mkdir -p build/${{ matrix.buildtype }}
+  #         tar -C build/${{ matrix.buildtype }} -xjvf ${{ matrix.buildtype }}.tar.bz2
+  #         rm ${{ matrix.buildtype }}.tar.bz2
+
+  #     - name: Remove global assets from build
+  #       if: env.IS_SINGLE_APP_BUILD == 'true'
+  #       run: ./script/github-actions/remove-global-assets.sh
+  #       env:
+  #         ENTRY_NAMES: ${{ needs.build.outputs.entry_names }}
+  #         APP_DIRS: ${{ needs.unit-tests.outputs.app_folders }}
+  #         BUILD_DIR: build/${{ matrix.buildtype }}
+
+  #     - name: Generate build details
+  #       run: |
+  #         cat > BUILD_ARTIFACT.txt << EOF
+  #         IS_SINGLE_APP_BUILD=${{ env.IS_SINGLE_APP_BUILD }}
+  #         REF=${{ github.sha }}
+  #         EOF
+
+  #     - name: Compress and archive single/grouped app build
+  #       if: env.IS_SINGLE_APP_BUILD == 'true'
+  #       run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+
+  #     - name: Configure AWS credentials (1)
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get AWS IAM role
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+  #     - name: Configure AWS Credentials (2)
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #     - name: Upload build
+  #       run: |
+  #         aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
+  #         aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
+
+  # set-deploy-environments:
+  #   name: Set Environments to Deploy
+  #   needs: [archive, build]
+  #   if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     environments: ${{ steps.set-environments.outputs.environments }}
+  #   env:
+  #     DEPLOY_TO_PRODUCTION: false # Enables production deployments for apps on the allowlist when set to true
+  #     DEV: "{
+  #         \\\"environment\\\": \\\"vagovdev\\\", 
+  #         \\\"bucket\\\": \\\"dev.va.gov\\\", 
+  #         \\\"asset_bucket\\\": \\\"dev-va-gov-assets\\\",
+  #         \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
+  #       }"
+  #     STAGING: "{
+  #         \\\"environment\\\": \\\"vagovstaging\\\", 
+  #         \\\"bucket\\\": \\\"staging.va.gov\\\", 
+  #         \\\"asset_bucket\\\": \\\"staging-va-gov-assets\\\",
+  #         \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
+  #       }"
+  #     PROD: "{
+  #         \\\"environment\\\": \\\"vagovprod\\\", 
+  #         \\\"bucket\\\": \\\"www.va.gov\\\", 
+  #         \\\"asset_bucket\\\": \\\"prod-va-gov-assets\\\",
+  #         \\\"iam_role\\\": \\\"AWS_FRONTEND_PROD_ROLE\\\"
+  #       }"
+  #   steps:
+  #     - name: Set environments for deploy matrix
+  #       id: set-environments
+  #       run: |
+  #         if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ needs.build.outputs.continuous_deployment }} == true ]]; then
+  #           echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}},${{env.PROD}}]}
+  #         else
+  #           echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}}]}
+  #         fi
   
-  deploy:
-    name: Deploy
-    needs: [build, set-deploy-environments]
-    if: always() && github.ref == 'refs/heads/main' && needs.set-deploy-environments.result == 'success'
+  # deploy:
+  #   name: Deploy
+  #   needs: [build, set-deploy-environments]
+  #   if: always() && github.ref == 'refs/heads/main' && needs.set-deploy-environments.result == 'success'
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix: ${{ fromJson(needs.set-deploy-environments.outputs.environments) }}
+  #   env:
+  #     IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Check if commit can be deployed
+  #       id: check-deployability
+  #       run: node ./script/github-actions/check-deployability.js
+  #       env:
+  #         BUILDTYPE: ${{ matrix.environment }}
+
+  #     - name: Configure AWS credentials (1)
+  #       if: steps.check-deployability.outputs.is_deployable == 'true'
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+
+  #     - name: Get AWS IAM role
+  #       if: steps.check-deployability.outputs.is_deployable == 'true'
+  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/${{ matrix.iam_role }}
+  #         env_variable_name: ${{ matrix.iam_role }}
+
+  #     - name: Configure AWS Credentials (2)
+  #       if: steps.check-deployability.outputs.is_deployable == 'true'
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-gov-west-1
+  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE != '' && env.AWS_FRONTEND_NONPROD_ROLE || env.AWS_FRONTEND_PROD_ROLE }}
+  #         role-duration-seconds: 900
+  #         role-session-name: vsp-frontendteam-githubaction
+
+  #     - name: Deploy
+  #       if: steps.check-deployability.outputs.is_deployable == 'true'
+  #       run: |
+  #         if [[ "${{ env.IS_ISOLATED_APP_BUILD }}" == "true" ]]; then
+  #           ./script/github-actions/partial-deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
+  #         else
+  #           ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
+  #         fi
+  #       env:
+  #         SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
+  #         DEST: s3://${{ matrix.bucket }}
+  #         ASSET_DEST: s3://${{ matrix.asset_bucket }}
+
+  # notify-failure:
+  #   name: Notify Failure
+  #   runs-on: ubuntu-latest
+  #   if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
+  #   needs: deploy
+  #   env:
+  #     ALERT_TEAMS: true # Alerts teams for single/grouped app builds when set to true
+  #     DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
+  #     VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Install dependencies
+  #       if: env.ALERT_TEAMS == 'true'
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+
+  #     - name: Get changed applications
+  #       id: get-changed-apps
+  #       if: env.ALERT_TEAMS == 'true'
+  #       uses: ./.github/workflows/get-changed-apps
+  #       with:
+  #         output-type: 'slack_group'
+
+  #     - name: Notify application team in Slack
+  #       if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+  #       continue-on-error: true
+  #       with:
+  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${{steps.get-changed-apps.outputs.slack_groups}} CI for your application failed on the `main` branch in `vets-website`: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>\n For help troubleshooting, see the <https://depo-platform-documentation.scrollhelp.site/developer-docs/Handling-failed-single%2Fgrouped-application-pipelines.2066645150.html|documentation> on failed workflow runs."}}]}]}'
+  #         channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  #     - name: Notify Slack
+  #       if: steps.get-changed-apps.outputs.slack_groups == ''
+  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+  #       continue-on-error: true
+  #       with:
+  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "`main` branch CI in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+  #         channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  notify-start:
+    name: Notify Start
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.set-deploy-environments.outputs.environments) }}
+    needs: set-env
     env:
-      IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
+      # DURATION: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
+      RELEASE_WAIT_MINUTES: ${{ 0 < 5 && 'a few' || 0 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Check if commit can be deployed
-        id: check-deployability
-        run: node ./script/github-actions/check-deployability.js
-        env:
-          BUILDTYPE: ${{ matrix.environment }}
-
-      - name: Configure AWS credentials (1)
-        if: steps.check-deployability.outputs.is_deployable == 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get AWS IAM role
-        if: steps.check-deployability.outputs.is_deployable == 'true'
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/${{ matrix.iam_role }}
-          env_variable_name: ${{ matrix.iam_role }}
-
-      - name: Configure AWS Credentials (2)
-        if: steps.check-deployability.outputs.is_deployable == 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE != '' && env.AWS_FRONTEND_NONPROD_ROLE || env.AWS_FRONTEND_PROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Deploy
-        if: steps.check-deployability.outputs.is_deployable == 'true'
-        run: |
-          if [[ "${{ env.IS_ISOLATED_APP_BUILD }}" == "true" ]]; then
-            ./script/github-actions/partial-deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
-          else
-            ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
-          fi
-        env:
-          SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
-          DEST: s3://${{ matrix.bucket }}
-          ASSET_DEST: s3://${{ matrix.asset_bucket }}
-
-  notify-failure:
-    name: Notify Failure
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
-    needs: deploy
-    env:
-      ALERT_TEAMS: true # Alerts teams for single/grouped app builds when set to true
-      DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
-      VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        if: env.ALERT_TEAMS == 'true'
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
-      - name: Get changed applications
-        id: get-changed-apps
-        if: env.ALERT_TEAMS == 'true'
-        uses: ./.github/workflows/get-changed-apps
-        with:
-          output-type: 'slack_group'
-
-      - name: Notify application team in Slack
-        if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-        continue-on-error: true
-        with:
-          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${{steps.get-changed-apps.outputs.slack_groups}} CI for your application failed on the `main` branch in `vets-website`: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>\n For help troubleshooting, see the <https://depo-platform-documentation.scrollhelp.site/developer-docs/Handling-failed-single%2Fgrouped-application-pipelines.2066645150.html|documentation> on failed workflow runs."}}]}]}'
-          channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Notify Slack
-        if: steps.get-changed-apps.outputs.slack_groups == ''
-        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "`main` branch CI in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
-          channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
+          channel_id: C032FM8LFCN
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1278,7 +1278,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"
+                        "text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what's coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"
                       }
                     }
                   ]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1256,7 +1256,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # DURATION: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
-      RELEASE_WAIT_MINUTES: ${{ 0 < 5 && 'a few' || 0 }}
+      RELEASE_WAIT_MINUTES: ${{ 10 < 5 && 'a few' || 10 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1251,12 +1251,28 @@ jobs:
   #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
   #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  set-env:
+    name: Set Env Variables
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get release wait time (scheduled release)
+        if: ${{ github.event.schedule != '' }}
+        run: echo 'RELEASE_WAIT=0' >> $GITHUB_ENV
+
   notify-start:
     name: Notify Start
     runs-on: ubuntu-latest
+    needs: set-env
     env:
-      # DURATION: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
-      RELEASE_WAIT_MINUTES: ${{ 0 < 5 && 'a few' || 0 }}
+      RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1254,7 +1254,6 @@ jobs:
   notify-start:
     name: Notify Start
     runs-on: ubuntu-latest
-    needs: set-env
     env:
       # DURATION: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
       RELEASE_WAIT_MINUTES: ${{ 0 < 5 && 'a few' || 0 }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1270,6 +1270,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           payload: | 
             {
+              "text": "Production deploy for vets-website coming up."
               "attachments": [
                 {
                   "color": "#07711E",

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1270,8 +1270,6 @@ jobs:
     name: Notify Start
     runs-on: ubuntu-latest
     needs: set-env
-    env:
-      RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -1279,6 +1277,8 @@ jobs:
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
+        env:
+          RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
         with:
           channel_id: C032FM8LFCN
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1265,7 +1265,23 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
           channel_id: C032FM8LFCN
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          payload: | 
+            {
+              "attachments": [
+                {
+                  "color": "#07711E",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1273,6 +1273,7 @@ jobs:
               "text": "Production deploy for vets-website coming up.",
               "attachments": [
                 {
+                  "pretext": "",
                   "color": "#07711E",
                   "blocks": [
                     {

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: self-hosted
     outputs:
       entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
+      continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
 
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
@@ -47,7 +48,7 @@ jobs:
         uses: ./.github/workflows/get-changed-apps
         with:
           delimiter: ','
-          output-type: 'entry_name'
+          output-type: 'entry_name, continuous_deployment'
 
       - name: Configure AWS Credentials
         if: ${{ matrix.buildtype == 'vagovprod' }}
@@ -1090,7 +1091,7 @@ jobs:
           aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
 
   set-deploy-environments:
-    name: Set environments to deploy
+    name: Set Environments to Deploy
     needs: [archive, build]
     if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
     runs-on: ubuntu-latest
@@ -1098,7 +1099,6 @@ jobs:
       environments: ${{ steps.set-environments.outputs.environments }}
     env:
       DEPLOY_TO_PRODUCTION: false # Enables production deployments for apps on the allowlist when set to true
-      IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
       DEV: "{
           \\\"environment\\\": \\\"vagovdev\\\", 
           \\\"bucket\\\": \\\"dev.va.gov\\\", 
@@ -1121,7 +1121,7 @@ jobs:
       - name: Set environments for deploy matrix
         id: set-environments
         run: |
-          if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ env.IS_ISOLATED_APP_BUILD }} == true ]]; then
+          if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ needs.build.outputs.continuous_deployment }} == true ]]; then
             echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}},${{env.PROD}}]}
           else
             echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}}]}
@@ -1152,7 +1152,7 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Check commit deployability
+      - name: Check if commit can be deployed
         id: check-deployability
         run: node ./script/github-actions/check-deployability.js
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1270,7 +1270,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           payload: | 
             {
-              "text": "Production deploy for vets-website coming up."
+              "text": "Production deploy for vets-website coming up.",
               "attachments": [
                 {
                   "color": "#07711E",

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1256,7 +1256,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # DURATION: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
-      RELEASE_WAIT_MINUTES: ${{ 10 < 5 && 'a few' || 10 }}
+      RELEASE_WAIT_MINUTES: ${{ 0 < 5 && 'a few' || 0 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1264,7 +1264,6 @@ jobs:
           fetch-depth: 0
 
       - name: Get release wait time (scheduled release)
-        if: ${{ github.event.schedule != '' }}
         run: echo 'RELEASE_WAIT=0' >> $GITHUB_ENV
 
   notify-start:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,1250 +12,19 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # build:
-  #   name: Build
-  #   runs-on: self-hosted
-  #   outputs:
-  #     entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
-  #     continuous_deployment: ${{ steps.get-changed-apps.outputs.continuous_deployment }}
-
-  #   env:
-  #     NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       buildtype: [vagovdev, vagovstaging, vagovprod]
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         delimiter: ','
-  #         output-type: 'entry_name, continuous_deployment'
-
-  #     - name: Configure AWS Credentials
-  #       if: ${{ matrix.buildtype == 'vagovprod' }}
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get Mapbox Token
-  #       if: ${{ matrix.buildtype == 'vagovprod' }}
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token
-  #         env_variable_name: MAPBOX_TOKEN
-
-  #     - name: Build
-  #       run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
-  #       timeout-minutes: 30
-  #       env:
-  #         ENTRY: ${{ steps.get-changed-apps.outputs.entry_names }}
-
-  #     - name: Generate build details
-  #       run: |
-  #         cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
-  #         BUILDTYPE=${{ matrix.buildtype }}
-  #         NODE_ENV=production
-  #         BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-  #         CHANGE_TARGET=null
-  #         RUN_ID=${{ github.run_id }}
-  #         RUN_NUMBER=${{ github.run_number }}
-  #         REF=${{ github.sha }}
-  #         BUILDTIME=$(date +%s)
-  #         EOF
-
-  #     - name: Compress and archive build
-  #       run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
-
-  #     - name: Upload build artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: ${{ matrix.buildtype }}.tar.bz2
-  #         path: ${{ matrix.buildtype }}.tar.bz2
-  #         retention-days: 1
-
-  # unit-tests:
-  #   name: Unit Tests
-  #   runs-on: self-hosted
-  #   outputs:
-  #     app_folders: ${{ steps.get-changed-apps.outputs.folders }}
-
-  #   env:
-  #     NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Create test results folder
-  #       run: mkdir -p test-results
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         delimiter: ','
-  #         output-type: 'folder'
-
-  #     - name: Run unit tests
-  #       run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} --coverage
-  #       env:
-  #         MOCHA_FILE: test-results/unit-tests.xml
-  #         APP_FOLDERS: ${{ steps.get-changed-apps.outputs.folders }}
-
-  #     - name: Archive unit test results
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: unit-test-report
-  #         path: mochawesome-report
-
-  #     - name: Generate coverage report by app
-  #       run: node script/app-coverage-report.js > test-results/coverage_report.txt
-
-  #     - name: Upload Coverage Report Artifact
-  #       uses: actions/upload-artifact@v3
-  #       if: ${{ always() }}
-  #       with:
-  #         name: unit-test-coverage-report
-  #         path: coverage/test-coverage-report.json
-
-  #     - name: Configure AWS credentials (1)
-  #       if: ${{ github.ref == 'refs/heads/main' }}
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get AWS IAM role
-  #       if: ${{ github.ref == 'refs/heads/main' }}
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-  #     - name: Configure AWS Credentials (2)
-  #       if: ${{ github.ref == 'refs/heads/main' }}
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #     - name: Upload coverage report to S3
-  #       if: ${{ github.ref == 'refs/heads/main' && steps.get-changed-apps.outputs.folders == '' }}
-  #       run: aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-
-  #     - name: Get code coverage
-  #       if: ${{ always() }}
-  #       id: code-coverage
-  #       run: echo ::set-output name=MARKDOWN::$(node ./script/github-actions/code-coverage-format-report.js)
-
-  #     - name: Publish test results
-  #       if: ${{ always() }}
-  #       continue-on-error: true
-  #       uses: mikepenz/action-junit-report@v2.8.4
-  #       with:
-  #         check_name: 'Unit Tests Summary'
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         report_paths: 'test-results/unit-tests.xml'
-  #         summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
-  #         fail_on_failure: 'true'
-
-  # contract-tests:
-  #   name: Contract Tests
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     tests: ${{ steps.get-tests.outputs.tests }}
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get Pact Broker password
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /dsva-vagov/pact-broker/utility/PACT_BROKER_BASIC_AUTH_PASSWORD
-  #         env_variable_name: PACT_BROKER_BASIC_AUTH_PASSWORD
-
-  #     - name: Get GitHub token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Create test results folder
-  #       run: mkdir -p test-results
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         output-type: 'folder'
-
-  #     - name: Get contract tests
-  #       id: get-tests
-  #       run: |
-  #         if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
-  #           echo ::set-output name=tests::$(find src -name "*.pact.spec.js")
-  #         else
-  #           echo ::set-output name=tests::$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.pact.spec.js")
-  #         fi
-
-  #     - name: Run contract tests
-  #       if: steps.get-tests.outputs.tests != ''
-  #       run: yarn test:unit-pact-config ${{ steps.get-tests.outputs.tests }}
-  #       env:
-  #         MOCHA_FILE: ./test-results/test-results.xml
-
-  #     - name: Print Pact failures
-  #       if: steps.get-tests.outputs.tests != '' && failure()
-  #       run: cat test-results/test-results.xml
-
-  #     - name: Run Pact publish
-  #       if: steps.get-tests.outputs.tests != ''
-  #       run: yarn pact:publish
-  #       env:
-  #         PACT_BROKER_BASIC_AUTH_USERNAME: pact-broker
-  #         PACT_BROKER_BASE_URL: https://dev.va.gov/_vfs/pact-broker/
-
-  #     - name: Run Pact verify
-  #       if: steps.get-tests.outputs.tests != ''
-  #       run: |
-  #         curl -v -X POST \
-  #         -H 'Authorization: token ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}' \
-  #         -H 'Accept: application/vnd.github.v3+json' \
-  #         https://api.github.com/repos/department-of-veterans-affairs/vets-api/actions/workflows/8289333/dispatches \
-  #         -d '{"ref": "master"}' \
-  #         --fail
-
-  #     - name: Archive contract test results
-  #       if: steps.get-tests.outputs.tests != ''
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: contract-test-report
-  #         path: mochawesome-report
-
-  #     - name: Archive contract test log
-  #       uses: actions/upload-artifact@v3
-  #       if: steps.get-tests.outputs.tests != '' && failure()
-  #       with:
-  #         name: contract-test-log
-  #         path: logs/pact.log
-
-  # security-audit:
-  #   name: Security Audit
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         output-type: 'entry_name'
-
-  #     - name: Audit dependencies
-  #       if: steps.get-changed-apps.outputs.entry_names == ''
-  #       run: yarn security-check
-
-  # linting:
-  #   name: Linting (All)
-  #   if: ${{ github.ref == 'refs/heads/main' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         output-type: 'folder'
-
-  #     - name: Annotate ESLint results
-  #       run: |
-  #         if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
-  #           yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
-  #         else
-  #           yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js \
-  #           ${{ steps.get-changed-apps.outputs.folders }}
-  #         fi
-
-  #     - name: Run Stylelint
-  #       if: ${{ always() }}
-  #       run: |
-  #         if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
-  #           yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
-  #         else
-  #           files=$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.scss")
-  #           if [[ -n "$files" ]]; then yarn run stylelint verbose --output-file stylelint-report.json --formatter json $(echo $files); fi
-  #         fi
-
-  #     - name: Annotate Stylelint results
-  #       if: ${{ always() }}
-  #       run: node ./script/github-actions/stylelint-annotation-format.js
-
-  # testing-reports-prep:
-  #   name: Testing Reports Prep
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: true
-  #   outputs:
-  #     app_list: ${{ env.APPLICATION_LIST }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Generate new application list
-  #       run: yarn generate-app-list
-  #     # exports app list and assigns to environmental variable at this step
-
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get va-vsp-bot token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-  #     - name: Init Dashboard Data Repo
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-  #     - name: Set Up BigQuery Creds
-  #       uses: ./.github/workflows/configure-bigquery
-
-  #     - name: Upload app list to BigQuery
-  #       run: yarn generate-app-list
-  #       working-directory: qa-standards-dashboard-data
-
-  # cypress-tests-prep:
-  #   name: Prep for Cypress Tests
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     tests: ${{ steps.tests.outputs.selected }}
-  #     app_urls: ${{ steps.get-changed-apps.outputs.urls }}
-  #     num_containers: ${{ steps.containers.outputs.num }}
-  #     ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         delimiter: ','
-  #         output-type: 'entry_name, url'
-
-  #     - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
-  #       run: node script/github-actions/select-cypress-tests.js
-  #       env:
-  #         RUN_FULL_SUITE: false
-  #         CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
-  #         APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
-  #         APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}
-
-  #     - name: Set output of TESTS
-  #       id: tests
-  #       run: echo ::set-output name=selected::$TESTS
-
-  #     - name: Set output of NUM_CONTAINERS
-  #       id: containers
-  #       run: echo ::set-output name=num::$NUM_CONTAINERS
-
-  #     - name: Set output of CI_NODE_INDEX
-  #       id: matrix
-  #       run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
-
-  # cypress-tests:
-  #   name: Cypress E2E Tests
-  #   runs-on: self-hosted
-  #   timeout-minutes: 60
-  #   needs: [build, cypress-tests-prep]
-  #   if: |
-  #     needs.build.result == 'success' &&
-  #     needs.cypress-tests-prep.result == 'success'
-  #   container:
-  #     image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
-  #     options: -u 1001:1001 -v /usr/local/share:/share
-
-  #   strategy:
-  #     fail-fast: false
-  #     max-parallel: 12
-  #     matrix:
-  #       ci_node_index: ${{ fromJson(needs.cypress-tests-prep.outputs.ci_node_index) }}
-
-  #   env:
-  #     CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
-  #     NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
-
-  #   steps:
-  #     # The following statement is included in each step because of a bug in
-  #     # GitHub's branch protection:
-  #     #
-  #     # if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #     #
-  #     # Previously, if no tests were selected, the branch protection check that
-  #     # requires the cypress-tests job to run was not satisfied. This update forces
-  #     # the job to always run, and skips each step if no tests are selected.
-  #     # Previously, the above conditional was included in the job's if statement.
-  #     - name: Configure AWS credentials
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Checkout vets-website
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       uses: actions/checkout@v3
-
-  #     - name: Download production build artifact
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: vagovprod.tar.bz2
-
-  #     - name: Unpack build
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       run: |
-  #         mkdir -p build/vagovprod
-  #         tar -C build/vagovprod -xjf vagovprod.tar.bz2
-
-  #     - name: Install dependencies
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 20
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           /github/home/.cache/Cypress
-  #           node_modules
-
-  #     - name: Start server
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
-
-  #     - name: Run Cypress tests
-  #       if: needs.cypress-tests-prep.outputs.tests != '[]'
-  #       run: node script/github-actions/run-cypress-tests.js
-  #       timeout-minutes: 40
-  #       env:
-  #         CYPRESS_CI: true
-  #         STEP: ${{ matrix.ci_node_index }}
-  #         TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
-  #         APP_URLS: ${{ needs.cypress-tests-prep.outputs.app_urls }}
-  #         NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
-
-  #     - name: Archive test videos
-  #       if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: cypress-video-artifacts
-  #         path: cypress/videos
-
-  #     - name: Archive test screenshots
-  #       if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: cypress-screenshot-artifacts
-  #         path: cypress/screenshots
-
-  #     - name: Archive Mochawesome test results
-  #       if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && always() }}
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: cypress-mochawesome-test-results
-  #         path: cypress/results
-  #         retention-days: 1
-
-  # testing-reports-contract-tests:
-  #   name: Testing Reports - Contract Tests
-  #   runs-on: ubuntu-latest
-  #   needs: [testing-reports-prep, contract-tests]
-  #   if: |
-  #     always() &&
-  #     needs.contract-tests.outputs.tests != '' &&
-  #     (needs.contract-tests.result == 'success' || needs.contract-tests.result == 'failure')
-  #   continue-on-error: true
-  #   env:
-  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-  #   steps:
-  #     - name: Set IS_MASTER_BUILD
-  #       run: |
-  #         if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-  #             echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
-  #         else
-  #             echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
-  #         fi
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     # ----------------
-  #     # | Notify Slack |
-  #     # ----------------
-
-  #     - name: Notify Slack about Contract test failures
-  #       if: ${{ github.ref == 'refs/heads/main' && needs.contract-tests.result == 'failure' }}
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-  #       continue-on-error: true
-  #       env:
-  #         SSL_CERT_DIR: /etc/ssl/certs
-  #       with:
-  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Contract tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
-  #         channel_id: C026PD47Z19 #gha-test-status
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  #     # ------------------------
-  #     # | Upload BigQuery Data |
-  #     # ------------------------
-
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get va-vsp-bot token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-  #     - name: Init Dashboard Data Repo
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-  #     - name: Set Up BigQuery Creds
-  #       uses: ./.github/workflows/configure-bigquery
-
-  #     - name: Get AWS IAM role
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-  #     - name: Set UUID for Mochawesome reports
-  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-  #     - name: Configure AWS Credentials (2)
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #     # ------------------------------------------------------
-  #     # | Publish Contract Test Report and Upload to BigQuery |
-  #     # ------------------------------------------------------
-
-  #     - name: Download Contract Test Mochawesome test results
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: contract-test-report
-  #         path: qa-standards-dashboard-data/src/testing-reports/data
-
-  #     - name: Create Contract Test report and post results to BigQuery
-  #       run: yarn contract-mochawesome-to-bigquery
-  #       working-directory: qa-standards-dashboard-data
-  #       env:
-  #         TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
-  #         TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
-  #         TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
-
-  #     - name: Upload Contract Test report to s3
-  #       run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-contract-test-reports --acl public-read --region us-gov-west-1 --recursive
-
-  #     # -------------------------
-  #     # | Contract Tests Summary |
-  #     # -------------------------
-
-  #     - name: Publish Contract test results
-  #       if: ${{ always() }}
-  #       uses: LouisBrunner/checks-action@v1.2.0
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         name: Contract Tests Summary
-  #         conclusion: ${{ needs.contract-tests.result }}
-  #         output: |
-  #           {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-
-  # testing-reports-unit-tests:
-  #   name: Testing Reports - Unit Tests
-  #   runs-on: ubuntu-latest
-  #   needs: [testing-reports-prep, unit-tests]
-  #   if: ${{ always() }}
-  #   continue-on-error: true
-  #   env:
-  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-  #   steps:
-  #     - name: Set IS_MASTER_BUILD
-  #       run: |
-  #         if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-  #             echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
-  #         else
-  #             echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
-  #         fi
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     # ----------------
-  #     # | Notify Slack |
-  #     # ----------------
-
-  #     - name: Notify Slack about Unit test failures
-  #       if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.result == 'failure' }}
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-  #       continue-on-error: true
-  #       env:
-  #         SSL_CERT_DIR: /etc/ssl/certs
-  #       with:
-  #         attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-  #         channel_id: C026PD47Z19 #gha-test-status
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  #     # ------------------------
-  #     # | Upload BigQuery Data |
-  #     # ------------------------
-
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get va-vsp-bot token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-  #     - name: Init Dashboard Data Repo
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-  #     - name: Set Up BigQuery Creds
-  #       uses: ./.github/workflows/configure-bigquery
-
-  #     - name: Get AWS IAM role
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-  #     - name: Set UUID for Mochawesome reports
-  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-  #     - name: Configure AWS Credentials (2)
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #     # --------------------------------------------------
-  #     # | Publish Unit Test Report and Upload to BigQuery |
-  #     # --------------------------------------------------
-
-  #     - name: Download Unit Test Mochawesome test results
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: unit-test-report
-  #         path: qa-standards-dashboard-data/src/testing-reports/data
-
-  #     - name: Create Unit Test report and post results to BigQuery
-  #       run: yarn unit-mochawesome-to-bigquery
-  #       working-directory: qa-standards-dashboard-data
-  #       env:
-  #         UNIT_TEST_RESULTS_TABLE_NAME: vets_website_unit_test_results
-  #         UNIT_TEST_EXECUTIONS_TABLE_NAME: unit_test_suite_executions
-  #         TEST_REPORTS_FOLDER_NAME: vets-website-unit-test-reports
-
-  #     - name: Upload Unit Test report to s3
-  #       run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
-
-  #     # -------------------------
-  #     # | Unit Tests Summary |
-  #     # -------------------------
-
-  #     - name: Unit test results
-  #       if: ${{ always() }}
-  #       uses: LouisBrunner/checks-action@v1.1.1
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         name: Unit Tests Summary
-  #         conclusion: ${{ needs.unit-tests.result }}
-  #         output: |
-  #           {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-
-  # testing-reports-unit-tests-coverage:
-  #   name: Testing Reports - Unit Tests Coverage
-  #   runs-on: ubuntu-latest
-  #   needs: [testing-reports-prep, unit-tests]
-  #   if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
-  #   continue-on-error: true
-  #   env:
-  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     # ------------------------
-  #     # | Upload BigQuery Data |
-  #     # ------------------------
-
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get va-vsp-bot token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-  #     - name: Init Dashboard Data Repo
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-  #     - name: Set Up BigQuery Creds
-  #       uses: ./.github/workflows/configure-bigquery
-
-  #     - name: Get AWS IAM role
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-  #     - name: Set UUID for Mochawesome reports
-  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-  #     - name: Configure AWS Credentials (2)
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #     # --------------------------------------
-  #     # | Publish Unit Test Coverage Report       |
-  #     # -------------------------------------
-
-  #     - name: Download Unit Test Coverage Report
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: unit-test-coverage-report
-  #         path: qa-standards-dashboard-data/src/testing-reports/data
-
-  #     - name: Process Coverage Report and post results to BigQuery
-  #       run: yarn unit-coverage-to-bigquery
-  #       working-directory: qa-standards-dashboard-data
-
-  # testing-reports-cypress:
-  #   name: Testing Reports - Cypress E2E Tests
-  #   runs-on: ubuntu-latest
-  #   needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
-  #   if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
-  #   env:
-  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-  #   continue-on-error: true
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     - name: Notify Slack about Cypress test failures
-  #       if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-  #       continue-on-error: true
-  #       env:
-  #         SSL_CERT_DIR: /etc/ssl/certs
-  #       with:
-  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
-  #         channel_id: C026PD47Z19 #gha-test-status
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  #       # ------------------------
-  #       # | Upload BigQuery Data |
-  #       # ------------------------
-
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get va-vsp-bot token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-  #     - name: Init Dashboard Data Repo
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
-
-  #     - name: Set Up BigQuery Creds
-  #       uses: ./.github/workflows/configure-bigquery
-
-  #     - name: Get AWS IAM role
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-  #     - name: Set UUID for Mochawesome reports
-  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-  #     - name: Configure AWS Credentials (2)
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #       # --------------------------------------
-  #       # | Publish Cypress E2E Testing Report |
-  #       # -------------------------------------
-
-  #     - name: Download Cypress E2E Mochawesome test results
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: cypress-mochawesome-test-results
-  #         path: qa-standards-dashboard-data/src/testing-reports/data
-
-  #     - name: Download Cypress E2E video artifacts
-  #       if: ${{ needs.cypress-tests.result == 'failure' }}
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: cypress-video-artifacts
-  #         path: qa-standards-dashboard-data/videos/${{ env.UUID }}
-
-  #     - name: Create Cypress E2E report and post results to BigQuery
-  #       run: yarn cypress-mochawesome-to-bigquery
-  #       working-directory: qa-standards-dashboard-data
-  #       env:
-  #         IS_MASTER_BUILD: false
-  #         TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
-  #         TEST_RESULTS_TABLE_NAME: cypress_test_results
-  #         TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports
-  #         TEST_RETRIES_TABLE_NAME: cypress_retry_records
-  #         NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
-  #         # env.MOCHAWESOME_REPORT_RESULTS is set and exported during the above step when the mochawesome report is generated.  It contains the output string for the publish step at the end of the job with the numbers from the Mochawesome report.
-
-  #     - name: Upload Cypress E2E test videos to s3
-  #       if: ${{ needs.cypress-tests.result == 'failure' }}
-  #       run: aws s3 cp qa-standards-dashboard-data/videos/${{ env.UUID }} s3://testing-tools-testing-reports/vets-website-cypress-reports/videos/${{ env.UUID }} --acl public-read --region us-gov-west-1 --recursive
-
-  #     - name: Upload Cypress E2E test report to s3
-  #       run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-cypress-reports --acl public-read --region us-gov-west-1 --recursive
-
-  #       # -------------------------
-  #       # | Cypress Tests Summary |
-  #       # -------------------------
-
-  #     - name: Publish Cypress test results
-  #       if: ${{ always() }}
-  #       uses: LouisBrunner/checks-action@v1.2.0
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         name: Cypress Tests Summary
-  #         conclusion: ${{ needs.cypress-tests.result }}
-  #         output: |
-  #           {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-
-  # archive:
-  #   name: Archive
-  #   runs-on: ubuntu-latest
-
-  #   strategy:
-  #     matrix:
-  #       buildtype: [vagovdev, vagovstaging, vagovprod]
-
-  #   needs:
-  #     [
-  #       build,
-  #       cypress-tests,
-  #       unit-tests,
-  #       contract-tests,
-  #       security-audit,
-  #       linting,
-  #     ]
-
-  #   env:
-  #     IS_SINGLE_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
-
-  #   # Archive should still run even when linting is skipped (as in PRs).
-  #   # This if overrides the dependency on linting success to include skipped.
-  #   # Because of always(), the rest of the needed jobs have to be checked too.
-  #   # By doing this, later jobs that need this job require similar overrides
-  #   # or else they will also be skipped when linting is skipped.
-  #   if: |
-  #     always() &&
-  #     (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'skipped') &&
-  #     needs.build.result == 'success' &&
-  #     needs.unit-tests.result == 'success' &&
-  #     needs.contract-tests.result == 'success' &&
-  #     needs.security-audit.result == 'success' &&
-  #     (needs.linting.result == 'success' || needs.linting.result == 'skipped')
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     - name: Download build artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: ${{ matrix.buildtype }}.tar.bz2
-
-  #     - name: Extract build artifact
-  #       if: env.IS_SINGLE_APP_BUILD == 'true'
-  #       run: |
-  #         mkdir -p build/${{ matrix.buildtype }}
-  #         tar -C build/${{ matrix.buildtype }} -xjvf ${{ matrix.buildtype }}.tar.bz2
-  #         rm ${{ matrix.buildtype }}.tar.bz2
-
-  #     - name: Remove global assets from build
-  #       if: env.IS_SINGLE_APP_BUILD == 'true'
-  #       run: ./script/github-actions/remove-global-assets.sh
-  #       env:
-  #         ENTRY_NAMES: ${{ needs.build.outputs.entry_names }}
-  #         APP_DIRS: ${{ needs.unit-tests.outputs.app_folders }}
-  #         BUILD_DIR: build/${{ matrix.buildtype }}
-
-  #     - name: Generate build details
-  #       run: |
-  #         cat > BUILD_ARTIFACT.txt << EOF
-  #         IS_SINGLE_APP_BUILD=${{ env.IS_SINGLE_APP_BUILD }}
-  #         REF=${{ github.sha }}
-  #         EOF
-
-  #     - name: Compress and archive single/grouped app build
-  #       if: env.IS_SINGLE_APP_BUILD == 'true'
-  #       run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
-
-  #     - name: Configure AWS credentials (1)
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get AWS IAM role
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-  #     - name: Configure AWS Credentials (2)
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #     - name: Upload build
-  #       run: |
-  #         aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
-  #         aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
-
-  # set-deploy-environments:
-  #   name: Set Environments to Deploy
-  #   needs: [archive, build]
-  #   if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     environments: ${{ steps.set-environments.outputs.environments }}
-  #   env:
-  #     DEPLOY_TO_PRODUCTION: false # Enables production deployments for apps on the allowlist when set to true
-  #     DEV: "{
-  #         \\\"environment\\\": \\\"vagovdev\\\", 
-  #         \\\"bucket\\\": \\\"dev.va.gov\\\", 
-  #         \\\"asset_bucket\\\": \\\"dev-va-gov-assets\\\",
-  #         \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
-  #       }"
-  #     STAGING: "{
-  #         \\\"environment\\\": \\\"vagovstaging\\\", 
-  #         \\\"bucket\\\": \\\"staging.va.gov\\\", 
-  #         \\\"asset_bucket\\\": \\\"staging-va-gov-assets\\\",
-  #         \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
-  #       }"
-  #     PROD: "{
-  #         \\\"environment\\\": \\\"vagovprod\\\", 
-  #         \\\"bucket\\\": \\\"www.va.gov\\\", 
-  #         \\\"asset_bucket\\\": \\\"prod-va-gov-assets\\\",
-  #         \\\"iam_role\\\": \\\"AWS_FRONTEND_PROD_ROLE\\\"
-  #       }"
-  #   steps:
-  #     - name: Set environments for deploy matrix
-  #       id: set-environments
-  #       run: |
-  #         if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ needs.build.outputs.continuous_deployment }} == true ]]; then
-  #           echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}},${{env.PROD}}]}
-  #         else
-  #           echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}}]}
-  #         fi
-  
-  # deploy:
-  #   name: Deploy
-  #   needs: [build, set-deploy-environments]
-  #   if: always() && github.ref == 'refs/heads/main' && needs.set-deploy-environments.result == 'success'
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix: ${{ fromJson(needs.set-deploy-environments.outputs.environments) }}
-  #   env:
-  #     IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Check if commit can be deployed
-  #       id: check-deployability
-  #       run: node ./script/github-actions/check-deployability.js
-  #       env:
-  #         BUILDTYPE: ${{ matrix.environment }}
-
-  #     - name: Configure AWS credentials (1)
-  #       if: steps.check-deployability.outputs.is_deployable == 'true'
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-
-  #     - name: Get AWS IAM role
-  #       if: steps.check-deployability.outputs.is_deployable == 'true'
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /frontend-team/github-actions/parameters/${{ matrix.iam_role }}
-  #         env_variable_name: ${{ matrix.iam_role }}
-
-  #     - name: Configure AWS Credentials (2)
-  #       if: steps.check-deployability.outputs.is_deployable == 'true'
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
-  #         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE != '' && env.AWS_FRONTEND_NONPROD_ROLE || env.AWS_FRONTEND_PROD_ROLE }}
-  #         role-duration-seconds: 900
-  #         role-session-name: vsp-frontendteam-githubaction
-
-  #     - name: Deploy
-  #       if: steps.check-deployability.outputs.is_deployable == 'true'
-  #       run: |
-  #         if [[ "${{ env.IS_ISOLATED_APP_BUILD }}" == "true" ]]; then
-  #           ./script/github-actions/partial-deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
-  #         else
-  #           ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
-  #         fi
-  #       env:
-  #         SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
-  #         DEST: s3://${{ matrix.bucket }}
-  #         ASSET_DEST: s3://${{ matrix.asset_bucket }}
-
-  # notify-failure:
-  #   name: Notify Failure
-  #   runs-on: ubuntu-latest
-  #   if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
-  #   needs: deploy
-  #   env:
-  #     ALERT_TEAMS: true # Alerts teams for single/grouped app builds when set to true
-  #     DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
-  #     VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Install dependencies
-  #       if: env.ALERT_TEAMS == 'true'
-  #       uses: ./.github/workflows/install
-  #       timeout-minutes: 30
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
-
-  #     - name: Get changed applications
-  #       id: get-changed-apps
-  #       if: env.ALERT_TEAMS == 'true'
-  #       uses: ./.github/workflows/get-changed-apps
-  #       with:
-  #         output-type: 'slack_group'
-
-  #     - name: Notify application team in Slack
-  #       if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-  #       continue-on-error: true
-  #       with:
-  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${{steps.get-changed-apps.outputs.slack_groups}} CI for your application failed on the `main` branch in `vets-website`: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>\n For help troubleshooting, see the <https://depo-platform-documentation.scrollhelp.site/developer-docs/Handling-failed-single%2Fgrouped-application-pipelines.2066645150.html|documentation> on failed workflow runs."}}]}]}'
-  #         channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  #     - name: Notify Slack
-  #       if: steps.get-changed-apps.outputs.slack_groups == ''
-  #       uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
-  #       continue-on-error: true
-  #       with:
-  #         payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "`main` branch CI in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
-  #         channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  set-env:
-    name: Set Env Variables
-    runs-on: ubuntu-latest
+  build:
+    name: Build
+    runs-on: self-hosted
     outputs:
-      RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
+      entry_names: ${{ steps.get-changed-apps.outputs.entry_names }}
+
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [vagovdev, vagovstaging, vagovprod]
 
     steps:
       - name: Checkout
@@ -1263,40 +32,1221 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get release wait time (scheduled release)
-        run: echo 'RELEASE_WAIT=10' >> $GITHUB_ENV
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
 
-  notify-start:
-    name: Notify Start
+      - name: Get changed applications
+        id: get-changed-apps
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          delimiter: ','
+          output-type: 'entry_name'
+
+      - name: Configure AWS Credentials
+        if: ${{ matrix.buildtype == 'vagovprod' }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Mapbox Token
+        if: ${{ matrix.buildtype == 'vagovprod' }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token
+          env_variable_name: MAPBOX_TOKEN
+
+      - name: Build
+        run: yarn build --verbose --buildtype=${{ matrix.buildtype }} ${ENTRY:+"--entry=$ENTRY"}
+        timeout-minutes: 30
+        env:
+          ENTRY: ${{ steps.get-changed-apps.outputs.entry_names }}
+
+      - name: Generate build details
+        run: |
+          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
+          BUILDTYPE=${{ matrix.buildtype }}
+          NODE_ENV=production
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          CHANGE_TARGET=null
+          RUN_ID=${{ github.run_id }}
+          RUN_NUMBER=${{ github.run_number }}
+          REF=${{ github.sha }}
+          BUILDTIME=$(date +%s)
+          EOF
+
+      - name: Compress and archive build
+        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.buildtype }}.tar.bz2
+          path: ${{ matrix.buildtype }}.tar.bz2
+          retention-days: 1
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: self-hosted
+    outputs:
+      app_folders: ${{ steps.get-changed-apps.outputs.folders }}
+
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Create test results folder
+        run: mkdir -p test-results
+
+      - name: Get changed applications
+        id: get-changed-apps
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          delimiter: ','
+          output-type: 'folder'
+
+      - name: Run unit tests
+        run: yarn test:unit ${APP_FOLDERS:+"{script,$APP_FOLDERS}/**/*.unit.spec.js?(x)"} --coverage
+        env:
+          MOCHA_FILE: test-results/unit-tests.xml
+          APP_FOLDERS: ${{ steps.get-changed-apps.outputs.folders }}
+
+      - name: Archive unit test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-test-report
+          path: mochawesome-report
+
+      - name: Generate coverage report by app
+        run: node script/app-coverage-report.js > test-results/coverage_report.txt
+
+      - name: Upload Coverage Report Artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: unit-test-coverage-report
+          path: coverage/test-coverage-report.json
+
+      - name: Configure AWS credentials (1)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get AWS IAM role
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Configure AWS Credentials (2)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Upload coverage report to S3
+        if: ${{ github.ref == 'refs/heads/main' && steps.get-changed-apps.outputs.folders == '' }}
+        run: aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+
+      - name: Get code coverage
+        if: ${{ always() }}
+        id: code-coverage
+        run: echo ::set-output name=MARKDOWN::$(node ./script/github-actions/code-coverage-format-report.js)
+
+      - name: Publish test results
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: mikepenz/action-junit-report@v2.8.4
+        with:
+          check_name: 'Unit Tests Summary'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: 'test-results/unit-tests.xml'
+          summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
+          fail_on_failure: 'true'
+
+  contract-tests:
+    name: Contract Tests
     runs-on: ubuntu-latest
-    needs: set-env
+    outputs:
+      tests: ${{ steps.get-tests.outputs.tests }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Pact Broker password
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/pact-broker/utility/PACT_BROKER_BASIC_AUTH_PASSWORD
+          env_variable_name: PACT_BROKER_BASIC_AUTH_PASSWORD
+
+      - name: Get GitHub token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Create test results folder
+        run: mkdir -p test-results
+
+      - name: Get changed applications
+        id: get-changed-apps
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          output-type: 'folder'
+
+      - name: Get contract tests
+        id: get-tests
+        run: |
+          if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
+            echo ::set-output name=tests::$(find src -name "*.pact.spec.js")
+          else
+            echo ::set-output name=tests::$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.pact.spec.js")
+          fi
+
+      - name: Run contract tests
+        if: steps.get-tests.outputs.tests != ''
+        run: yarn test:unit-pact-config ${{ steps.get-tests.outputs.tests }}
+        env:
+          MOCHA_FILE: ./test-results/test-results.xml
+
+      - name: Print Pact failures
+        if: steps.get-tests.outputs.tests != '' && failure()
+        run: cat test-results/test-results.xml
+
+      - name: Run Pact publish
+        if: steps.get-tests.outputs.tests != ''
+        run: yarn pact:publish
+        env:
+          PACT_BROKER_BASIC_AUTH_USERNAME: pact-broker
+          PACT_BROKER_BASE_URL: https://dev.va.gov/_vfs/pact-broker/
+
+      - name: Run Pact verify
+        if: steps.get-tests.outputs.tests != ''
+        run: |
+          curl -v -X POST \
+          -H 'Authorization: token ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}' \
+          -H 'Accept: application/vnd.github.v3+json' \
+          https://api.github.com/repos/department-of-veterans-affairs/vets-api/actions/workflows/8289333/dispatches \
+          -d '{"ref": "master"}' \
+          --fail
+
+      - name: Archive contract test results
+        if: steps.get-tests.outputs.tests != ''
+        uses: actions/upload-artifact@v3
+        with:
+          name: contract-test-report
+          path: mochawesome-report
+
+      - name: Archive contract test log
+        uses: actions/upload-artifact@v3
+        if: steps.get-tests.outputs.tests != '' && failure()
+        with:
+          name: contract-test-log
+          path: logs/pact.log
+
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Get changed applications
+        id: get-changed-apps
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          output-type: 'entry_name'
+
+      - name: Audit dependencies
+        if: steps.get-changed-apps.outputs.entry_names == ''
+        run: yarn security-check
+
+  linting:
+    name: Linting (All)
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Get changed applications
+        id: get-changed-apps
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          output-type: 'folder'
+
+      - name: Annotate ESLint results
+        run: |
+          if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
+            yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
+          else
+            yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js \
+            ${{ steps.get-changed-apps.outputs.folders }}
+          fi
+
+      - name: Run Stylelint
+        if: ${{ always() }}
+        run: |
+          if [[ -z "${{ steps.get-changed-apps.outputs.folders }}" ]]; then
+            yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
+          else
+            files=$(find ${{ steps.get-changed-apps.outputs.folders }} -name "*.scss")
+            if [[ -n "$files" ]]; then yarn run stylelint verbose --output-file stylelint-report.json --formatter json $(echo $files); fi
+          fi
+
+      - name: Annotate Stylelint results
+        if: ${{ always() }}
+        run: node ./script/github-actions/stylelint-annotation-format.js
+
+  testing-reports-prep:
+    name: Testing Reports Prep
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      app_list: ${{ env.APPLICATION_LIST }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Notify Slack
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        env:
-          RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
         with:
-          channel_id: C032FM8LFCN
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Generate new application list
+        run: yarn generate-app-list
+      # exports app list and assigns to environmental variable at this step
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          payload: | 
-            {
-              "attachments": [
-                {
-                  "color": "#07711E",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what's coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+      - name: Set Up BigQuery Creds
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Upload app list to BigQuery
+        run: yarn generate-app-list
+        working-directory: qa-standards-dashboard-data
+
+  cypress-tests-prep:
+    name: Prep for Cypress Tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.tests.outputs.selected }}
+      app_urls: ${{ steps.get-changed-apps.outputs.urls }}
+      num_containers: ${{ steps.containers.outputs.num }}
+      ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Get changed applications
+        id: get-changed-apps
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          delimiter: ','
+          output-type: 'entry_name, url'
+
+      - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
+        run: node script/github-actions/select-cypress-tests.js
+        env:
+          RUN_FULL_SUITE: false
+          CHANGED_FILE_PATHS: ${{ steps.get-changed-apps.outputs.changed_files }}
+          APP_URLS: ${{ steps.get-changed-apps.outputs.urls }}
+          APP_ENTRIES: ${{ steps.get-changed-apps.outputs.entry_names }}
+
+      - name: Set output of TESTS
+        id: tests
+        run: echo ::set-output name=selected::$TESTS
+
+      - name: Set output of NUM_CONTAINERS
+        id: containers
+        run: echo ::set-output name=num::$NUM_CONTAINERS
+
+      - name: Set output of CI_NODE_INDEX
+        id: matrix
+        run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
+
+  cypress-tests:
+    name: Cypress E2E Tests
+    runs-on: self-hosted
+    timeout-minutes: 60
+    needs: [build, cypress-tests-prep]
+    if: |
+      needs.build.result == 'success' &&
+      needs.cypress-tests-prep.result == 'success'
+    container:
+      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
+      options: -u 1001:1001 -v /usr/local/share:/share
+
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      matrix:
+        ci_node_index: ${{ fromJson(needs.cypress-tests-prep.outputs.ci_node_index) }}
+
+    env:
+      CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
+      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
+
+    steps:
+      # The following statement is included in each step because of a bug in
+      # GitHub's branch protection:
+      #
+      # if: needs.cypress-tests-prep.outputs.tests != '[]'
+      #
+      # Previously, if no tests were selected, the branch protection check that
+      # requires the cypress-tests job to run was not satisfied. This update forces
+      # the job to always run, and skips each step if no tests are selected.
+      # Previously, the above conditional was included in the job's if statement.
+      - name: Configure AWS credentials
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Checkout vets-website
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        uses: actions/checkout@v3
+
+      - name: Download production build artifact
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        uses: actions/download-artifact@v3
+        with:
+          name: vagovprod.tar.bz2
+
+      - name: Unpack build
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        run: |
+          mkdir -p build/vagovprod
+          tar -C build/vagovprod -xjf vagovprod.tar.bz2
+
+      - name: Install dependencies
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        uses: ./.github/workflows/install
+        timeout-minutes: 20
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            /github/home/.cache/Cypress
+            node_modules
+
+      - name: Start server
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        run: node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 &
+
+      - name: Run Cypress tests
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        run: node script/github-actions/run-cypress-tests.js
+        timeout-minutes: 40
+        env:
+          CYPRESS_CI: true
+          STEP: ${{ matrix.ci_node_index }}
+          TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
+          APP_URLS: ${{ needs.cypress-tests-prep.outputs.app_urls }}
+          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+
+      - name: Archive test videos
+        if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-video-artifacts
+          path: cypress/videos
+
+      - name: Archive test screenshots
+        if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-screenshot-artifacts
+          path: cypress/screenshots
+
+      - name: Archive Mochawesome test results
+        if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-mochawesome-test-results
+          path: cypress/results
+          retention-days: 1
+
+  testing-reports-contract-tests:
+    name: Testing Reports - Contract Tests
+    runs-on: ubuntu-latest
+    needs: [testing-reports-prep, contract-tests]
+    if: |
+      always() &&
+      needs.contract-tests.outputs.tests != '' &&
+      (needs.contract-tests.result == 'success' || needs.contract-tests.result == 'failure')
+    continue-on-error: true
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+    steps:
+      - name: Set IS_MASTER_BUILD
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
+              echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
+          else
+              echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # ----------------
+      # | Notify Slack |
+      # ----------------
+
+      - name: Notify Slack about Contract test failures
+        if: ${{ github.ref == 'refs/heads/main' && needs.contract-tests.result == 'failure' }}
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Contract tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+          channel_id: C026PD47Z19 #gha-test-status
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      # ------------------------
+      # | Upload BigQuery Data |
+      # ------------------------
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+      - name: Set Up BigQuery Creds
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Set UUID for Mochawesome reports
+        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      # ------------------------------------------------------
+      # | Publish Contract Test Report and Upload to BigQuery |
+      # ------------------------------------------------------
+
+      - name: Download Contract Test Mochawesome test results
+        uses: actions/download-artifact@v3
+        with:
+          name: contract-test-report
+          path: qa-standards-dashboard-data/src/testing-reports/data
+
+      - name: Create Contract Test report and post results to BigQuery
+        run: yarn contract-mochawesome-to-bigquery
+        working-directory: qa-standards-dashboard-data
+        env:
+          TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
+          TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
+          TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
+
+      - name: Upload Contract Test report to s3
+        run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-contract-test-reports --acl public-read --region us-gov-west-1 --recursive
+
+      # -------------------------
+      # | Contract Tests Summary |
+      # -------------------------
+
+      - name: Publish Contract test results
+        if: ${{ always() }}
+        uses: LouisBrunner/checks-action@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Contract Tests Summary
+          conclusion: ${{ needs.contract-tests.result }}
+          output: |
+            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+  testing-reports-unit-tests:
+    name: Testing Reports - Unit Tests
+    runs-on: ubuntu-latest
+    needs: [testing-reports-prep, unit-tests]
+    if: ${{ always() }}
+    continue-on-error: true
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+    steps:
+      - name: Set IS_MASTER_BUILD
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
+              echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
+          else
+              echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
+          fi
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # ----------------
+      # | Notify Slack |
+      # ----------------
+
+      - name: Notify Slack about Unit test failures
+        if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.result == 'failure' }}
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          channel_id: C026PD47Z19 #gha-test-status
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      # ------------------------
+      # | Upload BigQuery Data |
+      # ------------------------
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+      - name: Set Up BigQuery Creds
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Set UUID for Mochawesome reports
+        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      # --------------------------------------------------
+      # | Publish Unit Test Report and Upload to BigQuery |
+      # --------------------------------------------------
+
+      - name: Download Unit Test Mochawesome test results
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-test-report
+          path: qa-standards-dashboard-data/src/testing-reports/data
+
+      - name: Create Unit Test report and post results to BigQuery
+        run: yarn unit-mochawesome-to-bigquery
+        working-directory: qa-standards-dashboard-data
+        env:
+          UNIT_TEST_RESULTS_TABLE_NAME: vets_website_unit_test_results
+          UNIT_TEST_EXECUTIONS_TABLE_NAME: unit_test_suite_executions
+          TEST_REPORTS_FOLDER_NAME: vets-website-unit-test-reports
+
+      - name: Upload Unit Test report to s3
+        run: aws s3 cp qa-standards-dashboard-data/src/testing-reports/data s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
+
+      # -------------------------
+      # | Unit Tests Summary |
+      # -------------------------
+
+      - name: Unit test results
+        if: ${{ always() }}
+        uses: LouisBrunner/checks-action@v1.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Unit Tests Summary
+          conclusion: ${{ needs.unit-tests.result }}
+          output: |
+            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+  testing-reports-unit-tests-coverage:
+    name: Testing Reports - Unit Tests Coverage
+    runs-on: ubuntu-latest
+    needs: [testing-reports-prep, unit-tests]
+    if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
+    continue-on-error: true
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # ------------------------
+      # | Upload BigQuery Data |
+      # ------------------------
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+      - name: Set Up BigQuery Creds
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Set UUID for Mochawesome reports
+        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      # --------------------------------------
+      # | Publish Unit Test Coverage Report       |
+      # -------------------------------------
+
+      - name: Download Unit Test Coverage Report
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-test-coverage-report
+          path: qa-standards-dashboard-data/src/testing-reports/data
+
+      - name: Process Coverage Report and post results to BigQuery
+        run: yarn unit-coverage-to-bigquery
+        working-directory: qa-standards-dashboard-data
+
+  testing-reports-cypress:
+    name: Testing Reports - Cypress E2E Tests
+    runs-on: ubuntu-latest
+    needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
+    if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Notify Slack about Cypress test failures
+        if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+          channel_id: C026PD47Z19 #gha-test-status
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+        # ------------------------
+        # | Upload BigQuery Data |
+        # ------------------------
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Init Dashboard Data Repo
+        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+
+      - name: Set Up BigQuery Creds
+        uses: ./.github/workflows/configure-bigquery
+
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Set UUID for Mochawesome reports
+        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+        # --------------------------------------
+        # | Publish Cypress E2E Testing Report |
+        # -------------------------------------
+
+      - name: Download Cypress E2E Mochawesome test results
+        uses: actions/download-artifact@v3
+        with:
+          name: cypress-mochawesome-test-results
+          path: qa-standards-dashboard-data/src/testing-reports/data
+
+      - name: Download Cypress E2E video artifacts
+        if: ${{ needs.cypress-tests.result == 'failure' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: cypress-video-artifacts
+          path: qa-standards-dashboard-data/videos/${{ env.UUID }}
+
+      - name: Create Cypress E2E report and post results to BigQuery
+        run: yarn cypress-mochawesome-to-bigquery
+        working-directory: qa-standards-dashboard-data
+        env:
+          IS_MASTER_BUILD: false
+          TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
+          TEST_RESULTS_TABLE_NAME: cypress_test_results
+          TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports
+          TEST_RETRIES_TABLE_NAME: cypress_retry_records
+          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+          # env.MOCHAWESOME_REPORT_RESULTS is set and exported during the above step when the mochawesome report is generated.  It contains the output string for the publish step at the end of the job with the numbers from the Mochawesome report.
+
+      - name: Upload Cypress E2E test videos to s3
+        if: ${{ needs.cypress-tests.result == 'failure' }}
+        run: aws s3 cp qa-standards-dashboard-data/videos/${{ env.UUID }} s3://testing-tools-testing-reports/vets-website-cypress-reports/videos/${{ env.UUID }} --acl public-read --region us-gov-west-1 --recursive
+
+      - name: Upload Cypress E2E test report to s3
+        run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-cypress-reports --acl public-read --region us-gov-west-1 --recursive
+
+        # -------------------------
+        # | Cypress Tests Summary |
+        # -------------------------
+
+      - name: Publish Cypress test results
+        if: ${{ always() }}
+        uses: LouisBrunner/checks-action@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Cypress Tests Summary
+          conclusion: ${{ needs.cypress-tests.result }}
+          output: |
+            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+  archive:
+    name: Archive
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        buildtype: [vagovdev, vagovstaging, vagovprod]
+
+    needs:
+      [
+        build,
+        cypress-tests,
+        unit-tests,
+        contract-tests,
+        security-audit,
+        linting,
+      ]
+
+    env:
+      IS_SINGLE_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
+
+    # Archive should still run even when linting is skipped (as in PRs).
+    # This if overrides the dependency on linting success to include skipped.
+    # Because of always(), the rest of the needed jobs have to be checked too.
+    # By doing this, later jobs that need this job require similar overrides
+    # or else they will also be skipped when linting is skipped.
+    if: |
+      always() &&
+      (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'skipped') &&
+      needs.build.result == 'success' &&
+      needs.unit-tests.result == 'success' &&
+      needs.contract-tests.result == 'success' &&
+      needs.security-audit.result == 'success' &&
+      (needs.linting.result == 'success' || needs.linting.result == 'skipped')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.buildtype }}.tar.bz2
+
+      - name: Extract build artifact
+        if: env.IS_SINGLE_APP_BUILD == 'true'
+        run: |
+          mkdir -p build/${{ matrix.buildtype }}
+          tar -C build/${{ matrix.buildtype }} -xjvf ${{ matrix.buildtype }}.tar.bz2
+          rm ${{ matrix.buildtype }}.tar.bz2
+
+      - name: Remove global assets from build
+        if: env.IS_SINGLE_APP_BUILD == 'true'
+        run: ./script/github-actions/remove-global-assets.sh
+        env:
+          ENTRY_NAMES: ${{ needs.build.outputs.entry_names }}
+          APP_DIRS: ${{ needs.unit-tests.outputs.app_folders }}
+          BUILD_DIR: build/${{ matrix.buildtype }}
+
+      - name: Generate build details
+        run: |
+          cat > BUILD_ARTIFACT.txt << EOF
+          IS_SINGLE_APP_BUILD=${{ env.IS_SINGLE_APP_BUILD }}
+          REF=${{ github.sha }}
+          EOF
+
+      - name: Compress and archive single/grouped app build
+        if: env.IS_SINGLE_APP_BUILD == 'true'
+        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+
+      - name: Configure AWS credentials (1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Upload build
+        run: |
+          aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
+          aws s3 cp BUILD_ARTIFACT.txt s3://vetsgov-website-builds-s3-upload-test/build-artifacts/$GITHUB_SHA.txt --acl public-read --region us-gov-west-1
+
+  set-deploy-environments:
+    name: Set environments to deploy
+    needs: [archive, build]
+    if: always() && github.ref == 'refs/heads/main' && needs.archive.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.set-environments.outputs.environments }}
+    env:
+      DEPLOY_TO_PRODUCTION: false # Enables production deployments for apps on the allowlist when set to true
+      IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
+      DEV: "{
+          \\\"environment\\\": \\\"vagovdev\\\", 
+          \\\"bucket\\\": \\\"dev.va.gov\\\", 
+          \\\"asset_bucket\\\": \\\"dev-va-gov-assets\\\",
+          \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
+        }"
+      STAGING: "{
+          \\\"environment\\\": \\\"vagovstaging\\\", 
+          \\\"bucket\\\": \\\"staging.va.gov\\\", 
+          \\\"asset_bucket\\\": \\\"staging-va-gov-assets\\\",
+          \\\"iam_role\\\": \\\"AWS_FRONTEND_NONPROD_ROLE\\\"
+        }"
+      PROD: "{
+          \\\"environment\\\": \\\"vagovprod\\\", 
+          \\\"bucket\\\": \\\"www.va.gov\\\", 
+          \\\"asset_bucket\\\": \\\"prod-va-gov-assets\\\",
+          \\\"iam_role\\\": \\\"AWS_FRONTEND_PROD_ROLE\\\"
+        }"
+    steps:
+      - name: Set environments for deploy matrix
+        id: set-environments
+        run: |
+          if [[ ${{ env.DEPLOY_TO_PRODUCTION }} == true && ${{ env.IS_ISOLATED_APP_BUILD }} == true ]]; then
+            echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}},${{env.PROD}}]}
+          else
+            echo ::set-output name=environments::{\"include\":[${{env.DEV}},${{env.STAGING}}]}
+          fi
+  
+  deploy:
+    name: Deploy
+    needs: [build, set-deploy-environments]
+    if: always() && github.ref == 'refs/heads/main' && needs.set-deploy-environments.result == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.set-deploy-environments.outputs.environments) }}
+    env:
+      IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Check commit deployability
+        id: check-deployability
+        run: node ./script/github-actions/check-deployability.js
+        env:
+          BUILDTYPE: ${{ matrix.environment }}
+
+      - name: Configure AWS credentials (1)
+        if: steps.check-deployability.outputs.is_deployable == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get AWS IAM role
+        if: steps.check-deployability.outputs.is_deployable == 'true'
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/${{ matrix.iam_role }}
+          env_variable_name: ${{ matrix.iam_role }}
+
+      - name: Configure AWS Credentials (2)
+        if: steps.check-deployability.outputs.is_deployable == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE != '' && env.AWS_FRONTEND_NONPROD_ROLE || env.AWS_FRONTEND_PROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Deploy
+        if: steps.check-deployability.outputs.is_deployable == 'true'
+        run: |
+          if [[ "${{ env.IS_ISOLATED_APP_BUILD }}" == "true" ]]; then
+            ./script/github-actions/partial-deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
+          else
+            ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
+          fi
+        env:
+          SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
+          DEST: s3://${{ matrix.bucket }}
+          ASSET_DEST: s3://${{ matrix.asset_bucket }}
+
+  notify-failure:
+    name: Notify Failure
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
+    needs: deploy
+    env:
+      ALERT_TEAMS: true # Alerts teams for single/grouped app builds when set to true
+      DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
+      VETS_WEBSITE_CHANNEL_ID: C02V265VCGH #status-vets-website
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        if: env.ALERT_TEAMS == 'true'
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: Get changed applications
+        id: get-changed-apps
+        if: env.ALERT_TEAMS == 'true'
+        uses: ./.github/workflows/get-changed-apps
+        with:
+          output-type: 'slack_group'
+
+      - name: Notify application team in Slack
+        if: env.ALERT_TEAMS == 'true' && steps.get-changed-apps.outputs.slack_groups != ''
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        continue-on-error: true
+        with:
+          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${{steps.get-changed-apps.outputs.slack_groups}} CI for your application failed on the `main` branch in `vets-website`: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>\n For help troubleshooting, see the <https://depo-platform-documentation.scrollhelp.site/developer-docs/Handling-failed-single%2Fgrouped-application-pipelines.2066645150.html|documentation> on failed workflow runs."}}]}]}'
+          channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Notify Slack
+        if: steps.get-changed-apps.outputs.slack_groups == ''
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@main
+        continue-on-error: true
+        with:
+          payload: '{"attachments": [{"color": "#FF0800","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "`main` branch CI in `vets-website` failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+          channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1270,10 +1270,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           payload: | 
             {
-              "text": "Production deploy for vets-website coming up.",
               "attachments": [
                 {
-                  "pretext": "",
                   "color": "#07711E",
                   "blocks": [
                     {

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -98,8 +98,6 @@ jobs:
     name: Notify Start
     runs-on: ubuntu-latest
     needs: set-env
-    env:
-      RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -107,6 +105,8 @@ jobs:
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
+        env:
+          RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
         with:
           channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          channel_id: C032FM8LFCN
+          channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           payload: | 

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -94,22 +94,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # notify-start:
-  #   name: Notify Start
-  #   runs-on: ubuntu-latest
-  #   needs: set-env
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  notify-start:
+    name: Notify Start
+    runs-on: ubuntu-latest
+    needs: set-env
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Notify Slack
-  #       uses: ./.github/workflows/slack-notify
-  #       continue-on-error: true
-  #       with:
-  #         payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ fromJSON(needs.set-env.outputs.RELEASE_WAIT) < 5 && a few || needs.set-env.outputs.RELEASE_WAIT }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
-  #         channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Notify Slack
+      #   uses: ./.github/workflows/slack-notify
+      #   continue-on-error: true
+      #   with:
+      #     payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ fromJSON(needs.set-env.outputs.RELEASE_WAIT) < 5 && a few || needs.set-env.outputs.RELEASE_WAIT }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
+      #     channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   build:
     name: Build

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -98,18 +98,36 @@ jobs:
     name: Notify Start
     runs-on: ubuntu-latest
     needs: set-env
+    env:
+      RELEASE_WAIT_MINUTES: ${{ needs.set-env.outputs.RELEASE_WAIT < 5 && 'a few' || needs.set-env.outputs.RELEASE_WAIT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # - name: Notify Slack
-      #   uses: ./.github/workflows/slack-notify
-      #   continue-on-error: true
-      #   with:
-      #     payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ fromJSON(needs.set-env.outputs.RELEASE_WAIT) < 5 && a few || needs.set-env.outputs.RELEASE_WAIT }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
-      #     channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Notify Slack
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: true
+        with:
+          channel_id: C032FM8LFCN
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          payload: | 
+            {
+              "attachments": [
+                {
+                  "color": "#07711E",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "Stand by, production deploy for vets-website coming up in ${{ env.RELEASE_WAIT_MINUTES }} minutes. View what's coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
 
   build:
     name: Build

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -94,22 +94,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  notify-start:
-    name: Notify Start
-    runs-on: ubuntu-latest
-    needs: set-env
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  # notify-start:
+  #   name: Notify Start
+  #   runs-on: ubuntu-latest
+  #   needs: set-env
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
 
-      - name: Notify Slack
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        with:
-          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ fromJSON(needs.set-env.outputs.RELEASE_WAIT) < 5 && a few || needs.set-env.outputs.RELEASE_WAIT }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
-          channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #     - name: Notify Slack
+  #       uses: ./.github/workflows/slack-notify
+  #       continue-on-error: true
+  #       with:
+  #         payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for vets-website coming up in ${{ fromJSON(needs.set-env.outputs.RELEASE_WAIT) < 5 && a few || needs.set-env.outputs.RELEASE_WAIT }} minutes. View what is coming here: <https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}}]}]}'
+  #         channel_id: ${{ env.VETS_WEBSITE_CHANNEL_ID }}
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   build:
     name: Build


### PR DESCRIPTION
## Description
This PR fixes syntax issues with the `Notify Start` job in the daily production deploy workflow. Instead of adding the logic in the `text` field of the payload, the logic is moved to an environment variable.

## Testing done
Tested in Slack.

## Screenshots
**Message with a release wait of less than 5 minutes**
<img width="594" alt="image" src="https://user-images.githubusercontent.com/9042882/189011371-e0df1419-2c3e-42b9-8c14-f683c1f8a530.png">

**Message with a release wait of more than 5 minutes**
<img width="576" alt="image" src="https://user-images.githubusercontent.com/9042882/189011449-356b5ac4-2651-4976-b96a-5c6f035c64ce.png">

## Acceptance criteria
- [x] Daily Production Deploy workflow has proper syntax.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
