### PR TITLE
[CST] Adding feature flag for claim letters

### DIFF
--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -3,4 +3,4 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 
 export const isLoadingFeatures = state => toggleValues(state).loading;
 export const showClaimLettersFeature = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.claimLettersEnabled];
+  toggleValues(state)[FEATURE_FLAG_NAMES.claimLettersAccess];

--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -1,0 +1,6 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const isLoadingFeatures = state => toggleValues(state).loading;
+export const showClaimLettersFeature = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.claimLettersEnabled];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -23,6 +23,7 @@ export default Object.freeze({
   checkInExperienceLorotaDeletionEnabled: 'check_in_experience_lorota_deletion_enabled',
   checkInExperienceTravelReimbursement: 'check_in_experience_travel_reimbursement',
   checkVAInboxEnabled: 'check_va_inbox_enabled',
+  claimLettersAccess: 'claim_letters_access',
   coeAccess: 'coe_access',
   combinedDebtPortalAccess: 'combined_debt_portal_access',
   combinedFinancialStatusReport: 'combined_financial_status_report',


### PR DESCRIPTION
## Description
Adding a new feature flag for us to use as part of our staged rollout of our new claim letters feature

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47953

[Backend PR](https://github.com/department-of-veterans-affairs/vets-api/pull/10868)

## Acceptance criteria
- [x] `claimLettersAccess` feature flag added
- [x] Selector created to grab the feature flag from Redux

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
