### PR TITLE
Claims Status - change to use apiRequest

### DIFF
--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -586,7 +586,9 @@ export function getStemClaims() {
   return dispatch => {
     dispatch({ type: FETCH_STEM_CLAIMS_PENDING });
 
-    if (USE_MOCKS) return getStemClaimsMock(dispatch);
+    if (USE_MOCKS) {
+      return getStemClaimsMock(dispatch);
+    }
 
     return makeAuthRequest(
       '/v0/education_benefits_claims/stem_claim_status',
@@ -594,7 +596,6 @@ export function getStemClaims() {
       dispatch,
       res => {
         const stemClaims = res.data.map(addAttributes).filter(automatedDenial);
-
         dispatch({
           type: FETCH_STEM_CLAIMS_SUCCESS,
           stemClaims,

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1,9 +1,10 @@
 import merge from 'lodash/merge';
-import * as Sentry from '@sentry/browser';
+// import * as Sentry from '@sentry/browser';
 
 import environment from 'platform/utilities/environment';
-import localStorage from 'platform/utilities/storage/localStorage';
-import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
+// import localStorage from 'platform/utilities/storage/localStorage';
+import { apiRequest } from 'platform/utilities/api';
+// import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import { SET_UNAUTHORIZED } from '../actions/types';
 
 const evidenceGathering = 'Evidence gathering, review, and decision';
@@ -258,42 +259,18 @@ export function makeAuthRequest(
   onSuccess,
   onError,
 ) {
-  const csrfTokenStored = localStorage.getItem('csrfToken');
   const options = merge(
     {},
     {
       method: 'GET',
       credentials: 'include',
       mode: 'cors',
-      headers: {
-        'X-Key-Inflection': 'camel',
-        'Source-App-Name': window.appName,
-        'X-CSRF-Token': csrfTokenStored,
-      },
       responseType: 'json',
     },
     userOptions,
   );
 
-  fetch(`${environment.API_URL}${url}`, options)
-    .catch(err => {
-      Sentry.withScope(scope => {
-        scope.setExtra('error', err);
-        Sentry.captureMessage(`vets_client_error: ${err.message}`);
-      });
-
-      return Promise.reject(err);
-    })
-    .then(resp => {
-      if (resp.ok) {
-        if (options.responseType) {
-          return resp[options.responseType]();
-        }
-        return Promise.resolve();
-      }
-
-      return Promise.reject(resp);
-    })
+  apiRequest(`${environment.API_URL}${url}`, options)
     .then(onSuccess)
     .catch(resp => {
       if (resp.status === 401) {


### PR DESCRIPTION
## Description
This PR replaces the `fetchAndUpdateSSOeSession` with `apiRequest` for the `claims-status` application in order to be complient with OAuth session management.

Things that changed:
- Replace `fetchAndUpdateSSOeSession as fetch` with `apiRequest` in `helpers.js`
- Removes instance of mocking global fetch
- Replaces mocking global fetch with `msw`

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#48737


## Testing done
Unit tests / manual / E2E

## Screenshots
n/a

## Acceptance criteria
Using Sign in Service (OAuth) 
1. Open Sign in Modal > Ensure `oauth=true` is appended
- [x] When the Sign in Service access token expires, a `/refresh` is called after a `403: Access token is expired` is retrieved

Using eAuth/IAM
1. Open Sign in Modal > Ensure `oauth=false` is appended
- [x] Ensure that a `401` or `403` signs a user out

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
