### PR TITLE
Mhv 38408 Message Details defects + Custom Folder breadcrumbs

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ReplyHeader.jsx
+++ b/src/applications/mhv/secure-messaging/components/ReplyHeader.jsx
@@ -1,11 +1,22 @@
-import React from 'react';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import React, { useEffect, useRef } from 'react';
 import EmergencyNote from './EmergencyNote';
 
-const ReplyHeader = () => (
-  <header>
-    <h1>Reply</h1>
-    <EmergencyNote />
-  </header>
-);
+const ReplyHeader = () => {
+  const header = useRef();
+  useEffect(
+    () => {
+      focusElement(header.current);
+    },
+    [header],
+  );
+
+  return (
+    <header>
+      <h1 ref={header}>Reply</h1>
+      <EmergencyNote />
+    </header>
+  );
+};
 
 export default ReplyHeader;

--- a/src/applications/mhv/secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -18,22 +18,12 @@ const SmBreadcrumbs = () => {
 
   useEffect(
     () => {
-      const paths = [
-        {
-          path: `/message`,
-          label: messageDetails?.subject,
-        },
+      let paths = [
+        { path: `/message`, label: messageDetails?.subject },
         { path: '/reply', label: messageDetails?.subject },
         Constants.Breadcrumbs.COMPOSE,
         Constants.Breadcrumbs.DRAFT,
         Constants.Breadcrumbs.DRAFTS,
-        {
-          path: `/folder/${
-            activeFolder?.folderId
-            // ${messageDetails?.messageId}
-          }`,
-          label: activeFolder?.name,
-        },
         Constants.Breadcrumbs.FOLDERS,
         Constants.Breadcrumbs.SENT,
         Constants.Breadcrumbs.TRASH,
@@ -46,6 +36,19 @@ const SmBreadcrumbs = () => {
         },
         Constants.Breadcrumbs.FAQ,
       ];
+
+      if (activeFolder?.folderId) {
+        paths = [
+          ...paths,
+          {
+            path: `/folder`,
+            label: 'My folders',
+            children: [
+              { path: `/${activeFolder?.folderId}`, label: activeFolder?.name },
+            ],
+          },
+        ];
+      }
 
       function handleBreadCrumbs() {
         const arr = [];
@@ -71,7 +74,9 @@ const SmBreadcrumbs = () => {
               const child = path.children.find(
                 item => item.path.substring(1) === locationChildPath,
               );
-              arr.push(child);
+              if (child) {
+                arr.push(child);
+              }
             }
           }
         });

--- a/src/applications/mhv/secure-messaging/containers/Compose.jsx
+++ b/src/applications/mhv/secure-messaging/containers/Compose.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams, useHistory } from 'react-router-dom';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { clearDraft } from '../actions/draftDetails';
 import { retrieveMessage } from '../actions/messages';
 import { getTriageTeams } from '../actions/triageTeams';
@@ -19,6 +20,7 @@ const Compose = () => {
   const location = useLocation();
   const history = useHistory();
   const isDraftPage = location.pathname.includes('/draft');
+  const header = useRef();
 
   useEffect(
     () => {
@@ -36,6 +38,13 @@ const Compose = () => {
       }
     },
     [isDraftPage, draftId, activeFolder, dispatch, history],
+  );
+
+  useEffect(
+    () => {
+      focusElement(header.current);
+    },
+    [header],
   );
 
   let pageTitle;
@@ -72,7 +81,9 @@ const Compose = () => {
   return (
     <div className="vads-l-grid-container compose-container">
       <AlertBackgroundBox closeable />
-      <h1 className="page-title">{pageTitle}</h1>
+      <h1 className="page-title" ref={header}>
+        {pageTitle}
+      </h1>
       <EmergencyNote />
       <div>
         <BeforeMessageAddlInfo />

--- a/src/applications/mhv/secure-messaging/containers/MessageDetails.jsx
+++ b/src/applications/mhv/secure-messaging/containers/MessageDetails.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams, useHistory } from 'react-router-dom';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui/index';
 import NavigationLinks from '../components/NavigationLinks';
 import MessageThread from '../components/MessageThread/MessageThread';
 import { retrieveMessage } from '../actions/messages';
@@ -21,6 +22,7 @@ const MessageDetail = () => {
   const activeFolder = useSelector(state => state.sm.folders.folder);
   const location = useLocation();
   const history = useHistory();
+  const header = useRef();
 
   useEffect(
     () => {
@@ -36,6 +38,13 @@ const MessageDetail = () => {
     [dispatch, location, messageId, activeFolder, history],
   );
 
+  useEffect(
+    () => {
+      focusElement(header.current);
+    },
+    [header],
+  );
+
   let pageTitle;
 
   if (isSent) {
@@ -49,7 +58,9 @@ const MessageDetail = () => {
   return (
     <div className="vads-l-grid-container vads-u-margin-top--2 message-detail-container">
       <AlertBackgroundBox closeable />
-      <h1 className="vads-u-margin-top--2">{pageTitle}</h1>
+      <h1 className="vads-u-margin-top--2" ref={header}>
+        {pageTitle}
+      </h1>
 
       {message === undefined && (
         <va-loading-indicator

--- a/src/applications/mhv/secure-messaging/sass/compose.scss
+++ b/src/applications/mhv/secure-messaging/sass/compose.scss
@@ -47,6 +47,8 @@
       }
       h3 {
         margin: 0;
+        width: 80%;
+        overflow-wrap: break-word;
       }
     }
     .send-button-top {

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -33,6 +33,11 @@
       h3 {
         margin: none;
       }
+      h2 {
+        margin: 0;
+        width: 80%;
+        overflow-wrap: break-word;
+      }
     }
     .message-body {
       margin: 30px 0;
@@ -104,11 +109,10 @@
   display: none;
 }
 
-
 @media print {
   body {
     .secure-messaging-navigation {
-    display: none;
+      display: none;
     }
     .breadcrumbs {
       display: none;
@@ -136,8 +140,6 @@
     top: 0;
     .message-action-buttons {
       display: none;
-
     }
   }
-
 }

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -68,7 +68,7 @@ export const Breadcrumbs = {
   },
   DRAFTS: { path: '/drafts', label: 'Drafts' },
   DRAFT: { path: '/draft', label: 'Drafts' },
-  FOLDERS: { path: '/folders', label: 'Folders' },
+  FOLDERS: { path: '/folders', label: 'My folders' },
   SENT: { path: '/sent', label: 'Sent messages' },
   TRASH: { path: '/trash', label: 'Trash' },
   SEARCH: { path: '/search', label: 'Search messages' },


### PR DESCRIPTION
## Description

1. Navigation to message detail
    GIVEN User is on Message List view (i.e. Inbox)
    AND Scrolls further down to the bottom of the list
    WHEN navigating to Message Details by clicking on message link
    THEN User should be focused back to the message instead of remaining around the footer area and not seeing a message 

2. Long subject offsets action buttons
3. Fixing breadcrumbs on custom folder

## Original issue(s)
[SM to VA.gov: Defect - Focus on Message Details header](https://vajira.max.gov/browse/MHV-38408)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
