### PR TITLE
Updating unit tests to reflect feature flag, and fixed asset calculation

### DIFF
--- a/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
@@ -831,7 +831,7 @@ describe('fsr transform information', () => {
       expect(submissionObj.assets.usSavingsBonds).to.equal('25000.65');
       expect(submissionObj.assets.stocksAndOtherBonds).to.equal('50000.84');
       expect(submissionObj.assets.realEstateOwned).to.equal('800000.81');
-      expect(submissionObj.assets.totalAssets).to.equal('1084005.55');
+      expect(submissionObj.assets.totalAssets).to.equal('1099005.78');
     });
     describe('automobiles', () => {
       it('has valid structure', () => {
@@ -1099,6 +1099,67 @@ describe('fsr transform information', () => {
       expect(submissionObj.applicantCertifications.veteranDateSigned).to.equal(
         moment().format('MM/DD/YYYY'),
       );
+    });
+  });
+  describe('combined FSR', () => {
+    const cfsrInputObject = {
+      data: { ...inputObject.data, 'view:combinedFinancialStatusReport': true },
+    };
+    describe('cFSR - discretionaryIncome', () => {
+      it('has valid structure', () => {
+        const submissionObj = JSON.parse(transform(null, cfsrInputObject));
+        expect(submissionObj).haveOwnProperty('discretionaryIncome');
+        expect(submissionObj.discretionaryIncome).to.be.an('object');
+        expect(submissionObj.discretionaryIncome).haveOwnProperty(
+          'netMonthlyIncomeLessExpenses',
+        );
+        expect(submissionObj.discretionaryIncome).haveOwnProperty(
+          'amountCanBePaidTowardDebt',
+        );
+      });
+      it('has valid data', () => {
+        const submissionObj = JSON.parse(transform(null, cfsrInputObject));
+        expect(
+          submissionObj.discretionaryIncome.netMonthlyIncomeLessExpenses,
+        ).to.equal('12394.41');
+        expect(
+          submissionObj.discretionaryIncome.amountCanBePaidTowardDebt,
+        ).to.equal('61.02');
+      });
+    });
+    describe('cFSR - getTotalAssets helper', () => {
+      it('should return total value of assets', () => {
+        const totalAssets = {
+          assets: {
+            otherAssets: [
+              {
+                amount: '10',
+              },
+              {
+                amount: '10',
+              },
+            ],
+            recVehicleAmount: '100',
+            automobiles: [
+              {
+                resaleValue: '100',
+              },
+              {
+                resaleValue: '100',
+              },
+            ],
+          },
+          realEstateRecords: [
+            {
+              realEstateAmount: '1000',
+            },
+            {
+              realEstateAmount: '1000',
+            },
+          ],
+        };
+        expect(getTotalAssets(totalAssets)).to.equal(2320);
+      });
     });
   });
 });

--- a/src/applications/financial-status-report/tests/unit/unit-maximal.json
+++ b/src/applications/financial-status-report/tests/unit/unit-maximal.json
@@ -34,6 +34,11 @@
             }
           ],
           "recVehicleAmount": "15000.23",
+          "recVehicles": [
+            {
+              "recVehicleAmount": "15000.23"
+            }
+          ],
           "cashInBank": "3000.45",
           "cashOnHand": "10000.67",
           "usSavingsBonds": "25000.65",
@@ -421,7 +426,80 @@
             }
           }
         ],
-        "selectedCopays":[
+        "selectedDebtsAndCopays": [
+          {
+            "fileNumber": "796121200",
+            "payeeNumber": "00",
+            "personEntitled": "AJHONS",
+            "deductionCode": "30",
+            "benefitType": "Comp & Pen",
+            "diaryCode": "080",
+            "diaryCodeDescription": "Referred to the Department of the Treasury",
+            "amountOverpaid": 0,
+            "amountWithheld": 0,
+            "originalAr": 136.24,
+            "currentAr": 100,
+            "debtHistory": [
+              {
+                "date": "02/25/2009",
+                "letterCode": "914",
+                "description": "Paid In Full - Account balance cleared via offset, not including TOP."
+              },
+              {
+                "date": "02/07/2009",
+                "letterCode": "905",
+                "description": "Administrative Write Off"
+              },
+              {
+                "date": "12/03/2008",
+                "letterCode": "487",
+                "description": "Death Case Pending Action"
+              }
+            ],
+            "id": 0,
+            "debtType": "DEBT",
+            "resolutionOption": "waiver",
+            "resolutionWaiverCheck": true
+          },
+          {
+            "fileNumber": "796121200",
+            "payeeNumber": "00",
+            "personEntitled": "AJOHNS",
+            "deductionCode": "74",
+            "benefitType": "CH33 Student Tuition EDU",
+            "diaryCode": "117",
+            "diaryCodeDescription": "Pending payment",
+            "amountOverpaid": 0,
+            "amountWithheld": 475,
+            "originalAr": 2210.9,
+            "currentAr": 1000,
+            "debtHistory": [
+              {
+                "date": "04/01/2017",
+                "letterCode": 608,
+                "description": "Full C&P Benefit Offset Notifi"
+              },
+              {
+                "date": "11/18/2015",
+                "letterCode": 130,
+                "description": "Debt Increase - Due P"
+              },
+              {
+                "date": "04/08/2015",
+                "letterCode": 608,
+                "description": "Full C&P Benefit Offset Notifi"
+              },
+              {
+                "date": "03/26/2015",
+                "letterCode": 100,
+                "description": "First Demand Letter - Inactive Benefits - Due Process"
+              }
+            ],
+            "id": 3,
+            "debtType": "DEBT",
+            "resolutionOption": "monthly",
+            "resolutionComment": "50.51"
+          },
           {
             "id": "f4385298-08a6-42f8-a86f-50e97033fb85",
             "pSSeqNum": 506,
@@ -587,8 +665,12 @@
               "lbXFedexZipCde": null,
               "lbXFedexBarCde": null,
               "lbXFedexContact": null,
-              "lbXFedexContactTelNum": null
-            }
+              "lbXFedexContactTelNum": null,
+              "facilityName": "Bob Stump Department of Veterans Affairs Medical Center"
+            },
+            "debtType": "COPAY",
+            "resolutionOption": "compromise",
+            "resolutionComment": "10.51"
           },
           {
             "id": "b381cc7b-ea3a-49dc-a982-7146416ed373",
@@ -1232,8 +1314,12 @@
               "lbXFedexZipCde": null,
               "lbXFedexBarCde": null,
               "lbXFedexContact": null,
-              "lbXFedexContactTelNum": null
-            }
+              "lbXFedexContactTelNum": null,
+              "facilityName": "Ralph H. Johnson Department of Veterans Affairs Medical Center"
+            },
+            "debtType": "COPAY",
+            "resolutionOption": "waiver",
+            "resolutionWaiverCheck": true
           }
         ],
         "debt": {

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -251,9 +251,15 @@ export const getMonthlyExpenses = ({
   return utilities + installments + otherExp + totalExp;
 };
 
-export const getTotalAssets = ({ assets, realEstateRecords }) => {
+export const getTotalAssets = ({
+  assets,
+  realEstateRecords,
+  'view:combinedFinancialStatusReport': combinedFSR,
+}) => {
   const totOtherAssets = sumValues(assets.otherAssets, 'amount');
-  const totRecVehicles = sumValues(assets.recVehicles, 'recVehicleAmount');
+  const totRecVehicles = !combinedFSR
+    ? sumValues(assets.recVehicles, 'recVehicleAmount')
+    : Number(assets?.recVehicleAmount?.replaceAll(/[^0-9.-]/g, ''));
   const totVehicles = sumValues(assets.automobiles, 'resaleValue');
   const realEstate = sumValues(realEstateRecords, 'realEstateAmount');
   const totAssets = Object.values(assets)

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -254,7 +254,9 @@ export const transform = (formConfig, form) => {
       cashInBank: enhancedFSRActive ? calculatedCashInBank : assets.cashInBank,
       cashOnHand: enhancedFSRActive ? calculatedCashOnHand : assets.cashOnHand,
       automobiles: assets.automobiles,
-      trailersBoatsCampers: assets.recVehicleAmount,
+      trailersBoatsCampers: combinedFSRActive
+        ? sumValues(assets.recVehicles, 'recVehicleAmount')
+        : assets.recVehicleAmount,
       usSavingsBonds: enhancedFSRActive
         ? calculatedUsSavingsBonds
         : assets.usSavingsBonds,


### PR DESCRIPTION
## Description
Updated unit tests to include combined FSR feature flag, and updated `getTotalAssets` helper to accurately calculate 

## Testing done
Tested with and without combined FSR feature flag. 

## Acceptance criteria
- [ ] `getTotalAssets` calculation now reflects recreational vehicles with and without combined feature flag

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
