### PR TITLE
Supplemental Claims | Add feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -73,7 +73,6 @@ export default Object.freeze({
   hcaMedicareClaimNumberEnabled: 'hca_medicare_claim_number_enabled',
   hcaShortFormEnabled: 'hca_short_form_enabled',
   hcaUseFacilitiesApi: 'hca_use_facilities_API',
-  hlrv2: 'hlr_v2',
   loopPages: 'loop_pages',
   manageDependents: 'dependents_management',
   megaMenuMobileV2: 'mega_menu_mobile_v2',
@@ -134,6 +133,7 @@ export default Object.freeze({
   stemAutomatedDecision: 'stem_automated_decision',
   stemSCOEmail: 'stem_sco_email',
   subform89404192: 'subform_8940_4192',
+  supplementalClaim: 'supplemental_claim',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
   vaGlobalDowntimeNotification: 'va_global_downtime_notification',
   vaHomePreview:


### PR DESCRIPTION
## Description

We plan to release Supplemental Claims for 20-0995 in stages. Using the feature flag system will help us accomplish this.

[vets-api change in #11013](https://github.com/department-of-veterans-affairs/vets-api/pull/11013)

Also, removing `hlr_v2` - no longer used anywhere

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/48165

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Add `supplemental_claim` feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
