### PR TITLE
Profile/44886/update address validation alerts

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
@@ -14,11 +14,7 @@ describe('Personal and contact information', () => {
       addressPage.loadPage('bad-unit');
       addressPage.fillAddressForm(formFields);
       addressPage.saveForm();
-      addressPage.validateSavedForm(
-        formFields,
-        false,
-        'Please update or confirm your unit number',
-      );
+      addressPage.validateSavedForm(formFields, false, 'Confirm your address');
       addressPage.saveForm(true);
       addressPage.confirmAddress(formFields, [], true);
       cy.injectAxeThenAxeCheck();

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -14,16 +14,13 @@ describe('Personal and contact information', () => {
       addressPage.loadPage('bad-unit');
       addressPage.fillAddressForm(formFields);
       addressPage.saveForm();
-      addressPage.validateSavedForm(
-        formFields,
-        false,
-        'Please update or confirm your unit number',
-      );
+      addressPage.validateSavedForm(formFields, false, 'Confirm your address');
       addressPage.editAddress(
         [/^street address \(/i, /^street address line 2/i],
         [formFields.address, formFields.address2],
       );
       addressPage.validateSavedForm(formFields);
+      cy.injectAxeThenAxeCheck();
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -104,14 +104,17 @@ class AddressPage {
     !secondSave &&
       cy
         .findByTestId('mailingAddress')
-        .should('contain', 'Please confirm your address');
+        .should(
+          'contain',
+          'We can’t confirm the address you entered with the U.S. Postal Service.',
+        );
     alternateSuggestions.forEach(field =>
       cy.findByTestId('mailingAddress').should('contain', field),
     );
     missingUnit &&
       cy
         .findByTestId('mailingAddress')
-        .should('contain', 'Please add a unit number');
+        .should('contain', 'Confirm your address');
     cy.findByTestId('confirm-address-button').click({
       force: true,
     });
@@ -125,7 +128,7 @@ class AddressPage {
   };
 
   editAddress = (labels, fields) => {
-    cy.findByRole('button', { name: /edit your address/i }).click();
+    cy.findByRole('button', { name: /edit address/i }).click();
     this.confirmAddressFields(labels, fields);
     cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
     cy.findByRole('button', { name: /^use this address$/i }).click({

--- a/src/platform/user/profile/vap-svc/constants/addressValidationMessages.js
+++ b/src/platform/user/profile/vap-svc/constants/addressValidationMessages.js
@@ -27,16 +27,12 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
     ),
   },
   [ADDRESS_VALIDATION_TYPES.BAD_UNIT_OVERRIDE]: {
-    headline: 'Please update or confirm your unit number',
-    ModalText: ({ editFunction }) => (
+    headline: 'Confirm your address',
+    ModalText: () => (
       <p>
-        We couldn’t verify your address with the U.S. Postal Service because
-        there may be a problem with the unit number. Please{' '}
-        <button className="va-button-link" onClick={editFunction}>
-          edit your address
-        </button>{' '}
-        to update the unit number. If your unit number is already correct,
-        please continue with the address you entered below.
+        U.S. Postal Service records show that there may be a problem with the
+        unit number for this address. Confirm that you want us to use this
+        address as you entered it. Or, cancel to edit the address.
       </p>
     ),
   },
@@ -54,15 +50,12 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
     ),
   },
   [ADDRESS_VALIDATION_TYPES.MISSING_UNIT_OVERRIDE]: {
-    headline: 'Please add a unit number',
-    ModalText: ({ editFunction }) => (
+    headline: 'Confirm your address',
+    ModalText: () => (
       <p>
-        It looks like your address is missing a unit number. Please{' '}
-        <button className="va-button-link" onClick={editFunction}>
-          edit your address
-        </button>{' '}
-        to add a unit number. If you don’t have a unit number and the address
-        you entered below is correct, please select it.
+        U.S. Postal Service records show this address may need a unit number.
+        Confirm that you want us to use this address as you entered it. Or,
+        cancel to go back and add a unit number.
       </p>
     ),
   },
@@ -71,7 +64,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
     ModalText: ({ editFunction }) => (
       <p>
         We’re sorry. We couldn’t verify your address with the U.S. Postal
-        Service, so we won't be able to deliver your VA mail to that address.
+        Service, so we won’t be able to deliver your VA mail to that address.
         Please{' '}
         <button className="va-button-link" onClick={editFunction}>
           edit the address
@@ -81,17 +74,10 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
     ),
   },
   [ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS_OVERRIDE]: {
-    headline: 'Please confirm your address',
-    ModalText: ({ editFunction }) => (
-      <p>
-        We couldn’t confirm your address with the U.S. Postal Service. Please
-        verify your address so we can save it to your VA profile. If the address
-        you entered isn’t correct, please{' '}
-        <button className="va-button-link" onClick={editFunction}>
-          edit it
-        </button>{' '}
-        or choose a suggested address below.
-      </p>
+    headline:
+      'We can’t confirm the address you entered with the U.S. Postal Service.',
+    ModalText: () => (
+      <p>Tell us which of these addresses you’d like us to use.</p>
     ),
   },
   [ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS_NO_CONFIRMED]: {
@@ -109,16 +95,12 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
     ),
   },
   [ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS_NO_CONFIRMED_OVERRIDE]: {
-    headline: 'Please confirm your address',
-    ModalText: ({ editFunction }) => (
+    headline: 'Confirm your address',
+    ModalText: () => (
       <p>
-        We couldn’t confirm your address with the U.S. Postal Service. Please
-        verify your address so we can save it to your VA profile. If the address
-        you entered isn’t correct, please{' '}
-        <button className="va-button-link" onClick={editFunction}>
-          edit it
-        </button>
-        {'. '} If the address you entered below is correct, please select it.
+        We can’t confirm the address you entered with the U.S. Postal Service.
+        Confirm that you want us to use this address as you entered it. Or,
+        cancel to go back and edit it.
       </p>
     ),
   },

--- a/src/platform/user/profile/vap-svc/constants/addressValidationMessages.js
+++ b/src/platform/user/profile/vap-svc/constants/addressValidationMessages.js
@@ -1,4 +1,6 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export const ADDRESS_VALIDATION_TYPES = Object.freeze({
   BAD_UNIT: 'badUnitNumber',
@@ -19,7 +21,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       <p>
         We couldn’t verify your address with the U.S. Postal Service because
         there may be a problem with the unit number. Please{' '}
-        <button className="va-button-link" onClick={editFunction}>
+        <button type="button" className="va-button-link" onClick={editFunction}>
           edit your address
         </button>{' '}
         below to update the unit number.
@@ -42,7 +44,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       <p>
         We couldn’t verify your address with the U.S. Postal Service because
         it’s missing a unit number. Please{' '}
-        <button className="va-button-link" onClick={editFunction}>
+        <button type="button" className="va-button-link" onClick={editFunction}>
           edit your address
         </button>{' '}
         below to add a unit number.
@@ -66,8 +68,8 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
         We’re sorry. We couldn’t verify your address with the U.S. Postal
         Service, so we won’t be able to deliver your VA mail to that address.
         Please{' '}
-        <button className="va-button-link" onClick={editFunction}>
-          edit the address
+        <button type="button" className="va-button-link" onClick={editFunction}>
+          edit your address
         </button>{' '}
         you entered or choose a suggested address below.
       </p>
@@ -87,8 +89,8 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
         We couldn’t confirm your address with the U.S. Postal Service. Please
         verify your address so we can save it to your VA profile. If the address
         you entered isn’t correct, please{' '}
-        <button className="va-button-link" onClick={editFunction}>
-          edit it
+        <button type="button" className="va-button-link" onClick={editFunction}>
+          edit your address
         </button>
         {'. '}
       </p>
@@ -111,7 +113,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
         We’re sorry. We couldn’t verify your address with the U.S. Postal
         Service, so we will not be able to deliver your VA mail to that address.
         Please{' '}
-        <button className="va-button-link" onClick={editFunction}>
+        <button type="button" className="va-button-link" onClick={editFunction}>
           edit the address
         </button>{' '}
         you entered.
@@ -119,6 +121,13 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
     ),
   },
 });
+
+// this apparently doesn't work to make eslint happy
+ADDRESS_VALIDATION_MESSAGES[
+  ADDRESS_VALIDATION_TYPES.BAD_UNIT
+].ModalText.propTypes = {
+  editFunction: PropTypes.func.isRequired,
+};
 
 export const BAD_UNIT_NUMBER = 'STREET_NUMBER_VALIDATED_BUT_BAD_UNIT_NUMBER';
 export const MISSING_UNIT_NUMBER =

--- a/src/platform/user/profile/vap-svc/tests/addressValidationMessages.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/addressValidationMessages.unit.spec.js
@@ -15,12 +15,14 @@ describe('ADDRESS_VALIDATION_MESSAGES object', () => {
       const editSpy = sinon.spy();
       expect(typeof messageData).to.equal('object');
       expect(typeof messageData.headline).to.equal('string');
-      expect(typeof messageData.ModalText).to.equal('function');
       const modalTextComponent = mount(
         <messageData.ModalText editFunction={editSpy} />,
       );
-      modalTextComponent.find('button').simulate('click');
-      expect(editSpy.called).to.be.true;
+      const button = modalTextComponent.find('button');
+      if (button?.length > 0) {
+        button.simulate('click');
+        expect(editSpy.called).to.be.true;
+      }
       modalTextComponent.unmount();
     });
   });

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -426,7 +426,9 @@ describe('<AddressValidationModal/>', () => {
         .find('h3')
         .at(0)
         .text(),
-    ).to.equal('Please confirm your address');
+    ).to.equal(
+      'We can’t confirm the address you entered with the U.S. Postal Service.',
+    );
     component.unmount();
   });
 });

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
@@ -451,7 +451,9 @@ describe('<AddressValidationView/>', () => {
         .find('h4')
         .at(0)
         .text(),
-    ).to.equal('Please confirm your address');
+    ).to.equal(
+      'We can’t confirm the address you entered with the U.S. Postal Service.',
+    );
     component.unmount();
   });
 });


### PR DESCRIPTION
## Description
Updates the copy within the alerts for address validation. Lots of tests were checking this output so lots of tests also needed to be updated.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/44886

## Testing done
E2E and unit tests updated for address validation components.


## Acceptance criteria
- [x] address validation component content updated.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
