### PR TITLE
Certificate of Eligibility | Fix review & submit a11y

### DIFF
--- a/src/applications/lgy/coe/form/components/LoanReviewField.jsx
+++ b/src/applications/lgy/coe/form/components/LoanReviewField.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import text from '../content/loanHistory';
+
+// Review field added to fix improper DL & DIV wrapping of loan cards on the
+// review & submit page; renderedProperties is passed as a param, but is missing
+// the needed DL wrapper
+const LoanReviewField = ({ defaultEditButton, title, formData } = {}) => {
+  if ((formData?.relevantPriorLoans || []).length === 0) {
+    return null;
+  }
+
+  const keys = Object.keys(text);
+  const content = (formData?.relevantPriorLoans || []).map((loan, index) => (
+    <div key={index} className="review">
+      <div className="schemaform-field-container">
+        <div className="va-growable-background vads-u-margin-top--1">
+          <div className="row small-collapse">
+            <div className="small-12 columns">
+              <h5 className="schemaform-array-readonly-header">
+                VA-backed loan
+              </h5>
+              <dl className="review">
+                {keys.map(key => (
+                  <div key={key} className="review-row">
+                    <dt>{text[key].title}</dt>
+                    <dd>{text[key].value(loan)}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  ));
+
+  return (
+    <>
+      <div className="form-review-panel-page-header-row">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
+          {title}
+        </h4>
+        {defaultEditButton()}
+      </div>
+      {content}
+    </>
+  );
+};
+
+LoanReviewField.propTypes = {
+  defaultEditButton: PropTypes.element,
+  formData: PropTypes.shape({
+    relevantPriorLoans: PropTypes.array,
+  }),
+  title: PropTypes.string,
+};
+
+export default LoanReviewField;

--- a/src/applications/lgy/coe/form/config/chapters/loans/existingLoanScreener.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/existingLoanScreener.js
@@ -7,14 +7,10 @@ export const uiSchema = {
     'ui:title': 'Have you ever had a VA-backed loan?',
     'ui:widget': 'yesNo',
     'ui:options': {
-      // NOTE: using yesNoReverse flips the underlying value (true/false) associated
-      // with the yes/no radio buttons. Because of this, the 'yes' label is associated
-      // with false and vice versa.
       labels: {
-        Y: 'No, I’ve never had a VA-backed loan.',
-        N: 'Yes, I had a loan in the past or have one now.',
+        Y: 'Yes, I had a loan in the past or have one now.',
+        N: 'No, I’ve never had a VA-backed loan.',
       },
-      yesNoReverse: true,
     },
   },
 };

--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -9,6 +9,8 @@ import monthYearRangeUI from 'platform/forms-system/src/js/definitions/monthYear
 import { states } from 'platform/forms/address';
 
 import { loanHistory } from '../../schemaImports';
+import LoanReviewField from '../../../components/LoanReviewField';
+import text from '../../../content/loanHistory';
 
 const stateLabels = createUSAStateLabels(states);
 
@@ -57,12 +59,14 @@ PreviousLoanView.propTypes = {
 export const schema = loanHistory;
 
 export const uiSchema = {
+  'ui:objectViewField': LoanReviewField,
   relevantPriorLoans: {
     'ui:description': 'Tell us about all your VA-backed loans',
     'ui:options': {
       itemName: 'VA-backed Loan',
       viewField: PreviousLoanView,
       keepInPageOnReview: true,
+      customTitle: ' ', // Force outer DIV wrap (vs DL wrap, for a11y)
     },
     items: {
       'ui:title': 'Existing VA loan',
@@ -71,9 +75,9 @@ export const uiSchema = {
         itemName: 'VA-backed loan',
       },
       dateRange: monthYearRangeUI(
-        'Closing date of your loan',
-        'Date you paid off your loan (Leave this blank if it’s not paid off)',
-        'Date loan ended must be after the start of the loan',
+        text.loanClose.title,
+        text.loanPaid.title,
+        text.loanPaid.error,
         true, // allow start & end to be the same month/year
       ),
       propertyAddress: {
@@ -86,52 +90,51 @@ export const uiSchema = {
           'propertyZip',
         ],
         propertyAddress1: {
-          'ui:title': 'Street address',
-          'ui:errorMessages': { required: 'Please enter a street address' },
+          'ui:title': text.address1.title,
+          'ui:errorMessages': { required: text.address1.error },
         },
         propertyAddress2: {
-          'ui:title': 'Street address line 2',
+          'ui:title': text.address2.title,
           'ui:options': {
             hideEmptyValueInReview: true,
           },
         },
         propertyCity: {
-          'ui:title': `City`,
-          'ui:errorMessages': { required: 'Please enter a city' },
+          'ui:title': text.city.title,
+          'ui:errorMessages': { required: text.city.error },
         },
         propertyState: {
-          'ui:title': 'State',
+          'ui:title': text.state.title,
           'ui:options': {
             labels: stateLabels,
           },
-          'ui:errorMessages': { required: 'Please enter a state' },
+          'ui:errorMessages': { required: text.state.error },
         },
         propertyZip: {
-          'ui:title': 'Postal code',
+          'ui:title': text.postal.title,
           'ui:options': { widgetClassNames: 'usa-input-medium' },
           'ui:errorMessages': {
-            required: 'Please enter a postal code',
-            pattern:
-              'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+            required: text.postal.error,
+            pattern: text.postal.pattern,
           },
         },
       },
       vaLoanNumber: {
-        'ui:title': 'VA loan number',
+        'ui:title': text.loanNumber.title,
         'ui:options': { widgetClassNames: 'usa-input-medium' },
         'ui:errorMessages': {
-          pattern: 'Please enter numbers only (dashes allowed)',
+          pattern: text.loanNumber.pattern,
         },
       },
       propertyOwned: {
-        'ui:title': 'Do you still own this property?',
+        'ui:title': text.owned.title,
         'ui:widget': 'yesNo',
         'ui:options': {
           hideEmptyValueInReview: true,
         },
       },
       willRefinance: {
-        'ui:title': 'Do you want to refinance this loan?',
+        'ui:title': text.refinance.title,
         'ui:widget': 'yesNo',
         'ui:options': {
           hideEmptyValueInReview: true,

--- a/src/applications/lgy/coe/form/content/loanHistory.js
+++ b/src/applications/lgy/coe/form/content/loanHistory.js
@@ -1,0 +1,53 @@
+import { formatReviewDate } from 'platform/forms-system/src/js/helpers';
+import get from 'platform/utilities/data/get';
+
+export default {
+  loanClose: {
+    title: 'Closing date of your loan',
+    value: data => formatReviewDate(get('dateRange.from', data, ''), true),
+  },
+  loanPaid: {
+    title:
+      'Date you paid off your loan (Leave this blank if it’s not paid off)',
+    value: data => formatReviewDate(get('dateRange.to', data, ''), true),
+    error: 'Date loan ended must be after the start of the loan',
+  },
+  address1: {
+    title: 'Street address',
+    value: data => get('propertyAddress.propertyAddress1', data, ''),
+    error: 'Please enter a street address',
+  },
+  address2: {
+    title: 'Street address line 2',
+    value: data => get('propertyAddress.propertyAddress2', data, ''),
+  },
+  city: {
+    title: 'City',
+    value: data => get('propertyAddress.propertyCity', data, ''),
+    error: 'Please enter a city',
+  },
+  state: {
+    title: 'State',
+    value: data => get('propertyAddress.propertyState', data, ''),
+    error: 'Please enter a state',
+  },
+  postal: {
+    title: 'Postal code',
+    value: data => get('propertyAddress.propertyZip', data, ''),
+    error: 'Please enter a postal code',
+    pattern: 'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+  },
+  loanNumber: {
+    title: 'VA loan number',
+    value: data => get('vaLoanNumber', data, ''),
+    pattern: 'Please enter numbers only (dashes allowed)',
+  },
+  owned: {
+    title: 'Do you still own this property?',
+    value: data => (get('propertyOwned', data, '') ? 'Yes' : 'No'),
+  },
+  refinance: {
+    title: 'Do you want to refinance this loan?',
+    value: data => (get('willRefinance', data, '') ? 'Yes' : 'No'),
+  },
+};

--- a/src/applications/lgy/coe/form/tests/coe.cypress.spec.js
+++ b/src/applications/lgy/coe/form/tests/coe.cypress.spec.js
@@ -9,6 +9,8 @@ import manifest from '../manifest.json';
 import mockUser from './fixtures/mocks/user.json';
 import mockStatus from './fixtures/mocks/status.json';
 import mockUpload from './fixtures/mocks/upload.json';
+import mockInProgress from './fixtures/mocks/in-progress-forms.json';
+import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 
 const testConfig = createTestConfig(
   {
@@ -49,6 +51,8 @@ const testConfig = createTestConfig(
       cy.server();
       // Log in if the form requires an authenticated session.
       cy.login(mockUser);
+      cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+      cy.intercept('PUT', 'v0/in_progress_forms/26-1880', mockInProgress);
 
       cy.intercept('GET', '/v0/coe/status', mockStatus);
       cy.intercept('GET', '/v0/in_progress_forms/26-1880', {});

--- a/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
@@ -7,7 +7,6 @@
   "dateOfBirth": "1950-10-04",
   "applicantAddress": {
     "country": "USA",
-    "view:militaryBaseDescription": {},
     "street": "123 Faker Street",
     "city": "Bogusville",
     "state": "GA",

--- a/src/applications/lgy/coe/form/tests/fixtures/data/minimal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/minimal-test.json
@@ -7,7 +7,6 @@
   "dateOfBirth": "1950-10-04",
   "applicantAddress": {
     "country": "USA",
-    "view:militaryBaseDescription": {},
     "street": "123 Faker Street",
     "city": "Bogusville",
     "state": "GA",
@@ -15,7 +14,6 @@
   },
   "contactPhone": "4445551212",
   "contactEmail": "test2@test1.net",
-  "intent": "REFI",
   "identity": "DNANA",
   "periodsOfService": [
     {

--- a/src/applications/lgy/coe/form/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/mocks/feature-toggles.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "type": "feature_toggles",
+    "features": [{
+      "name": "coe_access",
+      "value": true
+    }],
+    "loading": false
+  }
+}

--- a/src/applications/lgy/coe/form/tests/fixtures/mocks/in-progress-forms.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/mocks/in-progress-forms.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "id": "1234",
+    "type": "in_progress_forms",
+    "attributes": {
+      "formId": "26-1880",
+      "createdAt": "2020-06-30T00:00:00.000Z",
+      "updatedAt": "2020-06-30T00:00:00.000Z",
+      "metadata": {
+        "version": 1,
+        "returnUrl": "/review-and-submit",
+        "savedAt": 1593500000000,
+        "lastUpdated": 1593500000000,
+        "expiresAt": 99999999999
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

While running e2e tests on the review & submit page, a previously passing problem showed up. When the previous loan chapter is expanded, there is a outer wrapping DL which has nested DIVs, and the cards within the chapter are missing the wrapping DL.

<img width="1267" alt="review & submit page showing html with dl wrapping 4 nested divs before reaching a div which should be a dl" src="https://user-images.githubusercontent.com/136959/189715857-58b7fc9b-8434-4b91-bcce-5494dcc2a990.png">

## Original Ticket

[#46916](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46916)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/review-and-submit`

## Background

The form system is using the platform review `ObjectField` to render the loan chapter. However, it is improperly wrapping the entire chapter in a DL, when it should be wrapping each card (array item) in a DL. In order to fix the outer wrap, a `customTitle` value was set to be a truthy value. This did not fix the inner DL wrapping, and in order to accomplish this, a custom `ui:objectViewField` was set to render the necessary semantic HTML.

## Steps to test

1. Go to https://staging.va.gov/housing-assistance/home-loans/request-coe-form-26-1880/introduction
2. Log into user 228 (Colder Polarbear)
3. Start the form
4. Enable the [save-in-progress menu](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-use-the-save-in-progress-m)
5. Open the save-in-progress menu
6. In a new tab, use "Copy raw contents" from the [COE maximal test data](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json)
7. Paste in the data into the save-in-progress menu
8. Set the return url to the review & submit page
9. Use the save-in-progress "Replace" button
10. Expand the "Your VA loan history accordion"
11. Run axe dev tools

## Code changes

- Fixed `existingLoanScreener` yes/no reverse as it was causing the minimal data e2e test to fail
- Updated test data to remove unnecessary data
- Fixed review & submit page a11y issue with wrapping DL/DIV

## How was your code tested

- Manual axe testing on the review & submit page
- Cypress e2e tests

## Acceptance criteria
- [x] Fixede review & submit page a11y issue
- [x] Fixed e2e tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specsv