### PR TITLE
Drop 25 runs to 20 to try and stop timeouts

### DIFF
--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -28,7 +28,7 @@ const batch = tests
   .join(',');
 
 let status = null;
-const runTestsInLoopUpTo = isStressTest ? 25 : 1;
+const runTestsInLoopUpTo = isStressTest ? 20 : 1;
 
 for (let i = 0; i < runTestsInLoopUpTo; i += 1) {
   if (longestTestIsPresent && step === lastStep) {


### PR DESCRIPTION
## Description
The E2E Stress test has been timing out almost every run. Lowering the amount of times for each test to run from 25 to 20 will hopefully fix this.

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/34250637/202769347-6254f4d3-0f79-4242-9b47-6b330d180492.png">

