### PR TITLE
Unwrap table from benefit info list in letters app

### DIFF
--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -188,7 +188,9 @@ export class VeteranBenefitSummaryLetter extends React.Component {
 
 VeteranBenefitSummaryLetter.propTypes = {
   benefitSummaryOptions: PropTypes.shape({
-    benefitInfo: PropTypes.shape({}),
+    benefitInfo: PropTypes.shape({
+      awardEffectiveDate: PropTypes.string,
+    }),
     serviceInfo: PropTypes.array,
   }),
   isVeteran: PropTypes.bool,

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -102,7 +102,9 @@ export class VeteranBenefitSummaryLetter extends React.Component {
     });
 
     const vaBenefitInformation = vaBenefitInfoItems.length ? (
-      <ul className="usa-unstyled-list">{vaBenefitInfoItems}</ul>
+      <ul className="usa-unstyled-list" id="benefitInfoList">
+        {vaBenefitInfoItems}
+      </ul>
     ) : null;
 
     let benefitSummaryContent;

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -87,38 +87,22 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       );
       if (optionText && displayOption) {
         vaBenefitInfoRows.push(
-          <tr key={`option${key}`}>
-            <th scope="row">
-              <input
-                aria-labelledby={`${key}Label`}
-                checked={requestOptions[benefitOptionsMap[key]]}
-                id={key}
-                name={key}
-                type="checkbox"
-                onChange={this.handleChange}
-              />
-              <label htmlFor={key}>
-                <div className="sr-only">{optionText}</div>
-              </label>
-            </th>
-            <td>
-              <div id={`${key}Label`}>{optionText}</div>
-            </td>
-          </tr>,
+          <li key={`option${key}`} className="form-checkbox">
+            <input
+              checked={requestOptions[benefitOptionsMap[key]]}
+              id={key}
+              name={key}
+              type="checkbox"
+              onChange={this.handleChange}
+            />
+            <label htmlFor={key}>{optionText}</label>
+          </li>,
         );
       }
     });
 
     const vaBenefitInformation = vaBenefitInfoRows.length ? (
-      <table id="benefitInfoTable">
-        <thead>
-          <tr>
-            <th scope="col">Include</th>
-            <th scope="col">Statement</th>
-          </tr>
-        </thead>
-        <tbody>{vaBenefitInfoRows}</tbody>
-      </table>
+      <ul className="usa-unstyled-list">{vaBenefitInfoRows}</ul>
     ) : null;
 
     let benefitSummaryContent;
@@ -165,10 +149,13 @@ export class VeteranBenefitSummaryLetter extends React.Component {
           <h4 className="vads-u-font-size--h2">
             VA benefit and disability information
           </h4>
-          <p>
-            Please choose what information you want to include in your letter.
-          </p>
-          {vaBenefitInformation}
+
+          <va-checkbox-group
+            error={null}
+            label="Please choose what information you want to include in your letter."
+          >
+            {vaBenefitInformation}
+          </va-checkbox-group>
         </div>
       );
     } else {

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -151,13 +151,12 @@ export class VeteranBenefitSummaryLetter extends React.Component {
           <h4 className="vads-u-font-size--h2">
             VA benefit and disability information
           </h4>
-
-          <va-checkbox-group
-            error={null}
-            label="Please choose what information you want to include in your letter."
-          >
+          <fieldset>
+            <legend className="vads-u-font-size--base vads-u-font-weight--normal">
+              Please choose what information you want to include in your letter
+            </legend>
             {vaBenefitInformation}
-          </va-checkbox-group>
+          </fieldset>
         </div>
       );
     } else {

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -65,7 +65,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       </tr>
     ));
 
-    const vaBenefitInfoRows = [];
+    const vaBenefitInfoItems = [];
     Object.keys(benefitInfo).forEach(key => {
       // Need to verify with EVSS and vets-api: values should be true, false, or
       // some value other than null or undefined, so this check should not be
@@ -86,7 +86,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
         benefitInfo.awardEffectiveDate,
       );
       if (optionText && displayOption) {
-        vaBenefitInfoRows.push(
+        vaBenefitInfoItems.push(
           <li key={`option${key}`} className="form-checkbox">
             <input
               checked={requestOptions[benefitOptionsMap[key]]}
@@ -101,8 +101,8 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       }
     });
 
-    const vaBenefitInformation = vaBenefitInfoRows.length ? (
-      <ul className="usa-unstyled-list">{vaBenefitInfoRows}</ul>
+    const vaBenefitInformation = vaBenefitInfoItems.length ? (
+      <ul className="usa-unstyled-list">{vaBenefitInfoItems}</ul>
     ) : null;
 
     let benefitSummaryContent;

--- a/src/applications/letters/tests/01-authed.cypress.spec.js
+++ b/src/applications/letters/tests/01-authed.cypress.spec.js
@@ -74,9 +74,9 @@ describe('Authed Letter Test', () => {
       force: true,
     });
     cy.get('#militaryService').should('not.be.checked');
-    cy.get('#benefitInfoTable input[type="checkbox"]').then(checkboxes => {
+    cy.get('#benefitInfoList input[type="checkbox"]').then(checkboxes => {
       cy.wrap(Array.from(checkboxes).map(checkbox => checkbox.id)).each(id => {
-        cy.get(`div#${id}label`).should('be.visible');
+        cy.get(`label[for="${id}"]`).should('be.visible');
         cy.get(`#${id}`).should('be.checked');
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(200);

--- a/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -41,15 +41,12 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     const tree = SkinDeep.shallowRender(
       <VeteranBenefitSummaryLetter {...defaultProps} />,
     );
-    const rows = tree
-      .dive(['div', '#benefitInfoTable', 'tbody'])
-      .everySubTree('tr');
-    expect(rows[0].dive(['th', 'input'])).not.to.be.empty;
-    expect(rows[0].dive(['td', '#hasAdaptedHousingLabel'])).not.to.be.empty;
+    const items = tree.dive(['#benefitInfoList']).everySubTree('li');
+    expect(items[0].dive(['input'])).not.to.be.empty;
+    expect(items[0].dive(['label'])).not.to.be.empty;
 
-    expect(rows[1].dive(['th', 'input'])).not.to.be.empty;
-    expect(rows[1].dive(['td', '#hasChapter35EligibilityLabel'])).not.to.be
-      .empty;
+    expect(items[1].dive(['input'])).not.to.be.empty;
+    expect(items[1].dive(['label'])).not.to.be.empty;
   });
 
   it('should show service info options', () => {
@@ -59,7 +56,7 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     expect(tree.subTree('#militaryService')).not.to.be.empty;
   });
 
-  it('renders error and hides benefit table if options not available', () => {
+  it('renders error and hides benefit list if options not available', () => {
     const props = set('optionsAvailable', false, defaultProps);
     const tree = SkinDeep.shallowRender(
       <VeteranBenefitSummaryLetter {...props} />,
@@ -68,7 +65,7 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     expect(headerText).to.equal(
       'Your VA Benefit Summary letter is currently unavailable',
     );
-    expect(tree.subTree('#benefitInfoTable')).to.be.false;
+    expect(tree.subTree('#benefitInfoList')).to.be.false;
   });
 
   it('should not render military service information section if no service history', () => {
@@ -175,10 +172,10 @@ describe('<VeteranBenefitSummaryLetter>', () => {
       <VeteranBenefitSummaryLetter {...defaultProps} />,
     );
     const benefitInfoRows = tree
-      .dive(['div', '#benefitInfoTable', 'tbody'])
-      .everySubTree('tr');
-    benefitInfoRows.forEach(row => {
-      expect(() => row.dive(['td', '#hasDeathResultOfDisability'])).to.throw();
+      .dive(['div', '#benefitInfoList'])
+      .everySubTree('li');
+    benefitInfoRows.forEach(item => {
+      expect(() => item.dive(['#hasDeathResultOfDisability'])).to.throw();
     });
   });
 


### PR DESCRIPTION
## Description
This pull request addresses an issue with options to include in the benefit letter. Originally, the options were placed in an HTML table. This made interacting with the options difficult when using a screen reader. This fix presents the checkboxes as a standard list of checkboxes. The table headings did not provide any additional context for the user.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#45945


## Testing done
- Updated unit tests
- Tested in Chrome
- Tested with VoiceOver

## Screenshots
<img width="647" alt="Screen Shot 2022-09-28 at 1 07 46 PM" src="https://user-images.githubusercontent.com/1094951/192887209-b5c74ccc-d1ee-4e55-8b18-d95ef5a0a397.png">

To see the previous iteration, go to the original issue

## How to test the code. 

This application requires both `vet360` and `evss` to run locally.

1. Sign in as user `+228`.
2. Go to http://localhost:3001/records/download-va-letters/letters/letter-list
3. Open the second-to-last accordion
4. The checkboxes should no longer appear inside a table


## Acceptance criteria
- [x] Tests continue to pass
- [x] Checkboxes are placed in a group with an accessible name

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
