### PR TITLE
Dhp 453 bugfix disconnect modal button

### DIFF
--- a/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
@@ -37,7 +37,6 @@ export const DeviceDisconnectionCard = ({ device }) => {
             onClick={() => setModalVisible(true)}
             data-testid={`${device.key}-disconnect-link`}
             id={`${device.key}-disconnect-link`}
-            onKeyDown={() => setModalVisible(true)}
             className="usa-button-secondary"
             aria-label={`Disconnect ${device.name}`}
           >

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -4,16 +4,15 @@ import environment from 'platform/utilities/environment';
 import { fireEvent, render } from '@testing-library/react';
 import { DeviceDisconnectionCard } from '../../components/DeviceDisconnectionCard';
 
-const device = {
-  name: 'Test Vendor',
-  key: 'test-vendor',
-  disconnectUrl: 'path/to/test-disconnect',
-};
-function getDisconnectModal(targetScreen) {
-  return targetScreen.queryByTestId('disconnect-modal');
-}
-
 describe('Device disconnection card', () => {
+  const device = {
+    name: 'Test Vendor',
+    key: 'test-vendor',
+    disconnectUrl: 'path/to/test-disconnect',
+  };
+  function getDisconnectModal(targetScreen) {
+    return targetScreen.queryByTestId('disconnect-modal');
+  }
   let disconnectBtn;
   let screen;
   beforeEach(async () => {
@@ -22,69 +21,69 @@ describe('Device disconnection card', () => {
       name: 'Disconnect Test Vendor',
     });
   });
-  it('Renders vendors name', () => {
-    expect(screen.getByText(/Test Vendor/)).to.exist;
-  });
-  it('Has aria label for screen reader users', () => {
-    expect(
-      screen
-        .getByTestId('test-vendor-disconnect-link')
-        .getAttribute('aria-label'),
-    ).to.equal('Disconnect Test Vendor');
-  });
-  it('Should not open Disconnect modal on tab press', async () => {
-    const tabKeyCode = 9;
-    disconnectBtn.focus();
-    fireEvent.keyDown(disconnectBtn, { keyCode: tabKeyCode });
-    expect(getDisconnectModal(screen)).to.not.exist;
-  });
-});
 
-describe('Device disconnection card modal', () => {
-  let screen;
-  let modal;
-  beforeEach(async () => {
-    screen = render(<DeviceDisconnectionCard device={device} />);
-    const disconnectBtn = screen.getByRole('button', {
-      name: 'Disconnect Test Vendor',
+  describe('Device disconnection card content', () => {
+    it('Renders vendors name', () => {
+      expect(screen.getByText(/Test Vendor/)).to.exist;
     });
-    fireEvent.click(disconnectBtn);
-    modal = getDisconnectModal(screen);
-  });
-  it('Should show modal when Disconnect is clicked', async () => {
-    expect(modal).to.exist;
-    expect(modal.getAttribute('modalTitle')).to.eq('Disconnect device');
-    expect(
-      screen.getByText(
-        'Disconnecting your Test Vendor will stop sharing data with the VA.',
-      ),
-    ).to.exist;
-    expect(modal.getAttribute('primaryButtonText')).to.eq('Disconnect device');
-    expect(modal.getAttribute('secondaryButtonText')).to.eq('Cancel');
-  });
-  it("Should close modal when 'Cancel' button is clicked", async () => {
-    const goBackBtn = modal.__events.secondaryButtonClick;
-    await goBackBtn();
-    expect(getDisconnectModal(screen)).to.not.exist;
-  });
-  it("Should close modal when 'X' button is clicked", async () => {
-    const xBtn = modal.__events.closeEvent;
-    await xBtn();
-    expect(getDisconnectModal(screen)).to.not.exist;
-  });
-  it("Should close modal when 'Disconnect device' button is clicked and redirect to disconnect url", async () => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        assign: () => {},
-        href: '/',
-      },
+    it('Has aria label for screen reader users', () => {
+      expect(
+        screen
+          .getByTestId('test-vendor-disconnect-link')
+          .getAttribute('aria-label'),
+      ).to.equal('Disconnect Test Vendor');
     });
-    const disconnectDeviceBtn = modal.__events.primaryButtonClick;
-    await disconnectDeviceBtn();
-    expect(getDisconnectModal(screen)).to.not.exist;
-    expect(global.window.location.href).to.eq(
-      `${environment.API_URL}/dhp_connected_devices${device.disconnectUrl}`,
-    );
+    it('Should not open Disconnect modal on tab press', async () => {
+      const tabKeyCode = 9;
+      disconnectBtn.focus();
+      fireEvent.keyDown(disconnectBtn, { keyCode: tabKeyCode });
+      expect(getDisconnectModal(screen)).to.not.exist;
+    });
+  });
+
+  describe('Device disconnection card modal', () => {
+    let modal;
+    beforeEach(async () => {
+      fireEvent.click(disconnectBtn);
+      modal = getDisconnectModal(screen);
+    });
+    it('Should show modal when Disconnect is clicked', async () => {
+      expect(modal).to.exist;
+      expect(modal.getAttribute('modalTitle')).to.eq('Disconnect device');
+      expect(
+        screen.getByText(
+          'Disconnecting your Test Vendor will stop sharing data with the VA.',
+        ),
+      ).to.exist;
+      expect(modal.getAttribute('primaryButtonText')).to.eq(
+        'Disconnect device',
+      );
+      expect(modal.getAttribute('secondaryButtonText')).to.eq('Cancel');
+    });
+    it("Should close modal when 'Cancel' button is clicked", async () => {
+      const cancelBtn = modal.__events.secondaryButtonClick;
+      await cancelBtn();
+      expect(getDisconnectModal(screen)).to.not.exist;
+    });
+    it("Should close modal when 'X' button is clicked", async () => {
+      const xBtn = modal.__events.closeEvent;
+      await xBtn();
+      expect(getDisconnectModal(screen)).to.not.exist;
+    });
+    it("Should close modal when 'Disconnect device' button is clicked and redirect to disconnect url", async () => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: {
+          assign: () => {},
+          href: '/',
+        },
+      });
+      const disconnectDeviceBtn = modal.__events.primaryButtonClick;
+      await disconnectDeviceBtn();
+      expect(getDisconnectModal(screen)).to.not.exist;
+      expect(global.window.location.href).to.eq(
+        `${environment.API_URL}/dhp_connected_devices${device.disconnectUrl}`,
+      );
+    });
   });
 });

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -1,45 +1,45 @@
 import React from 'react';
 import { expect } from 'chai';
 import environment from 'platform/utilities/environment';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
-import { render, fireEvent } from '@testing-library/react';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import { DeviceDisconnectionCard } from '../../components/DeviceDisconnectionCard';
 
-describe('Device disconnection card', () => {
-  it('Renders vendors name', () => {
-    const card = renderInReduxProvider(
-      <DeviceDisconnectionCard
-        device={{ name: 'Test Vendor' }}
-        onClickHandler="www.google.com"
-      />,
-    );
+const device = {
+  name: 'Test Vendor',
+  key: 'test-vendor',
+  disconnectUrl: 'path/to/test-disconnect',
+};
 
-    expect(card.getByText(/Test Vendor/)).to.exist;
+describe('Device disconnection card', () => {
+  let disconnectBtn;
+  let screen;
+  beforeEach(async () => {
+    screen = render(<DeviceDisconnectionCard device={device} />);
+    disconnectBtn = screen.getByRole('button', {
+      name: 'Disconnect Test Vendor',
+    });
+  });
+  it('Renders vendors name', () => {
+    expect(screen.getByText(/Test Vendor/)).to.exist;
   });
   it('Has aria label for screen reader users', () => {
-    const card = mount(
-      <DeviceDisconnectionCard
-        device={{ key: 'test-vendor', name: 'Test Vendor' }}
-      />,
-    );
     expect(
-      card
-        .find('[data-testid="test-vendor-disconnect-link"]')
-        .prop('aria-label'),
+      screen
+        .getByTestId('test-vendor-disconnect-link')
+        .getAttribute('aria-label'),
     ).to.equal('Disconnect Test Vendor');
-    card.unmount();
+  });
+  it('Should not open Disconnect modal on tab press', async () => {
+    const tabKeyCode = 9;
+    disconnectBtn.focus();
+    fireEvent.keyDown(disconnectBtn, { keyCode: tabKeyCode });
+    expect(screen.queryByTestId('disconnect-modal')).to.not.exist;
   });
 });
 
 describe('Device disconnection card modal', () => {
   let screen;
   let modal;
-  const device = {
-    name: 'Test Vendor',
-    key: 'test',
-    disconnectUrl: 'path/to/test-disconnect',
-  };
   beforeEach(async () => {
     screen = render(<DeviceDisconnectionCard device={device} />);
     const disconnectBtn = screen.getByRole('button', {

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -9,6 +9,9 @@ const device = {
   key: 'test-vendor',
   disconnectUrl: 'path/to/test-disconnect',
 };
+function getDisconnectModal(targetScreen) {
+  return targetScreen.queryByTestId('disconnect-modal');
+}
 
 describe('Device disconnection card', () => {
   let disconnectBtn;
@@ -33,7 +36,7 @@ describe('Device disconnection card', () => {
     const tabKeyCode = 9;
     disconnectBtn.focus();
     fireEvent.keyDown(disconnectBtn, { keyCode: tabKeyCode });
-    expect(screen.queryByTestId('disconnect-modal')).to.not.exist;
+    expect(getDisconnectModal(screen)).to.not.exist;
   });
 });
 
@@ -46,9 +49,8 @@ describe('Device disconnection card modal', () => {
       name: 'Disconnect Test Vendor',
     });
     fireEvent.click(disconnectBtn);
-    modal = screen.getByTestId('disconnect-modal');
+    modal = getDisconnectModal(screen);
   });
-
   it('Should show modal when Disconnect is clicked', async () => {
     expect(modal).to.exist;
     expect(modal.getAttribute('modalTitle')).to.eq('Disconnect device');
@@ -63,12 +65,12 @@ describe('Device disconnection card modal', () => {
   it("Should close modal when 'Cancel' button is clicked", async () => {
     const goBackBtn = modal.__events.secondaryButtonClick;
     await goBackBtn();
-    expect(screen.queryByTestId('disconnect-modal')).to.not.exist;
+    expect(getDisconnectModal(screen)).to.not.exist;
   });
   it("Should close modal when 'X' button is clicked", async () => {
     const xBtn = modal.__events.closeEvent;
     await xBtn();
-    expect(screen.queryByTestId('disconnect-modal')).to.not.exist;
+    expect(getDisconnectModal(screen)).to.not.exist;
   });
   it("Should close modal when 'Disconnect device' button is clicked and redirect to disconnect url", async () => {
     Object.defineProperty(window, 'location', {
@@ -80,7 +82,7 @@ describe('Device disconnection card modal', () => {
     });
     const disconnectDeviceBtn = modal.__events.primaryButtonClick;
     await disconnectDeviceBtn();
-    expect(screen.queryByTestId('disconnect-modal')).to.not.exist;
+    expect(getDisconnectModal(screen)).to.not.exist;
     expect(global.window.location.href).to.eq(
       `${environment.API_URL}/dhp_connected_devices${device.disconnectUrl}`,
     );


### PR DESCRIPTION
## Description
Fixes accessibility issue where pressing tab on the Disconnect button opens the modal

## Original issue(s)
https://app.zenhub.com/workspaces/department-of-veterans-affairsvagov-team-62447fb44deeed001392c57f/issues/department-of-veterans-affairs/va.gov-team/47164

## Testing done
Unit tests

## Acceptance criteria
Expected Behavior 
- Logged into staging.va.gov as a test user
- Fitbit connected 
- For keyboard only users
- [x] When you press Tab to select the "Disconnect" button and then Tab again the first FAQ question is selected.
- [x] When you press Tab to select the "Disconnect" button and then Enter, the Disconnect Modal should open

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
