### PR TITLE
Remove TOE, Fry, enrollment verification and education-letters from CD

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -30,15 +30,18 @@
     },
     {
       "rootFolder": "education-letters",
-      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>"
+      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>",
+      "continuousDeployment": false
     },
     {
       "rootFolder": "enrollment-verification",
-      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>"
+      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>",
+      "continuousDeployment": false
     },
     {
       "rootFolder": "fry-dea",
-      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>"
+      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>",
+      "continuousDeployment": false
     },
     {
       "rootFolder": "gi",
@@ -61,7 +64,8 @@
     },
     {
       "rootFolder": "toe",
-      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>"
+      "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>",
+      "continuousDeployment": false
     },
     {
       "rootFolder": "vaos",


### PR DESCRIPTION
## Description
The leadership team for the aforementioned apps has decided to opt out from continuous deployment at this time.

The key reasons we want to be exempt is we want to be able to:

- Verify code (including the feature flag code itself) with test data that is only available in staging/UAT prior to sending to production

- Enable VA stakeholders opportunity to validate the changes in the pull request prior to moving to production.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
