### PR TITLE
[VA-10907] Update Facility Health ATC links to go to Facility Page

### DIFF
--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { formatDateLong } from 'platform/utilities/date';
-import FacilityApiAlert from './FacilityApiAlert';
 import { connect } from 'react-redux';
 import _ from 'lodash';
+import FacilityApiAlert from './FacilityApiAlert';
 
 export class FacilityAppointmentWaitTimesWidget extends React.Component {
   appointmentWaitTime(waitTime, service, established = false) {
@@ -77,7 +77,11 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
                   Current as of {formatDateLong(facility.access.effectiveDate)}
                 </p>
                 <p className="vads-u-margin--0">
-                  <a href="https://www.accesstocare.va.gov/">
+                  <a
+                    href={`https://www.accesstocare.va.gov/FacilityPerformanceData/FacilityData?stationNumber=${
+                      facility.uniqueId
+                    }`}
+                  >
                     Learn more about VA appointment wait times
                   </a>
                 </p>

--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -4,6 +4,7 @@ import { formatDateLong } from 'platform/utilities/date';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import FacilityApiAlert from './FacilityApiAlert';
+import FacilityDataLink from './FacilityDataLink';
 
 export class FacilityAppointmentWaitTimesWidget extends React.Component {
   appointmentWaitTime(waitTime, service, established = false) {
@@ -77,13 +78,10 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
                   Current as of {formatDateLong(facility.access.effectiveDate)}
                 </p>
                 <p className="vads-u-margin--0">
-                  <a
-                    href={`https://www.accesstocare.va.gov/FacilityPerformanceData/FacilityData?stationNumber=${
-                      facility.uniqueId
-                    }`}
-                  >
-                    Learn more about VA appointment wait times
-                  </a>
+                  <FacilityDataLink
+                    facilityId={facility.uniqueId}
+                    text="Learn more about VA appointment wait times"
+                  />
                 </p>
               </div>
             </div>

--- a/src/applications/static-pages/facilities/FacilityDataLink.jsx
+++ b/src/applications/static-pages/facilities/FacilityDataLink.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function FacilityDataLink(facilityId, text) {
+  return (
+    <a
+      href={`https://www.accesstocare.va.gov/FacilityPerformanceData/FacilityData?stationNumber=${facilityId}`}
+    >
+      {text}
+    </a>
+  );
+}

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -4,6 +4,7 @@ import { formatDateLong } from 'platform/utilities/date';
 import { displayPercent } from 'platform/utilities/ui';
 import { connect } from 'react-redux';
 import FacilityApiAlert from './FacilityApiAlert';
+import FacilityDataLink from './FacilityDataLink';
 
 export function FacilityPatientSatisfactionScoresWidget(props) {
   if (props.loading || !Object.keys(props.facility).length) {
@@ -109,13 +110,10 @@ export function FacilityPatientSatisfactionScoresWidget(props) {
         Current as of {formatDateLong(facility.feedback.effectiveDate)}
       </p>
       <p>
-        <a
-          href={`https://www.accesstocare.va.gov/FacilityPerformanceData/FacilityData?stationNumber=${
-            facility.uniqueId
-          }`}
-        >
-          Learn more about Veteran satisfaction with access to care
-        </a>
+        <FacilityDataLink
+          facilityId={facility.uniqueId}
+          text="Learn more about Veteran satisfaction with access to care"
+        />
       </p>
     </div>
   );

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { formatDateLong } from 'platform/utilities/date';
 import { displayPercent } from 'platform/utilities/ui';
-import FacilityApiAlert from './FacilityApiAlert';
 import { connect } from 'react-redux';
+import FacilityApiAlert from './FacilityApiAlert';
 
 export function FacilityPatientSatisfactionScoresWidget(props) {
   if (props.loading || !Object.keys(props.facility).length) {
@@ -109,7 +109,11 @@ export function FacilityPatientSatisfactionScoresWidget(props) {
         Current as of {formatDateLong(facility.feedback.effectiveDate)}
       </p>
       <p>
-        <a href="https://www.accesstocare.va.gov/">
+        <a
+          href={`https://www.accesstocare.va.gov/FacilityPerformanceData/FacilityData?stationNumber=${
+            facility.uniqueId
+          }`}
+        >
           Learn more about Veteran satisfaction with access to care
         </a>
       </p>


### PR DESCRIPTION
## Description

Access to Care (ATC) data links should go to the facility's specific ATC data page, not the ATC homepage. This uses the facility unique ID to link to the needed page.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-team#10907

## Testing done

Visual

## Screenshots

<img width="708" alt="Screen Shot 2022-10-26 at 2 37 47 PM" src="https://user-images.githubusercontent.com/10790736/198108841-d4523ab1-e902-47c9-bbad-de9dfeed87f1.png">

<img width="776" alt="Screen Shot 2022-10-26 at 2 37 57 PM" src="https://user-images.githubusercontent.com/10790736/198108844-8668d930-3975-4b6c-91df-1bc4d486d447.png">

## Acceptance criteria

- [ ] Links related to wait times and satisfaction scores link to the facilities specific ATC data page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
