### PR TITLE
Remove stale feature flag reference from Health care application

### DIFF
--- a/src/applications/hca/HealthCareApp.jsx
+++ b/src/applications/hca/HealthCareApp.jsx
@@ -13,7 +13,6 @@ const HealthCareEntry = ({
   children,
   caregiverSigiEnabled = false,
   hcaAmericanIndianEnabled = false,
-  hcaMedicareClaimNumberEnabled = false,
   hcaShortFormEnabled = false,
   hcaUseFacilitiesApi = false,
   setFormData,
@@ -41,7 +40,6 @@ const HealthCareEntry = ({
         'view:isLoggedIn': isLoggedIn,
         'view:totalDisabilityRating': totalDisabilityRating || 0,
         'view:caregiverSIGIEnabled': caregiverSigiEnabled,
-        'view:hcaMedicareClaimNumberEnabled': hcaMedicareClaimNumberEnabled,
         'view:hcaAmericanIndianEnabled': hcaAmericanIndianEnabled,
         'view:useFacilitiesAPI': hcaUseFacilitiesApi,
       };
@@ -72,7 +70,6 @@ const HealthCareEntry = ({
     [
       caregiverSigiEnabled,
       hcaAmericanIndianEnabled,
-      hcaMedicareClaimNumberEnabled,
       hcaShortFormEnabled,
       hcaUseFacilitiesApi,
       formData.veteranFullName,
@@ -100,7 +97,6 @@ HealthCareEntry.propTypes = {
   getTotalDisabilityRating: PropTypes.func,
   hasSavedForm: PropTypes.bool,
   hcaAmericanIndianEnabled: PropTypes.bool,
-  hcaMedicareClaimNumberEnabled: PropTypes.bool,
   hcaShortFormEnabled: PropTypes.bool,
   hcaUseFacilitiesApi: PropTypes.bool,
   isLoggedIn: PropTypes.bool,
@@ -114,8 +110,6 @@ const mapStateToProps = state => ({
   formData: state.form.data,
   caregiverSigiEnabled: state.featureToggles.caregiverSigiEnabled,
   hcaAmericanIndianEnabled: state.featureToggles.hcaAmericanIndianEnabled,
-  hcaMedicareClaimNumberEnabled:
-    state.featureToggles.hcaMedicareClaimNumberEnabled,
   hcaShortFormEnabled: state.featureToggles.hcaShortFormEnabled,
   hcaUseFacilitiesApi: state.featureToggles.hcaUseFacilitiesApi,
   hasSavedForm: state?.user?.profile?.savedForms.some(

--- a/src/applications/hca/config/chapters/insuranceInformation/medicarePartAEffectiveDate.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/medicarePartAEffectiveDate.js
@@ -24,12 +24,9 @@ export default {
       'ui:title': 'What is your Medicare claim number?',
       'ui:description': MedicareClaimNumberDescription,
       'ui:reviewField': CustomReviewField,
-      'ui:required': formData => formData['view:hcaMedicareClaimNumberEnabled'],
+      'ui:required': () => true,
       'ui:errorMessages': {
         required: 'Please enter a valid 11-character Medicare claim number',
-      },
-      'ui:options': {
-        hideIf: formData => !formData['view:hcaMedicareClaimNumberEnabled'],
       },
     },
   },

--- a/src/applications/hca/tests/config/medicarePartAEffectiveDate.unit.spec.jsx
+++ b/src/applications/hca/tests/config/medicarePartAEffectiveDate.unit.spec.jsx
@@ -16,9 +16,8 @@ describe('Hca medicare', () => {
     schema,
     uiSchema,
   } = formConfig.chapters.insuranceInformation.pages.medicarePartAEffectiveDate;
-  const formData = {
-    'view:hcaMedicareClaimNumberEnabled': true,
-  };
+  const formData = {};
+
   it('should render', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-aiq.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-aiq.json
@@ -11,10 +11,6 @@
         "value": true
       },
       {
-        "name": "hcaMedicareClaimNumberEnabled",
-        "value": true
-      },
-      {
         "name": "hcaShortFormEnabled",
         "value": true
       },

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-shortForm.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-shortForm.json
@@ -11,10 +11,6 @@
         "value": false
       },
       {
-        "name": "hcaMedicareClaimNumberEnabled",
-        "value": false
-      },
-      {
         "name": "hcaShortFormEnabled",
         "value": true
       },

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "hcaMedicareClaimNumberEnabled",
-        "value": true
-      },
-      {
         "name": "hcaUseFacilitiesApi",
         "value": true
       }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -70,7 +70,6 @@ export default Object.freeze({
   giSandboxComparisonToolToggle: 'gi_sandbox_comparision_tool_toggle',
   hcaAmericanIndianEnabled: 'hca_american_indian_enabled',
   hcaEnrollmentStatusOverrideEnabled: 'hca_enrollment_status_override_enabled',
-  hcaMedicareClaimNumberEnabled: 'hca_medicare_claim_number_enabled',
   hcaShortFormEnabled: 'hca_short_form_enabled',
   hcaUseFacilitiesApi: 'hca_use_facilities_API',
   loopPages: 'loop_pages',


### PR DESCRIPTION
## Description
With the successful release and verification of the Medicare Claim Number field, there is stale functionality that is being controlled by the `hca_medicare_claim_number_enabled` feature flag. This PR removes the reference to this feature flag and the stale functionality that controls the content display.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49686

## Testing done
- [x] Unit tests

## Acceptance criteria
- [ ] Form field renders without the use of feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
