### PR TITLE
Add COE unique loan number validation

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -11,7 +11,10 @@ import { states } from 'platform/forms/address';
 import { loanHistory } from '../../schemaImports';
 import LoanReviewField from '../../../components/LoanReviewField';
 import text from '../../../content/loanHistory';
-import { validateVALoanNumber } from '../../../validations';
+import {
+  validateVALoanNumber,
+  validateUniqueVALoanNumber,
+} from '../../../validations';
 
 const stateLabels = createUSAStateLabels(states);
 
@@ -69,6 +72,7 @@ export const uiSchema = {
       keepInPageOnReview: true,
       customTitle: ' ', // Force outer DIV wrap (vs DL wrap, for a11y)
     },
+    'ui:validations': [validateUniqueVALoanNumber],
     items: {
       'ui:title': 'Existing VA loan',
       'ui:options': {

--- a/src/applications/lgy/coe/form/content/loanHistory.js
+++ b/src/applications/lgy/coe/form/content/loanHistory.js
@@ -43,6 +43,7 @@ export default {
     value: data => get('vaLoanNumber', data, ''),
     pattern: 'Please enter numbers only (dashes allowed)',
     lengthError: 'Make sure you include 12 digits.',
+    unique: 'Please enter a unique loan number',
   },
   owned: {
     title: 'Do you still own this property?',

--- a/src/applications/lgy/coe/form/tests/config/loans/loanHistory.unit.spec.jsx
+++ b/src/applications/lgy/coe/form/tests/config/loans/loanHistory.unit.spec.jsx
@@ -215,6 +215,7 @@ describe('COE applicant loan history', () => {
                   propertyState: 'AK',
                   propertyZip: '48017',
                 },
+                vaLoanNumber: '123456789012',
               },
               {
                 dateRange: {
@@ -227,6 +228,7 @@ describe('COE applicant loan history', () => {
                   propertyState: 'AK',
                   propertyZip: '48017',
                 },
+                vaLoanNumber: '123456789013',
               },
             ],
           }}

--- a/src/applications/lgy/coe/form/tests/validations.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/validations.unit.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 
 import {
   validateDocumentDescription,
+  validateUniqueVALoanNumber,
   validateVALoanNumber,
 } from '../validations';
 
@@ -29,6 +30,77 @@ describe('validateDocumentDescription', () => {
     validateDocumentDescription(errors(spy), fileList('Other', ''));
     expect(spy.called).to.be.true;
     expect(spy.calledWith('Please provide a description'));
+  });
+});
+
+describe('validateUniqueVALoanNumber', () => {
+  const errors = (...args) =>
+    args.map(spy => ({ vaLoanNumber: { addError: spy } }));
+  const getData = (...args) => args.map(data => ({ vaLoanNumber: data }));
+
+  it('should not return an error for unique 12-digit numbers', () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const data = getData('123456789012', '123456789011');
+    validateUniqueVALoanNumber(errors(spy1, spy2), data);
+    expect(spy1.notCalled).to.be.true;
+    expect(spy2.notCalled).to.be.true;
+  });
+  it('should not return an error for unique 12-digit numbers, ingnoring dashes', () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const data = getData('12-34-5-6789012', '12-34-5-6789011');
+    validateUniqueVALoanNumber(errors(spy1, spy2), data);
+    expect(spy1.notCalled).to.be.true;
+    expect(spy2.notCalled).to.be.true;
+  });
+  it('should return errors for non-unique 12-digit numbers', () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const data = getData('123456789012', '123456789012');
+    validateUniqueVALoanNumber(errors(spy1, spy2), data);
+    expect(spy1.called).to.be.true;
+    expect(spy2.called).to.be.true;
+  });
+  it('should return errors for non-unique 12-digit numbers, ignoring dashes/spaces', () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const data = getData('12-34-5-6789012', '12 34 5 6789012');
+    validateUniqueVALoanNumber(errors(spy1, spy2), data);
+    expect(spy1.called).to.be.true;
+    expect(spy2.called).to.be.true;
+  });
+  it('should return errors for ONLY non-unique 12-digit numbers', () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const spy3 = sinon.spy();
+    const data = getData(
+      '12-34-5-6789012',
+      '12-34-5-6789011',
+      '12 34 5 6789012',
+    );
+    validateUniqueVALoanNumber(errors(spy1, spy2, spy3), data);
+    expect(spy1.called).to.be.true;
+    expect(spy2.notCalled).to.be.true;
+    expect(spy3.called).to.be.true;
+  });
+  it('should return errors for multiple sets of non-unique 12-digit numbers', () => {
+    const spy1 = sinon.spy();
+    const spy2 = sinon.spy();
+    const spy3 = sinon.spy();
+    const spy4 = sinon.spy();
+
+    const data = getData(
+      '12-34-5-6789012',
+      '12-34-5-6789011',
+      '12 34 5 6789012',
+      '12-34-5-6789011',
+    );
+    validateUniqueVALoanNumber(errors(spy1, spy2, spy3, spy4), data);
+    expect(spy1.called).to.be.true;
+    expect(spy2.called).to.be.true;
+    expect(spy3.called).to.be.true;
+    expect(spy4.called).to.be.true;
   });
 });
 

--- a/src/applications/lgy/coe/form/validations.js
+++ b/src/applications/lgy/coe/form/validations.js
@@ -26,6 +26,22 @@ export const validateDocumentDescription = (errors, fileList) => {
   });
 };
 
+export const validateUniqueVALoanNumber = (errors, data) => {
+  const loans = (data || []).map(loan =>
+    replaceNonDigits(loan?.vaLoanNumber || ''),
+  );
+  const unique = new Set(loans);
+  if (loans.length && loans.length !== unique.size) {
+    loans.forEach((loan, index) => {
+      const indx = loans.findIndex(number => number === loan);
+      if (indx !== index) {
+        errors[index].vaLoanNumber.addError(text.loanNumber.unique);
+        errors[indx].vaLoanNumber.addError(text.loanNumber.unique);
+      }
+    });
+  }
+};
+
 export const validateVALoanNumber = (errors, loanNumber) => {
   const number = replaceNonDigits(loanNumber || '');
 


### PR DESCRIPTION
## Original Ticket

[#45026](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45026)

## URL of change

`/housing-assistance/home-loans/request-coe-form-26-1880/loan-history`

## Background

The VA loan number can be added in multiple entries within the loan history. We need to check and prevent duplicate loan numbers within the form. It's not defined as needing to be unique within the schema, but it makes sense to prevent duplicates.

## Steps to test

1. Pull in this branch or test in the review instance
2. Log in to user 228 (Mark Webb)
3. Fill out the form to get to the loan history page
4. In the first entry enter a memorable 12-digit VA loan number (dashes and spaces)
5. Add a second entry with the same 12-digits (dashes and spaces can be randomly placed, except at the beginning)
6. Verify that the "Please enter a unique loan number" error message shows up

<img width="385" alt="VA loan number input showing a error message stating 'please enter a unique loan number', the first entry is collapsed, but also has the same error message" src="https://user-images.githubusercontent.com/136959/191300746-77fb2ee5-2e5b-4944-9181-bf132ca6e50f.png">

## Code changes

- Added new unique validation test on VA loan numbers
- Ensure that all non-unique entries show an error
- Added unit tests

## How was your code tested

Unit tests

## Acceptance criteria
- [x] Add validation for
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs