### PR TITLE
Cypress fillDate update

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
@@ -8,10 +8,6 @@ import {
   WIZARD_STATUS,
 } from '../constants';
 
-// Date selects don't include leading zeros
-const mock120 = moment()
-  .add(120, 'days')
-  .format('YYYY-M-D');
 // Date saved to sessionStorage includes leading zeros
 const mockDate = moment()
   .add(120, 'days')
@@ -106,7 +102,7 @@ describe('526 wizard', () => {
     });
 
     cy.get('va-date').should('exist');
-    cy.fillDate('discharge-date', mock120);
+    cy.fillDate('discharge-date', mockDate);
 
     cy.checkStorage(FORM_STATUS_BDD, 'true');
     cy.checkStorage(SAVED_SEPARATION_DATE, mockDate);

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -38,7 +38,10 @@ Cypress.Commands.add('selectRadio', (fieldName, value) => {
   }
 });
 Cypress.Commands.add('fillDate', (fieldName, dateString) => {
-  const date = dateString.split('-');
+  // Split the date & remove leading zeros
+  const date = dateString
+    .split('-')
+    .map(number => parseInt(number, 10).toString());
   cy.document().then(doc => {
     const vaDate = doc.querySelector(`va-date[name="${fieldName}"]`);
     const monthYearOnly = doc.querySelector(
@@ -66,12 +69,9 @@ Cypress.Commands.add('fillDate', (fieldName, dateString) => {
             .type(date[0]);
         });
     } else {
-      cy.get(`#${fieldName}Month`).select(parseInt(date[1], 10).toString());
-      cy.get(`#${fieldName}Day`).select(parseInt(date[2], 10).toString());
-      cy.fill(
-        `input[name="${fieldName}Year"]`,
-        parseInt(date[0], 10).toString(),
-      );
+      cy.get(`#${fieldName}Month`).select(date[1]);
+      cy.get(`#${fieldName}Day`).select(date[2]);
+      cy.fill(`input[name="${fieldName}Year"]`, date[0]);
     }
   });
 });


### PR DESCRIPTION
## Description

The Cypress `cy.fillDate` command is passed a date string (YYYY-MM-DD) which includes leading zeros. The month and day select do not include leading zeros in both the React date component and the `va-date` web component, so the value needs to parsed to strip it out. This PR updates the Cypress command to automatically strip out the leading zeros, and remove form 526's need to format the date without leading zeros (YYYY-M-D)

Once updated, we can update the [Supplemental claims e2e test](https://github.com/department-of-veterans-affairs/vets-website/pull/22643/files#diff-6d5e66cb4b84321462aaeb3d27099df01a3caca749df7aea16c818590de7912eR75-R78) to not strip out the leading zeros.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/48163

## Testing done

Tested 526's wizard test

## Screenshots

<img width="329" alt="va-date web component html showing the options with values that do not include leading zeros" src="https://user-images.githubusercontent.com/136959/201137915-75c8d60c-42da-4900-82d9-5618d395f125.png">

## Acceptance criteria
- [x] Strip out leading zeros before filling in the React date & `va-date` web component
- [x] Cypress command is working

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
