### PR TITLE
table header padding on mobile adjusted

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-responsive-table.scss
+++ b/src/platform/site-wide/sass/modules/_m-responsive-table.scss
@@ -25,6 +25,7 @@
     th {
       border: none;
       display: block;
+      padding: 0;
     }
     td {
       padding-left: 0px;


### PR DESCRIPTION
## Description
Adjusted padding more new table row headers.  Paired with this PR: https://github.com/department-of-veterans-affairs/content-build/pull/1331

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10983)


## Testing done
Local visual testing

## Screenshots
<img width="1296" alt="Screen Shot 2022-10-17 at 2 15 56 PM" src="https://user-images.githubusercontent.com/61624970/196768998-ae890073-07d0-4cc7-8838-3c2f85e341df.png">
<img width="1296" alt="Screen Shot 2022-10-17 at 2 16 05 PM" src="https://user-images.githubusercontent.com/61624970/196769000-f878de4c-df41-4f56-a4dd-74c2f7cb5a1e.png">



## Acceptance criteria
- [ ] tables render the same as before only with each first element in a row is a table header

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
