### PR TITLE
Using startApp in favor of custom startup code

### DIFF
--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -1,46 +1,15 @@
 import 'platform/polyfills';
+import startApp from 'platform/startup';
 
 import './sass/claims-status.scss';
 
-import React from 'react';
-import { createHistory } from 'history';
-import { IndexRedirect, Route, Router, useRouterHistory } from 'react-router';
-import { Provider } from 'react-redux';
-
-import startReactApp from 'platform/startup/react';
-import createCommonStore from 'platform/startup/store';
-import startSitewideComponents from 'platform/site-wide';
-import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
-
-import { setLastPage } from './actions';
-import ClaimsStatusApp from './containers/ClaimsStatusApp';
 import manifest from './manifest.json';
 import routes from './routes';
 import reducer from './reducers';
 
-window.appName = manifest.entryName;
-
-const store = createCommonStore(reducer);
-connectFeatureToggle(store.dispatch);
-
-/* eslint-disable react-hooks/rules-of-hooks */
-const history = useRouterHistory(createHistory)({
-  basename: manifest.rootUrl,
+startApp({
+  entryName: manifest.entryName,
+  url: manifest.rootUrl,
+  reducer,
+  routes,
 });
-
-history.listen(location => {
-  store.dispatch(setLastPage(location.pathname));
-});
-
-startSitewideComponents(store);
-
-startReactApp(
-  <Provider store={store}>
-    <Router history={history}>
-      <Route path="/" component={ClaimsStatusApp}>
-        <IndexRedirect to="/your-claims" />
-        {routes}
-      </Route>
-    </Router>
-  </Provider>,
-);

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+
+import { setLastPage } from '../actions';
 import ClaimsAppealsUnavailable from '../components/ClaimsAppealsUnavailable';
 
 // This needs to be a React component for RequiredLoginView to pass down
@@ -18,7 +22,13 @@ function AppContent({ children, isDataAvailable }) {
   );
 }
 
-function ClaimsStatusApp({ user, children }) {
+function ClaimsStatusApp({ children, dispatchSetLastPage, router, user }) {
+  useEffect(() => {
+    router.listen(location => {
+      dispatchSetLastPage(location.pathname);
+    });
+  }, []);
+
   return (
     <RequiredLoginView
       verify
@@ -33,10 +43,24 @@ function ClaimsStatusApp({ user, children }) {
   );
 }
 
+ClaimsStatusApp.propTypes = {
+  children: PropTypes.object,
+  dispatchSetLastPage: PropTypes.func,
+  router: PropTypes.object,
+  user: PropTypes.object,
+};
+
 function mapStateToProps(state) {
   return { user: state.user };
 }
 
-export default connect(mapStateToProps)(ClaimsStatusApp);
+const mapDispatchToProps = {
+  dispatchSetLastPage: setLastPage,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withRouter(ClaimsStatusApp));
 
 export { ClaimsStatusApp, AppContent };

--- a/src/applications/claims-status/routes.jsx
+++ b/src/applications/claims-status/routes.jsx
@@ -14,57 +14,53 @@ import ClaimEstimationPage from './containers/ClaimEstimationPage';
 import AppealsV2StatusPage from './containers/AppealsV2StatusPage';
 import AppealsV2DetailPage from './containers/AppealsV2DetailPage';
 import AppealInfo from './containers/AppealInfo';
+import ClaimsStatusApp from './containers/ClaimsStatusApp';
 
-const routes = [
-  <Redirect
-    key="/track-claims/your-claims"
-    from="/disability-benefits/track-claims*"
-    to="/your-claims"
-  />,
-  <Route component={YourClaimsPageV2} key="/your-claims" path="/your-claims" />,
-  <Route
-    component={YourClaimLetters}
-    key="/your-claim-letters"
-    path="/your-claim-letters"
-  />,
-  /*
-  <Route
-    component={AppealLayout}
-    key="/appeals"
-    path="/appeals">
-    <Route
-      component={AppealStatusPage}
-      key=":id/status"
-      path=":id/status"/>,
-  </Route>,
-  */
-  <Route component={AppealInfo} key="/appeals/:id" path="/appeals/:id">
-    <IndexRedirect to="status" />
-    <Route component={AppealsV2StatusPage} key="status" path="status" />
-    <Route component={AppealsV2DetailPage} key="detail" path="detail" />
-  </Route>,
-  <Route component={ClaimPage} key="/your-claims/:id" path="/your-claims/:id">
-    <IndexRedirect to="status" />
-    <Route component={ClaimStatusPage} path="status" />,
-    <Route component={FilesPage} path="files" />,
-    <Route component={DetailsPage} path="details" />,
-    <Route component={AskVAPage} path="ask-va-to-decide" />,
-    <Route
-      component={DocumentRequestPage}
-      path="document-request/:trackedItemId"
+const routes = (
+  <Route path="/" component={ClaimsStatusApp}>
+    <IndexRedirect to="/your-claims" />
+    <Redirect
+      key="/track-claims/your-claims"
+      from="/disability-benefits/track-claims*"
+      to="/your-claims"
     />
     <Route
-      component={ClaimEstimationPage}
-      key="claim-estimate"
-      path="claim-estimate"
+      component={YourClaimsPageV2}
+      key="/your-claims"
+      path="/your-claims"
     />
-    ,
-  </Route>,
-  <Route
-    component={StemClaimStatusPage}
-    key="/your-stem-claims/:id/status"
-    path="/your-stem-claims/:id/status"
-  />,
-];
+    <Route
+      component={YourClaimLetters}
+      key="/your-claim-letters"
+      path="/your-claim-letters"
+    />
+    <Route component={AppealInfo} key="/appeals/:id" path="/appeals/:id">
+      <IndexRedirect to="status" />
+      <Route component={AppealsV2StatusPage} key="status" path="status" />
+      <Route component={AppealsV2DetailPage} key="detail" path="detail" />
+    </Route>
+    <Route component={ClaimPage} key="/your-claims/:id" path="/your-claims/:id">
+      <IndexRedirect to="status" />
+      <Route component={ClaimStatusPage} path="status" />,
+      <Route component={FilesPage} path="files" />,
+      <Route component={DetailsPage} path="details" />,
+      <Route component={AskVAPage} path="ask-va-to-decide" />,
+      <Route
+        component={DocumentRequestPage}
+        path="document-request/:trackedItemId"
+      />
+      <Route
+        component={ClaimEstimationPage}
+        key="claim-estimate"
+        path="claim-estimate"
+      />
+    </Route>
+    <Route
+      component={StemClaimStatusPage}
+      key="/your-stem-claims/:id/status"
+      path="/your-stem-claims/:id/status"
+    />
+  </Route>
+);
 
 export default routes;


### PR DESCRIPTION
## Description
Using startApp in favor of custom startup code. This will allow us to be more future-proof and avoid further incidents with the current custom startup code.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#49861

## Testing done
Tests still pass

## Acceptance criteria
- [x] SET_LAST_PAGE redux action is still being fired on route changes
- [x] `startApp` is being used instead of custom startup code

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
