### PR TITLE
Add screenshots for btsss errors

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -86,5 +86,7 @@ DOB validation page day-of: `yarn cy:run --env with_screenshots=true --spec src/
 
 Phone appointments PCI: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-phone.pci.cypress.spec.js`
 
+Travel Pay PCI: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js`
+
 ### Adding additional screenshots
 There is a cypress command that gets imported in our local commands named `createScreenshots`. It is best used after an axe check on the page you wish to capture. Add cy.createScreenshots([filename]) and also make sure that the test is imported in one of the screenshot scripts listed above. Filename syntax should be `application--page-name` example: `Pre-check-in--Validate-with-DOB`. The command will automatically get screenshots for translated versions of the page.

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
@@ -68,6 +68,7 @@ describe('Check In Experience', () => {
       TravelPages.attemptToGoToNextPage();
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Day-of-check-in--travel-pay--appointments');
       Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssSubmission();
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
@@ -51,25 +51,22 @@ describe('Check In Experience', () => {
       ApiInitializer.initializeBtsssPost.withFailure(400, 'CLM_011_LOL_DUNNO');
       TravelPages.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--travel-question');
       TravelPages.attemptToGoToNextPage();
       TravelPages.validatePageLoaded('vehicle');
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--vehicle-question');
       TravelPages.attemptToGoToNextPage();
       TravelPages.validatePageLoaded('address');
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--address-question');
       TravelPages.attemptToGoToNextPage();
       TravelPages.validatePageLoaded('mileage');
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--mileage-question');
       TravelPages.attemptToGoToNextPage();
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssGenericFailure();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Day-of-check-in--travel-pay--btsss-generic-error');
     });
     it('shows the correct error message for travel claim exists api error.', () => {
       ApiInitializer.initializeBtsssPost.withFailure(
@@ -78,25 +75,24 @@ describe('Check In Experience', () => {
       );
       TravelPages.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--travel-question');
       TravelPages.attemptToGoToNextPage();
       TravelPages.validatePageLoaded('vehicle');
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--vehicle-question');
       TravelPages.attemptToGoToNextPage();
       TravelPages.validatePageLoaded('address');
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--address-question');
       TravelPages.attemptToGoToNextPage();
       TravelPages.validatePageLoaded('mileage');
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--mileage-question');
       TravelPages.attemptToGoToNextPage();
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssTravelClaimExistsFailure();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Day-of-check-in--travel-pay--btsss-travel-claim-exists',
+      );
     });
   });
 });

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js
@@ -1,6 +1,7 @@
 (async () => {
   if (Cypress.env('with_screenshots')) {
     await import('../../../day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec');
+    await import('../../../day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec');
   }
 })();
 describe('Screenshots day-of travel pay', () => {


### PR DESCRIPTION
## Description

Adds screenshots for btsss errors

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done

cypress

## Screenshots


![Day-of-check-in--travel-pay--travel-question](https://user-images.githubusercontent.com/2982977/203162584-4d23fedb-87c5-4eb5-ba4e-6440b6ca21eb.png)
![Day-of-check-in--travel-pay--address-question](https://user-images.githubusercontent.com/2982977/203162564-a8e25d20-47be-4fa7-bbba-e38558a89193.png)
![Day-of-check-in--travel-pay--mileage-question](https://user-images.githubusercontent.com/2982977/203162581-3ba87d58-e071-4696-b3c3-88238d5d36cc.png)
![Day-of-check-in--travel-pay--vehicle-question](https://user-images.githubusercontent.com/2982977/203162585-048cb60a-18c8-44fc-ae94-76c5ab645e48.png)
![Day-of-check-in--travel-pay--appointments](https://user-images.githubusercontent.com/2982977/203162568-0c096af1-9fa8-4b21-9fe3-6b044b2e70c6.png)
![Day-of-check-in--travel-pay--btsss-generic-error](https://user-images.githubusercontent.com/2982977/203162570-f0505b6d-a22b-4c68-a8bf-3712bf41b1e4.png)
![Day-of-check-in--travel-pay--btsss-travel-claim-exists](https://user-images.githubusercontent.com/2982977/203162571-f0d47e0f-4fbe-4f67-9b06-652310dee523.png)
![Day-of-check-in--travel-pay--confirmation-ineligible](https://user-images.githubusercontent.com/2982977/203162574-36acc6d7-ceb6-4785-9689-4526147e1f48.png)
![Day-of-check-in--travel-pay--confirmation-no-claim-success](https://user-images.githubusercontent.com/2982977/203162577-fca9579d-cb12-48d3-ad42-400d44d4fe3e.png)
![Day-of-check-in--travel-pay--confirmation-success](https://user-images.githubusercontent.com/2982977/203162580-f6fd37ac-7e1a-4482-b987-6d88312f9fe7.png)



## Acceptance criteria
- [ ] Takes all the screenshots

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
