### PR TITLE
Check in/48431/do not allow user to file a travel claim if more than one appointment

### DIFF
--- a/src/applications/check-in/actions/day-of/index.js
+++ b/src/applications/check-in/actions/day-of/index.js
@@ -56,10 +56,12 @@ export const UPDATE_DAY_OF_CHECK_IN_FORM = 'UPDATE_DAY_OF_CHECK_IN_FORM';
 export const updateFormAction = ({
   patientDemographicsStatus,
   isTravelReimbursementEnabled,
+  appointments,
 }) => {
   const pages = updateForm(
     patientDemographicsStatus,
     isTravelReimbursementEnabled,
+    appointments,
   );
   return {
     type: UPDATE_DAY_OF_CHECK_IN_FORM,

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -300,7 +300,6 @@ class ApiInitializer {
       extraValidation = null,
       appointments = null,
       token = sharedData.get.defaultUUID,
-      numberOfCheckInAbledAppointments = 2,
       demographicsNeedsUpdate = true,
       demographicsConfirmedAt = null,
       nextOfKinNeedsUpdate = true,
@@ -310,9 +309,8 @@ class ApiInitializer {
       timezone = 'browser',
     } = {}) => {
       cy.intercept('GET', `/check_in/v2/patient_check_ins/*`, req => {
-        const rv = sharedData.get.createMultipleAppointments(
+        const rv = sharedData.get.createAppointments(
           token,
-          numberOfCheckInAbledAppointments,
           demographicsNeedsUpdate,
           demographicsConfirmedAt,
           nextOfKinNeedsUpdate,
@@ -348,7 +346,6 @@ class ApiInitializer {
     withBadData: ({
       extraValidation = null,
       token = sharedData.get.defaultUUID,
-      numberOfCheckInAbledAppointments = 2,
       demographicsNeedsUpdate = true,
       demographicsConfirmedAt = null,
       nextOfKinNeedsUpdate = true,
@@ -357,9 +354,8 @@ class ApiInitializer {
       emergencyContactConfirmedAt = null,
     } = {}) => {
       cy.intercept('GET', `/check_in/v2/patient_check_ins/*`, req => {
-        const rv = sharedData.get.createMultipleAppointments(
+        const rv = sharedData.get.createAppointments(
           token,
-          numberOfCheckInAbledAppointments,
           demographicsNeedsUpdate,
           demographicsConfirmedAt,
           nextOfKinNeedsUpdate,

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -82,6 +82,7 @@ class ApiInitializer {
           preCheckInEnabled: true,
           emergencyContactEnabled: true,
           checkInExperienceTravelReimbursement: true,
+          checkInExperienceLorotaSecurityUpdatesEnabled: true,
         }),
       );
     },

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -58,9 +58,9 @@ const responses = {
     const { uuid } = req.params;
     if (hasBeenValidated) {
       hasBeenValidated = false;
-      return res.json(sharedData.get.createMultipleAppointments(uuid, 3));
+      return res.json(sharedData.get.createAppointments(uuid));
     }
-    return res.json(sharedData.get.createMultipleAppointments(uuid));
+    return res.json(sharedData.get.createAppointments(uuid));
   },
   'POST /check_in/v2/patient_check_ins/': (req, res) => {
     const { uuid, appointmentIen, facilityId } =

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -8,6 +8,7 @@ const isoDateWithOffsetFormat = "yyyy-LL-dd'T'HH:mm:ss.SSSxxx";
 const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
 const aboutToExpireUUID = '25165847-2c16-4c8b-8790-5de37a7f427f';
 const pacificTimezoneUUID = '6c72b801-74ac-47fe-82af-cfe59744b45f';
+const allAppointmentTypesUUID = 'bb48c558-7b35-44ec-8ab7-32b7d49364fc';
 
 const mockDemographics = {
   emergencyContact: {
@@ -163,9 +164,8 @@ const createAppointment = ({
   };
 };
 
-const createMultipleAppointments = (
-  token,
-  numberOfCheckInAbledAppointments = 2,
+const createAppointments = (
+  token = defaultUUID,
   demographicsNeedsUpdate = false,
   demographicsConfirmedAt = null,
   nextOfKinNeedsUpdate = false,
@@ -173,18 +173,56 @@ const createMultipleAppointments = (
   emergencyContactNeedsUpdate = false,
   emergencyContactConfirmedAt = null,
 ) => {
-  const rv = {
-    id: token || defaultUUID,
+  const timezone =
+    token === pacificTimezoneUUID ? 'America/Los_Angeles' : 'browser';
+
+  let appointments = [
+    createAppointment({
+      eligibility: 'ELIGIBLE',
+      facilityId: 'ABC_123',
+      appointmentIen: `0001`,
+      clinicFriendlyName: `HEART CLINIC-1`,
+      uuid: token,
+      timezone,
+    }),
+  ];
+
+  if (token === allAppointmentTypesUUID) {
+    appointments = [
+      createAppointment({
+        eligibility: 'INELIGIBLE_TOO_LATE',
+        facilityId: 'ABC_123',
+        appointmentIen: '0000',
+        clinicFriendlyName: `HEART CLINIC-1`,
+      }),
+    ];
+    for (let i = 0; i < 3; i += 1) {
+      appointments.push(
+        createAppointment({
+          eligibility: 'ELIGIBLE',
+          facilityId: 'ABC_123',
+          appointmentIen: `000${i + 1}`,
+          clinicFriendlyName: `HEART CLINIC-${i}`,
+          uuid: token,
+          timezone,
+        }),
+      );
+    }
+    appointments.push(
+      createAppointment({
+        eligibility: 'INELIGIBLE_TOO_EARLY',
+        facilityId: 'ABC_123',
+        appointmentIen: `0050`,
+        clinicFriendlyName: `HEART CLINIC-E`,
+      }),
+    );
+  }
+
+  return {
+    id: token,
     payload: {
       demographics: mockDemographics,
-      appointments: [
-        createAppointment({
-          eligibility: 'INELIGIBLE_TOO_LATE',
-          facilityId: 'ABC_123',
-          appointmentIen: '0000',
-          clinicFriendlyName: `HEART CLINIC-1`,
-        }),
-      ],
+      appointments,
       patientDemographicsStatus: {
         demographicsNeedsUpdate,
         demographicsConfirmedAt,
@@ -195,38 +233,11 @@ const createMultipleAppointments = (
       },
     },
   };
-
-  let timezone = 'browser';
-  if (token === pacificTimezoneUUID) {
-    timezone = 'America/Los_Angeles';
-  }
-  for (let i = 0; i < numberOfCheckInAbledAppointments; i += 1) {
-    rv.payload.appointments.push(
-      createAppointment({
-        eligibility: 'ELIGIBLE',
-        facilityId: 'ABC_123',
-        appointmentIen: `000${i + 1}`,
-        clinicFriendlyName: `HEART CLINIC-${i}`,
-        uuid: token,
-        timezone,
-      }),
-    );
-  }
-  rv.payload.appointments.push(
-    createAppointment({
-      eligibility: 'INELIGIBLE_TOO_EARLY',
-      facilityId: 'ABC_123',
-      appointmentIen: `0050`,
-      clinicFriendlyName: `HEART CLINIC-E`,
-    }),
-  );
-
-  return rv;
 };
 
 module.exports = {
   aboutToExpireUUID,
-  createMultipleAppointments,
+  createAppointments,
   createAppointment,
   defaultUUID,
   mockDemographics,

--- a/src/applications/check-in/day-of/tests/e2e/already-validated-user/returning.user.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/already-validated-user/returning.user.cypress.spec.js
@@ -34,10 +34,10 @@ describe('Check In Experience', () => {
   it('Returning user', () => {
     cy.visitWithUUID();
     Appointments.validatePageLoaded();
-    Appointments.validateAppointmentLength(4);
+    Appointments.validateAppointmentLength(1);
     cy.injectAxe();
     cy.axeCheck();
-    Appointments.attemptCheckIn(3);
+    Appointments.attemptCheckIn(1);
     Confirmation.validatePageLoaded();
     cy.injectAxe();
     cy.axeCheck();

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/posting.appointment.data.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/posting.appointment.data.cypress.spec.js
@@ -41,9 +41,9 @@ describe('Check In Experience', () => {
       });
     });
     it('The second appointment is selected', () => {
-      Appointments.validateAppointmentLength(4);
+      Appointments.validateAppointmentLength(1);
       cy.injectAxeThenAxeCheck();
-      Appointments.attemptCheckIn(3);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
     });

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -12,7 +12,7 @@ import sharedData from '../../../../api/local-mock-api/mocks/v2/shared';
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
     beforeEach(() => {
-      const rv1 = sharedData.get.createMultipleAppointments();
+      const rv1 = sharedData.get.createAppointments();
       const earliest = sharedData.get.createAppointment();
       earliest.startTime = '2021-08-19T03:00:00';
       const midday = sharedData.get.createAppointment();
@@ -21,7 +21,7 @@ describe('Check In Experience -- ', () => {
       latest.startTime = '2027-08-19T18:00:00';
       rv1.payload.appointments = [latest, earliest, midday];
 
-      const rv2 = sharedData.get.createMultipleAppointments();
+      const rv2 = sharedData.get.createAppointments();
       const newLatest = sharedData.get.createAppointment();
       newLatest.startTime = '2027-08-19T17:00:00';
       rv2.payload.appointments = [newLatest, earliest, midday];

--- a/src/applications/check-in/day-of/tests/e2e/back-button/back.button.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/back-button/back.button.cypress.spec.js
@@ -21,9 +21,7 @@ describe('Check In Experience', () => {
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
-      });
+      initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
     });
     afterEach(() => {

--- a/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/confirmation-display/confirmation.display.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Check In Experience -- ', () => {
       EmergencyContact.attemptToGoToNextPage();
       NextOfKin.attemptToGoToNextPage();
       Appointments.validatePageLoaded();
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
     });
     afterEach(() => {
       cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/demographics-flags/demographics.flags.confirmation.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience', () => {
       initializeFeatureToggle.withDayOfDemographicsFlagsEnabled();
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 2,
-      });
+      initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
 
@@ -67,7 +65,7 @@ describe('Check In Experience', () => {
 
       Appointments.validatePageLoaded();
 
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
 
@@ -122,9 +120,7 @@ describe('Check In Experience', () => {
       initializeFeatureToggle.withDayOfDemographicsFlagsEnabled();
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 2,
-      });
+      initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
       // Response delayed by 5 seconds.
       initializeDemographicsPatch.withFailure(400, 5000);
@@ -156,7 +152,7 @@ describe('Check In Experience', () => {
 
       Appointments.validatePageLoaded();
 
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
 
@@ -195,7 +191,6 @@ describe('Check In Experience', () => {
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 2,
         demographicsNeedsUpdate: false,
         demographicsConfirmedAt: today.toISOString(),
         nextOfKinNeedsUpdate: false,
@@ -230,7 +225,7 @@ describe('Check In Experience', () => {
     });
     it('Do not send demographics confirmations if all confirm pages skipped', () => {
       Appointments.validatePageLoaded();
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
 
       cy.injectAxeThenAxeCheck();
       Confirmation.validatePageLoaded();

--- a/src/applications/check-in/day-of/tests/e2e/dob-validation/dob.validation.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/dob-validation/dob.validation.cypress.spec.js
@@ -15,9 +15,7 @@ describe('Check In Experience ', () => {
     } = ApiInitializer;
     initializeFeatureToggle.withLorotaSecurityUpdate();
     initializeSessionGet.withSuccessfulNewSession();
-    initializeCheckInDataGet.withSuccess({
-      numberOfCheckInAbledAppointments: 1,
-    });
+    initializeCheckInDataGet.withSuccess();
     initializeSessionPost.withSuccess();
 
     initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
     initializeDemographicsPatch.withSuccess();
-    initializeCheckInDataGet.withSuccess({
-      numberOfCheckInAbledAppointments: 1,
-    });
+    initializeCheckInDataGet.withSuccess();
     initializeCheckInDataPost.withFailure(200);
 
     cy.visitWithUUID();
@@ -42,7 +40,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5722 - Check in failed with a 200 and error message in the body', () => {
-    Appointments.attemptCheckIn(2);
+    Appointments.attemptCheckIn(1);
     Error.validatePageLoaded();
     cy.injectAxe();
     cy.axeCheck();

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.404.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.404.on.check-in.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
     initializeDemographicsPatch.withSuccess();
-    initializeCheckInDataGet.withSuccess({
-      numberOfCheckInAbledAppointments: 1,
-    });
+    initializeCheckInDataGet.withSuccess();
     initializeCheckInDataPost.withFailure(404);
 
     cy.window().then(window => {
@@ -38,7 +36,7 @@ describe('Check In Experience -- ', () => {
     NextOfKin.attemptToGoToNextPage();
     EmergencyContact.attemptToGoToNextPage();
     Appointments.validatePageLoaded();
-    Appointments.attemptCheckIn(2);
+    Appointments.attemptCheckIn(1);
   });
   afterEach(() => {
     cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.check-in.cypress.spec.js
@@ -23,9 +23,7 @@ describe('Check In Experience -- ', () => {
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
     initializeDemographicsPatch.withSuccess();
-    initializeCheckInDataGet.withSuccess({
-      numberOfCheckInAbledAppointments: 1,
-    });
+    initializeCheckInDataGet.withSuccess();
     initializeCheckInDataPost.withFailure(500);
 
     cy.visitWithUUID();
@@ -36,7 +34,7 @@ describe('Check In Experience -- ', () => {
     NextOfKin.attemptToGoToNextPage();
     EmergencyContact.attemptToGoToNextPage();
     Appointments.validatePageLoaded();
-    Appointments.attemptCheckIn(2);
+    Appointments.attemptCheckIn(1);
   });
   afterEach(() => {
     cy.window().then(window => {

--- a/src/applications/check-in/day-of/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -19,9 +19,7 @@ describe('Check In Experience -- ', () => {
         expect(req.body.session.lastName).to.equal('Smith');
         expect(req.body.session.last4).to.equal('4837');
       });
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
-      });
+      initializeCheckInDataGet.withSuccess();
       cy.visitWithUUID();
       ValidateVeteran.validatePage.dayOf();
     });

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience', () => {
       initializeFeatureToggle.withCurrentFeatures();
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
-      });
+      initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
     });
@@ -60,11 +58,11 @@ describe('Check In Experience', () => {
       NextOfKin.attemptToGoToNextPage();
 
       Appointments.validatePageLoaded();
-      Appointments.validateAppointmentLength(3);
+      Appointments.validateAppointmentLength(1);
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--Appointments');
 
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--Confirmation');

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
@@ -22,7 +22,12 @@ describe('Check In Experience', () => {
       initializeFeatureToggle.withCurrentFeatures();
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
-      initializeCheckInDataGet.withSuccess();
+      initializeCheckInDataGet.withSuccess({
+        appointments: [
+          { startTime: '2021-08-19T03:00:00' },
+          { startTime: '2021-08-19T03:30:00' },
+        ],
+      });
       initializeCheckInDataPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
     });
@@ -58,11 +63,11 @@ describe('Check In Experience', () => {
       NextOfKin.attemptToGoToNextPage();
 
       Appointments.validatePageLoaded();
-      Appointments.validateAppointmentLength(1);
+      Appointments.validateAppointmentLength(2);
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--Appointments');
 
-      Appointments.attemptCheckIn(1);
+      Appointments.attemptCheckIn(2);
       Confirmation.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--Confirmation');

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
@@ -28,20 +28,12 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeBtsssPost.withSuccess();
 
-      const rv1 = sharedData.get.createMultipleAppointments();
-      const earliest = sharedData.get.createAppointment();
-      earliest.startTime = '2021-08-19T03:00:00';
-      const midday = sharedData.get.createAppointment();
-      midday.startTime = '2021-08-19T13:00:00';
-      const latest = sharedData.get.createAppointment();
-      latest.startTime = '2027-08-19T18:00:00';
-      rv1.payload.appointments = [latest, earliest, midday];
+      const rv = sharedData.get.createMultipleAppointments();
+      const appointment = sharedData.get.createAppointment();
+      appointment.startTime = '2021-08-19T18:00:00';
+      rv.payload.appointments = [appointment];
 
-      const rv2 = sharedData.get.createMultipleAppointments();
-      const newLatest = sharedData.get.createAppointment();
-      newLatest.startTime = '2027-08-19T17:00:00';
-      rv2.payload.appointments = [newLatest, earliest, midday];
-      const responses = [rv1, rv2];
+      const responses = [rv];
 
       cy.intercept(
         {
@@ -63,7 +55,7 @@ describe('Check In Experience', () => {
       ValidateVeteran.validatePage.dayOf();
       cy.injectAxeThenAxeCheck();
 
-      ValidateVeteran.validateVeteran();
+      ValidateVeteran.validateVeteranDob();
       ValidateVeteran.attemptToGoToNextPage();
       Demographics.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
@@ -94,11 +86,11 @@ describe('Check In Experience', () => {
       TravelPages.attemptToGoToNextPage();
 
       Appointments.validatePageLoaded();
-      Appointments.validateAppointmentLength(3);
-      Appointments.validateAppointmentTime(3, '6:00 p.m.');
+      Appointments.validateAppointmentLength(1);
+      Appointments.validateAppointmentTime(1, '6:00 p.m.');
       cy.injectAxeThenAxeCheck();
 
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssSubmission();
       cy.injectAxeThenAxeCheck();
 

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/everything.happy.path.cypress.spec.js
@@ -28,7 +28,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeBtsssPost.withSuccess();
 
-      const rv = sharedData.get.createMultipleAppointments();
+      const rv = sharedData.get.createAppointments();
       const appointment = sharedData.get.createAppointment();
       appointment.startTime = '2021-08-19T18:00:00';
       rv.payload.appointments = [appointment];

--- a/src/applications/check-in/day-of/tests/e2e/routing/routing.refresh.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/routing/routing.refresh.cypress.spec.js
@@ -37,9 +37,7 @@ describe('Check In Experience', () => {
           session.post.createMockSuccessResponse('some-token', 'read.full'),
         );
       });
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
-      });
+      initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
     });
     afterEach(() => {

--- a/src/applications/check-in/day-of/tests/e2e/travel-address-display/travel-address.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-address-display/travel-address.display.cypress.spec.js
@@ -24,7 +24,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-address-display/travel-address.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-address-display/travel-address.display.cypress.spec.js
@@ -10,6 +10,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 describe('Check In Experience', () => {
   describe('travel address display', () => {
     beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -24,6 +25,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();

--- a/src/applications/check-in/day-of/tests/e2e/travel-mileage-display/travel-mileage.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-mileage-display/travel-mileage.display.cypress.spec.js
@@ -24,7 +24,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-mileage-display/travel-mileage.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-mileage-display/travel-mileage.display.cypress.spec.js
@@ -9,6 +9,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 
 describe('Check In Experience', () => {
   describe('travel mileage display', () => {
+    const appointments = [{ startTime: '2021-08-19T03:00:00' }];
     beforeEach(() => {
       const {
         initializeFeatureToggle,
@@ -24,6 +25,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.back.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.back.path.cypress.spec.js
@@ -25,7 +25,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.back.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.back.path.cypress.spec.js
@@ -11,6 +11,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 describe('Check In Experience', () => {
   describe('travel pay back path', () => {
     beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -25,6 +26,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
@@ -12,6 +12,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 describe('Check In Experience', () => {
   describe('travel pay path', () => {
     beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -27,6 +28,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       initializeBtsssPost.withSuccess();
@@ -67,7 +69,7 @@ describe('Check In Experience', () => {
       TravelPages.attemptToGoToNextPage();
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssSubmission();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--travel-pay--confirmation-success');
@@ -76,7 +78,7 @@ describe('Check In Experience', () => {
       TravelPages.validatePageLoaded();
       TravelPages.attemptToGoToNextPage('no');
       Appointments.validatePageLoaded();
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithNoBtsssClaim();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots(
@@ -112,7 +114,7 @@ describe('Check In Experience', () => {
       TravelPages.attemptToGoToNextPage('no');
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssIneligible();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots(

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
@@ -27,7 +27,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
@@ -12,6 +12,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 describe('Check In Experience', () => {
   describe('travel pay path', () => {
     beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -27,6 +28,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       initializeBtsssPost.withFailure();
@@ -67,7 +69,7 @@ describe('Check In Experience', () => {
       TravelPages.attemptToGoToNextPage();
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
-      Appointments.attemptCheckIn(2);
+      Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssSubmissionFailure();
       cy.injectAxeThenAxeCheck();
     });

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
@@ -27,7 +27,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-question-display/travel-question.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-question-display/travel-question.display.cypress.spec.js
@@ -24,7 +24,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-question-display/travel-question.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-question-display/travel-question.display.cypress.spec.js
@@ -10,6 +10,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 describe('Check In Experience', () => {
   describe('travel question display', () => {
     beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -24,6 +25,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();

--- a/src/applications/check-in/day-of/tests/e2e/travel-vehicle-display/travel-vehicle.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-vehicle-display/travel-vehicle.display.cypress.spec.js
@@ -24,7 +24,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         appointments,
       });
       initializeCheckInDataPost.withSuccess();

--- a/src/applications/check-in/day-of/tests/e2e/travel-vehicle-display/travel-vehicle.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-vehicle-display/travel-vehicle.display.cypress.spec.js
@@ -10,6 +10,7 @@ import TravelPages from '../../../../tests/e2e/pages/TravelPages';
 describe('Check In Experience', () => {
   describe('travel vehicle display', () => {
     beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
       const {
         initializeFeatureToggle,
         initializeSessionGet,
@@ -24,6 +25,7 @@ describe('Check In Experience', () => {
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
         numberOfCheckInAbledAppointments: 1,
+        appointments,
       });
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/skip.all.path.cypress.spec.js
@@ -22,7 +22,6 @@ describe('Check In Experience', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         demographicsNeedsUpdate: false,
         demographicsConfirmedAt: today.toISOString(),
         nextOfKinNeedsUpdate: false,

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.all.path.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience', () => {
       initializeSessionGet.withSuccessfulNewSession();
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
-      initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
-      });
+      initializeCheckInDataGet.withSuccess();
       initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();
       ValidateVeteran.validatePage.dayOf();

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.demographics.only.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.demographics.only.path.cypress.spec.js
@@ -23,7 +23,6 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         demographicsNeedsUpdate: true,
         nextOfKinNeedsUpdate: false,
         nextOfKinConfirmedAt: today.toISOString(),

--- a/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.next.of.kin.only.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/update-skip-path/update.next.of.kin.only.path.cypress.spec.js
@@ -23,7 +23,6 @@ describe('Check In Experience -- ', () => {
       initializeSessionPost.withSuccess();
       initializeDemographicsPatch.withSuccess();
       initializeCheckInDataGet.withSuccess({
-        numberOfCheckInAbledAppointments: 1,
         demographicsNeedsUpdate: false,
         demographicsConfirmedAt: today.toISOString(),
         nextOfKinNeedsUpdate: true,

--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -30,19 +30,20 @@ const useGetCheckInData = (refreshNeeded, appointmentsOnly = false) => {
     payload => {
       batch(() => {
         const {
-          appointments: appts,
-          demographics: demo,
+          appointments,
+          demographics,
           patientDemographicsStatus,
         } = payload;
         dispatch(triggerRefresh(false));
-        dispatch(receivedMultipleAppointmentDetails(appts, token));
+        dispatch(receivedMultipleAppointmentDetails(appointments, token));
 
         if (!appointmentsOnly) {
-          dispatch(receivedDemographicsData(demo));
+          dispatch(receivedDemographicsData(demographics));
           dispatch(
             updateFormAction({
               patientDemographicsStatus,
               isTravelReimbursementEnabled,
+              appointments,
             }),
           );
         }

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -19,7 +19,7 @@ describe('check in', () => {
     MockDate.reset();
   });
 
-  const { createAppointment, createMultipleAppointments } = get;
+  const { createAppointment, createAppointments } = get;
 
   describe('appointment navigation utils', () => {
     describe('hasMoreAppointmentsToCheckInto', () => {
@@ -35,7 +35,7 @@ describe('check in', () => {
         ).to.equal(false);
       });
       it('returns true if selected Appointment is undefined and more eligible appointments found', () => {
-        const response = createMultipleAppointments();
+        const response = createAppointments();
         const { appointments } = response.payload;
 
         expect(

--- a/src/applications/check-in/utils/navigation/day-of/index.js
+++ b/src/applications/check-in/utils/navigation/day-of/index.js
@@ -67,6 +67,7 @@ const createForm = () => {
 const updateForm = (
   patientDemographicsStatus,
   isTravelReimbursementEnabled,
+  appointments,
 ) => {
   const pages = CHECK_IN_FORM_PAGES.map(page => page.url);
 
@@ -75,6 +76,7 @@ const updateForm = (
     pages,
     URLS,
     isTravelReimbursementEnabled,
+    appointments,
   );
 };
 

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -10,6 +10,7 @@ const updateFormPages = (
   pages,
   URLS,
   isTravelReimbursementEnabled = false,
+  appointments = [],
 ) => {
   const skippedPages = [];
   const {
@@ -38,12 +39,6 @@ const updateFormPages = (
       needsUpdate: emergencyContactNeedsUpdate,
     },
   ];
-  const travelPayPages = [
-    URLS.TRAVEL_QUESTION,
-    URLS.TRAVEL_VEHICLE,
-    URLS.TRAVEL_ADDRESS,
-    URLS.TRAVEL_MILEAGE,
-  ];
   skippablePages.forEach(page => {
     const pageLastUpdated = page.confirmedAt
       ? new Date(page.confirmedAt)
@@ -56,8 +51,16 @@ const updateFormPages = (
       skippedPages.push(page.url);
     }
   });
-  // Skip travel pay if not enabled.
-  if (!isTravelReimbursementEnabled) {
+
+  const travelPayPages = [
+    URLS.TRAVEL_QUESTION,
+    URLS.TRAVEL_VEHICLE,
+    URLS.TRAVEL_ADDRESS,
+    URLS.TRAVEL_MILEAGE,
+  ];
+
+  // Skip travel pay if not enabled or if veteran has more than one appoinement for the day.
+  if (!isTravelReimbursementEnabled || appointments.length > 1) {
     skippedPages.push(...travelPayPages);
   }
   return pages.filter(page => !skippedPages.includes(page));

--- a/src/applications/check-in/utils/navigation/navigation.unit.spec.js
+++ b/src/applications/check-in/utils/navigation/navigation.unit.spec.js
@@ -16,11 +16,19 @@ describe('Global check in', () => {
         'contact-information',
         'next-of-kin',
         'emergency-contact',
+        'travel-pay',
+        'travel-vehicle',
+        'travel-address',
+        'travel-mileage',
       ];
       const URLS = {
         DEMOGRAPHICS: 'contact-information',
         EMERGENCY_CONTACT: 'emergency-contact',
         NEXT_OF_KIN: 'next-of-kin',
+        TRAVEL_QUESTION: 'travel-pay',
+        TRAVEL_VEHICLE: 'travel-vehicle',
+        TRAVEL_ADDRESS: 'travel-address',
+        TRAVEL_MILEAGE: 'travel-mileage',
       };
       it('should return all pages with emergency contact page', () => {
         const patientDemographicsStatus = {
@@ -31,10 +39,14 @@ describe('Global check in', () => {
           emergencyContactNeedsUpdate: true,
           emergencyContactConfirmedAt: '2021-12-01T00:00:00.000-05:00',
         };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [1];
         const form = updateFormPages(
           patientDemographicsStatus,
           testPages,
           URLS,
+          isTravelReimbursementEnabled,
+          appointments,
         );
         expect(form.length).to.equal(testPages.length);
       });
@@ -138,6 +150,54 @@ describe('Global check in', () => {
         );
         expect(form.find(page => page === URLS.EMERGENCY_CONTACT)).to.be
           .undefined;
+      });
+      it('should skip travel pages if appointments are greater than 1', () => {
+        MockDate.set('2022-01-08T06:00:00.000-05:00');
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: false,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: false,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: false,
+          emergencyContactConfirmedAt: '2022-01-01T08:00:00.000-05:00',
+        };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [1, 2, 3, 4];
+        const form = updateFormPages(
+          patientDemographicsStatus,
+          testPages,
+          URLS,
+          isTravelReimbursementEnabled,
+          appointments,
+        );
+        expect(form.find(page => page === URLS.TRAVEL_PAY)).to.be.undefined;
+        expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.be.undefined;
+        expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.be.undefined;
+        expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.be.undefined;
+      });
+      it('should show travel pages if there is only one appointment', () => {
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: true,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: true,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: true,
+          emergencyContactConfirmedAt: '2021-12-01T00:00:00.000-05:00',
+        };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [1];
+        expect(appointments).to.have.lengthOf(1);
+        const form = updateFormPages(
+          patientDemographicsStatus,
+          testPages,
+          URLS,
+          isTravelReimbursementEnabled,
+          appointments,
+        );
+        expect(form.find(page => page === URLS.TRAVEL_QUESTION)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.exist;
       });
     });
   });


### PR DESCRIPTION
## Description

Skips the travel pay questions if the veteran has more than one appointment for the day.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#48431](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48431)


## Testing done

- Visual
- Unit

## Acceptance criteria
- [ ] Form should skip travel pay questions if the veteran has more than one appointment
- [ ] Unit tests written to cover functionality

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
