### PR TITLE
10-10EZ | Implement Unit Tests for the InsuranceProviderViewField Component

### DIFF
--- a/src/applications/hca/tests/components/InsuranceProviderViewField.unit.spec.js
+++ b/src/applications/hca/tests/components/InsuranceProviderViewField.unit.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import InsuranceProviderViewField from '../../components/FormFields/InsuranceProviderViewField';
+
+describe('hca <InsuranceProviderViewField>', () => {
+  it('should render insurance provider name', () => {
+    const formData = {
+      insuranceName: 'Aetna',
+    };
+
+    const { getByText } = render(
+      <InsuranceProviderViewField formData={formData} />,
+    );
+
+    expect(getByText(/aetna/i)).to.exist;
+  });
+});


### PR DESCRIPTION
## Description
Implement unit tests for the InsuranceProviderViewField Component (hca/components/FormFields/InsuranceProviderViewField.jsx)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47772
