### PR TITLE
update test data

### DIFF
--- a/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
@@ -52,13 +52,13 @@ describe('selectAnnouncement', () => {
         {
           name: 'dummy8',
           paths: /^(\/unique-route-2\/)$/,
-          startsAt: '2022-11-11',
+          startsAt: '2052-11-11',
         },
         {
           name: 'dummy9',
           paths: /^(\/unique-route-3\/)$/,
           startsAt: '2019-11-11',
-          expiresAt: '2022-11-11',
+          expiresAt: '2052-11-11',
         },
       ],
     };


### PR DESCRIPTION
## Description
This PR updates some test data that started causing tests to fail today (11/11/2022) due to comparisons being made with the current date.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
