### PR TITLE
[DLD] Adding link to claim letters page to claim details

### DIFF
--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -11,7 +11,7 @@ const ClaimsDecision = ({ completedDate }) => (
   <>
     <va-alert>
       <h3 className="claims-alert-header vads-u-font-size--h4" slot="headline">
-        {headerText(completedDate)}
+        {completedDate && headerText(completedDate)}
       </h3>
       <p>
         We finished reviewing your claim and a decision has been made. You can

--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -2,37 +2,36 @@ import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 
-const formatCompletedDate = completedDate =>
-  moment(completedDate).format('MMM D, YYYY');
+const formatDate = closedDate => moment(closedDate).format('MMMM D, YYYY');
 
-const completedDateText = completedDate =>
-  `We finished reviewing your claim on ${formatCompletedDate(completedDate)}.`;
+const headerText = closedDate =>
+  `We closed your claim on ${formatDate(closedDate)}`;
 
 const ClaimsDecision = ({ completedDate }) => (
-  <va-alert background-only>
-    <h3 className="claims-alert-header vads-u-font-size--h4">
-      Your claim decision is ready
-    </h3>
-    <p>
-      {completedDate ? (
-        <>
-          {completedDateText(completedDate)}
-          <br />
-          <br />
-        </>
-      ) : null}
-      You’ll receive a packet by mail that includes details of your claim
-      decision.
-      <br />
-      <br />
-      <strong>Note:</strong> Please allow 7 to 10 business days for your packet
-      to arrive before contacting us.
-      <br />
-      <br />
-      If you haven’t received your packet yet, you can check your claim decision
-      online.
-    </p>
-    <h4 className="claims-paragraph-header vads-u-font-size--h5">Next steps</h4>
+  <>
+    <va-alert>
+      <h3 className="claims-alert-header vads-u-font-size--h4" slot="headline">
+        {headerText(completedDate)}
+      </h3>
+      <p>
+        We finished reviewing your claim and a decision has been made. You can
+        find your decision letter in the claim letters page.
+      </p>
+      <p>
+        A decision packet will also be mailed to you. Typically, decision
+        notices are received within 10 days, but this is dependent upon U.S.
+        Postal Service timeframes.
+      </p>
+      <p>
+        <a
+          className="vads-c-action-link--blue"
+          href="/track-claims/your-claim-letters"
+        >
+          Get your claim letters
+        </a>
+      </p>
+    </va-alert>
+    <h4 className="claims-paragraph-header vads-u-font-size--h3">Next steps</h4>
     <p>
       <strong>If you agree with your claim decision</strong>, you don’t need to
       do anything else.
@@ -72,7 +71,7 @@ const ClaimsDecision = ({ completedDate }) => (
         Apply for VA health care benefits
       </a>
     </p>
-  </va-alert>
+  </>
 );
 
 ClaimsDecision.propTypes = {

--- a/src/applications/claims-status/components/WIP.jsx
+++ b/src/applications/claims-status/components/WIP.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const WIP = () => (
+  <va-alert status="warning">
+    <h1 slot="headline" className="vads-u-font-size--h3">
+      We’re still working on this feature
+    </h1>
+    <p>
+      We’re rolling out the VA Claim Letters page in stages. It’s not quite
+      ready yet. Please check back again soon.
+    </p>
+    <p>
+      <a
+        href="/track-claims/your-claims"
+        className="u-vads-display--block u-vads-margin-top--2"
+      >
+        Return to VA Claims and Appeals page
+      </a>
+    </p>
+  </va-alert>
+);
+
+export default WIP;

--- a/src/applications/claims-status/components/WIP.jsx
+++ b/src/applications/claims-status/components/WIP.jsx
@@ -10,10 +10,7 @@ const WIP = () => (
       ready yet. Please check back again soon.
     </p>
     <p>
-      <a
-        href="/track-claims/your-claims"
-        className="u-vads-display--block u-vads-margin-top--2"
-      >
+      <a href="/track-claims/your-claims">
         Return to VA Claims and Appeals page
       </a>
     </p>

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -46,7 +46,7 @@ export default function ClaimsListItem({ claim }) {
             We sent you a development letter
           </li>
         ) : null}
-        {!claim.attributes.decisionLetterSent && (
+        {claim.attributes.decisionLetterSent && (
           <li className="claim-list-item-text">
             <i className="fa fa-envelope claim-list-item-icon" />
             You have a decision letter ready

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -46,12 +46,12 @@ export default function ClaimsListItem({ claim }) {
             We sent you a development letter
           </li>
         ) : null}
-        {claim.attributes.decisionLetterSent ? (
+        {!claim.attributes.decisionLetterSent && (
           <li className="claim-list-item-text">
             <i className="fa fa-envelope claim-list-item-icon" />
-            We sent you a decision letter
+            You have a decision letter ready
           </li>
-        ) : null}
+        )}
         {inProgress && claim.attributes.documentsNeeded ? (
           <li className="claim-list-item-text">
             <i className="fa fa-exclamation-triangle claim-list-item-icon" />

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -13,7 +13,7 @@ function AppContent({ children, isDataAvailable }) {
   return (
     <div className="claims-status-content">
       {!canUseApp && <ClaimsAppealsUnavailable />}
-      {canUseApp && <div>{children}</div>}
+      {canUseApp && <>{children}</>}
     </div>
   );
 }

--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 
 import { getClaimLetters } from '../actions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import ClaimLetterList from '../components/ClaimLetterList';
+import WIP from '../components/WIP';
 import { isLoadingFeatures, showClaimLettersFeature } from '../selectors';
 
 export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
@@ -20,24 +22,36 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
     return <va-loading-indicator message="Loading application..." />;
   }
 
+  let content;
+
   if (showClaimLetters) {
-    return (
-      <article id="claim-letters" className="row">
-        <div className="usa-width-two-thirds medium-8 columns">
-          <ClaimsBreadcrumbs />
-          <h1>Your VA claim letters</h1>
-          <div className="vads-u-font-size--lg vads-u-padding-bottom--1">
-            We send you letters to update you on the status of your claims,
-            appeals, and decision reviews. Download your claim letters on this
-            page.
-          </div>
-          <ClaimLetterList letters={letters} />
+    content = (
+      <>
+        <h1>Your VA claim letters</h1>
+        <div className="vads-u-font-size--lg vads-u-padding-bottom--1">
+          We send you letters to update you on the status of your claims,
+          appeals, and decision reviews. Download your claim letters on this
+          page.
         </div>
-      </article>
+        <ClaimLetterList letters={letters} />
+      </>
     );
+  } else {
+    content = <WIP />;
   }
 
-  return <></>;
+  return (
+    <article id="claim-letters" className="row vads-u-margin-bottom--5">
+      <div className="usa-width-two-thirds medium-8 columns">
+        <ClaimsBreadcrumbs>
+          <Link to="your-claim-letters" key="your-claim-letters">
+            Your VA claim letters
+          </Link>
+        </ClaimsBreadcrumbs>
+        {content}
+      </div>
+    </article>
+  );
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -6,12 +6,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
 
-@media (min-width: $medium-large-screen) {
-  #claim-letters {
-    margin-bottom: 8em;
-  }
-}
-
 .claim-list {
   margin-bottom: 2em;
 }

--- a/src/applications/claims-status/tests/components/ClaimsDecision.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsDecision.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('<ClaimsDecision>', () => {
       <ClaimsDecision completedDate={date} />,
     );
 
-    expect(tree.text()).not.to.contain('We finished reviewing your claim');
+    expect(tree.text()).not.to.contain('We closed your claim on');
   });
   it('should render message with date sentence', () => {
     const date = '2010-03-01';
@@ -19,7 +19,6 @@ describe('<ClaimsDecision>', () => {
       <ClaimsDecision completedDate={date} />,
     );
 
-    expect(tree.text()).to.contain('We finished reviewing your claim');
-    expect(tree.text()).to.contain('March 1, 2010');
+    expect(tree.text()).to.contain('We closed your claim on March 1, 2010');
   });
 });

--- a/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('<ClaimsListItemV2>', () => {
     };
     const tree = shallow(<ClaimsListItemV2 claim={claim} />);
     expect(tree.find('.communications').text()).to.contain(
-      'We sent you a decision letter',
+      'You have a decision letter ready',
     );
     tree.unmount();
   });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -104,7 +104,7 @@ class TrackClaimsPage {
     cy.get('.main va-alert')
       .should('be.visible')
       .then(alertElem => {
-        cy.wrap(alertElem).should('contain', 'Your claim decision is ready');
+        cy.wrap(alertElem).should('contain', 'We closed your claim on');
       });
 
     cy.get('.disability-benefits-timeline').should('not.exist');

--- a/src/applications/lgy/coe/shared/components/WIP.jsx
+++ b/src/applications/lgy/coe/shared/components/WIP.jsx
@@ -12,10 +12,7 @@ export const WIP = () => (
           stages. It’s not quite ready yet. Please check back again soon.
         </p>
         <p>
-          <a
-            href="/housing-assistance/home-loans/"
-            className="u-vads-display--block u-vads-margin-top--2"
-          >
+          <a href="/housing-assistance/home-loans/">
             Return to VA-backed Veterans home loans information page
           </a>
         </p>


### PR DESCRIPTION
## Description
* Add link to claim letters page to closed claim details
* Add WIP component to claim letters page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47953

## Screenshots
<details><summary>Claim Letters link</summary>

![Screen Shot 2022-10-19 at 1 20 26 PM](https://user-images.githubusercontent.com/13838621/196773213-98686e45-4bc1-4906-b674-1919b2c62397.png)
</details>
<details><summary>WIP Component</summary>

![Screen Shot 2022-10-19 at 1 17 08 PM](https://user-images.githubusercontent.com/13838621/196772434-32a71e9c-9dda-4612-9798-4b5503a9e1cb.png)
</details>

## Acceptance criteria
- [x] Link to claim letters is present when viewing the details for a closed claim that has a decision letter sent
- [x] WIP component is visible on claim letters page when feature toggle is disabled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
