### PR TITLE
[46671] Set FSR PDF from submission content with cFSR

### DIFF
--- a/src/applications/financial-status-report/containers/ConfirmationPage.jsx
+++ b/src/applications/financial-status-report/containers/ConfirmationPage.jsx
@@ -92,7 +92,10 @@ const RequestDetailsCard = ({ data, response }) => {
         <p className="vads-u-margin-y--0">P.O. Box 11930</p>
         <p className="vads-u-margin-y--0">St. Paul, MN 55111-0930</p>
         <p>
-          <DownloadFormPDF />
+          <DownloadFormPDF
+            pdfContent={response.content}
+            useContent={combinedFSR}
+          />
           <button
             className="usa-button-secondary button vads-u-background-color--white"
             onClick={windowPrint}


### PR DESCRIPTION
## Description
When combined FSR flag is turned on, set the downloadable PDF from the response content rather than a new API call

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#46671](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46671)


## Testing done
Local submission with feature on and off

## Screenshots
N/A

## Acceptance criteria
- [x] Combined FSR PDFs are set from response data

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
