### PR TITLE
Migrate to va-telephone component in secure messaging

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/UnauthContent/index.js
@@ -102,11 +102,7 @@ export const UnauthContent = () => (
     </p>
     <ul>
       <li>
-        Call{' '}
-        <a href="tel:988" aria-label="9 8 8">
-          988
-        </a>
-        , then select 1.
+        Call <va-telephone contact="988" />, then select 1.
       </li>
       <li>
         Start a{' '}
@@ -119,11 +115,7 @@ export const UnauthContent = () => (
         .
       </li>
       <li>
-        Text{' '}
-        <a href="tel:838255" aria-label="8 3 8 2 5 5">
-          838255
-        </a>
-        .
+        Text: <va-telephone contact="838255" sms />.
       </li>
     </ul>
     <h2>Can I use secure messaging with community (non-VA) providers?</h2>
@@ -156,13 +148,8 @@ export const UnauthContent = () => (
       </li>
       <li>
         Call the My HealtheVet help desk at{' '}
-        <a href="tel:18773270022" aria-label="8 7 7. 3 2 7. 0 0 2 2.">
-          877-327-0022
-        </a>{' '}
-        (
-        <a href=" tel:18008778339." aria-label=" TTY. 8 0 0. 8 7 7. 8 3 3 9.">
-          TTY: 800-877-8339
-        </a>
+        <va-telephone contact="8773270022" /> (
+        <va-telephone contact="8008778339" tty />
         ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
       </li>
       <li>


### PR DESCRIPTION
## Description
Switches phone numbers  in secure messaging to the new va-telephone component.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10868


## Testing done
Local visual testing and verified on test environment

## Screenshots
<img width="1126" alt="Screen Shot 2022-11-21 at 9 29 38 AM" src="https://user-images.githubusercontent.com/61624970/203080251-fa294daf-2a1b-4891-b0a4-e246c8d450a9.png">


## Acceptance criteria
## Acceptance Criteria

- [x] Update presentation of the SMS number to have colon after label, e.g. Text: [838255]()
- [x] change the href on this text link on the [secure-messaging page](https://staging.va.gov/health-care/secure-messaging/) to `sms:838255`. [Per [design system notes](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1246#issuecomment-1298566047), `Text: <a href="sms:838255" aria-label="8 3 8 3 5 5.">838255</a>`]
- [x] verify whether the disable-eslint comment that Ryan added is still necessary; remove if appropriate
- [x] search codebase for `838255` to make sure there aren't other instances of the number with `tel`
  - [x] fix any you find (within reason)
- [ ] test page in staging to confirm that tapping the number opens your SMS app instead of phone app
- [x] recommend (and ticket) whether the main VCL (Crisis Line) modal should be updated to use `<va-telephone>` also _whilst ensuring that component is made available to injected headers_

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
