### PR TITLE
set prefer-telephone-component eslint rule to warning

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -6,7 +6,7 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 2,
     'jsx-a11y/label-has-associated-control': 1,
     'jsx-a11y/no-static-element-interactions': 2,
-    '@department-of-veterans-affairs/prefer-telephone-component': 2,
+    '@department-of-veterans-affairs/prefer-telephone-component': 1,
     '@department-of-veterans-affairs/telephone-contact-3-or-10-digits': 2,
   },
 };


### PR DESCRIPTION
## Description
Reverting the prefer-telephone-component eslint rule to a warning until the Design System team can add SMS support.

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
