### PR TITLE
View Payments: Updating content in notice under payments table

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -137,10 +137,10 @@ class ViewPaymentsLists extends Component {
             {paymentsReceivedTable}
             <p>
               <strong>Note:</strong> Some payment details might not be available
-              online. For example, direct-deposit payments less than $1 or check
-              payments less than $5, won’t show in your online payment history.
-              Gross (before deductions) payments and changes will show only for
-              recurring and irregular compensation payments.
+              online. For example, direct-deposit payments of less than $1 or
+              check payments of less than $5, won’t show in your online payment
+              history. Gross (before deductions) payments and changes will show
+              only for recurring and irregular compensation payments.
             </p>
             <p>
               If you have questions about payments made by VA, please call the


### PR DESCRIPTION
## Description
Minor updates to the content in the note under the payments table

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49263


## Testing done
Tests still pass

## Screenshots
<details><summary>Before</summary>

![Screen Shot 2022-11-07 at 12 14 49 PM](https://user-images.githubusercontent.com/13838621/200384535-95b895f7-94a7-4b38-9d2c-417b898a750d.png)
</details>

<details><summary>After</summary>

![Screen Shot 2022-11-07 at 12 12 27 PM](https://user-images.githubusercontent.com/13838621/200384330-ace78459-9873-47b4-86b4-a38b3b2a8544.png)
</details>

## Acceptance criteria
- [x] Content has been updated to reflect recommendations from the content team

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
