### PR TITLE
My Education Benefits—Wait for Feature Flags to Load

### DIFF
--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -13,6 +13,7 @@ import { getAppData } from '../selectors/selectors';
 export const App = ({
   location,
   children,
+  featureTogglesLoaded,
   formData,
   setFormData,
   getPersonalInfo,
@@ -31,7 +32,8 @@ export const App = ({
     () => {
       if (
         !user.login.currentlyLoggedIn ||
-        (showUnverifiedUserAlert !== false && isLOA3 !== true)
+        !featureTogglesLoaded ||
+        (showUnverifiedUserAlert && isLOA3 !== true)
       ) {
         return;
       }
@@ -60,6 +62,7 @@ export const App = ({
     [
       claimantInfo,
       eligibility,
+      featureTogglesLoaded,
       fetchedEligibility,
       fetchedPersonalInfo,
       firstName,
@@ -93,6 +96,7 @@ App.propTypes = {
   children: PropTypes.object,
   claimantInfo: PropTypes.object,
   eligibility: PropTypes.object,
+  featureTogglesLoaded: PropTypes.bool,
   firstName: PropTypes.string,
   formData: PropTypes.object,
   getEligibility: PropTypes.func,

--- a/src/applications/my-education-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/my-education-benefits/containers/IntroductionPage.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import PropTypes from 'prop-types';
 
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 
 import { getAppData } from '../selectors/selectors';
@@ -9,15 +10,22 @@ import HowToApplyPost911GiBillV1 from '../components/HowToApplyPost911GiBillV1';
 import HowToApplyPost911GiBillV2 from '../components/HowToApplyPost911GiBillV2';
 import IntroductionLoginV1 from '../components/IntroductionLoginV1';
 import IntroductionLoginV2 from '../components/IntroductionLoginV2';
+import LoadingIndicator from '../components/LoadingIndicator';
 
-export const IntroductionPage = ({ route, showUnverifiedUserAlert }) => {
+export const IntroductionPage = ({
+  featureTogglesLoaded,
+  route,
+  showUnverifiedUserAlert,
+}) => {
   return (
     <div className="schemaform-intro">
       <FormTitle title="Apply for VA education benefits" />
       <p>Equal to VA Form 22-1990 (Application for VA Education Benefits)</p>
 
-      {showUnverifiedUserAlert === false && <HowToApplyPost911GiBillV1 />}
-      {showUnverifiedUserAlert && <HowToApplyPost911GiBillV2 route={route} />}
+      {featureTogglesLoaded &&
+        !showUnverifiedUserAlert && <HowToApplyPost911GiBillV1 />}
+      {featureTogglesLoaded &&
+        showUnverifiedUserAlert && <HowToApplyPost911GiBillV2 route={route} />}
 
       <h2>Follow these steps to get started</h2>
       <div className="process schemaform-process">
@@ -88,14 +96,21 @@ export const IntroductionPage = ({ route, showUnverifiedUserAlert }) => {
         </ol>
       </div>
 
-      {showUnverifiedUserAlert === false && (
-        <IntroductionLoginV1 route={route} />
-      )}
-      {showUnverifiedUserAlert && <IntroductionLoginV2 route={route} />}
+      {!featureTogglesLoaded && <LoadingIndicator />}
+      {featureTogglesLoaded &&
+        !showUnverifiedUserAlert && <IntroductionLoginV1 route={route} />}
+      {featureTogglesLoaded &&
+        showUnverifiedUserAlert && <IntroductionLoginV2 route={route} />}
 
       <OMBInfo resBurden={15} ombNumber="2900-0154" expDate="02/28/2023" />
     </div>
   );
+};
+
+IntroductionPage.propTypes = {
+  featureTogglesLoaded: PropTypes.bool,
+  route: PropTypes.object,
+  showUnverifiedUserAlert: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/my-education-benefits/selectors/selectors.js
+++ b/src/applications/my-education-benefits/selectors/selectors.js
@@ -7,6 +7,7 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 export const getAppData = state => ({
   eligibility: state.data?.eligibility,
+  featureTogglesLoaded: state.featureToggles?.loading === false,
   formId: state?.form?.formId,
   isClaimantCallComplete: state.data?.personalInfoFetchComplete,
   isEligibilityCallComplete: state.data?.eligibilityFetchComplete,


### PR DESCRIPTION
## Description
MEB redirects when a call to retrieve a claimant's information fails or is empty. Wait to retrieve claimant info until after feature flags are loaded because, if the `showUnverifiedUserAlert` feature flag is on (true) and the claimant does not have an LOA of 3, we do not retrieve their claimant info but rather prompt them to verify their ID.me account. In some cases, the claimant info call was going out prior to the feature flags being returned because we set `showUnverifiedUserAlert` to false if it's undefined to mitigate feature state not persisting (https://github.com/department-of-veterans-affairs/va.gov-team/issues/46741).