### PR TITLE
[eFSR] 48736 - Debt selection requirement updates and fixes

### DIFF
--- a/src/applications/financial-status-report/components/AvailableDebts.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebts.jsx
@@ -1,15 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import PropTypes from 'prop-types';
-import { uniqBy } from 'lodash';
 import { ErrorAlert } from './Alerts';
 import { fetchDebts } from '../actions';
 import DebtCard from './DebtCard';
-import { getStatements } from '../actions/copays';
-import DebtCheckBox from './DebtCheckBox';
-import CopayCheckBox from './CopayCheckBox';
-import { sortStatementsByDate } from '../utils/helpers';
 
 const NoDebts = () => (
   <div className="usa-alert background-color-only">
@@ -24,42 +19,20 @@ const NoDebts = () => (
   </div>
 );
 
-const AvailableDebts = ({ formContext }) => {
-  const { debts, statements, pending, isError, pendingCopays } = useSelector(
-    state => state.fsr,
-  );
-
-  const { data } = useSelector(state => state.form);
-  const isCFSRActive = data['view:combinedFinancialStatusReport'];
-
-  // copays
-  const sortedStatements = sortStatementsByDate(statements ?? []);
-  const statementsByUniqueFacility = uniqBy(sortedStatements, 'pSFacilityNum');
-
-  const [selectionError, setSelectionError] = useState(false);
-  useEffect(
-    () => {
-      setSelectionError(
-        formContext.submitted && !data.selectedDebtsAndCopays?.length,
-      );
-    },
-    [formContext.submitted, data.selectedDebtsAndCopays?.length],
-  );
+const AvailableDebts = () => {
+  const { debts, pending, isError } = useSelector(state => state.fsr);
 
   const dispatch = useDispatch();
   useEffect(
     () => {
       fetchDebts(dispatch);
-      if (isCFSRActive) {
-        getStatements(dispatch);
-      }
     },
-    [dispatch, isCFSRActive],
+    [dispatch],
   );
 
   if (isError) return <ErrorAlert />;
 
-  if (pending || (isCFSRActive && pendingCopays)) {
+  if (pending) {
     return (
       <div className="vads-u-margin--5">
         <va-loading-indicator
@@ -71,47 +44,11 @@ const AvailableDebts = ({ formContext }) => {
     );
   }
 
-  if (!debts.length && (!isCFSRActive || !statementsByUniqueFacility.length)) {
+  if (!debts.length) {
     return <NoDebts />;
   }
 
-  return isCFSRActive ? (
-    <>
-      <p className="vads-u-margin-bottom--3">
-        Select one or more debts you want to request relief for{' '}
-        <span className="required-text">(*Required)</span>
-      </p>
-      <div
-        className={
-          selectionError
-            ? 'error-line vads-u-margin-y--3 vads-u-padding-left--1 vads-u-margin-left--neg1p5'
-            : 'vads-u-margin-y--3'
-        }
-      >
-        {selectionError && (
-          <span
-            className="vads-u-font-weight--bold vads-u-color--secondary-dark"
-            role="alert"
-          >
-            <span className="sr-only">Error</span>
-            <p>Choose at least one debt</p>
-          </span>
-        )}
-        {debts.map((debt, index) => (
-          <DebtCheckBox debt={debt} key={`${index}-${debt.currentAr}`} />
-        ))}
-        {statementsByUniqueFacility.map(copay => (
-          <CopayCheckBox copay={copay} key={copay.id} />
-        ))}
-      </div>
-      <va-additional-info trigger="What if my debt isn’t listed here?">
-        If you received a letter about a VA benefit debt that isn’t listed here,
-        call us at <va-telephone contact="8008270648" /> (or{' '}
-        <va-telephone contact="6127136415" international /> from overseas).
-        We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-      </va-additional-info>
-    </>
-  ) : (
+  return (
     <>
       <p>
         Select one or more debts below. We’ll help you choose a debt repayment

--- a/src/applications/financial-status-report/components/AvailableDebts.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebts.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import PropTypes from 'prop-types';
@@ -24,7 +24,7 @@ const NoDebts = () => (
   </div>
 );
 
-const AvailableDebts = () => {
+const AvailableDebts = ({ formContext }) => {
   const { debts, statements, pending, isError, pendingCopays } = useSelector(
     state => state.fsr,
   );
@@ -35,6 +35,16 @@ const AvailableDebts = () => {
   // copays
   const sortedStatements = sortStatementsByDate(statements ?? []);
   const statementsByUniqueFacility = uniqBy(sortedStatements, 'pSFacilityNum');
+
+  const [selectionError, setSelectionError] = useState(false);
+  useEffect(
+    () => {
+      setSelectionError(
+        formContext.submitted && !data.selectedDebtsAndCopays?.length,
+      );
+    },
+    [formContext.submitted, data.selectedDebtsAndCopays?.length],
+  );
 
   const dispatch = useDispatch();
   useEffect(
@@ -68,14 +78,32 @@ const AvailableDebts = () => {
   return isCFSRActive ? (
     <>
       <p className="vads-u-margin-bottom--3">
-        Select one or more debts you want to request relief for
+        Select one or more debts you want to request relief for{' '}
+        <span className="required-text">(*Required)</span>
       </p>
-      {debts.map((debt, index) => (
-        <DebtCheckBox debt={debt} key={`${index}-${debt.currentAr}`} />
-      ))}
-      {statementsByUniqueFacility.map(copay => (
-        <CopayCheckBox copay={copay} key={copay.id} />
-      ))}
+      <div
+        className={
+          selectionError
+            ? 'error-line vads-u-margin-y--3 vads-u-padding-left--1 vads-u-margin-left--neg1p5'
+            : 'vads-u-margin-y--3'
+        }
+      >
+        {selectionError && (
+          <span
+            className="vads-u-font-weight--bold vads-u-color--secondary-dark"
+            role="alert"
+          >
+            <span className="sr-only">Error</span>
+            <p>Select at least one debt you want to request relief for</p>
+          </span>
+        )}
+        {debts.map((debt, index) => (
+          <DebtCheckBox debt={debt} key={`${index}-${debt.currentAr}`} />
+        ))}
+        {statementsByUniqueFacility.map(copay => (
+          <CopayCheckBox copay={copay} key={copay.id} />
+        ))}
+      </div>
       <va-additional-info trigger="What if my debt isn’t listed here?">
         If you received a letter about a VA benefit debt that isn’t listed here,
         call us at <va-telephone contact="8008270648" /> (or{' '}

--- a/src/applications/financial-status-report/components/AvailableDebts.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebts.jsx
@@ -94,7 +94,7 @@ const AvailableDebts = ({ formContext }) => {
             role="alert"
           >
             <span className="sr-only">Error</span>
-            <p>Select at least one debt you want to request relief for</p>
+            <p>Choose at least one debt</p>
           </span>
         )}
         {debts.map((debt, index) => (

--- a/src/applications/financial-status-report/components/AvailableDebts.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebts.jsx
@@ -145,6 +145,9 @@ const AvailableDebts = ({ formContext }) => {
 
 AvailableDebts.propTypes = {
   debts: PropTypes.array,
+  formContext: PropTypes.shape({
+    submitted: PropTypes.bool,
+  }),
   getDebts: PropTypes.func,
   isError: PropTypes.bool,
   pendingDebts: PropTypes.bool,

--- a/src/applications/financial-status-report/components/AvailableDebtsAndCopays.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebtsAndCopays.jsx
@@ -3,12 +3,14 @@ import { useSelector, useDispatch } from 'react-redux';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 import PropTypes from 'prop-types';
 import { uniqBy } from 'lodash';
+import Scroll from 'react-scroll';
 import { ErrorAlert } from './Alerts';
 import { fetchDebts } from '../actions';
 import { getStatements } from '../actions/copays';
 import DebtCheckBox from './DebtCheckBox';
 import CopayCheckBox from './CopayCheckBox';
 import { sortStatementsByDate } from '../utils/helpers';
+import { setFocus } from '../utils/fileValidation';
 
 const NoDebts = () => (
   <div className="usa-alert background-color-only">
@@ -22,6 +24,15 @@ const NoDebts = () => (
     </p>
   </div>
 );
+
+const { scroller } = Scroll;
+const scrollToTop = () => {
+  scroller.scrollTo('error-message-content', {
+    duration: 500,
+    delay: 0,
+    smooth: true,
+  });
+};
 
 const AvailableDebtsAndCopays = ({ formContext }) => {
   const { debts, statements, pending, isError, pendingCopays } = useSelector(
@@ -41,6 +52,16 @@ const AvailableDebtsAndCopays = ({ formContext }) => {
       );
     },
     [formContext.submitted, data.selectedDebtsAndCopays?.length],
+  );
+
+  useEffect(
+    () => {
+      if (selectionError) {
+        scrollToTop();
+        setFocus('[name="error-message-content"]');
+      }
+    },
+    [selectionError],
   );
 
   const dispatch = useDispatch();
@@ -85,6 +106,7 @@ const AvailableDebtsAndCopays = ({ formContext }) => {
       >
         {selectionError && (
           <span
+            name="error-message-content"
             className="vads-u-font-weight--bold vads-u-color--secondary-dark"
             role="alert"
           >

--- a/src/applications/financial-status-report/components/AvailableDebtsAndCopays.jsx
+++ b/src/applications/financial-status-report/components/AvailableDebtsAndCopays.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import PropTypes from 'prop-types';
+import { uniqBy } from 'lodash';
+import { ErrorAlert } from './Alerts';
+import { fetchDebts } from '../actions';
+import { getStatements } from '../actions/copays';
+import DebtCheckBox from './DebtCheckBox';
+import CopayCheckBox from './CopayCheckBox';
+import { sortStatementsByDate } from '../utils/helpers';
+
+const NoDebts = () => (
+  <div className="usa-alert background-color-only">
+    <div className="vads-u-margin-bottom--1">
+      <h4 className="vads-u-margin--0">You don’t have any VA debt</h4>
+    </div>
+    <p>
+      Our records show you don’t have any debt related to VA benefits. If you
+      think this is an error, please contact the Debt Management Center at{' '}
+      <va-telephone contact={CONTACTS.DMC} />
+    </p>
+  </div>
+);
+
+const AvailableDebtsAndCopays = ({ formContext }) => {
+  const { debts, statements, pending, isError, pendingCopays } = useSelector(
+    state => state.fsr,
+  );
+  const { data } = useSelector(state => state.form);
+
+  // copays
+  const sortedStatements = sortStatementsByDate(statements ?? []);
+  const statementsByUniqueFacility = uniqBy(sortedStatements, 'pSFacilityNum');
+
+  const [selectionError, setSelectionError] = useState(false);
+  useEffect(
+    () => {
+      setSelectionError(
+        formContext.submitted && !data.selectedDebtsAndCopays?.length,
+      );
+    },
+    [formContext.submitted, data.selectedDebtsAndCopays?.length],
+  );
+
+  const dispatch = useDispatch();
+  useEffect(
+    () => {
+      fetchDebts(dispatch);
+      getStatements(dispatch);
+    },
+    [dispatch],
+  );
+
+  if (isError) return <ErrorAlert />;
+
+  if (pending || pendingCopays) {
+    return (
+      <div className="vads-u-margin--5">
+        <va-loading-indicator
+          label="Loading"
+          message="Loading your information..."
+          set-focus
+        />
+      </div>
+    );
+  }
+
+  if (!debts.length && !statementsByUniqueFacility.length) {
+    return <NoDebts />;
+  }
+
+  return (
+    <>
+      <p className="vads-u-margin-bottom--3">
+        Select one or more debts you want to request relief for{' '}
+        <span className="required-text">(*Required)</span>
+      </p>
+      <div
+        className={
+          selectionError
+            ? 'error-line vads-u-margin-y--3 vads-u-padding-left--1 vads-u-margin-left--neg1p5'
+            : 'vads-u-margin-y--3'
+        }
+      >
+        {selectionError && (
+          <span
+            className="vads-u-font-weight--bold vads-u-color--secondary-dark"
+            role="alert"
+          >
+            <span className="sr-only">Error</span>
+            <p>Choose at least one debt</p>
+          </span>
+        )}
+        {debts.map((debt, index) => (
+          <DebtCheckBox debt={debt} key={`${index}-${debt.currentAr}`} />
+        ))}
+        {statementsByUniqueFacility.map(copay => (
+          <CopayCheckBox copay={copay} key={copay.id} />
+        ))}
+      </div>
+      <va-additional-info trigger="What if my debt isn’t listed here?">
+        If you received a letter about a VA benefit debt that isn’t listed here,
+        call us at <va-telephone contact="8008270648" /> (or{' '}
+        <va-telephone contact="6127136415" international /> from overseas).
+        We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+      </va-additional-info>
+    </>
+  );
+};
+
+AvailableDebtsAndCopays.propTypes = {
+  debts: PropTypes.array,
+  formContext: PropTypes.shape({
+    submitted: PropTypes.bool,
+  }),
+  getDebts: PropTypes.func,
+  isError: PropTypes.bool,
+  pendingDebts: PropTypes.bool,
+};
+
+export default AvailableDebtsAndCopays;

--- a/src/applications/financial-status-report/components/CopayCheckBox.jsx
+++ b/src/applications/financial-status-report/components/CopayCheckBox.jsx
@@ -62,8 +62,10 @@ const CopayCheckBox = ({ copay }) => {
         onChange={() => onChange(copay)}
       />
       <label className="vads-u-margin--0" htmlFor={copay.id}>
-        <div className="vads-u-margin-left--4 vads-u-margin-top--neg3">
-          <p className="vads-u-margin--0">{checkboxMainText}</p>
+        <div className="vads-u-margin-left--4 vads-u-margin-top--neg3 vads-u-padding-top--0p25">
+          <p className="vads-u-margin--0 vads-u-font-weight--bold">
+            {checkboxMainText}
+          </p>
           <p className="vads-u-margin--0 vads-u-font-size--sm vads-u-color--gray">
             {checkboxSubText}
           </p>

--- a/src/applications/financial-status-report/components/CopayCheckBox.jsx
+++ b/src/applications/financial-status-report/components/CopayCheckBox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { setData } from 'platform/forms-system/src/js/actions';
-import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
+import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
+import { getMedicalCenterNameByID } from '@department-of-veterans-affairs/platform-utilities/medical-centers';
 import { currency, endDate } from '../utils/helpers';
 
 const CopayCheckBox = ({ copay }) => {

--- a/src/applications/financial-status-report/components/CopayCheckBox.jsx
+++ b/src/applications/financial-status-report/components/CopayCheckBox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
-import { getMedicalCenterNameByID } from '@department-of-veterans-affairs/platform-utilities/medical-centers';
+import { setData } from 'platform/forms-system/src/js/actions';
+import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
 import { currency, endDate } from '../utils/helpers';
 
 const CopayCheckBox = ({ copay }) => {

--- a/src/applications/financial-status-report/components/DebtCheckBox.jsx
+++ b/src/applications/financial-status-report/components/DebtCheckBox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { setData } from 'platform/forms-system/src/js/actions';
+import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 import { format, isValid } from 'date-fns';
 import { head } from 'lodash';
 import { deductionCodes } from '../constants/deduction-codes';

--- a/src/applications/financial-status-report/components/DebtCheckBox.jsx
+++ b/src/applications/financial-status-report/components/DebtCheckBox.jsx
@@ -80,8 +80,10 @@ const DebtCheckBox = ({ debt }) => {
         onChange={() => onChange(debt)}
       />
       <label className="vads-u-margin--0" htmlFor={debtIdentifier}>
-        <div className="vads-u-margin-left--4 vads-u-margin-top--neg3">
-          <p className="vads-u-margin--0">{checkboxMainText}</p>
+        <div className="vads-u-margin-left--4 vads-u-margin-top--neg3 vads-u-padding-top--0p25">
+          <p className="vads-u-margin--0 vads-u-font-weight--bold">
+            {checkboxMainText}
+          </p>
           <p className="vads-u-margin--0 vads-u-font-size--sm vads-u-color--gray">
             {checkboxSubText}
           </p>

--- a/src/applications/financial-status-report/components/DebtCheckBox.jsx
+++ b/src/applications/financial-status-report/components/DebtCheckBox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
+import { setData } from 'platform/forms-system/src/js/actions';
 import { format, isValid } from 'date-fns';
 import { head } from 'lodash';
 import { deductionCodes } from '../constants/deduction-codes';

--- a/src/applications/financial-status-report/components/ResolutionOptions.jsx
+++ b/src/applications/financial-status-report/components/ResolutionOptions.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
+import { setData } from 'platform/forms-system/src/js/actions';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import { RESOLUTION_OPTION_TYPES } from '../constants';
 

--- a/src/applications/financial-status-report/components/ResolutionOptions.jsx
+++ b/src/applications/financial-status-report/components/ResolutionOptions.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { setData } from 'platform/forms-system/src/js/actions';
+import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import { RESOLUTION_OPTION_TYPES } from '../constants';
 

--- a/src/applications/financial-status-report/components/ResolutionOptions.jsx
+++ b/src/applications/financial-status-report/components/ResolutionOptions.jsx
@@ -121,7 +121,7 @@ const ResolutionOptions = ({ formContext }) => {
     <div
       className={
         resolutionError
-          ? 'error-line'
+          ? 'error-line vads-u-margin-y--3 vads-u-padding-left--1 vads-u-margin-left--neg1p5'
           : 'vads-u-margin-left--2 vads-u-margin-top--4'
       }
     >
@@ -185,7 +185,13 @@ const ResolutionOptions = ({ formContext }) => {
             />
             <label htmlFor="radio-compromise">{renderCompromiseText}</label>
           </div>
-          <div className={checkboxError ? 'error-line' : 'vads-u-margin-y--3'}>
+          <div
+            className={
+              checkboxError
+                ? 'error-line vads-u-margin-y--3 vads-u-padding-left--1 vads-u-margin-left--neg1p5'
+                : 'vads-u-margin-y--3'
+            }
+          >
             {checkboxError && (
               <span
                 className="vads-u-font-weight--bold vads-u-color--secondary-dark"

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -91,6 +91,18 @@ const formConfig = {
           title: 'Available Debts',
           uiSchema: pages.availableDebts.uiSchema,
           schema: pages.availableDebts.schema,
+          depends: formData => !formData['view:combinedFinancialStatusReport'],
+        },
+        combinedAvailableDebts: {
+          initialData: {
+            selectedDebts: [],
+            selectedDebtsAndCopays: [],
+          },
+          path: 'all-available-debts',
+          title: 'Available Debts',
+          uiSchema: pages.combinedDebts.uiSchema,
+          schema: pages.combinedDebts.schema,
+          depends: formData => formData['view:combinedFinancialStatusReport'],
         },
         contactInfo: {
           initialData: {

--- a/src/applications/financial-status-report/pages/index.js
+++ b/src/applications/financial-status-report/pages/index.js
@@ -1,6 +1,7 @@
 import * as veteranInfo from './veteran/veteranInfo';
 import * as contactInfo from './veteran/contact';
 import * as availableDebts from './veteran/debts';
+import * as combinedDebts from './veteran/combinedDebts';
 import * as employment from './income/employment';
 import * as employmentRecords from './income/employment/records';
 import * as additionalIncomeRecords from './income/additionalIncome/records';
@@ -51,6 +52,7 @@ import * as bankruptcyHistoryRecords from './bankruptcy/records';
 export {
   veteranInfo,
   availableDebts,
+  combinedDebts,
   employment,
   employmentRecords,
   income,

--- a/src/applications/financial-status-report/pages/veteran/combinedDebts.js
+++ b/src/applications/financial-status-report/pages/veteran/combinedDebts.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import AvailableDebtsAndCopays from '../../components/AvailableDebtsAndCopays';
+
+export const uiSchema = {
+  'ui:title': (
+    <span
+      className="vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--sans"
+      data-testid="debt-title"
+    >
+      What debt do you need help with?
+    </span>
+  ),
+  selectedDebtsAndCopays: {
+    'ui:field': AvailableDebtsAndCopays,
+    'ui:options': {
+      hideOnReview: true,
+    },
+    'ui:validations': [
+      (errors, debts) => {
+        if (!debts.length) {
+          errors.addError('Please select at least one debt.');
+        }
+      },
+    ],
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    selectedDebtsAndCopays: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/financial-status-report/pages/veteran/debts.js
+++ b/src/applications/financial-status-report/pages/veteran/debts.js
@@ -2,37 +2,47 @@ import React from 'react';
 import AvailableDebts from '../../components/AvailableDebts';
 
 export const uiSchema = {
-  availableDebts: {
-    'ui:title': (
-      <span
-        className="vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--sans"
-        data-testid="debt-title"
-      >
-        What debt do you need help with?
-      </span>
-    ),
-    'ui:widget': AvailableDebts,
-    'ui:required': formData => {
-      const { selectedDebts, selectedDebtsAndCopays = [] } = formData;
-
-      return formData['view:combinedFinancialStatusReport']
-        ? !selectedDebtsAndCopays.length
-        : !selectedDebts.length;
+  'ui:title': (
+    <span
+      className="vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--sans"
+      data-testid="debt-title"
+    >
+      What debt do you need help with?
+    </span>
+  ),
+  'ui:required': () => true,
+  'ui:errorMessages': {
+    required: 'Please select at least one debt.',
+  },
+  selectedDebtsAndCopays: {
+    'ui:title': 'inner title',
+    'ui:required': () => true,
+    'ui:errorMessages': {
+      required: 'Please select at least one debt. messages',
     },
+    'ui:field': AvailableDebts,
     'ui:options': {
       hideOnReview: true,
     },
-    'ui:errorMessages': {
-      required: 'Please select at least one debt.',
-    },
+    'ui:validations': [
+      (errors, testVal) => {
+        if (!testVal.length) {
+          errors.addError('Please select a debt silly');
+        }
+      },
+    ],
   },
 };
 
 export const schema = {
   type: 'object',
   properties: {
-    availableDebts: {
-      type: 'boolean',
+    selectedDebtsAndCopays: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {},
+      },
     },
   },
 };

--- a/src/applications/financial-status-report/pages/veteran/debts.js
+++ b/src/applications/financial-status-report/pages/veteran/debts.js
@@ -2,47 +2,34 @@ import React from 'react';
 import AvailableDebts from '../../components/AvailableDebts';
 
 export const uiSchema = {
-  'ui:title': (
-    <span
-      className="vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--sans"
-      data-testid="debt-title"
-    >
-      What debt do you need help with?
-    </span>
-  ),
-  'ui:required': () => true,
-  'ui:errorMessages': {
-    required: 'Please select at least one debt.',
-  },
-  selectedDebtsAndCopays: {
-    'ui:title': 'inner title',
-    'ui:required': () => true,
-    'ui:errorMessages': {
-      required: 'Please select at least one debt. messages',
+  availableDebts: {
+    'ui:title': (
+      <span
+        className="vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--sans"
+        data-testid="debt-title"
+      >
+        What debt do you need help with?
+      </span>
+    ),
+    'ui:widget': AvailableDebts,
+    'ui:required': formData => {
+      const { selectedDebts } = formData;
+      return !selectedDebts.length;
     },
-    'ui:field': AvailableDebts,
     'ui:options': {
       hideOnReview: true,
     },
-    'ui:validations': [
-      (errors, testVal) => {
-        if (!testVal.length) {
-          errors.addError('Please select a debt silly');
-        }
-      },
-    ],
+    'ui:errorMessages': {
+      required: 'Please select at least one debt.',
+    },
   },
 };
 
 export const schema = {
   type: 'object',
   properties: {
-    selectedDebtsAndCopays: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {},
-      },
+    availableDebts: {
+      type: 'boolean',
     },
   },
 };

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -326,6 +326,5 @@
 
 .error-line {
   border-left: 4px solid var(--color-secondary-dark);
-  padding-left: 0.75rem;
   position: relative;
 }

--- a/src/applications/financial-status-report/tests/e2e/cfsr-5655.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/cfsr-5655.cypress.spec.js
@@ -52,7 +52,7 @@ const testConfig = createTestConfig(
           .first()
           .click();
       },
-      'available-debts': ({ afterHook }) => {
+      'all-available-debts': ({ afterHook }) => {
         afterHook(() => {
           cy.get(`input[name="request-help-with-debt"]`)
             .first()

--- a/src/applications/financial-status-report/tests/e2e/cfsr-5655.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/cfsr-5655.cypress.spec.js
@@ -29,6 +29,10 @@ const testConfig = createTestConfig(
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
             { name: 'combined_financial_status_report', value: true },
+            {
+              name: 'combined_financial_status_report_enhancements',
+              value: false,
+            },
           ],
         },
       });

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655.cypress.spec.js
@@ -25,6 +25,11 @@ const testConfig = createTestConfig(
           features: [
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
+            { name: 'combined_financial_status_report', value: false },
+            {
+              name: 'combined_financial_status_report_enhancements',
+              value: false,
+            },
           ],
         },
       });


### PR DESCRIPTION
## Description
Debt selection (`*Required)` tag was appearing on the incorrect line and was disappearing/reappearing depending on selection which wasn't great.

So this update grew a bit larger than originally intended. Debt selection for the combined flag and the original card options have been separated out at the page level rather than the component level. This allows for the updated form data structure to play nice with the required property and will make for a smoother transition once we lock in the feature flag. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#48736

## Screenshots
<details><summary>Previous (click to expand)</summary>
<img width="926" alt="image" src="https://user-images.githubusercontent.com/25368370/202754576-2bdf893e-76c6-4087-9cf7-a2bc1a9098c4.png">

"What if my debt..." option is still present, just not as relevant to the screenshots so it was omitted
</details>
<details><summary>New (click to expand)</summary>
<img width="977" alt="image" src="https://user-images.githubusercontent.com/25368370/202754773-bab73fac-51ba-4cfc-b008-62bb487f064d.png">

"What if my debt..." option is still present, just not relevant to the screenshots so it was omitted
</details>

## Acceptance criteria
- [x] `(*Required)` on debt selection page showing appropriately. 
- [x] Validations for debt selection reworked and triggering better

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
