### PR TITLE
48951 add ga to claim letters download

### DIFF
--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
+import recordEvent from 'platform/monitoring/record-event';
 import environment from 'platform/utilities/environment';
 
 const downloadUrl = id => `${environment.API_URL}/v0/claim_letters/${id}`;
 
 const formatDate = date => {
   return format(new Date(date), 'MMMM dd, yyyy');
+};
+
+const clickHandler = () => {
+  recordEvent({ event: 'claim-letters-download' });
 };
 
 const ClaimLetterListItem = ({ letter }) => {
@@ -19,12 +24,16 @@ const ClaimLetterListItem = ({ letter }) => {
       <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
         {letter.typeDescription}
       </div>
-      <va-link
-        download
-        filetype="PDF"
-        href={downloadUrl(letter.documentId)}
-        text="Download letter"
-      />
+      {/* Using the div element here to capture the click event and make a call to GA */}
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div onClick={clickHandler} onKeyPress={clickHandler}>
+        <va-link
+          download
+          filetype="PDF"
+          href={downloadUrl(letter.documentId)}
+          text="Download letter"
+        />
+      </div>
     </li>
   );
 };

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -24,16 +24,13 @@ const ClaimLetterListItem = ({ letter }) => {
       <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
         {letter.typeDescription}
       </div>
-      {/* Using the div element here to capture the click event and make a call to GA */}
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      <div onClick={downloadHandler} onKeyPress={downloadHandler}>
-        <va-link
-          download
-          filetype="PDF"
-          href={downloadUrl(letter.documentId)}
-          text="Download letter"
-        />
-      </div>
+      <va-link
+        download
+        filetype="PDF"
+        href={downloadUrl(letter.documentId)}
+        onClick={downloadHandler}
+        text="Download letter"
+      />
     </li>
   );
 };

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -11,7 +11,7 @@ const formatDate = date => {
   return format(new Date(date), 'MMMM dd, yyyy');
 };
 
-const clickHandler = () => {
+const downloadHandler = () => {
   recordEvent({ event: 'claim-letters-download' });
 };
 
@@ -26,7 +26,7 @@ const ClaimLetterListItem = ({ letter }) => {
       </div>
       {/* Using the div element here to capture the click event and make a call to GA */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      <div onClick={clickHandler} onKeyPress={clickHandler}>
+      <div onClick={downloadHandler} onKeyPress={downloadHandler}>
         <va-link
           download
           filetype="PDF"


### PR DESCRIPTION
## Description
Adding a call to Google Analytics whenever the user clicks one of the download links
in the letters list

**NOTE:** I was wanting to use the `component-library-analytics` property that
should exist on the `va-link` component, but looking at the source I don't believe
that it is fully implemented ([source](https://github.com/department-of-veterans-affairs/component-library/blob/3c6e84e090cfc6598b433189d39aa48659e19226/packages/web-components/src/components/va-link/va-link.tsx#L87))

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48951

## Testing done
Tests still pass

## Acceptance criteria
- [x] GA event is pushed every time user clicks a download link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
