### PR TITLE
SessionTimeOut Modal Bug Fix (47924)

### DIFF
--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import differenceInSeconds from 'date-fns/differenceInSeconds';
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import recordEvent from 'platform/monitoring/record-event';
 import { logout as IAMLogout } from 'platform/user/authentication/utilities';
 import { refresh, logoutUrlSiS } from 'platform/utilities/oauth/utilities';
 import { teardownProfileSession } from 'platform/user/profile/utilities';
 import localStorage from 'platform/utilities/storage/localStorage';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 const MODAL_DURATION = 30; // seconds
 
@@ -86,7 +86,7 @@ class SessionTimeoutModal extends React.Component {
 
   render() {
     return (
-      <VaModal
+      <Modal
         hideCloseButton
         id="session-timeout-modal"
         focusSelector="button"
@@ -119,7 +119,7 @@ class SessionTimeoutModal extends React.Component {
             Sign out
           </button>
         </div>
-      </VaModal>
+      </Modal>
     );
   }
 }


### PR DESCRIPTION
## Description
< Modal > was recently replaced by < VaModal > in the SessionTimeOut Modal component. This caused a bug across the VA Platform, where the modal rendered as a div causing major issues to the platform's UI. This PR removes VA Modal and replaces it with Modal. 

## Original issue(s)
Closes [Bug Fix - Reverting use of VA Modal back to Modal in SessionTimeOut Component. #47924](https://github.com/department-of-veterans-affairs/va.gov-team/issues/47924)


## Testing done
unit, manual 

## Screenshots
![image](https://user-images.githubusercontent.com/108290062/194577634-e1eae51f-4617-4764-a154-fccee2d9e047.png)

## Acceptance criteria
- [x] VA Modal has been removed. 

## Definition of done
- [x] Events are logged appropriately
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
