### PR TITLE
Store patient phone and email in reasonCode.text field

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -23,14 +23,14 @@ import { selectFeatureVAOSServiceRequests } from '../../redux/selectors';
 function isValidComment(value) {
   // exclude the ^ since the caret is a delimiter for MUMPS (Vista)
   if (value !== null) {
-    return /^[^^]+$/g.test(value);
+    return /^[^|^]+$/g.test(value);
   }
   return true;
 }
 
 function validComment(errors, input) {
   if (input && !isValidComment(input)) {
-    errors.addError('following special character is not allowed: ^');
+    errors.addError('following special character is not allowed: ^ |');
   }
   if (input && !/\S/.test(input)) {
     errors.addError('Please provide a response');

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -34,15 +34,14 @@ function getReasonCode({ data, isCC, isAcheron }) {
         }`,
     );
     // TODO: Replace hard coded values.
-    const phoneNumber = `Phone Number: 123-456-7890|`;
-    const email = `Email: s@test.com|`;
-    const preferredDates = `Preferred Dates:${formattedDates.toString()}|`;
-    const reasonCode = `Reason Code: code_1|`;
+    const { phoneNumber, email } = data;
+    const preferredDates = `Preferred Dates:${formattedDates.toString()}`;
+    const reasonCode = `Reason Code: code_1`;
     reasonText = `comments:${data.reasonAdditionalInfo.slice(0, 250)}`;
     // Add phone number, email, preferred Date, reason Code to
     // appointmentInfo string in this order (phone number, email,
     // preferred Date, reason Code)
-    appointmentInfo = `${phoneNumber}${email}${preferredDates}${reasonCode}`;
+    appointmentInfo = `phone number: ${phoneNumber}|email: ${email}|${preferredDates}|${reasonCode}`;
   }
 
   return {
@@ -55,7 +54,7 @@ function getReasonCode({ data, isCC, isAcheron }) {
     // to be truncated to 250 char
     text:
       data.reasonAdditionalInfo && isAcheron
-        ? `${appointmentInfo}${reasonText}`
+        ? `${appointmentInfo}|${reasonText}`
         : reasonText,
   };
 }

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -94,12 +94,12 @@ function getAppointmentInfoFromComments(comments, key) {
   const appointmentInfo = comments?.split('|');
   if (key === 'phone') {
     const phone = appointmentInfo ? appointmentInfo[0]?.split(':')[1] : null;
-    const transformedPhone = { type: 'phone', value: phone };
+    const transformedPhone = { system: 'phone', value: phone };
     data.push(transformedPhone);
   }
   if (key === 'email') {
     const email = appointmentInfo ? appointmentInfo[1]?.split(':')[1] : null;
-    const transformedemail = { type: 'email', value: email };
+    const transformedemail = { system: 'email', value: email };
     data.push(transformedemail);
   }
   if (key === 'preferredDate') {


### PR DESCRIPTION
## Description
When the user enters their phone number and email to submit the VA request, the VAOS application will send the contact information in the reasonCode.text field

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47730


## Testing done
unit test

## Screenshots
**Confirmation Page**

<img width="304" alt="Screen Shot 2022-10-25 at 4 54 30 PM" src="https://user-images.githubusercontent.com/54327023/197913290-e72ea107-dd9e-4a30-a187-199084f987f9.png">

**POST API Payload** 
```
{
    "kind": "telehealth",
    "status": "proposed",
    "locationId": "983",
    "serviceType": "primaryCare",
    "reasonCode": {
        "coding": [
            {
                "code": "New Problem"
            }
        ],
        "text": "phone number: 6195551234|email: myemail72585885@unattended.com|Preferred Dates:10/31/2022 AM,10/31/2022 PM|Reason Code: code_1|comments:medical stuff"
    },
    "contact": {
        "telecom": [
            {
                "type": "phone",
                "value": "6195551234"
            },
            {
                "type": "email",
                "value": "myemail72585885@unattended.com"
            }
        ]
    },
    "requestedPeriods": [
        {
            "start": "2022-10-31T00:00:00Z",
            "end": "2022-10-31T11:59:00Z"
        }
    ],
    "preferredTimesForPhoneCall": []
}
```

## Acceptance criteria
- [ ] code should be behind the Acheron Service feature flag
- [ ] user cannot use the vertical pipe symbol in the comment field

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
