### PR TITLE
Certificate of Eligibility | Add VA loan number validation

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
+++ b/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
@@ -4,7 +4,7 @@ import { validateFileField } from 'platform/forms-system/src/js/validation';
 
 import FileField from './FileField';
 import UploadRequirements from './UploadRequirements';
-import { validateDocumentDescription } from '../../helpers';
+import { validateDocumentDescription } from '../../../validations';
 import { DOCUMENT_TYPES } from '../../../../status/constants';
 
 const DocumentUploadDescription = () => (

--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -11,6 +11,7 @@ import { states } from 'platform/forms/address';
 import { loanHistory } from '../../schemaImports';
 import LoanReviewField from '../../../components/LoanReviewField';
 import text from '../../../content/loanHistory';
+import { validateVALoanNumber } from '../../../validations';
 
 const stateLabels = createUSAStateLabels(states);
 
@@ -121,10 +122,12 @@ export const uiSchema = {
       },
       vaLoanNumber: {
         'ui:title': text.loanNumber.title,
+        'ui:description': text.loanNumber.description,
         'ui:options': { widgetClassNames: 'usa-input-medium' },
         'ui:errorMessages': {
           pattern: text.loanNumber.pattern,
         },
+        'ui:validations': [validateVALoanNumber],
       },
       propertyOwned: {
         'ui:title': text.owned.title,

--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -122,8 +122,10 @@ export const uiSchema = {
       },
       vaLoanNumber: {
         'ui:title': text.loanNumber.title,
-        'ui:description': text.loanNumber.description,
-        'ui:options': { widgetClassNames: 'usa-input-medium' },
+        'ui:description': <div>{text.loanNumber.description}</div>,
+        'ui:options': {
+          widgetClassNames: 'coe-loan-input',
+        },
         'ui:errorMessages': {
           pattern: text.loanNumber.pattern,
         },

--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -1,5 +1,9 @@
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
+import { NON_DIGIT_REGEX } from '../constants';
+
+export const replaceNonDigits = number =>
+  (number || '').replace(NON_DIGIT_REGEX, '');
 
 export const customCOEsubmit = (formConfig, form) => {
   const formCopy = cloneDeep(form);
@@ -33,6 +37,7 @@ export const customCOEsubmit = (formConfig, form) => {
           from: isoDateString(loan.dateRange.from),
           to: isoDateString(loan.dateRange.to),
         },
+        vaLoanNumber: replaceNonDigits(loan.vaLoanNumber),
       })),
     },
   };

--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -46,27 +46,3 @@ export const customCOEsubmit = (formConfig, form) => {
     },
   });
 };
-
-export const validateDocumentDescription = (errors, fileList) => {
-  fileList.forEach((file, index) => {
-    const error =
-      file.attachmentType === 'Other' && !file.attachmentDescription
-        ? 'Please provide a description'
-        : null;
-    if (error && !errors[index]) {
-      /* eslint-disable no-param-reassign */
-      errors[index] = {
-        attachmentDescription: {
-          __errors: [],
-          addError(msg) {
-            this.__errors.push(msg);
-          },
-        },
-      };
-      /* eslint-enable no-param-reassign */
-    }
-    if (error) {
-      errors[index].attachmentDescription.addError(error);
-    }
-  });
-};

--- a/src/applications/lgy/coe/form/constants.js
+++ b/src/applications/lgy/coe/form/constants.js
@@ -1,0 +1,5 @@
+// VA loan numbers are _always_ 12 digits (no dashes or spaces), according
+// to SME responses, see:
+// https://github.com/department-of-veterans-affairs/va.gov-team/issues/45026#issuecomment-1235860405
+export const LOAN_NUMBER_DIGIT_LENGTH = 12;
+export const NON_DIGIT_REGEX = /[^\d]/g;

--- a/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/form/containers/IntroductionPage.jsx
@@ -28,7 +28,7 @@ const IntroductionPage = ({ coe, loggedIn, route, status }) => {
   }
   if (loggedIn && coeCallEnded.includes(status)) {
     content = (
-      <>
+      <div className="vads-u-margin-bottom--2">
         <COEIntroPageBox
           referenceNumber={coe.referenceNumber}
           requestDate={coe.applicationCreateDate}
@@ -37,7 +37,7 @@ const IntroductionPage = ({ coe, loggedIn, route, status }) => {
         {coe.status !== COE_ELIGIBILITY_STATUS.denied && (
           <LoggedInContent route={route} status={coe.status} />
         )}
-      </>
+      </div>
     );
   }
 

--- a/src/applications/lgy/coe/form/content/loanHistory.js
+++ b/src/applications/lgy/coe/form/content/loanHistory.js
@@ -39,8 +39,10 @@ export default {
   },
   loanNumber: {
     title: 'VA loan number',
+    description: 'This number is 12 numbers long',
     value: data => get('vaLoanNumber', data, ''),
     pattern: 'Please enter numbers only (dashes allowed)',
+    lengthError: 'Please check that your VA loan number is 12 numbers long',
   },
   owned: {
     title: 'Do you still own this property?',

--- a/src/applications/lgy/coe/form/content/loanHistory.js
+++ b/src/applications/lgy/coe/form/content/loanHistory.js
@@ -39,10 +39,10 @@ export default {
   },
   loanNumber: {
     title: 'VA loan number',
-    description: 'This number is 12 numbers long',
+    description: 'This number has 12 digits.',
     value: data => get('vaLoanNumber', data, ''),
     pattern: 'Please enter numbers only (dashes allowed)',
-    lengthError: 'Please check that your VA loan number is 12 numbers long',
+    lengthError: 'Make sure you include 12 digits.',
   },
   owned: {
     title: 'Do you still own this property?',

--- a/src/applications/lgy/coe/form/sass/coe.scss
+++ b/src/applications/lgy/coe/form/sass/coe.scss
@@ -11,6 +11,11 @@
   }
 }
 
+.coe-loan-input,
+.usa-input-error input.coe-loan-input {
+  width: 35%;
+}
+
 .file-input-disabled {
   pointer-events: none;
   opacity: 0.3;

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -1,10 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as helpers from 'platform/forms-system/src/js/helpers';
-import {
-  customCOEsubmit,
-  validateDocumentDescription,
-} from '../../config/helpers';
+import { customCOEsubmit } from '../../config/helpers';
 
 const form = {
   data: {
@@ -52,36 +49,9 @@ afterEach(() => {
   sandbox.restore();
 });
 
-describe('coe helpers', () => {
-  describe('customCOEsubmit', () => {
-    it('should correctly format the form data', () => {
-      sandbox.stub(helpers, 'transformForSubmit').returns(formattedProperties);
-      expect(customCOEsubmit({}, form)).to.equal(result);
-    });
-  });
-  describe('validateDocumentDescription', () => {
-    const errors = addError => [{ attachmentDescription: { addError } }];
-    const fileList = (type, descrip) => [
-      {
-        attachmentType: type,
-        attachmentDescription: descrip,
-      },
-    ];
-    it('should not add an error for non-other type', () => {
-      const spy = sinon.spy();
-      validateDocumentDescription(errors(spy), fileList('ALTA statement', ''));
-      expect(spy.called).to.be.false;
-    });
-    it('should not add an error for Other-type with description', () => {
-      const spy = sinon.spy();
-      validateDocumentDescription(errors(spy), fileList('Other', 'ok'));
-      expect(spy.called).to.be.false;
-    });
-    it('should add an error for a missing attachmentDescription', () => {
-      const spy = sinon.spy();
-      validateDocumentDescription(errors(spy), fileList('Other', ''));
-      expect(spy.called).to.be.true;
-      expect(spy.calledWith('Please provide a description'));
-    });
+describe('customCOEsubmit', () => {
+  it('should correctly format the form data', () => {
+    sandbox.stub(helpers, 'transformForSubmit').returns(formattedProperties);
+    expect(customCOEsubmit({}, form)).to.equal(result);
   });
 });

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -27,6 +27,7 @@ const formattedProperties = {
         from: '1990-01-01T05:00:00.000Z',
         to: '1992-02-01T05:00:00.000Z',
       },
+      vaLoanNumber: '1-2-3-4-5-6-7-8-9-0-1-2',
     },
   ],
 };

--- a/src/applications/lgy/coe/form/tests/config/loans/loanHistory.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/config/loans/loanHistory.unit.spec.jsx
@@ -97,7 +97,7 @@ describe('COE applicant loan history', () => {
           data={{
             relevantPriorLoans: [
               {
-                vaLoanNumber: '1-234 5',
+                vaLoanNumber: '12-34-5-6789012',
               },
             ],
           }}
@@ -120,7 +120,7 @@ describe('COE applicant loan history', () => {
           data={{
             relevantPriorLoans: [
               {
-                vaLoanNumber: '-1-234-5',
+                vaLoanNumber: '-1-234-56789012',
               },
             ],
           }}
@@ -144,7 +144,7 @@ describe('COE applicant loan history', () => {
           data={{
             relevantPriorLoans: [
               {
-                vaLoanNumber: '1-234-5a',
+                vaLoanNumber: '1-234-56a789012',
               },
             ],
           }}

--- a/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json
@@ -46,7 +46,7 @@
         "propertyState": "AK",
         "propertyZip": "85274"
       },
-      "vaLoanNumber": "123-45",
+      "vaLoanNumber": "12-34-5-6789012",
       "propertyOwned": true,
       "willRefinance": false
     },
@@ -61,7 +61,7 @@
         "propertyState": "AK",
         "propertyZip": "85274"
       },
-      "vaLoanNumber": "100 23",
+      "vaLoanNumber": "21 09 8 7654321",
       "propertyOwned": true,
       "willRefinance": false
     }

--- a/src/applications/lgy/coe/form/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/data/transformed-maximal-test.json
@@ -48,7 +48,7 @@
             "propertyState": "AK",
             "propertyZip": "85274"
           },
-          "vaLoanNumber": "123-45",
+          "vaLoanNumber": "123456789012",
           "propertyOwned": true,
           "willRefinance": false
         },
@@ -64,7 +64,7 @@
             "propertyState": "AK",
             "propertyZip": "85274"
           },
-          "vaLoanNumber": "100 23",
+          "vaLoanNumber": "210987654321",
           "propertyOwned": true,
           "willRefinance": false
         }

--- a/src/applications/lgy/coe/form/tests/fixtures/mocks/submitted.js
+++ b/src/applications/lgy/coe/form/tests/fixtures/mocks/submitted.js
@@ -29,7 +29,7 @@ export const submitted = () => ({
     disabilityIndicator: true, // *
     relevantPriorLoans: [
       {
-        valoanNumber: '345678',
+        valoanNumber: '345678901234',
         startDate: '2020-06-13T17:47:21.1247', // *
         paidoffDate: '2020-06-13T17:47:21.1247',
         loanAmount: 0, // *

--- a/src/applications/lgy/coe/form/tests/validations.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/validations.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { validateDocumentDescription } from '../validations';
+
+describe('validateDocumentDescription', () => {
+  const errors = addError => [{ attachmentDescription: { addError } }];
+  const fileList = (type, descrip) => [
+    {
+      attachmentType: type,
+      attachmentDescription: descrip,
+    },
+  ];
+  it('should not add an error for non-other type', () => {
+    const spy = sinon.spy();
+    validateDocumentDescription(errors(spy), fileList('ALTA statement', ''));
+    expect(spy.called).to.be.false;
+  });
+  it('should not add an error for Other-type with description', () => {
+    const spy = sinon.spy();
+    validateDocumentDescription(errors(spy), fileList('Other', 'ok'));
+    expect(spy.called).to.be.false;
+  });
+  it('should add an error for a missing attachmentDescription', () => {
+    const spy = sinon.spy();
+    validateDocumentDescription(errors(spy), fileList('Other', ''));
+    expect(spy.called).to.be.true;
+    expect(spy.calledWith('Please provide a description'));
+  });
+});

--- a/src/applications/lgy/coe/form/tests/validations.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/validations.unit.spec.js
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { validateDocumentDescription } from '../validations';
+import {
+  validateDocumentDescription,
+  validateVALoanNumber,
+} from '../validations';
 
 describe('validateDocumentDescription', () => {
   const errors = addError => [{ attachmentDescription: { addError } }];
@@ -26,5 +29,40 @@ describe('validateDocumentDescription', () => {
     validateDocumentDescription(errors(spy), fileList('Other', ''));
     expect(spy.called).to.be.true;
     expect(spy.calledWith('Please provide a description'));
+  });
+});
+
+describe('validateVALoanNumber', () => {
+  const errors = addError => ({ addError });
+  it('should not return an error for a 12-digit number', () => {
+    const spy = sinon.spy();
+    validateVALoanNumber(errors(spy), '123456789012');
+    expect(spy.notCalled).to.be.true;
+  });
+  it('should not return an error for a 12-digit number with dashes', () => {
+    const spy = sinon.spy();
+    validateVALoanNumber(errors(spy), '1-2-3-4-5-6-7-8-9-0-1-2');
+    expect(spy.notCalled).to.be.true;
+  });
+  it('should not return an error for a 12-digit number with spaces', () => {
+    const spy = sinon.spy();
+    validateVALoanNumber(errors(spy), '1 2 3 4 5 6 7 8 9 0 1 2');
+    expect(spy.notCalled).to.be.true;
+  });
+  it('should not return an error for a 12-digit number with mixed dashes & spaces', () => {
+    const spy = sinon.spy();
+    validateVALoanNumber(errors(spy), '1-2 3-4 5-6 7-8 9-0 1-2');
+    expect(spy.notCalled).to.be.true;
+  });
+
+  it('should return an error for a non 12-digit number', () => {
+    const spy = sinon.spy();
+    validateVALoanNumber(errors(spy), '1234');
+    expect(spy.called).to.be.true;
+  });
+  it('should return an error for a non 12-digit number, but string length of 12', () => {
+    const spy = sinon.spy();
+    validateVALoanNumber(errors(spy), '1 2 3 4 5 6 ');
+    expect(spy.called).to.be.true;
   });
 });

--- a/src/applications/lgy/coe/form/validations.js
+++ b/src/applications/lgy/coe/form/validations.js
@@ -1,0 +1,23 @@
+export const validateDocumentDescription = (errors, fileList) => {
+  fileList.forEach((file, index) => {
+    const error =
+      file.attachmentType === 'Other' && !file.attachmentDescription
+        ? 'Please provide a description'
+        : null;
+    if (error && !errors[index]) {
+      /* eslint-disable no-param-reassign */
+      errors[index] = {
+        attachmentDescription: {
+          __errors: [],
+          addError(msg) {
+            this.__errors.push(msg);
+          },
+        },
+      };
+      /* eslint-enable no-param-reassign */
+    }
+    if (error) {
+      errors[index].attachmentDescription.addError(error);
+    }
+  });
+};

--- a/src/applications/lgy/coe/form/validations.js
+++ b/src/applications/lgy/coe/form/validations.js
@@ -1,3 +1,7 @@
+import { LOAN_NUMBER_DIGIT_LENGTH } from './constants';
+import { replaceNonDigits } from './config/helpers';
+import text from './content/loanHistory';
+
 export const validateDocumentDescription = (errors, fileList) => {
   fileList.forEach((file, index) => {
     const error =
@@ -20,4 +24,12 @@ export const validateDocumentDescription = (errors, fileList) => {
       errors[index].attachmentDescription.addError(error);
     }
   });
+};
+
+export const validateVALoanNumber = (errors, loanNumber) => {
+  const number = replaceNonDigits(loanNumber || '');
+
+  if (number.length !== LOAN_NUMBER_DIGIT_LENGTH) {
+    errors.addError(text.loanNumber.lengthError);
+  }
 };


### PR DESCRIPTION
## Original Ticket

[#45026](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45026)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/loan-history`

## Background

To ensure the Veteran is entering a 12-digit VA loan number, validation checks and error messages have been updated to remind the Veteran of this loan number length requirement. Additionally hint text is added below the label

<img width="558" alt="VA loan number input shown with label(VA loan number), hint text (This number has 12 digits) and error message (Make sure you include 12 digits) in vertical order. The width of the VA loan number input is wider than the zip code input above it, but not 100% width as the State select above the zip code" src="https://user-images.githubusercontent.com/136959/190230125-5f21f114-9177-4546-80ea-fb68e28dec12.png">

## Steps to test

1. Pull this form into your local environment, or test in the review instance
2. Go to `/housing-assistance/home-loans/request-coe-form-26-1880`
3. Log in with user 228 (Colder Polarbear)
4. Start the form
5. Enable & open the [save-in-progress menu](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-use-the-save-in-progress-m#VAFormsLibrary-HowtousetheSaveinProgressmenuforfasterdevelopment-Activating&Deactivating)
6. Use "Copy raw contents" to copy the [maximal-test data](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/lgy/coe/form/tests/fixtures/data/maximal-test.json)
7. Paste in the data into the save-in-progress menu
8. Set the return URL to match the URL of change above
9. Delete a single digit from the VA loan number input, then blur to see the error message.

## Code changes

- Add VA loan number validation (ignore dashes & spaces)
- Add validation unit tests
- Add VA loan number hint text
- Update hint text & error message content based on feedback
- Add CSS to expand the VA loan input to not overflow when 12 digits + 3 dashes are set as the value

## How was your code tested

Unit tests

## Acceptance criteria
- [x] Add VA loan number validation with suggested error message
- [x] Add hint text
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs