### PR TITLE
Updates the updateStateAndVerifier utility function

### DIFF
--- a/src/platform/user/authentication/components/CreateAccountLink.jsx
+++ b/src/platform/user/authentication/components/CreateAccountLink.jsx
@@ -22,20 +22,18 @@ export default function CreateAccountLink({
 }) {
   const [href, setHref] = useState('');
 
-  useEffect(
-    () => {
-      (async () => {
-        const url = await authUtilities.signupOrVerify({
-          policy,
-          isLink: true,
-          allowVerification: false,
-          useOAuth,
-        });
-        setHref(url);
-      })();
-    },
-    [policy, useOAuth],
-  );
+  useEffect(() => {
+    async function generateURL() {
+      const url = await authUtilities.signupOrVerify({
+        policy,
+        isLink: true,
+        allowVerification: false,
+        useOAuth,
+      });
+      setHref(url);
+    }
+    generateURL();
+  }, []);
 
   return (
     <a

--- a/src/platform/user/tests/authentication/components/CreateAccountLink.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/CreateAccountLink.unit.spec.js
@@ -1,23 +1,24 @@
 import React from 'react';
-import { SERVICE_PROVIDERS } from 'platform/user/authentication/constants';
 import { expect } from 'chai';
+import { SERVICE_PROVIDERS } from 'platform/user/authentication/constants';
 import * as authUtilities from 'platform/user/authentication/utilities';
 import CreateAccountLink from 'platform/user/authentication/components/CreateAccountLink';
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { mockCrypto } from 'platform/utilities/oauth/mockCrypto';
 
 const csps = ['logingov', 'idme'];
+const oldCrypto = global.window.crypto;
 
 describe('CreateAccountLink', () => {
   csps.forEach(policy => {
-    const oldCrypto = global.window.crypto;
-
     beforeEach(() => {
       global.window.crypto = mockCrypto;
+      window.location = new URL('https://dev.va.gov');
     });
 
     afterEach(() => {
       global.window.crypto = oldCrypto;
+      cleanup();
     });
 
     it(`should render correctly for each ${policy}`, async () => {

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -28,10 +28,6 @@ export async function pkceChallengeFromVerifier(v) {
 }
 
 export const saveStateAndVerifier = type => {
-  /*
-    Ensures saved state is not overwritten if location has state parameter.
-  */
-  if (window.location.search.includes(OAUTH_KEYS.STATE)) return null;
   const storage = localStorage;
 
   // Create and store a random "state" value

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -67,11 +67,6 @@ describe('OAuth - Utilities', () => {
   });
 
   describe('saveStateAndVerifier', () => {
-    it('should check to see if state is included in window.location', () => {
-      window.location = new URL('https://va.gov/?state=some_random_state');
-      expect(oAuthUtils.saveStateAndVerifier()).to.be.null;
-      window.location.search = '';
-    });
     it('should set sessionStorage', () => {
       oAuthUtils.saveStateAndVerifier();
       expect(!!localStorage.getItem('state')).to.be.true;

--- a/src/platform/utilities/tests/oauth/utilities.unit.spec.js
+++ b/src/platform/utilities/tests/oauth/utilities.unit.spec.js
@@ -67,6 +67,11 @@ describe('OAuth - Utilities', () => {
   });
 
   describe('saveStateAndVerifier', () => {
+    it('should check to see if state is included in window.location', () => {
+      window.location = new URL('https://va.gov/?state=some_random_state');
+      expect(oAuthUtils.saveStateAndVerifier()).to.not.be.null;
+      window.location.search = '';
+    });
     it('should set sessionStorage', () => {
       oAuthUtils.saveStateAndVerifier();
       expect(!!localStorage.getItem('state')).to.be.true;


### PR DESCRIPTION
## Description
This PR modifies the `udateStateAndVerifier` function that checks for the existence of the `state=<hash>` query parameter in the `window.location`.  This usually occurs when using the Sign in Service after a successful logout with Login.gov.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#47710


## Testing done
Unit / manual

## Screenshots
n/a

## Acceptance criteria
- [x] The `updateStateAndVerifier` function should not return `null` if a `state=<hash>` already exists after logout
- [x] I can still authentication when the `state=<hash>`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
