### PR TITLE
Mhv 37009 pull message detail from api

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
@@ -7,14 +7,14 @@ import AttachmentsList from './AttachmentsList';
 
 const MessageDetailBlock = props => {
   const {
-    attachments,
-    body,
+    messageId,
     category,
-    id,
-    recipientName,
-    senderName,
-    sentDate,
     subject,
+    body,
+    sentDate,
+    senderName,
+    recipientName,
+    attachments,
   } = props.message;
 
   const history = useHistory();
@@ -62,7 +62,7 @@ const MessageDetailBlock = props => {
           </p>
           <p>
             <strong>Message ID: </strong>
-            {id}
+            {messageId}
           </p>
         </section>
 
@@ -70,14 +70,15 @@ const MessageDetailBlock = props => {
           <pre>{body}</pre>
         </section>
 
-        {!!attachments.attachment.length && (
-          <>
-            <div className="message-body-attachments-label">
-              <strong>Attachments</strong>
-            </div>
-            <AttachmentsList attachments={attachments.attachment} />
-          </>
-        )}
+        {!!attachments &&
+          attachments.length > 0 && (
+            <>
+              <div className="message-body-attachments-label">
+                <strong>Attachments</strong>
+              </div>
+              <AttachmentsList attachments={attachments} />
+            </>
+          )}
 
         <div className="message-detail-note vads-u-text-align--center">
           <p>
@@ -89,7 +90,7 @@ const MessageDetailBlock = props => {
           </p>
         </div>
 
-        <MessageActionButtons id={id} />
+        <MessageActionButtons id={messageId} />
       </main>
     </section>
   );

--- a/src/applications/mhv/secure-messaging/containers/MessageDetails.jsx
+++ b/src/applications/mhv/secure-messaging/containers/MessageDetails.jsx
@@ -3,13 +3,13 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 import NavigationLinks from '../components/NavigationLinks';
 import MessageThread from '../components/MessageThread/MessageThread';
-import { getMessage } from '../actions';
+import { retrieveMessage } from '../actions/messages';
 import MessageDetailBlock from '../components/MessageDetailBlock';
 
 const MessageDetail = () => {
   const { messageId } = useParams();
   const dispatch = useDispatch();
-  const { isLoading, message, error } = useSelector(state => state.message);
+  const message = useSelector(state => state.sm.messageDetails.message);
   const isTrash = window.location.pathname.includes('/trash');
   const isSent = window.location.pathname.includes('/sent');
   const location = useLocation();
@@ -19,7 +19,7 @@ const MessageDetail = () => {
     () => {
       setid(messageId);
       if (id) {
-        dispatch(getMessage('message', id)); // 7155731 is the only message id that we have a mock api call for, all others will display an error message
+        dispatch(retrieveMessage(id)); // 7155731 is the only message id that we have a mock api call for, all others will display an error message
       }
     },
     [dispatch, location, messageId, id],
@@ -36,7 +36,7 @@ const MessageDetail = () => {
   }
 
   const content = () => {
-    if (isLoading) {
+    if (message === undefined) {
       return (
         <va-loading-indicator
           message="Loading your secure message..."
@@ -44,7 +44,7 @@ const MessageDetail = () => {
         />
       );
     }
-    if (error) {
+    if (message === null || message === false) {
       return (
         <va-alert status="error" visible class="vads-u-margin-y--9">
           <h2 slot="headline">We’re sorry. Something went wrong on our end</h2>

--- a/src/applications/mhv/secure-messaging/reducers/messageDetails.js
+++ b/src/applications/mhv/secure-messaging/reducers/messageDetails.js
@@ -19,12 +19,14 @@ export const messageDetailsReducer = (state = initialState, action) => {
         ...state,
         message: {
           ...action.response.data.attributes,
-          attachments: action.response.included.map(attachment => {
-            return {
-              attachmentId: attachment.id,
-              ...attachment.attributes,
-            };
-          }),
+          attachments: action.response.included
+            ? action.response.included.map(attachment => {
+                return {
+                  attachmentId: attachment.id,
+                  ...attachment.attributes,
+                };
+              })
+            : null,
         },
       };
     }


### PR DESCRIPTION
## Description
Changes to make the message details page dynamically pull message details from the api, instead of the existing mock data.

## Original issue(s)
https://vajira.max.gov/browse/MHV-37009


## Testing done
Manually tested several different messages, some with attachments, some without.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
