### PR TITLE
[DLD] Use receivedAt instead of uploadDate

### DIFF
--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -6,7 +6,7 @@ import environment from 'platform/utilities/environment';
 const downloadUrl = id => `${environment.API_URL}/v0/claim_letters/${id}`;
 
 const ClaimLetterListItem = ({ letter }) => {
-  const heading = `Letter dated ${letter.uploadDate}`;
+  const heading = `Letter dated ${letter.receivedAt}`;
 
   return (
     <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">

--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -74,7 +74,9 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
               Showing {fromToNums[0]} - {fromToNums[1]} of {totalItems.current}{' '}
               claim letters
             </p> */}
-            <ClaimLetterList letters={currentItems} />
+            {currentItems.length ? (
+              <ClaimLetterList letters={currentItems} />
+            ) : null}
             {totalPages.current > 1 && (
               <VaPagination
                 onPageSelect={e => onPageChange(e.detail.page)}


### PR DESCRIPTION
## Description
Using receivedAt instead of uploadDate for the letters app. The receivedAt date more closely aligns with when the letter is generated and in some cases the uploadDate can be years after the receivedAt date

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47953

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
