### PR TITLE
[DLD] Adding loading indicator

### DIFF
--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -11,10 +11,12 @@ import { isLoadingFeatures, showClaimLettersFeature } from '../selectors';
 
 export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
   const [letters, setLetters] = useState([]);
+  const [lettersLoading, setLettersLoading] = useState(true);
 
   useEffect(() => {
     getClaimLetters().then(data => {
       setLetters(data);
+      setLettersLoading(false);
     });
   }, []);
 
@@ -33,7 +35,11 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
           appeals, and decision reviews. Download your claim letters on this
           page.
         </div>
-        <ClaimLetterList letters={letters} />
+        {lettersLoading ? (
+          <va-loading-indicator message="Loading your claim letters..." />
+        ) : (
+          <ClaimLetterList letters={letters} />
+        )}
       </>
     );
   } else {


### PR DESCRIPTION
## Description
Adding a loading indicator to indicate when the letters list is loading

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47953

## Screenshots
![Screen Shot 2022-10-20 at 4 41 19 PM](https://user-images.githubusercontent.com/13838621/197064456-45cd2d75-3195-46d4-aa0f-58e75cee0a0e.png)

## Acceptance criteria
- [x] A loading indicator is shown when the list of letters is loading

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
