### PR TITLE
[MHV-336638] Adding Unit Tests for Message FAQ screen

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/containers/MessageFAQ.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/MessageFAQ.unit.spec.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import '@testing-library/react';
+import { expect } from 'chai';
+import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+
+import MessageFAQs from '../../containers/MessageFAQs';
+
+describe('Message FAQ container', () => {
+  const authUser = true;
+  const unAuthUser = false;
+
+  it('Contains `Messages FAQs` heading and unauthorized user component: `Sign in` to secure messages', () => {
+    const screen = renderWithStoreAndRouter(
+      <MessageFAQs isLoggedIn={unAuthUser} />,
+      {
+        path: '/faq',
+      },
+    );
+
+    expect(screen.findByText('Messages FAQs')).to.exist;
+    expect(screen.getByText('Sign in to send secure messages')).to.exist;
+  });
+
+  it('Loads FAQs component on authorized user screen', () => {
+    const screen = renderWithStoreAndRouter(
+      <MessageFAQs isLoggedIn={authUser} />,
+      {
+        path: '/faq',
+      },
+    );
+
+    const FAQs = screen.getByText('Frequently-asked questions');
+    expect(FAQs).to.exist;
+  });
+});


### PR DESCRIPTION
## Description

…Created starter/boilerplate unit tests for Message FAQ screen; checks for auth and unauth components.
**Note to dev: (As this screen progresses, continue to update with new unit tests.)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
https://vajira.max.gov/browse/MHV-33638

## Testing done

- [ ] 

## Screenshots
![Screenshot (177)](https://user-images.githubusercontent.com/59583325/196746711-5b5abdab-7310-4b61-bf1e-aae22e035da1.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
