### PR TITLE
Add va-accordion component ga4 mapping to staging.

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -95,11 +95,41 @@ const analyticsEvents = {
     { action: 'blur', event: 'int-text-input-blur', prefix: 'text-input' },
   ],
   'va-accordion': [
-    { action: 'expand', event: 'int-accordion-expand', prefix: 'accordion' },
+    {
+      action: 'expand',
+      event: 'int-accordion-expand',
+      prefix: 'accordion',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-accordion',
+        custom_string_1: 'component-library',
+        /* Component to GA4 parameters */
+        mapping: {
+          'accordion-header': 'heading_1',
+          'accordion-subheader': 'heading_2',
+          'accordion-level': 'custom_number_1',
+          'accordion-sectionHeading': 'custom_string_2',
+          version: 'component_version',
+        },
+      },
+    },
     {
       action: 'collapse',
       event: 'int-accordion-collapse',
       prefix: 'accordion',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-accordion',
+        custom_string_1: 'component-library',
+        /* Component to GA4 parameters */
+        mapping: {
+          'accordion-header': 'heading_1',
+          'accordion-subheader': 'heading_2',
+          'accordion-level': 'custom_number_1',
+          'accordion-sectionHeading': 'custom_string_2',
+          version: 'component_version',
+        },
+      },
     },
   ],
   'va-additional-info': [

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -248,7 +248,6 @@ const analyticsEvents = {
         custom_string_1: 'component-library',
         /* Component to GA4 parameters */
         mapping: {
-          'click-text': 'value',
           version: 'component_version',
         },
       },


### PR DESCRIPTION
## Description
This PR adds GA4 setup to the design system component analytics script for testing in staging. We are just testing the `va-accordion` component for now.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1174

## Testing done
Local environment.

## Acceptance criteria
- [ ] A GA4 dataLayer is added for the `va-accordion` component.
- [ ] The new dataLayer update only occurs in staging.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
