### PR TITLE
Adds error code 108

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -271,9 +271,9 @@ export default function RenderErrorContainer({
     case AUTH_ERRORS.MHV_VERIFICATION_ERROR.errorCode:
       alertContent = (
         <p className="vads-u-margin-top--0">
-          We’re having trouble signing you in to VA.gov right now because the
-          services you requested requires a Premium{' '}
-          <strong>My HealtheVet</strong> account.
+          We’re having trouble signing you in with your My Healthevet account
+          right now because the services you are requesting require you to have
+          a Premium <strong>My Healthevet</strong> account.
         </p>
       );
       troubleshootingContent = (
@@ -290,56 +290,53 @@ export default function RenderErrorContainer({
               Follow these 2 steps to get a Premium{' '}
               <strong>My HealtheVet</strong> account online.
             </p>
-            <p>
-              <ol
-                className="vads-u-padding--0 vads-u-margin--0"
-                style={{ listStylePosition: 'inside' }}
-              >
-                <li>
-                  <strong>
-                    Sign up for an account on the My HealtheVet website.
-                  </strong>{' '}
-                  You'll need to have your Social Security number on hand. Be
-                  sure to choose <strong>VA Patient</strong> on the registration
-                  form.
-                  <br />
-                  <a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">
-                    Sign up for a My HealtheVet account
+            <ol
+              className="vads-u-padding--0 vads-u-margin--0"
+              style={{ listStylePosition: 'inside' }}
+            >
+              <li>
+                <strong>
+                  Sign up for an account on the My HealtheVet website.
+                </strong>{' '}
+                You'll need to have your Social Security number on hand. Be sure
+                to choose <strong>VA Patient</strong> on the registration form.
+                <br />
+                <a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">
+                  Sign up for a My HealtheVet account
+                </a>
+                <br />
+                <p>
+                  <strong>Note:</strong> If you have a{' '}
+                  <strong>Login.gov</strong>, <strong>ID.me</strong>, or Premium{' '}
+                  <strong>DS Logon</strong> account, you can skip step 1 above
+                  and go right to step 2 to sign in to{' '}
+                  <strong>My HealtheVet</strong> with either of these accounts.
+                </p>
+              </li>
+              <li>
+                <strong>Upgrade to a Premium account.</strong> To do this, sign
+                in to <strong>My HealtheVet</strong> using your{' '}
+                <strong>Login.gov</strong>, <strong>ID.me</strong>, or Premium{' '}
+                <strong>DS Logon</strong> account credentials.
+                <br />
+                <p>
+                  Once signed in, select the <strong>Upgrade Now</strong> button
+                  at the top left side of the screen. Then, on the account
+                  upgrade page, check the box certifying that you're the owner
+                  of the account and approve the request, and click{' '}
+                  <strong>Continue</strong>
+                </p>
+                <p>
+                  The system will upgrade you to a Premium account.
+                  <a
+                    className="vads-u-display--inline-block"
+                    href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login"
+                  >
+                    Sign in to My HealtheVet
                   </a>
-                  <br />
-                  <p>
-                    <strong>Note:</strong> If you have a Premium{' '}
-                    <strong>DS Logon</strong> or <strong>ID.me</strong> account,
-                    you can skip step 1 above and go right to step 2 to sign in
-                    to <strong>My HealtheVet</strong> with either of these
-                    accounts.
-                  </p>
-                </li>
-                <li>
-                  <strong>Upgrade to a Premium account.</strong> To do this,
-                  sign in to <strong>My HealtheVet</strong> using your Premium{' '}
-                  <strong>DS Logon</strong> or <strong>ID.me</strong> user ID
-                  and password.
-                  <br />
-                  <p>
-                    Once signed in, select the <strong>Upgrade Now</strong>{' '}
-                    button at the top left side of the screen. Then, on the
-                    account upgrade page, check the box certifying that you're
-                    the owner of the account and approve the request, and click{' '}
-                    <strong>Continue</strong>
-                  </p>
-                  <p>
-                    The system will upgrade you to a Premium account.
-                    <a
-                      className="vads-u-display--inline-block"
-                      href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login"
-                    >
-                      Sign in to My HealtheVet
-                    </a>
-                  </p>
-                </li>
-              </ol>
-            </p>
+                </p>
+              </li>
+            </ol>
           </div>
           <div>
             <h3>Sign up for a Premium account in person</h3>
@@ -348,39 +345,36 @@ export default function RenderErrorContainer({
               person at a VA health facility if you’re a VA patient. You’ll need
               to bring this form and ID with you:
             </p>
-            <p>
-              <ul>
-                <li>
-                  <strong>
-                    A completed and signed Individuals’ Request for a Copy of
-                    Their Own Health Information (VA Form 10-5345a).
-                  </strong>{' '}
-                  This “VA release of information” form gives us permission to
-                  share an electronic copy of your health record with your
-                  online account. You can download a PDF copy of the form now,
-                  call ahead to ask the staff to mail you a form, or ask for a
-                  form when you get there.
-                  <a
-                    className="vads-u-display--inline-block"
-                    href="/find-forms/about-form-10-5345a"
-                  >
-                    Get VA Form 10-5345a to download
-                  </a>
-                  <a
-                    className="vads-u-display--inline-block"
-                    href="/find-locations/"
-                  >
-                    Find the phone number for your nearest VA health care
-                    facility
-                  </a>
-                </li>
-                <li>
-                  <strong>A government-issued photo ID.</strong> This can be
-                  either your Veteran Health Identification Card or a valid
-                  driver’s license.
-                </li>
-              </ul>
-            </p>
+            <ul>
+              <li>
+                <strong>
+                  A completed and signed Individuals’ Request for a Copy of
+                  Their Own Health Information (VA Form 10-5345a).
+                </strong>{' '}
+                This “VA release of information” form gives us permission to
+                share an electronic copy of your health record with your online
+                account. You can download a PDF copy of the form now, call ahead
+                to ask the staff to mail you a form, or ask for a form when you
+                get there.
+                <a
+                  className="vads-u-display--inline-block"
+                  href="/find-forms/about-form-10-5345a"
+                >
+                  Get VA Form 10-5345a to download
+                </a>
+                <a
+                  className="vads-u-display--inline-block"
+                  href="/find-locations/"
+                >
+                  Find the phone number for your nearest VA health care facility
+                </a>
+              </li>
+              <li>
+                <strong>A government-issued photo ID.</strong> This can be
+                either your Veteran Health Identification Card or a valid
+                driver’s license.
+              </li>
+            </ul>
             <p>
               A VA staff member will verify your identity. Then they’ll record
               your information in the <strong>My HealtheVet</strong> system and

--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -268,6 +268,140 @@ export default function RenderErrorContainer({
       );
       break;
 
+    case AUTH_ERRORS.MHV_VERIFICATION_ERROR.errorCode:
+      alertContent = (
+        <p className="vads-u-margin-top--0">
+          We’re having trouble signing you in to VA.gov right now because the
+          services you requested requires a Premium{' '}
+          <strong>My HealtheVet</strong> account.
+        </p>
+      );
+      troubleshootingContent = (
+        <>
+          <h2>How can I fix this issue?</h2>
+          <p className="va-introtext">
+            Read below to learn how to upgrade to a Premium{' '}
+            <strong>My HealtheVet</strong> account online or in person if you’re
+            a VA patient.
+          </p>
+          <div>
+            <h3>Sign up for a Premium account online</h3>
+            <p>
+              Follow these 2 steps to get a Premium{' '}
+              <strong>My HealtheVet</strong> account online.
+            </p>
+            <p>
+              <ol
+                className="vads-u-padding--0 vads-u-margin--0"
+                style={{ listStylePosition: 'inside' }}
+              >
+                <li>
+                  <strong>
+                    Sign up for an account on the My HealtheVet website.
+                  </strong>{' '}
+                  You'll need to have your Social Security number on hand. Be
+                  sure to choose <strong>VA Patient</strong> on the registration
+                  form.
+                  <br />
+                  <a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">
+                    Sign up for a My HealtheVet account
+                  </a>
+                  <br />
+                  <p>
+                    <strong>Note:</strong> If you have a Premium{' '}
+                    <strong>DS Logon</strong> or <strong>ID.me</strong> account,
+                    you can skip step 1 above and go right to step 2 to sign in
+                    to <strong>My HealtheVet</strong> with either of these
+                    accounts.
+                  </p>
+                </li>
+                <li>
+                  <strong>Upgrade to a Premium account.</strong> To do this,
+                  sign in to <strong>My HealtheVet</strong> using your Premium{' '}
+                  <strong>DS Logon</strong> or <strong>ID.me</strong> user ID
+                  and password.
+                  <br />
+                  <p>
+                    Once signed in, select the <strong>Upgrade Now</strong>{' '}
+                    button at the top left side of the screen. Then, on the
+                    account upgrade page, check the box certifying that you're
+                    the owner of the account and approve the request, and click{' '}
+                    <strong>Continue</strong>
+                  </p>
+                  <p>
+                    The system will upgrade you to a Premium account.
+                    <a
+                      className="vads-u-display--inline-block"
+                      href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login"
+                    >
+                      Sign in to My HealtheVet
+                    </a>
+                  </p>
+                </li>
+              </ol>
+            </p>
+          </div>
+          <div>
+            <h3>Sign up for a Premium account in person</h3>
+            <p>
+              You can get a Premium <strong>My HealtheVet</strong> account in
+              person at a VA health facility if you’re a VA patient. You’ll need
+              to bring this form and ID with you:
+            </p>
+            <p>
+              <ul>
+                <li>
+                  <strong>
+                    A completed and signed Individuals’ Request for a Copy of
+                    Their Own Health Information (VA Form 10-5345a).
+                  </strong>{' '}
+                  This “VA release of information” form gives us permission to
+                  share an electronic copy of your health record with your
+                  online account. You can download a PDF copy of the form now,
+                  call ahead to ask the staff to mail you a form, or ask for a
+                  form when you get there.
+                  <a
+                    className="vads-u-display--inline-block"
+                    href="/find-forms/about-form-10-5345a"
+                  >
+                    Get VA Form 10-5345a to download
+                  </a>
+                  <a
+                    className="vads-u-display--inline-block"
+                    href="/find-locations/"
+                  >
+                    Find the phone number for your nearest VA health care
+                    facility
+                  </a>
+                </li>
+                <li>
+                  <strong>A government-issued photo ID.</strong> This can be
+                  either your Veteran Health Identification Card or a valid
+                  driver’s license.
+                </li>
+              </ul>
+            </p>
+            <p>
+              A VA staff member will verify your identity. Then they’ll record
+              your information in the <strong>My HealtheVet</strong> system and
+              confirm you’re eligible for a Premium account. A copy of your VA
+              Form 10-5345a-MHV will be added to your VA medical record, and the
+              original paper copy will be shredded to protect your privacy.
+            </p>
+            <p>
+              <strong>Note:</strong> When you open or download a PDF file, you
+              create a temporary file on your computer. Other people may be able
+              to see this file—and any personal health information you fill
+              in—especially if you’re using a public or shared computer.
+            </p>
+          </div>
+          <Helpdesk>
+            If you’ve taken the steps above and still can’t sign in,
+          </Helpdesk>
+        </>
+      );
+      break;
+
     case AUTH_ERRORS.OAUTH_STATE_MISMATCH.errorCode:
       alertContent = (
         <p className="vads-u-margin-top--0">

--- a/src/platform/user/authentication/errors.js
+++ b/src/platform/user/authentication/errors.js
@@ -55,6 +55,10 @@ export const AUTH_ERRORS = {
     errorCode: '106',
     message: `Multiple Corp IDs`,
   },
+  MHV_VERIFICATION_ERROR: {
+    errorCode: '108',
+    message: `MHV Verification Error`,
+  },
   OAUTH_DEFAULT_ERROR: {
     errorCode: '201',
     message: `Unknown OAuth Error`,


### PR DESCRIPTION
## Description
This PR adds error code `108` for authentication specifically when dealing with LOA2/My HealtheVet Premium users and the mobile services they require.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#49747


## Testing done
Unit + manual

## Screenshots
![localhost_3001_auth_login_callback__code=108](https://user-images.githubusercontent.com/67602137/202292778-ce971e81-1ba2-406c-9507-c0ba26219dd7.png)


## Acceptance criteria
- [x] Error code `108` displays proper content requesting a My HealtheVet user upgrade their account to Premium
- [x] Content is free from errors and includes VA411 phone number

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
