### PR TITLE
Adding GA4 configuration for component library

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Attaches CustomEvent 'component-library-analytics' listener to document.body
  * to translate component library actions into analytics dataLayer events.

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -87,6 +87,10 @@ const analyticsEvents = {
       action: 'change',
       event: 'int-checkbox-option-click',
       prefix: 'checkbox',
+      ga4: {
+        event: 'form_input',
+        form_input_type: 'checkbox',
+      },
     },
   ],
   'va-text-input': [
@@ -213,6 +217,37 @@ export function subscribeComponentAnalyticsEvents(
     const action = component.find(ev => ev.action === e.detail.action);
     const { version } = e.detail;
 
+    /**
+     * Record a GA4 event.
+     * Checking to make sure the component has predefined GA4 details,
+     * then merge any dynamic GA4 details received from the event and
+     * send it to the dataLayer.
+     */
+    if (action && action.ga4) {
+      const { ga4 } = action;
+
+      /**
+       * Create the GA4 dataLayer event object with the
+       * component's predefined GA4 details.
+       */
+      let ga4DataLayer = { ...ga4 };
+
+      /**
+       * If the event includes additional GA4 details/context,
+       * add it to the GA4 dataLayer.
+       */
+      if (e.detail.ga4) {
+        ga4DataLayer = { ...ga4DataLayer, ...e.detail.ga4 };
+      }
+
+      // Send GA4 event to the dataLayer.
+      recordEvent(ga4DataLayer);
+    }
+
+    /**
+     * Record a GA event.
+     * To be removed when GA4 is primary.
+     */
     if (action) {
       const dataLayer = {
         event: action.event,


### PR DESCRIPTION
## Description
This update configures the component library [Google Analytics code in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/site-wide/component-library-analytics-setup.js) script to send data to both GA3 and GA4. It also adds GA4 predefined details for the `va-checkbox` component for initial testing.

References: 
[VA GA4 Documentation](https://docs.google.com/spreadsheets/d/1XDceQQVK6IGOl8R1OzhbncSc1Hrs37IEyQblW_Spk-Y/edit#gid=1403781092)

## Original issue(s)
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1174


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
