### PR TITLE
VACMS-10029: Updates whitelist to proper forumlary-advisor config

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -67,19 +67,9 @@
       "cookieOnly": false
     },
     {
-      "hostname": "va.gov/formularyadvisor",
-      "pathnameBeginning": "/",
-      "cookieOnly": true
-    },
-    {
-      "hostname": "www.va.gov/formularyadvisor",
-      "pathnameBeginning": "/",
-      "cookieOnly": true
-    },
-    {
-      "hostname": "vaww.internet.staging.va.gov/formularyadvisor",
-      "pathnameBeginning": "/",
-      "cookieOnly": true
+      "hostname": "vaww.internet.staging.va.gov",
+      "pathnameBeginning": "/formularyadvisor",
+      "cookieOnly": false
     },
     {
       "hostname": "www.healthquality.va.gov",


### PR DESCRIPTION
## Description
Proxy-rewrite whitelist configuration update for VA Formulary Advisor staging URL.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10029


## Testing done
Debugged/stepped through code locally line by line to determine that the current configuration was incorrect. The path needs to be separated from the domain. The next step is to confirm this works in staging. This does not pose any risk to production.
