### PR TITLE
Update vets-json-schema for 1010CG maxLength changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7c1e7fb2acb8e972535d8dcd251bf41cc8ef9608"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3f470a2f3e595b3466caeeeab80ce1b22b9c8c52"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19599,9 +19599,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#7c1e7fb2acb8e972535d8dcd251bf41cc8ef9608":
-  version "20.20.14"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7c1e7fb2acb8e972535d8dcd251bf41cc8ef9608"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#3f470a2f3e595b3466caeeeab80ce1b22b9c8c52":
+  version "20.22.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3f470a2f3e595b3466caeeeab80ce1b22b9c8c52"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
We recently learned our downstream system has maximum character length values for multiple fields in the 10-10CG Caregiver application that are different from those we have in the form schema. This PR bumps the vets-json-schema library to the latest version that includes the updates for these values.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48366

## Acceptance criteria
- [ ] Library is set to pull the latest version

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
