### PR TITLE
make cemetery note accessible through tab navigation

### DIFF
--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -99,11 +99,15 @@ export const sponsorMilitaryStatusDescription = (
 );
 
 export const desiredCemeteryNoteDescription = (
-  <va-alert status="info" background-only>
-    <strong>Please note:</strong> This doesn’t guarantee you’ll be buried in
-    your preferred cemetery. We’ll try to fulfill your wishes, but will assign a
-    gravesite in a cemetery with available space at the time of need.
-  </va-alert>
+  <va-additional-info
+    trigger="Learn more about why this doesn’t guarantee you’ll be buried in
+    your preferred cemetery"
+  >
+    <div>
+      We’ll try to fulfill your wishes, but will assign a gravesite in a
+      cemetery with available space at the time of need.
+    </div>
+  </va-additional-info>
 );
 
 export function isVeteran(item) {


### PR DESCRIPTION
## Description
This work makes the cemetery note accessible with tab navigation. It's an alternative solution to what's proposed in [another pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/22363).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47468


## Testing done
- MacOS/Chrome - Keyboard navigation
- MacOS/Chrome + VoiceOver

## Screenshots
![Screen Recording 2022-10-12 at 06 50 57 PM](https://user-images.githubusercontent.com/1094951/195462227-38739844-7953-402d-b10b-1078453d8700.gif)


## How to test

1. [Begin the pre need flow unsigned in ](https://localhost:3001/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/applicant-information)
2. Fill out the form to get to step 3
3. Note that the cemetery note below the Autosuggest uses `va-additional-info` instead of `va-alert`


## Acceptance criteria
- [x] Tests continue to pass
- [x] Cemetery note is accessible using tab navigation

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
