### PR TITLE
[#693] - adds ga tracking logic to the start chat button

### DIFF
--- a/src/applications/virtual-agent/components/chatbox/ChatboxDisclaimer.jsx
+++ b/src/applications/virtual-agent/components/chatbox/ChatboxDisclaimer.jsx
@@ -31,6 +31,12 @@ export const ChatboxDisclaimer = () => {
           data-testid="btnAcceptDisclaimer"
           className="usa-button-primary"
           onClick={() => {
+            if (window.recordEvent) {
+              window.recordEvent({
+                action: 'click',
+                event: 'cta-button-click',
+              });
+            }
             clearBotSessionStorage(true);
             dispatch({ type: ACCEPTED });
           }}


### PR DESCRIPTION
## Description

To aid in analytics and reporting, we need to explicitly register an event in GA when the "Start Chat" button is clicked.

## Original issue(s)

department-of-veterans-affairs/va-virtual-agent#693

## Testing done

Local tests, manual. Ensured that new event was firing. Need to get this into the wild to see if google analytics will pick it up.

## Screenshots

n/a
