### PR TITLE
[PCI] Disable ddog RUM session replay

### DIFF
--- a/src/applications/check-in/hooks/useDatadogRum.jsx
+++ b/src/applications/check-in/hooks/useDatadogRum.jsx
@@ -19,13 +19,12 @@ const initializeDatadogRum = () => {
       service: 'patient-check-in',
       env: environment.vspEnvironment(),
       sampleRate: 100,
-      sessionReplaySampleRate: 20,
+      sessionReplaySampleRate: 0,
       trackInteractions: true,
       trackResources: true,
       trackLongTasks: true,
       defaultPrivacyLevel: 'mask',
     });
-    datadogRum.startSessionReplayRecording();
   }
 };
 


### PR DESCRIPTION
## Description

This disables [session replay](https://docs.datadoghq.com/real_user_monitoring/session_replay/), at least for now. If we want to enable it in the future we'll need to add the session replay ingest host to the CSP as in https://github.com/department-of-veterans-affairs/devops/pull/12165

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48377


## Testing done

Tested from localhost to ensure that RUM events are still sent.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
