### PR TITLE
Add missing step to update-e2e-allow-list job in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -834,6 +834,14 @@ jobs:
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
 
+      - name: Create GitHub Issues for new flaky tests
+        if: ${{ env.NEW_DISALLOWED_TESTS != '[]' }}
+        run: yarn create-github-issues-for-flaky-tests
+        working-directory: qa-standards-dashboard-data
+        env:
+          TEST_REPORTS_FOLDER_NAME: vets-website-cypress-stress-test-reports
+          GITHUB_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+
   testing-reports-contract-tests:
     name: Testing Reports - Contract Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Regarding https://github.com/department-of-veterans-affairs/va.gov-team/labels/e2e-flaky-test

It doesn’t look like any issues are getting created when tests flake.

At the minimum, they should be created and assigned to Joe and Peter. That is, if there’s no team label, or if it’s invalid.

I think all flaky tests have been caught in CI so far, and there isn’t a `Create GitHub Issues for new flaky tests` step in the `update-e2e-allow-list` job in CI.

This PR will hopefully fix this issue.