### PR TITLE
(fix) update spacing

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -9,11 +9,11 @@ import { FIELD_NAMES } from '@@vap-svc/constants';
 const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
   return (
     <>
-      <p>
+      <p className="vads-u-margin-bottom--0">
         We’ll use the contact information from your profile to send you the
         notifications you choose:
       </p>
-      <ul>
+      <ul className="vads-u-margin-y--3">
         {emailAddress ? (
           <li className="vads-u-margin-y--0p5">
             {emailAddress}{' '}

--- a/src/applications/personalization/profile/components/notification-settings/HealthCareGroupSupportingText.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/HealthCareGroupSupportingText.jsx
@@ -6,7 +6,7 @@ import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selector
 
 const HealthCareGroupSupportingText = ({ authenticatedWithSSOe }) => {
   return (
-    <p className="vads-u-margin-top--0">
+    <p className="vads-u-margin-top--0 vads-u-margin-bottom--4">
       <a
         href={mhvUrl(authenticatedWithSSOe, 'home')}
         rel="noreferrer noopener"

--- a/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
@@ -20,7 +20,9 @@ const NotificationGroup = ({
 }) => {
   return (
     <div data-testid="notification-group">
-      <h2 className="vads-u-font-size--h3">{groupName}</h2>
+      <h2 className="vads-u-font-size--h3 vads-u-margin-top--4 vads-u-margin-bottom--1p5">
+        {groupName}
+      </h2>
       <div className="vads-u-margin-left--1p5">
         {itemIds.map(itemId => {
           if (

--- a/src/applications/personalization/profile/sass/notification-radio-buttons.scss
+++ b/src/applications/personalization/profile/sass/notification-radio-buttons.scss
@@ -29,7 +29,7 @@ input[type="checkbox"] {
 }
 
 .rb-fieldset-input {
-  margin-bottom: units(1.5);
+  margin-bottom: units(2);
   position: relative;
 }
 


### PR DESCRIPTION
## Description
A bunch of minor styling changes to the spacing for Notification Settings page of the Profile. Screenshots below show the new app | devtools | sketch design file, with arrows pointing to what is changed and where it correlates to the design file.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/48753


## Testing done
Visual testing and checked against devtools

## Screenshots

![Notif-settings-1](https://user-images.githubusercontent.com/8332986/202006020-92031f06-907d-4032-87b8-42824d8d9daf.png)

---

![Notif-settings-2](https://user-images.githubusercontent.com/8332986/202006043-e0cfc560-1165-40a7-9b97-febdca86f474.png)

---

![Notif-settings-3](https://user-images.githubusercontent.com/8332986/202006067-ab04f6c4-9907-48f3-8fa6-fa9d87e825b5.png)

---

![Notif-settings-4](https://user-images.githubusercontent.com/8332986/202006087-fccabfd0-9fe7-49d6-86fc-23b564fa375a.png)

---

![Notif-settings-5](https://user-images.githubusercontent.com/8332986/202006111-5cf9b594-0b97-4bd8-8257-625fbce088f4.png)

---

![Notif-settings-6](https://user-images.githubusercontent.com/8332986/202006141-dc0e770c-262f-48e5-8ea2-13f568bf2964.png)


## Acceptance criteria
- [x] Spacing has been updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
