### PR TITLE
Add GA event tag to track short form flow

### DIFF
--- a/src/applications/hca/components/FormAlerts/AuthenticatedShortFormAlert.jsx
+++ b/src/applications/hca/components/FormAlerts/AuthenticatedShortFormAlert.jsx
@@ -1,10 +1,22 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import recordEvent from 'platform/monitoring/record-event';
 
 const AuthenticatedShortFormAlert = ({ formData }) => {
   const disabilityRating = formData['view:totalDisabilityRating'];
+
+  // use logging to compare number of short forms started vs completed
+  useEffect(() => {
+    return () => {
+      recordEvent({
+        event: 'hca-short-form-flow',
+      });
+    };
+  }, []);
+
   return (
     <va-alert class="vads-u-margin-y--5" status="info">
       <h3 slot="headline">You can fill out a shorter application</h3>

--- a/src/applications/hca/components/FormAlerts/ServiceConnectedPayConfirmation.jsx
+++ b/src/applications/hca/components/FormAlerts/ServiceConnectedPayConfirmation.jsx
@@ -1,47 +1,59 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
+import recordEvent from 'platform/monitoring/record-event';
 
-const ServiceConnectedPayConfirmation = ({ goBack, goForward }) => (
-  <va-alert
-    class="vads-u-margin-x--neg2p5 vads-u-margin-top--2p5"
-    status="info"
-    background-only
-  >
-    <h3 className="vads-u-margin-top--0">
-      Confirm that you receive service-connected pay for a 50% or higher
-      disability rating.
-    </h3>
-    <p>
-      You selected that you currently receive service-connected disability pay
-      for a 50% or higher disability rating. This means that you meet one of our
-      eligibility criteria and we don’t need to ask your questions about other
-      criteria, like income and military service.
-    </p>
-    <div className="row form-progress-buttons schemaform-buttons">
-      <div className="small-5 medium-4 columns">
-        {goBack && (
+const ServiceConnectedPayConfirmation = ({ data, goBack, goForward }) => {
+  // use logging to compare number of short forms started vs completed
+  const onConfirm = () => {
+    recordEvent({
+      event: 'hca-short-form-flow',
+    });
+    goForward(data);
+  };
+
+  return (
+    <va-alert
+      class="vads-u-margin-x--neg2p5 vads-u-margin-top--2p5"
+      status="info"
+      background-only
+    >
+      <h3 className="vads-u-margin-top--0">
+        Confirm that you receive service-connected pay for a 50% or higher
+        disability rating.
+      </h3>
+      <p>
+        You selected that you currently receive service-connected disability pay
+        for a 50% or higher disability rating. This means that you meet one of
+        our eligibility criteria and we don’t need to ask your questions about
+        other criteria, like income and military service.
+      </p>
+      <div className="row form-progress-buttons schemaform-buttons">
+        <div className="small-5 medium-4 columns">
+          {goBack && (
+            <ProgressButton
+              buttonClass="hca-progress-button usa-button-secondary"
+              onButtonClick={goBack}
+              buttonText="Back"
+              beforeText="«"
+            />
+          )}
+        </div>
+        <div className="small-5 medium-4 end columns">
           <ProgressButton
-            buttonClass="hca-progress-button usa-button-secondary"
-            onButtonClick={goBack}
-            buttonText="Back"
-            beforeText="«"
+            buttonClass="hca-progress-button usa-button-primary"
+            onButtonClick={onConfirm}
+            buttonText="Confirm"
+            afterText="»"
           />
-        )}
+        </div>
       </div>
-      <div className="small-5 medium-4 end columns">
-        <ProgressButton
-          buttonClass="hca-progress-button usa-button-primary"
-          onButtonClick={goForward}
-          buttonText="Confirm"
-          afterText="»"
-        />
-      </div>
-    </div>
-  </va-alert>
-);
+    </va-alert>
+  );
+};
 
 ServiceConnectedPayConfirmation.propTypes = {
+  data: PropTypes.object,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
 };


### PR DESCRIPTION
## Description
The product owners and stakeholders of the Health Care application would like to track how many Veterans are entering the short form flow of the application. This will allow them to compare that volume to how many of those went on to complete and submit the application. This PR adds the event tags in the appropriate areas of the form to log that the user entered the short form flow.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47706

## Acceptance criteria
- [ ] Short form entry is able to be tracked from both entry scenarios

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
