### PR TITLE
[docs] Update teamsite link for Charles Proxy

### DIFF
--- a/src/applications/proxy-rewrite/README.md
+++ b/src/applications/proxy-rewrite/README.md
@@ -40,7 +40,7 @@ http://localhost:3001/?target=https://www.va.gov/health/
 `https://www.va.gov/health/` should load, but with your local `proxy-rewrite` bundle injected into the page. You can confirm this by checking you network requests or by adding an `alert` into your bundle entry.
 
 ## Charles Proxy
-You can also use an application called Charles Proxy to map the `proxy-rewrite` bundles of TeamSite pages to your local machine. This way you can navigate directly to `https://www.va.gov/health/` and when the request for the production bundle of `proxy-rewrite` is sent, Charles will have overridden that file to instead be served locally. Instructions to set this up are located here, https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Teamsite.md.
+You can also use an application called Charles Proxy to map the `proxy-rewrite` bundles of TeamSite pages to your local machine. This way you can navigate directly to `https://www.va.gov/health/` and when the request for the production bundle of `proxy-rewrite` is sent, Charles will have overridden that file to instead be served locally. Instructions to set this up are located here, https://depo-platform-documentation.scrollhelp.site/developer-docs/charles-proxy-setup-for-teamsite.
 
 ## What To Do When The Test Fails
 - If needed, run `npm run vrt` locally


### PR DESCRIPTION
## Description
Docs linked to broken link in va.gov-team repo. Docs for Charles Proxy are now in DEPO docs on Plat website: https://depo-platform-documentation.scrollhelp.site/developer-docs/charles-proxy-setup-for-teamsite

## Original issue(s)
No issue.


## Testing done
n/a

## Screenshots


## Acceptance criteria
- [ ] na

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
