### PR TITLE
reverts removal of AVA link on disclaimer page

### DIFF
--- a/src/applications/virtual-agent/components/page/Disclaimer.jsx
+++ b/src/applications/virtual-agent/components/page/Disclaimer.jsx
@@ -31,6 +31,9 @@ export default function Disclaimer() {
             </a>
           </li>
           <li>
+            <a href="https://ask.va.gov/">Contact us online through Ask VA</a>
+          </li>
+          <li>
             <a href="/resources/">Explore our resources and support content</a>
           </li>
         </ul>


### PR DESCRIPTION
## Description
Reverts previous edit to hide failing AVA. AVA is back up now.

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#648


## Testing done
manual

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
