### PR TITLE
47253 - VAOS code to re-direct Veterans to Cerner

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import recordEvent from 'platform/monitoring/record-event';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import { getLongTermAppointmentHistory } from '../../../services/var';

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -20,7 +20,7 @@ import { resetDataLayer } from '../../../utils/events';
 
 import { PODIATRY_ID, TYPES_OF_CARE } from '../../../utils/constants';
 import useFormState from '../../../hooks/useFormState';
-import { getLongTermAppointmentHistoryV2 } from '../../../services/vaos';
+import { getLongTermAppointmentHistoryV2 } from '../../../services/appointment';
 
 const pageKey = 'typeOfCare';
 const pageTitle = 'Choose the type of care you need';

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -4,19 +4,40 @@ import {
   selectVAPResidentialAddress,
 } from 'platform/user/selectors';
 
+import {
+  selectPatientFacilities as selectPatientFacilitiesDsot,
+  selectIsCernerOnlyPatient as selectIsCernerOnlyPatientDsot,
+  selectIsCernerPatient as selectIsCernerPatientDsot,
+} from 'platform/user/cerner-dsot/selectors';
+
+export const selectFeatureAcheronService = state =>
+  toggleValues(state).vaOnlineSchedulingAcheronService;
+
 export const selectIsCernerOnlyPatient = state =>
-  !!selectPatientFacilities(state)?.every(
-    f => f.isCerner && f.usesCernerAppointments,
-  );
+  selectFeatureAcheronService(state)
+    ? selectIsCernerOnlyPatientDsot(state)
+    : !!selectPatientFacilities(state)?.every(
+        f => f.isCerner && f.usesCernerAppointments,
+      );
 
 export const selectIsCernerPatient = state =>
-  selectPatientFacilities(state)?.some(
-    f => f.isCerner && f.usesCernerAppointments,
+  selectFeatureAcheronService(state)
+    ? selectIsCernerPatientDsot(state)
+    : selectPatientFacilities(state)?.some(
+        f => f.isCerner && f.usesCernerAppointments,
+      );
+
+export const selectRegisteredCernerFacilityIds = state => {
+  const data = selectFeatureAcheronService(state)
+    ? selectPatientFacilitiesDsot(state)
+    : selectPatientFacilities(state);
+
+  return (
+    data
+      ?.filter(f => f.isCerner && f.usesCernerAppointments)
+      .map(f => f.facilityId) || []
   );
-export const selectRegisteredCernerFacilityIds = state =>
-  selectPatientFacilities(state)
-    ?.filter(f => f.isCerner && f.usesCernerAppointments)
-    .map(f => f.facilityId) || [];
+};
 
 export const selectIsRegisteredToSacramentoVA = state =>
   selectPatientFacilities(state)?.some(f => f.facilityId === '612');
@@ -79,6 +100,3 @@ export const selectFeatureAppointmentList = state =>
 
 export const selectFeatureClinicFilter = state =>
   toggleValues(state).vaOnlineSchedulingClinicFilter;
-
-export const selectFeatureAcheronService = state =>
-  toggleValues(state).vaOnlineSchedulingAcheronService;

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -1,34 +1,33 @@
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
 import {
   selectPatientFacilities,
   selectVAPResidentialAddress,
-} from 'platform/user/selectors';
-
+} from '@department-of-veterans-affairs/platform-user/selectors';
 import {
   selectPatientFacilities as selectPatientFacilitiesDsot,
   selectIsCernerOnlyPatient as selectIsCernerOnlyPatientDsot,
   selectIsCernerPatient as selectIsCernerPatientDsot,
 } from 'platform/user/cerner-dsot/selectors';
 
-export const selectFeatureAcheronService = state =>
-  toggleValues(state).vaOnlineSchedulingAcheronService;
+export const selectFeatureUseDSOT = state =>
+  toggleValues(state).vaOnlineSchedulingUseDsot;
 
 export const selectIsCernerOnlyPatient = state =>
-  selectFeatureAcheronService(state)
+  selectFeatureUseDSOT(state)
     ? selectIsCernerOnlyPatientDsot(state)
     : !!selectPatientFacilities(state)?.every(
         f => f.isCerner && f.usesCernerAppointments,
       );
 
 export const selectIsCernerPatient = state =>
-  selectFeatureAcheronService(state)
+  selectFeatureUseDSOT(state)
     ? selectIsCernerPatientDsot(state)
     : selectPatientFacilities(state)?.some(
         f => f.isCerner && f.usesCernerAppointments,
       );
 
 export const selectRegisteredCernerFacilityIds = state => {
-  const data = selectFeatureAcheronService(state)
+  const data = selectFeatureUseDSOT(state)
     ? selectPatientFacilitiesDsot(state)
     : selectPatientFacilities(state);
 
@@ -100,3 +99,6 @@ export const selectFeatureAppointmentList = state =>
 
 export const selectFeatureClinicFilter = state =>
   toggleValues(state).vaOnlineSchedulingClinicFilter;
+
+export const selectFeatureAcheronService = state =>
+  toggleValues(state).vaOnlineSchedulingAcheronService;

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import asyncLoader from 'platform/utilities/ui/asyncLoader';
+import asyncLoader from '@department-of-veterans-affairs/platform-utilities/asyncLoader';
 import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 import VAOSApp from './components/VAOSApp';
 import ErrorBoundary from './components/ErrorBoundary';

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import asyncLoader from 'platform/utilities/ui/asyncLoader';
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 import VAOSApp from './components/VAOSApp';
 import ErrorBoundary from './components/ErrorBoundary';
 import { captureError } from './utils/error';
@@ -35,6 +36,7 @@ export default function createRoutesWithStore(store) {
             component={asyncLoader(() =>
               import(/* webpackChunkName: "vaos-form" */ './new-appointment')
                 .then(({ NewAppointment, reducer }) => {
+                  connectDrupalSourceOfTruthCerner(store.dispatch);
                   store.injectReducer('newAppointment', reducer);
                   return NewAppointment;
                 })

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -4,7 +4,7 @@
  */
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   getCancelReasons,

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -51,33 +51,7 @@ import {
   getUserTimezoneAbbr,
   stripDST,
 } from '../../utils/timezone';
-
-export const CANCELLED_APPOINTMENT_SET = new Set([
-  'CANCELLED BY CLINIC & AUTO RE-BOOK',
-  'CANCELLED BY CLINIC',
-  'CANCELLED BY PATIENT & AUTO-REBOOK',
-  'CANCELLED BY PATIENT',
-]);
-
-// Appointments in these "HIDE_STATUS_SET"s should show in list, but their status should be hidden
-export const FUTURE_APPOINTMENTS_HIDE_STATUS_SET = new Set([
-  'ACT REQ/CHECKED IN',
-  'ACT REQ/CHECKED OUT',
-]);
-
-export const PAST_APPOINTMENTS_HIDE_STATUS_SET = new Set([
-  'ACTION REQUIRED',
-  'INPATIENT APPOINTMENT',
-  'INPATIENT/ACT REQ',
-  'INPATIENT/CHECKED IN',
-  'INPATIENT/CHECKED OUT',
-  'INPATIENT/FUTURE',
-  'INPATIENT/NO ACT TAKN',
-  'NO ACTION TAKEN',
-  'NO-SHOW & AUTO RE-BOOK',
-  'NO-SHOW',
-  'NON-COUNT',
-]);
+import { getProviderName } from '../../utils/appointment';
 
 const CONFIRMED_APPOINTMENT_TYPES = new Set([
   APPOINTMENT_TYPES.ccAppointment,
@@ -658,22 +632,6 @@ export function isVideoHome(appointment) {
 }
 
 /**
- * Method to get patient video instruction
- * @param {Appointment} appointment A FHIR appointment resource
- * @return {string} Returns patient video instruction title and exclude remaining data
- */
-
-export function getPatientInstruction(appointment) {
-  if (appointment?.patientInstruction.includes('Medication Review')) {
-    return 'Medication Review';
-  }
-  if (appointment?.patientInstruction.includes('Video Visit Preparation')) {
-    return 'Video Visit Preparation';
-  }
-  return null;
-}
-
-/**
  * Get the name of the first preferred community care provider, or generic text
  *
  * @param {Appointment} appointment An appointment object
@@ -713,6 +671,7 @@ export function groupAppointmentsByMonth(appointments) {
       appointmentsByMonth[currentIndex].push(appt);
     } else {
       appointmentsByMonth.push([appt]);
+      // eslint-disable-next-line no-plusplus
       currentIndex++;
     }
   });
@@ -913,32 +872,6 @@ export async function cancelAppointment({ appointment, useV2 = false }) {
 }
 
 /**
- * Get the provider name based on api version
- *
- *
- * @export
- * @param {Object} appointment an appointment object
- * @returns {String} Returns the provider first and last name
- */
-export function getProviderName(appointment) {
-  if (appointment.version === 1) {
-    const { providerName } = appointment.communityCareProvider;
-    return providerName;
-  }
-
-  if (appointment.practitioners !== undefined) {
-    const providers = appointment.practitioners
-      .filter(person => !!person.name)
-      .map(person => `${person.name.given.join(' ')} ${person.name.family} `);
-    if (providers.length > 0) {
-      return providers;
-    }
-    return null;
-  }
-  return null;
-}
-
-/**
  * Get scheduled appointment information needed for generating
  * an .ics file.
  *
@@ -1124,3 +1057,53 @@ export async function fetchPreferredProvider(providerNpi) {
   const prov = await getPreferredCCProvider(providerNpi);
   return transformPreferredProviderV2(prov);
 }
+
+export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
+  const batch = [];
+  let promise = null;
+
+  return () => {
+    if (!promise || navigator.userAgent === 'node.js') {
+      // Creating an array of start and end dates for each chunk
+      const ranges = Array.from(Array(chunks).keys()).map(i => {
+        return {
+          start: moment()
+            .startOf('day')
+            .subtract(i + 1, 'year')
+            .utc()
+            .format(),
+
+          end: moment()
+            .startOf('day')
+            .subtract(i, 'year')
+            .utc()
+            .format(),
+        };
+      });
+
+      // There are three chunks with date ranges from the array created above.
+      // We're trying to run them serially, because we want to be careful about
+      // overloading the upstream service, so Promise.all doesn't fit here.
+      promise = ranges.reduce(async (prev, curr) => {
+        // NOTE: This is the secret sauce to run the fetch requests sequentially.
+        // Doing an 'await' on a non promise wraps it into a promise that is then awaited.
+        // In this case, the initial value of previous is set to an empty array.
+        //
+        // NOTE: fetchAppointments will run concurrently without this await 1st!
+        await prev;
+
+        // Next, fetch the appointments which will be chained which the previous await
+        const p1 = await fetchAppointments({
+          startDate: curr.start,
+          endDate: curr.end,
+          useV2VA: true,
+          useV2CC: true,
+        });
+        batch.push(p1);
+        return Promise.resolve([...batch].flat());
+      }, []);
+    }
+
+    return promise;
+  };
+})(3);

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -20,10 +20,9 @@ import {
 import {
   CANCELLED_APPOINTMENT_SET,
   FUTURE_APPOINTMENTS_HIDE_STATUS_SET,
+  getTypeOfCareById,
   PAST_APPOINTMENTS_HIDE_STATUS_SET,
-} from './index';
-
-import { getTypeOfCareById } from '../../utils/appointment';
+} from '../../utils/appointment';
 
 /**
  * Determines what type of appointment a VAR appointment object is depending on
@@ -201,7 +200,7 @@ function getAppointmentDuration(appt) {
       appt.vvsAppointments?.[0]?.duration,
     10,
   );
-  return isNaN(appointmentLength) ? 60 : appointmentLength;
+  return Number.isNaN(appointmentLength) ? 60 : appointmentLength;
 }
 
 /**

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { getPatientInstruction, getProviderName } from './index';
 import {
   APPOINTMENT_TYPES,
   PURPOSE_TEXT,
@@ -8,7 +7,11 @@ import {
 } from '../../utils/constants';
 import { getTimezoneByFacilityId } from '../../utils/timezone';
 import { transformFacilityV2 } from '../location/transformers.v2';
-import { getTypeOfCareById } from '../../utils/appointment';
+import {
+  getPatientInstruction,
+  getProviderName,
+  getTypeOfCareById,
+} from '../../utils/appointment';
 
 function getAppointmentType(appt) {
   if (appt.kind === 'cc' && appt.start) {

--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -1,8 +1,6 @@
 /**
  * @module services/Location
  */
-import environment from 'platform/utilities/environment';
-
 /*
  * Functions in here should map a var-resources API request to a similar response from
  * a FHIR resource request
@@ -43,6 +41,7 @@ import {
   transformSettingsV2,
   transformFacilityV2,
 } from './transformers.v2';
+import { getRealFacilityId } from '../../utils/appointment';
 
 /**
  * Fetch facility information for the facilities in the given site, based on type of care
@@ -265,22 +264,6 @@ export function getSiteIdFromFacilityId(id) {
 }
 
 /**
- * Converts back from a real facility id to our test facility ids
- * in lower environments
- *
- * @export
- * @param {string} facilityId - facility id to convert
- * @returns {string} A facility id with either 442 or 552 replaced with 983 or 984
- */
-export function getTestFacilityId(facilityId) {
-  if (!environment.isProduction() && facilityId) {
-    return facilityId.replace('442', '983').replace('552', '984');
-  }
-
-  return facilityId;
-}
-
-/**
  * Returns formatted address from facility details object
  *
  * @param {Location} facility A location, or object with an Address field
@@ -462,7 +445,11 @@ export async function fetchCommunityCareSupportedSites({
  * @returns {Boolean} Returns true if locationId starts with any of the Cerner site ids
  */
 export function isCernerLocation(locationId, cernerSiteIds = []) {
-  return cernerSiteIds.some(cernerId => locationId?.startsWith(cernerId));
+  return cernerSiteIds.some(cernerId => {
+    return getRealFacilityId(locationId)?.startsWith(
+      getRealFacilityId(cernerId),
+    );
+  });
 }
 
 /**

--- a/src/applications/vaos/services/location/transformers.js
+++ b/src/applications/vaos/services/location/transformers.js
@@ -3,7 +3,7 @@
  */
 
 import moment from 'moment';
-import environment from 'platform/utilities/environment';
+import { getTestFacilityId } from '../../utils/appointment';
 import { VHA_FHIR_ID } from '../../utils/constants';
 import { arrayToObject, dedupeArray } from '../../utils/data';
 
@@ -53,14 +53,10 @@ function isFacilityOpenAllDay(hours) {
   const sanitizedOperatingHours = hours.replace(/\s/g, '');
 
   // Escape early if it is 'Sunrise - Sunset'.
-  if (
+  return (
     sanitizedOperatingHours.toLowerCase() === 'sunrise-sunset' ||
     sanitizedOperatingHours === '24/7'
-  ) {
-    return true;
-  }
-
-  return false;
+  );
 }
 
 function isFacilityClosed(hours) {
@@ -142,21 +138,6 @@ function transformOperatingHours(facilityHours) {
         closingTime,
       };
     });
-}
-
-/**
- * Converts back from a real facility id to our test facility ids
- * in lower environments
- *
- * @param {String} facilityId - facility id to convert
- * @returns A facility id with either 442 or 552 replaced with 983 or 984
- */
-function getTestFacilityId(facilityId) {
-  if (facilityId && (!environment.isProduction() || window.Cypress)) {
-    return facilityId.replace('442', '983').replace('552', '984');
-  }
-
-  return facilityId;
 }
 
 /**

--- a/src/applications/vaos/services/mocks/v2/vamc-ehr.json
+++ b/src/applications/vaos/services/mocks/v2/vamc-ehr.json
@@ -1,0 +1,2017 @@
+{
+  "vamcEhrData": {
+    "loading": false,
+    "data": {
+      "ehrDataByVhaId": {
+        "402": {
+          "vhaId": "402",
+          "vamcFacilityName": "Togus VA Medical Center",
+          "vamcSystemName": "VA Maine health care",
+          "ehr": "vista"
+        },
+        "405": {
+          "vhaId": "405",
+          "vamcFacilityName": "White River Junction VA Medical Center",
+          "vamcSystemName": "VA White River Junction health care",
+          "ehr": "vista"
+        },
+        "436": {
+          "vhaId": "436",
+          "vamcFacilityName": "Fort Harrison VA Medical Center",
+          "vamcSystemName": "VA Montana health care",
+          "ehr": "vista"
+        },
+        "437": {
+          "vhaId": "437",
+          "vamcFacilityName": "Fargo VA Medical Center",
+          "vamcSystemName": "VA Fargo health care",
+          "ehr": "vista"
+        },
+        "438": {
+          "vhaId": "438",
+          "vamcFacilityName": "Royal C. Johnson Veterans\\' Memorial Hospital",
+          "vamcSystemName": "VA Sioux Falls health care",
+          "ehr": "vista"
+        },
+        "442": {
+          "vhaId": "442",
+          "vamcFacilityName": "Cheyenne VA Medical Center",
+          "vamcSystemName": "VA Cheyenne health care",
+          "ehr": "cerner"
+        },
+        "459": {
+          "vhaId": "459",
+          "vamcFacilityName": "Spark M. Matsunaga Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Pacific Islands health care",
+          "ehr": "vista"
+        },
+        "460": {
+          "vhaId": "460",
+          "vamcFacilityName": "Wilmington VA Medical Center",
+          "vamcSystemName": "VA Wilmington health care",
+          "ehr": "vista"
+        },
+        "463": {
+          "vhaId": "463",
+          "vamcFacilityName": "Anchorage VA Medical Center",
+          "vamcSystemName": "VA Alaska health care",
+          "ehr": "vista"
+        },
+        "501": {
+          "vhaId": "501",
+          "vamcFacilityName": "Raymond G. Murphy Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA New Mexico health care",
+          "ehr": "vista"
+        },
+        "502": {
+          "vhaId": "502",
+          "vamcFacilityName": "Alexandria VA Medical Center",
+          "vamcSystemName": "VA Alexandria health care",
+          "ehr": "vista"
+        },
+        "503": {
+          "vhaId": "503",
+          "vamcFacilityName": "James E. Van Zandt Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Altoona health care",
+          "ehr": "vista"
+        },
+        "504": {
+          "vhaId": "504",
+          "vamcFacilityName": "Thomas E. Creek Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Amarillo health care",
+          "ehr": "vista"
+        },
+        "506": {
+          "vhaId": "506",
+          "vamcFacilityName": "Lieutenant Colonel Charles S. Kettles VA Medical Center",
+          "vamcSystemName": "VA Ann Arbor health care",
+          "ehr": "vista"
+        },
+        "508": {
+          "vhaId": "508",
+          "vamcFacilityName": "Atlanta VA Medical Center",
+          "vamcSystemName": "VA Atlanta health care",
+          "ehr": "vista"
+        },
+        "509": {
+          "vhaId": "509",
+          "vamcFacilityName": "Charlie Norwood Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Augusta health care",
+          "ehr": "vista"
+        },
+        "512": {
+          "vhaId": "512",
+          "vamcFacilityName": "Baltimore VA Medical Center",
+          "vamcSystemName": "VA Maryland health care",
+          "ehr": "vista"
+        },
+        "515": {
+          "vhaId": "515",
+          "vamcFacilityName": "Battle Creek VA Medical Center",
+          "vamcSystemName": "VA Battle Creek health care",
+          "ehr": "vista"
+        },
+        "516": {
+          "vhaId": "516",
+          "vamcFacilityName": "C.W. Bill Young Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Bay Pines health care",
+          "ehr": "vista"
+        },
+        "517": {
+          "vhaId": "517",
+          "vamcFacilityName": "Beckley VA Medical Center",
+          "vamcSystemName": "VA Beckley health care",
+          "ehr": "vista"
+        },
+        "518": {
+          "vhaId": "518",
+          "vamcFacilityName": "Edith Nourse Rogers Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Bedford health care",
+          "ehr": "vista"
+        },
+        "519": {
+          "vhaId": "519",
+          "vamcFacilityName": "George H. O\\'Brien, Jr., Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA West Texas health care",
+          "ehr": "vista"
+        },
+        "520": {
+          "vhaId": "520",
+          "vamcFacilityName": "Biloxi VA Medical Center",
+          "vamcSystemName": "VA Gulf Coast health care",
+          "ehr": "vista"
+        },
+        "521": {
+          "vhaId": "521",
+          "vamcFacilityName": "Birmingham VA Medical Center",
+          "vamcSystemName": "VA Birmingham health care",
+          "ehr": "vista"
+        },
+        "523": {
+          "vhaId": "523",
+          "vamcFacilityName": "Jamaica Plain VA Medical Center",
+          "vamcSystemName": "VA Boston health care",
+          "ehr": "vista"
+        },
+        "526": {
+          "vhaId": "526",
+          "vamcFacilityName": "James J. Peters Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Bronx health care",
+          "ehr": "vista"
+        },
+        "528": {
+          "vhaId": "528",
+          "vamcFacilityName": "Buffalo VA Medical Center",
+          "vamcSystemName": "VA Western New York health care",
+          "ehr": "vista"
+        },
+        "529": {
+          "vhaId": "529",
+          "vamcFacilityName": "Abie Abraham VA Clinic",
+          "vamcSystemName": "VA Butler health care",
+          "ehr": "vista"
+        },
+        "531": {
+          "vhaId": "531",
+          "vamcFacilityName": "Boise VA Medical Center",
+          "vamcSystemName": "VA Boise health care",
+          "ehr": "vista"
+        },
+        "534": {
+          "vhaId": "534",
+          "vamcFacilityName": "Ralph H. Johnson Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Charleston health care",
+          "ehr": "vista"
+        },
+        "537": {
+          "vhaId": "537",
+          "vamcFacilityName": "Jesse Brown Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Chicago health care",
+          "ehr": "vista"
+        },
+        "538": {
+          "vhaId": "538",
+          "vamcFacilityName": "Chillicothe VA Medical Center",
+          "vamcSystemName": "VA Chillicothe health care",
+          "ehr": "vista"
+        },
+        "539": {
+          "vhaId": "539",
+          "vamcFacilityName": "Cincinnati VA Medical Center",
+          "vamcSystemName": "VA Cincinnati health care",
+          "ehr": "vista"
+        },
+        "540": {
+          "vhaId": "540",
+          "vamcFacilityName": "Louis A. Johnson Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Clarksburg health care",
+          "ehr": "vista"
+        },
+        "541": {
+          "vhaId": "541",
+          "vamcFacilityName": "Louis Stokes Cleveland Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Northeast Ohio health care",
+          "ehr": "vista"
+        },
+        "542": {
+          "vhaId": "542",
+          "vamcFacilityName": "Coatesville VA Medical Center",
+          "vamcSystemName": "VA Coatesville health care",
+          "ehr": "vista"
+        },
+        "544": {
+          "vhaId": "544",
+          "vamcFacilityName": "Wm. Jennings Bryan Dorn Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Columbia South Carolina health care",
+          "ehr": "vista"
+        },
+        "546": {
+          "vhaId": "546",
+          "vamcFacilityName": "Bruce W. Carter Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Miami health care",
+          "ehr": "vista"
+        },
+        "548": {
+          "vhaId": "548",
+          "vamcFacilityName": "West Palm Beach VA Medical Center",
+          "vamcSystemName": "VA West Palm Beach health care",
+          "ehr": "vista"
+        },
+        "549": {
+          "vhaId": "549",
+          "vamcFacilityName": "Dallas VA Medical Center",
+          "vamcSystemName": "VA North Texas health care",
+          "ehr": "vista"
+        },
+        "550": {
+          "vhaId": "550",
+          "vamcFacilityName": "Danville VA Medical Center",
+          "vamcSystemName": "VA Illiana health care",
+          "ehr": "vista"
+        },
+        "552": {
+          "vhaId": "552",
+          "vamcFacilityName": "Dayton VA Medical Center",
+          "vamcSystemName": "VA Dayton health care",
+          "ehr": "cerner"
+        },
+        "553": {
+          "vhaId": "553",
+          "vamcFacilityName": "John D. Dingell Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Detroit health care",
+          "ehr": "vista"
+        },
+        "554": {
+          "vhaId": "554",
+          "vamcFacilityName": "Rocky Mountain Regional VA Medical Center",
+          "vamcSystemName": "VA Eastern Colorado health care",
+          "ehr": "vista"
+        },
+        "557": {
+          "vhaId": "557",
+          "vamcFacilityName": "Carl Vinson Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Dublin health care",
+          "ehr": "vista"
+        },
+        "558": {
+          "vhaId": "558",
+          "vamcFacilityName": "Durham VA Medical Center",
+          "vamcSystemName": "VA Durham health care",
+          "ehr": "vista"
+        },
+        "561": {
+          "vhaId": "561",
+          "vamcFacilityName": "East Orange VA Medical Center",
+          "vamcSystemName": "VA New Jersey health care",
+          "ehr": "vista"
+        },
+        "562": {
+          "vhaId": "562",
+          "vamcFacilityName": "Erie VA Medical Center",
+          "vamcSystemName": "VA Erie health care",
+          "ehr": "vista"
+        },
+        "564": {
+          "vhaId": "564",
+          "vamcFacilityName": "Fayetteville VA Medical Center",
+          "vamcSystemName": "VA Fayetteville Arkansas health care",
+          "ehr": "vista"
+        },
+        "565": {
+          "vhaId": "565",
+          "vamcFacilityName": "Fayetteville VA Medical Center",
+          "vamcSystemName": "VA Fayetteville Coastal health care",
+          "ehr": "vista"
+        },
+        "568": {
+          "vhaId": "568",
+          "vamcFacilityName": "Fort Meade VA Medical Center",
+          "vamcSystemName": "VA Black Hills health care",
+          "ehr": "vista"
+        },
+        "570": {
+          "vhaId": "570",
+          "vamcFacilityName": "Fresno VA Medical Center",
+          "vamcSystemName": "VA Central California health care",
+          "ehr": "vista"
+        },
+        "573": {
+          "vhaId": "573",
+          "vamcFacilityName": "Malcom Randall Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA North Florida/South Georgia health care",
+          "ehr": "vista"
+        },
+        "575": {
+          "vhaId": "575",
+          "vamcFacilityName": "Grand Junction VA Medical Center",
+          "vamcSystemName": "VA Western Colorado health care",
+          "ehr": "vista"
+        },
+        "578": {
+          "vhaId": "578",
+          "vamcFacilityName": "Edward Hines Junior Hospital",
+          "vamcSystemName": "VA Hines health care",
+          "ehr": "vista"
+        },
+        "580": {
+          "vhaId": "580",
+          "vamcFacilityName": "Michael E. DeBakey Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Houston health care",
+          "ehr": "vista"
+        },
+        "581": {
+          "vhaId": "581",
+          "vamcFacilityName": "Hershel \"Woody\" Williams VA Medical Center",
+          "vamcSystemName": "VA Huntington health care",
+          "ehr": "vista"
+        },
+        "583": {
+          "vhaId": "583",
+          "vamcFacilityName": "Richard L. Roudebush Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Indiana health care",
+          "ehr": "vista"
+        },
+        "585": {
+          "vhaId": "585",
+          "vamcFacilityName": "Oscar G. Johnson Department of Veterans Affairs Medical Facility",
+          "vamcSystemName": "VA Iron Mountain health care",
+          "ehr": "vista"
+        },
+        "586": {
+          "vhaId": "586",
+          "vamcFacilityName": "G.V. (Sonny) Montgomery Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Jackson health care",
+          "ehr": "vista"
+        },
+        "589": {
+          "vhaId": "589",
+          "vamcFacilityName": "Kansas City VA Medical Center",
+          "vamcSystemName": "VA Kansas City health care",
+          "ehr": "vista"
+        },
+        "590": {
+          "vhaId": "590",
+          "vamcFacilityName": "Hampton VA Medical Center",
+          "vamcSystemName": "VA Hampton health care",
+          "ehr": "vista"
+        },
+        "593": {
+          "vhaId": "593",
+          "vamcFacilityName": "North Las Vegas VA Medical Center",
+          "vamcSystemName": "VA Southern Nevada health care",
+          "ehr": "vista"
+        },
+        "595": {
+          "vhaId": "595",
+          "vamcFacilityName": "Lebanon VA Medical Center",
+          "vamcSystemName": "VA Lebanon health care",
+          "ehr": "vista"
+        },
+        "596": {
+          "vhaId": "596",
+          "vamcFacilityName": "Franklin R. Sousley Campus",
+          "vamcSystemName": "VA Lexington health care",
+          "ehr": "vista"
+        },
+        "598": {
+          "vhaId": "598",
+          "vamcFacilityName": "John L. McClellan Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Central Arkansas health care",
+          "ehr": "vista"
+        },
+        "600": {
+          "vhaId": "600",
+          "vamcFacilityName": "Tibor Rubin VA Medical Center",
+          "vamcSystemName": "VA Long Beach health care",
+          "ehr": "vista"
+        },
+        "603": {
+          "vhaId": "603",
+          "vamcFacilityName": "Robley Rex Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Louisville health care",
+          "ehr": "vista"
+        },
+        "605": {
+          "vhaId": "605",
+          "vamcFacilityName": "Jerry L. Pettis Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Loma Linda health care",
+          "ehr": "vista"
+        },
+        "607": {
+          "vhaId": "607",
+          "vamcFacilityName": "William S. Middleton Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Madison health care",
+          "ehr": "vista"
+        },
+        "608": {
+          "vhaId": "608",
+          "vamcFacilityName": "Manchester VA Medical Center",
+          "vamcSystemName": "VA Manchester health care",
+          "ehr": "vista"
+        },
+        "610": {
+          "vhaId": "610",
+          "vamcFacilityName": "Marion VA Medical Center",
+          "vamcSystemName": "VA Northern Indiana health care",
+          "ehr": "vista"
+        },
+        "613": {
+          "vhaId": "613",
+          "vamcFacilityName": "Martinsburg VA Medical Center",
+          "vamcSystemName": "VA Martinsburg health care",
+          "ehr": "vista"
+        },
+        "614": {
+          "vhaId": "614",
+          "vamcFacilityName": "Memphis VA Medical Center",
+          "vamcSystemName": "VA Memphis health care",
+          "ehr": "vista"
+        },
+        "618": {
+          "vhaId": "618",
+          "vamcFacilityName": "Minneapolis VA Medical Center",
+          "vamcSystemName": "VA Minneapolis health care",
+          "ehr": "vista"
+        },
+        "619": {
+          "vhaId": "619",
+          "vamcFacilityName": "Central Alabama VA Medical Center-Montgomery",
+          "vamcSystemName": "VA Central Alabama health care",
+          "ehr": "vista"
+        },
+        "620": {
+          "vhaId": "620",
+          "vamcFacilityName": "Franklin Delano Roosevelt Hospital",
+          "vamcSystemName": "VA Hudson Valley health care",
+          "ehr": "vista"
+        },
+        "621": {
+          "vhaId": "621",
+          "vamcFacilityName": "James H. Quillen Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Mountain Home health care",
+          "ehr": "vista"
+        },
+        "623": {
+          "vhaId": "623",
+          "vamcFacilityName": "Jack C. Montgomery Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Eastern Oklahoma health care",
+          "ehr": "vista"
+        },
+        "626": {
+          "vhaId": "626",
+          "vamcFacilityName": "Nashville VA Medical Center",
+          "vamcSystemName": "VA Tennessee Valley health care",
+          "ehr": "vista"
+        },
+        "629": {
+          "vhaId": "629",
+          "vamcFacilityName": "New Orleans VA Medical Center",
+          "vamcSystemName": "VA Southeast Louisiana health care",
+          "ehr": "vista"
+        },
+        "630": {
+          "vhaId": "630",
+          "vamcFacilityName": "Margaret Cochran Corbin VA Campus",
+          "vamcSystemName": "VA New York Harbor health care",
+          "ehr": "vista"
+        },
+        "631": {
+          "vhaId": "631",
+          "vamcFacilityName": "Edward P. Boland Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Central Western Massachusetts health care",
+          "ehr": "vista"
+        },
+        "632": {
+          "vhaId": "632",
+          "vamcFacilityName": "Northport VA Medical Center",
+          "vamcSystemName": "VA Northport health care",
+          "ehr": "vista"
+        },
+        "635": {
+          "vhaId": "635",
+          "vamcFacilityName": "Oklahoma City VA Medical Center",
+          "vamcSystemName": "VA Oklahoma City health care",
+          "ehr": "vista"
+        },
+        "636": {
+          "vhaId": "636",
+          "vamcFacilityName": "Omaha VA Medical Center",
+          "vamcSystemName": "VA Nebraska-Western Iowa health care",
+          "ehr": "vista"
+        },
+        "637": {
+          "vhaId": "637",
+          "vamcFacilityName": "Charles George Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Asheville health care",
+          "ehr": "vista"
+        },
+        "640": {
+          "vhaId": "640",
+          "vamcFacilityName": "Palo Alto VA Medical Center",
+          "vamcSystemName": "VA Palo Alto health care",
+          "ehr": "vista"
+        },
+        "642": {
+          "vhaId": "642",
+          "vamcFacilityName": "Corporal Michael J. Crescenz Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Philadelphia health care",
+          "ehr": "vista"
+        },
+        "644": {
+          "vhaId": "644",
+          "vamcFacilityName": "Carl T. Hayden Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Phoenix health care",
+          "ehr": "vista"
+        },
+        "646": {
+          "vhaId": "646",
+          "vamcFacilityName": "Pittsburgh VA Medical Center-University Drive",
+          "vamcSystemName": "VA Pittsburgh health care",
+          "ehr": "vista"
+        },
+        "648": {
+          "vhaId": "648",
+          "vamcFacilityName": "Portland VA Medical Center",
+          "vamcSystemName": "VA Portland health care",
+          "ehr": "vista"
+        },
+        "649": {
+          "vhaId": "649",
+          "vamcFacilityName": "Bob Stump Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Northern Arizona health care",
+          "ehr": "vista"
+        },
+        "650": {
+          "vhaId": "650",
+          "vamcFacilityName": "Providence VA Medical Center",
+          "vamcSystemName": "VA Providence health care",
+          "ehr": "vista"
+        },
+        "652": {
+          "vhaId": "652",
+          "vamcFacilityName": "Hunter Holmes McGuire Hospital",
+          "vamcSystemName": "VA Richmond health care",
+          "ehr": "vista"
+        },
+        "653": {
+          "vhaId": "653",
+          "vamcFacilityName": "Roseburg VA Medical Center",
+          "vamcSystemName": "VA Roseburg health care",
+          "ehr": "cerner"
+        },
+        "654": {
+          "vhaId": "654",
+          "vamcFacilityName": "Ioannis A. Lougaris Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Sierra Nevada health care",
+          "ehr": "vista"
+        },
+        "655": {
+          "vhaId": "655",
+          "vamcFacilityName": "Aleda E. Lutz Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Saginaw health care",
+          "ehr": "vista"
+        },
+        "656": {
+          "vhaId": "656",
+          "vamcFacilityName": "St. Cloud VA Medical Center",
+          "vamcSystemName": "VA St Cloud health care",
+          "ehr": "vista"
+        },
+        "657": {
+          "vhaId": "657",
+          "vamcFacilityName": "John J. Cochran Veterans Hospital",
+          "vamcSystemName": "VA St Louis health care",
+          "ehr": "vista"
+        },
+        "658": {
+          "vhaId": "658",
+          "vamcFacilityName": "Salem VA Medical Center",
+          "vamcSystemName": "VA Salem health care",
+          "ehr": "vista"
+        },
+        "659": {
+          "vhaId": "659",
+          "vamcFacilityName": "W.G. (Bill) Hefner Salisbury Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Salisbury health care",
+          "ehr": "vista"
+        },
+        "660": {
+          "vhaId": "660",
+          "vamcFacilityName": "George E. Wahlen Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Salt Lake City health care",
+          "ehr": "vista"
+        },
+        "662": {
+          "vhaId": "662",
+          "vamcFacilityName": "San Francisco VA Medical Center",
+          "vamcSystemName": "VA San Francisco health care",
+          "ehr": "vista"
+        },
+        "663": {
+          "vhaId": "663",
+          "vamcFacilityName": "Seattle VA Medical Center",
+          "vamcSystemName": "VA Puget Sound health care",
+          "ehr": "vista"
+        },
+        "664": {
+          "vhaId": "664",
+          "vamcFacilityName": "Jennifer Moreno Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA San Diego health care",
+          "ehr": "vista"
+        },
+        "666": {
+          "vhaId": "666",
+          "vamcFacilityName": "Sheridan VA Medical Center",
+          "vamcSystemName": "VA Sheridan health care",
+          "ehr": "vista"
+        },
+        "667": {
+          "vhaId": "667",
+          "vamcFacilityName": "Overton Brooks Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Shreveport health care",
+          "ehr": "vista"
+        },
+        "668": {
+          "vhaId": "668",
+          "vamcFacilityName": "Mann-Grandstaff Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Spokane health care",
+          "ehr": "cerner"
+        },
+        "671": {
+          "vhaId": "671",
+          "vamcFacilityName": "Audie L. Murphy Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA South Texas health care",
+          "ehr": "vista"
+        },
+        "672": {
+          "vhaId": "672",
+          "vamcFacilityName": "San Juan VA Medical Center",
+          "vamcSystemName": "VA Caribbean health care",
+          "ehr": "vista"
+        },
+        "673": {
+          "vhaId": "673",
+          "vamcFacilityName": "James A. Haley Veterans\\' Hospital",
+          "vamcSystemName": "VA Tampa health care",
+          "ehr": "vista"
+        },
+        "674": {
+          "vhaId": "674",
+          "vamcFacilityName": "Olin E. Teague Veterans\\' Center",
+          "vamcSystemName": "VA Central Texas health care",
+          "ehr": "vista"
+        },
+        "675": {
+          "vhaId": "675",
+          "vamcFacilityName": "Orlando VA Medical Center",
+          "vamcSystemName": "VA Orlando health care",
+          "ehr": "vista"
+        },
+        "676": {
+          "vhaId": "676",
+          "vamcFacilityName": "Tomah VA Medical Center",
+          "vamcSystemName": "VA Tomah health care",
+          "ehr": "vista"
+        },
+        "678": {
+          "vhaId": "678",
+          "vamcFacilityName": "Tucson VA Medical Center",
+          "vamcSystemName": "VA Southern Arizona health care",
+          "ehr": "vista"
+        },
+        "679": {
+          "vhaId": "679",
+          "vamcFacilityName": "Tuscaloosa VA Medical Center",
+          "vamcSystemName": "VA Tuscaloosa health care",
+          "ehr": "vista"
+        },
+        "687": {
+          "vhaId": "687",
+          "vamcFacilityName": "Jonathan M. Wainwright Memorial VA Medical Center",
+          "vamcSystemName": "VA Walla Walla health care",
+          "ehr": "cerner"
+        },
+        "688": {
+          "vhaId": "688",
+          "vamcFacilityName": "Washington VA Medical Center",
+          "vamcSystemName": "VA Washington DC health care",
+          "ehr": "vista"
+        },
+        "689": {
+          "vhaId": "689",
+          "vamcFacilityName": "West Haven VA Medical Center",
+          "vamcSystemName": "VA Connecticut health care",
+          "ehr": "vista"
+        },
+        "691": {
+          "vhaId": "691",
+          "vamcFacilityName": "West Los Angeles VA Medical Center",
+          "vamcSystemName": "VA Greater Los Angeles health care",
+          "ehr": "vista"
+        },
+        "692": {
+          "vhaId": "692",
+          "vamcFacilityName": "White City VA Medical Center",
+          "vamcSystemName": "VA Southern Oregon health care",
+          "ehr": "cerner"
+        },
+        "693": {
+          "vhaId": "693",
+          "vamcFacilityName": "Wilkes-Barre VA Medical Center",
+          "vamcSystemName": "VA Wilkes-Barre health care",
+          "ehr": "vista"
+        },
+        "695": {
+          "vhaId": "695",
+          "vamcFacilityName": "Clement J. Zablocki Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Milwaukee health care",
+          "ehr": "vista"
+        },
+        "740": {
+          "vhaId": "740",
+          "vamcFacilityName": "Harlingen VA Clinic",
+          "vamcSystemName": "VA Texas Valley health care",
+          "ehr": "vista"
+        },
+        "756": {
+          "vhaId": "756",
+          "vamcFacilityName": "El Paso VA Clinic",
+          "vamcSystemName": "VA El Paso health care",
+          "ehr": "vista"
+        },
+        "757": {
+          "vhaId": "757",
+          "vamcFacilityName": "Chalmers P. Wylie Veterans Outpatient Clinic",
+          "vamcSystemName": "VA Central Ohio health care",
+          "ehr": "cerner"
+        },
+        "646A4": {
+          "vhaId": "646A4",
+          "vamcFacilityName": "H. John Heinz III Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Pittsburgh health care",
+          "ehr": "vista"
+        },
+        "405HA": {
+          "vhaId": "405HA",
+          "vamcFacilityName": "Burlington Lakeside VA Clinic",
+          "vamcSystemName": "VA White River Junction health care",
+          "ehr": "vista"
+        },
+        "523A4": {
+          "vhaId": "523A4",
+          "vamcFacilityName": "West Roxbury VA Medical Center",
+          "vamcSystemName": "VA Boston health care",
+          "ehr": "vista"
+        },
+        "523A5": {
+          "vhaId": "523A5",
+          "vamcFacilityName": "Brockton VA Medical Center",
+          "vamcSystemName": "VA Boston health care",
+          "ehr": "vista"
+        },
+        "528A5": {
+          "vhaId": "528A5",
+          "vamcFacilityName": "Canandaigua VA Medical Center",
+          "vamcSystemName": "VA Finger Lakes health care",
+          "ehr": "vista"
+        },
+        "528A6": {
+          "vhaId": "528A6",
+          "vamcFacilityName": "Bath VA Medical Center",
+          "vamcSystemName": "VA Finger Lakes health care",
+          "ehr": "vista"
+        },
+        "528A7": {
+          "vhaId": "528A7",
+          "vamcFacilityName": "Syracuse VA Medical Center",
+          "vamcSystemName": "VA Syracuse health care",
+          "ehr": "vista"
+        },
+        "528A8": {
+          "vhaId": "528A8",
+          "vamcFacilityName": "Samuel S. Stratton Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Albany health care",
+          "ehr": "vista"
+        },
+        "549A4": {
+          "vhaId": "549A4",
+          "vamcFacilityName": "Sam Rayburn Memorial Veterans Center",
+          "vamcSystemName": "VA North Texas health care",
+          "ehr": "vista"
+        },
+        "561A4": {
+          "vhaId": "561A4",
+          "vamcFacilityName": "Lyons VA Medical Center",
+          "vamcSystemName": "VA New Jersey health care",
+          "ehr": "vista"
+        },
+        "568A4": {
+          "vhaId": "568A4",
+          "vamcFacilityName": "Hot Springs VA Medical Center",
+          "vamcSystemName": "VA Black Hills health care",
+          "ehr": "vista"
+        },
+        "573A4": {
+          "vhaId": "573A4",
+          "vamcFacilityName": "Lake City VA Medical Center",
+          "vamcSystemName": "VA North Florida/South Georgia health care",
+          "ehr": "vista"
+        },
+        "581QB": {
+          "vhaId": "581QB",
+          "vamcFacilityName": "Huntington VA Mobile Clinic",
+          "vamcSystemName": "VA Huntington health care",
+          "ehr": "vista"
+        },
+        "589A4": {
+          "vhaId": "589A4",
+          "vamcFacilityName": "Harry S. Truman Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Columbia Missouri health care",
+          "ehr": "vista"
+        },
+        "589A7": {
+          "vhaId": "589A7",
+          "vamcFacilityName": "Robert J. Dole Department of Veterans Affairs Medical and Regional Office Center",
+          "vamcSystemName": "VA Wichita health care",
+          "ehr": "vista"
+        },
+        "596A4": {
+          "vhaId": "596A4",
+          "vamcFacilityName": "Troy Bowling Campus",
+          "vamcSystemName": "VA Lexington health care",
+          "ehr": "vista"
+        },
+        "610A4": {
+          "vhaId": "610A4",
+          "vamcFacilityName": "Fort Wayne VA Medical Center",
+          "vamcSystemName": "VA Northern Indiana health care",
+          "ehr": "vista"
+        },
+        "612A4": {
+          "vhaId": "612A4",
+          "vamcFacilityName": "Sacramento VA Medical Center",
+          "vamcSystemName": "VA Northern California health care",
+          "ehr": "vista"
+        },
+        "612GF": {
+          "vhaId": "612GF",
+          "vamcFacilityName": "Martinez VA Medical Center",
+          "vamcSystemName": "VA Northern California health care",
+          "ehr": "vista"
+        },
+        "620A4": {
+          "vhaId": "620A4",
+          "vamcFacilityName": "Castle Point VA Medical Center",
+          "vamcSystemName": "VA Hudson Valley health care",
+          "ehr": "vista"
+        },
+        "626A4": {
+          "vhaId": "626A4",
+          "vamcFacilityName": "Alvin C. York Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Tennessee Valley health care",
+          "ehr": "vista"
+        },
+        "630A4": {
+          "vhaId": "630A4",
+          "vamcFacilityName": "Brooklyn VA Medical Center",
+          "vamcSystemName": "VA New York Harbor health care",
+          "ehr": "vista"
+        },
+        "630A5": {
+          "vhaId": "630A5",
+          "vamcFacilityName": "St. Albans VA Medical Center",
+          "vamcSystemName": "VA New York Harbor health care",
+          "ehr": "vista"
+        },
+        "636A6": {
+          "vhaId": "636A6",
+          "vamcFacilityName": "Des Moines VA Medical Center",
+          "vamcSystemName": "VA Central Iowa health care",
+          "ehr": "vista"
+        },
+        "636A8": {
+          "vhaId": "636A8",
+          "vamcFacilityName": "Iowa City VA Medical Center",
+          "vamcSystemName": "VA Iowa City health care",
+          "ehr": "vista"
+        },
+        "640A0": {
+          "vhaId": "640A0",
+          "vamcFacilityName": "Palo Alto VA Medical Center-Menlo Park",
+          "vamcSystemName": "VA Palo Alto health care",
+          "ehr": "vista"
+        },
+        "640A4": {
+          "vhaId": "640A4",
+          "vamcFacilityName": "Palo Alto VA Medical Center-Livermore",
+          "vamcSystemName": "VA Palo Alto health care",
+          "ehr": "vista"
+        },
+        "648A4": {
+          "vhaId": "648A4",
+          "vamcFacilityName": "Portland VA Medical Center-Vancouver",
+          "vamcSystemName": "VA Portland health care",
+          "ehr": "vista"
+        },
+        "657A0": {
+          "vhaId": "657A0",
+          "vamcFacilityName": "St. Louis VA Medical Center-Jefferson Barracks",
+          "vamcSystemName": "VA St Louis health care",
+          "ehr": "vista"
+        },
+        "657A4": {
+          "vhaId": "657A4",
+          "vamcFacilityName": "John J. Pershing Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Poplar Bluff health care",
+          "ehr": "vista"
+        },
+        "657A5": {
+          "vhaId": "657A5",
+          "vamcFacilityName": "Marion VA Medical Center",
+          "vamcSystemName": "VA Marion health care",
+          "ehr": "vista"
+        },
+        "663A4": {
+          "vhaId": "663A4",
+          "vamcFacilityName": "American Lake VA Medical Center",
+          "vamcSystemName": "VA Puget Sound health care",
+          "ehr": "vista"
+        },
+        "756QB": {
+          "vhaId": "756QB",
+          "vamcFacilityName": "El Paso Central VA Clinic",
+          "vamcSystemName": "VA El Paso health care",
+          "ehr": "vista"
+        },
+        "549A5": {
+          "vhaId": "549A5",
+          "vamcFacilityName": "Garland VA Medical Center",
+          "vamcSystemName": "VA North Texas health care",
+          "ehr": "vista"
+        },
+        "674A4": {
+          "vhaId": "674A4",
+          "vamcFacilityName": "Doris Miller Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Central Texas health care",
+          "ehr": "vista"
+        },
+        "589A5": {
+          "vhaId": "589A5",
+          "vamcFacilityName": "Colmery-O\\'Neil Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Eastern Kansas health care",
+          "ehr": "vista"
+        },
+        "589A6": {
+          "vhaId": "589A6",
+          "vamcFacilityName": "Dwight D. Eisenhower Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Eastern Kansas health care",
+          "ehr": "vista"
+        },
+        "512GD": {
+          "vhaId": "512GD",
+          "vamcFacilityName": "Loch Raven VA Medical Center",
+          "vamcSystemName": "VA Maryland health care",
+          "ehr": "vista"
+        },
+        "512A5": {
+          "vhaId": "512A5",
+          "vamcFacilityName": "Perry Point VA Medical Center",
+          "vamcSystemName": "VA Maryland health care",
+          "ehr": "vista"
+        },
+        "619A4": {
+          "vhaId": "619A4",
+          "vamcFacilityName": "Central Alabama VA Medical Center-Tuskegee",
+          "vamcSystemName": "VA Central Alabama health care",
+          "ehr": "vista"
+        }
+      },
+      "cernerFacilities": [
+        {
+          "vhaId": "442",
+          "vamcFacilityName": "Cheyenne VA Medical Center",
+          "vamcSystemName": "VA Cheyenne health care",
+          "ehr": "cerner"
+        },
+        {
+          "vhaId": "552",
+          "vamcFacilityName": "Dayton VA Medical Center",
+          "vamcSystemName": "VA Dayton health care",
+          "ehr": "cerner"
+        },
+        {
+          "vhaId": "653",
+          "vamcFacilityName": "Roseburg VA Medical Center",
+          "vamcSystemName": "VA Roseburg health care",
+          "ehr": "cerner"
+        },
+        {
+          "vhaId": "687",
+          "vamcFacilityName": "Jonathan M. Wainwright Memorial VA Medical Center",
+          "vamcSystemName": "VA Walla Walla health care",
+          "ehr": "cerner"
+        },
+        {
+          "vhaId": "692",
+          "vamcFacilityName": "White City VA Medical Center",
+          "vamcSystemName": "VA Southern Oregon health care",
+          "ehr": "cerner"
+        },
+        {
+          "vhaId": "757",
+          "vamcFacilityName": "Chalmers P. Wylie Veterans Outpatient Clinic",
+          "vamcSystemName": "VA Central Ohio health care",
+          "ehr": "cerner"
+        },
+        {
+          "vhaId": "668",
+          "vamcFacilityName": "Mann-Grandstaff Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Spokane health care",
+          "ehr": "cerner"
+        }
+      ],
+      "vistaFacilities": [
+        {
+          "vhaId": "646",
+          "vamcFacilityName": "Pittsburgh VA Medical Center-University Drive",
+          "vamcSystemName": "VA Pittsburgh health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "646A4",
+          "vamcFacilityName": "H. John Heinz III Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Pittsburgh health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "405",
+          "vamcFacilityName": "White River Junction VA Medical Center",
+          "vamcSystemName": "VA White River Junction health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "405HA",
+          "vamcFacilityName": "Burlington Lakeside VA Clinic",
+          "vamcSystemName": "VA White River Junction health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "436",
+          "vamcFacilityName": "Fort Harrison VA Medical Center",
+          "vamcSystemName": "VA Montana health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "437",
+          "vamcFacilityName": "Fargo VA Medical Center",
+          "vamcSystemName": "VA Fargo health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "438",
+          "vamcFacilityName": "Royal C. Johnson Veterans\\' Memorial Hospital",
+          "vamcSystemName": "VA Sioux Falls health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "459",
+          "vamcFacilityName": "Spark M. Matsunaga Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Pacific Islands health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "460",
+          "vamcFacilityName": "Wilmington VA Medical Center",
+          "vamcSystemName": "VA Wilmington health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "463",
+          "vamcFacilityName": "Anchorage VA Medical Center",
+          "vamcSystemName": "VA Alaska health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "501",
+          "vamcFacilityName": "Raymond G. Murphy Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA New Mexico health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "502",
+          "vamcFacilityName": "Alexandria VA Medical Center",
+          "vamcSystemName": "VA Alexandria health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "503",
+          "vamcFacilityName": "James E. Van Zandt Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Altoona health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "504",
+          "vamcFacilityName": "Thomas E. Creek Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Amarillo health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "508",
+          "vamcFacilityName": "Atlanta VA Medical Center",
+          "vamcSystemName": "VA Atlanta health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "509",
+          "vamcFacilityName": "Charlie Norwood Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Augusta health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "515",
+          "vamcFacilityName": "Battle Creek VA Medical Center",
+          "vamcSystemName": "VA Battle Creek health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "517",
+          "vamcFacilityName": "Beckley VA Medical Center",
+          "vamcSystemName": "VA Beckley health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "518",
+          "vamcFacilityName": "Edith Nourse Rogers Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Bedford health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "519",
+          "vamcFacilityName": "George H. O\\'Brien, Jr., Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA West Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "520",
+          "vamcFacilityName": "Biloxi VA Medical Center",
+          "vamcSystemName": "VA Gulf Coast health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "521",
+          "vamcFacilityName": "Birmingham VA Medical Center",
+          "vamcSystemName": "VA Birmingham health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "523",
+          "vamcFacilityName": "Jamaica Plain VA Medical Center",
+          "vamcSystemName": "VA Boston health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "523A4",
+          "vamcFacilityName": "West Roxbury VA Medical Center",
+          "vamcSystemName": "VA Boston health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "523A5",
+          "vamcFacilityName": "Brockton VA Medical Center",
+          "vamcSystemName": "VA Boston health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "526",
+          "vamcFacilityName": "James J. Peters Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Bronx health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "528",
+          "vamcFacilityName": "Buffalo VA Medical Center",
+          "vamcSystemName": "VA Western New York health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "528A5",
+          "vamcFacilityName": "Canandaigua VA Medical Center",
+          "vamcSystemName": "VA Finger Lakes health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "528A6",
+          "vamcFacilityName": "Bath VA Medical Center",
+          "vamcSystemName": "VA Finger Lakes health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "528A7",
+          "vamcFacilityName": "Syracuse VA Medical Center",
+          "vamcSystemName": "VA Syracuse health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "528A8",
+          "vamcFacilityName": "Samuel S. Stratton Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Albany health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "529",
+          "vamcFacilityName": "Abie Abraham VA Clinic",
+          "vamcSystemName": "VA Butler health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "531",
+          "vamcFacilityName": "Boise VA Medical Center",
+          "vamcSystemName": "VA Boise health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "534",
+          "vamcFacilityName": "Ralph H. Johnson Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Charleston health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "537",
+          "vamcFacilityName": "Jesse Brown Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Chicago health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "538",
+          "vamcFacilityName": "Chillicothe VA Medical Center",
+          "vamcSystemName": "VA Chillicothe health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "539",
+          "vamcFacilityName": "Cincinnati VA Medical Center",
+          "vamcSystemName": "VA Cincinnati health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "540",
+          "vamcFacilityName": "Louis A. Johnson Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Clarksburg health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "541",
+          "vamcFacilityName": "Louis Stokes Cleveland Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Northeast Ohio health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "542",
+          "vamcFacilityName": "Coatesville VA Medical Center",
+          "vamcSystemName": "VA Coatesville health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "544",
+          "vamcFacilityName": "Wm. Jennings Bryan Dorn Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Columbia South Carolina health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "546",
+          "vamcFacilityName": "Bruce W. Carter Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Miami health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "548",
+          "vamcFacilityName": "West Palm Beach VA Medical Center",
+          "vamcSystemName": "VA West Palm Beach health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "549",
+          "vamcFacilityName": "Dallas VA Medical Center",
+          "vamcSystemName": "VA North Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "549A4",
+          "vamcFacilityName": "Sam Rayburn Memorial Veterans Center",
+          "vamcSystemName": "VA North Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "550",
+          "vamcFacilityName": "Danville VA Medical Center",
+          "vamcSystemName": "VA Illiana health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "553",
+          "vamcFacilityName": "John D. Dingell Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Detroit health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "554",
+          "vamcFacilityName": "Rocky Mountain Regional VA Medical Center",
+          "vamcSystemName": "VA Eastern Colorado health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "558",
+          "vamcFacilityName": "Durham VA Medical Center",
+          "vamcSystemName": "VA Durham health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "561",
+          "vamcFacilityName": "East Orange VA Medical Center",
+          "vamcSystemName": "VA New Jersey health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "561A4",
+          "vamcFacilityName": "Lyons VA Medical Center",
+          "vamcSystemName": "VA New Jersey health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "562",
+          "vamcFacilityName": "Erie VA Medical Center",
+          "vamcSystemName": "VA Erie health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "564",
+          "vamcFacilityName": "Fayetteville VA Medical Center",
+          "vamcSystemName": "VA Fayetteville Arkansas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "565",
+          "vamcFacilityName": "Fayetteville VA Medical Center",
+          "vamcSystemName": "VA Fayetteville Coastal health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "568",
+          "vamcFacilityName": "Fort Meade VA Medical Center",
+          "vamcSystemName": "VA Black Hills health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "568A4",
+          "vamcFacilityName": "Hot Springs VA Medical Center",
+          "vamcSystemName": "VA Black Hills health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "570",
+          "vamcFacilityName": "Fresno VA Medical Center",
+          "vamcSystemName": "VA Central California health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "573",
+          "vamcFacilityName": "Malcom Randall Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA North Florida/South Georgia health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "573A4",
+          "vamcFacilityName": "Lake City VA Medical Center",
+          "vamcSystemName": "VA North Florida/South Georgia health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "575",
+          "vamcFacilityName": "Grand Junction VA Medical Center",
+          "vamcSystemName": "VA Western Colorado health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "578",
+          "vamcFacilityName": "Edward Hines Junior Hospital",
+          "vamcSystemName": "VA Hines health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "580",
+          "vamcFacilityName": "Michael E. DeBakey Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Houston health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "581",
+          "vamcFacilityName": "Hershel \"Woody\" Williams VA Medical Center",
+          "vamcSystemName": "VA Huntington health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "581QB",
+          "vamcFacilityName": "Huntington VA Mobile Clinic",
+          "vamcSystemName": "VA Huntington health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "583",
+          "vamcFacilityName": "Richard L. Roudebush Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Indiana health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "585",
+          "vamcFacilityName": "Oscar G. Johnson Department of Veterans Affairs Medical Facility",
+          "vamcSystemName": "VA Iron Mountain health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "586",
+          "vamcFacilityName": "G.V. (Sonny) Montgomery Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Jackson health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "589",
+          "vamcFacilityName": "Kansas City VA Medical Center",
+          "vamcSystemName": "VA Kansas City health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "589A4",
+          "vamcFacilityName": "Harry S. Truman Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Columbia Missouri health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "589A7",
+          "vamcFacilityName": "Robert J. Dole Department of Veterans Affairs Medical and Regional Office Center",
+          "vamcSystemName": "VA Wichita health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "590",
+          "vamcFacilityName": "Hampton VA Medical Center",
+          "vamcSystemName": "VA Hampton health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "593",
+          "vamcFacilityName": "North Las Vegas VA Medical Center",
+          "vamcSystemName": "VA Southern Nevada health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "595",
+          "vamcFacilityName": "Lebanon VA Medical Center",
+          "vamcSystemName": "VA Lebanon health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "596",
+          "vamcFacilityName": "Franklin R. Sousley Campus",
+          "vamcSystemName": "VA Lexington health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "596A4",
+          "vamcFacilityName": "Troy Bowling Campus",
+          "vamcSystemName": "VA Lexington health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "598",
+          "vamcFacilityName": "John L. McClellan Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Central Arkansas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "600",
+          "vamcFacilityName": "Tibor Rubin VA Medical Center",
+          "vamcSystemName": "VA Long Beach health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "603",
+          "vamcFacilityName": "Robley Rex Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Louisville health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "605",
+          "vamcFacilityName": "Jerry L. Pettis Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Loma Linda health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "607",
+          "vamcFacilityName": "William S. Middleton Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA Madison health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "608",
+          "vamcFacilityName": "Manchester VA Medical Center",
+          "vamcSystemName": "VA Manchester health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "610",
+          "vamcFacilityName": "Marion VA Medical Center",
+          "vamcSystemName": "VA Northern Indiana health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "610A4",
+          "vamcFacilityName": "Fort Wayne VA Medical Center",
+          "vamcSystemName": "VA Northern Indiana health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "612A4",
+          "vamcFacilityName": "Sacramento VA Medical Center",
+          "vamcSystemName": "VA Northern California health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "612GF",
+          "vamcFacilityName": "Martinez VA Medical Center",
+          "vamcSystemName": "VA Northern California health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "613",
+          "vamcFacilityName": "Martinsburg VA Medical Center",
+          "vamcSystemName": "VA Martinsburg health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "614",
+          "vamcFacilityName": "Memphis VA Medical Center",
+          "vamcSystemName": "VA Memphis health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "618",
+          "vamcFacilityName": "Minneapolis VA Medical Center",
+          "vamcSystemName": "VA Minneapolis health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "620",
+          "vamcFacilityName": "Franklin Delano Roosevelt Hospital",
+          "vamcSystemName": "VA Hudson Valley health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "620A4",
+          "vamcFacilityName": "Castle Point VA Medical Center",
+          "vamcSystemName": "VA Hudson Valley health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "621",
+          "vamcFacilityName": "James H. Quillen Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Mountain Home health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "623",
+          "vamcFacilityName": "Jack C. Montgomery Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Eastern Oklahoma health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "626",
+          "vamcFacilityName": "Nashville VA Medical Center",
+          "vamcSystemName": "VA Tennessee Valley health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "626A4",
+          "vamcFacilityName": "Alvin C. York Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Tennessee Valley health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "629",
+          "vamcFacilityName": "New Orleans VA Medical Center",
+          "vamcSystemName": "VA Southeast Louisiana health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "630",
+          "vamcFacilityName": "Margaret Cochran Corbin VA Campus",
+          "vamcSystemName": "VA New York Harbor health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "630A4",
+          "vamcFacilityName": "Brooklyn VA Medical Center",
+          "vamcSystemName": "VA New York Harbor health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "630A5",
+          "vamcFacilityName": "St. Albans VA Medical Center",
+          "vamcSystemName": "VA New York Harbor health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "631",
+          "vamcFacilityName": "Edward P. Boland Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Central Western Massachusetts health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "632",
+          "vamcFacilityName": "Northport VA Medical Center",
+          "vamcSystemName": "VA Northport health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "635",
+          "vamcFacilityName": "Oklahoma City VA Medical Center",
+          "vamcSystemName": "VA Oklahoma City health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "636",
+          "vamcFacilityName": "Omaha VA Medical Center",
+          "vamcSystemName": "VA Nebraska-Western Iowa health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "636A6",
+          "vamcFacilityName": "Des Moines VA Medical Center",
+          "vamcSystemName": "VA Central Iowa health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "636A8",
+          "vamcFacilityName": "Iowa City VA Medical Center",
+          "vamcSystemName": "VA Iowa City health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "637",
+          "vamcFacilityName": "Charles George Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Asheville health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "640",
+          "vamcFacilityName": "Palo Alto VA Medical Center",
+          "vamcSystemName": "VA Palo Alto health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "640A0",
+          "vamcFacilityName": "Palo Alto VA Medical Center-Menlo Park",
+          "vamcSystemName": "VA Palo Alto health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "640A4",
+          "vamcFacilityName": "Palo Alto VA Medical Center-Livermore",
+          "vamcSystemName": "VA Palo Alto health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "642",
+          "vamcFacilityName": "Corporal Michael J. Crescenz Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Philadelphia health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "644",
+          "vamcFacilityName": "Carl T. Hayden Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Phoenix health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "648",
+          "vamcFacilityName": "Portland VA Medical Center",
+          "vamcSystemName": "VA Portland health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "648A4",
+          "vamcFacilityName": "Portland VA Medical Center-Vancouver",
+          "vamcSystemName": "VA Portland health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "649",
+          "vamcFacilityName": "Bob Stump Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Northern Arizona health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "650",
+          "vamcFacilityName": "Providence VA Medical Center",
+          "vamcSystemName": "VA Providence health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "652",
+          "vamcFacilityName": "Hunter Holmes McGuire Hospital",
+          "vamcSystemName": "VA Richmond health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "654",
+          "vamcFacilityName": "Ioannis A. Lougaris Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Sierra Nevada health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "655",
+          "vamcFacilityName": "Aleda E. Lutz Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Saginaw health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "656",
+          "vamcFacilityName": "St. Cloud VA Medical Center",
+          "vamcSystemName": "VA St Cloud health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "657",
+          "vamcFacilityName": "John J. Cochran Veterans Hospital",
+          "vamcSystemName": "VA St Louis health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "657A0",
+          "vamcFacilityName": "St. Louis VA Medical Center-Jefferson Barracks",
+          "vamcSystemName": "VA St Louis health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "657A4",
+          "vamcFacilityName": "John J. Pershing Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Poplar Bluff health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "657A5",
+          "vamcFacilityName": "Marion VA Medical Center",
+          "vamcSystemName": "VA Marion health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "658",
+          "vamcFacilityName": "Salem VA Medical Center",
+          "vamcSystemName": "VA Salem health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "659",
+          "vamcFacilityName": "W.G. (Bill) Hefner Salisbury Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Salisbury health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "660",
+          "vamcFacilityName": "George E. Wahlen Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Salt Lake City health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "662",
+          "vamcFacilityName": "San Francisco VA Medical Center",
+          "vamcSystemName": "VA San Francisco health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "663A4",
+          "vamcFacilityName": "American Lake VA Medical Center",
+          "vamcSystemName": "VA Puget Sound health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "664",
+          "vamcFacilityName": "Jennifer Moreno Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA San Diego health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "666",
+          "vamcFacilityName": "Sheridan VA Medical Center",
+          "vamcSystemName": "VA Sheridan health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "667",
+          "vamcFacilityName": "Overton Brooks Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Shreveport health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "671",
+          "vamcFacilityName": "Audie L. Murphy Memorial Veterans\\' Hospital",
+          "vamcSystemName": "VA South Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "672",
+          "vamcFacilityName": "San Juan VA Medical Center",
+          "vamcSystemName": "VA Caribbean health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "673",
+          "vamcFacilityName": "James A. Haley Veterans\\' Hospital",
+          "vamcSystemName": "VA Tampa health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "674",
+          "vamcFacilityName": "Olin E. Teague Veterans\\' Center",
+          "vamcSystemName": "VA Central Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "675",
+          "vamcFacilityName": "Orlando VA Medical Center",
+          "vamcSystemName": "VA Orlando health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "676",
+          "vamcFacilityName": "Tomah VA Medical Center",
+          "vamcSystemName": "VA Tomah health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "678",
+          "vamcFacilityName": "Tucson VA Medical Center",
+          "vamcSystemName": "VA Southern Arizona health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "679",
+          "vamcFacilityName": "Tuscaloosa VA Medical Center",
+          "vamcSystemName": "VA Tuscaloosa health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "688",
+          "vamcFacilityName": "Washington VA Medical Center",
+          "vamcSystemName": "VA Washington DC health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "689",
+          "vamcFacilityName": "West Haven VA Medical Center",
+          "vamcSystemName": "VA Connecticut health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "691",
+          "vamcFacilityName": "West Los Angeles VA Medical Center",
+          "vamcSystemName": "VA Greater Los Angeles health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "693",
+          "vamcFacilityName": "Wilkes-Barre VA Medical Center",
+          "vamcSystemName": "VA Wilkes-Barre health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "695",
+          "vamcFacilityName": "Clement J. Zablocki Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Milwaukee health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "740",
+          "vamcFacilityName": "Harlingen VA Clinic",
+          "vamcSystemName": "VA Texas Valley health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "756",
+          "vamcFacilityName": "El Paso VA Clinic",
+          "vamcSystemName": "VA El Paso health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "756QB",
+          "vamcFacilityName": "El Paso Central VA Clinic",
+          "vamcSystemName": "VA El Paso health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "549A5",
+          "vamcFacilityName": "Garland VA Medical Center",
+          "vamcSystemName": "VA North Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "402",
+          "vamcFacilityName": "Togus VA Medical Center",
+          "vamcSystemName": "VA Maine health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "516",
+          "vamcFacilityName": "C.W. Bill Young Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Bay Pines health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "674A4",
+          "vamcFacilityName": "Doris Miller Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Central Texas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "663",
+          "vamcFacilityName": "Seattle VA Medical Center",
+          "vamcSystemName": "VA Puget Sound health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "589A5",
+          "vamcFacilityName": "Colmery-O\\'Neil Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Eastern Kansas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "589A6",
+          "vamcFacilityName": "Dwight D. Eisenhower Department of Veterans Affairs Medical Center",
+          "vamcSystemName": "VA Eastern Kansas health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "557",
+          "vamcFacilityName": "Carl Vinson Veterans\\' Administration Medical Center",
+          "vamcSystemName": "VA Dublin health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "512",
+          "vamcFacilityName": "Baltimore VA Medical Center",
+          "vamcSystemName": "VA Maryland health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "512GD",
+          "vamcFacilityName": "Loch Raven VA Medical Center",
+          "vamcSystemName": "VA Maryland health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "512A5",
+          "vamcFacilityName": "Perry Point VA Medical Center",
+          "vamcSystemName": "VA Maryland health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "506",
+          "vamcFacilityName": "Lieutenant Colonel Charles S. Kettles VA Medical Center",
+          "vamcSystemName": "VA Ann Arbor health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "619",
+          "vamcFacilityName": "Central Alabama VA Medical Center-Montgomery",
+          "vamcSystemName": "VA Central Alabama health care",
+          "ehr": "vista"
+        },
+        {
+          "vhaId": "619A4",
+          "vamcFacilityName": "Central Alabama VA Medical Center-Tuskegee",
+          "vamcSystemName": "VA Central Alabama health care",
+          "ehr": "vista"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -13,10 +13,8 @@ import { captureError } from '../../utils/error';
 import { ELIGIBILITY_REASONS } from '../../utils/constants';
 import { promiseAllFromObject } from '../../utils/data';
 import { getAvailableHealthcareServices } from '../healthcare-service';
-import {
-  getLongTermAppointmentHistoryV2,
-  getPatientEligibility,
-} from '../vaos';
+import { getPatientEligibility } from '../vaos';
+import { getLongTermAppointmentHistoryV2 } from '../appointment';
 
 /**
  * @typedef PatientEligibilityForType

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -2,7 +2,7 @@
  * Functions related to patient specific information
  * @module services/Patient
  */
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import {
   checkPastVisits,
   getLongTermAppointmentHistory,

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -1,6 +1,5 @@
 import appendQuery from 'append-query';
-import moment from 'moment';
-import { fetchAppointments } from '../appointment';
+import { getTestFacilityId } from '../../utils/appointment';
 import { apiRequestWithUrl, parseApiList, parseApiObject } from '../utils';
 
 export function postAppointment(appointment) {
@@ -42,7 +41,7 @@ export function getAppointment(id) {
 export function getFacilities(ids, children = false) {
   return apiRequestWithUrl(
     `/vaos/v2/facilities?children=${children}&${ids
-      .map(id => `ids[]=${id}`)
+      .map(id => `ids[]=${getTestFacilityId(id)}`)
       .join('&')}`,
   ).then(parseApiList);
 }
@@ -94,55 +93,6 @@ export function getAvailableV2Slots(facilityId, clinicId, startDate, endDate) {
     `/vaos/v2/locations/${facilityId}/clinics/${clinicId}/slots?start=${startDate}&end=${endDate}`,
   ).then(parseApiList);
 }
-export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
-  const batch = [];
-  let promise = null;
-
-  return () => {
-    if (!promise || navigator.userAgent === 'node.js') {
-      // Creating an array of start and end dates for each chunk
-      const ranges = Array.from(Array(chunks).keys()).map(i => {
-        return {
-          start: moment()
-            .startOf('day')
-            .subtract(i + 1, 'year')
-            .utc()
-            .format(),
-
-          end: moment()
-            .startOf('day')
-            .subtract(i, 'year')
-            .utc()
-            .format(),
-        };
-      });
-
-      // There are three chunks with date ranges from the array created above.
-      // We're trying to run them serially, because we want to be careful about
-      // overloading the upstream service, so Promise.all doesn't fit here.
-      promise = ranges.reduce(async (prev, curr) => {
-        // NOTE: This is the secret sauce to run the fetch requests sequentially.
-        // Doing an 'await' on a non promise wraps it into a promise that is then awaited.
-        // In this case, the initial value of previous is set to an empty array.
-        //
-        // NOTE: fetchAppointments will run concurrently without this await 1st!
-        await prev;
-
-        // Next, fetch the appointments which will be chained which the previous await
-        const p1 = await fetchAppointments({
-          startDate: curr.start,
-          endDate: curr.end,
-          useV2VA: true,
-          useV2CC: true,
-        });
-        batch.push(p1);
-        return Promise.resolve([...batch].flat());
-      }, []);
-    }
-
-    return promise;
-  };
-})(3);
 
 export function getPreferredCCProvider(id) {
   return apiRequestWithUrl(`/vaos/v2/providers/${id}`, {

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -11,11 +11,11 @@ import {
 import {
   fetchBookedAppointment,
   getAppointmentRequests,
+  getLongTermAppointmentHistoryV2,
 } from '../../../services/appointment';
 import { VIDEO_TYPES } from '../../../utils/constants';
 import moment from '../../../lib/moment-tz';
 import { createMockAppointmentByVersion } from '../../mocks/data';
-import { getLongTermAppointmentHistoryV2 } from '../../../services/vaos';
 import {
   getDateRanges,
   mockVAOSAppointmentsFetch,

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -6,7 +6,7 @@ import {
   mockFetch,
   setFetchJSONFailure,
   setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+} from '@department-of-veterans-affairs/platform-testing/helpers';
 
 import {
   fetchBookedAppointment,

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -13,7 +13,7 @@ import {
   CANCELLED_APPOINTMENT_SET,
   PAST_APPOINTMENTS_HIDE_STATUS_SET,
   FUTURE_APPOINTMENTS_HIDE_STATUS_SET,
-} from '../../../services/appointment';
+} from '../../../utils/appointment';
 import { transformATLASLocation } from '../../../services/location/transformers';
 
 const now = moment();

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -4,7 +4,7 @@
  *
  */
 
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import {
   TYPES_OF_EYE_CARE,
   TYPES_OF_SLEEP_CARE,

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -10,7 +10,35 @@ import {
   TYPES_OF_SLEEP_CARE,
   AUDIOLOGY_TYPES_OF_CARE,
   TYPES_OF_CARE,
-} from '../utils/constants';
+} from './constants';
+
+export const CANCELLED_APPOINTMENT_SET = new Set([
+  'CANCELLED BY CLINIC & AUTO RE-BOOK',
+  'CANCELLED BY CLINIC',
+  'CANCELLED BY PATIENT & AUTO-REBOOK',
+  'CANCELLED BY PATIENT',
+]);
+
+// Appointments in these "HIDE_STATUS_SET"s should show in list, but their status should be hidden
+export const FUTURE_APPOINTMENTS_HIDE_STATUS_SET = new Set([
+  'ACT REQ/CHECKED IN',
+  'ACT REQ/CHECKED OUT',
+]);
+
+export const PAST_APPOINTMENTS_HIDE_STATUS_SET = new Set([
+  'ACTION REQUIRED',
+  'INPATIENT APPOINTMENT',
+  'INPATIENT/ACT REQ',
+  'INPATIENT/CHECKED IN',
+  'INPATIENT/CHECKED OUT',
+  'INPATIENT/FUTURE',
+  'INPATIENT/NO ACT TAKN',
+  'NO ACTION TAKEN',
+  'NO-SHOW & AUTO RE-BOOK',
+  'NO-SHOW',
+  'NON-COUNT',
+]);
+
 /**
  * Replaces a mock facility id with a real facility id in non production environments
  *
@@ -21,6 +49,21 @@ import {
 export function getRealFacilityId(facilityId) {
   if (!environment.isProduction() && facilityId) {
     return facilityId.replace('983', '442').replace('984', '552');
+  }
+
+  return facilityId;
+}
+
+/**
+ * Converts back from a real facility id to our test facility ids
+ * in lower environments
+ *
+ * @param {String} facilityId - facility id to convert
+ * @returns A facility id with either 442 or 552 replaced with 983 or 984
+ */
+export function getTestFacilityId(facilityId) {
+  if (facilityId && (!environment.isProduction() || window.Cypress)) {
+    return facilityId.replace('442', '983').replace('552', '984');
   }
 
   return facilityId;
@@ -38,4 +81,46 @@ export function getTypeOfCareById(inputId) {
     ({ idV2 = '', ccId = '', id = '' }) =>
       idV2 === inputId || ccId === inputId || id === inputId,
   );
+}
+
+/**
+ * Method to get patient video instruction
+ * @param {Appointment} appointment A FHIR appointment resource
+ * @return {string} Returns patient video instruction title and exclude remaining data
+ */
+
+export function getPatientInstruction(appointment) {
+  if (appointment?.patientInstruction.includes('Medication Review')) {
+    return 'Medication Review';
+  }
+  if (appointment?.patientInstruction.includes('Video Visit Preparation')) {
+    return 'Video Visit Preparation';
+  }
+  return null;
+}
+
+/**
+ * Get the provider name based on api version
+ *
+ *
+ * @export
+ * @param {Object} appointment an appointment object
+ * @returns {String} Returns the provider first and last name
+ */
+export function getProviderName(appointment) {
+  if (appointment.version === 1) {
+    const { providerName } = appointment.communityCareProvider;
+    return providerName;
+  }
+
+  if (appointment.practitioners !== undefined) {
+    const providers = appointment.practitioners
+      .filter(person => !!person.name)
+      .map(person => `${person.name.given.join(' ')} ${person.name.family} `);
+    if (providers.length > 0) {
+      return providers;
+    }
+    return null;
+  }
+  return null;
 }


### PR DESCRIPTION
## Description
The PR contains the initial changes to retrieve Acheron data from Drupal

## Original issue(s)
fixes department-of-veterans-affairs/va.gov-team#47253


## Testing done
Unit

## Screenshots


## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
