### PR TITLE
Add canceled booked feature flag

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -68,6 +68,9 @@ export const selectFeaturePocHealthApt = state =>
 export const selectFeatureStatusImprovement = state =>
   toggleValues(state).vaOnlineSchedulingStatusImprovement;
 
+export const selectFeatureStatusImprovementCanceled = state =>
+  toggleValues(state).vaOnlineSchedulingStatusImprovementCanceled;
+
 export const selectFeatureFilter36Vats = state =>
   toggleValues(state).vaOnlineFilter36Vats;
 

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -574,6 +574,7 @@ const responses = {
         { name: 'vaOnlineSchedulingVariantTesting', value: false },
         { name: 'vaOnlineSchedulingPocHealthApt', value: true },
         { name: 'vaOnlineSchedulingStatusImprovement', value: true },
+        { name: 'vaOnlineSchedulingStatusImprovementCanceled', value: true },
         { name: 'vaOnlineFilter36Vats', value: true },
         { name: 'vaOnlineSchedulingVAOSV2Next', value: true },
         { name: 'vaOnlineSchedulingAppointmentList', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -161,6 +161,7 @@ export default Object.freeze({
   vaOnlineSchedulingVariantTesting: 'va_online_scheduling_variant_testing',
   vaOnlineSchedulingPocHealthApt: 'va_online_scheduling_poc_health_apt',
   vaOnlineSchedulingStatusImprovement: 'va_online_scheduling_status_improvement',
+  vaOnlineSchedulingStatusImprovementCanceled: 'va_online_scheduling_status_improvement_canceled',
   vaOnlineSchedulingClinicLocation: 'va_online_scheduling_clinic_location',
   vaOnlineSchedulingVaosV2Next: 'va_online_scheduling_vaos_v2_next',
   vaOnlineSchedulingAppointmentList: 'va_online_scheduling_appointment_list',


### PR DESCRIPTION
## Description
Add feature toggle flag `va_online_scheduling_status_improvement_canceled` to display canceled booked appointments in the VAOS app
## Original issue(s)
department-of-veterans-affairs/va.gov-team#48733


## Testing done
n/a

## Screenshots
n/a

## Acceptance criteria
- [ ]Toggle is created
- 
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
