### PR TITLE
removes JSON.parse in customCOEsubmit

### DIFF
--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -38,7 +38,7 @@ export const customCOEsubmit = (formConfig, form) => {
   };
 
   // transformForSubmit returns a JSON string
-  const formData = JSON.parse(transformForSubmit(formConfig, formattedForm));
+  const formData = transformForSubmit(formConfig, formattedForm);
 
   return JSON.stringify({
     lgyCoeClaim: {

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -1,21 +1,62 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import formConfig from '../../config/form';
+import * as helpers from 'platform/forms-system/src/js/helpers';
 import {
   customCOEsubmit,
   validateDocumentDescription,
 } from '../../config/helpers';
-import maximalTest from '../fixtures/data/maximal-test.json';
-import maximalTestResult from '../fixtures/data/transformed-maximal-test.json';
+
+const form = {
+  data: {
+    periodsOfService: [{ dateRange: { from: '2010-10-10', to: '2012-12-12' } }],
+    relevantPriorLoans: [
+      { dateRange: { from: '1990-01-XX', to: '1992-02-XX' } },
+    ],
+  },
+};
+
+const formattedProperties = {
+  periodsOfService: [
+    {
+      dateRange: {
+        from: '2010-10-10T00:00:00.000Z',
+        to: '2012-12-12T00:00:00.000Z',
+      },
+    },
+  ],
+  relevantPriorLoans: [
+    {
+      dateRange: {
+        from: '1990-01-01T05:00:00.000Z',
+        to: '1992-02-01T05:00:00.000Z',
+      },
+    },
+  ],
+};
+
+const result = JSON.stringify({
+  lgyCoeClaim: {
+    form: {
+      ...formattedProperties,
+    },
+  },
+});
+
+let sandbox;
+
+beforeEach(() => {
+  sandbox = sinon.sandbox.create();
+});
+
+afterEach(() => {
+  sandbox.restore();
+});
 
 describe('coe helpers', () => {
   describe('customCOEsubmit', () => {
     it('should correctly format the form data', () => {
-      const submitting = JSON.parse(
-        customCOEsubmit(formConfig, { data: maximalTest }),
-      );
-      expect(submitting).to.deep.equal(maximalTestResult);
+      sandbox.stub(helpers, 'transformForSubmit').returns(formattedProperties);
+      expect(customCOEsubmit({}, form)).to.equal(result);
     });
   });
   describe('validateDocumentDescription', () => {


### PR DESCRIPTION
## Description

This undoes a change to `formData` from a few weeks ago where JSON.parse was used. It was causing issues on submission as the API was expecting a string for the payload.