### PR TITLE
Adding GA4 setup for va-promo-banner component.

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -166,6 +166,18 @@ const analyticsEvents = {
       action: 'linkClick',
       event: 'nav-promo-banner-link-click',
       prefix: 'promo-banner',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-promo-banner',
+        custom_string_1: 'component-library',
+        /* Component to GA4 parameters */
+        mapping: {
+          'promo-banner-type': 'type',
+          'promo-banner-href': 'href',
+          'promo-banner-text': 'text',
+          version: 'component_version',
+        },
+      },
     },
   ],
   'va-radio': [
@@ -206,7 +218,7 @@ const analyticsEvents = {
         custom_string_1: 'component-library',
         /* Component to GA4 parameters */
         mapping: {
-          'click-text': 'click_text',
+          'click-text': 'value',
           version: 'component_version',
         },
       },


### PR DESCRIPTION
## Description
This PR adds additional GA4 setup to the design system component analytics script for testing in staging. We are just testing the `va-promo-banner` component here.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1174

## Testing done
Local environment

## Acceptance criteria
- [ ] The va-promo-banner dataLayer push for GA4 has been updated to include the requested keys/variables.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
