### PR TITLE
10678 - Removed default Health Care selection for Mega Menu

### DIFF
--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -180,7 +180,7 @@ header.merger {
   }
   @include media($small-desktop-screen) {
     &.vetnav-submenu--expanded {
-      width: 100% !important;
+      width: 1008px !important;
     }
   }
 }

--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -170,6 +170,21 @@ header.merger {
   }
 }
 
+#vetnav-va-benefits-and-health-care.vetnav-panel {
+  width: 250px !important;
+
+  @include media($medium-large-screen) {
+    &.vetnav-submenu--expanded {
+      width: 768px !important;
+    }
+  }
+  @include media($small-desktop-screen) {
+    &.vetnav-submenu--expanded {
+      width: 100% !important;
+    }
+  }
+}
+
 footer.footer {
   font-size: 16px;
   width: 100%;

--- a/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
@@ -58,7 +58,6 @@ export default class MegaMenu extends React.Component {
         <MenuSection
           key={`${section}-${i}`}
           title={section.title}
-          defaultSection={this.defaultSection(item.menuSections)}
           currentSection={currentSection}
           updateCurrentSection={() => this.updateCurrentSection(section.title)}
           links={section.links}
@@ -87,6 +86,7 @@ export default class MegaMenu extends React.Component {
   handleDocumentClick = event => {
     if (this.props.currentDropdown && !this.menuRef.contains(event.target)) {
       this.props.toggleDropDown('');
+      this.props.updateCurrentSection('');
     }
   };
 
@@ -99,14 +99,6 @@ export default class MegaMenu extends React.Component {
     this.props.updateCurrentSection('');
     this.props.toggleDropDown('');
   };
-
-  defaultSection(sections) {
-    if (this.mobileMediaQuery?.matches) {
-      return '';
-    }
-
-    return sections[0].title;
-  }
 
   toggleDropDown(title) {
     if (this.props.currentDropdown === title) {
@@ -135,6 +127,8 @@ export default class MegaMenu extends React.Component {
       linkClicked,
       columnThreeLinkClicked,
     } = this.props;
+
+    const hasOpenSubMenu = currentSection !== '';
 
     return (
       <div className="login-container" {...display}>
@@ -172,7 +166,10 @@ export default class MegaMenu extends React.Component {
                       aria-haspopup={!!item.menuSections}
                       className="vetnav-level1"
                       data-e2e-id={`${_.kebabCase(item.title)}-${i}`}
-                      onClick={() => this.toggleDropDown(item.title)}
+                      onClick={() => {
+                        this.toggleDropDown(item.title);
+                        this.props.updateCurrentSection('');
+                      }}
                     >
                       {item.title}
                     </button>
@@ -189,7 +186,9 @@ export default class MegaMenu extends React.Component {
                   )}
                   <div
                     id={`vetnav-${_.kebabCase(item.title)}`}
-                    className="vetnav-panel"
+                    className={`vetnav-panel ${
+                      hasOpenSubMenu ? 'vetnav-submenu--expanded' : ''
+                    }`}
                     hidden={currentDropdown !== item.title}
                   >
                     {item.title === currentDropdown &&
@@ -200,9 +199,6 @@ export default class MegaMenu extends React.Component {
                                 <MenuSection
                                   key={`${section}-${j}`}
                                   title={section.title}
-                                  defaultSection={this.defaultSection(
-                                    item.menuSections,
-                                  )}
                                   currentSection={currentSection}
                                   updateCurrentSection={() =>
                                     this.updateCurrentSection(section.title)

--- a/src/platform/site-wide/mega-menu/components/MenuSection.jsx
+++ b/src/platform/site-wide/mega-menu/components/MenuSection.jsx
@@ -22,12 +22,6 @@ class MenuSection extends React.Component {
     }
   }
 
-  getCurrentSection() {
-    return this.props.currentSection
-      ? this.props.currentSection
-      : this.props.defaultSection;
-  }
-
   getId(title) {
     return `vetnav-${_.kebabCase(title)}-ms`;
   }
@@ -53,9 +47,9 @@ class MenuSection extends React.Component {
       mobileMediaQuery,
       smallDesktopMediaQuery,
       title,
+      currentSection,
     } = this.props;
 
-    const currentSection = this.getCurrentSection(this.props);
     const show = currentSection === title;
     const isPlainLink = !!href;
 
@@ -153,8 +147,8 @@ MenuSection.propTypes = {
       href: PropTypes.string.isRequired,
     }),
   }),
+  currentSection: PropTypes.string,
   href: PropTypes.string,
-  defaultSection: PropTypes.string.isRequired,
   linkClicked: PropTypes.func.isRequired,
   columnThreeLinkClicked: PropTypes.func.isRequired,
 };

--- a/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
@@ -6,11 +6,19 @@
  * @testrailinfo runName SH-e2e-MegaMenu
  */
 // Relative imports.
-import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import { mockUser } from 'applications/personalization/profile/tests/fixtures/users/user.js';
 
 Cypress.Commands.add(
   'checkMenuItem',
-  (selector, expectedPath, parentMenuSelector = false) => {
+  (
+    selector,
+    expectedPath,
+    parentMenuSelector = false,
+    grandParentMenuSelector = false,
+  ) => {
+    if (grandParentMenuSelector) {
+      cy.get(grandParentMenuSelector).click();
+    }
     if (parentMenuSelector) {
       cy.get(parentMenuSelector).click();
     }
@@ -26,27 +34,35 @@ const testFirstMenuSection = isMobile => {
     'not.exist',
   );
   cy.get('[data-e2e-id="va-benefits-and-health-care-0"]').click();
-  cy.get('[data-e2e-id="vetnav-level2--disability"]').click();
-  cy.get('[data-e2e-id="view-all-in-disability"]');
-  cy.get('[data-e2e-id="vetnav-column-one-header"]');
-  cy.get('[data-e2e-id="eligibility-0"]');
-  cy.get('[data-e2e-id="about-va-1"]');
-  cy.checkMenuItem('[data-e2e-id="find-a-va-location-2"]', 'find-locations');
+  cy.get('[data-e2e-id="vetnav-level2--health-care"]').click();
+  cy.get('[data-e2e-id="va-benefits-and-health-care-0"]').click();
   cy.checkMenuItem(
     '[data-e2e-id="how-to-apply-1"]',
     'health-care/how-to-apply',
+    '[data-e2e-id="vetnav-level2--health-care"]',
     '[data-e2e-id="va-benefits-and-health-care-0"]',
   );
   cy.checkMenuItem(
     '[data-e2e-id="family-and-caregiver-health-benefits-2"]',
     'health-care/family-caregiver-benefits',
+    '[data-e2e-id="vetnav-level2--health-care"]',
     '[data-e2e-id="va-benefits-and-health-care-0"]',
   );
   cy.checkMenuItem(
     '[data-e2e-id="view-your-lab-and-test-results-3"]',
     'health-care/view-test-and-lab-results',
+    '[data-e2e-id="vetnav-level2--health-care"]',
     '[data-e2e-id="va-benefits-and-health-care-0"]',
   );
+
+  cy.get('[data-e2e-id="va-benefits-and-health-care-0"]').click();
+  cy.get('[data-e2e-id="vetnav-level2--disability"]').click();
+  cy.get('[data-e2e-id="view-all-in-disability"]');
+  cy.get('[data-e2e-id="vetnav-column-one-header"]');
+  cy.get('[data-e2e-id="eligibility-0"]');
+
+  cy.get('[data-e2e-id="about-va-1"]');
+  cy.checkMenuItem('[data-e2e-id="find-a-va-location-2"]', 'find-locations');
 };
 
 const testSecondMenuSection = isMobile => {

--- a/src/platform/site-wide/sass/modules/_m-vet-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-vet-nav.scss
@@ -353,6 +353,21 @@ body.va-pos-fixed {
   }
 }
 
+#vetnav-va-benefits-and-health-care.vetnav-panel {
+  width: 250px;
+
+  @include media($medium-large-screen) {
+    &.vetnav-submenu--expanded {
+      width: 768px;
+    }
+  }
+  @include media($small-desktop-screen) {
+    &.vetnav-submenu--expanded {
+      width: 1008px;
+    }
+  }
+}
+
 .vetnav-panel--submenu {
   &:not([hidden]) {
     background-color: $color-primary-darkest;


### PR DESCRIPTION
## Description
department-of-veterans-affairs/va.gov-cms/issues/10811
This change removed the default section selection under the VA Benefit and Health care Mega Menu. It adjust the width to be just the menu subsections until a subsection is selected.

## Original issue(s)
department-of-veterans-affairs/va.gov-cms/issues/10811


## Testing done
- [x] Assure the menu panel resizes appropriatelt on medium and small desktop sized screens.
- [x] Assure the other menus aren't affected adversely.
- [x] Assure the mega menu functionality isn't adversely affected on sites where the mega menu is injected.

## Screenshots
![189729353-23935d11-054a-4117-be21-03952acbabf7](https://user-images.githubusercontent.com/732460/189988284-48749aa4-05c6-4a9c-9c3c-f7ebfde4e4f5.png)


## Acceptance criteria
- [x] When the user opens the megamenu, they should see only the dropdown containing the benefit hub links. 
- [x] To open any Hub's sub-menu/panel, the user has to click on one of the first-level options.


## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
