### PR TITLE
Supplemental Claims | Add React Widget

### DIFF
--- a/src/applications/static-pages/supplemental-claim/components/App/index.js
+++ b/src/applications/static-pages/supplemental-claim/components/App/index.js
@@ -1,0 +1,37 @@
+// Node modules.
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+export const App = ({ show }) => {
+  return show ? (
+    <div>
+      <h2>How do I file a Supplemental Claim?</h2>
+      <p>You can file a Supplemental Claim online right now.</p>
+      <a
+        href="/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995"
+        className="vads-c-action-link--green"
+      >
+        File a Supplemental Claim
+      </a>
+    </div>
+  ) : (
+    <div>
+      <h2>How do I file a Supplemental Claim?</h2>
+    </div>
+  );
+};
+
+App.propTypes = {
+  // From mapStateToProps.
+  show: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  show: state?.featureToggles?.supplementalClaim,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(App);

--- a/src/applications/static-pages/supplemental-claim/index.js
+++ b/src/applications/static-pages/supplemental-claim/index.js
@@ -1,0 +1,23 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "form-0995" */
+    './components/App').then(module => {
+      const App = module.default;
+      connectFeatureToggle(store.dispatch);
+
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};


### PR DESCRIPTION
## Description
The Drupal [content info page](https://staging.va.gov/decision-reviews/supplemental-claim/) will get a React component injected on to that page which uses a feature flag to show an action link that directs the Veteran to start the online form.

We're leaving this in draft until we get the content recommendations for the page.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/48808

## Testing done
Pending

## Screenshots
N/A

## Acceptance criteria
- [x]  User will see, or not see, the start the online Supplemental Claim form depending on the state of the feature flag
- [x]  User will be directed to the /start page after activating the action link
- [x]  Accessibility testing complete
- [x]  Reviewed and approved by product and/or design

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
