### PR TITLE
CST: Isolating application

### DIFF
--- a/src/applications/personalization/dashboard/claims-and-appeals-helpers.js
+++ b/src/applications/personalization/dashboard/claims-and-appeals-helpers.js
@@ -1,0 +1,37 @@
+// Appeals helpers
+const APPEAL_TYPES = {
+  legacy: 'legacyAppeal',
+  supplementalClaim: 'supplementalClaim',
+  higherLevelReview: 'higherLevelReview',
+  appeal: 'appeal',
+};
+
+export const appealTypes = Object.values(APPEAL_TYPES);
+
+// Claims helpers
+const evidenceGathering = 'Evidence gathering, review, and decision';
+
+const PHASE_MAP = {
+  1: 'Claim received',
+  2: 'Initial review',
+  3: evidenceGathering,
+  4: evidenceGathering,
+  5: evidenceGathering,
+  6: evidenceGathering,
+  7: 'Preparation for notification',
+  8: 'Complete',
+};
+
+export function getClaimType(claim) {
+  return (
+    claim?.attributes?.claimType || 'disability compensation'
+  ).toLowerCase();
+}
+
+export function getPhaseDescription(phase) {
+  return PHASE_MAP[phase];
+}
+
+export function isClaimComplete(claim) {
+  return claim.attributes.decisionLetterSent || claim.attributes.phase === 8;
+}

--- a/src/applications/personalization/dashboard/components/ClaimsListItem.jsx
+++ b/src/applications/personalization/dashboard/components/ClaimsListItem.jsx
@@ -4,11 +4,12 @@ import { Link } from 'react-router';
 import moment from 'moment';
 
 import recordEvent from 'platform/monitoring/record-event';
+
 import {
+  getClaimType,
   getPhaseDescription,
   isClaimComplete,
-  getClaimType,
-} from '../../../claims-status/utils/helpers';
+} from '../claims-and-appeals-helpers';
 
 function listPhase(phase) {
   return phase === 8 ? 'Closed' : getPhaseDescription(phase);

--- a/src/applications/personalization/dashboard/components/claims-and-appeals/HighlightedClaimAppeal.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals/HighlightedClaimAppeal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { appealTypes } from '~/applications/claims-status/utils/appeals-v2-helpers';
+import { appealTypes } from '../../claims-and-appeals-helpers';
 
 import Claim from './Claim';
 import Appeal from './Appeal';


### PR DESCRIPTION
## Description
Isolating the CST application so that it can be added to the single-app build allowlist.
In order to accomplish this, moving code imported by `personalization/dashboard` into the `personalization/dashboard` application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49830

## Testing done
Tests still pass

## Acceptance criteria
- [x] CST is isolated
- [x] Code imported from CST by `personalization/dashboard` is moved into the importing app

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
