### PR TITLE
Crisis line component added to mobile footer

### DIFF
--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -47,19 +47,20 @@ export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
 
       {/* Alert when the user's browser is Internet Explorer. */}
       {/* @TODO Wrap this web-component into its own react component. */}
-      {loaded && isBrowserIE() && (
-        <va-banner
-          headline="You'll need to use a different web browser"
-          show-close
-          type="warning"
-          visible
-        >
-          You’re using Internet Explorer right now to access VA.gov. Microsoft
-          stopped supporting all versions of this browser on June 15, 2022. This
-          means that you’ll need to switch to another browser, like Microsoft
-          Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
-        </va-banner>
-      )}
+      {loaded &&
+        isBrowserIE() && (
+          <va-banner
+            headline="You'll need to use a different web browser"
+            show-close
+            type="warning"
+            visible
+          >
+            You’re using Internet Explorer right now to access VA.gov. Microsoft
+            stopped supporting all versions of this browser on June 15, 2022.
+            This means that you’ll need to switch to another browser, like
+            Microsoft Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
+          </va-banner>
+        )}
     </div>
   );
 };

--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -27,7 +27,7 @@ export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
       <OfficialGovtWebsite />
 
       {/* Veteran crisis line */}
-      <VeteranCrisisLine />
+      <VeteranCrisisLine id="header-crisis-line" />
 
       <nav className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0">
         {/* Logo row */}
@@ -47,20 +47,19 @@ export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
 
       {/* Alert when the user's browser is Internet Explorer. */}
       {/* @TODO Wrap this web-component into its own react component. */}
-      {loaded &&
-        isBrowserIE() && (
-          <va-banner
-            headline="You'll need to use a different web browser"
-            show-close
-            type="warning"
-            visible
-          >
-            You’re using Internet Explorer right now to access VA.gov. Microsoft
-            stopped supporting all versions of this browser on June 15, 2022.
-            This means that you’ll need to switch to another browser, like
-            Microsoft Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
-          </va-banner>
-        )}
+      {loaded && isBrowserIE() && (
+        <va-banner
+          headline="You'll need to use a different web browser"
+          show-close
+          type="warning"
+          visible
+        >
+          You’re using Internet Explorer right now to access VA.gov. Microsoft
+          stopped supporting all versions of this browser on June 15, 2022. This
+          means that you’ll need to switch to another browser, like Microsoft
+          Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
+        </va-banner>
+      )}
     </div>
   );
 };

--- a/src/platform/site-wide/header/components/VeteranCrisisLine/index.js
+++ b/src/platform/site-wide/header/components/VeteranCrisisLine/index.js
@@ -3,11 +3,12 @@ import React from 'react';
 // Relative imports.
 import recordEvent from 'platform/monitoring/record-event';
 
-export const VeteranCrisisLine = () => (
+export const VeteranCrisisLine = props => (
   <div className="vads-u-background-color--secondary-darkest vads-u-display--flex vads-u-flex-direction--row vads-u-align-items--center vads-u-justify-content--center vads-u-text-align--center vads-u-padding--0p5">
     <button
       className="va-button-link vads-u-color--white vads-u-text-decoration--none va-overlay-trigger"
       data-show="#modal-crisisline"
+      id={props.id}
       onClick={() => {
         recordEvent({ event: 'nav-crisis-header' });
         recordEvent({ event: 'nav-jumplink-click' });

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,6 +1,7 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:988"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
+const firstOpenControl = '[data-show=modal-crisisline]';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 
@@ -9,7 +10,7 @@ describe('Accessible Modal Test', () => {
     cy.visit('/');
 
     // Open modal
-    cy.get('[id=header-crisis-line]')
+    cy.get(firstOpenControl)
       .focus()
       .realPress('Enter');
     cy.injectAxeThenAxeCheck();
@@ -30,7 +31,7 @@ describe('Accessible Modal Test', () => {
     cy.get('body').should('not.have.class', 'va-pos-fixed');
 
     // REturn focus to appropriate open controls
-    cy.get('[id=header-crisis-line]').should('be.focused');
+    cy.get(firstOpenControl).should('be.focused');
 
     cy.get(thirdOpenControl)
       .focus()

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -37,6 +37,7 @@ describe('Accessible Modal Test', () => {
       .should('be.focused');
 
     cy.get(thirdOpenControl)
+      .first()
       .focus()
       .realPress('Enter');
     cy.get(firstModalItem).should('be.focused');

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,7 +1,7 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:988"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
-const firstOpenControl = '[data-show=modal-crisisline]';
+const firstOpenControl = '[data-show="#modal-crisisline"]';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,7 +1,7 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:988"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
-const firstOpenControl = '#a35dd69f2d763f4b0c8a74fbf13aa447';
+const firstOpenControl = '[data-show="#modal-crisisline"]';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 
@@ -11,6 +11,7 @@ describe('Accessible Modal Test', () => {
 
     // Open modal
     cy.get(firstOpenControl)
+      .first()
       .focus()
       .realPress('Enter');
     cy.injectAxeThenAxeCheck();
@@ -31,7 +32,9 @@ describe('Accessible Modal Test', () => {
     cy.get('body').should('not.have.class', 'va-pos-fixed');
 
     // Return focus to appropriate open controls
-    cy.get(firstOpenControl).should('be.focused');
+    cy.get(firstOpenControl)
+      .first()
+      .should('be.focused');
 
     cy.get(thirdOpenControl)
       .focus()

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,7 +1,7 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:988"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
-const firstOpenControl = 'button.va-crisis-line.va-overlay-trigger';
+const firstOpenControl = '#header-crisis-line';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,7 +1,7 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:988"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
-const firstOpenControl = '[data-show="#modal-crisisline"]';
+const firstOpenControl = '#a35dd69f2d763f4b0c8a74fbf13aa447';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 
@@ -30,7 +30,7 @@ describe('Accessible Modal Test', () => {
     cy.get(overlay).should('not.have.class', 'va-overlay--open');
     cy.get('body').should('not.have.class', 'va-pos-fixed');
 
-    // REturn focus to appropriate open controls
+    // Return focus to appropriate open controls
     cy.get(firstOpenControl).should('be.focused');
 
     cy.get(thirdOpenControl)

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,7 +1,6 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:988"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
-const firstOpenControl = '#header-crisis-line';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 
@@ -10,7 +9,7 @@ describe('Accessible Modal Test', () => {
     cy.visit('/');
 
     // Open modal
-    cy.get(firstOpenControl)
+    cy.get('[id=header-crisis-line]')
       .focus()
       .realPress('Enter');
     cy.injectAxeThenAxeCheck();
@@ -31,7 +30,7 @@ describe('Accessible Modal Test', () => {
     cy.get('body').should('not.have.class', 'va-pos-fixed');
 
     // REturn focus to appropriate open controls
-    cy.get(firstOpenControl).should('be.focused');
+    cy.get('[id=header-crisis-line]').should('be.focused');
 
     cy.get(thirdOpenControl)
       .focus()

--- a/src/platform/site-wide/va-footer/components/MobileLinks.jsx
+++ b/src/platform/site-wide/va-footer/components/MobileLinks.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { FOOTER_COLUMNS } from '../helpers';
 import LanguageSupport from './LanguageSupport';
+import VeteranCrisisLine from '../../header/components/VeteranCrisisLine';
 
 export default function MobileLinks({ links, visible, langConfig }) {
   return (
@@ -10,6 +11,9 @@ export default function MobileLinks({ links, visible, langConfig }) {
       className="usa-grid-full flex-container usa-grid-flex-mobile va-footer-content"
     >
       <ul className="usa-accordion va-footer-accordion">
+        <li>
+          <VeteranCrisisLine id="footer-crisis-line" />
+        </li>
         <li>
           <button
             className="usa-button-unstyled usa-accordion-button va-footer-button"


### PR DESCRIPTION
## Description
Added the crisis line banner to the footer on mobile.  Given a unique ID for each header and fooder for 508 purposes

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10668


## Testing done
Local visual testing,  checked for keyboard accessibility 

## Screenshots
<img width="466" alt="Screen Shot 2022-09-14 at 2 26 56 PM" src="https://user-images.githubusercontent.com/61624970/190233536-c4d89a83-fa9f-4550-8268-aa10ceebe03d.png">
<img width="449" alt="Screen Shot 2022-09-14 at 11 37 35 AM" src="https://user-images.githubusercontent.com/61624970/190233204-d07959d9-f7a3-4725-b1e6-4655807e607e.png">
<img width="1111" alt="Screen Shot 2022-09-14 at 12 17 28 PM" src="https://user-images.githubusercontent.com/61624970/190233206-ea16bd12-814b-4232-8918-61e793a0fbd4.png">



## Acceptance criteria
- [x] VCL modal trigger appears in footer, as per Sketch file, with its own ID for 508 purposes, to distinguish it from the prompt in the header.
- [ ]  Review on review instance with Wes or designer (Val Rundle?) before merge


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
