### PR TITLE
49913 - Revert pending requests filtering back to using the Created Date

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -226,7 +226,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
               .subtract(120, 'days')
               .format('YYYY-MM-DD'),
             endDate: moment()
-              .add(featureVAOSServiceRequests ? 121 : 0, 'days')
+              .add(featureVAOSServiceRequests ? 1 : 0, 'days')
               .format('YYYY-MM-DD'),
             useV2: featureVAOSServiceRequests,
             useAcheron: featureAcheronVAOSServiceRequests,
@@ -358,7 +358,7 @@ export function fetchPendingAppointments() {
           .subtract(120, 'days')
           .format('YYYY-MM-DD'),
         endDate: moment()
-          .add(featureVAOSServiceRequests ? 121 : 0, 'days')
+          .add(featureVAOSServiceRequests ? 1 : 0, 'days')
           .format('YYYY-MM-DD'),
         useV2: featureVAOSServiceRequests,
         useAcheron: featureAcheronVAOSServiceRequests,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.jsx
@@ -101,7 +101,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
           .subtract(120, 'days')
           .format('YYYY-MM-DD'),
         end: moment()
-          .add(121, 'days')
+          .add(1, 'days')
           .format('YYYY-MM-DD'),
         statuses: ['proposed', 'cancelled'],
         requests: [appointment, canceledAppointment],
@@ -196,7 +196,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
           .subtract(120, 'days')
           .format('YYYY-MM-DD'),
         end: moment()
-          .add(121, 'days')
+          .add(1, 'days')
           .format('YYYY-MM-DD'),
         statuses: ['proposed', 'cancelled'],
         requests: [appointment],
@@ -245,7 +245,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
           .subtract(120, 'days')
           .format('YYYY-MM-DD'),
         end: moment()
-          .add(121, 'days')
+          .add(1, 'days')
           .format('YYYY-MM-DD'),
         statuses: ['proposed', 'cancelled'],
         requests: [{}],
@@ -338,7 +338,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
           .subtract(120, 'days')
           .format('YYYY-MM-DD'),
         end: moment()
-          .add(121, 'days')
+          .add(1, 'days')
           .format('YYYY-MM-DD'),
         statuses: ['proposed', 'cancelled'],
         requests: [appointment],

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -310,7 +310,7 @@ describe('VAOS <RequestedAppointmentsList> with the VAOS service', () => {
         .subtract(120, 'days')
         .format('YYYY-MM-DD'),
       end: moment()
-        .add(121, 'days')
+        .add(1, 'days')
         .format('YYYY-MM-DD'),
       statuses: ['proposed', 'cancelled'],
       requests: [appointment],
@@ -374,7 +374,7 @@ describe('VAOS <RequestedAppointmentsList> with the VAOS service', () => {
         .subtract(120, 'days')
         .format('YYYY-MM-DD'),
       end: moment()
-        .add(121, 'days')
+        .add(1, 'days')
         .format('YYYY-MM-DD'),
       statuses: ['proposed', 'cancelled'],
       requests: [ccAppointmentRequest],
@@ -492,7 +492,7 @@ describe('VAOS <RequestedAppointmentsList> with the VAOS service', () => {
         .subtract(120, 'days')
         .format('YYYY-MM-DD'),
       end: moment()
-        .add(121, 'days')
+        .add(1, 'days')
         .format('YYYY-MM-DD'),
       statuses: ['proposed', 'cancelled'],
       requests: [appointment, appointment2, appointment3],


### PR DESCRIPTION
This reverts this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/22626) 

## Description

https://github.com/department-of-veterans-affairs/va.gov-team/issues/49913
## Original issue(s)
[department-of-veterans-affairs/va.gov-team#49913](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49913)


## Testing done
- e2e testing
- unit testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
