### PR TITLE
Update security not in mpi alert content

### DIFF
--- a/src/applications/personalization/common/e2eHelpers.js
+++ b/src/applications/personalization/common/e2eHelpers.js
@@ -1,0 +1,26 @@
+export const checkForLegacyLoadingIndicator = (loadingMessage = '') => {
+  cy.findByRole('progressbar').should('exist');
+
+  if (loadingMessage) {
+    cy.findByText(loadingMessage, { exact: false }).should('exist');
+  }
+
+  cy.findByRole('progressbar').should('not.exist', { timeout: 3000 });
+
+  if (loadingMessage) {
+    cy.findByText(loadingMessage, { exact: false }).should('not.exist');
+  }
+};
+
+export const checkForWebComponentLoadingIndicator = (loadingMessage = '') => {
+  cy.find('va-loading-indicator').should('exist');
+
+  if (loadingMessage) {
+    cy.find('va-loading-indicator')
+      .shadow()
+      .findByText(loadingMessage, { exact: false })
+      .should('exist');
+  }
+
+  cy.find('va-loading-indicator', { timeout: 3000 }).should('not.exist');
+};

--- a/src/applications/personalization/components/NotInMPIError.jsx
+++ b/src/applications/personalization/components/NotInMPIError.jsx
@@ -1,38 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
 
-const NotInMPIError = ({ className, level }) => {
-  const content = (
-    <>
-      <p>
-        We’re sorry. We’re having trouble matching your information to our
-        records. So we can’t give you access to VA.gov tools right now. Please
-        contact the VA help desk at <Telephone contact={CONTACTS.VA_311} />{' '}
-        (TTY: <Telephone contact={CONTACTS['711']} />) to verify and update your
-        records.
-      </p>
-    </>
-  );
-
+const NotInMPIError = ({ className }) => {
   return (
     <div className={className}>
-      <AlertBox
-        headline="We’re having trouble verifying your identity"
-        content={content}
-        status="warning"
-        level={level}
-      />
+      <va-alert status="warning">
+        <h2 slot="headline">
+          We can’t match your information with our Veteran records
+        </h2>
+        <p>
+          You may not be able to use some tools and features right now. But
+          we’re working to connect with your records. Try again soon.
+        </p>
+      </va-alert>
     </div>
   );
 };
 
 NotInMPIError.propTypes = {
   className: PropTypes.string,
-  level: PropTypes.number.isRequired,
 };
 
 export default NotInMPIError;

--- a/src/applications/personalization/components/NotInMPIError.unit.spec.jsx
+++ b/src/applications/personalization/components/NotInMPIError.unit.spec.jsx
@@ -1,26 +1,26 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
 
 import NotInMPI from './NotInMPIError';
 
 describe('NotInMPI', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = mount(<NotInMPI />);
+    wrapper = render(<NotInMPI />);
   });
 
   it('should render the correct text', () => {
     expect(
-      wrapper.text().includes('We’re having trouble verifying your identity'),
-    ).to.be.true;
+      wrapper.findByText(
+        'We can’t match your information with our Veteran records',
+      ),
+    ).to.exist;
     expect(
-      wrapper
-        .text()
-        .includes(
-          'We’re sorry. We’re having trouble matching your information to our records. So we can’t give you access to VA.gov tools right now. Please contact the VA help desk',
-        ),
-    ).to.be.true;
+      wrapper.findByText(
+        'You may not be able to use some tools and features right now. But we’re working to connect with your records. Try again soon.',
+      ),
+    ).to.exist;
     wrapper.unmount();
   });
 });

--- a/src/applications/personalization/dashboard/tests/e2e/not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/not-in-mpi-error.cypress.spec.js
@@ -1,3 +1,4 @@
+import { checkForLegacyLoadingIndicator } from 'applications/personalization/common/e2eHelpers';
 import { mockLocalStorage } from './dashboard-e2e-helpers';
 import mockNotInMPIUser from '~/applications/personalization/profile/tests/fixtures/users/user-not-in-mpi.json';
 import { mockGETEndpoints } from '~/applications/personalization/profile/tests/e2e/helpers';
@@ -27,12 +28,12 @@ describe('MyVA Dashboard', () => {
     it('should show a "not in MPI" error in place of the claims/appeals and health care sections', () => {
       cy.visit('my-va/');
 
+      checkForLegacyLoadingIndicator('loading your information');
+
       cy.findByRole('heading', {
-        name: /We’re having trouble verifying your identity/i,
+        name: /We can’t match your information with our Veteran records/i,
       }).should('exist');
-      cy.findByText(/we can’t give you access to VA.gov tools/i).should(
-        'exist',
-      );
+      cy.findByText(/Try again soon/i).should('exist');
       cy.findByTestId('dashboard-section-health-care').should('not.exist');
       cy.findByTestId('dashboard-section-claims-and-appeals').should(
         'not.exist',

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
@@ -95,10 +95,7 @@ export const AccountSecurityContent = ({
         />
       )}
       {showNotInMPIError && (
-        <NotInMPIError
-          level={2}
-          className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
-        />
+        <NotInMPIError className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" />
       )}
       <ProfileInfoTable data={securitySections} fieldName="accountSecurity" />
       <AlertBox

--- a/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -1,3 +1,4 @@
+import { checkForLegacyLoadingIndicator } from 'applications/personalization/common/e2eHelpers';
 import { PROFILE_PATHS } from '../../constants';
 
 import mockUserNotInMPI from '../fixtures/users/user-not-in-mpi.json';
@@ -18,13 +19,7 @@ function test(mobile = false) {
     cy.viewport('iphone-4');
   }
 
-  // should show a loading indicator
-  cy.findByRole('progressbar').should('exist');
-  cy.findByText(/loading your information/i).should('exist');
-
-  // and then the loading indicator should be removed
-  cy.findByRole('progressbar').should('not.exist');
-  cy.findByText(/loading your information/i).should('not.exist');
+  checkForLegacyLoadingIndicator('loading your information');
 
   // should redirect to profile/account-security on load
   cy.url().should(
@@ -37,9 +32,9 @@ function test(mobile = false) {
     .should('exist')
     .closest('va-alert')
     .should('exist');
-  cy.findByText(/we can’t give you access to VA.gov tools/i)
+  cy.findByText(/Try again soon/i)
     .should('exist')
-    .closest('.usa-alert-warning')
+    .closest('va-alert')
     .should('exist');
 
   subNavOnlyContainsAccountSecurity(mobile);

--- a/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -33,9 +33,9 @@ function test(mobile = false) {
   );
 
   // Should show a "not in MPI" error
-  cy.findByText(/We’re having trouble verifying your identity/i)
+  cy.findByText(/We can’t match your information with our Veteran records/i)
     .should('exist')
-    .closest('.usa-alert-warning')
+    .closest('va-alert')
     .should('exist');
   cy.findByText(/we can’t give you access to VA.gov tools/i)
     .should('exist')


### PR DESCRIPTION
## Description
The alert for if a user is not in MPI has changed in regards to its content.

Tests were needing some work, and I built some helper functions for E2E testing the loading indicators, which is a repeated task, so hopefully those can be useful.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/48501

## Testing done
Updated Unit tests and E2E that rely on this component/content.

## Screenshots
![Screen Shot 2022-11-10 at 10 47 02 AM](https://user-images.githubusercontent.com/8332986/201173898-d2770161-953b-4f8c-9d50-0e330bab3f91.png)


## Acceptance criteria
- [x] Content for alert updated

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
