### PR TITLE
HOTFIX pass null to redux connect

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -248,6 +248,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default connect(
-  {},
+  null,
   mapDispatchToProps,
 )(AuthApp);


### PR DESCRIPTION
## Description
The auth app component was getting an empty object passed to the redux connect function instead of null, and it was breaking the sign in process. This is a quick hotfix to fix

## Original issue(s)
hotfix


## Testing done
Manually tested

## Acceptance criteria
- [x] AuthApp no longer broken

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
