### PR TITLE
[DLD] Hide link to claim letters page when feature flag is disabled

### DIFF
--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -7,29 +7,33 @@ const formatDate = closedDate => moment(closedDate).format('MMMM D, YYYY');
 const headerText = closedDate =>
   `We closed your claim on ${formatDate(closedDate)}`;
 
-const ClaimsDecision = ({ completedDate }) => (
+const ClaimsDecision = ({ completedDate, showClaimLettersLink }) => (
   <>
     <va-alert>
       <h3 className="claims-alert-header vads-u-font-size--h4" slot="headline">
         {completedDate && headerText(completedDate)}
       </h3>
       <p>
-        We finished reviewing your claim and a decision has been made. You can
-        find your decision letter in the claim letters page.
+        We finished reviewing your claim and a decision has been made.{' '}
+        {showClaimLettersLink && (
+          <>You can find your decision letter in the claim letters page.</>
+        )}
       </p>
       <p>
         A decision packet will also be mailed to you. Typically, decision
         notices are received within 10 days, but this is dependent upon U.S.
         Postal Service timeframes.
       </p>
-      <p>
-        <a
-          className="vads-c-action-link--blue"
-          href="/track-claims/your-claim-letters"
-        >
-          Get your claim letters
-        </a>
-      </p>
+      {showClaimLettersLink && (
+        <p>
+          <a
+            className="vads-c-action-link--blue"
+            href="/track-claims/your-claim-letters"
+          >
+            Get your claim letters
+          </a>
+        </p>
+      )}
     </va-alert>
     <h4 className="claims-paragraph-header vads-u-font-size--h3">Next steps</h4>
     <p>
@@ -76,6 +80,7 @@ const ClaimsDecision = ({ completedDate }) => (
 
 ClaimsDecision.propTypes = {
   completedDate: PropTypes.string,
+  showClaimLettersLink: PropTypes.bool,
 };
 
 export default ClaimsDecision;

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
-import NeedFilesFromYou from '../components/NeedFilesFromYou';
-import ClaimsDecision from '../components/ClaimsDecision';
+import { clearNotification } from '../actions';
 import ClaimComplete from '../components/ClaimComplete';
-import ClaimsTimeline from '../components/ClaimsTimeline';
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
+import ClaimsDecision from '../components/ClaimsDecision';
+import ClaimsTimeline from '../components/ClaimsTimeline';
+import NeedFilesFromYou from '../components/NeedFilesFromYou';
 import { showClaimLettersFeature } from '../selectors';
-import { setUpPage, isTab, setFocus } from '../utils/page';
 import {
   itemsNeedingAttentionFromVet,
   getClaimType,
   getCompletedDate,
 } from '../utils/helpers';
-import { clearNotification } from '../actions';
+import { setUpPage, isTab, setFocus } from '../utils/page';
 
 class ClaimStatusPage extends React.Component {
   componentDidMount() {
@@ -136,6 +137,17 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   clearNotification,
+};
+
+ClaimStatusPage.propTypes = {
+  claim: PropTypes.object,
+  clearNotification: PropTypes.func,
+  lastPage: PropTypes.string,
+  loading: PropTypes.bool,
+  message: PropTypes.string,
+  params: PropTypes.object,
+  showClaimLettersLink: PropTypes.bool,
+  synced: PropTypes.bool,
 };
 
 export default connect(

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -8,13 +8,13 @@ import ClaimsDecision from '../components/ClaimsDecision';
 import ClaimComplete from '../components/ClaimComplete';
 import ClaimsTimeline from '../components/ClaimsTimeline';
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
+import { showClaimLettersFeature } from '../selectors';
 import { setUpPage, isTab, setFocus } from '../utils/page';
 import {
   itemsNeedingAttentionFromVet,
   getClaimType,
   getCompletedDate,
 } from '../utils/helpers';
-
 import { clearNotification } from '../actions';
 
 class ClaimStatusPage extends React.Component {
@@ -56,7 +56,13 @@ class ClaimStatusPage extends React.Component {
   }
 
   render() {
-    const { claim, loading, message, synced } = this.props;
+    const {
+      claim,
+      loading,
+      message,
+      showClaimLettersLink,
+      synced,
+    } = this.props;
 
     let content = null;
     // claim can be null
@@ -78,7 +84,10 @@ class ClaimStatusPage extends React.Component {
             <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
           ) : null}
           {attributes.decisionLetterSent && !attributes.open ? (
-            <ClaimsDecision completedDate={getCompletedDate(claim)} />
+            <ClaimsDecision
+              completedDate={getCompletedDate(claim)}
+              showClaimLettersLink={showClaimLettersLink}
+            />
           ) : null}
           {!attributes.decisionLetterSent && !attributes.open ? (
             <ClaimComplete completedDate={getCompletedDate(claim)} />
@@ -120,6 +129,7 @@ function mapStateToProps(state) {
     claim: claimsState.claimDetail.detail,
     message: claimsState.notifications.message,
     lastPage: claimsState.routing.lastPage,
+    showClaimLettersLink: showClaimLettersFeature(state),
     synced: claimsState.claimSync.synced,
   };
 }


### PR DESCRIPTION
## Description
When the `claim_letters_access` feature toggle is disabled, users should not be able to see the link the the claim letters page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47953

## Screenshots
<details><summary>Feature toggle enabled</summary>

![Screen Shot 2022-10-20 at 4 44 36 PM](https://user-images.githubusercontent.com/13838621/197066785-f60008dd-3dcf-4f61-9793-a4981208a580.png)
</details>
<details><summary>Feature toggle disabled</summary>

![Screen Shot 2022-10-20 at 4 55 36 PM](https://user-images.githubusercontent.com/13838621/197066849-1d0c5bc1-c0a6-42b7-9d49-254f27e3d57d.png)
</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
