### PR TITLE
Fix flash on check-in confirmation page when travel pay enabled

### DIFF
--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -196,7 +196,10 @@ const CheckInConfirmation = props => {
     );
   };
 
-  if (travelPayClaimRequested === false || travelPayClaimSent) {
+  if (
+    !isTravelReimbursementEnabled ||
+    (travelPayClaimRequested === false || travelPayClaimSent)
+  ) {
     return renderConfirmationMessage();
   }
 

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -32,6 +32,7 @@ const CheckInConfirmation = props => {
     travelPayClaimError,
     travelPayClaimData,
     travelPayClaimRequested,
+    travelPayClaimSent,
   } = useSendTravelPayClaim();
 
   const appointment = selectedAppointment;
@@ -195,7 +196,11 @@ const CheckInConfirmation = props => {
     );
   };
 
-  return isLoading ? renderLoadingMessage() : renderConfirmationMessage();
+  if (travelPayClaimRequested === false || travelPayClaimSent) {
+    return renderConfirmationMessage();
+  }
+
+  return renderLoadingMessage();
 };
 
 CheckInConfirmation.propTypes = {

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -198,6 +198,7 @@ const CheckInConfirmation = props => {
 
   if (
     !isTravelReimbursementEnabled ||
+    !travelPayEligible ||
     (travelPayClaimRequested === false || travelPayClaimSent)
   ) {
     return renderConfirmationMessage();

--- a/src/applications/check-in/hooks/useSendTravelPayClaim.jsx
+++ b/src/applications/check-in/hooks/useSendTravelPayClaim.jsx
@@ -9,7 +9,7 @@ const useSendTravelPayClaim = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [travelPayClaimData, setTravelPayClaimData] = useState(null);
   const [travelPayClaimError, setTravelPayClaimError] = useState(false);
-  const [travelPayClaimRequested, setTravelPayClaimRequested] = useState(false);
+  const [travelPayClaimRequested, setTravelPayClaimRequested] = useState();
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
   const featureToggles = useSelector(selectFeatureToggles);
@@ -38,6 +38,7 @@ const useSendTravelPayClaim = () => {
       ) {
         return;
       }
+
       setIsLoading(true);
       api.v2
         .postDayOfTravelPayClaim(travelPayData)
@@ -69,6 +70,7 @@ const useSendTravelPayClaim = () => {
     isLoading,
     travelPayClaimData,
     travelPayClaimRequested,
+    travelPayClaimSent,
   };
 };
 

--- a/src/applications/check-in/hooks/useTravelPayFlags.jsx
+++ b/src/applications/check-in/hooks/useTravelPayFlags.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { makeSelectCurrentContext, makeSelectForm } from '../selectors';
 
 const useTravelPayFlags = () => {
-  const [travelPayClaimSent, setTravelPayClaimSent] = useState(false);
+  const [travelPayClaimSent, setTravelPayClaimSent] = useState();
   const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
   const context = useSelector(selectCurrentContext);
   const { token } = context;


### PR DESCRIPTION
## Description

This fixes a "flash" from the non-travel pay content to the loading widget when the check-in confirmation screen is first shown.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48413

## How to QA

Ensure the non-travel pay path works correctly and that a flash is not shown on the check-in confirmation page. This can be confirmed with a console log just above `return renderConfirmationMessage();` in CheckInConfirmation.jsx.

## Testing done
Manual testing, updates to keep e2e tests working.
