### PR TITLE
Integrate Appeals-995 E2E-specs with TestRail

### DIFF
--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -11,12 +11,17 @@ import { mockContestableIssues } from './995.cypress.helpers';
 import mockTelephoneUpdate from './fixtures/mocks/telephone-update.json';
 import mockTelephoneUpdateSuccess from './fixtures/mocks/telephone-update-success.json';
 
-describe.skip('995 contact info loop', () => {
+describe('995 contact info loop', () => {
+  Cypress.config({ requestTimeout: 10000 });
+  before(() => {
+    if (Cypress.env('CI')) this.skip();
+  });
+
   beforeEach(() => {
     window.dataLayer = [];
     cy.intercept('GET', '/v0/feature_toggles?*', {
       data: { features: [{ name: 'supplemental_claim', value: true }] },
-    });
+    }).as('features');
 
     setStoredSubTask({ benefitType: 'compensation' });
     cy.intercept(
@@ -36,6 +41,7 @@ describe.skip('995 contact info loop', () => {
     cy.intercept('GET', '/v0/maintenance_windows', []);
 
     cy.visit(BASE_URL);
+    cy.wait('@features');
     cy.injectAxe();
   });
 
@@ -52,7 +58,7 @@ describe.skip('995 contact info loop', () => {
       .click();
   };
 
-  it('should edit info on a new page & cancel returns to contact info page', () => {
+  it('should edit info on a new page & cancel returns to contact info page - C30848', () => {
     getToContactPage();
 
     // Contact info

--- a/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
@@ -2,18 +2,23 @@ import { resetStoredSubTask } from 'platform/forms/sub-task';
 
 import { BASE_URL } from '../constants';
 
-describe.skip('995 subtask', () => {
+describe('995 subtask', () => {
+  before(() => {
+    if (Cypress.env('CI')) this.skip();
+  });
+
   beforeEach(() => {
     window.dataLayer = [];
     cy.intercept('GET', '/v0/feature_toggles?*', {
       data: { features: [{ name: 'supplemental_claim', value: true }] },
-    });
+    }).as('features');
 
     resetStoredSubTask();
     cy.visit(`${BASE_URL}/start`);
+    cy.wait('@features');
   });
 
-  it('should show error when nothing selected', () => {
+  it('should show error when nothing selected - C30850', () => {
     cy.location('pathname').should('eq', `${BASE_URL}/start`);
     cy.injectAxeThenAxeCheck();
 
@@ -26,7 +31,7 @@ describe.skip('995 subtask', () => {
     cy.location('pathname').should('eq', `${BASE_URL}/start`);
   });
 
-  it('should go to intro page when compensation is selected', () => {
+  it('should go to intro page when compensation is selected - C30851', () => {
     cy.location('pathname').should('eq', `${BASE_URL}/start`);
     cy.injectAxeThenAxeCheck();
 
@@ -36,7 +41,7 @@ describe.skip('995 subtask', () => {
     cy.location('pathname').should('eq', `${BASE_URL}/introduction`);
   });
 
-  it('should go to non-compensation type page when another type is selected', () => {
+  it('should go to non-compensation type page when another type is selected - C30852', () => {
     cy.location('pathname').should('eq', `${BASE_URL}/start`);
     cy.injectAxeThenAxeCheck();
 

--- a/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
@@ -11,15 +11,14 @@ describe('995 subtask', () => {
     window.dataLayer = [];
     cy.intercept('GET', '/v0/feature_toggles?*', {
       data: { features: [{ name: 'supplemental_claim', value: true }] },
-    }).as('features');
+    });
 
     resetStoredSubTask();
     cy.visit(`${BASE_URL}/start`);
-    cy.wait('@features');
+    cy.location('pathname').should('eq', `${BASE_URL}/start`);
   });
 
   it('should show error when nothing selected - C30850', () => {
-    cy.location('pathname').should('eq', `${BASE_URL}/start`);
     cy.injectAxeThenAxeCheck();
 
     cy.findByText(/continue/i, { selector: 'va-button' }).click();
@@ -32,7 +31,6 @@ describe('995 subtask', () => {
   });
 
   it('should go to intro page when compensation is selected - C30851', () => {
-    cy.location('pathname').should('eq', `${BASE_URL}/start`);
     cy.injectAxeThenAxeCheck();
 
     cy.selectRadio('benefitType', 'compensation');
@@ -42,7 +40,6 @@ describe('995 subtask', () => {
   });
 
   it('should go to non-compensation type page when another type is selected - C30852', () => {
-    cy.location('pathname').should('eq', `${BASE_URL}/start`);
     cy.injectAxeThenAxeCheck();
 
     cy.selectRadio('benefitType', 'other');


### PR DESCRIPTION
## Description

Update Appeals 995 Cypress E2E-specs with TestRail test case management system:
- Configure Cypress where needed to work with custom reporter &mdash; increase requestTimeout for intercepts.
- Enable local running &mdash; make skips CI-only.
- Append TestRail Case IDs to test-titles.

## Original issue(s)
[n/a; QA-internal work]

## Testing done
- Ran specs locally &mdash; [results successfully posted to TestRail](https://dsvavsp.testrail.io/index.php?/runs/overview/61) [under Thursday, November 10, 2022].  See also screenshot below.
- No changes made to application code

### Screenshot
![image](https://user-images.githubusercontent.com/587583/201197650-dcd2b893-0812-41b0-9583-718dd4186d35.png)


## Acceptance criteria
- [ ] Code reviewer(s) approved changes.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
