### PR TITLE
[mhv-33660] removed "move" button from sent messages

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons.jsx
@@ -86,7 +86,9 @@ const MessageActionButtons = props => {
 
       {isDeleteVisible && deleteMessageModal()}
 
-      <MoveMessageToFolderBtn messageId={id} allFolders={folders} />
+      {activeFolder?.folderId !== Constants.DefaultFolders.SENT.id && (
+        <MoveMessageToFolderBtn messageId={id} allFolders={folders} />
+      )}
 
       <button
         type="button"

--- a/src/applications/mhv/secure-messaging/tests/containers/Folders.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/Folders.unit.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderWithStoreAndRouter } from 'platform/testing/unit/react-testing-library-helpers';
+import { expect } from 'chai';
+import { folderList } from '../fixtures/folder-response.json';
+import reducer from '../../reducers';
+import Folders from '../../containers/Folders';
+
+describe('Folders Landing Page', () => {
+  const initialState = {
+    sm: {
+      folders: { folderList },
+      search: {},
+    },
+  };
+
+  it('renders without errors', () => {
+    const screen = renderWithStoreAndRouter(<Folders />, {
+      initialState,
+      reducers: reducer,
+      path: `/folders`,
+    });
+    expect(screen.findByText('My folders')).to.exist;
+  });
+});


### PR DESCRIPTION
## Description
As a SM user I want to be able to delete a message from the Message Details page (no permanent deletion is allowed with the exception of draft messages) so I can remove it from my current view and move it to my trash folder.

Everything on the front-end appears to be working. However, there appears to be an error with the mhv-apis in the staging environment. This PR only changes the move message button. After this PR, it will not appear on messages in the Sent folder.

## Original issue(s)
https://vajira.max.gov/browse/MHV-33660


## Testing done
Manual testing in both the Dev and Staging environments.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
