### PR TITLE
Supplemental Claims | Update 5103 acknowledgement page

### DIFF
--- a/src/applications/appeals/995/content/noticeOfAcknowledgement.jsx
+++ b/src/applications/appeals/995/content/noticeOfAcknowledgement.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export const acknowledge5103Description = (
+  <>
+    <h3>Review and acknowledge this notice of evidence needed.</h3>
+    <p>
+      You’ll need to submit new evidence we haven’t reviewed before that’s
+      related to the issue you’re claiming.
+    </p>
+    <p>
+      <strong>
+        We’ll look for evidence that shows both of these are true:
+      </strong>
+    </p>
+    <ul>
+      <li>
+        You have a current physical or mental disability (damage to your body or
+        mind that makes you less able—or totally unable—to do everyday tasks,
+        including meaningful work), <strong>and</strong>
+      </li>
+      <li>
+        An event, injury, or illness that happened while you were serving in the
+        military caused this disability
+      </li>
+    </ul>
+    <p>
+      You’ll need to submit or give us permission to gather medical evidence
+      from a VA medical center, other federal facility, or your private health
+      care provider.
+    </p>
+  </>
+);
+
+export const acknowledge5103Error =
+  'You need to certify that you have reviewed the notice of evidence needed.';
+
+export const acknowledge5103Label = (
+  <>
+    <strong>I certify that</strong> I have reviewed the notice of evidence
+    needed
+  </>
+);

--- a/src/applications/appeals/995/pages/noticeOfAcknowledgement.js
+++ b/src/applications/appeals/995/pages/noticeOfAcknowledgement.js
@@ -1,35 +1,21 @@
-import React from 'react';
+import {
+  acknowledge5103Description,
+  acknowledge5103Label,
+  acknowledge5103Error,
+} from '../content/noticeOfAcknowledgement';
 
 export default {
   uiSchema: {
-    'ui:description': (
-      <div>
-        <p>
-          The 5103 Notice regarding new & relevant evidence must be acknowledged
-          when the issue(s) being contested is a Disability Compensation issue.
-        </p>
-        <p>
-          The notice can be found{' '}
-          <a
-            href="http://www.va.gov/disability/how-to-file-claim/evidence-needed"
-            rel="noreferrer"
-            target="_blank"
-          >
-            here
-          </a>
-          .
-        </p>
-      </div>
-    ),
+    'ui:description': acknowledge5103Description,
     'ui:options': {
       forceDivWrapper: true,
     },
     form5103Acknowledged: {
       'ui:widget': 'checkbox',
-      'ui:title': <strong>Yes, I acknowledge</strong>,
+      'ui:title': acknowledge5103Label,
       'ui:required': () => true,
       'ui:errorMessages': {
-        enum: 'Please acknowledge',
+        enum: acknowledge5103Error,
       },
       'ui:options': {
         forceDivWrapper: true,
@@ -43,9 +29,6 @@ export default {
       form5103Acknowledged: {
         type: 'boolean',
         enum: [true],
-        enumNames: Object.values({
-          true: 'Yes, I acknowledge',
-        }),
       },
     },
   },

--- a/src/applications/appeals/995/tests/pages/noticeOfAcknowledgement.unit.spec.js
+++ b/src/applications/appeals/995/tests/pages/noticeOfAcknowledgement.unit.spec.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import sinon from 'sinon';
 
-import {
-  DefinitionTester,
-  selectCheckbox,
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
+
+const mouseClick = new MouseEvent('click', {
+  bubbles: true,
+  cancelable: true,
+});
 
 describe('Supplemental Claims notice-of-acknowledgement page', () => {
   const {
@@ -17,7 +20,7 @@ describe('Supplemental Claims notice-of-acknowledgement page', () => {
   } = formConfig.chapters.acknowledgement.pages.notice5103;
 
   it('should render', () => {
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         schema={schema}
@@ -27,13 +30,12 @@ describe('Supplemental Claims notice-of-acknowledgement page', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(1);
-    form.unmount();
+    expect($('input', container)).to.exist;
   });
 
-  it('should allow submit', () => {
+  it('should prevent continuing with checkbox unchecked', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         schema={schema}
@@ -43,10 +45,26 @@ describe('Supplemental Claims notice-of-acknowledgement page', () => {
         onSubmit={onSubmit}
       />,
     );
+    fireEvent.submit($('form', container));
+    expect($('.usa-input-error', container)).to.exist;
+    expect(onSubmit.called).to.be.false;
+  });
 
-    selectCheckbox(form, 'root_form5103Acknowledged', true);
-    form.find('form').simulate('submit');
+  it('should allow submit with checkbox checked', () => {
+    const onSubmit = sinon.spy();
+    const { container } = render(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.click($('input[type="checkbox"]', container), mouseClick);
+    fireEvent.submit($('form', container));
+    expect($('.usa-input-error', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
-    form.unmount();
   });
 });


### PR DESCRIPTION
## Description

Updating the content of the notice of acknowledgement (5103) page. Since this checkbox is required, the unit test also needed to be updated.

- [DESIGN](https://www.sketch.com/s/d2416db4-9a4f-4919-abe4-20ba4bdcfd89/p/9872C53A-62DB-47BB-87D4-3480519D4B45/canvas)
- [CONTENT](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/decision-reviews/Supplemental-Claims/design/sourceofcontenttruth.md)
- [Prototype](https://www.figma.com/proto/JveclTFbNNSmx4eiYwbZdZ/Supplemental-Claims?node-id=70%3A5676&scaling=scale-down&page-id=10%3A1697&starting-point-node-id=70%3A5676)

## Original issue(s)

[#48399](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48399)

## Testing done

- Updated page unit tests
- Checked e2e tests working as expected
- Performed manual axe-check

## Screenshots

<img width="749" alt="Notice of acknowledgement page with a certification checkbox at the bottom of the long paragraph" src="https://user-images.githubusercontent.com/136959/200884349-e180de38-d944-4b83-b38f-f70c4f8e7d4e.png">

<details><summary>Page showing error message</summary>

<!-- leave a blank line above -->
<img width="755" alt="Notice of acknowledgement page showing an error above the unchecked checkbox stating that you need to certify that you have reviewed the notice of evidence needed" src="https://user-images.githubusercontent.com/136959/200884345-40cc8f14-4587-4c06-b52f-7b1aee6f6d7e.png">
</details>

## Acceptance criteria
- [x] Content updated
- [x] Checkbox is required & shows an error if left unchecked
- [x] Updated unit tests
- [x] Updated e2e tests
- [x] Accessibility checks in place and done

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
