### PR TITLE
[DLD] Use descriptionType for letter subtext

### DIFF
--- a/src/applications/claims-status/components/ClaimLetterList.jsx
+++ b/src/applications/claims-status/components/ClaimLetterList.jsx
@@ -9,9 +9,12 @@ const renderLetters = letters =>
   ));
 
 const ClaimLetterList = ({ letters }) => (
-  <ol className="usa-unstyled-list vads-u-margin--0">
-    {renderLetters(letters)}
-  </ol>
+  <>
+    {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+    <ol className="usa-unstyled-list vads-u-margin--0" role="list">
+      {renderLetters(letters)}
+    </ol>
+  </>
 );
 
 ClaimLetterList.propTypes = {

--- a/src/applications/claims-status/components/ClaimLetterList.jsx
+++ b/src/applications/claims-status/components/ClaimLetterList.jsx
@@ -3,11 +3,16 @@ import PropTypes from 'prop-types';
 
 import ClaimLetterListItem from './ClaimLetterListItem';
 
-const ClaimLetterList = ({ letters }) => {
-  return letters.map(letter => (
+const renderLetters = letters =>
+  letters.map(letter => (
     <ClaimLetterListItem key={letter.documentId} letter={letter} />
   ));
-};
+
+const ClaimLetterList = ({ letters }) => (
+  <ol className="vads-u-margin--0 vads-u-padding--0">
+    {renderLetters(letters)}
+  </ol>
+);
 
 ClaimLetterList.propTypes = {
   letters: PropTypes.array,

--- a/src/applications/claims-status/components/ClaimLetterList.jsx
+++ b/src/applications/claims-status/components/ClaimLetterList.jsx
@@ -9,7 +9,7 @@ const renderLetters = letters =>
   ));
 
 const ClaimLetterList = ({ letters }) => (
-  <ol className="vads-u-margin--0 vads-u-padding--0">
+  <ol className="usa-unstyled-list vads-u-margin--0">
     {renderLetters(letters)}
   </ol>
 );

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -14,10 +14,7 @@ const ClaimLetterListItem = ({ letter }) => {
   const heading = `Letter dated ${formatDate(letter.receivedAt)}`;
 
   return (
-    <li
-      className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2"
-      role="list"
-    >
+    <li className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">
       <h2 className="vads-u-font-size--h4">{heading}</h2>
       <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
         {letter.typeDescription}

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -4,41 +4,20 @@ import PropTypes from 'prop-types';
 
 import environment from 'platform/utilities/environment';
 
-const docTypeToDescription = {
-  '184': 'Notification Letter',
-  '339': 'Rating Decision Letter',
-};
-
-const subjectToDescription = {
-  'Intent to File': 'Notice of receipt of Intent to File',
-};
-
 const downloadUrl = id => `${environment.API_URL}/v0/claim_letters/${id}`;
 
 const formatDate = date => {
   return format(new Date(date), 'MMMM dd, yyyy');
 };
 
-const documentDescription = ({ docType, subject }) => {
-  if (subject) {
-    return subjectToDescription[subject];
-  }
-
-  if (docType) {
-    return docTypeToDescription[docType];
-  }
-
-  return 'Notification Letter';
-};
-
 const ClaimLetterListItem = ({ letter }) => {
   const heading = `Letter dated ${formatDate(letter.receivedAt)}`;
 
   return (
-    <div className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">
-      <h4>{heading}</h4>
+    <li className="vads-u-display--block vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">
+      <h2 className="vads-u-font-size--h4">{heading}</h2>
       <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
-        {documentDescription(letter)}
+        {letter.typeDescription}
       </div>
       <va-link
         download
@@ -46,7 +25,7 @@ const ClaimLetterListItem = ({ letter }) => {
         href={downloadUrl(letter.documentId)}
         text="Download letter"
       />
-    </div>
+    </li>
   );
 };
 

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -14,7 +14,10 @@ const ClaimLetterListItem = ({ letter }) => {
   const heading = `Letter dated ${formatDate(letter.receivedAt)}`;
 
   return (
-    <li className="vads-u-display--block vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">
+    <li
+      className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2"
+      role="list"
+    >
       <h2 className="vads-u-font-size--h4">{heading}</h2>
       <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
         {letter.typeDescription}


### PR DESCRIPTION
## Description
* Using the `descriptionType` attribute to display letter subtext
* Also implemented a few accessibility fixes, namely:
    * Use `ol` and `li` tags for ordered list
    * Headings should be `h2`'s styled as `h4`'s, instead of `h4`'s

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49359


## Screenshots
<details><summary>Before</summary>

![Screen Shot 2022-11-09 at 12 55 17 PM](https://user-images.githubusercontent.com/13838621/200916977-cae5b8a8-b593-454b-90e9-68783dcefc14.png)
</details>

<details><summary>After</summary>

![Screen Shot 2022-11-09 at 12 53 58 PM](https://user-images.githubusercontent.com/13838621/200917075-c4c36cd7-a769-4080-b663-e3986ef8e9c7.png)
</details>

## Acceptance criteria
- [x] Letter subtext uses `descriptionType` instead of `subject`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
