### PR TITLE
footer, mocked and injected headers updated

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -82,7 +82,7 @@ export default `
           )}" class="va-header-logo">
           <img src="${replaceWithStagingDomain(
             'https://www.va.gov/img/header-logo.png',
-          )}" alt="Go to VA.gov"/>
+          )}" alt="VA logo and seal"/>
           </a>
         </div>
         <div id="va-nav-controls"></div>

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -120,7 +120,7 @@
         <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
           <div class="va-header-logo-wrapper">
             <a href="/" class="va-header-logo">
-              <img src="/img/header-logo.png" alt="Go to VA.gov"/>
+              <img src="/img/header-logo.png" alt="VA logo and seal"/>
             </a>
           </div>
           <div id="va-nav-controls"></div>

--- a/src/platform/site-wide/va-footer/components/Footer.jsx
+++ b/src/platform/site-wide/va-footer/components/Footer.jsx
@@ -64,7 +64,7 @@ class Footer extends Component {
                 src={replaceWithStagingDomain(
                   'https://www.va.gov/img/homepage/va-logo-white.png',
                 )}
-                alt="VA logo"
+                alt="VA logo and seal"
                 width="200"
                 className="vads-u-height--auto"
               />


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11271

updated alt text in header logo.  Updated footer link text for consistency 

## Testing done
local testing in chrome

## Screenshots
<img width="664" alt="Screen Shot 2022-10-24 at 3 00 22 PM" src="https://user-images.githubusercontent.com/61624970/197604720-e2f04150-7e1d-4606-9068-7a7f24731dc2.png">
<img width="1240" alt="Screen Shot 2022-10-25 at 11 45 20 AM" src="https://user-images.githubusercontent.com/61624970/197820441-c8e4e3f3-7814-478f-8fe3-6bde528a5f34.png">


## Acceptance criteria
- [ ] Alt text is updated on mocked and injected headers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
