### PR TITLE
Add CST to allowlist

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -76,6 +76,10 @@
     {
       "rootFolder": "lgy",
       "slackGroup": "@benefits-app-builds"
+    },
+    {
+      "rootFolder": "claims-status",
+      "slackGroup": "@benefits-app-builds"
     }
   ]
 }


### PR DESCRIPTION
## Description
Adds the Claims Status Tool to the allowlist

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49834

## Acceptance criteria
- [x] `claims-status` app added to `config/changed-apps-build.json`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
