### PR TITLE
Add design system component GA4 setup for testing in staging.

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -1,9 +1,11 @@
+/* eslint-disable camelcase */
 /**
  * Attaches CustomEvent 'component-library-analytics' listener to document.body
  * to translate component library actions into analytics dataLayer events.
  */
 import _recordEvent from 'platform/monitoring/record-event';
 import { getSectionLabel } from 'applications/static-pages/subscription-creators/subscribeAccordionEvents';
+import environment from 'platform/utilities/environment';
 
 const analyticsEvents = {
   Modal: [{ action: 'show', event: 'int-modal-show', prefix: 'modal' }],
@@ -198,6 +200,15 @@ const analyticsEvents = {
     {
       action: 'click',
       event: 'nav-jumplink-click',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-on-this-page',
+        /* Component to GA4 parameters */
+        mapping: {
+          'click-text': 'value',
+          version: 'component_version',
+        },
+      },
     },
   ],
 };
@@ -265,6 +276,41 @@ export function subscribeComponentAnalyticsEvents(
       });
 
       recordEvent(clearedDataLayer);
+
+      /**
+       * GA4 dataLayer push.
+       */
+      if (!environment.isProduction() && action?.ga4) {
+        /**
+         * Creating the GA4 dataLayer object by combining the existing
+         * GA dataLayer with the defined GA4 parameters.
+         */
+        const ga4DataLayer = {
+          ...dataLayer,
+          ...action.ga4,
+          action: action.event,
+        };
+
+        /**
+         * Mapping the GA4 parameters to the Web Component event details.
+         */
+        const ga4Mapping = action?.ga4?.mapping;
+
+        if (ga4Mapping) {
+          for (const key of Object.keys(ga4Mapping)) {
+            const newKey = action.ga4.mapping[key];
+
+            ga4DataLayer[newKey] = dataLayer[key];
+          }
+
+          /**
+           * Cleaning up the GA4 mapping object from the dataLayer.
+           */
+          delete ga4DataLayer.mapping;
+        }
+
+        recordEvent(ga4DataLayer);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR adds GA4 setup to the design system component analytics script for testing in staging. We are just testing the `va-on-this-page` component for now.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1174

## Testing done
Local environment.

## Screenshots
![Screen Shot 2022-09-29 at 2 57 55 PM](https://user-images.githubusercontent.com/872479/193129735-b0897699-8357-4875-98f5-f8d75d67ddc0.png)

## Acceptance criteria
- [ ] A GA4 event is added to the dataLayer.
- [ ] The new dataLayer update only occurs in staging.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
