### PR TITLE
11324 Updates to GA Event Labels

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -94,16 +94,18 @@ export class Main extends Component {
 
   linkClicked = link => {
     const linkName = link.text || link.title;
+    const { currentSection } = this.props;
     recordEvent({
       event: 'nav-header-link',
-      'nav-header-action': `Navigation - Header - Open Link - ${linkName}`,
+      'nav-header-action': `Header - ${currentSection} - ${linkName}`,
     });
   };
 
   columnThreeLinkClicked = link => {
+    const { currentSection } = this.props;
     recordEvent({
       event: 'nav-hub-containers',
-      'nav-hub-action': link.text,
+      'nav-hub-action': `Header - ${currentSection} - ${link.text}`,
     });
   };
 

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -1,3 +1,5 @@
+/* eslint jsx-a11y/click-events-have-key-events:  1 */
+/* eslint jsx-a11y/no-static-element-interactions:  1 */
 // Node modules.
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -107,7 +109,17 @@ class SearchHelpSignIn extends Component {
         )}
 
         {/* Sign in | First name (if logged in) */}
-        <div className="sign-in-nav">{this.renderSignInContent()}</div>
+        <div
+          className="sign-in-nav"
+          onClick={() =>
+            recordEvent({
+              event: 'nav-header-sign-in',
+              'header-sign-in-action': 'Header - Sign in',
+            })
+          }
+        >
+          {this.renderSignInContent()}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Description
Adds new, unique action labels to homepage CTAs, OPIA Promos and Promo Banner

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11324

Has sibling PR in content-build: https://github.com/department-of-veterans-affairs/content-build/pull/1357

## Testing done
Manually testing via Chrome Analytics Debugger extension


## Acceptance criteria
- [x] Mega menu events identify the benefit program from which it was clicked
   - [x] Header - Disability - Check your claim or appeal status
   - [x] Header - Life insurance - Check your appeal status
   - [x] Header - Housing - Check your appeal status
   - [x] Header - Disability - View your payment history
   - [x] Header - Education - View your payment history
   - [x] Header - Records - View your payment history
   - [x] Header - Records - Request your military records
   - [x] Header - Burials and memorials - Request your military records
Events on boxes at far right of mega menu are tracked and identified distinctly from other mega menu events
   - [x] Header - Education - GI Bill comparison tool
   - [x] Header - Records - Confirm your VA benefit status
- [x] CTAs below benefit hub are tracked and identifiable as interactions occurring on the CTAs, rather than elsewhere on the page
   - [x] Homepage CTA - Find a location
   - [x] Homepage CTA - Crisis Line
   - [x] Homepage CTA - Sign In
- [x] Sign in events on the header are uniquely identified as occurring in the header
   - [x] Header - Sign in
- [x] Events on OPIA promo spots are tracked and identifiable as interactions occurring on the promo spots, rather than elsewhere on the page
   - [x] Homepage - [title] promo - for any OPIA promo above the footer on current homepage
- [x] Events on PACT Act banner alert are tracked and identified as initiated on alert banner, rather than from a promo block or elsewhere
  - [x] Footer alert - [title]

## QA Notes
To help make QA easier, I recommen filtering by the following action names to confirm action/event is being logged to Google Anayltics via [this extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna)
- For  Megamenu Link Click, you'll be looking for an action called 'nav-header-action'
- For Megamenu 3rd Column Promo clicks, you'll be looking for an action called 'nav-hub-action'
- For Homepage CTA clicks, action name is 'homepage-cta-action'
- For Header Sign In button clicks, action name is 'header-sign-in-action'
- For OPIA Homepage Promo clicks, action name is 'homepage-promo-action'
- For Promo Banner clicks, action name is 'promo-banner-action'

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
