### PR TITLE
[VA-11514] Fix FacilityDataLink props destructuring

### DIFF
--- a/src/applications/static-pages/facilities/FacilityDataLink.jsx
+++ b/src/applications/static-pages/facilities/FacilityDataLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function FacilityDataLink(facilityId, text) {
+export default function FacilityDataLink({ facilityId, text }) {
   return (
     <a
       href={`https://www.accesstocare.va.gov/FacilityPerformanceData/FacilityData?stationNumber=${facilityId}`}


### PR DESCRIPTION
## Description

Appointment wait times aren't loading properly. This is due to one of the components being loaded within it not loading properties correctly, breaking the larger component.

## Original issue(s)

Closes department-of-veterans-affairs/va.gov-cms#11514

## Testing done

Visual

## Acceptance criteria
- [ ]  `FacilityAppointmentWaitTimesWidget` and `FacilityPatientSatisfactionScoresWidget` loads right.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
