### PR TITLE
Display label value on review page for HCA gender questions

### DIFF
--- a/src/applications/hca/config/chapters/veteranInformation/birthSex.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthSex.js
@@ -3,7 +3,6 @@ import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 import { genderLabels } from 'platform/static-data/labels';
 
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import CustomReviewField from '../../../components/FormReview/CustomReviewField';
 import { NotHighDisability } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
@@ -22,7 +21,6 @@ export default {
     },
     gender: {
       'ui:title': 'What sex were you assigned at birth?',
-      'ui:reviewField': CustomReviewField,
       'ui:widget': 'radio',
       'ui:options': {
         labels: genderLabels,

--- a/src/applications/hca/config/chapters/veteranInformation/veteranGender.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranGender.js
@@ -1,7 +1,6 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 
-import CustomReviewField from '../../../components/FormReview/CustomReviewField';
 import { SIGIGenderDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
 import { NotHighDisability } from '../../../utils/helpers';
@@ -25,7 +24,6 @@ export default {
       'ui:description': SIGIGenderDescription,
       sigiGenders: {
         'ui:title': 'Select your gender identity',
-        'ui:reviewField': CustomReviewField,
         'ui:widget': 'radio',
         'ui:options': {
           labels: {


### PR DESCRIPTION
## Description
This PR updates the display values for the two gender questions in the Health care application. Currently the review page displays the "value" of the selection (M for Male, F for Female, etc). This update displays the Label instead of the shorthand value that gets consumed by the backend.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31735

## Acceptance criteria
- [ ] Review page uses plain language labels for value display

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
