### PR TITLE
enabled custom messaging for Downtime notifications

### DIFF
--- a/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
+++ b/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
@@ -13,6 +13,7 @@ export default function DowntimeMessage({
   startTime,
   endTime,
   status,
+  description,
   children,
 }) {
   const dispatch = useDispatch();
@@ -27,6 +28,15 @@ export default function DowntimeMessage({
           headline="The VA appointments tool is down for maintenance"
           status="warning"
         >
+          !!description ? (
+          <p>
+            {description} We’re sorry it’s not working right now. If you need to
+            request or confirm an appointment during this time, please call your
+            local VA medical center. Use the{' '}
+            <a href="/find-locations">VA facility locator</a> to find contact
+            information for your medical center.
+          </p>
+          ) : (
           <p>
             We’re making updates to the tool on {startTime.format('MMMM Do')}{' '}
             between {startTime.format('LT')} and {endTime.format('LT')}. We’re
@@ -35,6 +45,7 @@ export default function DowntimeMessage({
             center. Use the <a href="/find-locations">VA facility locator</a> to
             find contact information for your medical center.
           </p>
+          )
         </InfoAlert>
       </FullWidthLayout>
     );
@@ -53,6 +64,15 @@ export default function DowntimeMessage({
           modalTitle="VA online scheduling will be down for maintenance"
           data-testid="downtime-approaching-modal"
         >
+          !!description ? (
+          <p>
+            {description} We’re sorry it’s not working right now. If you need to
+            request or confirm an appointment during this time, please call your
+            local VA medical center. Use the{' '}
+            <a href="/find-locations">VA facility locator</a> to find contact
+            information for your medical center.
+          </p>
+          ) : (
           <p>
             We’re doing work on the VA appointments tool on{' '}
             {startTime.format('MMMM Do')} between {startTime.format('LT')} and{' '}
@@ -61,6 +81,7 @@ export default function DowntimeMessage({
             center. Use the <a href="/find-locations">VA facility locator</a> to
             find contact information for your medical center.
           </p>
+          )
           <button
             type="button"
             className="usa-button-secondary"
@@ -76,6 +97,7 @@ export default function DowntimeMessage({
 }
 DowntimeMessage.propTypes = {
   children: PropTypes.string,
+  description: PropTypes.string,
   endTime: PropTypes.string,
   startTime: PropTypes.string,
   status: PropTypes.string,

--- a/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
+++ b/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
@@ -20,11 +20,12 @@ export default function DowntimeMessage({
   const isDowntimeWarningDismissed = useSelector(state =>
     state.scheduledDowntime.dismissedDowntimeWarnings.includes(appTitle),
   );
-  const splitDescription = description.split('|');
-  const notificationTitle = splitDescription.length > 1 && splitDescription[0];
+  const splitDescription = description?.split('|');
+  const notificationTitle =
+    splitDescription?.length > 1 && splitDescription?.[0];
   const descriptionBody = notificationTitle
-    ? splitDescription[1]
-    : splitDescription[0];
+    ? splitDescription?.[1]
+    : splitDescription?.[0];
   if (status === externalServiceStatus.down) {
     return (
       <FullWidthLayout>
@@ -80,7 +81,6 @@ export default function DowntimeMessage({
           }
           data-testid="downtime-approaching-modal"
         >
-          {' '}
           {descriptionBody ? (
             <>
               <p>{descriptionBody}</p>

--- a/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
+++ b/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
@@ -38,17 +38,7 @@ export default function DowntimeMessage({
           status="warning"
         >
           {descriptionBody ? (
-            <>
-              <p>{descriptionBody}</p>
-              <p>
-                {' '}
-                We’re sorry it’s not working right now. If you need to request
-                or confirm an appointment during this time, please call your
-                local VA medical center. Use the{' '}
-                <a href="/find-locations">VA facility locator</a> to find
-                contact information for your medical center.
-              </p>
-            </>
+            <p>{descriptionBody}</p>
           ) : (
             <p>
               We’re making updates to the tool on {startTime.format('MMMM Do')}{' '}
@@ -82,17 +72,7 @@ export default function DowntimeMessage({
           data-testid="downtime-approaching-modal"
         >
           {descriptionBody ? (
-            <>
-              <p>{descriptionBody}</p>
-              <p>
-                {' '}
-                We’re sorry it’s not working right now. If you need to request
-                or confirm an appointment during this time, please call your
-                local VA medical center. Use the{' '}
-                <a href="/find-locations">VA facility locator</a> to find
-                contact information for your medical center.
-              </p>
-            </>
+            <p>{descriptionBody}</p>
           ) : (
             <p>
               We’re doing work on the VA appointments tool on{' '}

--- a/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
+++ b/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
@@ -13,39 +13,52 @@ export default function DowntimeMessage({
   startTime,
   endTime,
   status,
-  description,
   children,
+  description,
 }) {
   const dispatch = useDispatch();
   const isDowntimeWarningDismissed = useSelector(state =>
     state.scheduledDowntime.dismissedDowntimeWarnings.includes(appTitle),
   );
+  const splitDescription = description.split('|');
+  const notificationTitle = splitDescription.length > 1 && splitDescription[0];
+  const descriptionBody = notificationTitle
+    ? splitDescription[1]
+    : splitDescription[0];
   if (status === externalServiceStatus.down) {
     return (
       <FullWidthLayout>
         <InfoAlert
           className="vads-u-margin-bottom--4"
-          headline="The VA appointments tool is down for maintenance"
+          headline={
+            notificationTitle ||
+            'The VA appointments tool is down for maintenance'
+          }
           status="warning"
         >
-          !!description ? (
-          <p>
-            {description} We’re sorry it’s not working right now. If you need to
-            request or confirm an appointment during this time, please call your
-            local VA medical center. Use the{' '}
-            <a href="/find-locations">VA facility locator</a> to find contact
-            information for your medical center.
-          </p>
+          {descriptionBody ? (
+            <>
+              <p>{descriptionBody}</p>
+              <p>
+                {' '}
+                We’re sorry it’s not working right now. If you need to request
+                or confirm an appointment during this time, please call your
+                local VA medical center. Use the{' '}
+                <a href="/find-locations">VA facility locator</a> to find
+                contact information for your medical center.
+              </p>
+            </>
           ) : (
-          <p>
-            We’re making updates to the tool on {startTime.format('MMMM Do')}{' '}
-            between {startTime.format('LT')} and {endTime.format('LT')}. We’re
-            sorry it’s not working right now. If you need to request or confirm
-            an appointment during this time, please call your local VA medical
-            center. Use the <a href="/find-locations">VA facility locator</a> to
-            find contact information for your medical center.
-          </p>
-          )
+            <p>
+              We’re making updates to the tool on {startTime.format('MMMM Do')}{' '}
+              between {startTime.format('LT')} and {endTime.format('LT')}. We’re
+              sorry it’s not working right now. If you need to request or
+              confirm an appointment during this time, please call your local VA
+              medical center. Use the{' '}
+              <a href="/find-locations">VA facility locator</a> to find contact
+              information for your medical center.
+            </p>
+          )}
         </InfoAlert>
       </FullWidthLayout>
     );
@@ -61,27 +74,35 @@ export default function DowntimeMessage({
           visible={!isDowntimeWarningDismissed}
           status="warning"
           role="alertdialog"
-          modalTitle="VA online scheduling will be down for maintenance"
+          modalTitle={
+            notificationTitle ||
+            'VA online scheduling will be down for maintenance'
+          }
           data-testid="downtime-approaching-modal"
         >
-          !!description ? (
-          <p>
-            {description} We’re sorry it’s not working right now. If you need to
-            request or confirm an appointment during this time, please call your
-            local VA medical center. Use the{' '}
-            <a href="/find-locations">VA facility locator</a> to find contact
-            information for your medical center.
-          </p>
+          {' '}
+          {descriptionBody ? (
+            <>
+              <p>{descriptionBody}</p>
+              <p>
+                {' '}
+                We’re sorry it’s not working right now. If you need to request
+                or confirm an appointment during this time, please call your
+                local VA medical center. Use the{' '}
+                <a href="/find-locations">VA facility locator</a> to find
+                contact information for your medical center.
+              </p>
+            </>
           ) : (
-          <p>
-            We’re doing work on the VA appointments tool on{' '}
-            {startTime.format('MMMM Do')} between {startTime.format('LT')} and{' '}
-            {endTime.format('LT')}. If you need to request or confirm an
-            appointment during this time, please call your local VA medical
-            center. Use the <a href="/find-locations">VA facility locator</a> to
-            find contact information for your medical center.
-          </p>
-          )
+            <p>
+              We’re doing work on the VA appointments tool on{' '}
+              {startTime.format('MMMM Do')} between {startTime.format('LT')} and{' '}
+              {endTime.format('LT')}. If you need to request or confirm an
+              appointment during this time, please call your local VA medical
+              center. Use the <a href="/find-locations">VA facility locator</a>{' '}
+              to find contact information for your medical center.
+            </p>
+          )}
           <button
             type="button"
             className="usa-button-secondary"
@@ -96,9 +117,9 @@ export default function DowntimeMessage({
   );
 }
 DowntimeMessage.propTypes = {
-  children: PropTypes.string,
+  children: PropTypes.node,
   description: PropTypes.string,
-  endTime: PropTypes.string,
-  startTime: PropTypes.string,
+  endTime: PropTypes.object,
+  startTime: PropTypes.object,
   status: PropTypes.string,
 };

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -110,6 +110,7 @@ class DowntimeNotification extends React.Component {
           status: this.props.status,
           startTime: this.props.startTime,
           endTime: this.props.endTime,
+          description: this.props.description,
         },
         children,
       );

--- a/src/platform/monitoring/DowntimeNotification/util/helpers.js
+++ b/src/platform/monitoring/DowntimeNotification/util/helpers.js
@@ -7,7 +7,6 @@ import ENVIRONMENTS from 'site/constants/environments';
 
 import externalServiceStatus from '../config/externalServiceStatus';
 import defaultExternalServices from '../config/externalServices';
-
 /**
  * Derives downtime status based on a time range
  * @param {string|Date|Moment} startTime
@@ -70,6 +69,7 @@ export function createServiceMap(maintenanceWindows = []) {
         externalService,
         startTime: startTimeRaw,
         endTime: endTimeRaw,
+        description,
       },
     } = maintenanceWindow;
 
@@ -82,6 +82,7 @@ export function createServiceMap(maintenanceWindows = []) {
       status,
       startTime,
       endTime,
+      description,
     });
   }
 


### PR DESCRIPTION
## Description
We want to add the ability to pass custom messages to the DownTime Notifications component using Pager Duty.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#49303


## Testing done


## Screenshots
when custom title & message is passed in pager duty:
<img width="1001" alt="Screen Shot 2022-11-04 at 10 52 24 AM" src="https://user-images.githubusercontent.com/47654119/200005275-a06be37b-4dc9-402d-8861-317331ac9328.png">


when only custom message is passed in pager duty:
<img width="1001" alt="Screen Shot 2022-11-04 at 10 52 03 AM" src="https://user-images.githubusercontent.com/47654119/200005184-1f812324-1c1a-4470-bb65-a4bfe3ecba0f.png">


when no custom title or message is passed in pager duty:
<img width="1001" alt="Screen Shot 2022-11-04 at 1 25 26 AM" src="https://user-images.githubusercontent.com/47654119/199896666-f540e799-1729-4647-91db-0d950111a87d.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
