### PR TITLE
ESLint: Deprecate FileInput React component for the va-file-input web component.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,10 @@ module.exports = {
         name: '@department-of-veterans-affairs/component-library/RadioButtons',
         use: '<va-radio>',
       },
+      {
+        name: '@department-of-veterans-affairs/component-library/FileInput',
+        use: '<va-file-input>',
+      },
     ],
     'jsx-a11y/control-has-associated-label': 1, // 2
     'jsx-a11y/click-events-have-key-events': 1, // 24


### PR DESCRIPTION
## Description
This will add a deprecation warning for the FileInput React component now that the [va-file-input web component](https://design.va.gov/components/form/file-input) is available.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1048

## Testing done
VS Code

## Screenshots

![Screen Shot 2022-09-19 at 9 57 21 AM](https://user-images.githubusercontent.com/872479/191048725-cfda0187-e009-48e2-b77c-a4eede19347c.png)

## Acceptance criteria
- [ ] If the FileInput React component is being imported, an ESLint warning appears that recommends using the va-file-input web component instead.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
