### PR TITLE
Use a regular import for the minimal stylesheet

### DIFF
--- a/src/applications/check-in/pre-check-in/app-entry.jsx
+++ b/src/applications/check-in/pre-check-in/app-entry.jsx
@@ -1,6 +1,5 @@
 import 'platform/polyfills';
-import environment from 'platform/utilities/environment';
-// import 'platform/site-wide/sass/minimal.scss';
+import 'platform/site-wide/sass/minimal.scss';
 import '../sass/check-in.scss';
 
 import startApp from 'platform/startup';
@@ -11,10 +10,6 @@ import manifest from './manifest.json';
 
 import '../utils/i18n/i18n';
 import '../utils/defineWebComponents';
-
-if (!environment.isProduction()) {
-  import('platform/site-wide/sass/minimal.scss');
-}
 
 startApp({
   url: manifest.rootUrl,


### PR DESCRIPTION
## Description

This reverts https://github.com/department-of-veterans-affairs/vets-website/pull/22667/commits/017fb54a869467bb1b569e331ccd3def64239596 in #22667. We noticed on dev & staging that the compiled minimal stylesheet wasn't in the same S3 buckets as the other assets, so it wasn't able to find the fonts.

### Location of typical stylesheet

The `pre-check-in.css` stylesheet was build based off of the `.scss` import in the app's entry file, and deployed to an S3 bucket meant for assets:

![image](https://user-images.githubusercontent.com/2008881/202769799-aae977c4-6efa-4ac6-9d8b-2b59ce5bcb10.png)

### Location of dynamically imported stylesheet

The dynamic import meant that this stylesheet wasn't deployed to the same S3 bucket where the font files are.

![image](https://user-images.githubusercontent.com/2008881/202770005-8349287a-d004-4b73-be38-9a9939ca6a63.png)

That meant that CSS like this:

![image](https://user-images.githubusercontent.com/2008881/202770390-4f0b69c5-c4c1-46fd-a7f3-ce436061bd94.png)

Wasn't able to find the font files since they don't exist at `dev.va.gov/generated/fa-solid-900.eot`.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
