### PR TITLE
Hot fix for VerifyAccountLink Testing Suite (#47790)

### DIFF
--- a/src/platform/user/tests/authentication/components/VerifyAccountLink.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/VerifyAccountLink.unit.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { SERVICE_PROVIDERS } from 'platform/user/authentication/constants';
 import * as authUtilities from 'platform/user/authentication/utilities';
 import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
@@ -44,8 +44,7 @@ describe('VerifyAccountLink', () => {
         useOAuth: false,
       });
 
-      expect(anchor.href).to.eql(href);
-
+      await waitFor(() => expect(anchor.href).to.eql(href));
       screen.unmount();
     });
 
@@ -54,13 +53,14 @@ describe('VerifyAccountLink', () => {
       const anchor = await screen.findByTestId(policy);
       const expectedAcr =
         externalApplicationsConfig.default.oAuthOptions.acrVerify[policy];
-      expect(anchor.href).to.include(`type=${policy}`);
-      expect(anchor.href).to.include(`acr=${expectedAcr}`);
-      expect(anchor.href).to.include(`client_id=web`);
-      expect(anchor.href).to.include('/authorize');
-      expect(anchor.href).to.include('response_type=code');
-      expect(anchor.href).to.include('code_challenge=');
-      expect(anchor.href).to.include('state=');
+
+      await waitFor(() => expect(anchor.href).to.include(`type=${policy}`));
+      await waitFor(() => expect(anchor.href).to.include(`acr=${expectedAcr}`));
+      await waitFor(() => expect(anchor.href).to.include(`client_id=web`));
+      await waitFor(() => expect(anchor.href).to.include('/authorize'));
+      await waitFor(() => expect(anchor.href).to.include('response_type=code'));
+      await waitFor(() => expect(anchor.href).to.include('code_challenge='));
+      await waitFor(() => expect(anchor.href).to.include('state='));
       screen.unmount();
     });
   });


### PR DESCRIPTION
## Description
Hot fix for the VerifyAccountLink testing suite.

## Original issue(s)
Closes [VerifyAccountLink Unit Test Fix #47790](https://github.com/department-of-veterans-affairs/va.gov-team/issues/47790)

## Testing done
Unit

## Acceptance criteria
- [x] VerifyAccountLink unit tests pass locally and via CI.

## Definition of done
- [x] Events are logged appropriately
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
