### PR TITLE
Google Analytics (GA4): Update component keys for GA4 staging testing.

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -203,9 +203,10 @@ const analyticsEvents = {
       ga4: {
         event: 'interaction',
         component_name: 'va-on-this-page',
+        custom_string_1: 'component-library',
         /* Component to GA4 parameters */
         mapping: {
-          'click-text': 'value',
+          'click-text': 'click_text',
           version: 'component_version',
         },
       },
@@ -277,9 +278,7 @@ export function subscribeComponentAnalyticsEvents(
 
       recordEvent(clearedDataLayer);
 
-      /**
-       * GA4 dataLayer push.
-       */
+      // GA4 dataLayer push.
       if (!environment.isProduction() && action?.ga4) {
         /**
          * Creating the GA4 dataLayer object by combining the existing
@@ -291,9 +290,7 @@ export function subscribeComponentAnalyticsEvents(
           action: action.event,
         };
 
-        /**
-         * Mapping the GA4 parameters to the Web Component event details.
-         */
+        // Mapping the GA4 parameters to the Web Component event details.
         const ga4Mapping = action?.ga4?.mapping;
 
         if (ga4Mapping) {
@@ -301,11 +298,12 @@ export function subscribeComponentAnalyticsEvents(
             const newKey = action.ga4.mapping[key];
 
             ga4DataLayer[newKey] = dataLayer[key];
+
+            // Clean up old GA dataLayer values.
+            delete ga4DataLayer[key];
           }
 
-          /**
-           * Cleaning up the GA4 mapping object from the dataLayer.
-           */
+          // Clean up the GA4 mapping object from the dataLayer.
           delete ga4DataLayer.mapping;
         }
 


### PR DESCRIPTION
## Description
This is a continuation of the work done in #22293. We need to make a few minor updates to the GA4 dataLayer object so that it maps correctly to the Google Analytics dashboard.

Example:
```
{
    event: "interaction",
    custom_string_1: "component-library",
    click_text: "Track your claim or appeal on your mobile device",
    action: "nav-jumplink-click",
    component_name:  "va-on-this-page",
}
```

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1174

## Testing done
Local environment

## Acceptance criteria
- [ ] The va-on-this-page dataLayer push for GA4 has been updated to include the requested keys/variables.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
