### PR TITLE
Add css prop for spell out number with screen reader

### DIFF
--- a/src/applications/personalization/profile/sass/personal-contact-information.scss
+++ b/src/applications/personalization/profile/sass/personal-contact-information.scss
@@ -7,3 +7,8 @@
 .email-address-symbol::after {
   content: "\200B";
 }
+
+#root_inputPhoneNumber {
+  speak-as: spell-out;
+  speak: spell-out;
+}


### PR DESCRIPTION
## Description
Adds a specific 'speak' or 'speak-as' property to the phone input to indicate to screen readers that the value of the phone input should be read one digit at a time instead of read a a single number

Example would be if the user is entering a new number and has so far only entered 3 numbers like '630' into the input then it should be read as 'six three zero' instead of 'six hundred thirty'

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44534

## Testing done
Manually tested via Voice Over on Mac with Chrome and Firefox

## Acceptance criteria
- [x] Screen reader reads number one by one when entered into input field

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
