### PR TITLE
Store feature toggles in session storage

### DIFF
--- a/config/cypress.config.js
+++ b/config/cypress.config.js
@@ -192,6 +192,7 @@ const cypressConfig = {
     baseUrl: 'http://localhost:3001',
     specPattern: 'src/**/tests/**/*.cypress.spec.js?(x)',
     supportFile: 'src/platform/testing/e2e/cypress/support/index.js',
+    experimentalSessionAndOrigin: true,
   },
 };
 

--- a/src/applications/coronavirus-research/sign-up/tests/reviewAndSubmit.cypress.spec.js
+++ b/src/applications/coronavirus-research/sign-up/tests/reviewAndSubmit.cypress.spec.js
@@ -3,17 +3,15 @@ import featureTogglesEnabled from './fixtures/toggle-covid-feature.json';
 
 describe('COVID-19 Research Form', () => {
   describe('when entering valid information and submitting the sign up form', () => {
-    before(() => {
+    beforeEach(() => {
       cy.intercept('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
         'feature',
       );
+      cy.visit('coronavirus-research/volunteer/sign-up');
     });
 
-    before(() => {
-      cy.visit('coronavirus-research/volunteer/sign-up');
-      cy.injectAxe();
-    });
     it('should load form page', () => {
+      cy.injectAxe();
       cy.url().should('include', 'coronavirus-research/volunteer/sign-up');
       cy.axeCheck();
       cy.get('h1').contains(

--- a/src/applications/coronavirus-research/sign-up/tests/reviewAndSubmit.cypress.spec.js
+++ b/src/applications/coronavirus-research/sign-up/tests/reviewAndSubmit.cypress.spec.js
@@ -8,10 +8,10 @@ describe('COVID-19 Research Form', () => {
         'feature',
       );
       cy.visit('coronavirus-research/volunteer/sign-up');
+      cy.injectAxe();
     });
 
     it('should load form page', () => {
-      cy.injectAxe();
       cy.url().should('include', 'coronavirus-research/volunteer/sign-up');
       cy.axeCheck();
       cy.get('h1').contains(

--- a/src/applications/coronavirus-research/update/tests/reviewAndSubmitUpdate.cypress.spec.js
+++ b/src/applications/coronavirus-research/update/tests/reviewAndSubmitUpdate.cypress.spec.js
@@ -3,16 +3,14 @@ import featureTogglesEnabled from './fixtures/toggle-covid-feature.json';
 
 describe('COVID-19 Research Form', () => {
   describe('when entering valid information and submitting', () => {
-    before(() => {
+    beforeEach(() => {
       cy.intercept('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
         'feature',
       );
-    });
-
-    before(() => {
       cy.visit('coronavirus-research/volunteer/update/update-form?id=abc123');
       cy.injectAxe();
     });
+
     // Skipping tests until routing is in place
     it('should load form page', () => {
       cy.url().should('include', 'coronavirus-research/volunteer/update');

--- a/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
+++ b/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
@@ -14,11 +14,11 @@ describe(manifest.appName, () => {
       },
     };
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
+    cy.visit(manifest.rootUrl);
+    cy.injectAxe();
   });
 
   it('is accessible', () => {
-    cy.visit(manifest.rootUrl);
-    cy.injectAxe();
     cy.axeCheck();
 
     cy.url().should(
@@ -35,7 +35,6 @@ describe(manifest.appName, () => {
     });
     // Tests that login modal appears after clicking
     cy.get('#signin-signup-modal').should('be.visible');
-    cy.injectAxe();
     cy.axeCheck();
 
     cy.get('.va-modal-close').click({

--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -5,6 +5,7 @@ import { getFlipperId } from './helpers';
 const FLIPPER_ID = getFlipperId();
 const TOGGLE_VALUES_PATH = `/v0/feature_toggles?&cookie_id=${FLIPPER_ID}`;
 const TOGGLE_POLLING_INTERVAL = 5000;
+const TOGGLE_STORAGE_KEY = 'featureToggles';
 
 let flipperClientInstance;
 
@@ -71,15 +72,14 @@ function FlipperClient({
       }
       */
     let data;
+    const featureToggles = sessionStorage.getItem(TOGGLE_STORAGE_KEY);
 
-    if (sessionStorage.getItem('vaFeatureToggles')) {
-      const dataFromStorage = sessionStorage.getItem('vaFeatureToggles');
-      data = JSON.parse(dataFromStorage);
+    if (featureToggles) {
+      data = JSON.parse(featureToggles);
     } else {
       const response = await _fetchToggleValues();
       data = response.data;
-      const saveData = JSON.stringify(data);
-      sessionStorage.setItem('vaFeatureToggles', saveData);
+      sessionStorage.setItem(TOGGLE_STORAGE_KEY, JSON.stringify(data));
     }
 
     const { features = [] } = data;

--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -69,9 +69,19 @@ function FlipperClient({
             }
           ]
       }
+      */
+    let data;
+
+    if (sessionStorage.getItem('vaFeatureToggles')) {
+      const dataFromStorage = sessionStorage.getItem('vaFeatureToggles');
+      data = JSON.parse(dataFromStorage);
+    } else {
+      const response = await _fetchToggleValues();
+      data = response.data;
+      const saveData = JSON.stringify(data);
+      sessionStorage.setItem('vaFeatureToggles', saveData);
     }
-    */
-    const { data } = await _fetchToggleValues();
+
     const { features = [] } = data;
     return features.reduce((acc, toggle) => {
       acc[toggle.name] = toggle.value;


### PR DESCRIPTION
## Description
Stores feature toggles in session storage to reduce API calls.

As a result of storing feature toggles in session storage, some Cypress tests failed due to expecting a mock call to the feature toggle endpoint. Enabling the experimental feature [experimentalSessionAndOrigin](https://docs.cypress.io/api/commands/session#Syntax) resolved most of the test failures. This feature clears the page before each test along with all active session data. This behavior will be the default in a future major Cypress update. A few test suites needed to be refactored to visit the URL before each test in order to work with the experimental feature turned on.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48374


## Testing done
Tested locally and in CI.

## Acceptance criteria
- [x] Feature toggle values are stored in sessionStorage once fetched.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
