### PR TITLE
update address variable setting to avoid invalid validation

### DIFF
--- a/src/applications/toe/helpers.jsx
+++ b/src/applications/toe/helpers.jsx
@@ -130,26 +130,36 @@ export function prefillTransformer(pages, formData, metadata, state) {
   const profile = stateUser?.profile;
   const vet360ContactInfo = stateUser.vet360ContactInformation;
 
-  const userAddressLine1 =
-    profile?.addressLine1 ||
-    vet360ContactInfo?.addressLine1 ||
-    contactInfo?.addressLine1;
-  const userAddressLine2 =
-    profile?.addressLine2 ||
-    vet360ContactInfo?.addressLine2 ||
-    contactInfo?.addressLine2;
-  const userCity =
-    profile?.city || vet360ContactInfo?.city || contactInfo?.city;
-  const userState =
-    profile?.stateCode ||
-    vet360ContactInfo?.stateCode ||
-    contactInfo?.stateCode;
-  const userPostalCode =
-    profile?.zipcode || vet360ContactInfo?.zipcode || contactInfo?.zipcode;
-  const userCountryCode =
-    profile?.countryCode ||
-    vet360ContactInfo?.countryCode ||
-    contactInfo?.countryCode;
+  let userAddressLine1;
+  let userAddressLine2;
+  let userCity;
+  let userState;
+  let userPostalCode;
+  let userCountryCode;
+
+  if (profile?.addressLine1) {
+    userAddressLine1 = profile?.addressLine1;
+    userAddressLine2 = profile?.addressLine2;
+    userCity = profile?.city;
+    userState = profile?.stateCode;
+    userPostalCode = profile?.zipCode;
+    userCountryCode = profile?.countryCode;
+  } else if (vet360ContactInfo?.addressLine1) {
+    userAddressLine1 = vet360ContactInfo?.addressLine1;
+    userAddressLine2 = vet360ContactInfo?.addressLine2;
+    userCity = vet360ContactInfo?.city;
+    userState = vet360ContactInfo?.stateCode;
+    userPostalCode = vet360ContactInfo?.zipCode;
+    userCountryCode = vet360ContactInfo?.countryCode;
+  } else {
+    userAddressLine1 = contactInfo?.addressLine1;
+    userAddressLine2 = contactInfo?.addressLine2;
+    userCity = contactInfo?.city;
+    userState = contactInfo?.stateCode;
+    userPostalCode = contactInfo?.zipCode;
+    userCountryCode = contactInfo?.countryCode;
+  }
+
   const emailAddress =
     profile?.email ||
     vet360ContactInfo?.email?.emailAddress ||
@@ -234,7 +244,7 @@ export function prefillTransformer(pages, formData, metadata, state) {
     [formFields.viewMailingAddress]: {
       [formFields.address]: {
         street: userAddressLine1,
-        street2: userAddressLine2,
+        street2: userAddressLine2 || undefined,
         city: userCity,
         state: userState,
         postalCode: userPostalCode,


### PR DESCRIPTION
## Description
Update the way address variables are assigned so it uses all of a data source or none of it and account for address line 2 being an empty string so it doesn't fire a validation error in the ui.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
