### PR TITLE
Supplemental Claims | Update evidence upload endpoint

### DIFF
--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -29,10 +29,10 @@ export const BENEFIT_OFFICES_URL = `${SC_INFO_URL}#find-addresses-for-other-bene
 export const CONTESTABLE_ISSUES_API =
   '/supplemental_claims/contestable_issues/';
 
-// Evidence upload API
+// Evidence upload API - same endpoint as NOD
 export const EVIDENCE_UPLOAD_API = `${
   environment.API_URL
-}/v1/decision_review_evidence?sub_type=SC`;
+}/v0/decision_review_evidence`;
 
 // key for contestedIssues to indicate that the user selected the issue
 export const SELECTED = 'view:selected';

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -1,3 +1,5 @@
+import environment from 'platform/utilities/environment';
+
 import constants from 'vets-json-schema/dist/constants.json';
 // import schema from './config/form-0995-schema.json';
 
@@ -26,6 +28,11 @@ export const BENEFIT_OFFICES_URL = `${SC_INFO_URL}#find-addresses-for-other-bene
 // not shown are the `v0` prefix and `{benefit_type}` suffix
 export const CONTESTABLE_ISSUES_API =
   '/supplemental_claims/contestable_issues/';
+
+// Evidence upload API
+export const EVIDENCE_UPLOAD_API = `${
+  environment.API_URL
+}/v1/decision_review_evidence?sub_type=SC`;
 
 // key for contestedIssues to indicate that the user selected the issue
 export const SELECTED = 'view:selected';

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -1,11 +1,14 @@
-import environment from 'platform/utilities/environment';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import { focusElement } from 'platform/utilities/ui';
 import _ from 'platform/utilities/data';
 
 import fullSchema from '../config/form-0995-schema.json';
 
-import { MAX_FILE_SIZE_BYTES, SUPPORTED_UPLOAD_TYPES } from '../constants';
+import {
+  EVIDENCE_UPLOAD_API,
+  SUPPORTED_UPLOAD_TYPES,
+  MAX_FILE_SIZE_BYTES,
+} from '../constants';
 
 export const ancillaryFormUploadUi = content => {
   // a11y focus management. Move focus to select after upload
@@ -22,11 +25,9 @@ export const ancillaryFormUploadUi = content => {
   return fileUploadUI(content.label, {
     itemDescription: content.description,
     hideLabelText: !content.label,
-    fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
+    fileUploadUrl: EVIDENCE_UPLOAD_API,
     addAnotherLabel,
     fileTypes: SUPPORTED_UPLOAD_TYPES,
-    // not sure what to do here... we need to differentiate pdf vs everything
-    // else; the check is in the actions.js > uploadFile function
     maxSize: MAX_FILE_SIZE_BYTES,
     minSize: 1,
     createPayload: (file, _formId, password) => {


### PR DESCRIPTION
## Description

While building out the framework for Supplemental Claims (SC), the backend was not yet built out, so the Notice of Disagreement (NOD) endpoint (`v0/upload_supporting_evidence`) was reused for testing purposes.

~Since the NOD endpoint is not specific enough, a new upload endpoint will be added to support both NOD & SC - `v1/decision_review_evidence?sub_type=[NOD|SC]` (not yet implemented)~

Update: We're keeping the `v0/decision_review_evidence` endpoint in place

Update 2: We may still need a new endpoint, since we're talking about including some needed PDF checks of page size restrictions and prevent blank page submissions.

## Original issue(s)

[#49231](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49231)

## Testing done

Pending backend completion & updating frontend evidence flow

## Screenshots

N/A

## Acceptance criteria
- [x] Switch to use the new combined SC/NOD evidence upload endpoint

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
