### PR TITLE
Mhv 38182 get default folder bug

### DIFF
--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -95,11 +95,14 @@ export const getMessageCategoryList = () => {
  * @returns
  */
 export const getMessageList = folderId => {
-  return apiRequest(`${apiBasePath}/messaging/folders/${folderId}/messages`, {
-    headers: {
-      'Content-Type': 'application/json',
+  return apiRequest(
+    `${apiBasePath}/messaging/folders/${folderId}/messages?useCache=false`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
     },
-  });
+  );
 };
 
 /**

--- a/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
+++ b/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
@@ -75,10 +75,10 @@ const FolderListView = () => {
   );
 
   useInterval(() => {
-    if (folder) {
-      dispatch(getMessages(folder.folderId, true));
+    if (folderId) {
+      dispatch(getMessages(folderId, true));
     }
-  }, 5000);
+  }, 60000);
 
   let content;
   if (messages === undefined) {


### PR DESCRIPTION
## Description
The getMessages call can run before the path of a default folder is set, producing a "something went wrong" error message.

## Original issue(s)
https://vajira.max.gov/browse/MHV-38182


## Testing done
Manual testing by calling all of the default folders several times each.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
