### PR TITLE
Claims notification has title now

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -30,7 +30,6 @@ import {
   DowntimeNotification,
   externalServices,
 } from '~/platform/monitoring/DowntimeNotification';
-import externalServiceStatus from '~/platform/monitoring/DowntimeNotification/config/externalServiceStatus';
 
 import NameTag from '~/applications/personalization/components/NameTag';
 import MPIConnectionError from '~/applications/personalization/components/MPIConnectionError';
@@ -52,31 +51,7 @@ import DashboardWidgetWrapper from './DashboardWidgetWrapper';
 import { getAllPayments } from '../actions/payments';
 import Notifications from './notifications/Notifications';
 import { canAccess } from '../selectors';
-
-const renderWidgetDowntimeNotification = (downtime, children) => {
-  if (downtime.status === externalServiceStatus.down) {
-    return (
-      <div className="vads-l-row">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3">
-          <va-alert status="error">
-            <h2 slot="headline">
-              We can’t access any claims or appeals information right now
-            </h2>
-            <div>
-              <p>
-                We’re sorry. We’re working to fix some problems with the claims
-                or appeals tool right now and cannot display your information on
-                this page. Please check back after{' '}
-                {downtime.endTime.format('MMMM D [at] LT')}
-              </p>
-            </div>
-          </va-alert>
-        </div>
-      </div>
-    );
-  }
-  return children;
-};
+import { RenderClaimsWidgetDowntimeNotification } from './RenderWidgetDowntimeNotification';
 
 const DashboardHeader = ({ showNotifications, paymentsError }) => {
   return (
@@ -262,7 +237,7 @@ const Dashboard = ({
                     externalServices.mhv,
                     externalServices.appeals,
                   ]}
-                  render={renderWidgetDowntimeNotification}
+                  render={RenderClaimsWidgetDowntimeNotification}
                 >
                   <ClaimsAndAppeals />
                 </DowntimeNotification>
@@ -274,7 +249,7 @@ const Dashboard = ({
                     externalServices.mhv,
                     externalServices.appeals,
                   ]}
-                  render={renderWidgetDowntimeNotification}
+                  render={RenderClaimsWidgetDowntimeNotification}
                 >
                   <ClaimsAndAppealsV2 />
                 </DowntimeNotification>

--- a/src/applications/personalization/dashboard/components/RenderWidgetDowntimeNotification.jsx
+++ b/src/applications/personalization/dashboard/components/RenderWidgetDowntimeNotification.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import externalServiceStatus from '~/platform/monitoring/DowntimeNotification/config/externalServiceStatus';
+import DashboardWidgetWrapper from './DashboardWidgetWrapper';
+
+export const RenderClaimsWidgetDowntimeNotification = (downtime, children) => {
+  if (downtime.status === externalServiceStatus.down) {
+    return (
+      <div
+        className="vads-u-margin-y--6"
+        data-testid="dashboard-section-claims-and-appeals-loader-v2"
+      >
+        <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
+          Claims and appeals
+        </h2>
+        <div className="vads-l-row">
+          <DashboardWidgetWrapper>
+            <div className="vads-u-margin-bottom--2p5">
+              <va-alert status="error">
+                <h2 slot="headline">
+                  We can’t access any claims or appeals information right now
+                </h2>
+                <div>
+                  <p>
+                    We’re sorry. We’re working to fix some problems with the
+                    claims or appeals tool right now and cannot display your
+                    information on this page. Please check back after{' '}
+                    {downtime.endTime.format('MMMM D [at] LT')}
+                  </p>
+                </div>
+              </va-alert>
+            </div>
+          </DashboardWidgetWrapper>
+        </div>
+      </div>
+    );
+  }
+  return children;
+};


### PR DESCRIPTION
## Description
Claims downtime notification did not have a title for the section and looked very strange for the user if there was a notification

## Testing done
manual testing done and e2e tests pass

## Screenshots
![Screenshot 2022-10-19 203311](https://user-images.githubusercontent.com/84803567/196830194-a8ceddc5-9e77-4984-b02e-c0825c26f821.png)