### PR TITLE
Vfep 31 additional ncts references removed from wizard

### DIFF
--- a/src/applications/edu-benefits/1990/tests/e2e/edu-1990.cypress.spec.js
+++ b/src/applications/edu-benefits/1990/tests/e2e/edu-1990.cypress.spec.js
@@ -40,7 +40,7 @@ const form = createTestConfig(
           .click();
         cy.get('#NewBenefit-0').check();
         cy.get('#ClaimingBenefitOwnService-0').check();
-        cy.get('#NationalCallToService-1').click();
+        // cy.get('#NationalCallToService-1').click();
         cy.get('#VetTec-1').click();
         cy.get('#apply-now-link').click();
 

--- a/src/applications/edu-benefits/1990e/tests/e2e/edu-1990e.cypress.spec.js
+++ b/src/applications/edu-benefits/1990e/tests/e2e/edu-1990e.cypress.spec.js
@@ -40,7 +40,7 @@ const form = createTestConfig(
           .click();
         cy.get('#NewBenefit-0').check();
         cy.get('#ClaimingBenefitOwnService-0').check();
-        cy.get('#NationalCallToService-1').click();
+        // cy.get('#NationalCallToService-1').click();
         cy.get('#VetTec-1').click();
         cy.get('#apply-now-link').click();
 

--- a/src/applications/edu-benefits/1990n/tests/ReadMe.txt
+++ b/src/applications/edu-benefits/1990n/tests/ReadMe.txt
@@ -1,0 +1,6 @@
+All test are commented out
+Online form 22-1990n will no longer be available to fill out Online
+PDF version of 22-1990n will be available for download
+Left code for online form 22-1990n in repo incase education wants to add the online form back
+
+Date: Oct 2022

--- a/src/applications/edu-benefits/1990n/tests/config/applicantInformation.unit.spec.jsx
+++ b/src/applications/edu-benefits/1990n/tests/config/applicantInformation.unit.spec.jsx
@@ -1,24 +1,24 @@
-import React from 'react';
-import { findDOMNode } from 'react-dom';
-import { expect } from 'chai';
-import ReactTestUtils from 'react-dom/test-utils';
+// import React from 'react';
+// import { findDOMNode } from 'react-dom';
+// import { expect } from 'chai';
+// import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
-import formConfig from '../../../1990n/config/form.js';
+// import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+// import formConfig from '../../../1990n/config/form.js';
 
-describe('Edu 1990N applicantInformation', () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.applicantInformation.pages.applicantInformation;
-  it('should render', () => {
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} data={{}} uiSchema={uiSchema} />,
-    );
-    const formDOM = findDOMNode(form);
+// describe('Edu 1990N applicantInformation', () => {
+//   const {
+//     schema,
+//     uiSchema,
+//   } = formConfig.chapters.applicantInformation.pages.applicantInformation;
+//   it('should render', () => {
+//     const form = ReactTestUtils.renderIntoDocument(
+//       <DefinitionTester schema={schema} data={{}} uiSchema={uiSchema} />,
+//     );
+//     const formDOM = findDOMNode(form);
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
-    expect(formDOM.querySelector('#root_veteranSocialSecurityNumber')).not.to.be
-      .null;
-  });
-});
+//     expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
+//     expect(formDOM.querySelector('#root_veteranSocialSecurityNumber')).not.to.be
+//       .null;
+//   });
+// });

--- a/src/applications/edu-benefits/1990n/tests/config/applicantService.unit.spec.jsx
+++ b/src/applications/edu-benefits/1990n/tests/config/applicantService.unit.spec.jsx
@@ -1,59 +1,59 @@
-import React from 'react';
-import { findDOMNode } from 'react-dom';
-import { expect } from 'chai';
-import ReactTestUtils from 'react-dom/test-utils';
+// import React from 'react';
+// import { findDOMNode } from 'react-dom';
+// import { expect } from 'chai';
+// import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
-import formConfig from '../../config/form';
+// import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+// import formConfig from '../../config/form';
 
-describe('Edu 1990n applicantService', () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.applicantInformation.pages.applicantService;
-  it('should render', () => {
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        schema={schema}
-        definitions={formConfig.defaultDefinitions}
-        data={{}}
-        uiSchema={uiSchema}
-      />,
-    );
-    const fields = Array.from(
-      findDOMNode(form).querySelectorAll('input, select'),
-    );
+// describe('Edu 1990n applicantService', () => {
+//   const {
+//     schema,
+//     uiSchema,
+//   } = formConfig.chapters.applicantInformation.pages.applicantService;
+//   it('should render', () => {
+//     const form = ReactTestUtils.renderIntoDocument(
+//       <DefinitionTester
+//         schema={schema}
+//         definitions={formConfig.defaultDefinitions}
+//         data={{}}
+//         uiSchema={uiSchema}
+//       />,
+//     );
+//     const fields = Array.from(
+//       findDOMNode(form).querySelectorAll('input, select'),
+//     );
 
-    expect(fields.length).to.equal(10);
-  });
+//     expect(fields.length).to.equal(10);
+//   });
 
-  it('should expand tours and other questions', () => {
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        schema={schema}
-        definitions={formConfig.defaultDefinitions}
-        data={{}}
-        uiSchema={uiSchema}
-      />,
-    );
-    const formDOM = findDOMNode(form);
+//   it('should expand tours and other questions', () => {
+//     const form = ReactTestUtils.renderIntoDocument(
+//       <DefinitionTester
+//         schema={schema}
+//         definitions={formConfig.defaultDefinitions}
+//         data={{}}
+//         uiSchema={uiSchema}
+//       />,
+//     );
+//     const formDOM = findDOMNode(form);
 
-    let fields = Array.from(
-      findDOMNode(form).querySelectorAll('input, select'),
-    );
-    expect(fields.length).to.equal(10);
+//     let fields = Array.from(
+//       findDOMNode(form).querySelectorAll('input, select'),
+//     );
+//     expect(fields.length).to.equal(10);
 
-    const currentlyActiveDuty = formDOM.querySelector(
-      '#root_currentlyActiveDuty_yesYes',
-    );
-    ReactTestUtils.Simulate.change(currentlyActiveDuty, {
-      target: {
-        checked: true,
-      },
-    });
+//     const currentlyActiveDuty = formDOM.querySelector(
+//       '#root_currentlyActiveDuty_yesYes',
+//     );
+//     ReactTestUtils.Simulate.change(currentlyActiveDuty, {
+//       target: {
+//         checked: true,
+//       },
+//     });
 
-    fields = Array.from(findDOMNode(form).querySelectorAll('input, select'));
+//     fields = Array.from(findDOMNode(form).querySelectorAll('input, select'));
 
-    expect(fields.length).to.equal(14);
-  });
-});
+//     expect(fields.length).to.equal(14);
+//   });
+// });

--- a/src/applications/edu-benefits/1990n/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/1990n/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,31 +1,31 @@
-import React from 'react';
-import { expect } from 'chai';
+// import React from 'react';
+// import { expect } from 'chai';
 
-import { ConfirmationPage } from '../../containers/ConfirmationPage';
-import { shallow } from 'enzyme';
-import { ConfirmationPageContent } from '../../../components/ConfirmationPageContent';
+// import { ConfirmationPage } from '../../containers/ConfirmationPage';
+// import { shallow } from 'enzyme';
+// import { ConfirmationPageContent } from '../../../components/ConfirmationPageContent';
 
-const form = {
-  submission: {
-    response: {
-      attributes: {},
-    },
-  },
-  data: {
-    veteranFullName: {
-      first: 'Jane',
-      last: 'Doe',
-    },
-    benefit: 'chapter35',
-  },
-};
+// const form = {
+//   submission: {
+//     response: {
+//       attributes: {},
+//     },
+//   },
+//   data: {
+//     veteranFullName: {
+//       first: 'Jane',
+//       last: 'Doe',
+//     },
+//     benefit: 'chapter35',
+//   },
+// };
 
-describe('Edu 1990n <ConfirmationPage>', () => {
-  it('should render', () => {
-    const tree = shallow(<ConfirmationPage form={form} />);
-    expect(tree).to.not.be.undefined;
-    expect(tree.find(ConfirmationPageContent)).to.not.be.undefined;
+// describe('Edu 1990n <ConfirmationPage>', () => {
+//   it('should render', () => {
+//     const tree = shallow(<ConfirmationPage form={form} />);
+//     expect(tree).to.not.be.undefined;
+//     expect(tree.find(ConfirmationPageContent)).to.not.be.undefined;
 
-    tree.unmount();
-  });
-});
+//     tree.unmount();
+//   });
+// });

--- a/src/applications/edu-benefits/1990n/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/1990n/tests/containers/IntroductionPage.unit.spec.jsx
@@ -1,63 +1,63 @@
-import React from 'react';
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
-import { IntroductionPage } from 'applications/edu-benefits/1990n/containers/IntroductionPage';
-import {
-  WIZARD_STATUS_COMPLETE,
-  getWizardStatus,
-} from 'applications/static-pages/wizard';
+// import React from 'react';
+// import { expect } from 'chai';
+// import { shallow } from 'enzyme';
+// import { IntroductionPage } from 'applications/edu-benefits/1990n/containers/IntroductionPage';
+// import {
+//   WIZARD_STATUS_COMPLETE,
+//   getWizardStatus,
+// } from 'applications/static-pages/wizard';
 
-describe('the Edu-Benefit 1990E Introduction Page', () => {
-  it('should show the wizard if showWizard is set to true', () => {
-    const fakeStore = {
-      getState: () => ({
-        showWizard: true,
-        route: { formConfig: {} },
-      }),
-      subscribe: () => {},
-      dispatch: () => {},
-    };
+// describe('the Edu-Benefit 1990E Introduction Page', () => {
+//   it('should show the wizard if showWizard is set to true', () => {
+//     const fakeStore = {
+//       getState: () => ({
+//         showWizard: true,
+//         route: { formConfig: {} },
+//       }),
+//       subscribe: () => {},
+//       dispatch: () => {},
+//     };
 
-    const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
-    expect(wrapper.exists('WizardContainer')).to.equal(true);
-    expect(wrapper.exists('.subway-map')).to.equal(false);
-    wrapper.unmount();
-  });
+//     const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
+//     expect(wrapper.exists('WizardContainer')).to.equal(true);
+//     expect(wrapper.exists('.subway-map')).to.equal(false);
+//     wrapper.unmount();
+//   });
 
-  it('should show the subway map if showWizard is set to false', () => {
-    const fakeStore = {
-      getState: () => ({
-        showWizard: false,
-        route: { formConfig: {} },
-      }),
-      subscribe: () => {},
-      dispatch: () => {},
-    };
+//   it('should show the subway map if showWizard is set to false', () => {
+//     const fakeStore = {
+//       getState: () => ({
+//         showWizard: false,
+//         route: { formConfig: {} },
+//       }),
+//       subscribe: () => {},
+//       dispatch: () => {},
+//     };
 
-    const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
-    expect(wrapper.exists('WizardContainer')).to.equal(false);
-    expect(wrapper.exists('.subway-map')).to.equal(true);
-    wrapper.unmount();
-  });
+//     const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
+//     expect(wrapper.exists('WizardContainer')).to.equal(false);
+//     expect(wrapper.exists('.subway-map')).to.equal(true);
+//     wrapper.unmount();
+//   });
 
-  it('should show the subway map if the wizard was completed', () => {
-    const fakeStore = {
-      getState: () => ({
-        showWizard: true,
-        route: { formConfig: {} },
-      }),
-      subscribe: () => {},
-      dispatch: () => {},
-    };
+//   it('should show the subway map if the wizard was completed', () => {
+//     const fakeStore = {
+//       getState: () => ({
+//         showWizard: true,
+//         route: { formConfig: {} },
+//       }),
+//       subscribe: () => {},
+//       dispatch: () => {},
+//     };
 
-    const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
-    const instance = wrapper.instance();
-    instance.setWizardStatus(WIZARD_STATUS_COMPLETE);
-    const status = getWizardStatus().then(() => {
-      expect(status).to.equal(WIZARD_STATUS_COMPLETE);
-    });
-    expect(wrapper.exists('WizardContainer')).to.equal(false);
-    expect(wrapper.exists('.subway-map')).to.equal(true);
-    wrapper.unmount();
-  });
-});
+//     const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
+//     const instance = wrapper.instance();
+//     instance.setWizardStatus(WIZARD_STATUS_COMPLETE);
+//     const status = getWizardStatus().then(() => {
+//       expect(status).to.equal(WIZARD_STATUS_COMPLETE);
+//     });
+//     expect(wrapper.exists('WizardContainer')).to.equal(false);
+//     expect(wrapper.exists('.subway-map')).to.equal(true);
+//     wrapper.unmount();
+//   });
+// });

--- a/src/applications/edu-benefits/1990n/tests/e2e/edu-1990n.cypress.spec.js
+++ b/src/applications/edu-benefits/1990n/tests/e2e/edu-1990n.cypress.spec.js
@@ -1,61 +1,61 @@
-import path from 'path';
-import testForm from 'platform/testing/e2e/cypress/support/form-tester';
-import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-import formConfig from '../../config/form';
-import manifest from '../../manifest.json';
-import mockUser from './fixtures/mocks/mock-user.json';
-import featureToggles from './fixtures/mocks/feature-toggles.json';
+// import path from 'path';
+// import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+// import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+// import formConfig from '../../config/form';
+// import manifest from '../../manifest.json';
+// import mockUser from './fixtures/mocks/mock-user.json';
+// import featureToggles from './fixtures/mocks/feature-toggles.json';
 
-Cypress.config('waitForAnimations', true);
+// Cypress.config('waitForAnimations', true);
 
-const form = createTestConfig(
-  {
-    dataPrefix: 'data',
-    dataSets: ['minimal'],
-    fixtures: {
-      data: path.join(__dirname, 'fixtures', 'data'),
-      mocks: path.join(__dirname, 'fixtures', 'mocks'),
-    },
-    setupPerTest: () => {
-      cy.login(mockUser);
-      cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
-      cy.intercept('POST', '/v0/education_benefits_claims/1990n', {
-        data: {
-          attributes: {
-            confirmationNumber: 'BB935000000F3VnCAW',
-            submittedAt: '2020-08-09T19:18:11+00:00',
-          },
-        },
-      });
-      cy.get('@testData').then(testData => {
-        cy.intercept('GET', '/v0/in_progress_forms/1990n', testData);
-      });
-    },
-    pageHooks: {
-      introduction: ({ afterHook }) => {
-        cy.findByText(/Find the right application form/i, {
-          selector: 'button',
-        })
-          .first()
-          .click();
-        cy.get('#NewBenefit-0').check();
-        cy.get('#ClaimingBenefitOwnService-0').check();
-        cy.get('#NationalCallToService-0').click();
-        cy.get('#apply-now-link').click();
+// const form = createTestConfig(
+//   {
+//     dataPrefix: 'data',
+//     dataSets: ['minimal'],
+//     fixtures: {
+//       data: path.join(__dirname, 'fixtures', 'data'),
+//       mocks: path.join(__dirname, 'fixtures', 'mocks'),
+//     },
+//     setupPerTest: () => {
+//       cy.login(mockUser);
+//       cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
+//       cy.intercept('POST', '/v0/education_benefits_claims/1990n', {
+//         data: {
+//           attributes: {
+//             confirmationNumber: 'BB935000000F3VnCAW',
+//             submittedAt: '2020-08-09T19:18:11+00:00',
+//           },
+//         },
+//       });
+//       cy.get('@testData').then(testData => {
+//         cy.intercept('GET', '/v0/in_progress_forms/1990n', testData);
+//       });
+//     },
+//     pageHooks: {
+//       introduction: ({ afterHook }) => {
+//         cy.findByText(/Find the right application form/i, {
+//           selector: 'button',
+//         })
+//           .first()
+//           .click();
+//         cy.get('#NewBenefit-0').check();
+//         cy.get('#ClaimingBenefitOwnService-0').check();
+//         cy.get('#NationalCallToService-0').click();
+//         cy.get('#apply-now-link').click();
 
-        afterHook(() => {
-          cy.findAllByText(/Start the education application/i, {
-            selector: 'button',
-          })
-            .first()
-            .click();
-        });
-      },
-    },
-    skip: false,
-  },
-  manifest,
-  formConfig,
-);
+//         afterHook(() => {
+//           cy.findAllByText(/Start the education application/i, {
+//             selector: 'button',
+//           })
+//             .first()
+//             .click();
+//         });
+//       },
+//     },
+//     skip: false,
+//   },
+//   manifest,
+//   formConfig,
+// );
 
-testForm(form);
+// testForm(form);

--- a/src/applications/edu-benefits/1990n/tests/e2e/edu-1990n.cypress.spec.js
+++ b/src/applications/edu-benefits/1990n/tests/e2e/edu-1990n.cypress.spec.js
@@ -1,61 +1,61 @@
-// import path from 'path';
-// import testForm from 'platform/testing/e2e/cypress/support/form-tester';
-// import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-// import formConfig from '../../config/form';
-// import manifest from '../../manifest.json';
-// import mockUser from './fixtures/mocks/mock-user.json';
-// import featureToggles from './fixtures/mocks/feature-toggles.json';
+import path from 'path';
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import mockUser from './fixtures/mocks/mock-user.json';
+import featureToggles from './fixtures/mocks/feature-toggles.json';
 
-// Cypress.config('waitForAnimations', true);
+Cypress.config('waitForAnimations', true);
 
-// const form = createTestConfig(
-//   {
-//     dataPrefix: 'data',
-//     dataSets: ['minimal'],
-//     fixtures: {
-//       data: path.join(__dirname, 'fixtures', 'data'),
-//       mocks: path.join(__dirname, 'fixtures', 'mocks'),
-//     },
-//     setupPerTest: () => {
-//       cy.login(mockUser);
-//       cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
-//       cy.intercept('POST', '/v0/education_benefits_claims/1990n', {
-//         data: {
-//           attributes: {
-//             confirmationNumber: 'BB935000000F3VnCAW',
-//             submittedAt: '2020-08-09T19:18:11+00:00',
-//           },
-//         },
-//       });
-//       cy.get('@testData').then(testData => {
-//         cy.intercept('GET', '/v0/in_progress_forms/1990n', testData);
-//       });
-//     },
-//     pageHooks: {
-//       introduction: ({ afterHook }) => {
-//         cy.findByText(/Find the right application form/i, {
-//           selector: 'button',
-//         })
-//           .first()
-//           .click();
-//         cy.get('#NewBenefit-0').check();
-//         cy.get('#ClaimingBenefitOwnService-0').check();
-//         cy.get('#NationalCallToService-0').click();
-//         cy.get('#apply-now-link').click();
+const form = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataSets: ['minimal'],
+    fixtures: {
+      data: path.join(__dirname, 'fixtures', 'data'),
+      mocks: path.join(__dirname, 'fixtures', 'mocks'),
+    },
+    setupPerTest: () => {
+      cy.login(mockUser);
+      cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
+      cy.intercept('POST', '/v0/education_benefits_claims/1990n', {
+        data: {
+          attributes: {
+            confirmationNumber: 'BB935000000F3VnCAW',
+            submittedAt: '2020-08-09T19:18:11+00:00',
+          },
+        },
+      });
+      cy.get('@testData').then(testData => {
+        cy.intercept('GET', '/v0/in_progress_forms/1990n', testData);
+      });
+    },
+    // pageHooks: {
+    //   introduction: ({ afterHook }) => {
+    //     cy.findByText(/Find the right application form/i, {
+    //       selector: 'button',
+    //     })
+    //       .first()
+    //       .click();
+    //     cy.get('#NewBenefit-0').check();
+    //     cy.get('#ClaimingBenefitOwnService-0').check();
+    //     cy.get('#NationalCallToService-0').click();
+    //     cy.get('#apply-now-link').click();
 
-//         afterHook(() => {
-//           cy.findAllByText(/Start the education application/i, {
-//             selector: 'button',
-//           })
-//             .first()
-//             .click();
-//         });
-//       },
-//     },
-//     skip: false,
-//   },
-//   manifest,
-//   formConfig,
-// );
+    //     afterHook(() => {
+    //       cy.findAllByText(/Start the education application/i, {
+    //         selector: 'button',
+    //       })
+    //         .first()
+    //         .click();
+    //     });
+    //   },
+    // },
+    skip: false,
+  },
+  manifest,
+  formConfig,
+);
 
-// testForm(form);
+testForm(form);

--- a/src/applications/edu-benefits/1990n/tests/e2e/edu-1990n.cypress.spec.js
+++ b/src/applications/edu-benefits/1990n/tests/e2e/edu-1990n.cypress.spec.js
@@ -1,61 +1,61 @@
-import path from 'path';
-import testForm from 'platform/testing/e2e/cypress/support/form-tester';
-import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-import formConfig from '../../config/form';
-import manifest from '../../manifest.json';
-import mockUser from './fixtures/mocks/mock-user.json';
-import featureToggles from './fixtures/mocks/feature-toggles.json';
+// import path from 'path';
+// import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+// import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+// import formConfig from '../../config/form';
+// import manifest from '../../manifest.json';
+// import mockUser from './fixtures/mocks/mock-user.json';
+// import featureToggles from './fixtures/mocks/feature-toggles.json';
 
-Cypress.config('waitForAnimations', true);
+// Cypress.config('waitForAnimations', true);
 
-const form = createTestConfig(
-  {
-    dataPrefix: 'data',
-    dataSets: ['minimal'],
-    fixtures: {
-      data: path.join(__dirname, 'fixtures', 'data'),
-      mocks: path.join(__dirname, 'fixtures', 'mocks'),
-    },
-    setupPerTest: () => {
-      cy.login(mockUser);
-      cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
-      cy.intercept('POST', '/v0/education_benefits_claims/1990n', {
-        data: {
-          attributes: {
-            confirmationNumber: 'BB935000000F3VnCAW',
-            submittedAt: '2020-08-09T19:18:11+00:00',
-          },
-        },
-      });
-      cy.get('@testData').then(testData => {
-        cy.intercept('GET', '/v0/in_progress_forms/1990n', testData);
-      });
-    },
-    // pageHooks: {
-    //   introduction: ({ afterHook }) => {
-    //     cy.findByText(/Find the right application form/i, {
-    //       selector: 'button',
-    //     })
-    //       .first()
-    //       .click();
-    //     cy.get('#NewBenefit-0').check();
-    //     cy.get('#ClaimingBenefitOwnService-0').check();
-    //     cy.get('#NationalCallToService-0').click();
-    //     cy.get('#apply-now-link').click();
+// const form = createTestConfig(
+//   {
+//     dataPrefix: 'data',
+//     dataSets: ['minimal'],
+//     fixtures: {
+//       data: path.join(__dirname, 'fixtures', 'data'),
+//       mocks: path.join(__dirname, 'fixtures', 'mocks'),
+//     },
+//     setupPerTest: () => {
+//       cy.login(mockUser);
+//       cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
+//       cy.intercept('POST', '/v0/education_benefits_claims/1990n', {
+//         data: {
+//           attributes: {
+//             confirmationNumber: 'BB935000000F3VnCAW',
+//             submittedAt: '2020-08-09T19:18:11+00:00',
+//           },
+//         },
+//       });
+//       cy.get('@testData').then(testData => {
+//         cy.intercept('GET', '/v0/in_progress_forms/1990n', testData);
+//       });
+//     },
+//     pageHooks: {
+//       introduction: ({ afterHook }) => {
+//         cy.findByText(/Find the right application form/i, {
+//           selector: 'button',
+//         })
+//           .first()
+//           .click();
+//         cy.get('#NewBenefit-0').check();
+//         cy.get('#ClaimingBenefitOwnService-0').check();
+//         cy.get('#NationalCallToService-0').click();
+//         cy.get('#apply-now-link').click();
 
-    //     afterHook(() => {
-    //       cy.findAllByText(/Start the education application/i, {
-    //         selector: 'button',
-    //       })
-    //         .first()
-    //         .click();
-    //     });
-    //   },
-    // },
-    skip: false,
-  },
-  manifest,
-  formConfig,
-);
+//         afterHook(() => {
+//           cy.findAllByText(/Start the education application/i, {
+//             selector: 'button',
+//           })
+//             .first()
+//             .click();
+//         });
+//       },
+//     },
+//     skip: false,
+//   },
+//   manifest,
+//   formConfig,
+// );
 
-testForm(form);
+// testForm(form);

--- a/src/applications/edu-benefits/1990n/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/edu-benefits/1990n/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -6,7 +6,7 @@
       { "name": "show_edu_benefits_1995_wizard", "value": true },
       { "name": "show_edu_benefits_5495_wizard", "value": true },
       { "name": "show_edu_benefits_0994_wizard", "value": true },
-      { "name": "show_edu_benefits_1990n_wizard", "value": true },
+      { "name": "show_edu_benefits_1990n_wizard", "value": false },
       { "name": "show_edu_benefits_5490_wizard", "value": true },
       { "name": "show_edu_benefits_1990e_wizard", "value": true },
       { "name": "show_edu_benefits_1990_wizard", "value": true }

--- a/src/applications/edu-benefits/tests/edu-apply-wizard.cypress.spec.js
+++ b/src/applications/edu-benefits/tests/edu-apply-wizard.cypress.spec.js
@@ -19,27 +19,6 @@ describe('Education Application Wizard', () => {
       .get('label[for="serviceBenefitBasedOn-0"]')
       .should('be.visible');
 
-    // Select veteran
-    // cy.get('input[id="serviceBenefitBasedOn-0"]')
-    //   .click()
-    //   .get('label[for="nationalCallToService-0"]')
-    //   .should('be.visible');
-
-    // Select national call to service
-    // cy.get('#nationalCallToService-0')
-    //   .click()
-    //   .get('#apply-now-link')
-    //   .should('be.visible');
-
-    // cy.get('#apply-now-link')
-    //   .should('have.attr', 'href')
-    //   .and(
-    //     'contain',
-    //     '/education/apply-for-education-benefits/application/1990N',
-    //   );
-
-    // cy.get('main .usa-alert-warning').should('be.visible');
-
     // Select non-veteran
     cy.get('#serviceBenefitBasedOn-1').click();
 

--- a/src/applications/edu-benefits/wizard/pages/ApplyNow.jsx
+++ b/src/applications/edu-benefits/wizard/pages/ApplyNow.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { pageNames } from './pageList';
 import {
   WIZARD_STATUS_COMPLETE,
   getReferredBenefit,
   formIdSuffixes,
 } from 'applications/static-pages/wizard/';
 import recordEvent from 'platform/monitoring/record-event';
+import { pageNames } from './pageList';
 
 const ApplyNow = ({ getPageStateFromPageName, setWizardStatus }) => {
   const [url, setUrl] = useState('');
@@ -14,9 +14,6 @@ const ApplyNow = ({ getPageStateFromPageName, setWizardStatus }) => {
     ?.selected;
   const claimingBenefitAnswer = getPageStateFromPageName(
     pageNames.claimingBenefitOwnService,
-  )?.selected;
-  const nationalCallToServiceAnswer = getPageStateFromPageName(
-    pageNames.nationalCallToService,
   )?.selected;
   const sponsorDeceasedAnswer = getPageStateFromPageName(
     pageNames.sponsorDeceased,
@@ -80,7 +77,6 @@ const ApplyNow = ({ getPageStateFromPageName, setWizardStatus }) => {
           event: 'edu-howToApply-applyNow',
           'edu-benefitUpdate': newBenefitAnswer,
           'edu-isBenefitClaimForSelf': claimingBenefitAnswer,
-          'edu-isNationalCallToServiceBenefit': nationalCallToServiceAnswer,
           'edu-isVetTec': vetTecAnswer,
           'edu-hasSponsorTransferredBenefits': hasSponsoredTransferredBenefitsAnswer,
           'edu-isReceivingSponsorBenefits': receivingSponsorBenefitsAnswer,

--- a/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
+++ b/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { pageNames } from './pageList';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
+import { pageNames } from './pageList';
 
 const claimingBenefitOwnServiceOptions = [
   { label: 'Yes', value: 'yes' },
@@ -29,16 +29,14 @@ const ClaimingBenefitOwnService = ({
         const transferredBenefitsAnswer = getPageStateFromPageName(
           pageNames.transferredBenefits,
         )?.selected;
-        const nationalCallToServiceAnswer = getPageStateFromPageName(
-          pageNames.nationalCallToService,
-        )?.selected;
         if (
           newBenefitAnswer === 'new' &&
           value === 'no' &&
           transferredBenefitsAnswer === 'no'
         ) {
           return setPageState({ selected: value }, pageNames.sponsorDeceased);
-        } else if (
+        }
+        if (
           newBenefitAnswer === 'new' &&
           value === 'no' &&
           sponsorDeceasedAnswer === 'yes'
@@ -46,22 +44,14 @@ const ClaimingBenefitOwnService = ({
           const { FORM_ID_5490 } = formIdSuffixes;
           setReferredBenefit(FORM_ID_5490);
           return setPageState({ selected: value }, pageNames.applyNow);
-        } else if (
-          newBenefitAnswer === 'new' &&
-          nationalCallToServiceAnswer === 'no' &&
-          value === 'yes'
-        ) {
-          return setPageState({ selected: value }, pageNames.vetTec);
-        } else if (newBenefitAnswer === 'new' && value === 'yes') {
-          return setPageState(
-            { selected: value },
-            pageNames.nationalCallToService,
-          );
-        } else if (newBenefitAnswer === 'new' && value === 'no') {
-          return setPageState({ selected: value }, pageNames.sponsorDeceased);
-        } else {
-          return setPageState({ selected: value });
         }
+        if (newBenefitAnswer === 'new' && value === 'yes') {
+          return setPageState({ selected: value }, pageNames.vetTec);
+        }
+        if (newBenefitAnswer === 'new' && value === 'no') {
+          return setPageState({ selected: value }, pageNames.sponsorDeceased);
+        }
+        return setPageState({ selected: value });
       }}
       value={{ value: state.selected }}
     />

--- a/src/applications/edu-benefits/wizard/pages/NewBenefit.jsx
+++ b/src/applications/edu-benefits/wizard/pages/NewBenefit.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
-import { pageNames } from './pageList';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
+import { pageNames } from './pageList';
 
 const newBenefitOptions = [
   { label: 'Applying for a new benefit', value: 'new' },
@@ -46,43 +46,37 @@ const NewBenefit = ({
       const transferredBenefitsAnswer = getPageStateFromPageName(
         pageNames.transferredBenefits,
       )?.selected;
-      const nationalCallToServiceAnswer = getPageStateFromPageName(
-        pageNames.nationalCallToService,
-      )?.selected;
       if (
-        value === 'new' &&
-        claimingBenefitOwnServiceAnswer === 'yes' &&
-        nationalCallToServiceAnswer === 'yes'
-      ) {
-        return setPageState({ selected: value }, pageNames.warningAlert);
-      } else if (
         (value === 'new' &&
           claimingBenefitOwnServiceAnswer === 'no' &&
           sponsorDeceasedAnswer === 'no') ||
         value === 'update'
       ) {
         return setPageState({ selected: value }, pageNames.transferredBenefits);
-      } else if (
+      }
+      if (
         (value === 'update' && transferredBenefitsAnswer === 'own') ||
         (value === 'update' && transferredBenefitsAnswer === 'transferred')
       ) {
         const { FORM_ID_1995 } = formIdSuffixes;
         setReferredBenefit(FORM_ID_1995);
         return setPageState({ selected: value }, pageNames.applyNow);
-      } else if (value === 'update' && transferredBenefitsAnswer === 'fry') {
+      }
+      if (value === 'update' && transferredBenefitsAnswer === 'fry') {
         const { FORM_ID_5495 } = formIdSuffixes;
         setReferredBenefit(FORM_ID_5495);
         return setPageState({ selected: value }, pageNames.applyNow);
-      } else if (value === 'new') {
+      }
+      if (value === 'new') {
         return setPageState(
           { selected: value },
           pageNames.claimingBenefitOwnService,
         );
-      } else if (value === 'extend') {
-        return setPageState({ selected: value }, pageNames.STEMScholarship);
-      } else {
-        return setPageState({ selected: value });
       }
+      if (value === 'extend') {
+        return setPageState({ selected: value }, pageNames.STEMScholarship);
+      }
+      return setPageState({ selected: value });
     }}
     value={{ value: state.selected }}
   />

--- a/src/applications/edu-benefits/wizard/pages/VetTec.jsx
+++ b/src/applications/edu-benefits/wizard/pages/VetTec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
-import { pageNames } from './pageList';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
+import { pageNames } from './pageList';
 
 const vetTecOptions = [
   { label: 'Yes', value: 'yes' },
@@ -29,28 +29,17 @@ const VetTec = ({
       const claimingBenefitOwnServiceAnswer = getPageStateFromPageName(
         pageNames.claimingBenefitOwnService,
       )?.selected;
-      const nationalCallToServiceAnswer = getPageStateFromPageName(
-        pageNames.nationalCallToService,
-      )?.selected;
-      if (
-        claimingBenefitOwnServiceAnswer === 'yes' &&
-        nationalCallToServiceAnswer === 'no' &&
-        value === 'yes'
-      ) {
+      if (claimingBenefitOwnServiceAnswer === 'yes' && value === 'yes') {
         const { FORM_ID_0994 } = formIdSuffixes;
         setReferredBenefit(FORM_ID_0994);
         return setPageState({ selected: value }, pageNames.applyNow);
-      } else if (
-        claimingBenefitOwnServiceAnswer === 'yes' &&
-        nationalCallToServiceAnswer === 'no' &&
-        value === 'no'
-      ) {
+      }
+      if (claimingBenefitOwnServiceAnswer === 'yes' && value === 'no') {
         const { FORM_ID_1990 } = formIdSuffixes;
         setReferredBenefit(FORM_ID_1990);
         return setPageState({ selected: value }, pageNames.applyNow);
-      } else {
-        return setPageState({ selected: value });
       }
+      return setPageState({ selected: value });
     }}
     value={{ value: state.selected }}
   />

--- a/src/applications/edu-benefits/wizard/pages/index.js
+++ b/src/applications/edu-benefits/wizard/pages/index.js
@@ -1,7 +1,6 @@
 import NewBenefit from './NewBenefit';
 import ClaimingBenefitOwnService from './ClaimingBenefitOwnService';
 import TransferredBenefits from './TransferredBenefits';
-import NationalCallToService from './NationalCallToService';
 import SponsorDeceased from './SponsorDeceased';
 import VetTec from './VetTec';
 import WarningAlert from './WarningAlert';
@@ -12,7 +11,6 @@ export default [
   NewBenefit,
   ClaimingBenefitOwnService,
   TransferredBenefits,
-  NationalCallToService,
   SponsorDeceased,
   VetTec,
   WarningAlert,

--- a/src/applications/edu-benefits/wizard/pages/pageList.js
+++ b/src/applications/edu-benefits/wizard/pages/pageList.js
@@ -2,7 +2,6 @@ export const pageNames = {
   newBenefit: 'NewBenefit',
   claimingBenefitOwnService: 'ClaimingBenefitOwnService',
   transferredBenefits: 'TransferredBenefits',
-  nationalCallToService: 'NationalCallToService',
   sponsorDeceased: 'SponsorDeceased',
   vetTec: 'VetTec',
   warningAlert: 'WarningAlert',

--- a/src/applications/static-pages/wizard/index.js
+++ b/src/applications/static-pages/wizard/index.js
@@ -28,7 +28,6 @@ export const formIdSuffixes = {
   FORM_ID_5495: '5495',
   FORM_ID_5490: '5490',
   FORM_ID_1990E: '1990E',
-  FORM_ID_1990N: '1990N',
 };
 
 export const getReferredBenefit = async () =>
@@ -48,6 +47,7 @@ export class Wizard extends React.Component {
       wizardStatus: getWizardStatus(),
     };
   }
+
   get currentPage() {
     const { pageHistory, currentPageIndex } = this.state;
     return pageHistory[currentPageIndex];

--- a/src/applications/static-pages/wizard/tests/edu-benefits.unit.spec.jsx
+++ b/src/applications/static-pages/wizard/tests/edu-benefits.unit.spec.jsx
@@ -226,38 +226,39 @@ describe('the Education Benefits Wizard', () => {
     wrapper.unmount();
   });
   // Failed on master: http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/10187/tests
-  it.skip('should take you to the 1990N form', () => {
-    const wrapper = mount(<Wizard {...defaultProps} />);
-    wrapper.find('.wizard-button').simulate('click');
-    expect(wrapper.state('pageHistory')[0].state).to.be.undefined;
-    wrapper.find('#NewBenefit-0').invoke('onChange')({
-      target: { value: 'new' },
-    });
-    expect(wrapper.state('pageHistory')[0].state).to.deep.equal({
-      selected: 'new',
-    });
-    wrapper.find('#ClaimingBenefitOwnService-1').invoke('onChange')({
-      target: { value: 'yes' },
-    });
-    expect(wrapper.state('pageHistory')[1].state).to.deep.equal({
-      selected: 'yes',
-    });
-    wrapper.find('#NationalCallToService-0').invoke('onChange')({
-      target: { value: 'yes' },
-    });
-    expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
-      selected: 'yes',
-    });
-    expect(wrapper.find('WarningAlert').exists()).to.equal(true);
-    const benefit = sessionStorage.getItem('benefitReferred');
-    expect(benefit).to.equal(formIdSuffixes.FORM_ID_1990N);
-    wrapper.find('#apply-now-link').invoke('onClick')({
-      preventDefault: () => {},
-    });
-    const wizardStatus = sessionStorage.getItem('wizardStatus');
-    expect(wizardStatus).to.equal(WIZARD_STATUS_COMPLETE);
-    wrapper.unmount();
-  });
+  // Online Form 1990n is being removed. Only PDF version will remian for download
+  // it.skip('should take you to the 1990N form', () => {
+  //   const wrapper = mount(<Wizard {...defaultProps} />);
+  //   wrapper.find('.wizard-button').simulate('click');
+  //   expect(wrapper.state('pageHistory')[0].state).to.be.undefined;
+  //   wrapper.find('#NewBenefit-0').invoke('onChange')({
+  //     target: { value: 'new' },
+  //   });
+  //   expect(wrapper.state('pageHistory')[0].state).to.deep.equal({
+  //     selected: 'new',
+  //   });
+  //   wrapper.find('#ClaimingBenefitOwnService-1').invoke('onChange')({
+  //     target: { value: 'yes' },
+  //   });
+  //   expect(wrapper.state('pageHistory')[1].state).to.deep.equal({
+  //     selected: 'yes',
+  //   });
+  //   wrapper.find('#NationalCallToService-0').invoke('onChange')({
+  //     target: { value: 'yes' },
+  //   });
+  //   expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
+  //     selected: 'yes',
+  //   });
+  //   expect(wrapper.find('WarningAlert').exists()).to.equal(true);
+  //   const benefit = sessionStorage.getItem('benefitReferred');
+  //   expect(benefit).to.equal(formIdSuffixes.FORM_ID_1990N);
+  //   wrapper.find('#apply-now-link').invoke('onClick')({
+  //     preventDefault: () => {},
+  //   });
+  //   const wizardStatus = sessionStorage.getItem('wizardStatus');
+  //   expect(wizardStatus).to.equal(WIZARD_STATUS_COMPLETE);
+  //   wrapper.unmount();
+  // });
   it('should take you to the 1995 form when using your own benefit', () => {
     const wrapper = mount(<Wizard {...defaultProps} />);
     wrapper.find('.wizard-button').simulate('click');

--- a/src/applications/static-pages/wizard/tests/edu-benefits.unit.spec.jsx
+++ b/src/applications/static-pages/wizard/tests/edu-benefits.unit.spec.jsx
@@ -167,16 +167,16 @@ describe('the Education Benefits Wizard', () => {
     expect(wrapper.state('pageHistory')[1].state).to.deep.equal({
       selected: 'yes',
     });
-    wrapper.find('#NationalCallToService-1').invoke('onChange')({
-      target: { value: 'no' },
-    });
-    expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
-      selected: 'no',
-    });
+    // wrapper.find('#NationalCallToService-1').invoke('onChange')({
+    //   target: { value: 'no' },
+    // });
+    // expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
+    //   selected: 'no',
+    // });
     wrapper.find('#VetTec-1').invoke('onChange')({
       target: { value: 'no' },
     });
-    expect(wrapper.state('pageHistory')[3].state).to.deep.equal({
+    expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
       selected: 'no',
     });
     const benefit = sessionStorage.getItem('benefitReferred');
@@ -204,16 +204,16 @@ describe('the Education Benefits Wizard', () => {
     expect(wrapper.state('pageHistory')[1].state).to.deep.equal({
       selected: 'yes',
     });
-    wrapper.find('#NationalCallToService-1').invoke('onChange')({
-      target: { value: 'no' },
-    });
-    expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
-      selected: 'no',
-    });
+    // wrapper.find('#NationalCallToService-1').invoke('onChange')({
+    //   target: { value: 'no' },
+    // });
+    // expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
+    //   selected: 'no',
+    // });
     wrapper.find('#VetTec-0').invoke('onChange')({
       target: { value: 'yes' },
     });
-    expect(wrapper.state('pageHistory')[3].state).to.deep.equal({
+    expect(wrapper.state('pageHistory')[2].state).to.deep.equal({
       selected: 'yes',
     });
     const benefit = sessionStorage.getItem('benefitReferred');


### PR DESCRIPTION
## Description
Vfep 31 additional ncts references removed from wizard, in addition all cypress tests have been commented out since the online form is being removed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
pipeline/cypress testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
