### PR TITLE
Adds conditional rescue if the fn doesn't have a string in argument

### DIFF
--- a/src/applications/toe/helpers.jsx
+++ b/src/applications/toe/helpers.jsx
@@ -24,10 +24,13 @@ export function titleCase(str) {
 }
 
 export function obfuscate(str, numVisibleChars = 4, obfuscateChar = '●') {
+  if (!str) {
+    return '';
+  }
+
   if (str.length <= numVisibleChars) {
     return str;
   }
-
   return (
     obfuscateChar.repeat(str.length - numVisibleChars) +
     str.substring(str.length - numVisibleChars, str.length)


### PR DESCRIPTION
## Description
Adds conditional rescue of obfuscate function if the string argument is empty to prevent page from collapsing.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
