### PR TITLE
[#MHV-36024] Updated API call to match new API; refresh folders after renaming

### DIFF
--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -53,15 +53,13 @@ export const createFolder = folderName => {
  * @returns
  */
 export const updateFolderName = (folderId, folderName) => {
-  return apiRequest(
-    `${apiBasePath}/messaging/folders/${folderId}/rename/${folderName}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  return apiRequest(`${apiBasePath}/messaging/folders/${folderId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
     },
-  );
+    body: JSON.stringify({ name: folderName }),
+  });
 };
 
 /**

--- a/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
+++ b/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
@@ -6,7 +6,12 @@ import React, { useState, useEffect } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { navigateToFoldersPage } from '../util/helpers';
-import { delFolder, getFolders, renameFolder } from '../actions/folders';
+import {
+  delFolder,
+  getFolders,
+  renameFolder,
+  retrieveFolder,
+} from '../actions/folders';
 
 const ManageFolderButtons = () => {
   const dispatch = useDispatch();
@@ -69,10 +74,15 @@ const ManageFolderButtons = () => {
     if (folderName === '' || folderName.match(/^[\s]+$/)) {
       setNameWarning('Folder name cannot be blank');
     } else if (folderMatch.length > 0) {
-      setNameWarning('Folder name alreeady in use. Please use another name.');
+      setNameWarning('Folder name already in use. Please use another name.');
     } else if (folderName.match(/^[0-9a-zA-Z\s]+$/)) {
       closeRenameModal();
-      dispatch(renameFolder(folderId, folderName));
+      dispatch(renameFolder(folderId, folderName)).then(() => {
+        // Refresh the folder name in the "My folders" page--otherwise the old name flashes on-screen for a second.
+        dispatch(getFolders());
+        // Refresh the folder name on the folder detail page.
+        dispatch(retrieveFolder(folderId));
+      });
     } else {
       setNameWarning(
         'Folder name can only contain letters, numbers, and spaces.',


### PR DESCRIPTION
## Description
Connected the SM frontend to the new "Rename Folder" API in the backend.

## Original issue(s)
https://vajira.max.gov/browse/MHV-36024
SM to VA.gov: Folders - Rename Folder API in Vets.gov
User Story: As the front end, I want to have the ability to rename a folder, so that I can communicate with the MHV rename folder API.

## Testing done
Manual testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
