### PR TITLE
Supplemental Claims | Update manifest

### DIFF
--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -5,7 +5,7 @@ import constants from 'vets-json-schema/dist/constants.json';
 export const DECISION_REVIEWS_URL = '/decision-reviews';
 export const SC_INFO_URL = `${DECISION_REVIEWS_URL}/supplemental-claim`;
 // Same as "rootUrl" in manifest.json
-export const BASE_URL = `${SC_INFO_URL}/request-supplemental-claim-form-20-0995`;
+export const BASE_URL = `${SC_INFO_URL}/file-supplemental-claim-form-20-0995`;
 
 export const FORM_URL = 'https://www.vba.va.gov/pubs/forms/VBA-20-0995-ARE.pdf';
 

--- a/src/applications/appeals/995/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/containers/ConfirmationPage.jsx
@@ -36,7 +36,7 @@ export class ConfirmationPage extends React.Component {
         <p className="screen-only">Please print this page for your records.</p>
         <div className="inset">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
-            Request a Supplemental Claim Claim{' '}
+            File a Supplemental Claim Claim{' '}
             <span className="vads-u-font-weight--normal">(Form {formId})</span>
           </h3>
           {fullName ? (

--- a/src/applications/appeals/995/manifest.json
+++ b/src/applications/appeals/995/manifest.json
@@ -2,6 +2,6 @@
   "appName": "File a Supplemental Claim",
   "entryFile": "./app-entry.jsx",
   "entryName": "995-supplemental-claim",
-  "rootUrl": "/decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995",
+  "rootUrl": "/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995",
   "productId": "05712241-0f46-4e84-8d3e-70a6cf412a5e"
 }

--- a/src/applications/appeals/995/tests/routes.unit.spec.js
+++ b/src/applications/appeals/995/tests/routes.unit.spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import routes from '../routes';
+
+describe('Form 996 routes', () => {
+  const { onEnter } = routes[1].indexRoute;
+  it('should redirect from the root to /introduction', () => {
+    const replace = sinon.spy();
+    onEnter(null, replace);
+    expect(replace.calledWith('/introduction')).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description

After updating the `content-build` registry to match [IA recommendations](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48796), the manifest for the form didn't match. This PR updates the manifest URL and title.

## Original issue(s)

[#48796](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48796)

## Testing done

Added route unit test

## Screenshots

N/A

## Acceptance criteria
- [x] Update front-end manifest to match content build registry
- [x] Add router unit test

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
