### PR TITLE
Certificate of Eligibility | Update and add e2e tests

### DIFF
--- a/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
@@ -3,17 +3,13 @@ import path from 'path';
 import formConfig from '../config/form';
 import { CONTESTABLE_ISSUES_API, WIZARD_STATUS } from '../constants';
 
-import {
-  mockContestableIssues,
-  // getRandomDate,
-  fixDecisionDates,
-} from './hlr.cypress.helpers';
+import { mockContestableIssues, fixDecisionDates } from './hlr.cypress.helpers';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockStatus from './fixtures/mocks/profile-status.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUser from './fixtures/mocks/user.json';
 
-describe('Notice of Disagreement keyboard only navigation', () => {
+describe('Higher-Level Review keyboard only navigation', () => {
   before(() => {
     window.sessionStorage.removeItem(WIZARD_STATUS);
 

--- a/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
@@ -65,7 +65,7 @@ const ConfirmationPage = ({ form }) => {
         )}
 
         <button
-          className="vads-u-margin-top--3 usa-button"
+          className="vads-u-margin-top--3 usa-button screen-only"
           onClick={printPage}
           type="button"
         >

--- a/src/applications/lgy/coe/form/tests/coe-keyboard-only.cypress.spec.js
+++ b/src/applications/lgy/coe/form/tests/coe-keyboard-only.cypress.spec.js
@@ -1,0 +1,194 @@
+import formConfig from '../config/form';
+
+import mockUser from './fixtures/mocks/user.json';
+import mockStatus from './fixtures/mocks/status.json';
+import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
+import data from './fixtures/data/maximal-test.json';
+
+describe('Certificate of Eligibility keyboard only navigation', () => {
+  it('should navigate through a maximal form', () => {
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', 'v0/in_progress_forms/26-1880', {});
+    cy.intercept('PUT', 'v0/in_progress_forms/26-1880', {});
+    cy.intercept('GET', '/v0/coe/status', mockStatus);
+    cy.intercept('POST', formConfig.submitUrl, { status: 200 });
+
+    cy.login(mockUser);
+
+    const { chapters } = formConfig;
+    cy.visit('/housing-assistance/home-loans/request-coe-form-26-1880');
+    cy.injectAxeThenAxeCheck();
+
+    // Intro page
+    cy.tabToStartForm();
+
+    // Veteran personal info
+    cy.url().should(
+      'include',
+      chapters.applicantInformationChapter.pages.applicantInformationSummary
+        .path,
+    );
+    cy.typeInFullName('root_fullName_', data.fullName);
+    cy.typeInDate('root_dateOfBirth', data.dateOfBirth);
+    cy.tabToContinueForm();
+
+    // Contact info
+    cy.url().should(
+      'include',
+      chapters.contactInformationChapter.pages.mailingAddress.path,
+    );
+    cy.tabToElement('#root_applicantAddress_country');
+    cy.chooseSelectOptionUsingValue(data.applicantAddress.country);
+    cy.typeInIfDataExists(
+      '#root_applicantAddress_street',
+      data.applicantAddress.street,
+    );
+    cy.typeInIfDataExists(
+      '#root_applicantAddress_street2',
+      data.applicantAddress.street2,
+    );
+    cy.typeInIfDataExists(
+      '#root_applicantAddress_city',
+      data.applicantAddress.city,
+    );
+    cy.tabToElement('#root_applicantAddress_state');
+    cy.chooseSelectOptionUsingValue(data.applicantAddress.state);
+    cy.typeInIfDataExists(
+      '#root_applicantAddress_postalCode',
+      data.applicantAddress.postalCode,
+    );
+    cy.tabToContinueForm();
+
+    // Additional contact info
+    cy.url().should(
+      'include',
+      chapters.contactInformationChapter.pages.additionalInformation.path,
+    );
+    cy.typeInIfDataExists('#root_contactPhone', data.contactPhone);
+    cy.typeInIfDataExists('#root_contactEmail', data.contactEmail);
+    cy.tabToContinueForm();
+
+    // Service status
+    cy.url().should(
+      'include',
+      chapters.serviceHistoryChapter.pages.serviceStatus.path,
+    );
+    cy.tabToElement('input[name="root_identity"]');
+    cy.chooseRadio(data.identity);
+    cy.tabToContinueForm();
+
+    // Service history
+    cy.url().should(
+      'include',
+      chapters.serviceHistoryChapter.pages.serviceHistory.path,
+    );
+    const toursLength = data.periodsOfService.length;
+    data.periodsOfService.forEach((period, index) => {
+      const branchSelector = `#root_periodsOfService_${index}_serviceBranch`;
+      if (index < toursLength) {
+        cy.get(':focus').then($el => {
+          // service branch is focused when add another button is activated
+          if (!$el.is(branchSelector)) {
+            cy.tabToElement(
+              branchSelector,
+              index === 0, // forward or backward
+              true, // exists?
+            );
+          }
+          cy.findSelectOptionByTyping(period.serviceBranch);
+          cy.typeInDate(
+            `root_periodsOfService_${index}_dateRange_from`,
+            data.periodsOfService[index].dateRange.from,
+          );
+          cy.typeInDate(
+            `root_periodsOfService_${index}_dateRange_to`,
+            data.periodsOfService[index].dateRange.to,
+          );
+          if (index + 1 < toursLength) {
+            cy.tabToElement('.va-growable-add-btn');
+            cy.realPress('Space');
+          }
+        });
+      }
+    });
+    cy.tabToContinueForm();
+
+    // Loan history
+    cy.url().should('include', chapters.loansChapter.pages.loanScreener.path);
+    cy.tabToElement('[name="root_vaLoanIndicator"]');
+    cy.chooseRadio(data.vaLoanIndicator ? 'Y' : 'N');
+    cy.tabToContinueForm();
+
+    // Loan intent
+    cy.url().should('include', chapters.loansChapter.pages.loanIntent.path);
+    cy.tabToElement('[name="root_intent"]');
+    cy.chooseRadio(data.intent);
+    cy.tabToContinueForm();
+
+    // Loan history
+    // Only adding one loan because tabbing takes a lot of time
+    cy.url().should('include', chapters.loansChapter.pages.loanHistory.path);
+    if (data.relevantPriorLoans.length) {
+      const index = 0;
+      const root = `root_relevantPriorLoans_${index}_`;
+      const firstLoan = data.relevantPriorLoans?.[index];
+
+      const from = firstLoan.dateRange.from
+        .split('-')
+        .map(v => parseInt(v, 10).toString());
+      cy.tabToElement(`#${root}dateRange_fromMonth`);
+      cy.chooseSelectOptionUsingValue(from[1]);
+      cy.tabToElement(`input[name="${root}dateRange_fromYear"]`);
+      cy.typeInFocused(from[0]);
+
+      const to = firstLoan.dateRange.to
+        .split('-')
+        .map(v => parseInt(v, 10).toString());
+      cy.tabToElement(`#${root}dateRange_toMonth`);
+      cy.chooseSelectOptionUsingValue(to[1]);
+      cy.tabToElement(`input[name="${root}dateRange_toYear"]`);
+      cy.typeInFocused(to[0]);
+
+      cy.typeInIfDataExists(
+        `#${root}propertyAddress_propertyAddress1`,
+        firstLoan.propertyAddress.propertyAddress1,
+      );
+      cy.typeInIfDataExists(
+        `#${root}propertyAddress_propertyAddress2`,
+        firstLoan.propertyAddress.propertyAddress2,
+      );
+      cy.typeInIfDataExists(
+        `#${root}propertyAddress_propertyCity`,
+        firstLoan.propertyAddress.propertyCity,
+      );
+      cy.tabToElement(`#${root}propertyAddress_propertyState`);
+      cy.chooseSelectOptionUsingValue(firstLoan.propertyAddress.propertyState);
+      cy.typeInIfDataExists(
+        `#${root}propertyAddress_propertyZip`,
+        firstLoan.propertyAddress.propertyZip,
+      );
+
+      cy.typeInIfDataExists(`#${root}vaLoanNumber`, firstLoan.vaLoanNumber);
+      cy.tabToElement(`[name="${root}propertyOwned"]`);
+      cy.chooseRadio(firstLoan.propertyOwned ? 'Y' : 'N');
+      cy.tabToElement(`[name="${root}willRefinance"]`);
+      cy.chooseRadio(firstLoan.willRefinance ? 'Y' : 'N');
+    }
+
+    cy.tabToContinueForm();
+
+    // Upload supporting docs
+    // TODO: Figure out how to test keyboard only uploads
+    cy.tabToContinueForm();
+
+    // Review & submit page
+    cy.url().should('include', 'review-and-submit');
+    cy.tabToElement('[name="privacyAgreementAccepted"]');
+    cy.realPress('Space');
+    cy.tabToSubmitForm();
+
+    // Check confirmation page print button
+    cy.url().should('include', 'confirmation');
+    cy.get('button.screen-only').should('exist');
+  });
+});

--- a/src/applications/lgy/coe/form/tests/coe.cypress.spec.js
+++ b/src/applications/lgy/coe/form/tests/coe.cypress.spec.js
@@ -56,6 +56,7 @@ const testConfig = createTestConfig(
 
       cy.intercept('GET', '/v0/coe/status', mockStatus);
       cy.intercept('GET', '/v0/in_progress_forms/26-1880', {});
+      cy.intercept('PUT', '/v0/in_progress_forms/26-1880', {});
       cy.intercept('POST', '/v0/claim_attachments', mockUpload);
 
       cy.route('POST', formConfig.submitUrl, { status: 200 });

--- a/src/applications/lgy/coe/status/tests/DocumentUploader.cypress.spec.js
+++ b/src/applications/lgy/coe/status/tests/DocumentUploader.cypress.spec.js
@@ -8,8 +8,6 @@ import { COE_ELIGIBILITY_STATUS } from '../../shared/constants';
 const uploadImgPath =
   'src/applications/lgy/coe/status/tests/components/DocumentUploader/testPicture.jpeg';
 
-// Skip tests in CI until the app is released.
-// Remove this block when the app has a content page in production.
 describe(manifest.appName, () => {
   beforeEach(() => {
     cy.login();

--- a/src/applications/lgy/coe/status/tests/DocumentUploader.cypress.spec.js
+++ b/src/applications/lgy/coe/status/tests/DocumentUploader.cypress.spec.js
@@ -1,87 +1,86 @@
 import manifest from '../manifest.json';
 
+import mockFeatureToggles from '../../form/tests/fixtures/mocks/feature-toggles.json';
+import mockDocuments from '../../form/tests/fixtures/mocks/documents.json';
+
+import { COE_ELIGIBILITY_STATUS } from '../../shared/constants';
+
+const uploadImgPath =
+  'src/applications/lgy/coe/status/tests/components/DocumentUploader/testPicture.jpeg';
+
+// Skip tests in CI until the app is released.
+// Remove this block when the app has a content page in production.
 describe(manifest.appName, () => {
-  // Skip tests in CI until the app is released.
-  // Remove this block when the app has a content page in production.
-
-  const openPage = () => {
+  beforeEach(() => {
     cy.login();
-    cy.visit(manifest.rootUrl)
-      .injectAxe()
-      .axeCheck();
-
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/coe/documents', mockDocuments);
     cy.intercept('GET', '/v0/coe/status', {
       statusCode: 201,
       body: {
         data: {
-          attributes: 'pending-upload',
+          attributes: {
+            status: COE_ELIGIBILITY_STATUS.pendingUpload,
+          },
         },
       },
     }).as('pendingUpload');
-    cy.wait('@pendingUpload');
-  };
-
-  it.skip('Should render on pending-upload status', () => {
-    openPage();
-    // A status alert should be visible
-    cy.findByText(/We need more information from you/i).should('exist');
-
-    cy.findByText(/Select a document to upload/i).should('exist');
   });
 
-  it.skip('Should show an error message when no file is added and the user tries to submit', () => {
-    openPage();
-    // Find the submit button and click it
-    cy.findByText(/Submit Files/i).click();
-
-    cy.findByText(/Please choose a file to upload./i).should('exist');
+  it('Should render on pending-upload status', () => {
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
+    cy.get('@pendingUpload').then(() => {
+      // A status alert should be visible
+      cy.findByText(/We need more information from you/i).should('exist');
+      cy.findByText(/Select a document to upload/i).should('exist');
+    });
   });
 
-  it.skip('Should add a single file and show in file list', () => {
-    openPage();
+  it('Should show an error message when no file is added and the user tries to submit', () => {
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
 
-    cy.get('#errorable-select-1').select('Statement of service');
-
-    cy.get('input[type="file"]').selectFile(
-      'src/applications/lgy/coe/status/tests/components/document-uploader/testPicture.jpeg',
-      { force: true },
-    );
-
-    cy.findByText(/testPicture.jpeg/i).should('exist');
+    cy.get('@pendingUpload').then(() => {
+      // Find the submit button and click it
+      cy.findByText(/Submit Files/i).click();
+      cy.findByText(/Please choose a file to upload./i).should('exist');
+    });
   });
 
-  it.skip('Should add multiple files and show in file list', () => {
-    openPage();
+  it('Should add a single file and show in file list', () => {
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
 
-    cy.get('input[type="file"]').selectFile(
-      'src/applications/lgy/coe/status/tests/components/document-uploader/testPicture.jpeg',
-      { force: true },
-    );
-
-    cy.get('#errorable-select-1').select('Statement of service');
-
-    cy.get('input[type="file"]').selectFile(
-      'src/applications/lgy/coe/status/tests/components/document-uploader/testPicture.jpeg',
-      { force: true },
-    );
-
-    cy.findByText(/Statement of service/i).should('exist');
+    cy.get('@pendingUpload').then(() => {
+      cy.get('#errorable-select-1').select('Statement of service');
+      cy.get('input[type="file"]').selectFile(uploadImgPath, { force: true });
+      cy.findByText(/testPicture.jpeg/i).should('exist');
+    });
   });
 
-  it.skip('Should delete a file when delete file button is clicked', () => {
-    openPage();
+  it('Should add multiple files and show in file list', () => {
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
 
-    cy.get('#errorable-select-1').select('Statement of service');
+    cy.get('@pendingUpload').then(() => {
+      cy.get('input[type="file"]').selectFile(uploadImgPath, { force: true });
+      cy.get('#errorable-select-1').select('Statement of service');
+      cy.get('input[type="file"]').selectFile(uploadImgPath, { force: true });
+      cy.findByText(/Statement of service/i).should('exist');
+    });
+  });
 
-    cy.get('input[type="file"]').selectFile(
-      'src/applications/lgy/coe/status/tests/components/document-uploader/testPicture.jpeg',
-      { force: true },
-    );
+  it('Should delete a file when delete file button is clicked', () => {
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
 
-    cy.findByText(/testPicture.jpeg/i).should('exist');
-
-    cy.findByText(/Delete file/i).click();
-
-    cy.findByText(/testPicture.jpeg/i).should('not.exist');
+    cy.get('@pendingUpload').then(() => {
+      cy.get('#errorable-select-1').select('Statement of service');
+      cy.get('input[type="file"]').selectFile(uploadImgPath, { force: true });
+      cy.findByText(/testPicture.jpeg/i).should('exist');
+      cy.findByText(/Delete file/i).click();
+      cy.findByText(/testPicture.jpeg/i).should('not.exist');
+    });
   });
 });

--- a/src/applications/lgy/coe/status/tests/coe-status.cypress.spec.js
+++ b/src/applications/lgy/coe/status/tests/coe-status.cypress.spec.js
@@ -1,15 +1,9 @@
 import manifest from '../manifest.json';
 
 describe(manifest.appName, () => {
-  // Skip tests in CI until the app is released.
-  // Remove this block when the app has a content page in production.
-  before(function() {
-    if (Cypress.env('CI')) this.skip();
-  });
-
   it('is accessible', () => {
-    cy.visit(manifest.rootUrl)
-      .injectAxe()
-      .axeCheck();
+    cy.login();
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
   });
 });


### PR DESCRIPTION
## Original Ticket

[#46034](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46034)

## URL of change

- `/housing-assistance/home-loans/request-coe-form-26-1880/`
- `/housing-assistance/home-loans/check-coe-status/your-coe`

## Background

COE e2e tests have been disabled in CI due to the apps not being built in production. We recently [implemented the feature flag for the form & status app](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46328) and [enabled the build in production](https://github.com/department-of-veterans-affairs/content-build/pull/1302)

## Steps to test

1. E2E tests are run in this PR's continuous integration
2. Verify all E2E tests passing, or pull in the branch locally and test COE E2E tests

## Code changes

- Add COE keyboard-only e2e tests
- Update COE form e2e tests
- Update COE status e2e tests
- Fix HLR keyboard-only e2e test description (out-of-scope)

## How was your code tested

- Ran all e2e tests locally
- This PR CI

## Acceptance criteria
- [x] Add keyboard-only e2e test
- [x] Update COE form e2e test
- [x] Update COE status e2e tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs