### PR TITLE
Bump component-library to version 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^11.5.5",
+    "@department-of-veterans-affairs/component-library": "^12.0.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,13 +2505,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^11.5.5":
-  version "11.5.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-11.5.5.tgz#a7cb577f50d0cf1e7131928348cd314fcd4ceb76"
-  integrity sha512-8bOQrM+HN+Wbrqy1/JtjDyICzUiVNRxm4peF4QV7lCDC4O0v//yomAs+tKL42aiAh5p6QTK2HxmF6LYV1aFt8g==
+"@department-of-veterans-affairs/component-library@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-12.0.0.tgz#ac3969c0f5c94b605f2287198ffe2b742438de60"
+  integrity sha512-xhOLJ6dlDraKhb/tpDgY/0ZoolxOIiwzA3c6ZgIhSy8gmCjhnFGGyNUiwxhoUG34yebgCokXLwn52HlNHotbdg==
   dependencies:
-    "@department-of-veterans-affairs/react-components" "7.0.1"
-    "@department-of-veterans-affairs/web-components" "4.12.5"
+    "@department-of-veterans-affairs/react-components" "8.0.0"
+    "@department-of-veterans-affairs/web-components" "4.13.2"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2543,10 +2543,10 @@
     yeoman-generator "^5.6.1"
     yosay "^2.0.2"
 
-"@department-of-veterans-affairs/react-components@7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-7.0.1.tgz#028b42813ee811927cc93793dd66a2a641170755"
-  integrity sha512-Z67ikFe45v7WCuALOVi8EFPSu9snYRcMLza2uEV9X+xzSNZmohcMwrWBYtiPAxcgBq2KC75SzbZFB2Crr6pa/Q==
+"@department-of-veterans-affairs/react-components@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-8.0.0.tgz#1df916d653a3267fed962482571e8f851b9cb90f"
+  integrity sha512-WaJePVNQAVRgjn8gHZotHaRd58Irds0LCEEVyWLVuPNbTxXAlRvG7LSh8VkYsD2rlvF4Zsz1cBlgJ7DI71NtDQ==
   dependencies:
     classnames "^2.2.6"
     prop-types "^15.6.2"
@@ -2584,10 +2584,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.12.5":
-  version "4.12.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.12.5.tgz#cde9c98d7bc981ae4d580e0ca0f5ab9e6ae095c6"
-  integrity sha512-JuPOmqrGgyoXQaGDluzDwmQYphqDI6mNyrK6sCj76bSkgmZJG2gpzQVO1zGZaddqQJoFiIUtjPxfdDtpT7VDSQ==
+"@department-of-veterans-affairs/web-components@4.13.2":
+  version "4.13.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.13.2.tgz#30879c5a8700cd5fabcf8c703779c0dd84243888"
+  integrity sha512-bpZYG7QzhXrLsSZcWw7NY67QtqfrjnB8TjWUIRI4DgrCaXF7lamRrFFI/zntP0SKEDENlpaiHS09ut6y4dSuyw==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description

This includes a major version change which removes 3 React components:

- `Date`
- `MonthYear`
- `NumberInput`

It also includes translation functionality for the "On this page" component and a [fix for height calculation](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v11.6.1) for the additional info and expandable alert components.

## Original issue(s)
N/A


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
