### PR TITLE
Sm search messages page

### DIFF
--- a/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
@@ -30,11 +30,8 @@ const LandingPageAuth = () => {
       dispatch(getTriageTeams());
       dispatch(getCategories());
       // landing page retrieves only Inbox messages.
-      dispatch(retrieveFolder(Folder.INBOX));
-      dispatch(getMessages(Folder.INBOX));
-      // dispatch(retrieveMessage(522265));
-      // dispatch(retrieveMessage(7178447));
-      // dispatch(retrieveFolder(0));
+      dispatch(retrieveFolder(Folder.INBOX.id));
+      dispatch(getMessages(Folder.INBOX.id));
     },
     [dispatch],
   );

--- a/src/applications/mhv/secure-messaging/containers/SearchMessages.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchMessages.jsx
@@ -1,24 +1,32 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import SearchForm from '../components/SearchForm';
 import SearchResults from '../components/SearchResults';
 import CondensedSearchForm from '../components/CondensedSearchForm';
 
 const Search = () => {
-  const queryParams = new URLSearchParams(window.location.search);
   const searchParams = {};
-  let advanced;
-  for (const [key, value] of queryParams.entries()) {
-    if (key === 'advanced') advanced = value;
-    else searchParams[key] = value;
-  }
+  const history = useHistory();
+  const location = useLocation();
 
-  const advancedSearchOpen = advanced && advanced === 'true';
+  const [advancedSearchOpen, setAdvancedSearchOpen] = useState(false);
   const searchRequested = !!Object.keys(searchParams).length;
 
   const toggleAdvancedSearchHandler = () => {
-    queryParams.append('advanced', 'true');
-    window.location.search = queryParams;
+    history.push('/search?advanced=true');
+    setAdvancedSearchOpen(true);
   };
+
+  useEffect(
+    () => {
+      if (location.search === '?advanced=true') {
+        setAdvancedSearchOpen(true);
+      } else {
+        setAdvancedSearchOpen(false);
+      }
+    },
+    [location.search],
+  );
 
   let pageTitle;
   let altAdvancedSearchToggle;

--- a/src/applications/mhv/secure-messaging/containers/SearchMessages.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchMessages.jsx
@@ -46,7 +46,10 @@ const Search = () => {
   } else if (searchRequested) pageTitle = 'Search results';
 
   return (
-    <div className="vads-l-grid-container search-messages">
+    <div
+      className="vads-l-grid-container search-messages"
+      data-testid="search-messages"
+    >
       <h1 className="page-title">{pageTitle}</h1>
 
       {searchRequested ? (

--- a/src/applications/mhv/secure-messaging/tests/containers/SearchMessages.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/SearchMessages.unit.spec.jsx
@@ -1,18 +1,22 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
+import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
 import SearchMessages from '../../containers/SearchMessages';
 
 describe('SearchMessages container', () => {
   it('should not be empty', () => {
-    const tree = SkinDeep.shallowRender(<SearchMessages />);
+    const screen = renderWithStoreAndRouter(<SearchMessages />, {
+      path: '/search',
+    });
 
-    expect(tree.subTree('.search-messages')).not.to.be.empty;
+    expect(screen.getByTestId('search-messages')).to.not.be.empty;
   });
 
   it('should contain an h1 element with page title', () => {
-    const tree = SkinDeep.shallowRender(<SearchMessages />);
+    const screen = renderWithStoreAndRouter(<SearchMessages />, {
+      path: '/search',
+    });
 
-    expect(tree.subTree('.page-title').text()).to.equal('Search messages');
+    expect(screen.findByText('Search messages')).to.exist;
   });
 });


### PR DESCRIPTION
## Description
When this page was built initially, the `Router` wasn't configured properly, preventing from using `useLocation` and `useHistory` hooks to switch between basic and advanced views. This fix includes native router navigation and url path handling. 
Additionally, minor bug fix on `Auth landing page` 

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
