### PR TITLE
Fixes the logout bug for Sign in Service

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -26,7 +26,7 @@ export function PersonalizationDropdown(props) {
     () => (
       <a
         href={isSSOe ? logoutUrl() : logoutUrlSiS()}
-        onClick={() => logoutEvent(csp)}
+        onClick={() => logoutEvent(csp, { shouldWait: !isSSOe, duration: 350 })}
       >
         Sign Out
       </a>

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -296,9 +296,19 @@ export const logoutUrlSiS = () => {
   return new URL(API_SIGN_IN_SERVICE_URL({ endpoint: 'logout' })).href;
 };
 
-export const logoutEvent = ({ signInServiceName }) => {
+export const logoutEvent = async (signInServiceName, wait = {}) => {
+  const { duration = 500, shouldWait } = wait;
+  const sleep = time => {
+    return new Promise(resolve => setTimeout(resolve, time));
+  };
   recordEvent({ event: `${AUTH_EVENTS.OAUTH_LOGOUT}-${signInServiceName}` });
 
   updateLoggedInStatus(false);
-  teardownProfileSession();
+
+  if (shouldWait) {
+    await sleep(duration);
+    teardownProfileSession();
+  } else {
+    teardownProfileSession();
+  }
 };

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import localStorage from 'platform/utilities/storage/localStorage';
@@ -10,6 +11,7 @@ import {
 
 import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
 import environment from 'platform/utilities/environment';
+import * as profileUtils from 'platform/user/profile/utilities';
 import {
   AUTHORIZE_KEYS_WEB,
   AUTHORIZE_KEYS_MOBILE,
@@ -370,12 +372,37 @@ describe('OAuth - Utilities', () => {
     });
   });
 
-  describe('logout', () => {
+  describe('logoutUrlSiS', () => {
     it('should redirect to backend for logout', () => {
       window.location = new URL('https://va.gov/?state=some_random_state');
       const url = oAuthUtils.logoutUrlSiS();
       window.location = url;
       expect(window.location).to.eql(url);
+    });
+  });
+
+  describe('logoutEvent', () => {
+    it('should teardown profile', async () => {
+      localStorage.setItem('hasSession', true);
+      const teardownSpy = sinon.spy(profileUtils, 'teardownProfileSession');
+      oAuthUtils.logoutEvent('logingov');
+
+      expect(teardownSpy.called).to.be.true;
+      expect(localStorage.getItem('hasSession')).to.be.null;
+      teardownSpy.restore();
+    });
+    it('should teardown profile after a certain duration', async () => {
+      localStorage.setItem('hasSession', true);
+      const teardownSpy = sinon.spy(profileUtils, 'teardownProfileSession');
+      await oAuthUtils.logoutEvent('logingov', {
+        shouldWait: true,
+        duration: 300,
+      });
+
+      expect(teardownSpy.called).to.be.true;
+      expect(localStorage.getItem('hasSession')).to.be.null;
+
+      teardownSpy.restore();
     });
   });
 });


### PR DESCRIPTION
## Description
This PR updates the `logoutEvent` to add a waiting period when it calls the `teardownProfileSession` function that removes cookies before making a logout request for the Sign in Service

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#46820


## Testing done
Unit testing & manual

## Screenshots
n/a

## Acceptance criteria
- [x] The `logoutEvent` successfully calls the `teardownProfileSession` function after 350ms
- [x] Unit tests pass as expected
