### PR TITLE
Fix issue with failing community care cypress test

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -82,7 +82,9 @@ describe('VAOS community care flow', () => {
     // Verify community care checked
     cy.get('#root_facilityType_1').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Choose an appointment day and time step
     cy.url().should(
@@ -105,7 +107,9 @@ describe('VAOS community care flow', () => {
       '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
     ).should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // What's the closest city to you step
     cy.url().should(
@@ -116,7 +120,9 @@ describe('VAOS community care flow', () => {
     cy.get('#root_communityCareSystemId_0').click();
     cy.get('#root_communityCareSystemId_0').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Tell us your community care preferences step
     cy.url().should(
@@ -132,7 +138,9 @@ describe('VAOS community care flow', () => {
     // Verify selected provider
     cy.get('#providerPostSelectionHeader').contains(/Selected provider/i);
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Tell us the reason for this appointment step
     cy.url().should(
@@ -149,7 +157,9 @@ describe('VAOS community care flow', () => {
       'This is a very good reason.',
     );
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Your contact information step
     cy.url().should(
@@ -168,7 +178,9 @@ describe('VAOS community care flow', () => {
     cy.get('#root_email').should('have.value', 'veteran@gmail.com');
     cy.get('#root_email').should('have.value', 'veteran@gmail.com');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Review your appointment details step
     cy.url().should(
@@ -176,8 +188,8 @@ describe('VAOS community care flow', () => {
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
     );
     cy.axeCheckBestPractice();
-    // Click continue button
-    cy.get('.usa-button').click();
+    // Click request appointment button
+    cy.findByText('Request appointment').click();
 
     // Check form requestBody is as expected
     cy.wait('@v0:create:appointment:request').should(xhr => {
@@ -267,7 +279,9 @@ describe('VAOS community care flow', () => {
     // Verify primary care checked
     cy.get('input[value="323"]').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Choose where you want to receive your care step
     cy.url().should(
@@ -280,7 +294,9 @@ describe('VAOS community care flow', () => {
     // Verify community care checked
     cy.get('#root_facilityType_1').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Choose an appointment day and time step
     cy.url().should(
@@ -303,7 +319,9 @@ describe('VAOS community care flow', () => {
       '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
     ).should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // What's the closest city to you step
     cy.url().should(
@@ -315,7 +333,9 @@ describe('VAOS community care flow', () => {
     // Select city
     cy.get('#root_communityCareSystemId_0').click();
     cy.get('#root_communityCareSystemId_0').should('be.checked');
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Tell us your community care preferences step
     cy.url().should(
@@ -332,7 +352,9 @@ describe('VAOS community care flow', () => {
     cy.axeCheckBestPractice();
     cy.findByText(/cancel/i).click();
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     cy.url().should(
       'contain',
@@ -343,7 +365,9 @@ describe('VAOS community care flow', () => {
     cy.get('#root_preferredLanguage').select('english');
     cy.get('#root_preferredLanguage').should('have.value', 'english');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Tell us the reason for this appointment step
     cy.url().should(
@@ -360,7 +384,9 @@ describe('VAOS community care flow', () => {
       'This is a very good reason.',
     );
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Your contact information step
     cy.url().should(
@@ -379,7 +405,9 @@ describe('VAOS community care flow', () => {
     cy.get('#root_email').should('have.value', 'veteran@gmail.com');
     cy.get('#root_email').should('have.value', 'veteran@gmail.com');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Review your appointment details step
     cy.url().should(
@@ -387,8 +415,8 @@ describe('VAOS community care flow', () => {
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
     );
     cy.axeCheckBestPractice();
-    // Click continue button
-    cy.get('.usa-button').click();
+    // Click request appointment button
+    cy.findByText('Request appointment').click();
 
     // Check form requestBody is as expected
     cy.wait('@v0:create:appointment:request').should(xhr => {
@@ -484,7 +512,9 @@ describe('VAOS community care flow using VAOS service', () => {
     // Verify primary care checked
     cy.get('input[value="323"]').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Choose where you want to receive your care step
     cy.url().should('contain', 'new-appointment/choose-facility-type');
@@ -494,7 +524,9 @@ describe('VAOS community care flow using VAOS service', () => {
     // Verify community care checked
     cy.get('#root_facilityType_1').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Choose an appointment day and time step
     cy.url().should(
@@ -517,7 +549,9 @@ describe('VAOS community care flow using VAOS service', () => {
       '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
     ).should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // What's the closest city to you step
     cy.url().should(
@@ -529,7 +563,9 @@ describe('VAOS community care flow using VAOS service', () => {
     // Select city
     cy.get('#root_communityCareSystemId_0').click();
     cy.get('#root_communityCareSystemId_0').should('be.checked');
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Tell us your community care preferences step
     cy.url().should(
@@ -546,7 +582,9 @@ describe('VAOS community care flow using VAOS service', () => {
     cy.axeCheckBestPractice();
     cy.findByText(/cancel/i).click();
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     cy.url().should(
       'contain',
@@ -557,7 +595,9 @@ describe('VAOS community care flow using VAOS service', () => {
     cy.get('#root_preferredLanguage').select('english');
     cy.get('#root_preferredLanguage').should('have.value', 'english');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Tell us the reason for this appointment step
     cy.url().should(
@@ -574,7 +614,9 @@ describe('VAOS community care flow using VAOS service', () => {
       'This is a very good reason.',
     );
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Your contact information step
     cy.url().should(
@@ -593,7 +635,9 @@ describe('VAOS community care flow using VAOS service', () => {
     cy.get('#root_email').should('have.value', 'veteran@gmail.com');
     cy.get('#root_email').should('have.value', 'veteran@gmail.com');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Review your appointment details step
     cy.url().should(
@@ -601,8 +645,8 @@ describe('VAOS community care flow using VAOS service', () => {
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
     );
     cy.axeCheckBestPractice();
-    // Click continue button
-    cy.get('.usa-button').click();
+    // Click request appointment button
+    cy.findByText('Request appointment').click();
 
     // Check form requestBody is as expected
     cy.wait('@v2:create:appointment').should(xhr => {


### PR DESCRIPTION
## Description
There was an issue with a failing VAOS Community Care cypress test that emerged in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/22256#discussion_r988329159). 

This change resolves that error and those tests no longer need to be skipped.

## Testing done
- e2e testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
