### PR TITLE
Remove verify email fields from Health care application

### DIFF
--- a/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
@@ -2,7 +2,6 @@ import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
-import { validateMatch } from 'platform/forms-system/src/js/validation';
 
 import { ShortFormAlert } from '../../../components/FormAlerts';
 import { ContactInfoDescription } from '../../../components/FormDescriptions';
@@ -26,9 +25,7 @@ export default {
     'view:contactInfoDescription': {
       'ui:description': ContactInfoDescription,
     },
-    'ui:validations': [validateMatch('email', 'view:emailConfirmation')],
     email: emailUI(),
-    'view:emailConfirmation': emailUI('Re-enter email address'),
     homePhone: phoneUI('Home telephone number'),
     mobilePhone: phoneUI('Mobile telephone number'),
   },
@@ -39,7 +36,6 @@ export default {
       'view:prefillMessage': emptyObjectSchema,
       'view:contactInfoDescription': emptyObjectSchema,
       email,
-      'view:emailConfirmation': email,
       homePhone: phone,
       mobilePhone: phone,
     },

--- a/src/applications/hca/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/hca/tests/config/veteranInformation.unit.spec.jsx
@@ -252,7 +252,7 @@ describe('HCA veteranInformation', () => {
     );
     const formDOM = findDOMNode(form);
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(4);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(3);
     expect(formDOM.querySelector('#root_email')).not.to.be.null;
   });
 });

--- a/src/applications/hca/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/hca/tests/e2e/fixtures/data/maximal-test.json
@@ -94,7 +94,6 @@
     "lastDischargeDate": "2005-02-01",
     "dischargeType": "general",
     "email": "test@test.com",
-    "view:emailConfirmation": "test@test.com",
     "homePhone": "5555555555",
     "mobilePhone": "4444444444",
     "veteranAddress": {

--- a/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
@@ -8,7 +8,6 @@ import mockUserAiq from './fixtures/mocks/mockUserAiq';
 import minTestData from './fixtures/data/minimal-test.json';
 import * as aiqHelpers from './helpers';
 
-const mockUserAttrs = mockUserAiq.data.attributes;
 const testData = minTestData.data;
 
 const disabilityRating = 90;
@@ -135,9 +134,6 @@ describe('HCA-Shortform-Authenticated-High-Disability', () => {
     aiqHelpers.shortFormAdditionalHelpAssertion();
 
     cy.wait('@mockSip');
-    cy.get('[name*="emailConfirmation"]')
-      .scrollIntoView()
-      .type(mockUserAttrs.profile.email);
 
     // medicaid
     aiqHelpers.goToNextPage('/insurance-information/medicaid');
@@ -259,9 +255,6 @@ describe('HCA-Shortform-Authenticated-Low-Disability', () => {
 
     aiqHelpers.goToNextPage('/veteran-information/contact-information');
     cy.wait('@mockSip');
-    cy.get('[name*="emailConfirmation"]')
-      .scrollIntoView()
-      .type(mockUserAttrs.profile.email);
 
     cy.injectAxe();
     cy.axeCheck();

--- a/src/applications/hca/tests/e2e/helpers.js
+++ b/src/applications/hca/tests/e2e/helpers.js
@@ -1,7 +1,5 @@
-import mockUserAiq from './fixtures/mocks/mockUserAiq';
 import minTestData from './fixtures/data/minimal-test.json';
 
-const mockUserAttrs = mockUserAiq.data.attributes;
 const testData = minTestData.data;
 
 export const goToNextPage = pagePath => {
@@ -41,9 +39,6 @@ export const advanceFromAiqToReviewPage = () => {
     .check('Y');
   goToNextPage('/veteran-information/contact-information');
   cy.wait('@mockSip');
-  cy.get('[name*="emailConfirmation"]')
-    .scrollIntoView()
-    .type(mockUserAttrs.profile.email);
   goToNextPage('/va-benefits/basic-information');
   cy.get('[name="root_vaCompensationType"]').check('none');
   goToNextPage('/va-benefits/pension-information');
@@ -105,9 +100,6 @@ export const advanceToServiceInfoPage = () => {
 
   goToNextPage('/veteran-information/contact-information');
   cy.wait('@mockSip');
-  cy.get('[name*="emailConfirmation"]')
-    .scrollIntoView()
-    .type(mockUserAttrs.profile.email);
 
   goToNextPage('/va-benefits/basic-information');
   cy.get('[name="root_vaCompensationType"]').check('none');


### PR DESCRIPTION
## Description
The Forms Team has updated their patterns to move away from having an email confirmation field in cases that aren't related to the user creating an account. This PR removes all the verify email fields from the Health care application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46144

## Testing done
- [x] Cypress tests

## Acceptance criteria
- [ ] Email fields follow the proper pattern set by the Forms Team

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
