### PR TITLE
removing pst-flt from code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,10 +8,10 @@
 
 # VSP
 *       @department-of-veterans-affairs/platform-release-tools
-src/applications/_mock-form @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
-src/applications/burial-poc-v6 @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
-src/platform/forms        @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
-src/platform/forms-system @department-of-veterans-affairs/pst-forms-library @department-of-veterans-affairs/platform-design-system-fe
+src/applications/_mock-form @department-of-veterans-affairs/platform-design-system-fe
+src/applications/burial-poc-v6 @department-of-veterans-affairs/platform-design-system-fe
+src/platform/forms        @department-of-veterans-affairs/platform-design-system-fe
+src/platform/forms-system @department-of-veterans-affairs/platform-design-system-fe
 script/component-migration @department-of-veterans-affairs/platform-design-system-fe
 
 # VSP-Identity authentication


### PR DESCRIPTION
## Description

Removing the `Platform Spike Team - Forms Library Team` from the CODEOWNERS file.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#571](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/571)

## Acceptance criteria
- [ ] PST-FLT is removed and no longer required for approvals

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
