### PR TITLE
Use new DS utility classes in check-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,6 +248,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@department-of-veterans-affairs/component-library": "^12.0.0",
+    "@department-of-veterans-affairs/css-library": "^0.1.0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -23,7 +23,7 @@ const Footer = ({ router, isPreCheckIn }) => {
       {isPreCheckIn ? (
         <div data-testid="pre-check-in-message">
           <p>
-            <span className="vads-u-font-weight--bold">
+            <span className="vads-font-weight-bold">
               {t(
                 'for-questions-about-your-appointment-or-if-you-have-a-health-related-concern',
               )}
@@ -36,7 +36,7 @@ const Footer = ({ router, isPreCheckIn }) => {
             .
           </p>
           <p>
-            <span className="vads-u-font-weight--bold">
+            <span className="vads-font-weight-bold">
               {t(
                 'for-questions-about-how-to-fill-out-your-pre-check-in-tasks-or-if-you-need-help-with-the-form',
               )}
@@ -55,21 +55,19 @@ const Footer = ({ router, isPreCheckIn }) => {
         <p data-testid="day-of-check-in-message">
           <Trans
             i18nKey="for-questions-about-your-appointment"
-            components={[
-              <span key="bold" className="vads-u-font-weight--bold" />,
-            ]}
+            components={[<span key="bold" className="vads-font-weight-bold" />]}
           />
         </p>
       )}
       {currentPage === 'introduction' && (
         <p data-testid="intro-extra-message">
-          <span className="vads-u-font-weight--bold">
+          <span className="vads-font-weight-bold">
             {t(
               'if-you-need-to-talk-to-someone-right-away-or-need-emergency-care',
             )}
           </span>{' '}
           call <va-telephone contact="911" />,{' '}
-          <span className="vads-u-font-weight--bold">or</span>{' '}
+          <span className="vads-font-weight-bold">or</span>{' '}
           {t('call-the-veterans-crisis-hotline-at')}{' '}
           <va-telephone contact="988" /> {t('and-select-1')}
         </p>
@@ -81,7 +79,7 @@ const Footer = ({ router, isPreCheckIn }) => {
               <Trans
                 i18nKey="for-questions-about-travel-reimbursement"
                 components={[
-                  <span key="bold" className="vads-u-font-weight--bold" />,
+                  <span key="bold" className="vads-font-weight-bold" />,
                 ]}
               />
             </p>

--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -16,7 +16,7 @@ const Footer = ({ router, isPreCheckIn }) => {
     <footer>
       <h2
         data-testid="heading"
-        className="vads-u-font-size--lg vads-u-padding-bottom--1 vads-u-border-bottom--3px vads-u-border-color--primary"
+        className="vads-font-lg vads-padding-bottom-1 vads-border-bottom-3px vads-border-primary"
       >
         {t('need-help')}
       </h2>

--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -1,4 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "~@department-of-veterans-affairs/css-library/dist/utilities";
 
 dt{
   font-weight: bold;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,6 +2537,11 @@
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
+"@department-of-veterans-affairs/css-library@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/css-library/-/css-library-0.1.0.tgz#287b6f67daad87e81bb55395d36f508aa21a3082"
+  integrity sha512-Bu4a+Yms4W3QbIf+aRWKHSK1V5tE/ThnYemnDZZoN5VSLb5AQeqG4yFXC4s2VLVfGdKZChrFmUoPNd/LDQ8mOg==
+
 "@department-of-veterans-affairs/eslint-plugin@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.6.0.tgz#9a34ae8ab8d0e65e2cdabf9e446176c25dc1b9b9"


### PR DESCRIPTION
## Description

This is a demo to show how the still-in-progress `css-library` package can be used.

![A screenshot of the site running locally with the check-in footer highlighted, both in its rendered form and as raw markup in the inspector. The new utility classes are highlighted as well](https://user-images.githubusercontent.com/2008881/199615393-2c65cdc4-e549-409b-82bc-072b3ca56150.png)


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
