### PR TITLE
remove arrow functions

### DIFF
--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -13,7 +13,7 @@ import mockTelephoneUpdateSuccess from './fixtures/mocks/telephone-update-succes
 
 describe('995 contact info loop', () => {
   Cypress.config({ requestTimeout: 10000 });
-  before(() => {
+  before(function() {
     if (Cypress.env('CI')) this.skip();
   });
 

--- a/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
@@ -3,7 +3,7 @@ import { resetStoredSubTask } from 'platform/forms/sub-task';
 import { BASE_URL } from '../constants';
 
 describe('995 subtask', () => {
-  before(() => {
+  before(function() {
     if (Cypress.env('CI')) this.skip();
   });
 

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-compose.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-compose.cypress.spec.js
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 
 describe(manifest.appName, () => {
-  before(() => {
+  before(function() {
     if (Cypress.env('CI')) this.skip();
   });
 

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
@@ -4,7 +4,7 @@ import PatientMessagesLandingPage from './pages/PatientMessagesLandingPage';
 beforeEach(() => {});
 
 describe(manifest.appName, () => {
-  before(() => {
+  before(function() {
     if (Cypress.env('CI')) this.skip();
   });
 


### PR DESCRIPTION
## Description
This PR updates the syntax to skip cypress tests during CI by swapping an arrow function for a normal function to avoid issues with `this`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
