### PR TITLE
[CST] Use feature toggle for claim letters page access

### DIFF
--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
 import startReactApp from 'platform/startup/react';
 import createCommonStore from 'platform/startup/store';
 import startSitewideComponents from 'platform/site-wide';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 
 import { setLastPage } from './actions';
 import ClaimsStatusApp from './containers/ClaimsStatusApp';
@@ -20,6 +21,7 @@ import reducer from './reducers';
 window.appName = manifest.entryName;
 
 const store = createCommonStore(reducer);
+connectFeatureToggle(store.dispatch);
 
 /* eslint-disable react-hooks/rules-of-hooks */
 const history = useRouterHistory(createHistory)({

--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -1,32 +1,53 @@
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import { getClaimLetters } from '../actions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import ClaimLetterList from '../components/ClaimLetterList';
+import { isLoadingFeatures, showClaimLettersFeature } from '../selectors';
 
-const YourClaimLetters = () => {
+export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
   const [letters, setLetters] = useState([]);
 
   useEffect(() => {
     getClaimLetters().then(data => {
       setLetters(data);
     });
-  });
+  }, []);
 
-  return (
-    <article id="claim-letters" className="row">
-      <div className="usa-width-two-thirds medium-8 columns">
-        <ClaimsBreadcrumbs />
-        <h1>Your VA claim letters</h1>
-        <div className="vads-u-font-size--lg vads-u-padding-bottom--1">
-          We send you letters to update you on the status of your claims,
-          appeals, and decision reviews. Download your claim letters on this
-          page.
+  if (isLoading) {
+    return <va-loading-indicator message="Loading application..." />;
+  }
+
+  if (showClaimLetters) {
+    return (
+      <article id="claim-letters" className="row">
+        <div className="usa-width-two-thirds medium-8 columns">
+          <ClaimsBreadcrumbs />
+          <h1>Your VA claim letters</h1>
+          <div className="vads-u-font-size--lg vads-u-padding-bottom--1">
+            We send you letters to update you on the status of your claims,
+            appeals, and decision reviews. Download your claim letters on this
+            page.
+          </div>
+          <ClaimLetterList letters={letters} />
         </div>
-        <ClaimLetterList letters={letters} />
-      </div>
-    </article>
-  );
+      </article>
+    );
+  }
+
+  return <></>;
 };
 
-export default YourClaimLetters;
+const mapStateToProps = state => ({
+  isLoading: isLoadingFeatures(state),
+  showClaimLetters: showClaimLettersFeature(state),
+});
+
+YourClaimLetters.propTypes = {
+  isLoading: PropTypes.bool,
+  showClaimLetters: PropTypes.bool,
+};
+
+export default connect(mapStateToProps)(YourClaimLetters);


### PR DESCRIPTION
## Description
Using feature toggle to gate access to the claim letters page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47953

## Acceptance criteria
- [x] Claim letters page is hidden when `claim-letters-access` flipper is disabled
- [x] Claim letters page is visible when `claim-letters-access` flipper is enabled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
