### PR TITLE
[FSR] - bug - Spouse Social Security monthly  income calculation

### DIFF
--- a/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
@@ -122,7 +122,7 @@ describe('fsr transform helper functions', () => {
   // Depends on sumValues, filterReduceByName, otherDeductionsAmt
   describe('getMonthlyIncome helper', () => {
     it('should return monthy income based on veterans net and other income, and spouses net and other income', () => {
-      expect(getMonthlyIncome(inputObject.data)).to.equal(20398.05);
+      expect(getMonthlyIncome(inputObject.data)).to.equal(20597.85);
     });
   });
 
@@ -800,7 +800,7 @@ describe('fsr transform information', () => {
       const submissionObj = JSON.parse(transform(null, inputObject));
       expect(
         submissionObj.discretionaryIncome.netMonthlyIncomeLessExpenses,
-      ).to.equal('12194.61');
+      ).to.equal('12394.41');
       expect(
         submissionObj.discretionaryIncome.amountCanBePaidTowardDebt,
       ).to.equal('800.97');

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -209,7 +209,7 @@ export const getMonthlyIncome = ({
   const spGrossSalary = sumValues(spCurrEmployment, 'spouseGrossSalary');
   const spAddlInc = sumValues(spAddlIncome, 'amount');
   const spSocialSecAmt = Number(
-    socialSecurity.socialSecAmt?.replaceAll(/[^0-9.-]/g, '') ?? 0,
+    socialSecurity.spouse?.socialSecAmt?.replaceAll(/[^0-9.-]/g, '') ?? 0,
   );
   const spComp = Number(
     benefits.spouseBenefits.compensationAndPension?.replaceAll(


### PR DESCRIPTION
## Description
Updated helper to accurately calculate Spouse Social Security for calculating monthly income. 

## Testing done
Updated transform unit testers

## Acceptance criteria
- [ ] Net monthly income accurately calculating
- [ ] Unit tests accurately reflect changes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
