### PR TITLE
MHV-33548 SM to VA.gov:  Compose - Display contact list in "to" field dropdown

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { capitalize } from 'lodash';
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { useDispatch } from 'react-redux';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FileInput from './FileInput';
@@ -246,14 +246,14 @@ const ComposeForm = props => {
         </section>
         <div className="compose-form-actions vads-u-display--flex">
           <button
-            type="button"
+            type="submit"
             className="vads-u-flex--1"
             data-testid="Send-Button"
           >
             Send
           </button>
           <button
-            type="button"
+            type="submit"
             className="usa-button-secondary vads-u-flex--1"
             data-testid="Save-Draft-Button"
             onClick={() => saveDraftHandler('manual')}

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -244,23 +244,25 @@ const ComposeForm = props => {
             setAttachments={setAttachments}
           />
         </section>
-        <div className="compose-form-actions">
+        <div className="compose-form-actions vads-u-display--flex">
           <button
-            type="submit"
-            className="send-button-bottom"
+            type="button"
+            className="vads-u-flex--1"
             data-testid="Send-Button"
           >
             Send
           </button>
           <button
             type="button"
-            className="usa-button-secondary save-draft-button"
+            className="usa-button-secondary vads-u-flex--1"
             data-testid="Save-Draft-Button"
             onClick={() => saveDraftHandler('manual')}
           >
             Save draft
           </button>
-          {draft && <DiscardDraft draft={draft} />}
+          <div className="vads-u-flex--1 vads-u-display--flex">
+            {draft && <DiscardDraft draft={draft} />}
+          </div>
         </div>
       </div>
       <DraftSavedInfo />

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -11,6 +11,7 @@ import { saveDraft } from '../../actions/draftDetails';
 import DraftSavedInfo from './DraftSavedInfo';
 import useDebounce from '../../hooks/use-debounce';
 import DiscardDraft from '../Draft/DiscardDraft';
+import { sortRecipients } from '../../util/helpers';
 
 const ComposeForm = props => {
   const { draft, recipients } = props;
@@ -167,24 +168,30 @@ const ComposeForm = props => {
         </button>
       </div>
       <div className="compose-inputs-container">
-        <VaSelect
-          id="recipient-dropdown"
-          label="To"
-          name="to"
-          value={selectedRecipient}
-          onVaSelect={e => setSelectedRecipient(e.detail.value)}
-          class="composeSelect"
-          data-testid="compose-select"
-        >
-          {recipientsList.map(item => (
-            <option key={item.id} value={item.id}>
-              {item.name}
-            </option>
-          ))}
-        </VaSelect>
-        <button type="button" className="link-button edit-input-button">
-          Edit List
-        </button>
+        {recipientsList && (
+          <>
+            <VaSelect
+              enable-analytics
+              id="recipient-dropdown"
+              label="To"
+              name="to"
+              value={selectedRecipient}
+              onVaSelect={e => setSelectedRecipient(e.detail.value)}
+              class="composeSelect"
+              data-testid="compose-select"
+            >
+              {sortRecipients(recipientsList)?.map(item => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                </option>
+              ))}
+            </VaSelect>
+            <button type="button" className="link-button edit-input-button">
+              Edit List
+            </button>
+          </>
+        )}
+
         <CategoryInput
           category={category}
           categoryError={categoryError}

--- a/src/applications/mhv/secure-messaging/components/Draft/DiscardDraft.jsx
+++ b/src/applications/mhv/secure-messaging/components/Draft/DiscardDraft.jsx
@@ -27,7 +27,7 @@ const DiscardDraft = props => {
       <button
         type="button"
         data-testid="discard-draft-button"
-        className="usa-button-secondary"
+        className="usa-button-secondary discard-draft-button vads-u-flex--fill vads-u-margin-right--0"
         onClick={() => {
           setIsModalVisible(true);
         }}

--- a/src/applications/mhv/secure-messaging/components/Draft/DiscardDraft.jsx
+++ b/src/applications/mhv/secure-messaging/components/Draft/DiscardDraft.jsx
@@ -25,7 +25,7 @@ const DiscardDraft = props => {
   return (
     <>
       <button
-        type="button"
+        type="submit"
         data-testid="discard-draft-button"
         className="usa-button-secondary discard-draft-button vads-u-flex--fill vads-u-margin-right--0"
         onClick={() => {

--- a/src/applications/mhv/secure-messaging/sass/compose.scss
+++ b/src/applications/mhv/secure-messaging/sass/compose.scss
@@ -95,8 +95,7 @@
       .compose-form-actions {
         display: flex;
         flex-direction: column;
-        .send-button-bottom,
-        .save-draft-button {
+        .send-button-bottom {
           height: 36px;
           margin: 0;
         }

--- a/src/applications/mhv/secure-messaging/util/helpers.js
+++ b/src/applications/mhv/secure-messaging/util/helpers.js
@@ -46,3 +46,16 @@ export const dateFormat = (timestamp, format = null) => {
     .tz(timestamp, timeZone)
     .format(format || 'MMMM d, YYYY, h:mm a z');
 };
+
+export const sortRecipients = recipientsList => {
+  const isAlphabetical = str => /^\w/.test(str);
+  let list = [];
+  if (recipientsList.length > 0) {
+    list = recipientsList.sort(
+      (a, b) =>
+        isAlphabetical(a.name) - isAlphabetical(b.name) ||
+        a.name.localeCompare(b.name),
+    );
+  }
+  return list;
+};


### PR DESCRIPTION
## Description
SM to VA.gov:  Compose - Display contact list in "to" field dropdown

User Story: As a SM user, I want to be able to view a list of possible contacts when I am composing a new message so that I can be sure my message goes to the correct recipient(s).

## Original issue(s)
[MHV-33548 SM to VA.gov:  Compose - Display contact list in "to" field dropdown](https://vajira.max.gov/browse/MHV-33548)


## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/87077843/200360026-487459f6-510c-4527-b5df-5bf0fdf2b9b0.png)


## Acceptance criteria
- AC1 The "To" field on the Compose or new message page has a dropdown component.
- AC2 The dropdown list has contacts (triage groups) displayed.
- AC3 The user is able to select a contact and the contact appears on the "To" line.
- AC4 Sort is alphabetical --upper case vs lowercase should NOT be a factor.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
