### PR TITLE
46903 fix treatment specialty label

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -41,10 +41,10 @@ export default function DetailsCC({
   };
 
   const ShowTreatmentSpecialty = () => {
-    if (featureVaosV2Next && treatmentSpecialty) {
+    if (featureVaosV2Next && !!treatmentSpecialty) {
       return (
         <div
-          data-test-id="appointment-treatment-specialty"
+          data-testid="appointment-treatment-specialty"
           className="vads-u-margin-bottom--1"
         >
           {treatmentSpecialty}

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -93,7 +93,6 @@ export function transformVAOSAppointment(appt) {
     appointmentType === APPOINTMENT_TYPES.request ||
     appointmentType === APPOINTMENT_TYPES.ccRequest;
   const providers = appt.practitioners;
-  const ccTreatingSpecialty = !appt.extension?.ccTreatingSpecialty;
   const timezone = getTimezoneByFacilityId(appt.locationId);
 
   const start = timezone ? moment(appt.start).tz(timezone) : moment(appt.start);
@@ -206,7 +205,7 @@ export function transformVAOSAppointment(appt) {
       isCC && !isRequest
         ? {
             practiceName: appt.extension?.ccLocation?.practiceName,
-            treatmentSpecialty: ccTreatingSpecialty,
+            treatmentSpecialty: appt.extension?.ccTreatingSpecialty,
             address: appt.extension?.ccLocation?.address,
             telecom: appt.extension?.ccLocation?.telecom,
             providers: (providers || []).map(provider => ({

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -726,6 +726,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
     expect(screen.getByText(/Community care/)).to.be.ok;
     expect(screen.getByText(/Atlantic Medical Care/)).to.be.ok;
   });
+
   it('should not display type of care when serviceType is missing or null', async () => {
     // Given when the staff schedules the Community Care appointment for the Veteran
     const url = '/cc/01aa456cc';
@@ -788,7 +789,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
     expect(screen.queryByText(/Type of care/i)).not.to.exist;
   });
 
-  it('should not display treatment specialty if treatmentSpecialty is missing or null', async () => {
+  it('should not display treatment specialty if treatmentSpecialty is missing and vaOnlineSchedulingVAOSV2Next is true', async () => {
     // Given when the staff schedules the Community Care appointment for the Veteran
     const url = '/cc/01aa456cc';
     const appointmentTime = moment().add(1, 'days');
@@ -810,6 +811,128 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
       start: appointmentTime,
       communityCareProvider: {
         providerName: 'Atlantic Medical Care',
+      },
+    };
+
+    const appointment = createMockAppointmentByVersion({
+      version: 2,
+      ...data,
+    });
+
+    mockSingleVAOSAppointmentFetch({
+      appointment,
+    });
+
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState: {
+        featureToggles: {
+          ...initialState.featureToggles,
+          vaOnlineSchedulingVAOSServiceVAAppointments: true,
+          vaOnlineSchedulingVAOSServiceCCAppointments: true,
+          vaOnlineSchedulingVAOSV2Next: true,
+        },
+      },
+      path: url,
+    });
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: new RegExp(
+          appointmentTime.format('dddd, MMMM D, YYYY [at] h:mm a'),
+          'i',
+        ),
+      }),
+    ).to.be.ok;
+
+    expect(screen.queryByTestId('appointment-treatment-specialty')).to.be.null;
+  });
+
+  it('should not display treatment specialty if treatmentSpecialty is empty and vaOnlineSchedulingVAOSV2Next is true', async () => {
+    // Given when the staff schedules the Community Care appointment for the Veteran
+    const url = '/cc/01aa456cc';
+    const appointmentTime = moment().add(1, 'days');
+    // When the treatmentSpecialty is blank or null
+    const data = {
+      id: '01aa456cc',
+      kind: 'cc',
+      practitioners: [
+        {
+          identifier: [{ system: null, value: '123' }],
+          name: {
+            family: 'Medical Care',
+            given: ['Atlantic'],
+          },
+        },
+      ],
+      description: 'community care appointment',
+      comment: 'test comment',
+      start: appointmentTime,
+      communityCareProvider: {
+        providerName: 'Atlantic Medical Care',
+        treatmentSpecialty: '',
+      },
+    };
+
+    const appointment = createMockAppointmentByVersion({
+      version: 2,
+      ...data,
+    });
+
+    mockSingleVAOSAppointmentFetch({
+      appointment,
+    });
+
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState: {
+        featureToggles: {
+          ...initialState.featureToggles,
+          vaOnlineSchedulingVAOSServiceVAAppointments: true,
+          vaOnlineSchedulingVAOSServiceCCAppointments: true,
+          vaOnlineSchedulingVAOSV2Next: true,
+        },
+      },
+      path: url,
+    });
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: new RegExp(
+          appointmentTime.format('dddd, MMMM D, YYYY [at] h:mm a'),
+          'i',
+        ),
+      }),
+    ).to.be.ok;
+
+    expect(screen.queryByTestId('appointment-treatment-specialty')).to.be.null;
+  });
+
+  it('should not display treatment specialty if treatmentSpecialty is null and vaOnlineSchedulingVAOSV2Next is true', async () => {
+    // Given when the staff schedules the Community Care appointment for the Veteran
+    const url = '/cc/01aa456cc';
+    const appointmentTime = moment().add(1, 'days');
+    // When the treatmentSpecialty is blank or null
+    const data = {
+      id: '01aa456cc',
+      kind: 'cc',
+      practitioners: [
+        {
+          identifier: [{ system: null, value: '123' }],
+          name: {
+            family: 'Medical Care',
+            given: ['Atlantic'],
+          },
+        },
+      ],
+      description: 'community care appointment',
+      comment: 'test comment',
+      start: appointmentTime,
+      communityCareProvider: {
+        providerName: 'Atlantic Medical Care',
+        treatmentSpecialty: null,
       },
     };
 


### PR DESCRIPTION
## Description
This PR fixes and issue with the unit tests for the treatment specialty feature and corrects and issue with the conditional display of the treatment specialty.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team/issues/46903](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46903)


## Testing done
- Unit testing
- e2e testing
- Manual local testing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
