### PR TITLE
added acheron header

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -14,6 +14,7 @@ import {
   selectFeatureVAOSServiceCCAppointments,
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureFacilitiesServiceV2,
+  selectFeatureAcheronService,
 } from '../../redux/selectors';
 
 import { getRequestMessages } from '../../services/var';
@@ -181,6 +182,9 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
     const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
       getState(),
     );
+    const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
+      getState(),
+    );
 
     dispatch({
       type: FETCH_FUTURE_APPOINTMENTS,
@@ -211,6 +215,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             .format('YYYY-MM-DD'),
           useV2VA: featureVAOSServiceVAAppointments,
           useV2CC: featureVAOSServiceCCAppointments,
+          useAcheron: featureAcheronVAOSServiceRequests,
         }),
       ];
 
@@ -224,6 +229,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
               .add(featureVAOSServiceRequests ? 1 : 0, 'days')
               .format('YYYY-MM-DD'),
             useV2: featureVAOSServiceRequests,
+            useAcheron: featureAcheronVAOSServiceRequests,
           })
             .then(requests => {
               dispatch({
@@ -343,6 +349,9 @@ export function fetchPendingAppointments() {
       const featureFacilitiesServiceV2 = selectFeatureFacilitiesServiceV2(
         state,
       );
+      const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
+        state,
+      );
 
       const pendingAppointments = await getAppointmentRequests({
         startDate: moment()
@@ -352,6 +361,7 @@ export function fetchPendingAppointments() {
           .add(featureVAOSServiceRequests ? 1 : 0, 'days')
           .format('YYYY-MM-DD'),
         useV2: featureVAOSServiceRequests,
+        useAcheron: featureAcheronVAOSServiceRequests,
       });
 
       dispatch({
@@ -407,6 +417,9 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
     const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
       getState(),
     );
+    const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
+      getState(),
+    );
 
     dispatch({
       type: FETCH_PAST_APPOINTMENTS,
@@ -424,6 +437,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
           endDate,
           useV2VA: featureVAOSServiceVAAppointments,
           useV2CC: featureVAOSServiceCCAppointments,
+          useAcheron: featureAcheronVAOSServiceRequests,
         }),
       ];
 
@@ -486,6 +500,9 @@ export function fetchRequestDetails(id) {
       const featureFacilitiesServiceV2 = selectFeatureFacilitiesServiceV2(
         state,
       );
+      const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
+        state,
+      );
       let request = selectAppointmentById(state, id, [
         APPOINTMENT_TYPES.ccRequest,
         APPOINTMENT_TYPES.request,
@@ -503,6 +520,7 @@ export function fetchRequestDetails(id) {
         request = await fetchRequestById({
           id,
           useV2: featureVAOSServiceRequests,
+          useAcheron: featureAcheronVAOSServiceRequests,
         });
         facilityId = getVAAppointmentLocationId(request);
         facility = state.appointments.facilityData?.[facilityId];
@@ -555,6 +573,9 @@ export function fetchConfirmedAppointmentDetails(id, type) {
       const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
         state,
       );
+      const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
+        state,
+      );
       const useV2 =
         type === 'cc'
           ? featureVAOSServiceCCAppointments
@@ -577,6 +598,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
           id,
           type,
           useV2,
+          useAcheron: featureAcheronVAOSServiceRequests,
         });
       }
 
@@ -647,6 +669,9 @@ export function confirmCancelAppointment() {
     const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
       getState(),
     );
+    const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
+      getState(),
+    );
 
     try {
       dispatch({
@@ -660,6 +685,7 @@ export function confirmCancelAppointment() {
             appointment.status === APPOINTMENT_STATUS.proposed) ||
           (featureVAOSServiceVAAppointments &&
             appointment.status !== APPOINTMENT_STATUS.proposed),
+        useAcheron: featureAcheronVAOSServiceRequests,
       });
 
       dispatch({

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -36,6 +36,7 @@ export default function TypeOfCarePage() {
     showDirectScheduling,
     showPodiatryApptUnavailableModal,
     useV2,
+    useAcheron,
   } = useSelector(selectTypeOfCarePage, shallowEqual);
 
   const history = useHistory();
@@ -116,7 +117,7 @@ export default function TypeOfCarePage() {
             // This could get called multiple times, but the function is memoized
             // and returns the previous promise if it eixsts
             if (showDirectScheduling) {
-              if (useV2) getLongTermAppointmentHistoryV2();
+              if (useV2) getLongTermAppointmentHistoryV2(useAcheron);
               else getLongTermAppointmentHistory();
             }
 

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -787,6 +787,7 @@ export function submitAppointmentOrRequest(history) {
         if (featureVAOSServiceVAAppointments) {
           appointment = await createAppointment({
             appointment: transformFormToVAOSAppointment(getState()),
+            useAcheron: featureAcheronVAOSServiceRequests,
           });
         } else {
           const appointmentBody = transformFormToAppointment(getState());
@@ -895,7 +896,10 @@ export function submitAppointmentOrRequest(history) {
             getState(),
             featureAcheronVAOSServiceRequests,
           );
-          requestData = await createAppointment({ appointment: requestBody });
+          requestData = await createAppointment({
+            appointment: requestBody,
+            useAcheron: featureAcheronVAOSServiceRequests,
+          });
         } else if (isCommunityCare) {
           requestBody = transformFormToCCRequest(getState());
           requestData = await submitRequest('cc', requestBody);

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -23,6 +23,7 @@ import {
   selectFeatureDirectScheduling,
   selectRegisteredCernerFacilityIds,
   selectFeatureVAOSServiceVAAppointments,
+  selectFeatureAcheronService,
 } from '../../redux/selectors';
 import { removeDuplicateId } from '../../utils/data';
 
@@ -387,6 +388,7 @@ export function selectTypeOfCarePage(state) {
   const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
     state,
   );
+  const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(state);
 
   return {
     ...address,
@@ -398,6 +400,7 @@ export function selectTypeOfCarePage(state) {
     showPodiatryApptUnavailableModal:
       newAppointment.showPodiatryAppointmentUnavailableModal,
     useV2: featureVAOSServiceVAAppointments,
+    useAcheron: featureAcheronVAOSServiceRequests,
   };
 }
 

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -371,6 +371,7 @@ export async function fetchFlowEligibilityAndClinics({
   directSchedulingEnabled,
   useV2 = false,
   featureClinicFilter = false,
+  useAcheron = false,
 }) {
   const directSchedulingAvailable =
     locationSupportsDirectScheduling(location, typeOfCare) &&
@@ -406,9 +407,9 @@ export async function fetchFlowEligibilityAndClinics({
 
     if (isDirectAppointmentHistoryRequired) {
       if (useV2) {
-        apiCalls.pastAppointments = getLongTermAppointmentHistoryV2().catch(
-          createErrorHandler('direct-no-matching-past-clinics-error'),
-        );
+        apiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
+          useAcheron,
+        ).catch(createErrorHandler('direct-no-matching-past-clinics-error'));
       } else {
         apiCalls.pastAppointments = getLongTermAppointmentHistory().catch(
           createErrorHandler('direct-no-matching-past-clinics-error'),


### PR DESCRIPTION
## Description
To access the appointment functionality, VAOS FE will be passing the ACHERON_REQUESTS=true header to appointment put, get and post requests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49059


## Testing done


## Screenshots
<img width="1001" alt="Screen Shot 2022-11-02 at 4 22 22 PM" src="https://user-images.githubusercontent.com/47654119/199594891-dc0daef8-3f7f-4dae-a837-d0979ffb1ac3.png">

<img width="1001" alt="Screen Shot 2022-11-02 at 4 22 50 PM" src="https://user-images.githubusercontent.com/47654119/199594972-b960873d-8a2b-4339-8c2f-1cbedad39ea3.png">

<img width="1001" alt="Screen Shot 2022-11-02 at 4 24 11 PM" src="https://user-images.githubusercontent.com/47654119/199595177-8ee939c0-3ba3-414f-9fbd-e5183a2ca038.png">



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
