### PR TITLE
[47820] Fix Veteran Social Security populating Spouse field

### DIFF
--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -91,7 +91,7 @@ export const transform = (formConfig, form) => {
   const spGrossSalary = sumValues(spCurrEmployment, 'spouseGrossSalary');
   const spAddlInc = sumValues(spAddlIncome, 'amount');
   const spSocialSecAmt = Number(
-    socialSecurity.socialSecAmt?.replaceAll(',', '') ?? 0,
+    socialSecurity.spouse?.socialSecAmt?.replaceAll(',', '') ?? 0,
   );
   const spComp = Number(
     benefits.spouseBenefits.compensationAndPension?.replaceAll(',', '') ?? 0,


### PR DESCRIPTION
## Description
The social security value from the Veteran was populating in the Spouse field of the FSR form even when the Veteran specified they were did not have a spouse

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#47820](https://github.com/department-of-veterans-affairs/va.gov-team/issues/47820)


## Testing done
Tested with both no spouse and with separate spouse income

## Screenshots


## Acceptance criteria
- [x] Social Security amounts are separated between Veteran and Spouse

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
