### PR TITLE
CustomPage enhancements

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -180,6 +180,10 @@ class FormPage extends React.Component {
             goBack={this.goBack}
             goForward={this.onSubmit}
             goToPath={this.goToPath}
+            setFormData={this.props.setData}
+            formContext={formContext}
+            contentBeforeButtons={contentBeforeButtons}
+            contentAfterButtons={contentAfterButtons}
           />
         </div>
       );
@@ -230,12 +234,30 @@ const mapDispatchToProps = {
 
 FormPage.propTypes = {
   form: PropTypes.object.isRequired,
+  appStateData: PropTypes.shape({}),
+  blockScrollOnMount: PropTypes.bool,
+  contentAfterButtons: PropTypes.element,
+  contentBeforeButtons: PropTypes.element,
+  formContext: PropTypes.shape({
+    onReviewPage: PropTypes.bool,
+  }),
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+  params: PropTypes.shape({
+    index: PropTypes.number, // for testing only?
+  }),
   route: PropTypes.shape({
     pageConfig: PropTypes.shape({
+      arrayPath: PropTypes.string,
+      CustomPage: PropTypes.element,
+      onContinue: PropTypes.func,
+      pageClass: PropTypes.string,
       pageKey: PropTypes.string.isRequired,
       schema: PropTypes.object.isRequired,
+      showPagePerItem: PropTypes.bool,
+      title: PropTypes.string,
       uiSchema: PropTypes.object.isRequired,
-      onContinue: PropTypes.func,
       updateFormData: PropTypes.func,
     }),
     pageList: PropTypes.arrayOf(
@@ -244,9 +266,11 @@ FormPage.propTypes = {
       }),
     ),
   }),
-  contentBeforeButtons: PropTypes.element,
-  contentAfterButtons: PropTypes.element,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
   setData: PropTypes.func,
+  uploadFile: PropTypes.func,
 };
 
 export default withRouter(

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -181,7 +181,6 @@ class FormPage extends React.Component {
             goForward={this.onSubmit}
             goToPath={this.goToPath}
             setFormData={this.props.setData}
-            formContext={formContext}
             contentBeforeButtons={contentBeforeButtons}
             contentAfterButtons={contentAfterButtons}
           />

--- a/src/platform/forms-system/src/js/routing.js
+++ b/src/platform/forms-system/src/js/routing.js
@@ -41,7 +41,7 @@ export function getPreviousPagePath(pageList, data, pathname) {
  */
 export function checkValidPagePath(pageList, data, pathname) {
   // ignore search parameters for custom pages goToPath
-  const name = pathname.split('?')[0];
+  const name = (pathname || '').split('?')[0];
   return getActiveExpandedPages(pageList, data).some(
     page => page.path === name,
   );

--- a/src/platform/forms-system/src/js/routing.js
+++ b/src/platform/forms-system/src/js/routing.js
@@ -40,8 +40,10 @@ export function getPreviousPagePath(pageList, data, pathname) {
  * @returns {Boolean}
  */
 export function checkValidPagePath(pageList, data, pathname) {
+  // ignore search parameters for custom pages goToPath
+  const name = pathname.split('?')[0];
   return getActiveExpandedPages(pageList, data).some(
-    page => page.path === pathname,
+    page => page.path === name,
   );
 }
 

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -477,7 +477,6 @@ describe('Schemaform <FormPage>', () => {
 
     it('should render a custom component instead of SchemaForm', () => {
       const CustomPage = () => <div>Hello, world!</div>;
-      const formContext = { onReviewPage: false };
       const contentBeforeButtons = 'before';
       const contentAfterButtons = 'after';
       const tree = SkinDeep.shallowRender(
@@ -485,7 +484,6 @@ describe('Schemaform <FormPage>', () => {
           form={makeBypassForm(CustomPage)()}
           route={makeBypassRoute(CustomPage)()}
           location={location}
-          formContext={formContext}
           contentBeforeButtons={contentBeforeButtons}
           contentAfterButtons={contentAfterButtons}
         />,
@@ -494,7 +492,6 @@ describe('Schemaform <FormPage>', () => {
       expect(tree.everySubTree('SchemaForm')).to.be.empty;
       expect(tree.everySubTree('CustomPage')).not.to.be.empty;
       const { props } = tree.everySubTree('CustomPage')[0].getRenderOutput();
-      expect(props.formContext).to.deep.equal(formContext);
       expect(props.contentBeforeButtons).to.equal(contentBeforeButtons);
       expect(props.contentAfterButtons).to.equal(contentAfterButtons);
     });

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -173,7 +173,7 @@ describe('Schemaform <FormPage>', () => {
             type="button"
             onClick={e => {
               e.preventDefault();
-              goToPath('/testing');
+              goToPath('/testing?index=3');
             }}
           >
             go
@@ -192,7 +192,7 @@ describe('Schemaform <FormPage>', () => {
     );
 
     fireEvent.click(getByText(/go/));
-    expect(router.push.calledWith('/testing')).to.be.true;
+    expect(router.push.calledWith('/testing?index=3')).to.be.true;
   });
   it('should go back to the previous page if the custom path is invalid', () => {
     const router = {
@@ -477,16 +477,26 @@ describe('Schemaform <FormPage>', () => {
 
     it('should render a custom component instead of SchemaForm', () => {
       const CustomPage = () => <div>Hello, world!</div>;
+      const formContext = { onReviewPage: false };
+      const contentBeforeButtons = 'before';
+      const contentAfterButtons = 'after';
       const tree = SkinDeep.shallowRender(
         <FormPage
           form={makeBypassForm(CustomPage)()}
           route={makeBypassRoute(CustomPage)()}
           location={location}
+          formContext={formContext}
+          contentBeforeButtons={contentBeforeButtons}
+          contentAfterButtons={contentAfterButtons}
         />,
       );
 
       expect(tree.everySubTree('SchemaForm')).to.be.empty;
       expect(tree.everySubTree('CustomPage')).not.to.be.empty;
+      const { props } = tree.everySubTree('CustomPage')[0].getRenderOutput();
+      expect(props.formContext).to.deep.equal(formContext);
+      expect(props.contentBeforeButtons).to.equal(contentBeforeButtons);
+      expect(props.contentAfterButtons).to.equal(contentAfterButtons);
     });
 
     it('should return the entire form data to the CustomPage when showPagePerIndex is true', () => {

--- a/src/platform/forms-system/test/js/routing.unit.spec.js
+++ b/src/platform/forms-system/test/js/routing.unit.spec.js
@@ -177,6 +177,22 @@ describe('Schemaform routing', () => {
       };
       expect(checkValidPagePath(pageList, data, pathname)).to.be.true;
     });
+    it('should return true for paths with a search parameter', () => {
+      const pageList = getPageList();
+      const pathname = '/testing/last-page?index=3';
+      const data = {
+        arrayProp: [{}],
+      };
+      expect(checkValidPagePath(pageList, data, pathname)).to.be.true;
+    });
+    it('should return false for undefined or empty paths', () => {
+      const pageList = getPageList();
+      const data = {
+        arrayProp: [{}],
+      };
+      expect(checkValidPagePath(pageList, data)).to.be.false;
+      expect(checkValidPagePath(pageList, data, '')).to.be.false;
+    });
     it('should return false for paths that are conditionally not met', () => {
       const pathname = '/testing/0/conditional-page';
       const data = {


### PR DESCRIPTION
## Description

This PR updates the `FormPage` to provide additional parameters to the `CustomPage` component:
- `contentBeforeButtons` - this includes the "Finish this application later" link to be rendered above the navigation buttons
- `contentAfterButtons` - this includes the save status alert showing that any changes have been auto-saved
- `setFormData` - set form data action with the addition of saving the in progress data and updating the save status message
- Updated and organized prop types section

Within the `routing.js` file, the `checkValidPagePath` function was updated to ignore any search parameters within the path. In our case, we're navigating over several custom pages but we need to maintain an index (but we're not using the built-in `pagePerItemIndex` because the array is being dynamically built, and not pre-populated. From my experience with the form system, the `pagePerItemIndex` has been used in form 526 to ask follow up questions in an already existing array of items.

## Original issue(s)

[#48163](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48163)

## Testing done

Added unit tests

## Screenshots

Custom page with before & after content rendered - note the use of `va-button` makes the back & continue buttons narrower than the form progress buttons

<img width="562" alt="Finish this application later & save-in-progress menu shown above narrower back & continue buttons, with a your application has been saved alert message below the buttons" src="https://user-images.githubusercontent.com/136959/196968001-2e636b5e-8177-4886-8a04-ea940f71675f.png">

<details><summary>Typical FormPage navigation section</summary>

<img width="558" alt="Finish this application later & save-in-progress menu shown above typical-sized back & continue buttons, with a your application has been saved alert message below the buttons" src="https://user-images.githubusercontent.com/136959/196969368-eb5c35c8-d9ea-4747-a684-9dc75e6687b7.png"></details>

## Acceptance criteria
- [x] CustomPage receives save in progress link, status and autosaving set form data properties
- [x] Page path validation ignores search parameters
- [x] Additional unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable - see [#48526](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48526)
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
