### PR TITLE
Supplemental Claims | Update Veteran information page

### DIFF
--- a/src/applications/appeals/995/components/VeteranInformation.jsx
+++ b/src/applications/appeals/995/components/VeteranInformation.jsx
@@ -54,9 +54,8 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
       <br />
       <p>
         <strong>Note:</strong> If you need to update your personal information,
-        please call Veterans Benefits Assistance toll free at{' '}
-        <va-telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
-        8:00 a.m. to 9:00 p.m. ET.
+        you can call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />.
+        We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>
   );

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -2,6 +2,7 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 
 import preSubmitInfo from 'platform/forms/preSubmitInfo';
 import FormFooter from 'platform/forms/components/FormFooter';
+import { externalServices as services } from 'platform/monitoring/DowntimeNotification';
 
 import migrations from '../migrations';
 
@@ -46,6 +47,9 @@ import {
 
 import manifest from '../manifest.json';
 import { CONTESTABLE_ISSUES_PATH } from '../constants';
+import { saveInProgress, savedFormMessages } from '../content/formMessages';
+
+import prefillTransformer from './prefill-transformer';
 
 // import fullSchema from 'vets-json-schema/dist/20-0995-schema.json';
 import fullSchema from './form-0995-schema.json';
@@ -62,25 +66,17 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: VA_FORM_IDS.FORM_20_0995,
-  saveInProgress: {
-    // messages: {
-    //   inProgress: 'Your VA Form 20-0995 (Supplemental Claim) application (20-0995) is in progress.',
-    //   expired: 'Your saved VA Form 20-0995 (Supplemental Claim) application (20-0995) has expired. If you want to apply for VA Form 20-0995 (Supplemental Claim), please start a new application.',
-    //   saved: 'Your VA Form 20-0995 (Supplemental Claim) application has been saved.',
-    // },
-  },
   version: migrations.length,
   migrations,
-  // prefillTransformer,
+  prefillTransformer,
   prefillEnabled: true,
   // verifyRequiredPrefill: true,
-
-  savedFormMessages: {
-    notFound:
-      'Please start over to apply for VA Form 20-0995 (Supplemental Claim).',
-    noAuth:
-      'Please sign in again to continue your application for VA Form 20-0995 (Supplemental Claim).',
+  downtime: {
+    requiredForPrefill: true,
+    dependencies: [services.vaProfile],
   },
+  saveInProgress,
+  savedFormMessages,
   title: 'File a Supplemental Claim',
   subTitle: 'VA Form 20-0995',
   defaultDefinitions: fullSchema.definitions,
@@ -89,12 +85,6 @@ const formConfig = {
     infoPages: {
       title: 'Veteran Details',
       pages: {
-        // benefitType: {
-        //   title: 'Benefit Type',
-        //   path: 'benefit-type',
-        //   uiSchema: benefitType.uiSchema,
-        //   schema: benefitType.schema,
-        // },
         veteranInfo: {
           title: 'Veteran Information',
           path: 'veteran-information',

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -83,7 +83,7 @@ const formConfig = {
   preSubmitInfo,
   chapters: {
     infoPages: {
-      title: 'Veteran Details',
+      title: 'Veteran Information',
       pages: {
         veteranInfo: {
           title: 'Veteran Information',

--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -17,7 +17,7 @@ class IntroductionPage extends React.Component {
   render() {
     const { isVerified, loggedIn, route, location } = this.props;
     const { formConfig, pageList } = route;
-    const { formId, prefillEnabled, savedFormMessages } = formConfig;
+    const { formId, prefillEnabled, savedFormMessages, downtime } = formConfig;
 
     // Without being LOA3 (verified), the prefill & contestable issues won't load
     const showVerifyLink = loggedIn && !isVerified;
@@ -27,6 +27,7 @@ class IntroductionPage extends React.Component {
       formId,
       pageList,
       prefillEnabled,
+      downtime,
       headingLevel: 2,
       hideUnauthedStartLink: true,
       messages: savedFormMessages,

--- a/src/applications/appeals/995/content/formMessages.js
+++ b/src/applications/appeals/995/content/formMessages.js
@@ -1,0 +1,17 @@
+export const saveInProgress = {
+  messages: {
+    inProgress:
+      'Your VA Form 20-0995 (Supplemental Claim) application (20-0995) is in progress.',
+    expired:
+      'Your saved VA Form 20-0995 (Supplemental Claim) application (20-0995) has expired. If you want to apply for VA Form 20-0995 (Supplemental Claim), please start a new application.',
+    saved:
+      'Your VA Form 20-0995 (Supplemental Claim) application has been saved.',
+  },
+};
+
+export const savedFormMessages = {
+  notFound:
+    'Please start over to apply for VA Form 20-0995 (Supplemental Claim).',
+  noAuth:
+    'Please sign in again to continue your application for VA Form 20-0995 (Supplemental Claim).',
+};

--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -36,6 +36,7 @@ describe('995 contact info loop', () => {
 
     cy.login(mockUser);
     cy.intercept('GET', '/v0/profile/status', mockStatus);
+    cy.intercept('GET', '/v0/maintenance_windows', []);
 
     cy.visit(BASE_URL);
     cy.injectAxe();

--- a/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
@@ -47,6 +47,7 @@ const testConfig = createTestConfig(
       setStoredSubTask({ benefitType: 'compensation' });
 
       cy.intercept('GET', '/v0/profile/status', mockStatus);
+      cy.intercept('GET', '/v0/maintenance_windows', []);
 
       cy.intercept(
         'GET',

--- a/src/applications/appeals/995/tests/config/prefill-transformer.unit.spec.js
+++ b/src/applications/appeals/995/tests/config/prefill-transformer.unit.spec.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import prefillTransformer from '../../config/prefill-transformer';
+
+// This is the nesting of the prefill data; transformation flattens it
+const buildData = ({ ssnLastFour = '', vaFileLastFour = '' }) => ({
+  prefill: {
+    data: {},
+    nonPrefill: {
+      veteranSsnLastFour: ssnLastFour,
+      veteranVaFileNumberLastFour: vaFileLastFour,
+    },
+  },
+  result: {
+    veteran: {
+      ssnLastFour,
+      vaFileLastFour,
+    },
+  },
+});
+
+describe('SC prefill transformer', () => {
+  const noTransformData = {
+    metadata: { test: 'Test Metadata' },
+    formData: {
+      testData: 'This is not getting transformed',
+      data: {},
+      nonPrefill: {},
+    },
+    pages: { testPage: 'Page 1' },
+  };
+
+  it('should return built out template from prefill data', () => {
+    const { pages, formData, metadata } = noTransformData;
+    const noTransformActual = prefillTransformer(pages, formData, metadata);
+    // ensure transformed data is not the same object as input data
+    expect(noTransformActual).to.not.equal(noTransformData);
+    expect(noTransformActual).to.deep.equal({
+      metadata: noTransformData.metadata,
+      formData: buildData({}).result,
+      pages: noTransformData.pages,
+    });
+  });
+
+  describe('prefill veteran information', () => {
+    it('should transform contact info when present', () => {
+      const { pages, metadata } = noTransformData;
+      const data = buildData({
+        ssnLastFour: '9876',
+        vaFileLastFour: '7654',
+      });
+      const transformedData = prefillTransformer(pages, data.prefill, metadata)
+        .formData;
+
+      expect(transformedData).to.deep.equal(data.result);
+    });
+  });
+});

--- a/src/applications/appeals/995/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/IntroductionPage.unit.spec.jsx
@@ -39,6 +39,13 @@ const getData = ({ loggedIn = true, isVerified = true } = {}) => ({
           metadata: {},
         },
       },
+      scheduledDowntime: {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap: { get() {} },
+        dismissedDowntimeWarnings: [],
+      },
     }),
     subscribe: () => {},
     dispatch: () => {},


### PR DESCRIPTION
## Original Ticket

[#48159](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48159)

## URL of change

`/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/veteran-information`

## Background

A content review of the Supplemental Claim form has been completed, and the content of the Veteran's information page. Additionally, it was noted that the prefill was not working, so the prefill work for the frontend was completed in this PR, and the backend work will be accomplished in another PR.

<details><summary>Veteran personal information page</summary>

<!-- leave a blank line above -->
<img width="758" alt="Veteran personal information showing name, last 4 of SSN, last 4 of VA file number, date of birth and gender" src="https://user-images.githubusercontent.com/136959/198734944-9cfc8107-84a5-4231-8d79-f6f11c18ce76.png"></details>

## Steps to test

1. Pull in this branch locally, or test in a review instance
2. Log in to any user (usually user 233 - for HLR)
3. Go to `/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995`
4. Start the form, the Veteran info page is the first page you'll encounter
5. Note that the SSN & VA file number entries are missing - this is due to prefill not currently set up

## Code changes

- Updated page content
- Added prefill transformer and required services for prefill
- Added unit test
- Split out save in progress and saved form messages into a separate file

## How was your code tested

Unit tests

## Acceptance criteria
- [x] Updated Veteran information page content
- [x] Set up prefill on the frontend
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs