### PR TITLE
Supplemental Claim | Update Sub-task content & add tests

### DIFF
--- a/src/applications/appeals/995/subtask/SubTaskContainer.jsx
+++ b/src/applications/appeals/995/subtask/SubTaskContainer.jsx
@@ -10,6 +10,13 @@ export const SubTaskContainer = () => (
   <article className="row">
     <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
       <SubTask pages={pages} />
+      <p>
+        If you don’t think this is the right form for you, find out about other
+        decision review options.
+      </p>
+      <a href="/resources/choosing-a-decision-review-option/">
+        Learn about choosing a decision review option
+      </a>
     </div>
     <FormFooter formConfig={formConfig} />
   </article>

--- a/src/applications/appeals/995/subtask/pages/other.jsx
+++ b/src/applications/appeals/995/subtask/pages/other.jsx
@@ -23,16 +23,20 @@ const DecisionReviewPage = () => {
   return (
     <div id={pageNames.other}>
       <h1 className="vads-u-margin-bottom--0">
-        Filing non-disability Supplemental Claims
+        Filing if your Supplemental Claim isn’t for a disability
       </h1>
       <p>
-        We don’t support claims other than disability online at this time.
-        You’ll need to fill out and submit VA Form 20-0995 by mail or in person.
+        We can accept online Supplemental Claims only for disability claims at
+        this time. For other types of claims, you’ll need to fill out and submit
+        VA Form 20-0995 by mail or in person.
+      </p>
+      <p>
+        Send the completed form to the benefit office that matches the benefit
+        type you select on the form.
       </p>
       <a href={BENEFIT_OFFICES_URL} onClick={handlers.officeLinkClick}>
-        Send the completed form to the benefit office
+        Find the address for mailing your form
       </a>{' '}
-      that matches the benefit type you select on the form.
       <p className="vads-u-margin-bottom--0">
         <DownloadLink content="Download VA Form 20-0995" />
       </p>

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -11,8 +11,8 @@ import { BASE_URL } from '../../constants';
 import pageNames from './pageNames';
 
 const content = {
-  groupLabel: 'For what type of claim are you requesting a Supplemental Claim?',
-  errorMessage: 'Please choose a benefit type',
+  groupLabel: 'What type of claim are you filing a Supplemental Claim for?',
+  errorMessage: 'You must choose a claim type',
 };
 
 const options = [
@@ -22,7 +22,7 @@ const options = [
   },
   {
     value: pageNames.other,
-    label: 'Claim other than disability compensation',
+    label: 'Another type of claim (not a disability claim)',
   },
 ];
 
@@ -60,14 +60,12 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
 
   return (
     <>
-      <h1 className="vads-u-margin-bottom--0">
-        Is Supplemental Claim VA Form 20-0995 what I need?
-      </h1>
+      <h1 className="vads-u-margin-bottom--0">Is this the form I need?</h1>
       <p>
-        Use this form if you disagree with our decision on your claim and have
-        new and relevant evidence to submit.
+        Use this Supplemental Claim form if you disagree with our decision on
+        your claim and have new and relevant evidence to submit.
       </p>
-      <p>Answer a question to get started.</p>
+      <p>Answer this question to get started:</p>
       <VaRadio
         label={content.groupLabel}
         error={error ? content.errorMessage : null}

--- a/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
@@ -1,0 +1,61 @@
+import { resetStoredSubTask } from 'platform/forms/sub-task';
+
+import { BASE_URL } from '../constants';
+
+describe('995 subtask', () => {
+  beforeEach(() => {
+    window.dataLayer = [];
+    cy.intercept('GET', '/v0/feature_toggles?*', {
+      data: {
+        type: 'feature_toggles',
+        features: [],
+      },
+    });
+
+    resetStoredSubTask();
+    cy.visit(`${BASE_URL}/start`);
+  });
+
+  it('should show error when nothing selected', () => {
+    cy.location('pathname').should('eq', `${BASE_URL}/start`);
+    cy.injectAxeThenAxeCheck();
+
+    cy.findByText(/continue/i, { selector: 'va-button' }).click();
+    cy.get('va-radio')
+      .shadow()
+      .find('#error-message')
+      .contains('You must choose a claim type');
+
+    cy.location('pathname').should('eq', `${BASE_URL}/start`);
+  });
+
+  it('should go to intro page when compensation is selected', () => {
+    cy.location('pathname').should('eq', `${BASE_URL}/start`);
+    cy.injectAxeThenAxeCheck();
+
+    cy.selectRadio('benefitType', 'compensation');
+    cy.findByText(/continue/i, { selector: 'va-button' }).click();
+
+    cy.location('pathname').should('eq', `${BASE_URL}/introduction`);
+  });
+
+  it('should go to non-compensation type page when another type is selected', () => {
+    cy.location('pathname').should('eq', `${BASE_URL}/start`);
+    cy.injectAxeThenAxeCheck();
+
+    cy.selectRadio('benefitType', 'other');
+    cy.findByText(/continue/i, { selector: 'va-button' }).click();
+
+    cy.location('pathname').should('eq', `${BASE_URL}/start`);
+    cy.get('h1').contains('Claim isn’t for a disability');
+    cy.findByText('Find the address for mailing your form', { selector: 'a' })
+      .should('have.attr', 'href')
+      .and(
+        'contain',
+        '/decision-reviews/supplemental-claim#find-addresses-for-other-benef-8804',
+      );
+    cy.findByText('Download VA Form 20-0995', { selector: 'a' })
+      .should('have.attr', 'href')
+      .and('contain', 'https://www.vba.va.gov/pubs/forms/VBA-20-0995-ARE.pdf');
+  });
+});

--- a/src/applications/appeals/995/tests/subtask/subtask.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/subtask/subtask.unit.spec.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, fireEvent } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import SubTask, {
+  setStoredSubTask,
+  resetStoredSubTask,
+} from 'platform/forms/sub-task';
+
+import pages from '../../subtask/pages';
+
+const mouseClick = new MouseEvent('click', {
+  bubbles: true,
+  cancelable: true,
+});
+
+const mockStore = (data = {}) => {
+  setStoredSubTask(data);
+  return {
+    getState: () => ({
+      form: {
+        data,
+      },
+      formContext: {
+        onReviewPage: false,
+        reviewMode: false,
+        touched: {},
+        submitted: false,
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => ({
+      setFormData: () => {},
+    }),
+  };
+};
+
+describe('the Supplemental Claims Sub-task', () => {
+  after(() => {
+    resetStoredSubTask();
+  });
+  it('should render the SubTask as a form element', () => {
+    const { container } = render(
+      <Provider store={mockStore()}>
+        <SubTask pages={pages} />
+      </Provider>,
+    );
+    const form = $('form[data-page="start"]', container);
+    expect(form).to.exist;
+    expect($('va-radio-option[value="compensation"]', form)).to.exist;
+    expect($('va-radio-option[value="other"]', form)).to.exist;
+    expect($('va-button[continue]', container)).to.exist;
+  });
+  it('should go to the "other" SubTask page and back to "start"', () => {
+    const { container } = render(
+      <Provider store={mockStore({ benefitType: 'other' })}>
+        <SubTask pages={pages} />
+      </Provider>,
+    );
+
+    expect($('form[data-page="start"]', container)).to.exist;
+
+    fireEvent.click($('va-button[continue]', container), mouseClick);
+    expect($('form[data-page="other"]', container)).to.exist;
+    expect($('a[download]', container)).to.exist;
+
+    fireEvent.click($('va-button[back]', container), mouseClick);
+    expect($('form[data-page="start"]', container)).to.exist;
+  });
+  it('should show an error when no selection is made', () => {
+    const { container } = render(
+      <Provider store={mockStore()}>
+        <SubTask pages={pages} />
+      </Provider>,
+    );
+
+    expect($('form[data-page="start"]', container)).to.exist;
+    const vaRadio = $('va-radio', container);
+    expect(vaRadio).to.exist;
+    expect(vaRadio.error).to.be.null;
+
+    fireEvent.click($('va-button[continue]', container), mouseClick);
+    expect($('form[data-page="start"]', container)).to.exist;
+    expect(vaRadio.error).to.contain('choose a claim type');
+  });
+  it('should go to the Introduction page when complete', () => {
+    const router = { push: sinon.spy() };
+    const { container } = render(
+      <Provider store={mockStore({ benefitType: 'compensation' })}>
+        <SubTask pages={pages} router={router} />
+      </Provider>,
+    );
+
+    expect($('form[data-page="start"]', container)).to.exist;
+
+    fireEvent.click($('va-button[continue]', container), mouseClick);
+    expect(router.push.args[0][0]).to.include('/introduction');
+  });
+});

--- a/src/platform/forms/tests/sub-task/basic-2-page.unit.spec.jsx
+++ b/src/platform/forms/tests/sub-task/basic-2-page.unit.spec.jsx
@@ -50,8 +50,8 @@ describe('the Supplemental Claims Sub-task', () => {
     );
     const form = $('form[data-page="start"]', container);
     expect(form).to.exist;
-    expect($('va-radio-option[label^="Disability"]', form)).to.exist;
-    expect($('va-radio-option[label^="Claim other"]', form)).to.exist;
+    expect($('va-radio-option[value="compensation"]', form)).to.exist;
+    expect($('va-radio-option[value="other"]', form)).to.exist;
     expect($('va-button[continue]', container)).to.exist;
   });
   it('should go to the "other" SubTask page and back to "start"', () => {
@@ -84,7 +84,7 @@ describe('the Supplemental Claims Sub-task', () => {
 
     fireEvent.click($('va-button[continue]', container), mouseClick);
     expect($('form[data-page="start"]', container)).to.exist;
-    expect(vaRadio.error).to.contain('choose a benefit type');
+    expect(vaRadio.error).to.contain('choose');
   });
   it('should go to the Introduction page when complete', () => {
     const router = { push: sinon.spy() };

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -26,7 +26,15 @@ Cypress.Commands.add('fill', (selector, value) => {
 });
 Cypress.Commands.add('selectRadio', (fieldName, value) => {
   if (value !== 'undefined') {
-    cy.get(`input[name="${fieldName}"][value="${value}"]`).click();
+    cy.document().then(doc => {
+      const attrs = `[name="${fieldName}"][value="${value}"]`;
+      const vaRadioOption = doc.querySelector(`va-radio-option${attrs}`);
+      if (vaRadioOption) {
+        cy.wrap(vaRadioOption).click();
+      } else {
+        cy.get(`input${attrs}`).click();
+      }
+    });
   }
 });
 Cypress.Commands.add('fillDate', (fieldName, dateString) => {


### PR DESCRIPTION
## Original Ticket

[#48142](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48142)

## URL of change

`/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995/start`

## Background

The sub-task for Supplemental Claim form is already in place, but the content needed updating. Additionally, unit tests and Cypress e2e tests were created to test this functionality.

- [DESIGN](https://www.sketch.com/s/d2416db4-9a4f-4919-abe4-20ba4bdcfd89/v/Mdvgll/p/0454C07B-0B34-46F7-9287-200FD43F78D5/canvas?posX=-586.8563232421875&posY=-56.14762878417969&zoom=0.9312365055084229)
- [CONTENT](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/decision-reviews/Supplemental-Claims/design/sourceofcontenttruth.md)

Because the `SubTask` component was build for Supplemental Claims, the platform unit tests were based on the previous content, and therefore needed to be updated, using more generic selectors, to pass.

Additionally, the Cypress command `selectRadio` was updated to work with the `va-radio-option` web component.

## Steps to test

1. Pull in this branch locally, or test in the review instance
2. Go to the URL of change (no need to log in)
3. Activate the "Continue" button without choosing an option
4. An error will appear
5. Choose "Another type of claim..."
6. This will take you to a new page, still within the `/start` URL letting the Veteran know to download and submit the form
7. Activate the "Back" button
8. Choose "Disability compensation claim"
9. Activate the "Continue" button
10. You should now be on the SC introduction page

## Code changes

- Updated SC content and error message based on the content source of truth
- Added sub-task unit tests, modified from `src/platform/forms/tests/sub-task/basic-2-page.unit.spec.jsx`
- Added Cypress e2e test for sub-task
- Updated `src/platform/forms/tests/sub-task/basic-2-page.unit.spec.jsx` to be more generic
- Updated Cypress `selectRadio` command to work with `va-radio-option` web component 

## How was your code tested

- Unit tests
- Cypress e2e tests

## Acceptance criteria
- [x] Update SC sub-task content
- [x] Add unit tests & e2e test
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs