### PR TITLE
Update validate message for email address

### DIFF
--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -56,6 +56,16 @@ const initialSchema = {
   },
 };
 
+function validateLength(errors, email) {
+  const MAX_LENGTH = 50;
+
+  if (email && email?.length > MAX_LENGTH) {
+    errors.addError(
+      `We do not support email addresses that exceeds ${MAX_LENGTH} characters`,
+    );
+  }
+}
+
 function recordPopulatedEvents(email, phone) {
   recordEvent({
     event: `${GA_PREFIX}-contact-info-email-${
@@ -140,7 +150,9 @@ export default function ContactInfoPage() {
     bestTimeToCall: {
       'ui:title': 'What are the best times for us to call you?',
       'ui:validations':
-        !featureAcheronService && flowType === FLOW_TYPES.REQUEST
+        (!featureAcheronService && flowType === FLOW_TYPES.REQUEST) ||
+        (featureAcheronService &&
+          userData.facilityType === FACILITY_TYPES.COMMUNITY_CARE)
           ? [validateBooleanGroup]
           : [],
       'ui:options': {
@@ -165,7 +177,13 @@ export default function ContactInfoPage() {
         'ui:options': { widgetClassNames: 'vaos-form__checkbox' },
       },
     },
-    email: { 'ui:title': 'Your email address' },
+    email: {
+      'ui:title': 'Your email address',
+      'ui:errorMessages': {
+        required: 'Please enter an email address',
+      },
+      'ui:validations': featureAcheronService ? [validateLength] : [],
+    },
   };
 
   const { data, schema, setData } = useFormState({


### PR DESCRIPTION
## Description
Update the alerts for the email field on the Contact Information page in VAOS for direct scheduling, VA and Community Care request flow behind the `va_online_scheduling_acheron_service` toggle flag

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48685


## Testing done
unit test

## Screenshots
<img width="542" alt="Screen Shot 2022-11-08 at 7 18 48 AM" src="https://user-images.githubusercontent.com/54327023/200607675-68d2cb11-20b6-425c-9fcb-b6b44aa6dc1f.png">

<img width="548" alt="Screen Shot 2022-11-08 at 7 19 02 AM" src="https://user-images.githubusercontent.com/54327023/200607747-05d257df-cf95-4175-b01d-e4d142b34405.png">

<img width="541" alt="Screen Shot 2022-11-08 at 7 19 41 AM" src="https://user-images.githubusercontent.com/54327023/200607773-be5b0539-222d-42c9-b5a4-ad18be0d18d5.png">


## Acceptance criteria
- [ ] Given the user is on the Confirm your contact information page
When the user enters an invalid email address
Then an error message will display `Please enter a valid email address`
- [ ] Given the user is on the Confirm your contact information page
When the user leaves the email field empty
Then an error message will display `Please enter an email address`
- [ ] Given the user is on the Confirm your contact information page
When the user enters more than 50 characters in the email field
Then an error message will display `We don't support email addresses that exceed 50 characters`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
