### PR TITLE
Bump Formation to version 7.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@department-of-veterans-affairs/component-library": "^13.3.0",
-    "@department-of-veterans-affairs/formation": "^7.0.2",
+    "@department-of-veterans-affairs/formation": "^7.0.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,10 +2544,10 @@
   dependencies:
     jsx-ast-utils "^3.3.3"
 
-"@department-of-veterans-affairs/formation@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.2.tgz#fa828af9c456c69d86cb9a9f7f216a1b9ba3c2d4"
-  integrity sha512-OfLkYXM3v8OVgtyh07xjTnhw0sVMH6ma5tghCxdbxCcRdcja+lYGrQr0WXhWIqPWP0s7aD783fVvF/pT9xfk0g==
+"@department-of-veterans-affairs/formation@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.3.tgz#452206ad64000179cba8eb9f7dd7e852eb1ae7b3"
+  integrity sha512-VDS/PQLSwh2pe4zD9idlx5vg/xwEr8+5jlY4Xm9SMPMk9zcS2BXRSZBVq4aDP0CEWat3qpoiOBZWgAy+OeLJDQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
We updated the base font color in https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/883 so this PR is to bump Formation in vets-website to apply that update.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/935

## Testing done
Local

## Screenshots

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
