### PR TITLE
[eFSR] - 48279 - Fix for installment contracts undefined data breaking pdf generation

### DIFF
--- a/src/applications/financial-status-report/pages/expenses/repayments/records.js
+++ b/src/applications/financial-status-report/pages/expenses/repayments/records.js
@@ -107,6 +107,7 @@ export const schema = {
           },
           creditorName: {
             type: 'string',
+            default: '',
           },
           originalAmount: {
             type: 'string',

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -66,7 +66,8 @@ export const sumValues = (arr, key) => {
   const isArrValid = Array.isArray(arr) && arr.length && hasProperty(arr, key);
   if (!isArrValid) return 0;
   return arr.reduce(
-    (acc, item) => acc + (Number(item[key]?.replaceAll(/[^0-9.-]/g, '')) ?? 0),
+    (acc, item) =>
+      acc + (item[key] ? Number(item[key]?.replaceAll(/[^0-9.-]/g, '')) : 0),
     0,
   );
 };


### PR DESCRIPTION
## Description
- Updated helper `sumValues` function to better handle undefined `originalAmount` values to allow `totalOfInstallmentContractsAndOtherDebts` to calculate correctly. 
- Added default value of an empty string for `creditorName` to avoid any other issues. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48279

## Acceptance criteria
- [ ] Submission object for FSR generates valid pdf with no values for `originalAmount` or `creditorName`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
