### PR TITLE
Comment out back to appointments link and tests

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -27,6 +27,8 @@ class ApiInitializer {
           emergencyContactEnabled: true,
           checkInExperiencePhoneAppointmentsEnabled: true,
           checkInExperienceLorotaSecurityUpdatesEnabled: false,
+          checkInExperienceLorotaDeletionEnabled: true,
+          checkInExperienceTravelReimbursement: false,
         }),
       );
     },
@@ -79,6 +81,7 @@ class ApiInitializer {
           checkInExperienceEnabled: true,
           preCheckInEnabled: true,
           emergencyContactEnabled: true,
+          checkInExperienceTravelReimbursement: true,
         }),
       );
     },

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -189,6 +189,7 @@ const CheckInConfirmation = props => {
         ) : (
           <TravelPayReimbursementLink />
         )}
+        {/* Commenting out temporarily see: https://github.com/department-of-veterans-affairs/va.gov-team/issues/48126 */}
         {/* <BackToAppointments appointments={appointments} /> */}
       </Wrapper>
     );

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -6,7 +6,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
-import BackToAppointments from '../../../components/BackToAppointments';
+// import BackToAppointments from '../../../components/BackToAppointments';
 import TravelPayReimbursementLink from '../../../components/TravelPayReimbursementLink';
 import Wrapper from '../../../components/layout/Wrapper';
 import AppointmentConfirmationListItem from '../../../components/AppointmentDisplay/AppointmentConfirmationListItem';
@@ -14,7 +14,11 @@ import useSendTravelPayClaim from '../../../hooks/useSendTravelPayClaim';
 import ExternalLink from '../../../components/ExternalLink';
 
 const CheckInConfirmation = props => {
-  const { appointments, selectedAppointment, triggerRefresh } = props;
+  const {
+    // appointments,
+    selectedAppointment,
+    triggerRefresh,
+  } = props;
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
   const featureToggles = useSelector(selectFeatureToggles);
@@ -185,7 +189,7 @@ const CheckInConfirmation = props => {
         ) : (
           <TravelPayReimbursementLink />
         )}
-        <BackToAppointments appointments={appointments} />
+        {/* <BackToAppointments appointments={appointments} /> */}
       </Wrapper>
     );
   };

--- a/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
@@ -52,10 +52,10 @@ describe('Check In Experience -- ', () => {
       Confirmation.validateBTSSSLink();
       cy.injectAxeThenAxeCheck();
     });
-    it('confirm back button', () => {
-      Confirmation.validateBackButton();
-      cy.injectAxeThenAxeCheck();
-    });
+    // it('confirm back button', () => {
+    //   Confirmation.validateBackButton();
+    //   cy.injectAxeThenAxeCheck();
+    // });
     it('refreshes appointment data when pressing the browser back button', () => {
       Confirmation.validatePageLoaded();
       cy.intercept(

--- a/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
@@ -95,13 +95,13 @@ describe('Check In Experience', () => {
         .its('response.statusCode')
         .should('equal', 200);
 
-      Confirmation.attemptGoBackToAppointments();
-      Appointments.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
+      // Confirmation.attemptGoBackToAppointments();
+      // Appointments.validatePageLoaded();
+      // cy.injectAxeThenAxeCheck();
 
-      Appointments.attemptCheckIn(3);
-      Confirmation.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
+      // Appointments.attemptCheckIn(3);
+      // Confirmation.validatePageLoaded();
+      // cy.injectAxeThenAxeCheck();
 
       // call should not occur a second time if first call was successful
       cy.get('@demographicsPatchSpy').then(spy => {
@@ -165,18 +165,18 @@ describe('Check In Experience', () => {
         .its('response.statusCode')
         .should('equal', 400);
 
-      Confirmation.attemptGoBackToAppointments();
-      Appointments.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
+      // Confirmation.attemptGoBackToAppointments();
+      // Appointments.validatePageLoaded();
+      // cy.injectAxeThenAxeCheck();
 
-      Appointments.attemptCheckIn(3);
-      Confirmation.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
+      // Appointments.attemptCheckIn(3);
+      // Confirmation.validatePageLoaded();
+      // cy.injectAxeThenAxeCheck();
 
-      cy.wait('@demographicsPatchFailureAlias');
-      cy.get('@demographicsPatchFailureAlias')
-        .its('response.statusCode')
-        .should('equal', 400);
+      // cy.wait('@demographicsPatchFailureAlias');
+      // cy.get('@demographicsPatchFailureAlias')
+      //   .its('response.statusCode')
+      //   .should('equal', 400);
     });
   });
   describe('All confirmation pages skipped', () => {

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
@@ -102,12 +102,12 @@ describe('Check In Experience', () => {
       Confirmation.validatePageLoadedWithBtsssSubmission();
       cy.injectAxeThenAxeCheck();
 
-      Confirmation.attemptGoBackToAppointments();
-      Appointments.validatePageLoaded();
-      Appointments.validateAppointmentLength(3);
-      // Validate that appointments are refreshed.
-      Appointments.validateAppointmentTime(3, '5:00 p.m.');
-      cy.injectAxeThenAxeCheck();
+      // Confirmation.attemptGoBackToAppointments();
+      // Appointments.validatePageLoaded();
+      // Appointments.validateAppointmentLength(3);
+      // // Validate that appointments are refreshed.
+      // Appointments.validateAppointmentTime(3, '5:00 p.m.');
+      // cy.injectAxeThenAxeCheck();
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -54,13 +54,13 @@ class Confirmation {
       .and('include.text', 'TRAVEL CLAIM ERROR PLACEHOLDER');
   };
 
-  validateBackButton = () => {
-    cy.get('[data-testid=go-to-appointments-button]', {
-      timeout: Timeouts.slow,
-    })
-      .should('be.visible')
-      .and('include.text', 'Go to another appointment');
-  };
+  // validateBackButton = () => {
+  //   cy.get('[data-testid=go-to-appointments-button]', {
+  //     timeout: Timeouts.slow,
+  //   })
+  //     .should('be.visible')
+  //     .and('include.text', 'Go to another appointment');
+  // };
 
   validateConfirmationAlert = () => {
     cy.get('[data-testid="confirmation-alert"]')


### PR DESCRIPTION
## Description

- Comments out the "Go back to appointments" link in the confirmation view. 
- Comments out related tests. 


## Original issue(s)
[department-of-veterans-affairs/va.gov-team#48126](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48126)


## Testing done

- Visual
- Cypress

## Screenshots

![Screen Shot 2022-10-12 at 4 38 24 PM](https://user-images.githubusercontent.com/2982977/195443178-1fa0d824-d3d9-4b0f-b9be-19f02596489f.png)

## Acceptance criteria
- [ ] The link is removed
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
