### PR TITLE
Certificate of Eligibility | Use feature toggle for rendering app

### DIFF
--- a/src/applications/lgy/coe/form/containers/App.jsx
+++ b/src/applications/lgy/coe/form/containers/App.jsx
@@ -53,7 +53,7 @@ const mapDispatchToProps = {
 const mapStateToProps = state => ({
   isLoading: isLoadingFeatures(state),
   loggedIn: isLoggedIn(state),
-  showCoe: !showCoeFeature(state),
+  showCoe: showCoeFeature(state),
 });
 
 App.propTypes = {

--- a/src/applications/lgy/coe/form/containers/App.jsx
+++ b/src/applications/lgy/coe/form/containers/App.jsx
@@ -22,17 +22,23 @@ function App({
 }) {
   useEffect(
     () => {
-      if (typeof getCoeMock === 'function' && !environment.isProduction()) {
-        getCoeMock(!loggedIn);
-      } else {
-        getCoe(!loggedIn);
+      if (showCoe) {
+        if (typeof getCoeMock === 'function' && !environment.isProduction()) {
+          getCoeMock(!loggedIn);
+        } else {
+          getCoe(!loggedIn);
+        }
       }
     },
-    [getCoe, getCoeMock, loggedIn],
+    [showCoe, getCoe, getCoeMock, loggedIn],
   );
 
+  if (isLoading) {
+    return <va-loading-indicator message="Loading application..." />;
+  }
+
   // Show WIP alert if the feature flag isn't set
-  return showCoe && !isLoading ? (
+  return showCoe ? (
     <article
       id="form-26-1880"
       data-location={`${location?.pathname?.slice(1)}`}

--- a/src/applications/lgy/coe/form/containers/App.jsx
+++ b/src/applications/lgy/coe/form/containers/App.jsx
@@ -8,8 +8,18 @@ import { isLoggedIn } from 'platform/user/selectors';
 
 import { generateCoe } from '../../shared/actions';
 import formConfig from '../config/form';
+import { isLoadingFeatures, showCoeFeature } from '../../shared/utils/helpers';
+import { WIP } from '../../shared/components/WIP';
 
-function App({ children, getCoe, getCoeMock, location, loggedIn }) {
+function App({
+  children,
+  getCoe,
+  getCoeMock,
+  isLoading,
+  location,
+  loggedIn,
+  showCoe,
+}) {
   useEffect(
     () => {
       if (typeof getCoeMock === 'function' && !environment.isProduction()) {
@@ -21,7 +31,8 @@ function App({ children, getCoe, getCoeMock, location, loggedIn }) {
     [getCoe, getCoeMock, loggedIn],
   );
 
-  return (
+  // Show WIP alert if the feature flag isn't set
+  return showCoe && !isLoading ? (
     <article
       id="form-26-1880"
       data-location={`${location?.pathname?.slice(1)}`}
@@ -30,6 +41,8 @@ function App({ children, getCoe, getCoeMock, location, loggedIn }) {
         {children}
       </RoutedSavableApp>
     </article>
+  ) : (
+    <WIP />
   );
 }
 
@@ -38,7 +51,9 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = state => ({
+  isLoading: isLoadingFeatures(state),
   loggedIn: isLoggedIn(state),
+  showCoe: !showCoeFeature(state),
 });
 
 App.propTypes = {
@@ -46,7 +61,9 @@ App.propTypes = {
   getCoe: PropTypes.func.isRequired,
   location: PropTypes.object.isRequired,
   getCoeMock: PropTypes.func,
+  isLoading: PropTypes.bool,
   loggedIn: PropTypes.bool,
+  showCoe: PropTypes.bool,
 };
 
 export default connect(

--- a/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
@@ -8,7 +8,11 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import App from '../../containers/App';
 
-const getData = ({ loggedIn = true, getCoeMock = () => {} } = {}) => ({
+const getData = ({
+  loggedIn = true,
+  getCoeMock = () => {},
+  showCOE = true,
+} = {}) => ({
   props: {
     children: <div>children</div>,
     formData: {},
@@ -32,6 +36,11 @@ const getData = ({ loggedIn = true, getCoeMock = () => {} } = {}) => ({
           metadata: {},
         },
       },
+      featureToggles: {
+        loading: false,
+        // eslint-disable-next-line camelcase
+        coe_access: showCOE,
+      },
     }),
     subscribe: () => {},
     dispatch: () => {},
@@ -51,6 +60,21 @@ describe('App', () => {
     const article = $('#form-26-1880', container);
     expect(article).to.exist;
     expect(article.dataset.location).to.eq('introduction');
+  });
+
+  it('should render WIP alert', () => {
+    const { props, mockStore } = getData({ showCOE: false });
+    const { container } = render(
+      <div>
+        <Provider store={mockStore}>
+          <App {...props} />
+        </Provider>
+      </div>,
+    );
+    expect($('va-alert', container)).to.exist;
+    expect($('h1', container).textContent).to.contain(
+      'We’re still working on this feature',
+    );
   });
 
   it.skip('should call API if logged in', async () => {

--- a/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/containers/App.unit.spec.jsx
@@ -12,6 +12,7 @@ const getData = ({
   loggedIn = true,
   getCoeMock = () => {},
   showCOE = true,
+  loading = false,
 } = {}) => ({
   props: {
     children: <div>children</div>,
@@ -37,7 +38,7 @@ const getData = ({
         },
       },
       featureToggles: {
-        loading: false,
+        loading,
         // eslint-disable-next-line camelcase
         coe_access: showCOE,
       },
@@ -60,6 +61,18 @@ describe('App', () => {
     const article = $('#form-26-1880', container);
     expect(article).to.exist;
     expect(article.dataset.location).to.eq('introduction');
+  });
+
+  it('should render loading indicator', () => {
+    const { props, mockStore } = getData({ loading: true });
+    const { container } = render(
+      <div>
+        <Provider store={mockStore}>
+          <App {...props} />
+        </Provider>
+      </div>,
+    );
+    expect($('va-loading-indicator', container)).to.exist;
   });
 
   it('should render WIP alert', () => {

--- a/src/applications/lgy/coe/shared/components/WIP.jsx
+++ b/src/applications/lgy/coe/shared/components/WIP.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export const WIP = () => (
+  <div className="row vads-u-margin-bottom--5">
+    <div className="usa-width-two-thirds medium-8 columns">
+      <va-alert status="warning">
+        <h1 slot="headline" className="vads-u-font-size--h3">
+          We’re still working on this feature
+        </h1>
+        <p>
+          We’re rolling out the VA home loan Certificate of Eligibility form in
+          stages. It’s not quite ready yet. Please check back again soon.
+        </p>
+        <p>
+          <a
+            href="/housing-assistance/home-loans/"
+            className="u-vads-display--block u-vads-margin-top--2"
+          >
+            Return to VA-backed Veterans home loans information page
+          </a>
+        </p>
+      </va-alert>
+    </div>
+  </div>
+);

--- a/src/applications/lgy/coe/shared/utils/helpers.js
+++ b/src/applications/lgy/coe/shared/utils/helpers.js
@@ -1,0 +1,6 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const isLoadingFeatures = state => toggleValues(state).loading;
+export const showCoeFeature = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.coeAccess];

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -17,6 +17,8 @@ import {
   Ineligible,
   Pending,
 } from '../components/statuses';
+import { isLoadingFeatures, showCoeFeature } from '../../shared/utils/helpers';
+import { WIP } from '../../shared/components/WIP';
 
 const App = ({
   certificateOfEligibility: { coe, generateAutoCoeStatus, profileIsUpdating },
@@ -24,10 +26,19 @@ const App = ({
   getCoeMock,
   loggedIn,
   user,
+  showCoe,
+  isLoading,
 }) => {
   useEffect(
     () => {
-      if (!profileIsUpdating && !coe) {
+      if (
+        // Show WIP alert if the feature flag isn't set - remove once @ 100%
+        !isLoading &&
+        showCoe &&
+        // get COE status
+        !profileIsUpdating &&
+        !coe
+      ) {
         if (typeof getCoeMock === 'function' && !environment.isProduction()) {
           getCoeMock(!loggedIn);
         } else {
@@ -35,8 +46,13 @@ const App = ({
         }
       }
     },
-    [coe, getCoe, getCoeMock, loggedIn, profileIsUpdating],
+    [coe, getCoe, getCoeMock, isLoading, loggedIn, profileIsUpdating, showCoe],
   );
+
+  // Show WIP alert if the feature flag isn't set - remove once @ 100%
+  if (!showCoe) {
+    return <WIP />;
+  }
 
   let content;
 
@@ -111,6 +127,8 @@ const mapStateToProps = state => ({
   certificateOfEligibility: state.certificateOfEligibility,
   user: state.user,
   loggedIn: isLoggedIn(state),
+  isLoading: isLoadingFeatures(state),
+  showCoe: !showCoeFeature(state),
 });
 
 const mapDispatchToProps = {
@@ -121,7 +139,9 @@ App.propTypes = {
   certificateOfEligibility: PropTypes.object,
   getCoe: PropTypes.func,
   getCoeMock: PropTypes.func,
+  isLoading: PropTypes.bool,
   loggedIn: PropTypes.bool,
+  showCoe: PropTypes.bool,
   user: PropTypes.object,
 };
 

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -128,7 +128,7 @@ const mapStateToProps = state => ({
   user: state.user,
   loggedIn: isLoggedIn(state),
   isLoading: isLoadingFeatures(state),
-  showCoe: !showCoeFeature(state),
+  showCoe: showCoeFeature(state),
 });
 
 const mapDispatchToProps = {

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -50,13 +50,17 @@ const App = ({
   );
 
   // Show WIP alert if the feature flag isn't set - remove once @ 100%
-  if (!showCoe) {
+  if (!showCoe && !isLoading) {
     return <WIP />;
   }
 
   let content;
 
-  if (generateAutoCoeStatus === CALLSTATUS.idle || profileIsUpdating) {
+  if (
+    generateAutoCoeStatus === CALLSTATUS.idle ||
+    profileIsUpdating ||
+    isLoading
+  ) {
     content = <va-loading-indicator message="Loading application..." />;
   } else if (generateAutoCoeStatus === CALLSTATUS.pending) {
     content = (

--- a/src/applications/lgy/coe/status/routes.jsx
+++ b/src/applications/lgy/coe/status/routes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router';
-import App from './containers/App.jsx';
+import App from './containers/App';
 
 const routes = <Route path="/" component={App} />;
 

--- a/src/applications/lgy/coe/status/tests/containers/App.unit.spec.jsx
+++ b/src/applications/lgy/coe/status/tests/containers/App.unit.spec.jsx
@@ -15,6 +15,7 @@ const getData = ({
   coe = '',
   generateAutoCoeStatus = '',
   profileIsUpdating = false,
+  showCOE = true,
 } = {}) => ({
   props: {
     getCoe: () => {},
@@ -40,6 +41,11 @@ const getData = ({
         coe: coe ? { status: coe, referenceNumber: '123' } : null,
         generateAutoCoeStatus,
         profileIsUpdating,
+      },
+      featureToggles: {
+        loading: false,
+        // eslint-disable-next-line camelcase
+        coe_access: showCOE,
       },
     }),
     subscribe: () => {},


### PR DESCRIPTION
## Original Ticket

[#46328](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46328)

## URL of change

- Form: `/housing-assistance/home-loans/request-coe-form-26-1880/`
- Status: `/housing-assistance/home-loans/check-coe-status/your-coe/`

## Background

The COE form and status apps were set to always render. This PR uses the feature flag `coe_access` to render the app, or show a work-in-progress alert.

## Steps to test

1. Pull in this branch locally
2. Go to http://localhost:3000/flipper/features/coe_access and disable the feature
3. Go to either URL of change
4. A Work-In-Progress alert will show

## Code changes

- Added feature flag check to both the COE form & status apps
- Ensure that only the loading indicator is shown while features are being loaded
- Added unit tests

## How was your code tested

Unit & manual testing

## Acceptance criteria
- [x] Show WIP alert when COE feature flag is disabled (`false`)
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs