### PR TITLE
Mhv 38060 no messages alert

### DIFF
--- a/src/applications/mhv/secure-messaging/actions/messages.js
+++ b/src/applications/mhv/secure-messaging/actions/messages.js
@@ -20,21 +20,21 @@ export const getMessages = (folderId, update = false) => async dispatch => {
   if (!update) {
     dispatch({ type: Actions.Message.CLEAR_LIST });
   }
-  const response = await getMessageList(folderId);
-  if (response?.data.length === 0) {
+  try {
+    const response = await getMessageList(folderId);
+    dispatch({
+      type: Actions.Message.GET_LIST,
+      response,
+    });
+  } catch (e) {
     dispatch(
       addAlert(
-        Constants.ALERT_TYPE_INFO,
+        Constants.ALERT_TYPE_ERROR,
         '',
-        Constants.Alerts.Message.NO_MESSAGES,
+        Constants.Alerts.Message.GET_MESSAGE_ERROR,
       ),
     );
   }
-  // TODO Add error handling
-  dispatch({
-    type: Actions.Message.GET_LIST,
-    response,
-  });
 };
 
 export const retrieveMessageHistory = (

--- a/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
+++ b/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 import { clearMessage, getMessages } from '../actions/messages';
-import { DefaultFolders as Folders } from '../util/constants';
+import { DefaultFolders as Folders, Alerts } from '../util/constants';
 import useInterval from '../hooks/use-interval';
 import MessageList from '../components/MessageList/MessageList';
 import FolderHeader from '../components/MessageList/FolderHeader';
@@ -13,7 +13,6 @@ import { closeAlert } from '../actions/alerts';
 const FolderListView = () => {
   const dispatch = useDispatch();
   const [folderId, setFolderId] = useState(null);
-  const [hideOtherAlerts, setHideOtherAlerts] = useState(false);
   const error = null;
   const messages = useSelector(state => state.sm.messages?.messageList);
   const folder = useSelector(state => state.sm.folders.folder);
@@ -63,15 +62,6 @@ const FolderListView = () => {
     [folderId, dispatch],
   );
 
-  useEffect(
-    () => {
-      if (messages?.length === 0) {
-        setHideOtherAlerts(true);
-      }
-    },
-    [messages],
-  );
-
   // clear out alerts if user navigates away from this component
   useEffect(
     () => {
@@ -105,7 +95,9 @@ const FolderListView = () => {
           Displaying 0 of 0 messages
         </div>
         <div className="vads-u-margin-top--3 vads-u-margin-bottom--4">
-          <AlertBackgroundBox noIcon />
+          <va-alert background-only="true" status="info">
+            <p className="vads-u-margin--0">{Alerts.Message.NO_MESSAGES}</p>
+          </va-alert>
         </div>
       </>
     );
@@ -130,7 +122,7 @@ const FolderListView = () => {
   return (
     <div className="vads-l-grid-container vads-u-padding--0">
       <div className="main-content">
-        {hideOtherAlerts ? null : <AlertBackgroundBox closeable />}
+        <AlertBackgroundBox closeable />
         {folder?.folderId === undefined && (
           <va-loading-indicator message="Loading your messages..." setFocus />
         )}

--- a/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
+++ b/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
@@ -95,8 +95,12 @@ const FolderListView = () => {
           Displaying 0 of 0 messages
         </div>
         <div className="vads-u-margin-top--3 vads-u-margin-bottom--4">
-          <va-alert background-only="true" status="info">
-            <p className="vads-u-margin--0">{Alerts.Message.NO_MESSAGES}</p>
+          <va-alert
+            background-only="true"
+            status="info"
+            className="vads-u-margin-bottom--1 va-alert"
+          >
+            <p className="vads-u-margin-y--0">{Alerts.Message.NO_MESSAGES}</p>
           </va-alert>
         </div>
       </>

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -21,6 +21,7 @@ export const DefaultFolders = {
 
 export const Alerts = {
   Message: {
+    GET_MESSAGE_ERROR: 'We’re sorry. Something went wrong on our end.',
     DELETE_MESSAGE_SUCCESS: 'Message was successfully moved to Trash.',
     DELETE_MESSAGE_ERROR:
       'Message could not be deleted. Try again later. If this problem persists, contact the help desk.',


### PR DESCRIPTION
## Description
Separated the no messages alert from the other alerts so that they can both be visible.

## Original issue(s)
https://vajira.max.gov/browse/MHV-38060


## Testing done
Testing done of several alerts and folder states.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
