### PR TITLE
10405 update va health link text in footer

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -76,10 +76,10 @@
     },
     {
       "column": 2,
-      "href": "https://www.accesstocare.va.gov/ourproviders/",
+      "href": "https://www.accesstocare.va.gov/",
       "order": 2,
       "target": "_blank",
-      "title": "VA health care provider",
+      "title": "VA health care access and quality",
       "rel": "noopener noreferrer"
     },
     {


### PR DESCRIPTION
## Description
Update footer links for parity with content-build changes for the vets-website mocked footer.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/content-build/pull/1299)


## Testing done


## Screenshots


## Acceptance criteria
- [ ] footer is the same as content build after changes in 10405

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
