### PR TITLE
Add spacing around form nav buttons

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNavButtons.jsx
+++ b/src/platform/forms-system/src/js/components/FormNavButtons.jsx
@@ -12,7 +12,7 @@ import ProgressButton from './ProgressButton';
  * navigate the user to the next page only if validation is successful.
  */
 const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
-  <div className="row form-progress-buttons schemaform-buttons">
+  <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--2">
     <div className="small-6 medium-5 columns">
       {goBack && (
         <ProgressButton

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -43,11 +43,7 @@ class SaveFormLink extends React.Component {
     const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
     return (
-      <div
-        className={`${
-          this.props.children ? 'vads-u-display--inline' : ''
-        }vads-u-margin-top--2`}
-      >
+      <div className={this.props.children ? 'vads-u-display--inline' : ''}>
         <Element name="saveFormLinkTop" />
         {saveErrors.has(savedStatus) && (
           <div

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -3,12 +3,13 @@ import Scroll from 'react-scroll';
 import PropTypes from 'prop-types';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { SAVE_STATUSES, saveErrors } from './actions';
 import { focusElement, getScrollOptions } from 'platform/utilities/ui';
+
+import { SAVE_STATUSES, saveErrors } from './actions';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
 import SipsDevModal from './SaveInProgressDevModal';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 class SaveFormLink extends React.Component {
   componentDidMount() {
@@ -42,7 +43,11 @@ class SaveFormLink extends React.Component {
     const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
     return (
-      <div className={this.props.children ? 'vads-u-display--inline' : ''}>
+      <div
+        className={`${
+          this.props.children ? 'vads-u-display--inline' : ''
+        }vads-u-margin-top--2`}
+      >
         <Element name="saveFormLinkTop" />
         {saveErrors.has(savedStatus) && (
           <div
@@ -57,6 +62,7 @@ class SaveFormLink extends React.Component {
               <span>
                 Sorry, you’re signed out. Please{' '}
                 <button
+                  type="button"
                   className="va-button-link"
                   onClick={this.openLoginModal}
                 >
@@ -86,16 +92,25 @@ class SaveFormLink extends React.Component {
 }
 
 SaveFormLink.propTypes = {
-  locationPathname: PropTypes.string.isRequired,
   form: PropTypes.shape({
     formId: PropTypes.string.isRequired,
     version: PropTypes.number.isRequired,
     data: PropTypes.object.isRequired,
     trackingPrefix: PropTypes.string.isRequired,
     savedStatus: PropTypes.string.isRequired,
+    submission: PropTypes.object.isRequired,
   }).isRequired,
-  user: PropTypes.object.isRequired,
+  locationPathname: PropTypes.string.isRequired,
+  saveAndRedirectToReturnUrl: PropTypes.func.isRequired,
   toggleLoginModal: PropTypes.func.isRequired,
+  user: PropTypes.object.isRequired,
+  children: PropTypes.any,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      appType: PropTypes.string,
+    }),
+  }),
+  savedStatus: PropTypes.string,
 };
 
 export default SaveFormLink;

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -161,7 +161,7 @@ const SipsDevModal = props => {
       <button
         key={showLink}
         type="button"
-        className="va-button-link vads-u-margin-left--1"
+        className="va-button-link vads-u-margin-left--2"
         onClick={handlers.openSipsModal}
       >
         <i aria-hidden="true" className="fas fa-cog" role="img" /> Open


### PR DESCRIPTION
## Description

The back and continue form navigation buttons are in close proximity (around 8px) to the "Finish this application later" link above and save-in-progress status alert below.

<img width="557" alt="finish this application later in very close to the top of the form back button and the top of the save in progress alert is very close to the bottom of the back button" src="https://user-images.githubusercontent.com/136959/199312602-933b820c-508f-40fe-bfd5-7af9598d30d0.png">

We should at least double this spacing.

Additionally, the space between the "Finish this application later" and "Open save-in-progress menu" links need to be doubled.

## Original issue(s)
[#49092](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49092)

## Testing done

Visual testing

## Screenshots

After

<img width="556" alt="Finish this application link above and with a 2 em spacing between the back & continue buttons, then a 2 em spacing to the save in progress status message - your application has been saved..." src="https://user-images.githubusercontent.com/136959/199330690-ec654d72-9df2-4b0b-b63c-3768e974c022.png">

## Acceptance criteria
- [x] Add vertical spacing around form navigation buttons
- [x] Add horizontal spacing between finish this app and open save-in-progress links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
