### PR TITLE
Add two new sass modules to minimal stylesheet

### DIFF
--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -2,6 +2,7 @@
 @import "modules/m-overrides";
 
 @import "~uswds/src/stylesheets/core/variables";
+@import "~uswds/src/stylesheets/core/base";
 @import "~uswds/src/stylesheets/core/fonts";
 @import "~uswds/src/stylesheets/core/utilities";
 @import "~uswds/src/stylesheets/core/grid";
@@ -23,6 +24,7 @@
 
 @import "~@department-of-veterans-affairs/formation/sass/base/b-font-faces";
 @import "~@department-of-veterans-affairs/formation/sass/base/va";
+@import "~@department-of-veterans-affairs/formation/sass/base/b-utils";
 @import "~@department-of-veterans-affairs/formation/sass/layout/flex-grid";
 
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-megamenu";


### PR DESCRIPTION
## Description

The `core/base` import from `uswds` is for the focus mixin with the gold color and the `base/b-utils` import from `formation` is for mobile styling.


## Testing done
Visual check

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/2008881/203144499-12ebef89-4d76-46ec-ac21-c07a6fad6939.png)

### After

![image](https://user-images.githubusercontent.com/2008881/203144584-c47e2b6b-6685-4d42-975f-79aed958d280.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
