### PR TITLE
Logic to inject header after skiplink

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -167,7 +167,9 @@ function activateInjectedAssets() {
       }
 
       throw new Error(
-        `vets_headerFooter_error: Failed to fetch header and footer menu data: ${resp.statusText}`,
+        `vets_headerFooter_error: Failed to fetch header and footer menu data: ${
+          resp.statusText
+        }`,
       );
     })
     .then(headerFooterData => {

--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -13,12 +13,12 @@ import startMobileMenuButton from 'platform/site-wide/mobile-menu-button';
 import startUserNavWidget from 'platform/site-wide/user-nav';
 import startVAFooter, { footerElemementId } from 'platform/site-wide/va-footer';
 import { addOverlayTriggers } from 'platform/site-wide/legacy/menu';
+import { getAssetPath } from '~/platform/site-wide/helpers/team-sites/get-asset-path';
+import { getTargetEnv } from '~/platform/site-wide/helpers/team-sites/get-target-env';
 import redirectIfNecessary from './redirects';
 import headerPartial from './partials/header';
 import footerPartial from './partials/footer';
 import proxyWhitelist from './proxy-rewrite-whitelist.json';
-import { getAssetPath } from '~/platform/site-wide/helpers/team-sites/get-asset-path';
-import { getTargetEnv } from '~/platform/site-wide/helpers/team-sites/get-target-env';
 
 function createMutationObserverCallback() {
   // Find native header, footer, etc based on page path
@@ -57,6 +57,7 @@ function createMutationObserverCallback() {
 function activateHeaderFooter() {
   // Set up elements for the new header and footer
   const headerContainer = document.createElement('div');
+  const skipLink = document.getElementById('skiplink');
   headerContainer.innerHTML = headerPartial;
   headerContainer.classList.add('consolidated');
 
@@ -64,7 +65,12 @@ function activateHeaderFooter() {
   footerContainer.innerHTML = footerPartial;
   footerContainer.classList.add('consolidated');
 
-  document.body.insertBefore(headerContainer, document.body.firstChild);
+  if (skipLink) {
+    document.body.insertBefore(headerContainer, skipLink.nextSibling);
+  } else {
+    document.body.insertBefore(headerContainer, document.body.firstChild);
+  }
+
   document.body.appendChild(footerContainer);
 }
 
@@ -161,9 +167,7 @@ function activateInjectedAssets() {
       }
 
       throw new Error(
-        `vets_headerFooter_error: Failed to fetch header and footer menu data: ${
-          resp.statusText
-        }`,
+        `vets_headerFooter_error: Failed to fetch header and footer menu data: ${resp.statusText}`,
       );
     })
     .then(headerFooterData => {

--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -66,11 +66,10 @@ function activateHeaderFooter() {
   footerContainer.classList.add('consolidated');
 
   if (skipLink) {
-    document.body.insertBefore(headerContainer, skipLink.nextSibling);
-  } else {
-    document.body.insertBefore(headerContainer, document.body.firstChild);
+    skipLink.after(headerContainer);
+  } else if (document.body.firstChild) {
+    document.body.firstChild.before(headerContainer);
   }
-
   document.body.appendChild(footerContainer);
 }
 


### PR DESCRIPTION
## Description
Added logic to inject header after skiplink if it is present.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11085

## Testing done
local testing:
1. start up vets-website with yarn watch local-proxy-rewrite
2. navigate to http://localhost:3001/?target=https://www.va.gov/wholehealth/ to observe changes


## Screenshots
before: 
<img width="806" alt="Screen Shot 2022-10-12 at 11 50 24 AM" src="https://user-images.githubusercontent.com/61624970/195391032-aa5fa2cf-b4d9-470c-b215-e8901b85678f.png">

after:
<img width="806" alt="Screen Shot 2022-10-12 at 11 50 54 AM" src="https://user-images.githubusercontent.com/61624970/195391067-622bb050-ed22-4584-b8df-08d25f5508da.png">


## Acceptance criteria
- [ ] Header is injected after skiplink if present, otherwise at the top of body.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
