### PR TITLE
Remove verify email fields from Caregivers application

### DIFF
--- a/src/applications/caregivers/config/chapters/primary/primaryContact.js
+++ b/src/applications/caregivers/config/chapters/primary/primaryContact.js
@@ -1,5 +1,4 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
-import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import {
   primaryCaregiverFields,
   emptyObjectSchema,
@@ -15,9 +14,9 @@ import {
 import { primaryInputLabel } from '../../../definitions/UIDefinitions/caregiverUI';
 import PrimaryCaregiverDescription from '../../../components/FormDescriptions/PrimaryCaregiverDescription';
 
+const { address } = fullSchema.definitions;
 const { primaryCaregiver } = fullSchema.properties;
 const primaryCaregiverProps = primaryCaregiver.properties;
-const { address } = fullSchema.definitions;
 
 const primaryContactInfoPage = {
   uiSchema: {
@@ -36,10 +35,6 @@ const primaryContactInfoPage = {
     ),
     [primaryCaregiverFields.emailEncouragementMessage]: emailEncouragementUI(),
     [primaryCaregiverFields.email]: emailUI(primaryInputLabel),
-    [primaryCaregiverFields.verifyEmail]: confirmationEmailUI(
-      primaryInputLabel,
-      primaryCaregiverFields.email,
-    ),
     [primaryCaregiverFields.vetRelationship]: vetRelationshipUI(
       primaryInputLabel,
     ),
@@ -65,7 +60,6 @@ const primaryContactInfoPage = {
         primaryCaregiverProps.alternativePhoneNumber,
       [primaryCaregiverFields.emailEncouragementMessage]: emptyObjectSchema,
       [primaryCaregiverFields.email]: primaryCaregiverProps.email,
-      [primaryCaregiverFields.verifyEmail]: primaryCaregiverProps.email,
       [primaryCaregiverFields.vetRelationship]:
         primaryCaregiverProps.vetRelationship,
     },

--- a/src/applications/caregivers/config/chapters/secondaryOne/secondaryCaregiverContact.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/secondaryCaregiverContact.js
@@ -1,5 +1,4 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
-import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import {
   secondaryOneFields,
   emptyObjectSchema,
@@ -19,9 +18,9 @@ import {
 } from '../../../definitions/UIDefinitions/caregiverUI';
 import SecondaryCaregiverDescription from '../../../components/FormDescriptions/SecondaryCaregiverDescription';
 
+const { address } = fullSchema.definitions;
 const { secondaryCaregiverOne } = fullSchema.properties;
 const secondaryCaregiverOneProps = secondaryCaregiverOne.properties;
-const { address } = fullSchema.definitions;
 
 const secondaryCaregiverContactPage = {
   uiSchema: {
@@ -41,10 +40,6 @@ const secondaryCaregiverContactPage = {
     ),
     [secondaryOneFields.emailEncouragementMessage]: emailEncouragementUI(),
     [secondaryOneFields.email]: emailUI(secondaryOneInputLabel),
-    [secondaryOneFields.verifyEmail]: confirmationEmailUI(
-      secondaryOneInputLabel,
-      secondaryOneFields.email,
-    ),
     [secondaryOneFields.vetRelationship]: vetRelationshipUI(
       secondaryOneInputLabel,
     ),
@@ -71,7 +66,6 @@ const secondaryCaregiverContactPage = {
         secondaryCaregiverOneProps.alternativePhoneNumber,
       [secondaryOneFields.emailEncouragementMessage]: emptyObjectSchema,
       [secondaryOneFields.email]: secondaryCaregiverOneProps.email,
-      [secondaryOneFields.verifyEmail]: secondaryCaregiverOneProps.email,
       [secondaryOneFields.vetRelationship]:
         secondaryCaregiverOneProps.vetRelationship,
       [secondaryOneFields.hasSecondaryCaregiverTwo]: {

--- a/src/applications/caregivers/config/chapters/secondaryTwo/secondaryTwoContactInfo.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/secondaryTwoContactInfo.js
@@ -1,5 +1,4 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
-import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import {
   secondaryTwoFields,
   emptyObjectSchema,
@@ -16,10 +15,9 @@ import {
 import { secondaryTwoInputLabel } from '../../../definitions/UIDefinitions/caregiverUI';
 import SecondaryCaregiverDescription from '../../../components/FormDescriptions/SecondaryCaregiverDescription';
 
+const { address } = fullSchema.definitions;
 const { secondaryCaregiverTwo } = fullSchema.properties;
 const secondaryCaregiverTwoProps = secondaryCaregiverTwo.properties;
-
-const { address } = fullSchema.definitions;
 
 const secondaryTwoContactPage = {
   uiSchema: {
@@ -39,10 +37,6 @@ const secondaryTwoContactPage = {
     ),
     [secondaryTwoFields.emailEncouragementMessage]: emailEncouragementUI(),
     [secondaryTwoFields.email]: emailUI(secondaryTwoInputLabel),
-    [secondaryTwoFields.verifyEmail]: confirmationEmailUI(
-      secondaryTwoInputLabel,
-      secondaryTwoFields.email,
-    ),
     [secondaryTwoFields.vetRelationship]: vetRelationshipUI(
       secondaryTwoInputLabel,
     ),
@@ -68,7 +62,6 @@ const secondaryTwoContactPage = {
         secondaryCaregiverTwoProps.alternativePhoneNumber,
       [secondaryTwoFields.emailEncouragementMessage]: emptyObjectSchema,
       [secondaryTwoFields.email]: secondaryCaregiverTwoProps.email,
-      [secondaryTwoFields.verifyEmail]: secondaryCaregiverTwoProps.email,
       [secondaryTwoFields.vetRelationship]:
         secondaryCaregiverTwoProps.vetRelationship,
     },

--- a/src/applications/caregivers/config/chapters/veteran/vetContactInfo.js
+++ b/src/applications/caregivers/config/chapters/veteran/vetContactInfo.js
@@ -1,5 +1,4 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
-import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import {
   veteranFields,
   emptyObjectSchema,
@@ -31,10 +30,6 @@ const vetContactInfoPage = {
     ),
     [veteranFields.emailEncouragementMessage]: emailEncouragementUI(),
     [veteranFields.email]: emailUI(vetInputLabel),
-    [veteranFields.verifyEmail]: confirmationEmailUI(
-      vetInputLabel,
-      veteranFields.email,
-    ),
   },
   schema: {
     type: 'object',
@@ -45,7 +40,6 @@ const vetContactInfoPage = {
       [veteranFields.alternativePhoneNumber]: phone,
       [veteranFields.emailEncouragementMessage]: emptyObjectSchema,
       [veteranFields.email]: veteranProps.email,
-      [veteranFields.verifyEmail]: veteranProps.email,
     },
   },
 };

--- a/src/applications/caregivers/definitions/constants.js
+++ b/src/applications/caregivers/definitions/constants.js
@@ -13,7 +13,6 @@ export const veteranFields = {
   previousTreatmentFacility: 'veteranLastTreatmentFacility',
   primaryPhoneNumber: 'veteranPrimaryPhoneNumber',
   ssn: 'veteranSsnOrTin',
-  verifyEmail: 'view:veteranEmail',
 };
 
 export const primaryCaregiverFields = {
@@ -27,7 +26,6 @@ export const primaryCaregiverFields = {
   hasSecondaryCaregiverOne: 'view:hasSecondaryCaregiverOne',
   primaryPhoneNumber: 'primaryPrimaryPhoneNumber',
   ssn: 'primarySsnOrTin',
-  verifyEmail: 'view:primaryEmail',
   vetRelationship: 'primaryVetRelationship',
   hasHealthInsurance: 'primaryHasHealthInsurance',
   hasPrimaryCaregiver: 'view:hasPrimaryCaregiver',
@@ -44,7 +42,6 @@ export const secondaryOneFields = {
   hasSecondaryCaregiverTwo: 'view:hasSecondaryCaregiverTwo',
   primaryPhoneNumber: 'secondaryOnePrimaryPhoneNumber',
   ssn: 'secondaryOneSsnOrTin',
-  verifyEmail: 'view:secondaryOneEmail',
   vetRelationship: 'secondaryOneVetRelationship',
 };
 
@@ -58,7 +55,6 @@ export const secondaryTwoFields = {
   gender: 'secondaryTwoGender',
   primaryPhoneNumber: 'secondaryTwoPrimaryPhoneNumber',
   ssn: 'secondaryTwoSsnOrTin',
-  verifyEmail: 'view:secondaryTwoEmail',
   vetRelationship: 'secondaryTwoVetRelationship',
 };
 

--- a/src/applications/caregivers/tests/e2e/fixtures/data/oneSecondaryCaregivers.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/oneSecondaryCaregivers.json
@@ -8,7 +8,6 @@
   },
   "secondaryOnePrimaryPhoneNumber": "8785485485",
   "secondaryOneEmail": "minimouse@disney.com",
-  "view:secondaryOneEmail": "minimouse@disney.com",
   "secondaryOneVetRelationship": "Friend/Neighbor",
   "view:hasSecondaryCaregiverTwo": false,
   "view:hasPrimaryCaregiver": true,

--- a/src/applications/caregivers/tests/e2e/fixtures/data/secondaryOneOnly.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/secondaryOneOnly.json
@@ -8,7 +8,6 @@
     },
     "secondaryOnePrimaryPhoneNumber": "8785485485",
     "secondaryOneEmail": "minimouse@disney.com",
-    "view:secondaryOneEmail": "minimouse@disney.com",
     "secondaryOneVetRelationship": "Friend/Neighbor",
     "view:hasSecondaryCaregiverTwo": false,
     "view:hasPrimaryCaregiver": false,

--- a/src/applications/caregivers/tests/e2e/fixtures/data/twoSecondaryCaregivers.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/twoSecondaryCaregivers.json
@@ -8,7 +8,6 @@
   },
   "secondaryTwoPrimaryPhoneNumber": "9872247857",
   "secondaryTwoEmail": "minimouse@disney.com",
-  "view:secondaryTwoEmail": "minimouse@disney.com",
   "view:hasPrimaryCaregiver": true,
   "secondaryTwoVetRelationship": "Relative - Other",
   "secondaryTwoFullName": {
@@ -27,7 +26,6 @@
   },
   "secondaryOnePrimaryPhoneNumber": "8785485485",
   "secondaryOneEmail": "minimouse@disney.com",
-  "view:secondaryOneEmail": "minimouse@disney.com",
   "secondaryOneVetRelationship": "Friend/Neighbor",
   "view:hasSecondaryCaregiverTwo": true,
   "secondaryOneFullName": {


### PR DESCRIPTION
## Description
The Forms Team has updated their patterns to move away from having an email confirmation field in cases that aren't related to the user creating an account. This PR removes all the verify email fields from the Caregivers application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46144

## Testing done
- [x] Cypress tests

## Acceptance criteria
- [ ] Email fields follow the proper pattern set by the Forms Team

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
