### PR TITLE
Supplemental Claim | Update prefill transformer to match data

### DIFF
--- a/src/applications/appeals/995/config/prefill-transformer.js
+++ b/src/applications/appeals/995/config/prefill-transformer.js
@@ -1,12 +1,8 @@
-/* Copied from 0996 (HLR) - vets-api/config/form_profile_mappings/20-0996.yml
-nonPrefill:
-  veteranSsnLastFour:
-  veteranVaFileNumberLastFour:
-*/
+/* See vets-api/config/form_profile_mappings/20-0995.yml */
 
 export default function prefillTransformer(pages, formData, metadata) {
   const { veteranSsnLastFour = '', veteranVaFileNumberLastFour = '' } =
-    formData?.nonPrefill || {};
+    formData || {};
 
   return {
     pages,

--- a/src/applications/appeals/995/tests/config/prefill-transformer.unit.spec.js
+++ b/src/applications/appeals/995/tests/config/prefill-transformer.unit.spec.js
@@ -4,11 +4,8 @@ import prefillTransformer from '../../config/prefill-transformer';
 // This is the nesting of the prefill data; transformation flattens it
 const buildData = ({ ssnLastFour = '', vaFileLastFour = '' }) => ({
   prefill: {
-    data: {},
-    nonPrefill: {
-      veteranSsnLastFour: ssnLastFour,
-      veteranVaFileNumberLastFour: vaFileLastFour,
-    },
+    veteranSsnLastFour: ssnLastFour,
+    veteranVaFileNumberLastFour: vaFileLastFour,
   },
   result: {
     veteran: {
@@ -24,7 +21,6 @@ describe('SC prefill transformer', () => {
     formData: {
       testData: 'This is not getting transformed',
       data: {},
-      nonPrefill: {},
     },
     pages: { testPage: 'Page 1' },
   };
@@ -41,17 +37,18 @@ describe('SC prefill transformer', () => {
     });
   });
 
-  describe('prefill veteran information', () => {
-    it('should transform contact info when present', () => {
-      const { pages, metadata } = noTransformData;
-      const data = buildData({
-        ssnLastFour: '9876',
-        vaFileLastFour: '7654',
-      });
-      const transformedData = prefillTransformer(pages, data.prefill, metadata)
-        .formData;
+  it('should transform ssn & vafn when present', () => {
+    const { pages, metadata } = noTransformData;
+    const data = buildData({
+      ssnLastFour: '9876',
+      vaFileLastFour: '7654',
+    });
+    const transformedData = prefillTransformer(pages, data.prefill, metadata);
 
-      expect(transformedData).to.deep.equal(data.result);
+    expect(transformedData).to.deep.equal({
+      pages,
+      formData: data.result,
+      metadata,
     });
   });
 });


### PR DESCRIPTION
## Description

The prefill data for the last 4 SSN and VA File number was added to vets-api. This PR updates the prefill transformer to match the data.

## Original issue(s)

[#48159](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48159)

## Testing done

Updated unit test

## Screenshots

<img width="465" alt="Supplemental Claim Veteran info page showing the last 4 SSN and last 4 VA File number along with Veteran name, date of birth and gender" src="https://user-images.githubusercontent.com/136959/200363514-c7f687f7-14be-466c-b836-940350257573.png">

## Acceptance criteria
- [x] Veteran's last 4 SSN showing on info page
- [x] Veteran's last 4 VA file number showing on info page
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
