### PR TITLE
47435 Use apiRequest in COE form

### DIFF
--- a/src/applications/lgy/coe/status/components/DocumentUploader/submit.js
+++ b/src/applications/lgy/coe/status/components/DocumentUploader/submit.js
@@ -1,5 +1,5 @@
 import environment from 'platform/utilities/environment';
-import { fetchAndUpdateSessionExpiration } from 'platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export const submitToAPI = (state, setState) => {
   // if no file has been added, show an error message
@@ -16,23 +16,19 @@ export const submitToAPI = (state, setState) => {
     submissionPending: true,
   });
 
-  fetchAndUpdateSessionExpiration(
-    `${environment.API_URL}/v0/coe/document_upload`,
-    {
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Key-Inflection': 'camel',
-        'Source-App-Name': window.appName,
-        'X-CSRF-Token': state.token,
-      },
-      method: 'POST',
-      body: JSON.stringify({
-        files: state.files,
-      }),
+  apiRequest(`${environment.API_URL}/v0/coe/document_upload`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
+      'X-CSRF-Token': state.token,
     },
-  )
-    .then(res => res.json())
+    method: 'POST',
+    body: JSON.stringify({
+      files: state.files,
+    }),
+  })
     .then(body => {
       if (body?.errors) {
         throw new Error('error');

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -341,8 +341,13 @@ describe('Schemaform save / load actions:', () => {
       const dispatch = sinon.spy();
       global.fetch.returns(
         Promise.resolve({
-          url: environment.API_URL,
+          headers: new Headers({
+            'X-CSRF-Token': 'Fake token',
+            'Content-Type': 'application/json',
+          }),
           ok: false,
+          json: () => Promise.resolve({}),
+          url: environment.API_URL,
           status: 401,
         }),
       );
@@ -359,8 +364,13 @@ describe('Schemaform save / load actions:', () => {
       const dispatch = sinon.spy();
       global.fetch.returns(
         Promise.resolve({
-          url: environment.API_URL,
+          headers: new Headers({
+            'X-CSRF-Token': 'Fake token',
+            'Content-Type': 'application/json',
+          }),
           ok: false,
+          json: () => Promise.resolve({}),
+          url: environment.API_URL,
           status: 404,
         }),
       );
@@ -374,7 +384,18 @@ describe('Schemaform save / load actions:', () => {
     it('dispatches a not-found if the api returns an empty object', () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_10_10EZ, {});
       const dispatch = sinon.spy();
-      setFetchJSONResponse(global.fetch.onCall(0), {});
+      global.fetch.returns(
+        Promise.resolve({
+          headers: new Headers({
+            'X-CSRF-Token': 'Fake token',
+            'Content-Type': 'application/json',
+          }),
+          ok: true,
+          json: () => Promise.resolve({}),
+          url: environment.API_URL,
+          status: 200,
+        }),
+      );
 
       return thunk(dispatch, getState).then(() => {
         expect(dispatch.calledTwice).to.be.true;
@@ -385,7 +406,18 @@ describe('Schemaform save / load actions:', () => {
     it("dispatches an invalid-data if the data returned from the api isn't an object", () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_10_10EZ, {});
       const dispatch = sinon.spy();
-      setFetchJSONResponse(global.fetch.onCall(0), []); // return not an object
+      global.fetch.returns(
+        Promise.resolve({
+          headers: new Headers({
+            'X-CSRF-Token': 'Fake token',
+            'Content-Type': 'application/json',
+          }),
+          ok: true,
+          json: () => Promise.resolve('foo'),
+          url: environment.API_URL,
+          status: 200,
+        }),
+      );
 
       return thunk(dispatch, getState).then(() => {
         expect(dispatch.calledTwice).to.be.true;
@@ -412,7 +444,18 @@ describe('Schemaform save / load actions:', () => {
     it('dispatches a failure on api response error', () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_10_10EZ, {});
       const dispatch = sinon.spy();
-      setFetchJSONFailure(global.fetch.onCall(0));
+      global.fetch.returns(
+        Promise.resolve({
+          headers: new Headers({
+            'X-CSRF-Token': 'Fake token',
+            'Content-Type': 'application/json',
+          }),
+          ok: false,
+          json: () => Promise.resolve({}),
+          url: environment.API_URL,
+          status: 500,
+        }),
+      );
 
       return thunk(dispatch, getState).then(() => {
         expect(dispatch.calledTwice).to.be.true;
@@ -423,15 +466,12 @@ describe('Schemaform save / load actions:', () => {
     it('dispatches a failure on network error', () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_10_10EZ, {});
       const dispatch = sinon.spy();
-      setFetchJSONResponse(
-        global.fetch.onCall(0),
-        Promise.reject(new Error('No network connection')),
-      );
+      global.fetch.returns(Promise.reject(new Error('No network connection')));
 
       return thunk(dispatch, getState).then(() => {
         expect(dispatch.calledTwice).to.be.true;
         expect(
-          dispatch.calledWith(setFetchFormStatus(LOAD_STATUSES.clientFailure)),
+          dispatch.calledWith(setFetchFormStatus(SAVE_STATUSES.clientFailure)),
         ).to.be.true;
       });
     });
@@ -441,8 +481,13 @@ describe('Schemaform save / load actions:', () => {
         const dispatch = sinon.spy();
         global.fetch.returns(
           Promise.resolve({
-            url: environment.API_URL,
+            headers: new Headers({
+              'X-CSRF-Token': 'Fake token',
+              'Content-Type': 'application/json',
+            }),
             ok: false,
+            json: () => Promise.resolve({}),
+            url: environment.API_URL,
             status: 401,
           }),
         );


### PR DESCRIPTION
## Description

Use apiRequest in COE form.

**Context:**

During testing, we noticed that our auth tokens were expiring midway through completing the COE form.  This is because we were using `fetchAndUpdateSessionExpiration` in our `fetchInProgressForm` action ([link](https://github.com/department-of-veterans-affairs/vets-website/blob/a6eb76b16e503096e9c0b0c7a07754d80a6fa40a/src/platform/forms/save-in-progress/actions.js#L259)) and in `DocumentUploader/submit.js` ([link](https://github.com/department-of-veterans-affairs/vets-website/blob/c3067e59b5bd0f3206b3b9e6e81b30487a9ac585/src/applications/lgy/coe/status/components/DocumentUploader/submit.js#L19)), instead of `apiRequest` ([link](https://github.com/department-of-veterans-affairs/vets-website/blob/0a8692b443a29b5a6476256f4d075e1491e3fe83/src/platform/utilities/api/index.js#L54)).  See [Slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1665003605654539?thread_ts=1665002706.486319&cid=CBU0KDSB1).  Unlike the other request methods, `apiRequest` renews expired tokens.  This PR is a big step towards using  `apiRequest` throughout the COE form.

This is one of two issues blocking us from moving into QA.

**Solution:**

Updating `DocumentUploader/submit.js` was a simple task.  Updating `fetchInProgressForm` was more complicated.  This is because 1)  `fetchInProgressForm`'s error handling relies heavily on the http status of the response, but 2) `apiRequest` did not expose the http status on error.  To be specific, when `apiRequest` receives an error [not caused by an expired auth token](https://github.com/department-of-veterans-affairs/vets-website/blob/0a8692b443a29b5a6476256f4d075e1491e3fe83/src/platform/utilities/api/index.js#L114), it would [reject the promise with the json response body](https://github.com/department-of-veterans-affairs/vets-website/blob/0a8692b443a29b5a6476256f4d075e1491e3fe83/src/platform/utilities/api/index.js#L136), but not the response object and the status code contained therein.

This PR adds a `rejectWithFullResponse` argument to `apiRequest`.  When `true`, request errors not caused by an expired auth token cause the promise to be rejected with the `Response` object.  This allows `fetchInProgressForm` to consume the http status of the response, just as it did before.

With respect to _successful_ requests, because `apiRequest` resolves promises with the response body, rather than the `Response` object itself, I have had to re-write `fetchInProgressForm` accordingly. While reviewing this PR, you'll notice some strange-ness around Promise rejection. Namely, that Promises are not rejected with Errors, and that Promises can be rejected with more than one kind of type. While this is not ideal, 1) `fetchInProgressForm` and `apiRequest` were already doing this, 2) my PR is focused on an urgent bugfix, not a larger re-write of `fetchInProgressForm` and `apiRequest`, and 3) `apiRequest` was built on the assumption that most http error statuses will, unlike `fetch`, reject Promises rather than resolve them (meaning, I am forced to surface http error statuses through `reject`).

I could re-write `apiRequest` to handle errors differently, but because it is so widely used, it's difficult for me to justify the kind of re-write that would put me on what could be a lengthy test-fixing expedition.

**Outstanding issues:**

There are other COE endpoints (GETs) not addressed by this PR, like `GET /v0/coe/document_download/{id}` and `GET /v0/coe/download_coe`. We consume these endpoints through `href`s and not `fetch` requests, so it's not immediately clear to me how to avoid the expired auth token issue for these endpoints. I can explore this later.

## Original issue(s)

department-of-veterans-affairs/va.gov-team#47435

## Testing done

- Unit tests pass.
- E2E tests pass.
- Tested locally, MacOS/Chrome.

## Screenshots

![image](https://user-images.githubusercontent.com/7520103/195685133-a0f8a756-1dee-4e6b-a4be-513b4aca1679.png)

## How to review and test

Quick summary: the point of this PR is to use `apiRequest` to make HTTP requests, instead of `fetchAndUpdateSessionExpiration`. In order to use `apiRequest`, I have had to make small changes to `apiRequest` and refactor a `fetchInProgressForm` function in `src/platform/utilities/api/index.js`. Everything should work like it did before -- we're just using a better HTTP request function now. That being said, in reviewing this PR, please:

- Read the description above to understand how I approached this problem.
- Skim over my code and think about whether you agree with this approach in a general sense.
- If you're feeling good about it, have a closer look at the code (`fetchInProgressForm`, in particular) to make sure that the code is doing the same thing as before.
- To test locally:
  - Log in as `vets.gov.user+228@gmail.com`
  - Go to `http://localhost:3001/housing-assistance/home-loans/request-coe-form-26-1880/introduction`
  - Open up the network tab in dev tools, and filter to XHR requests only
  - Click "Start a new request" and go through the COE form. Fill it out however you want.
  - Confirm that the network requests are still succeeding. (See screenshot above).

## Acceptance criteria

- [ ] Tests still pass.
- [ ] Can navigate through COE form, and network requests to `/v0/coe/document_upload` and `/v0/in_progress_forms/:form_id` still succeed.

## Definition of done

- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
