### PR TITLE
secure messaging breadcrumbs bug fix

### DIFF
--- a/src/applications/mhv/secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from 'react-router-dom';
 // temporarily using deprecated Breadcrumbs React component due to issues with VaBreadcrumbs that are pending resolution
 // import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+import { replaceWithStagingDomain } from '~/platform/utilities/environment/stagingDomains';
 import { setBreadcrumbs } from '../../actions/breadcrumbs';
 import * as Constants from '../../util/constants';
 
@@ -19,7 +20,7 @@ const SmBreadcrumbs = () => {
     () => {
       const paths = [
         {
-          path: `/message/${messageDetails?.messageId}`,
+          path: `/message`,
           label: messageDetails?.subject,
         },
         { path: '/reply', label: messageDetails?.subject },
@@ -27,7 +28,10 @@ const SmBreadcrumbs = () => {
         Constants.Breadcrumbs.DRAFT,
         Constants.Breadcrumbs.DRAFTS,
         {
-          path: `/folder/${activeFolder?.folderId}`,
+          path: `/folder/${
+            activeFolder?.folderId
+            // ${messageDetails?.messageId}
+          }`,
           label: activeFolder?.name,
         },
         Constants.Breadcrumbs.FOLDERS,
@@ -45,9 +49,12 @@ const SmBreadcrumbs = () => {
 
       function handleBreadCrumbs() {
         const arr = [];
-        arr.push({ path: 'https://www.va.gov', label: 'VA.gov home' });
         arr.push({
-          path: 'https://www.va.gov/health-care/',
+          path: replaceWithStagingDomain('https://www.va.gov'),
+          label: 'VA.gov home',
+        });
+        arr.push({
+          path: replaceWithStagingDomain('https://www.va.gov/health-care/'),
           label: 'My Health',
         });
         arr.push({ path: '/', label: 'Messages' });

--- a/src/applications/mhv/secure-messaging/tests/components/CategoryInput.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/CategoryInput.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { beforeEach } from 'mocha';
 import { expect } from 'chai';
 import reducer from '../../reducers';

--- a/src/applications/mhv/secure-messaging/tests/components/DiscardDraft.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/DiscardDraft.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
 import { fireEvent } from '@testing-library/react';
 import { beforeEach } from 'mocha';

--- a/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/MoveMessageToFolderBtn.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/MoveMessageToFolderBtn.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/dom';
 import { expect } from 'chai';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import folderResponse from '../../fixtures/folder-response.json';
 import reducers from '~/applications/mhv/secure-messaging/reducers';
 import MoveMessageToFolderBtn from '../../../components/MessageActionButtons/MoveMessageToFolderBtn';

--- a/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/PrintBtn.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/PrintBtn.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/dom';
 import { expect } from 'chai';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import PrintBtn from '../../../components/MessageActionButtons/PrintBtn';
 import messageResponse from '../../fixtures/message-response.json';
 import reducers from '~/applications/mhv/secure-messaging/reducers';

--- a/src/applications/mhv/secure-messaging/tests/components/Search/BasicSearchForm.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Search/BasicSearchForm.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
 import { folderList } from '../../fixtures/folder-response.json';
 import reducer from '../../../reducers';

--- a/src/applications/mhv/secure-messaging/tests/components/Search/CondensedSearchForm.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Search/CondensedSearchForm.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
 import { searchResults } from '../../fixtures/search-response.json';
 import { folder } from '../../fixtures/folder-inbox-metadata.json';

--- a/src/applications/mhv/secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
 import SmBreadcrumbs from '../../components/shared/SmBreadcrumbs';
 import messageResponse from '../fixtures/message-response.json';
@@ -31,7 +31,7 @@ describe('Breadcrumbs', () => {
       path: Constants.Breadcrumbs.COMPOSE.path,
     });
     expect(
-      await screen.getByText(Constants.Breadcrumbs.COMPOSE.label, {
+      await screen.findByText(Constants.Breadcrumbs.COMPOSE.label, {
         exact: true,
       }),
     );

--- a/src/applications/mhv/secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
@@ -15,91 +15,95 @@ describe('Breadcrumbs', () => {
     },
   };
 
-  it('on Message Details renders without errors', () => {
+  it('on Message Details renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
       path: `/message/${messageResponse.messageId}`,
     });
-    expect(screen.findByText(messageResponse.subject, { exact: true }));
+    expect(await screen.findByText(messageResponse.subject, { exact: true }));
   });
 
-  it('on Compose renders without errors', () => {
+  it('on Compose renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
       path: Constants.Breadcrumbs.COMPOSE.path,
     });
     expect(
-      screen.findByText(Constants.Breadcrumbs.COMPOSE.label, { exact: true }),
+      await screen.getByText(Constants.Breadcrumbs.COMPOSE.label, {
+        exact: true,
+      }),
     );
   });
 
-  it('on Drafts Folder renders without errors', () => {
+  it('on Drafts Folder renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
       path: Constants.Breadcrumbs.DRAFTS.path,
     });
     expect(
-      screen.findByText(Constants.Breadcrumbs.DRAFTS.label, {
+      await screen.findByText(Constants.Breadcrumbs.DRAFTS.label, {
         exact: true,
       }),
     );
   });
 
-  it('on Sent Folder renders without errors', () => {
+  it('on Sent Folder renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
       path: Constants.Breadcrumbs.SENT.path,
     });
     expect(
-      screen.findByText(Constants.Breadcrumbs.SENT.label, {
+      await screen.findByText(Constants.Breadcrumbs.SENT.label, {
         exact: true,
       }),
     );
   });
 
-  it('on Trash Folder renders without errors', () => {
+  it('on Trash Folder renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
       path: Constants.Breadcrumbs.TRASH.path,
     });
     expect(
-      screen.findByText(Constants.Breadcrumbs.TRASH.label, {
+      await screen.findByText(Constants.Breadcrumbs.TRASH.label, {
         exact: true,
       }),
     );
   });
 
-  it('on Search Folder renders without errors', () => {
+  it('on Search Folder renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
       path: Constants.Breadcrumbs.SEARCH.path,
     });
     expect(
-      screen.findByText(Constants.Breadcrumbs.SEARCH.label, {
+      await screen.findByText(Constants.Breadcrumbs.SEARCH.label, {
         exact: true,
       }),
     );
   });
 
-  it('on Advanced Search Folder renders without errors', () => {
+  it('on Advanced Search Folder renders without errors', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,
       reducers: reducer,
-      path: Constants.Breadcrumbs.SEARCH_ADVANCED.path,
+      path: `${Constants.Breadcrumbs.SEARCH.path}${
+        Constants.Breadcrumbs.SEARCH_ADVANCED.path
+      }`,
     });
     expect(
-      screen.findByText(Constants.Breadcrumbs.SEARCH.label, {
+      await screen.findByText(Constants.Breadcrumbs.SEARCH.label, {
         exact: true,
       }),
     );
     expect(
-      screen.findByText(Constants.Breadcrumbs.SEARCH_ADVANCED.label, {
+      await screen.findByText(Constants.Breadcrumbs.SEARCH_ADVANCED.label, {
         exact: true,
       }),
     );

--- a/src/applications/mhv/secure-messaging/tests/components/reply.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/reply.unit.spec.jsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import React from 'react';
 import messageResponse from '../fixtures/message-response.json';
 import reducers from '~/applications/mhv/secure-messaging/reducers';

--- a/src/applications/mhv/secure-messaging/tests/components/shared/AlertBackroundBox.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/shared/AlertBackroundBox.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import reducer from '../../../reducers';
 import AlertBackgroundBox from '../../../components/shared/AlertBackgroundBox';
 import { Alerts } from '../../../util/constants';


### PR DESCRIPTION
## Description
Fixing a bug where on MessageDetail view the breadcrumb would not display a message subject

## Original issue(s)
[SM to VA.gov - Message Detail bug](https://vajira.max.gov/browse/MHV-38041)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
