### PR TITLE
[CST] Remove unused action creators

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -32,29 +32,19 @@ const USE_MOCKS = CAN_USE_MOCKS && SHOULD_USE_MOCKS;
 // -------------------- v2 and v1 -------------
 export const FETCH_APPEALS_SUCCESS = 'FETCH_APPEALS_SUCCESS';
 // -------------------- v1 --------------------
-export const SET_CLAIMS = 'SET_CLAIMS';
-export const SET_APPEALS = 'SET_APPEALS';
-export const FETCH_CLAIMS = 'FETCH_CLAIMS';
-export const FETCH_APPEALS = 'FETCH_APPEALS';
 export const FETCH_STEM_CLAIMS_PENDING = 'FETCH_STEM_CLAIMS_PENDING';
 export const FETCH_STEM_CLAIMS_SUCCESS = 'FETCH_STEM_CLAIMS_SUCCESS';
 export const FETCH_STEM_CLAIMS_ERROR = 'FETCH_STEM_CLAIMS_ERROR';
-export const FILTER_CLAIMS = 'FILTER_CLAIMS';
-export const SORT_CLAIMS = 'SORT_CLAIMS';
-export const CHANGE_CLAIMS_PAGE = 'CHANGE_CLAIMS_PAGE';
 export const GET_CLAIM_DETAIL = 'GET_CLAIM_DETAIL';
 export const SET_CLAIM_DETAIL = 'SET_CLAIM_DETAIL';
-export const GET_APPEALS_DETAIL = 'GET_APPEALS_DETAIL';
 export const SUBMIT_DECISION_REQUEST = 'SUBMIT_DECISION_REQUEST';
 export const SET_DECISION_REQUESTED = 'SET_DECISION_REQUESTED';
 export const SET_DECISION_REQUEST_ERROR = 'SET_DECISION_REQUEST_ERROR';
 export const SET_CLAIMS_UNAVAILABLE = 'SET_CLAIMS_UNAVAILABLE';
-export const SET_APPEALS_UNAVAILABLE = 'SET_APPEALS_UNAVAILABLE';
 export const SET_UNAUTHORIZED = 'SET_UNAUTHORIZED';
 export const RESET_UPLOADS = 'RESET_UPLOADS';
 export const ADD_FILE = 'ADD_FILE';
 export const REMOVE_FILE = 'REMOVE_FILE';
-export const SUBMIT_FILES = 'SUBMIT_FILES';
 export const SET_UPLOADING = 'SET_UPLOADING';
 export const SET_UPLOADER = 'SET_UPLOADER';
 export const DONE_UPLOADING = 'DONE_UPLOADING';
@@ -85,23 +75,7 @@ export function setAdditionalEvidenceNotification(message) {
   };
 }
 
-export function getAppeals(filter) {
-  return dispatch => {
-    dispatch({ type: FETCH_APPEALS });
-
-    makeAuthRequest(
-      '/v0/appeals',
-      null,
-      dispatch,
-      appeals => {
-        dispatch({ type: SET_APPEALS, filter, appeals: appeals.data });
-      },
-      () => dispatch({ type: SET_APPEALS_UNAVAILABLE }),
-    );
-  };
-}
-
-export function fetchAppealsSuccess(response) {
+function fetchAppealsSuccess(response) {
   const appeals = response.data;
   return {
     type: FETCH_APPEALS_SUCCESS,
@@ -143,7 +117,7 @@ export function getAppealsV2() {
   };
 }
 
-export function fetchClaimsSuccess(response) {
+function fetchClaimsSuccess(response) {
   return {
     type: FETCH_CLAIMS_SUCCESS,
     claims: response.data,
@@ -186,7 +160,7 @@ export function pollRequest(options) {
   );
 }
 
-export function getSyncStatus(claimsAsyncResponse) {
+function getSyncStatus(claimsAsyncResponse) {
   return get('meta.syncStatus', claimsAsyncResponse, null);
 }
 
@@ -279,33 +253,6 @@ export function getClaimsV2(options = {}) {
       shouldSucceed: response => getSyncStatus(response) === 'SUCCESS',
       target: '/evss_claims_async',
     });
-  };
-}
-
-export function filterClaims(filter) {
-  return {
-    type: FILTER_CLAIMS,
-    filter,
-  };
-}
-
-export function sortClaims(sortProperty) {
-  return {
-    type: SORT_CLAIMS,
-    sortProperty,
-  };
-}
-
-export function changePage(page) {
-  return {
-    type: CHANGE_CLAIMS_PAGE,
-    page,
-  };
-}
-
-export function setUnavailable() {
-  return {
-    type: SET_CLAIMS_UNAVAILABLE,
   };
 }
 

--- a/src/applications/claims-status/reducers/claim-sync.js
+++ b/src/applications/claims-status/reducers/claim-sync.js
@@ -2,7 +2,6 @@ import set from 'platform/utilities/data/set';
 
 import {
   SET_CLAIM_DETAIL,
-  SET_CLAIMS,
   SET_CLAIMS_UNAVAILABLE,
   SET_UNAUTHORIZED,
 } from '../actions';
@@ -16,7 +15,6 @@ const initialState = {
 export default function claimDetailReducer(state = initialState, action) {
   switch (action.type) {
     case SET_CLAIM_DETAIL:
-    case SET_CLAIMS:
       return {
         ...state,
         synced: action.meta.syncStatus === 'SUCCESS',

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -11,15 +11,11 @@ import {
   addFile,
   CANCEL_UPLOAD,
   cancelUpload,
-  CHANGE_CLAIMS_PAGE,
-  changePage,
   CLEAR_NOTIFICATION,
   clearNotification,
   CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION,
   clearAdditionalEvidenceNotification,
-  FETCH_APPEALS,
   GET_CLAIM_DETAIL,
-  getAppeals,
   getClaimDetail,
   getClaimsV2,
   getStemClaims,
@@ -28,10 +24,7 @@ import {
   removeFile,
   RESET_UPLOADS,
   resetUploads,
-  SET_APPEALS_UNAVAILABLE,
-  SET_APPEALS,
   SET_CLAIM_DETAIL,
-  SET_CLAIMS_UNAVAILABLE,
   SET_DECISION_REQUEST_ERROR,
   SET_DECISION_REQUESTED,
   SET_FIELDS_DIRTY,
@@ -42,7 +35,6 @@ import {
   setLastPage,
   setNotification,
   setAdditionalEvidenceNotification,
-  setUnavailable,
   SUBMIT_DECISION_REQUEST,
   submitRequest,
   UPDATE_FIELD,
@@ -70,25 +62,6 @@ describe('Actions', () => {
       expect(action).to.eql({
         type: SET_ADDITIONAL_EVIDENCE_NOTIFICATION,
         message: 'Testing',
-      });
-    });
-  });
-  describe('changePage', () => {
-    it('should return the correct action object', () => {
-      const action = changePage('Testing');
-
-      expect(action).to.eql({
-        type: CHANGE_CLAIMS_PAGE,
-        page: 'Testing',
-      });
-    });
-  });
-  describe('setUnavailable', () => {
-    it('should return the correct action object', () => {
-      const action = setUnavailable();
-
-      expect(action).to.eql({
-        type: SET_CLAIMS_UNAVAILABLE,
       });
     });
   });
@@ -208,43 +181,7 @@ describe('Actions', () => {
       global.window.dataLayer = oldDataLayer;
     });
   });
-  describe('getAppeals', () => {
-    beforeEach(() => mockFetch());
-    it('should fetch claims', done => {
-      const appeals = [];
-      setFetchJSONResponse(global.fetch.onCall(0), appeals);
-      const thunk = getAppeals();
-      const dispatchSpy = sinon.spy();
-      const dispatch = action => {
-        dispatchSpy(action);
-        if (dispatchSpy.callCount === 2) {
-          expect(dispatchSpy.firstCall.args[0].type).to.eql(FETCH_APPEALS);
-          expect(dispatchSpy.secondCall.args[0].type).to.eql(SET_APPEALS);
-          done();
-        }
-      };
 
-      thunk(dispatch);
-    });
-    it('should fail on error', done => {
-      const appeals = [];
-      setFetchJSONFailure(global.fetch.onCall(0), appeals);
-      const thunk = getAppeals();
-      const dispatchSpy = sinon.spy();
-      const dispatch = action => {
-        dispatchSpy(action);
-        if (dispatchSpy.callCount === 2) {
-          expect(dispatchSpy.firstCall.args[0].type).to.eql(FETCH_APPEALS);
-          expect(dispatchSpy.secondCall.args[0].type).to.eql(
-            SET_APPEALS_UNAVAILABLE,
-          );
-          done();
-        }
-      };
-
-      thunk(dispatch);
-    });
-  });
   describe('getClaimsV2', () => {
     let dispatchSpy;
     let pollStatusSpy;

--- a/src/applications/claims-status/tests/reducers/claim-sync.unit.spec.jsx
+++ b/src/applications/claims-status/tests/reducers/claim-sync.unit.spec.jsx
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import claimSync from '../../reducers/claim-sync';
 import {
-  SET_CLAIMS,
   SET_CLAIM_DETAIL,
   SET_CLAIMS_UNAVAILABLE,
   SET_UNAUTHORIZED,
@@ -49,44 +48,6 @@ describe('Claim sync reducer', () => {
           updatedAt: 'test',
         },
       },
-      meta: {
-        syncStatus: 'SUCCESS',
-      },
-    });
-
-    expect(state.synced).to.be.true;
-    expect(state.available).to.be.true;
-    expect(state.authorized).to.be.true;
-  });
-  it('should set out of sync on list request', () => {
-    const state = claimSync(undefined, {
-      type: SET_CLAIMS,
-      claims: [
-        {
-          attributes: {
-            updatedAt: 'test',
-          },
-        },
-      ],
-      meta: {
-        syncStatus: 'FAILED',
-      },
-    });
-
-    expect(state.synced).to.be.false;
-    expect(state.available).to.be.true;
-    expect(state.authorized).to.be.true;
-  });
-  it('should set in sync on list request', () => {
-    const state = claimSync(undefined, {
-      type: SET_CLAIMS,
-      claims: [
-        {
-          attributes: {
-            updatedAt: 'test',
-          },
-        },
-      ],
       meta: {
         syncStatus: 'SUCCESS',
       },


### PR DESCRIPTION
## Description
Removing unused action creators. Most of these are associated with the V1 version of the Claims Status Tool

## Original issue(s)
department-of-veterans-affairs/va.gov-team#43964

## Acceptance criteria
- [x] Tests still pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
