### PR TITLE
DLD: Format claim letter `received_at` field value

### DIFF
--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -1,16 +1,45 @@
 import React from 'react';
+import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
 import environment from 'platform/utilities/environment';
 
+const docTypeToDescription = {
+  '184': 'Notification Letter',
+  '339': 'Rating Decision Letter',
+};
+
+const subjectToDescription = {
+  'Intent to File': 'Notice of receipt of Intent to File',
+};
+
 const downloadUrl = id => `${environment.API_URL}/v0/claim_letters/${id}`;
 
+const formatDate = date => {
+  return format(new Date(date), 'MMMM dd, yyyy');
+};
+
+const documentDescription = ({ docType, subject }) => {
+  if (subject) {
+    return subjectToDescription[subject];
+  }
+
+  if (docType) {
+    return docTypeToDescription[docType];
+  }
+
+  return 'Notification Letter';
+};
+
 const ClaimLetterListItem = ({ letter }) => {
-  const heading = `Letter dated ${letter.receivedAt}`;
+  const heading = `Letter dated ${formatDate(letter.receivedAt)}`;
 
   return (
     <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">
       <h4>{heading}</h4>
+      <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
+        {documentDescription(letter)}
+      </div>
       <va-link
         download
         filetype="PDF"


### PR DESCRIPTION
## Description
vets-api is now returning the `received_at` field in it's original format,
so we need to format it on the frontend. Also adding a description based
on a combination of the `subject` and the `doc_type` fields

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49024


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
