### PR TITLE
VAOS updated jsdoc comment

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -1118,7 +1118,7 @@ export function getAppointmentTimezone(appointment) {
  *
  * @export
  * @param {String} providerNpi An id for the provider to fetch info for
- * @returns {transformed Provider} transformed Provider info
+ * @returns {Provider} A transformed Provider resource
  */
 export async function fetchPreferredProvider(providerNpi) {
   const prov = await getPreferredCCProvider(providerNpi);


### PR DESCRIPTION
Signed-off-by: Ryan Shaw <ryan.shaw@adhocteam.us>

## Description
Was getting this error when compiling documentation locally:

```
$ jsdoc -c src/applications/vaos/jsdoc.json
ERROR: Unable to parse a tag's type expression for source file /Users/ryanshaw/src/va.gov/vets-website/src/applications/vaos/services/appointment/index.js in line 1116 with tag title "returns" and text "{transformed Provider} transformed Provider info": Invalid type expression "transformed Provider": Expected "|" but "P" found.
ERROR: Unable to parse a tag's type expression for source file /Users/ryanshaw/src/va.gov/vets-website/src/applications/vaos/services/appointment/index.js in line 1123 with tag title "returns" and text "{transformed Provider} transformed Provider info": Invalid type expression "transformed Provider": Expected "|" but "P" found.
```

## Testing done
- Successfully compiled docs locally

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
