### PR TITLE
fixes the format of infoToken parsing in formatInfoCookie

### DIFF
--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -233,10 +233,12 @@ export const formatInfoCookie = cookieStringRaw => {
     : cookieStringRaw;
   return decoded.split(',+:').reduce((obj, cookieString) => {
     const [key, value] = cookieString.replace(/{:|}/g, '').split('=>');
-    const preformattedValue = value
+    const formattedValue = value
       .replaceAll('++00:00', '')
-      .replaceAll('+', ' ');
-    const formattedValue = preformattedValue.replace(/,|\.\d+/g, '');
+      .replaceAll('+', ' ')
+      .replace(',', '')
+      .replace(/\.\d+/g, '');
+
     return { ...obj, [key]: new Date(formattedValue) };
   }, {});
 };

--- a/src/platform/utilities/oauth/utilities.js
+++ b/src/platform/utilities/oauth/utilities.js
@@ -233,7 +233,10 @@ export const formatInfoCookie = cookieStringRaw => {
     : cookieStringRaw;
   return decoded.split(',+:').reduce((obj, cookieString) => {
     const [key, value] = cookieString.replace(/{:|}/g, '').split('=>');
-    const formattedValue = value.replaceAll('++00:00', '').replaceAll('+', ' ');
+    const preformattedValue = value
+      .replaceAll('++00:00', '')
+      .replaceAll('+', ' ');
+    const formattedValue = preformattedValue.replace(/,|\.\d+/g, '');
     return { ...obj, [key]: new Date(formattedValue) };
   }, {});
 };


### PR DESCRIPTION
## Description
This PR standardizes the way the `new Date()` works across different browsers. There is a bug in Safari usage of `new Date()` in which it will return `Invalid Date` for unparsable dates (that work in Chrome & Firefox).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit

## Screenshots
n/a

## Acceptance criteria
- [x] The JS date never returns `Invalid Date`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
