### PR TITLE
Remove contact field on post call for acheron

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -30,7 +30,7 @@ function isValidComment(value) {
 
 function validComment(errors, input) {
   if (input && !isValidComment(input)) {
-    errors.addError('following special character is not allowed: ^ |');
+    errors.addError('following special characters are not allowed: ^ |');
   }
   if (input && !/\S/.test(input)) {
     errors.addError('Please provide a response');

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -156,7 +156,7 @@ export function transformFormToVAOSVARequest(
   const data = getFormData(state);
   const typeOfCare = getTypeOfCare(data);
 
-  return {
+  const postBody = {
     kind: data.visitType,
     status: 'proposed',
     locationId: data.vaFacility,
@@ -168,18 +168,7 @@ export function transformFormToVAOSVARequest(
       isAcheron: featureAcheronVAOSServiceRequests,
     }),
     // comment: data.reasonAdditionalInfo,
-    contact: {
-      telecom: [
-        {
-          type: 'phone',
-          value: data.phoneNumber,
-        },
-        {
-          type: 'email',
-          value: data.email,
-        },
-      ],
-    },
+    // contact field removed for acheron service
     requestedPeriods: featureAcheronVAOSServiceRequests
       ? [
           {
@@ -203,6 +192,25 @@ export function transformFormToVAOSVARequest(
     preferredTimesForPhoneCall: Object.entries(data.bestTimeToCall || {})
       .filter(item => item[1])
       .map(item => titleCase(item[0])),
+  };
+
+  if (featureAcheronVAOSServiceRequests) return postBody;
+
+  // add the contact field for non acheron service
+  return {
+    ...postBody,
+    contact: {
+      telecom: [
+        {
+          type: 'phone',
+          value: data.phoneNumber,
+        },
+        {
+          type: 'email',
+          value: data.email,
+        },
+      ],
+    },
   };
 }
 

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -92,16 +92,21 @@ function getAtlasLocation(appt) {
 function getAppointmentInfoFromComments(comments, key) {
   const data = [];
   const appointmentInfo = comments?.split('|');
-  if (key === 'phone') {
-    const phone = appointmentInfo ? appointmentInfo[0]?.split(':')[1] : null;
+  if (key === 'contact') {
+    const phone = appointmentInfo
+      ? appointmentInfo[0]?.split(':')[1].trim()
+      : null;
+    const email = appointmentInfo
+      ? appointmentInfo[1]?.split(':')[1].trim()
+      : null;
+
     const transformedPhone = { system: 'phone', value: phone };
-    data.push(transformedPhone);
+    const transformedEmail = { system: 'email', value: email };
+
+    data.push(transformedPhone, transformedEmail);
+    return data;
   }
-  if (key === 'email') {
-    const email = appointmentInfo ? appointmentInfo[1]?.split(':')[1] : null;
-    const transformedemail = { system: 'email', value: email };
-    data.push(transformedemail);
-  }
+
   if (key === 'preferredDate') {
     const preferredDates = appointmentInfo
       ? appointmentInfo[2]?.split(':')[1]?.split(',')
@@ -150,6 +155,21 @@ function getAppointmentInfoFromComments(comments, key) {
     return data;
   }
   return data;
+}
+
+function getPatientContact(appt) {
+  if (appt.contact?.telecom?.length > 0) {
+    // for non acheron service
+    return {
+      telecom: appt.contact?.telecom.map(contact => ({
+        system: contact.type,
+        value: contact.value,
+      })),
+    };
+  }
+  return {
+    telecom: getAppointmentInfoFromComments(appt.reasonCode.text, 'contact'),
+  };
 }
 
 export function transformVAOSAppointment(appt) {
@@ -226,12 +246,7 @@ export function transformVAOSAppointment(appt) {
           },
         ],
       },
-      contact: {
-        telecom: appt.contact?.telecom.map(contact => ({
-          system: contact.type,
-          value: contact.value,
-        })),
-      },
+      contact: getPatientContact(appt),
     };
   }
 

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -127,7 +127,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
     fireEvent.click(screen.getByText(/Continue/));
 
     expect(await screen.findByRole('alert')).to.contain.text(
-      'following special character is not allowed: ^',
+      'following special characters are not allowed: ^ |',
     );
   });
 


### PR DESCRIPTION
## Description
When VAOS migrate to the Acheron Service, the BE will not be using the contact field. This PR is to remove the contact field in the POST call if it is under the Acheron flag

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47730


## Testing done
unit

## Screenshots
<img width="503" alt="Screen Shot 2022-10-27 at 9 58 07 AM" src="https://user-images.githubusercontent.com/54327023/198358295-12fce8d6-7d04-465a-8a99-21c185c34aeb.png">

**Post Call for Acheron service flag**
```
{
    "kind": "telehealth",
    "status": "proposed",
    "locationId": "983",
    "serviceType": "optometry",
    "reasonCode": {
        "coding": [
            {
                "code": "New Problem"
            }
        ],
        "text": "phone number: 3213214444|email: myemail72585885@unattended.com|Preferred Dates:11/01/2022 PM,11/02/2022 PM,11/03/2022 PM|Reason Code: code_1|comments:Test Acheron contact field"
    },
    "requestedPeriods": [
        {
            "start": "2022-11-01T12:00:00Z",
            "end": "2022-11-01T23:59:00Z"
        }
    ],
    "preferredTimesForPhoneCall": []
}
```
**Post call for non Acheron**
```
{
    "kind": "phone",
    "status": "proposed",
    "locationId": "983",
    "serviceType": "primaryCare",
    "reasonCode": {
        "coding": [
            {
                "code": "Routine Follow-up"
            }
        ],
        "text": "testing post call"
    },
    "requestedPeriods": [
        {
            "start": "2022-11-07T00:00:00Z",
            "end": "2022-11-07T11:59:00Z"
        },
        {
            "start": "2022-11-08T00:00:00Z",
            "end": "2022-11-08T11:59:00Z"
        },
        {
            "start": "2022-11-09T00:00:00Z",
            "end": "2022-11-09T11:59:00Z"
        }
    ],
    "preferredTimesForPhoneCall": [
        "Morning",
        "Afternoon",
        "Evening"
    ],
    "contact": {
        "telecom": [
            {
                "type": "phone",
                "value": "6195551234"
            },
            {
                "type": "email",
                "value": "myemail72585885@unattended.com"
            }
        ]
    }
}
```


## Acceptance criteria
- [ ] do not pass contact field in the POST call under the acheron service

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
