### PR TITLE
Add logging to Health Care application for submissions containing SIGI value

### DIFF
--- a/src/applications/hca/HealthCareApp.jsx
+++ b/src/applications/hca/HealthCareApp.jsx
@@ -11,7 +11,7 @@ import formConfig from './config/form';
 const HealthCareEntry = ({
   location,
   children,
-  caregiverSIGIEnabled = false,
+  caregiverSigiEnabled = false,
   hcaAmericanIndianEnabled = false,
   hcaMedicareClaimNumberEnabled = false,
   hcaShortFormEnabled = false,
@@ -40,7 +40,7 @@ const HealthCareEntry = ({
       const defaultViewFields = {
         'view:isLoggedIn': isLoggedIn,
         'view:totalDisabilityRating': totalDisabilityRating || 0,
-        'view:caregiverSIGIEnabled': caregiverSIGIEnabled,
+        'view:caregiverSIGIEnabled': caregiverSigiEnabled,
         'view:hcaMedicareClaimNumberEnabled': hcaMedicareClaimNumberEnabled,
         'view:hcaAmericanIndianEnabled': hcaAmericanIndianEnabled,
         'view:useFacilitiesAPI': hcaUseFacilitiesApi,
@@ -70,7 +70,7 @@ const HealthCareEntry = ({
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      caregiverSIGIEnabled,
+      caregiverSigiEnabled,
       hcaAmericanIndianEnabled,
       hcaMedicareClaimNumberEnabled,
       hcaShortFormEnabled,
@@ -91,7 +91,7 @@ const HealthCareEntry = ({
 };
 
 HealthCareEntry.propTypes = {
-  caregiverSIGIEnabled: PropTypes.bool,
+  caregiverSigiEnabled: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
@@ -112,7 +112,7 @@ HealthCareEntry.propTypes = {
 
 const mapStateToProps = state => ({
   formData: state.form.data,
-  caregiverSIGIEnabled: state.featureToggles.caregiverSIGIEnabled,
+  caregiverSigiEnabled: state.featureToggles.caregiverSigiEnabled,
   hcaAmericanIndianEnabled: state.featureToggles.hcaAmericanIndianEnabled,
   hcaMedicareClaimNumberEnabled:
     state.featureToggles.hcaMedicareClaimNumberEnabled,

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-aiq.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-aiq.json
@@ -3,7 +3,7 @@
     "type": "feature_toggles",
     "features": [
       {
-        "name": "caregiverSIGIEnabled",
+        "name": "caregiverSigiEnabled",
         "value": false
       },
       {

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-shortForm.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-shortForm.json
@@ -3,7 +3,7 @@
     "type": "feature_toggles",
     "features": [
       {
-        "name": "caregiverSIGIEnabled",
+        "name": "caregiverSigiEnabled",
         "value": false
       },
       {

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -3,7 +3,7 @@
     "type": "feature_toggles",
     "features": [
       {
-        "name": "caregiverSIGIEnabled",
+        "name": "caregiverSigiEnabled",
         "value": true
       },
       {

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -198,6 +198,13 @@ export function transform(formConfig, form) {
     });
   }
 
+  // use logging to track volume of forms submitted with SIGI question answered
+  if (form.data.sigiGenders) {
+    recordEvent({
+      event: 'hca-submission-with-sigi-value',
+    });
+  }
+
   return JSON.stringify({
     gaClientId,
     asyncCompatible: true,


### PR DESCRIPTION
## Description
The product owners and stakeholders for the Health Care application would like to track the volume of health care application submissions that contain a value for a new question that allows Veterans to select their gender identity. This PR adds the logging event to track submissions that contain a value. NOTE: we are not logging which values are being selected, only that a value exists.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25414

## Acceptance criteria
- [ ] Event tag has been added to track submissions containing a value for this question

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
