### PR TITLE
[#MHV-36566] Added redux functionality for attachments and folder

### DIFF
--- a/src/applications/mhv/secure-messaging/actions/folders.js
+++ b/src/applications/mhv/secure-messaging/actions/folders.js
@@ -1,5 +1,5 @@
 import { Actions } from '../util/actionTypes';
-import { getFolderList } from '../api/SmApi';
+import { getFolderList, getFolder } from '../api/SmApi';
 
 export const getFolders = () => async dispatch => {
   const response = await getFolderList();
@@ -11,6 +11,21 @@ export const getFolders = () => async dispatch => {
   } else {
     dispatch({
       type: Actions.Folder.GET_LIST,
+      response,
+    });
+  }
+};
+
+export const retrieveFolder = folderId => async dispatch => {
+  const response = await getFolder(folderId);
+  if (response.errors) {
+    dispatch({
+      type: Actions.Alert.ADD_ALERT,
+      payload: response.errors[0],
+    });
+  } else {
+    dispatch({
+      type: Actions.Folder.GET,
       response,
     });
   }

--- a/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
@@ -39,7 +39,8 @@ const LandingPageAuth = () => {
     dispatch(getFolders());
     dispatch(getCategories());
     // dispatch(getMessages(522243));
-    // dispatch(retrieveMessage(522265));
+    // dispatch(retrieveMessage(7178447));
+    // dispatch(retrieveFolder(0));
   }, []);
 
   useInterval(() => {

--- a/src/applications/mhv/secure-messaging/reducers/folders.js
+++ b/src/applications/mhv/secure-messaging/reducers/folders.js
@@ -1,6 +1,9 @@
 import { Actions } from '../util/actionTypes';
 
 const initialState = {
+  /**
+   * The current in-focus folder, i.e. the folder being viewed by the user
+   */
   folder: undefined,
   /**
    * The list of the current user's Secure Messaging folders
@@ -24,7 +27,11 @@ export const foldersReducer = (state = initialState, action) => {
           };
         }),
       };
-    case 'b':
+    case Actions.Folder.GET:
+      return {
+        ...state,
+        folder: action.response.data.attributes,
+      };
     default:
       return state;
   }

--- a/src/applications/mhv/secure-messaging/reducers/messageDetails.js
+++ b/src/applications/mhv/secure-messaging/reducers/messageDetails.js
@@ -15,11 +15,16 @@ const initialState = {
 export const messageDetailsReducer = (state = initialState, action) => {
   switch (action.type) {
     case Actions.Message.GET: {
-      const msgAttr = action.response.data.attributes;
       return {
         ...state,
         message: {
-          ...msgAttr,
+          ...action.response.data.attributes,
+          attachments: action.response.included.map(attachment => {
+            return {
+              attachmentId: attachment.id,
+              ...attachment.attributes,
+            };
+          }),
         },
       };
     }
@@ -27,10 +32,7 @@ export const messageDetailsReducer = (state = initialState, action) => {
       return {
         ...state,
         messageHistory: action.response.data.map(message => {
-          const msgAttr = message.attributes.attributes;
-          return {
-            ...msgAttr,
-          };
+          return message.attributes.attributes;
         }),
       };
     }

--- a/src/applications/mhv/secure-messaging/util/actionTypes.js
+++ b/src/applications/mhv/secure-messaging/util/actionTypes.js
@@ -11,6 +11,7 @@ export const Actions = {
     GET_HISTORY: 'SM_DRAFT_GET_HISTORY',
   },
   Folder: {
+    GET: 'SM_FOLDER_GET',
     GET_LIST: 'SM_FOLDER_GET_LIST',
   },
   Message: {


### PR DESCRIPTION
## Description
Added redux functionality to pull attachments from the backend into state, as well as the currently viewed folder.

## Original issue(s)
https://vajira.max.gov/browse/MHV-36566
VA.gov SM: Build redux actions/reducers to modify state based on API calls
Ensure that the application state is appropriately built out and responds correctly to the responses from API calls.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
