### PR TITLE
Enrollment Verification — Update Mappings for Verified vs. Unverified Enrollment Periods

### DIFF
--- a/src/applications/enrollment-verification/components/EnrollmentVerificationMonth.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationMonth.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import EnrollmentVerificationMonthInfo from './EnrollmentVerificationMonthInfo';
 import VerifyYourEnrollments from './VerifyYourEnrollments';
-import { STATUS, VERIFICATION_RESPONSE } from '../constants';
+import { STATUS } from '../constants';
 import { MONTH_PROP_TYPE, STATUS_PROP_TYPE } from '../helpers';
 
 const verifiedMonthStatusMessage = (
@@ -50,8 +51,8 @@ const contactScoMonthStatusMessage = (
   </p>
 );
 
-function getMonthStatusMessage(month, status) {
-  if (month.verificationResponse === VERIFICATION_RESPONSE.CORRECT) {
+function getMonthStatusMessage(month, status, lastCertifiedThroughDate) {
+  if (month.certifiedEndDate <= lastCertifiedThroughDate) {
     return verifiedMonthStatusMessage;
   }
 
@@ -67,8 +68,16 @@ function getMonthStatusMessage(month, status) {
   }
 }
 
-export default function EnrollmentVerificationMonth({ month, status }) {
-  const monthStatusMessage = getMonthStatusMessage(month, status);
+export default function EnrollmentVerificationMonth({
+  lastCertifiedThroughDate,
+  month,
+  status,
+}) {
+  const monthStatusMessage = getMonthStatusMessage(
+    month,
+    status,
+    lastCertifiedThroughDate,
+  );
 
   return (
     <div className="ev-enrollment-month vads-u-margin-y--3">
@@ -83,6 +92,7 @@ export default function EnrollmentVerificationMonth({ month, status }) {
 }
 
 EnrollmentVerificationMonth.propTypes = {
+  lastCertifiedThroughDate: PropTypes.string.isRequired,
   month: MONTH_PROP_TYPE.isRequired,
   status: STATUS_PROP_TYPE.isRequired,
 };

--- a/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
@@ -15,6 +15,9 @@ function EnrollmentVerificationMonths({ enrollmentVerification, status }) {
       return (
         <EnrollmentVerificationMonth
           key={index}
+          lastCertifiedThroughDate={
+            enrollmentVerification.lastCertifiedThroughDate
+          }
           month={month}
           status={status}
         />

--- a/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
+++ b/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
@@ -88,9 +88,10 @@ export const VerifyEnrollmentsPage = ({
       ev.certifiedEndDate > enrollmentVerification?.lastCertifiedThroughDate,
   );
   const unverifiedMonths =
-    earliestUnverifiedMonthIndex > -1 &&
-    evs.slice(0, earliestUnverifiedMonthIndex + 1).reverse();
-  const month = unverifiedMonths && unverifiedMonths[currentMonth];
+    earliestUnverifiedMonthIndex > -1
+      ? evs.slice(0, earliestUnverifiedMonthIndex + 1).reverse()
+      : [];
+  const month = unverifiedMonths.length && unverifiedMonths[currentMonth];
   const informationIncorrectMonth = unverifiedMonths?.find(
     m => m.verificationStatus === VERIFICATION_STATUS_INCORRECT,
   );

--- a/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
+++ b/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -87,10 +87,13 @@ export const VerifyEnrollmentsPage = ({
     ev =>
       ev.certifiedEndDate > enrollmentVerification?.lastCertifiedThroughDate,
   );
-  const unverifiedMonths =
-    earliestUnverifiedMonthIndex > -1
-      ? evs.slice(0, earliestUnverifiedMonthIndex + 1).reverse()
-      : [];
+  const unverifiedMonths = useMemo(
+    () =>
+      earliestUnverifiedMonthIndex === -1
+        ? []
+        : evs.slice(0, earliestUnverifiedMonthIndex + 1).reverse(),
+    [earliestUnverifiedMonthIndex, evs],
+  );
   const month = unverifiedMonths.length && unverifiedMonths[currentMonth];
   const informationIncorrectMonth = unverifiedMonths?.find(
     m => m.verificationStatus === VERIFICATION_STATUS_INCORRECT,

--- a/src/applications/enrollment-verification/helpers/index.js
+++ b/src/applications/enrollment-verification/helpers/index.js
@@ -174,28 +174,22 @@ export const getEnrollmentVerificationStatus = enrollmentVerification => {
 
 /**
  * Create an Enrollment Verification DTO to submit to the server.
- * @param {object} ev The original EV object we recieved when
- * the application loaded.
- * @param {number} evIndex The index of the enrollment to reference.
+ * @param {object} enrollmentVerification The EV object
  * @param {string} status The status of the enrollment.
  * @returns An Enrollment Verification DTO.
  */
-const mapEnrollmentVerificationForSubmission = (ev, evIndex, status) => {
-  const enrollmentVerification = ev.enrollmentVerifications[evIndex];
+const mapEnrollmentVerificationForSubmission = (
+  enrollmentVerification,
+  status,
+) => {
   return {
-    claimandId: ev.claimantId,
-    enrollmentCertifyRequests: [
-      {
-        claimandId: ev.claimantId,
-        certifiedPeriodBeginDate: enrollmentVerification.certifiedBeginDate,
-        certifiedPeriodEndDate: enrollmentVerification.certifiedEndDate,
-        certifiedThroughDate: enrollmentVerification.certifiedEndDate,
-        certificationMethod: CERTIFICATION_METHOD,
-        appCommunication: {
-          responseType: status,
-        },
-      },
-    ],
+    certifiedPeriodBeginDate: enrollmentVerification.certifiedBeginDate,
+    certifiedPeriodEndDate: enrollmentVerification.certifiedEndDate,
+    certifiedThroughDate: enrollmentVerification.certifiedEndDate,
+    certificationMethod: CERTIFICATION_METHOD,
+    appCommunication: {
+      responseType: status,
+    },
   };
 };
 
@@ -265,8 +259,7 @@ export const mapEnrollmentVerificationsForSubmission = ev => {
 
     enrollmentVerificationsDto.push(
       mapEnrollmentVerificationForSubmission(
-        ev,
-        mostRecentCorrectEnrollmentIndex,
+        ev.enrollmentVerifications[mostRecentCorrectEnrollmentIndex],
         VERIFICATION_RESPONSE.CORRECT,
       ),
     );
@@ -274,12 +267,13 @@ export const mapEnrollmentVerificationsForSubmission = ev => {
   if (e.verificationStatus === VERIFICATION_STATUS_INCORRECT) {
     enrollmentVerificationsDto.push(
       mapEnrollmentVerificationForSubmission(
-        ev,
-        mostRecentVerifiedEnrollmentIndex,
+        ev.enrollmentVerifications[mostRecentVerifiedEnrollmentIndex],
         VERIFICATION_RESPONSE.INCORRECT,
       ),
     );
   }
 
-  return enrollmentVerificationsDto;
+  return {
+    enrollmentCertifyRequests: enrollmentVerificationsDto,
+  };
 };


### PR DESCRIPTION
## Description
Update object mappings and logic to match the object we receive from the Enrollment Verification service. `lastCertifiedThroughDate` is the ultimate source of truth for determining if an enrollment period has been verified or not. `verificationResponse` is not set for all enrollment periods when multiple enrollment periods are verified at once and, therefore, should not be referenced when determining the verified status for an enrollment period.