### PR TITLE
Updates configs + tests for VA OCC Mobile

### DIFF
--- a/src/applications/login/tests/containers/SignInApp.unit.spec.js
+++ b/src/applications/login/tests/containers/SignInApp.unit.spec.js
@@ -83,7 +83,7 @@ describe.skip('SignInApp', () => {
     expect(defaultProps.router.push.called).to.be.false;
   });
 
-  ['ebenefits', 'mhv'].forEach(app => {
+  ['ebenefits', 'mhv', 'vaoccmobile'].forEach(app => {
     it(`should change 'oauth=true' to 'oauth=false' if the 'application=${app}' is not OAuth authorized`, () => {
       const defaultProps = generateProps({
         query: { oauth: true, application: app },
@@ -100,7 +100,7 @@ describe.skip('SignInApp', () => {
     });
   });
 
-  ['vamobile', 'vaoccmobile'].forEach(app => {
+  ['vamobile'].forEach(app => {
     it(`should keep 'oauth=false' if 'application=${app}' specified it`, () => {
       const defaultProps = generateProps({
         query: { oauth: false, application: app },

--- a/src/platform/user/authentication/config/constants.js
+++ b/src/platform/user/authentication/config/constants.js
@@ -30,8 +30,4 @@ export const defaultWebOAuthOptions = {
   acrVerify: { idme: 'loa3', logingov: 'ial2' },
 };
 
-export const OAuthEnabledApplications = [
-  undefined /* default */,
-  'vamobile',
-  'vaoccmobile',
-];
+export const OAuthEnabledApplications = [undefined /* default */, 'vamobile'];

--- a/src/platform/user/authentication/config/dev.config.js
+++ b/src/platform/user/authentication/config/dev.config.js
@@ -75,7 +75,7 @@ export default {
     allowedSignUpProviders: { ...defaultSignUpProviders },
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
-    OAuthEnabled: true,
+    OAuthEnabled: false,
     requiresVerification: true,
     oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_OCC_MOBILE],

--- a/src/platform/user/authentication/config/prod.config.js
+++ b/src/platform/user/authentication/config/prod.config.js
@@ -75,7 +75,7 @@ export default {
     allowedSignUpProviders: { ...defaultSignUpProviders },
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
-    OAuthEnabled: true,
+    OAuthEnabled: false,
     requiresVerification: true,
     oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_OCC_MOBILE],

--- a/src/platform/user/authentication/config/staging.config.js
+++ b/src/platform/user/authentication/config/staging.config.js
@@ -75,7 +75,7 @@ export default {
     allowedSignUpProviders: { ...defaultSignUpProviders },
     isMobile: true,
     queryParams: { ...defaultMobileQueryParams },
-    OAuthEnabled: true,
+    OAuthEnabled: false,
     requiresVerification: true,
     oAuthOptions: defaultMobileOAuthOptions,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.VA_OCC_MOBILE],


### PR DESCRIPTION
## Description
This PR changes the configuration files in (dev, staging, and production) for the VA OCC Mobile application.  Specifically it does not allow OAuth (Sign in Service) to be utilized on VA.gov in each environment.  Addtionally it updates the unit tests in the SignInApp component which is the Unified Sign in Page.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#49071


## Testing done
Unit testing / manual

## Screenshots
n/a

## Acceptance criteria
On the Unified Sign in Page (USiP) with the query parameter `application=vaoccmobile`
- [x] By default I can confirm that the `oauth=false` query parameter is appended
- [x] Setting the `oauth=true` query parameter, resets to `oauth=false`
- [x] Setting the `oauth=false` query paramter stays the same as `oauth=false`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
