### PR TITLE
46877/fix styling anomaly

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/UpdateAddressAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/UpdateAddressAlert.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import NewTabAnchor from '../../../components/NewTabAnchor';
 import InfoAlert from '../../../components/InfoAlert';
 
 export default function UpdateAddressAlert({ onClickUpdateAddress }) {
   const headline =
     'To use some of the tool’s features, you need a home address on file';
+  const style = {
+    width: 'fit-content',
+    webkitWidth: 'fit-content',
+  };
 
   return (
     <InfoAlert
@@ -16,13 +21,18 @@ export default function UpdateAddressAlert({ onClickUpdateAddress }) {
         To update your address, go to your VA.gov profile. Please allow some
         time for your address update to process through our system. <br />
         <NewTabAnchor
+          style={style}
           href="/change-address/#how-do-i-change-my-address-in-"
           className="usa-button usa-button-primary vads-u-margin-top--4"
           onClick={() => onClickUpdateAddress(headline)}
         >
-          Update your address
+          Update your address!
         </NewTabAnchor>
       </p>
     </InfoAlert>
   );
 }
+
+UpdateAddressAlert.propTypes = {
+  onClickUpdateAddress: PropTypes.func,
+};

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/UpdateAddressAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/UpdateAddressAlert.jsx
@@ -26,7 +26,7 @@ export default function UpdateAddressAlert({ onClickUpdateAddress }) {
           className="usa-button usa-button-primary vads-u-margin-top--4"
           onClick={() => onClickUpdateAddress(headline)}
         >
-          Update your address!
+          Update your address
         </NewTabAnchor>
       </p>
     </InfoAlert>


### PR DESCRIPTION
## Description
On Staging VAOS Choose-type-of-care page [during scheduling], ...home address... alert, Update... button spills-out beyond right border of alert-box.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46877


## Testing done


## Screenshots
<img width="385" alt="Screen Shot 2022-09-14 at 10 30 38 AM" src="https://user-images.githubusercontent.com/47654119/190183213-f93c3cc9-902f-44e7-8e73-0eba3cef1460.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
