### PR TITLE
46903 add treatment specialty to book cc detail page

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -41,7 +41,7 @@ export default function DetailsCC({
   };
 
   const ShowTreatmentSpecialty = () => {
-    if (featureVaosV2Next) {
+    if (featureVaosV2Next && treatmentSpecialty) {
       return (
         <>
           <div data-test-id="appointment-treatment-specialty">

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -18,7 +18,7 @@ export default function DetailsCC({
   useV2 = false,
   featureVaosV2Next = false,
 }) {
-  const header = 'Community care';
+  const header = 'Community care provider';
   const facility = appointment.communityCareProvider;
   const typeOfCare = getTypeOfCareById(appointment.vaos.apiData.serviceType);
   const { treatmentSpecialty } = facility;

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -13,10 +13,15 @@ import ProviderName from './ProviderName';
 import CCInstructions from './CCInstructions';
 import { getTypeOfCareById } from '../../../utils/appointment';
 
-export default function DetailsCC({ appointment, useV2 = false }) {
+export default function DetailsCC({
+  appointment,
+  useV2 = false,
+  featureVaosV2Next = false,
+}) {
   const header = 'Community care';
   const facility = appointment.communityCareProvider;
   const typeOfCare = getTypeOfCareById(appointment.vaos.apiData.serviceType);
+  const { treatmentSpecialty } = facility;
 
   const ShowTypeOfCare = () => {
     if (useV2 && typeOfCare) {
@@ -35,6 +40,19 @@ export default function DetailsCC({ appointment, useV2 = false }) {
     return null;
   };
 
+  const ShowTreatmentSpecialty = () => {
+    if (featureVaosV2Next) {
+      return (
+        <>
+          <div data-test-id="appointment-treatment-specialty">
+            {treatmentSpecialty}
+          </div>
+        </>
+      );
+    }
+    return null;
+  };
+
   return (
     <>
       <Breadcrumbs>
@@ -47,6 +65,7 @@ export default function DetailsCC({ appointment, useV2 = false }) {
       <ShowTypeOfCare />
       <TypeHeader isCC>{header}</TypeHeader>
       <ProviderName appointment={appointment} useV2={useV2} />
+      <ShowTreatmentSpecialty />
       <FacilityAddress
         facility={facility}
         showDirectionsLink={!!appointment.communityCareProvider?.address}
@@ -63,5 +82,6 @@ export default function DetailsCC({ appointment, useV2 = false }) {
 
 DetailsCC.propTypes = {
   appointment: PropTypes.object.isRequired,
+  featureVaosV2Next: PropTypes.bool,
   useV2: PropTypes.bool,
 };

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -43,11 +43,12 @@ export default function DetailsCC({
   const ShowTreatmentSpecialty = () => {
     if (featureVaosV2Next && treatmentSpecialty) {
       return (
-        <>
-          <div data-test-id="appointment-treatment-specialty">
-            {treatmentSpecialty}
-          </div>
-        </>
+        <div
+          data-test-id="appointment-treatment-specialty"
+          className="vads-u-margin-bottom--1"
+        >
+          {treatmentSpecialty}
+        </div>
       );
     }
     return null;

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -11,6 +11,7 @@ import ErrorMessage from '../../../components/ErrorMessage';
 import FullWidthLayout from '../../../components/FullWidthLayout';
 import { fetchConfirmedAppointmentDetails } from '../../redux/actions';
 import { getConfirmedAppointmentDetailsInfo } from '../../redux/selectors';
+import { selectFeatureVaosV2Next } from '../../../redux/selectors';
 import DetailsVA from './DetailsVA';
 import DetailsCC from './DetailsCC';
 import DetailsVideo from './DetailsVideo';
@@ -27,6 +28,9 @@ export default function ConfirmedAppointmentDetailsPage() {
   } = useSelector(
     state => getConfirmedAppointmentDetailsInfo(state, id),
     shallowEqual,
+  );
+  const featureVaosV2Next = useSelector(state =>
+    selectFeatureVaosV2Next(state),
   );
   const appointmentDate = moment.parseZone(appointment?.start);
 
@@ -100,7 +104,13 @@ export default function ConfirmedAppointmentDetailsPage() {
           useV2={useV2}
         />
       )}
-      {isCommunityCare && <DetailsCC appointment={appointment} useV2={useV2} />}
+      {isCommunityCare && (
+        <DetailsCC
+          appointment={appointment}
+          useV2={useV2}
+          featureVaosV2Next={featureVaosV2Next}
+        />
+      )}
       <CancelAppointmentModal />
     </PageLayout>
   );

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -93,9 +93,7 @@ export function transformVAOSAppointment(appt) {
     appointmentType === APPOINTMENT_TYPES.request ||
     appointmentType === APPOINTMENT_TYPES.ccRequest;
   const providers = appt.practitioners;
-  const cTreatingSpecialty = !appt.extension?.ccTreatingSpecialty
-    ? null
-    : appt.extension.ccTreatingSpecialty;
+  const ccTreatingSpecialty = !appt.extension?.ccTreatingSpecialty;
   const timezone = getTimezoneByFacilityId(appt.locationId);
 
   const start = timezone ? moment(appt.start).tz(timezone) : moment(appt.start);
@@ -208,7 +206,7 @@ export function transformVAOSAppointment(appt) {
       isCC && !isRequest
         ? {
             practiceName: appt.extension?.ccLocation?.practiceName,
-            treatmentSpecialty: cTreatingSpecialty,
+            treatmentSpecialty: ccTreatingSpecialty,
             address: appt.extension?.ccLocation?.address,
             telecom: appt.extension?.ccLocation?.telecom,
             providers: (providers || []).map(provider => ({

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -93,6 +93,9 @@ export function transformVAOSAppointment(appt) {
     appointmentType === APPOINTMENT_TYPES.request ||
     appointmentType === APPOINTMENT_TYPES.ccRequest;
   const providers = appt.practitioners;
+  const cTreatingSpecialty = !appt.extension?.ccTreatingSpecialty
+    ? null
+    : appt.extension.ccTreatingSpecialty;
   const timezone = getTimezoneByFacilityId(appt.locationId);
 
   const start = timezone ? moment(appt.start).tz(timezone) : moment(appt.start);
@@ -205,7 +208,7 @@ export function transformVAOSAppointment(appt) {
       isCC && !isRequest
         ? {
             practiceName: appt.extension?.ccLocation?.practiceName,
-            treatmentSpecialty: appt.extension?.ccTreatingSpecialty,
+            treatmentSpecialty: cTreatingSpecialty,
             address: appt.extension?.ccLocation?.address,
             telecom: appt.extension?.ccLocation?.telecom,
             providers: (providers || []).map(provider => ({

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -205,6 +205,7 @@ export function transformVAOSAppointment(appt) {
       isCC && !isRequest
         ? {
             practiceName: appt.extension?.ccLocation?.practiceName,
+            treatmentSpecialty: appt.extension?.ccTreatingSpecialty,
             address: appt.extension?.ccLocation?.address,
             telecom: appt.extension?.ccLocation?.telecom,
             providers: (providers || []).map(provider => ({

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -53,7 +53,7 @@
           },
           "hsrmTaskId": "",
           "hsrmConsultId": "984_644056",
-          "ccTreatingSpecialty": "Optometrist"
+          "ccTreatingSpecialty": "Optometry"
         },
         "location": {
           "id": "984",
@@ -158,7 +158,7 @@
           },
           "hsrmTaskId": "",
           "hsrmConsultId": "984_644056",
-          "ccTreatingSpecialty": "Optometrist"
+          "ccTreatingSpecialty": "Podiatry"
         },
         "location": {
           "id": "984",
@@ -263,7 +263,7 @@
           },
           "hsrmTaskId": "12881",
           "hsrmConsultId": "984_644233",
-          "ccTreatingSpecialty": "Podiatrist"
+          "ccTreatingSpecialty": "Podiatry"
         },
         "location": {
           "id": "984",

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -241,7 +241,8 @@
             },
             "telecom": []
           },
-          "hsrmTaskId": ""
+          "hsrmTaskId": "",
+          "ccTreatingSpecialty": ""
         },
         "location": {
           "id": "984",
@@ -486,7 +487,8 @@
               "postalCode": "45414",
               "text": "1601 Needmore Rd Ste 1\nDayton OH 45414"
             }
-          }
+          },
+          "ccTreatingSpecialty": ""
         },
         "preferredTimesForPhoneCall": [],
         "priority": 0,

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1,6 +1,111 @@
 {
   "data": [
     {
+      "id": "1150111CC",
+      "type": "appointments",
+      "attributes": {
+        "id": "1150111CC",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524669||4||1"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1679635460"
+          }
+        ],
+        "kind": "cc",
+        "status": "booked",
+        "description": "Eye Care Examination SEOC 1.3.10 PRCT",
+        "patientIcn": "1013124304V115761",
+        "locationId": "984",
+        "practitioners": [
+          {
+            "name": {
+              "family": "BERMEL",
+              "given": [
+                "MICHAEL"
+              ]
+            }
+          }
+        ],
+        "start": "2022-08-22T12:00:00Z",
+        "created": "2022-08-22T20:33:54Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "10640 MAIN ST ; STE 100"
+              ],
+              "city": "FAIRFAX",
+              "state": "VA",
+              "postalCode": "22030",
+              "text": "10640 MAIN ST ; STE 100\nFAIRFAX VA 22030"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "703-691-2020"
+              }
+            ]
+          },
+          "hsrmTaskId": "",
+          "hsrmConsultId": "984_644056",
+          "ccTreatingSpecialty": "Optometrist"
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "115069",
       "type": "appointments",
       "attributes": {
@@ -137,6 +242,111 @@
         ],
         "start": "2022-10-22T12:00:00Z",
         "created": "2022-10-22T20:33:54Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "1323 W 3RD ST"
+              ],
+              "city": "DAYTON",
+              "state": "OH",
+              "postalCode": "45402",
+              "text": "1323 W 3RD ST\nDAYTON OH 45402"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "937-228-3668"
+              }
+            ]
+          },
+          "hsrmTaskId": "12881",
+          "hsrmConsultId": "984_644233",
+          "ccTreatingSpecialty": "Podiatrist"
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "124999CC",
+      "type": "appointments",
+      "attributes": {
+        "id": "124999CC",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524669||4||1"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1679635460"
+          }
+        ],
+        "kind": "cc",
+        "status": "cancelled",
+        "description": "Podiatry DS SEOC 1.0.8 PRCT",
+        "patientIcn": "1013124304V115761",
+        "locationId": "984",
+        "practitioners": [
+          {
+            "name": {
+              "family": "RICHMOND",
+              "given": [
+                "TANISHA R"
+              ]
+            }
+          }
+        ],
+        "start": "2022-06-22T12:00:00Z",
+        "created": "2022-06-22T20:33:54Z",
         "cancellable": false,
         "extension": {
           "ccLocation": {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1,6 +1,216 @@
 {
   "data": [
     {
+      "id": "115069",
+      "type": "appointments",
+      "attributes": {
+        "id": "115069",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524669||4||1"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1679635460"
+          }
+        ],
+        "kind": "cc",
+        "status": "booked",
+        "description": "Eye Care Examination SEOC 1.3.10 PRCT",
+        "patientIcn": "1013124304V115761",
+        "locationId": "984",
+        "practitioners": [
+          {
+            "name": {
+              "family": "BERMEL",
+              "given": [
+                "MICHAEL"
+              ]
+            }
+          }
+        ],
+        "start": "2022-12-22T12:00:00Z",
+        "created": "2022-12-22T20:33:54Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "10640 MAIN ST ; STE 100"
+              ],
+              "city": "FAIRFAX",
+              "state": "VA",
+              "postalCode": "22030",
+              "text": "10640 MAIN ST ; STE 100\nFAIRFAX VA 22030"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "703-691-2020"
+              }
+            ]
+          },
+          "hsrmTaskId": "",
+          "hsrmConsultId": "984_644056",
+          "ccTreatingSpecialty": "Optometrist"
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "124063",
+      "type": "appointments",
+      "attributes": {
+        "id": "124063",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524669||4||1"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1679635460"
+          }
+        ],
+        "kind": "cc",
+        "status": "cancelled",
+        "description": "Podiatry DS SEOC 1.0.8 PRCT",
+        "patientIcn": "1013124304V115761",
+        "locationId": "984",
+        "practitioners": [
+          {
+            "name": {
+              "family": "RICHMOND",
+              "given": [
+                "TANISHA R"
+              ]
+            }
+          }
+        ],
+        "start": "2022-10-22T12:00:00Z",
+        "created": "2022-10-22T20:33:54Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "1323 W 3RD ST"
+              ],
+              "city": "DAYTON",
+              "state": "OH",
+              "postalCode": "45402",
+              "text": "1323 W 3RD ST\nDAYTON OH 45402"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "937-228-3668"
+              }
+            ]
+          },
+          "hsrmTaskId": "12881",
+          "hsrmConsultId": "984_644233",
+          "ccTreatingSpecialty": "Podiatrist"
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "110143CC",
       "type": "appointments",
       "attributes": {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -318,7 +318,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": { "text": "Follow-up/Routine: I have a headache" },
+        "reasonCode": {
+          "text": "Follow-up/Routine: I have a headache"
+        },
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
@@ -352,7 +354,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"text": "Follow-up/Routine: Covid shot"},
+        "reasonCode": {
+          "text": "Follow-up/Routine: Covid shot"
+        },
         "requestedPeriods": null,
         "serviceType": "covid",
         "slot": null,
@@ -414,12 +418,14 @@
               "postalCode": "45414",
               "text": "1601 Needmore Rd Ste 1\nDayton OH 45414"
             },
-            "telecom": [{
-              "system": "phone",
-              "value": "723-234-4565"
-            }]
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "723-234-4565"
+              }
+            ]
           }
-        },        
+        },
         "preferredTimesForPhoneCall": [],
         "priority": 0,
         "reasonCode": {},
@@ -435,7 +441,13 @@
       "id": "22aa789cc",
       "type": "cc_appointments",
       "attributes": {
-        "cancelationReason": { "coding": [{ "code": "pat" }] },
+        "cancelationReason": {
+          "coding": [
+            {
+              "code": "pat"
+            }
+          ]
+        },
         "clinic": null,
         "comment": "test",
         "contact": {
@@ -512,10 +524,12 @@
         "patientInstruction": "Video Visit Preparation contains extraneous stuff",
         "practitioners": [
           {
-            "identifier": [{
-              "system": null,
-              "value": "1801312053"
-            }],
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
             "name": {
               "family": "Normal",
               "given": [
@@ -526,7 +540,13 @@
         ],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"coding": [{"code": "New Issue"}]},
+        "reasonCode": {
+          "coding": [
+            {
+              "code": "New Issue"
+            }
+          ]
+        },
         "requestedPeriods": null,
         "serviceType": "outpatientMentalHealth",
         "slot": null,
@@ -564,10 +584,12 @@
         "patientInstruction": "Medication Review",
         "practitioners": [
           {
-            "identifier": [{
-              "system": null,
-              "value": "1801312053"
-            }],
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
             "name": {
               "family": "Smith",
               "given": [
@@ -629,11 +651,13 @@
         "patientInstruction": "Medication Review to prepare patient",
         "practitioners": [
           {
-            "identifier": [{
-              "system": null,
-              "value": "1801312053"
-            }],
-            "name":{
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
               "family": "Smith",
               "given": [
                 "Megan"
@@ -642,11 +666,13 @@
             "practiceName": null
           },
           {
-            "identifier": [{
-              "system": null,
-              "value": "1801312053"
-            }],
-            "name":{
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
               "family": "Dali",
               "given": [
                 "Salvador"
@@ -732,10 +758,12 @@
         "patientIcn": null,
         "practitioners": [
           {
-            "identifier": [{
-              "system": null,
-              "value": "1801312053"
-            }],
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
             "name": {
               "family": "Nightingale",
               "given": [
@@ -784,7 +812,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"text": "New issue: Phone appointment"},
+        "reasonCode": {
+          "text": "New issue: Phone appointment"
+        },
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
@@ -797,7 +827,13 @@
       "id": "11aa456ph",
       "type": "Appointment",
       "attributes": {
-        "cancelationReason": { "coding": [{ "code": "pat" }] },
+        "cancelationReason": {
+          "coding": [
+            {
+              "code": "pat"
+            }
+          ]
+        },
         "clinic": "308",
         "comment": "New issue: Phone appointment",
         "contact": {
@@ -818,7 +854,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"text": "New issue: Phone appointment"},
+        "reasonCode": {
+          "text": "New issue: Phone appointment"
+        },
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
@@ -852,7 +890,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"text": "Medication concern: I ran out of meds"},
+        "reasonCode": {
+          "text": "Medication concern: I ran out of meds"
+        },
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
@@ -886,10 +926,12 @@
         "patientInstruction": "Video Visit Preparation",
         "practitioners": [
           {
-            "identifier": [{
-              "system": null,
-              "value": "1801312053"
-            }],
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
             "name": {
               "family": "Jones",
               "given": [
@@ -917,7 +959,13 @@
       "id": "08aa456va",
       "type": "Appointment",
       "attributes": {
-        "cancelationReason": { "coding": [{ "code": "prov" }] },
+        "cancelationReason": {
+          "coding": [
+            {
+              "code": "prov"
+            }
+          ]
+        },
         "clinic": null,
         "comment": "Follow-up/Routine: comment test",
         "contact": {
@@ -938,7 +986,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"text": "Follow-up/Routine: comment test"},
+        "reasonCode": {
+          "text": "Follow-up/Routine: comment test"
+        },
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
@@ -951,7 +1001,13 @@
       "id": "08aa457va",
       "type": "Appointment",
       "attributes": {
-        "cancelationReason": { "coding": [{ "code": "pat" }] },
+        "cancelationReason": {
+          "coding": [
+            {
+              "code": "pat"
+            }
+          ]
+        },
         "clinic": null,
         "comment": "Follow-up/Routine: comment test",
         "contact": {
@@ -972,7 +1028,9 @@
         "practitioners": [],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {"text": "Follow-up/Routine: comment test"},
+        "reasonCode": {
+          "text": "Follow-up/Routine: comment test"
+        },
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
@@ -1069,6 +1127,6 @@
           }
         }
       }
-    }    
+    }
   ]
 }

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -848,6 +848,67 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
     expect(screen.queryByTestId('appointment-treatment-specialty')).to.be.null;
   });
 
+  it('should not display treatment specialty if treatmentSpecialty is is present and vaOnlineSchedulingVAOSV2Next is false', async () => {
+    // Given when the staff schedules the Community Care appointment for the Veteran
+    const url = '/cc/01aa456cc';
+    const appointmentTime = moment().add(1, 'days');
+    // When the treatmentSpecialty is blank or null
+    const data = {
+      id: '01aa456cc',
+      kind: 'cc',
+      practitioners: [
+        {
+          identifier: [{ system: null, value: '123' }],
+          name: {
+            family: 'Medical Care',
+            given: ['Atlantic'],
+          },
+        },
+      ],
+      description: 'community care appointment',
+      comment: 'test comment',
+      start: appointmentTime,
+      communityCareProvider: {
+        providerName: 'Atlantic Medical Care',
+        treatmentSpecialty: 'Optometry',
+      },
+    };
+
+    const appointment = createMockAppointmentByVersion({
+      version: 2,
+      ...data,
+    });
+
+    mockSingleVAOSAppointmentFetch({
+      appointment,
+    });
+
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState: {
+        featureToggles: {
+          ...initialState.featureToggles,
+          vaOnlineSchedulingVAOSServiceVAAppointments: true,
+          vaOnlineSchedulingVAOSServiceCCAppointments: true,
+          vaOnlineSchedulingVAOSV2Next: false,
+        },
+      },
+      path: url,
+    });
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: new RegExp(
+          appointmentTime.format('dddd, MMMM D, YYYY [at] h:mm a'),
+          'i',
+        ),
+      }),
+    ).to.be.ok;
+
+    expect(screen.queryByTestId('appointment-treatment-specialty')).to.be.null;
+  });
+
   it('should not show "Add to Calendar" for canceled appointments', async () => {
     // Given a user with a canceled CC appointment
     const url = '/cc/01aa456cc';

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -788,6 +788,66 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
     expect(screen.queryByText(/Type of care/i)).not.to.exist;
   });
 
+  it('should not display treatment specialty if treatmentSpecialty is missing or null', async () => {
+    // Given when the staff schedules the Community Care appointment for the Veteran
+    const url = '/cc/01aa456cc';
+    const appointmentTime = moment().add(1, 'days');
+    // When the treatmentSpecialty is blank or null
+    const data = {
+      id: '01aa456cc',
+      kind: 'cc',
+      practitioners: [
+        {
+          identifier: [{ system: null, value: '123' }],
+          name: {
+            family: 'Medical Care',
+            given: ['Atlantic'],
+          },
+        },
+      ],
+      description: 'community care appointment',
+      comment: 'test comment',
+      start: appointmentTime,
+      communityCareProvider: {
+        providerName: 'Atlantic Medical Care',
+      },
+    };
+
+    const appointment = createMockAppointmentByVersion({
+      version: 2,
+      ...data,
+    });
+
+    mockSingleVAOSAppointmentFetch({
+      appointment,
+    });
+
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState: {
+        featureToggles: {
+          ...initialState.featureToggles,
+          vaOnlineSchedulingVAOSServiceVAAppointments: true,
+          vaOnlineSchedulingVAOSServiceCCAppointments: true,
+          vaOnlineSchedulingVAOSV2Next: true,
+        },
+      },
+      path: url,
+    });
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: new RegExp(
+          appointmentTime.format('dddd, MMMM D, YYYY [at] h:mm a'),
+          'i',
+        ),
+      }),
+    ).to.be.ok;
+
+    expect(screen.queryByTestId('appointment-treatment-specialty')).to.be.null;
+  });
+
   it('should not show "Add to Calendar" for canceled appointments', async () => {
     // Given a user with a canceled CC appointment
     const url = '/cc/01aa456cc';

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -711,6 +711,7 @@ describe('VAOS Appointment service', () => {
               lastName: 'CAMPBELL',
             },
           },
+          treatmentSpecialty: 'Optometry',
         },
       };
 
@@ -750,6 +751,10 @@ describe('VAOS Appointment service', () => {
           {
             op: 'remove',
             path: ['communityCareProvider', 'providers'],
+          },
+          {
+            op: 'remove',
+            path: ['communityCareProvider', 'treatmentSpecialty'],
           },
           { op: 'remove', path: ['practitioners'] },
           { op: 'remove', path: ['vaos', 'facilityData'] },


### PR DESCRIPTION
## Description
HSRM is passing Treatment Specialty in `vaos-service` and the frontend will need to display the specialty for the provider on the booked Community Care appointment details page. The Veteran will be able to see the provider's specialty when they are viewing their Community Care appointment.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#46903
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46903
)
## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
