### PR TITLE
PROD & Staging: VAOS v2 - New Requests only displays after re-loading the page

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -220,7 +220,9 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             startDate: moment()
               .subtract(120, 'days')
               .format('YYYY-MM-DD'),
-            endDate: moment().format('YYYY-MM-DD'),
+            endDate: moment()
+              .add(featureVAOSServiceRequests ? 1 : 0, 'days')
+              .format('YYYY-MM-DD'),
             useV2: featureVAOSServiceRequests,
           })
             .then(requests => {


### PR DESCRIPTION
## Description
During VAOS and HSRM integration testing call scheduled on 10/25, we have encountered an issue related to newly created Community Care request. These requests were displaying in pending queue only after refreshing the page. If the user navigates to the home screen and goes back to pending queue the request disappears again. There were no errors in the Dev Tools or Backend logs during testing.

Replicated the scenario in staging for both VA and CC request flow, but noticed this issue is only related to CC flow. VA flow is working as expected. Validated the request is making its way through to HSRM.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#48766


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
