### PR TITLE
Fix breadcrumb links

### DIFF
--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -158,7 +158,7 @@
             <% if (index === breadcrumbs_override.length - 1) { %>
             aria-current="page"
             <% } %>
-            href="<%= path %>">
+            href="/<%= path %>">
             <%= name %>
           </a>
         </li>


### PR DESCRIPTION
## Description
This PR fixes breadcrumb links in the landing page template. Links were not correct due to a missing `/`.
[Slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1662734962515229)

## Testing done
Tested locally.

## Acceptance criteria
- [x] Breadcrumb links are accurately generated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
