### PR TITLE
workspace site-wide linting fix

### DIFF
--- a/src/platform/site-wide/banners/index.js
+++ b/src/platform/site-wide/banners/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 // Relative imports.
 import startReactApp from '../../startup/react';
-import widgetTypes from '~/applications/static-pages/widgetTypes';
+import widgetTypes from 'applications/static-pages/widgetTypes';
 
 // Are you looking for where this is used?
 // Search for `data-widget-type="banner"` and `data-widget-type="maintenance-banner"` to find all the places this React widget is used.

--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -8,8 +8,8 @@ import OfficialGovtWebsite from '../OfficialGovtWebsite';
 import VeteranCrisisLine from '../VeteranCrisisLine';
 import addFocusBehaviorToCrisisLineModal from '../../../accessible-VCL-modal';
 import { addOverlayTriggers } from '../../../legacy/menu';
-import { isBrowserIE } from '~/platform/site-wide/helpers/detection/is-browser';
-import { useOnLoaded } from '~/platform/site-wide/hooks/events/use-on-loaded';
+import { isBrowserIE } from 'platform/site-wide/helpers/detection/is-browser';
+import { useOnLoaded } from 'platform/site-wide/hooks/events/use-on-loaded';
 
 export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/platform/site-wide/header/components/Header/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Header/index.unit.spec.js
@@ -5,8 +5,8 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 // 1st-party imports
-import * as isBrowser from '~/platform/site-wide/helpers/detection/is-browser';
-import * as useOnLoadedHook from '~/platform/site-wide/hooks/events/use-on-loaded';
+import * as isBrowser from 'platform/site-wide/helpers/detection/is-browser';
+import * as useOnLoadedHook from 'platform/site-wide/hooks/events/use-on-loaded';
 import { Header } from '.';
 
 describe('Header <Header>', () => {

--- a/src/platform/site-wide/helpers/team-sites/get-asset-path.js
+++ b/src/platform/site-wide/helpers/team-sites/get-asset-path.js
@@ -1,4 +1,4 @@
-import buckets from '~/site/constants/buckets';
+import buckets from 'site/constants/buckets';
 
 /**
  * Performs a static lookup from the `buckets` dictionary of AWS S3 Bucket URLs.

--- a/src/platform/site-wide/helpers/team-sites/web-components.js
+++ b/src/platform/site-wide/helpers/team-sites/web-components.js
@@ -1,5 +1,5 @@
-import { getAssetPath } from '~/platform/site-wide/helpers/team-sites/get-asset-path';
-import { getTargetEnv } from '~/platform/site-wide/helpers/team-sites/get-target-env';
+import { getAssetPath } from 'platform/site-wide/helpers/team-sites/get-asset-path';
+import { getTargetEnv } from 'platform/site-wide/helpers/team-sites/get-target-env';
 
 /*
  * This file is intended to support legacy pages.

--- a/src/platform/site-wide/mega-menu/tests/main.unit.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/main.unit.spec.js
@@ -62,4 +62,3 @@ describe('mega-menu', () => {
     });
   });
 });
-

--- a/src/platform/site-wide/mega-menu/tests/main.unit.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/main.unit.spec.js
@@ -62,3 +62,4 @@ describe('mega-menu', () => {
     });
   });
 });
+

--- a/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
@@ -6,7 +6,7 @@
  * @testrailinfo runName SH-e2e-MegaMenu
  */
 // Relative imports.
-import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import { mockUser } from 'applications/personalization/profile/tests/fixtures/users/user.js';
 
 Cypress.Commands.add(
   'checkMenuItem',

--- a/src/platform/site-wide/side-nav/index.js
+++ b/src/platform/site-wide/side-nav/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 // Relative
 import startReactApp from '../../startup/react';
 import { normalizeSideNavData } from './helpers';
-import widgetTypes from '~/applications/static-pages/widgetTypes';
+import widgetTypes from 'applications/static-pages/widgetTypes';
 
 // Are you looking for where this is used?
 // Search for `<div data-widget-type="side-nav"></div>` to find all the places


### PR DESCRIPTION
## Description
PR to fix linting error blocking  CI to Dev/Staging. 


## Original issue(s)
department-of-veterans-affairs/va.gov-team#39205


## Testing done
local testing passed. project built successfully; browser testing in local, dev, staging, prod , RI environments.


## Acceptance criteria
- [x] does not change vets-website behavior

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs



## Overall testing
1. Delete all pertinent `node_modules` folders

2. Run `yarn install`

3. Check `./node_modules/@department-of-veterans-affairs/applications-<your-application-name>`  exists.
    1. Example that has a workspace: `./node_modules/@department-of-veterans-affairs/platform-user` (has package.json in directory)
    2. Example that DOES not have a workspace: `./node_modules/@department-of-veterans-affairs/applications-login` (does not have package.json in directory)
    
4. Check your application’s root `node_modules` to make sure non-hoisted dependencies are present and correct

5. Run `yarn watch` to test for compilation and runtime errors; the yarn workspaces installation should NOT affect the import/export running of current code (only provide a new option)

6. Run unit tests

7. Confirm imports using the format @department-of-veterans-affairs/... function properly

## Scripts testing
1. Testing workspaces are working by run `demo` command
    1. Example: `yarn workspace @department-of-veterans-affairs/platform-site-wide run demo`