### PR TITLE
Move check image and content out of figure.

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
@@ -264,39 +264,28 @@ export const BankInfo = ({
       </p>
       <div className="vads-u-margin-bottom--2">
         <va-additional-info trigger="Where can I find these numbers?">
-          <figure
-            className="vads-u-margin-x--0"
-            role="figure"
-            aria-labelledby={`${type}-check-caption`}
-          >
-            {/* eslint-disable jsx-a11y/no-redundant-roles */}
-            <img
-              src="/img/direct-deposit-check-guide.svg"
-              role="img"
-              alt="A personal check"
-            />
-            {/* eslint-enable jsx-a11y/no-redundant-roles */}
-            <figcaption
-              id={`${type}-check-caption`}
-              className="vads-u-font-size--base vads-u-font-weight--normal vads-u-font-family--sans vads-u-width--auto vads-u-color--gray-dark"
-            >
-              <p>
-                The bank routing number is the first 9 digits on the bottom left
-                corner of a printed check. Your account number is the second set
-                of numbers on the bottom of a check, just to the right of the
-                bank routing number.
-              </p>
-              <p>If you don’t have a printed check, you can:</p>
-              <ul>
-                <li>
-                  Sign in to your online bank account and check your account
-                  details, or
-                </li>
-                <li>Check your bank statement, or</li>
-                <li>Call your bank</li>
-              </ul>
-            </figcaption>
-          </figure>
+          <img
+            src="/img/direct-deposit-check-guide.svg"
+            alt="A personal check"
+          />
+
+          <p className="vads-u-padding-top--2">
+            The bank routing number is the first 9 digits on the bottom left
+            corner of a printed check. Your account number is the second set of
+            numbers on the bottom of a check, just to the right of the bank
+            routing number.
+          </p>
+          <p className="vads-u-padding-y--2">
+            If you don’t have a printed check, you can:
+          </p>
+          <ul>
+            <li>
+              Sign in to your online bank account and check your account
+              details, or
+            </li>
+            <li>Check your bank statement, or</li>
+            <li>Call your bank</li>
+          </ul>
         </va-additional-info>
       </div>
       <div data-testid={`${formPrefix}-bank-info-form`} ref={editBankInfoForm}>


### PR DESCRIPTION
## Description
Through our accessibility audit it was discovered that wrapping the further information for the Direct Deposit check in a figure and figure caption makes it easy to skip with a screen reader. This PR moved it out of the figure caption, and also styles it to be consistent with the design file that was given.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/47003


## Testing done
Manual Testing for visual styling. 

## Screenshots
![Screen Shot 2022-09-26 at 9 33 01 AM](https://user-images.githubusercontent.com/8332986/192318797-c38422e8-324b-4294-a22d-cdb009d71d03.png)


## Acceptance criteria
- [x] Content moved from figure element
- [x] Content styled to match mock given in original issue

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
