### PR TITLE
Profile/31408/update editing alert button styles

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
@@ -385,7 +385,7 @@ export const BankInfo = ({
           {`You haven't finished editing and saving the changes to your direct deposit information. If you cancel now, we won't save your changes.`}
         </p>
         <button
-          className="usa-button-secondary"
+          className="usa-button-primary"
           type="button"
           onClick={() => {
             setShowConfirmCancelModal(false);
@@ -394,6 +394,7 @@ export const BankInfo = ({
           Continue Editing
         </button>
         <button
+          className="usa-button-secondary"
           type="button"
           onClick={() => {
             setShowConfirmCancelModal(false);

--- a/src/applications/personalization/profile/tests/e2e/contact-information/mailing-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/mailing-address.cypress.spec.js
@@ -145,7 +145,9 @@ const confirmWebAddressesAreBlocked = () => {
 
   // cancel out of edit mode and discard unsaved changes
   cy.findByRole('button', { name: /cancel/i }).click();
-  cy.findByRole('alertdialog')
+
+  cy.findByTestId('confirm-cancel-modal')
+    .shadow()
     .findByRole('button', { name: /cancel/i })
     .click();
 };

--- a/src/applications/personalization/profile/tests/e2e/contact-information/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/modals.cypress.spec.js
@@ -59,14 +59,17 @@ const checkModals = options => {
   });
 
   // Confirmation modal appears, confirm cancel
-  cy.get('.va-modal').within(() => {
-    cy.contains(
-      `You haven't finished editing and saving the changes to your ${sectionName}.`,
-    ).should('exist');
-    cy.findByRole('button', { name: /Cancel/i }).click({
-      force: true,
-    });
-  });
+
+  cy.findByTestId('confirm-cancel-modal')
+    .findByText(
+      `You haven't finished editing and saving the changes to your ${sectionName}. If you cancel now, we won't save your changes.`,
+    )
+    .should('exist');
+
+  cy.findByTestId('confirm-cancel-modal')
+    .shadow()
+    .findByRole('button', { name: /cancel/i })
+    .click();
 };
 
 const checkRemovalWhileEditingModal = options => {
@@ -267,14 +270,12 @@ describe('when moving to other profile sections', () => {
       name: /military information/i,
     }).click({
       // using force: true since there are times when the click does not
-      // register and the bank info form does not open
+      // register and the form does not open
       force: true,
     });
     cy.findByRole('link', {
       name: /contact.*information/i,
     }).click({
-      // using force: true since there are times when the click does not
-      // register and the bank info form does not open
       force: true,
     });
     cy.findByRole('button', {

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-gender-identity.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-gender-identity.cypress.spec.js
@@ -32,8 +32,9 @@ describe('Gender identity field tests on the personal information page', () => {
     // should show cancel editing alert
     cy.findByRole('alertdialog').should('exist');
 
-    cy.findByRole('button', { name: 'Cancel' })
-      .should('exist')
+    cy.findByTestId('confirm-cancel-modal')
+      .shadow()
+      .findByRole('button', { name: /cancel/i })
       .click();
 
     cy.findByText(genderEditInputLabel).should('not.exist');

--- a/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-information/personal-info-preferred-name.cypress.spec.js
@@ -33,8 +33,9 @@ describe('Preferred name field tests on the personal information page', () => {
     // should show cancel editing alert
     cy.findByRole('alertdialog').should('exist');
 
-    cy.findByRole('button', { name: 'Cancel' })
-      .should('exist')
+    cy.findByTestId('confirm-cancel-modal')
+      .shadow()
+      .findByRole('button', { name: /cancel/i })
       .click();
 
     cy.findByText(nameEditInputLabel).should('not.exist');

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const ConfirmCancelModal = props => {
   const { activeSection, closeModal, onHide, isVisible } = props;
 
   return (
-    <Modal
-      title="Are you sure?"
+    <VaModal
+      modalTitle="Are you sure?"
       status="warning"
       visible={isVisible}
-      onClose={onHide}
+      onCloseEvent={onHide}
     >
       <p>
         {`You haven't finished editing and saving the changes to your ${activeSection}. If you cancel now, we won't save your changes.`}
       </p>
       <button
-        className="usa-button-secondary"
+        type="button"
+        className="usa-button-primary"
         onClick={() => {
           onHide();
         }}
@@ -24,6 +25,8 @@ const ConfirmCancelModal = props => {
         Continue Editing
       </button>
       <button
+        type="button"
+        className="usa-button-secondary"
         onClick={() => {
           onHide();
           closeModal();
@@ -31,15 +34,15 @@ const ConfirmCancelModal = props => {
       >
         Cancel
       </button>
-    </Modal>
+    </VaModal>
   );
 };
 
 ConfirmCancelModal.propTypes = {
-  activeSection: PropTypes.string,
   closeModal: PropTypes.func.isRequired,
   isVisible: PropTypes.bool.isRequired,
   onHide: PropTypes.func.isRequired,
+  activeSection: PropTypes.string,
 };
 
 export default ConfirmCancelModal;

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
@@ -1,40 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const ConfirmCancelModal = props => {
   const { activeSection, closeModal, onHide, isVisible } = props;
 
+  const handlers = {
+    primary: () => onHide(),
+    secondary: () => {
+      onHide();
+      closeModal();
+    },
+  };
+
   return (
-    <Modal
-      title="Are you sure?"
+    <VaModal
+      modalTitle="Are you sure?"
       status="warning"
       visible={isVisible}
-      onClose={onHide}
+      onCloseEvent={onHide}
+      onPrimaryButtonClick={handlers.primary}
+      onSecondaryButtonClick={handlers.secondary}
+      primaryButtonText="Continue Editing"
+      secondaryButtonText="Cancel"
     >
       <p>
         {`You haven't finished editing and saving the changes to your ${activeSection}. If you cancel now, we won't save your changes.`}
       </p>
-      <button
-        type="button"
-        className="usa-button-primary"
-        onClick={() => {
-          onHide();
-        }}
-      >
-        Continue Editing
-      </button>
-      <button
-        type="button"
-        className="usa-button-secondary"
-        onClick={() => {
-          onHide();
-          closeModal();
-        }}
-      >
-        Cancel
-      </button>
-    </Modal>
+    </VaModal>
   );
 };
 

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
@@ -5,6 +5,12 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 const ConfirmCancelModal = props => {
   const { activeSection, closeModal, onHide, isVisible } = props;
 
+  // return null to avoid even having the web component in dom
+  // when not needed (this makes testing easier as well)
+  if (!isVisible) {
+    return null;
+  }
+
   const handlers = {
     primary: () => onHide(),
     secondary: () => {
@@ -23,6 +29,7 @@ const ConfirmCancelModal = props => {
       onSecondaryButtonClick={handlers.secondary}
       primaryButtonText="Continue Editing"
       secondaryButtonText="Cancel"
+      data-testid="confirm-cancel-modal"
     >
       <p>
         {`You haven't finished editing and saving the changes to your ${activeSection}. If you cancel now, we won't save your changes.`}

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 const ConfirmCancelModal = props => {
   const { activeSection, closeModal, onHide, isVisible } = props;
 
   return (
-    <VaModal
-      modalTitle="Are you sure?"
+    <Modal
+      title="Are you sure?"
       status="warning"
       visible={isVisible}
-      onCloseEvent={onHide}
+      onClose={onHide}
     >
       <p>
         {`You haven't finished editing and saving the changes to your ${activeSection}. If you cancel now, we won't save your changes.`}
@@ -34,7 +34,7 @@ const ConfirmCancelModal = props => {
       >
         Cancel
       </button>
-    </VaModal>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## Description
Updates the ConfirmCancelModal to use different button types. See screenshots below, we are basically switching the primary and secondary button styles to align with the other alerts site wide. In doing so, we also migrated this component to use the Web Component version of the modal.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31408


## Testing done
Updated E2E tests. These had to be updated because the web components cannot be accessed the same way as a vanilla react component can be accessed within cypress.

## Screenshots
BEFORE

![](https://user-images.githubusercontent.com/55992116/174860147-9d5c0eef-c37a-430a-a7c0-c9020b51bdeb.png)

AFTER

![Screen Shot 2022-10-04 at 11 21 17 AM](https://user-images.githubusercontent.com/8332986/194623736-4414a5c3-1eef-41cf-a5f8-36520ad6125a.png)


## Acceptance criteria
- [x] Button styles changed
- [x] E2E tests updated and passing

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
