### PR TITLE
[VA-10656] Remove covid_vaccine_scheduling_frontend flipper

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -28,7 +28,6 @@ import UrgentCareResult from './search-results-items/UrgentCareResult';
 import EmergencyCareResult from './search-results-items/EmergencyCareResult';
 import Covid19Result from './search-results-items/Covid19Result';
 import SearchResultMessage from './SearchResultMessage';
-import { covidVaccineSchedulingFrontend } from '../utils/featureFlagSelectors';
 
 export const ResultsList = ({
   facilityTypeName,
@@ -88,9 +87,6 @@ export const ResultsList = ({
                 location={result}
                 key={result.id}
                 index={index}
-                showCovidVaccineSchedulingLinks={
-                  props.showCovidVaccineSchedulingLinks
-                }
                 showCovidVaccineWalkInAvailabilityText={
                   (walkInsAccepted || '').toLowerCase() === 'true'
                 }
@@ -278,7 +274,6 @@ ResultsList.propTypes = {
   results: PropTypes.array,
   searchError: PropTypes.object,
   searchString: PropTypes.string,
-  showCovidVaccineSchedulingLinks: PropTypes.string,
 };
 
 function mapDispatchToProps(dispatch) {
@@ -314,7 +309,6 @@ function mapStateToProps(state) {
     searchString,
     selectedResult: state.searchResult.selectedResult,
     resultTime: state.searchResult.resultTime,
-    showCovidVaccineSchedulingLinks: covidVaccineSchedulingFrontend(state),
     facilityLocatorShowHealthConnectNumber: toggleValues(state)[
       FEATURE_FLAG_NAMES.facilityLocatorShowHealthConnectNumber
     ],

--- a/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
+++ b/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
@@ -14,7 +14,6 @@ import CovidPhoneLink from './common/Covid19PhoneLink';
 const Covid19Result = ({
   location,
   index,
-  showCovidVaccineSchedulingLinks,
   showCovidVaccineWalkInAvailabilityText,
 }) => {
   const {
@@ -65,20 +64,19 @@ const Covid19Result = ({
           )}
         <LocationAddress location={location} />
         <LocationDirectionsLink location={location} from="SearchResult" />
-        {showCovidVaccineSchedulingLinks &&
-          covidSchedulingAvailable && (
-            <a
-              className="vads-c-action-link--blue vads-u-margin-bottom--1 vads-u-display--inline-block vads-u-margin-top--0"
-              href="/health-care/schedule-view-va-appointments/appointments/"
-              onClick={() =>
-                recordEvent({
-                  'cta-action-link-click': 'fl-schedule-covid-vaccine',
-                })
-              }
-            >
-              Schedule an appointment online
-            </a>
-          )}
+        {covidSchedulingAvailable && (
+          <a
+            className="vads-c-action-link--blue vads-u-margin-bottom--1 vads-u-display--inline-block vads-u-margin-top--0"
+            href="/health-care/schedule-view-va-appointments/appointments/"
+            onClick={() =>
+              recordEvent({
+                'cta-action-link-click': 'fl-schedule-covid-vaccine',
+              })
+            }
+          >
+            Schedule an appointment online
+          </a>
+        )}
         {showCovidVaccineWalkInAvailabilityText && (
           <strong className="vads-u-margin-bottom--2 vads-u-display--block">
             Walk-ins accepted
@@ -87,9 +85,7 @@ const Covid19Result = ({
         {appointmentPhone ? (
           <CovidPhoneLink
             phone={appointmentPhone}
-            showCovidVaccineSchedulingLink={
-              showCovidVaccineSchedulingLinks && covidSchedulingAvailable
-            }
+            showCovidVaccineSchedulingLink={covidSchedulingAvailable}
             showCovidVaccineWalkInAvailabilityText={
               showCovidVaccineWalkInAvailabilityText
             }
@@ -122,7 +118,6 @@ Covid19Result.propTypes = {
   location: PropTypes.object,
   query: PropTypes.object,
   index: PropTypes.number,
-  showCovidVaccineSchedulingLinks: PropTypes.bool,
   showCovidVaccineWalkInAvailabilityText: PropTypes.bool,
 };
 

--- a/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
+++ b/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import recordEvent from 'platform/monitoring/record-event';
 import LocationDirectionsLink from './common/LocationDirectionsLink';
 import { isVADomain } from '../../utils/helpers';
 import { recordResultClickEvents } from '../../utils/analytics';
@@ -21,15 +20,12 @@ const Covid19Result = ({
     website,
     operatingStatus,
     detailedServices,
-    tmpCovidOnlineScheduling,
     phone,
   } = location.attributes;
   const appointmentPhone = detailedServices
     ? detailedServices[0]?.appointmentPhones[0]
     : null;
   const infoURL = detailedServices ? detailedServices[0]?.path : null;
-  const covidSchedulingAvailable =
-    tmpCovidOnlineScheduling || detailedServices?.onlineSchedulingAvailable;
 
   return (
     <div className="facility-result" id={location.id} key={location.id}>
@@ -64,19 +60,6 @@ const Covid19Result = ({
           )}
         <LocationAddress location={location} />
         <LocationDirectionsLink location={location} from="SearchResult" />
-        {covidSchedulingAvailable && (
-          <a
-            className="vads-c-action-link--blue vads-u-margin-bottom--1 vads-u-display--inline-block vads-u-margin-top--0"
-            href="/health-care/schedule-view-va-appointments/appointments/"
-            onClick={() =>
-              recordEvent({
-                'cta-action-link-click': 'fl-schedule-covid-vaccine',
-              })
-            }
-          >
-            Schedule an appointment online
-          </a>
-        )}
         {showCovidVaccineWalkInAvailabilityText && (
           <strong className="vads-u-margin-bottom--2 vads-u-display--block">
             Walk-ins accepted
@@ -85,7 +68,6 @@ const Covid19Result = ({
         {appointmentPhone ? (
           <CovidPhoneLink
             phone={appointmentPhone}
-            showCovidVaccineSchedulingLink={covidSchedulingAvailable}
             showCovidVaccineWalkInAvailabilityText={
               showCovidVaccineWalkInAvailabilityText
             }

--- a/src/applications/facility-locator/components/search-results-items/common/Covid19PhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/Covid19PhoneLink.jsx
@@ -4,7 +4,6 @@ import { parsePhoneNumber } from '../../../utils/phoneNumbers';
 
 const Covid19PhoneLink = ({
   phone,
-  showCovidVaccineSchedulingLink,
   showCovidVaccineWalkInAvailabilityText,
   labelId,
 }) => {
@@ -20,9 +19,7 @@ const Covid19PhoneLink = ({
 
   const { extension: parsedExtension, contact } = parsePhoneNumber(number);
 
-  let labelText = showCovidVaccineSchedulingLink
-    ? 'Or call to schedule'
-    : 'Call to schedule';
+  let labelText = 'Call to schedule';
 
   if (showCovidVaccineWalkInAvailabilityText) {
     labelText = 'Or make an appointment';

--- a/src/applications/facility-locator/tests/components/search-results/common/Covid19PhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/common/Covid19PhoneLink.unit.spec.jsx
@@ -21,22 +21,6 @@ describe('Covid19PhoneLink', () => {
     wrapper.unmount();
   });
 
-  it('Should render correct labelText', () => {
-    const phone = {
-      number: '999-456-7890',
-    };
-    const wrapper = shallow(
-      <Covid19PhoneLink phone={phone} showCovidVaccineSchedulingLink />,
-    );
-    expect(
-      wrapper
-        .find('strong')
-        .text()
-        .trim(),
-    ).to.equal('Or call to schedule:');
-    wrapper.unmount();
-  });
-
   it('Should render with number and extension', () => {
     const phone = {
       number: '999-456-7890',

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -25,9 +25,6 @@ export const facilityLocatorShowOperationalHoursSpecialInstructions = state =>
     FEATURE_FLAG_NAMES.facilityLocatorShowOperationalHoursSpecialInstructions
   ];
 
-export const covidVaccineSchedulingFrontend = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.covidVaccineSchedulingFrontend];
-
 export const facilityLocatorLatLongOnly = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilityLocatorLatLongOnly];
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -29,7 +29,6 @@ export default Object.freeze({
   combinedDebtPortalAccess: 'combined_debt_portal_access',
   combinedFinancialStatusReport: 'combined_financial_status_report',
   combinedFinancialStatusReportEnhancements: 'combined_financial_status_report_enhancements',
-  covidVaccineSchedulingFrontend: 'covid_vaccine_scheduling_frontend',
   covidVaccineUpdatesCTA: 'covid_vaccine_registration_frontend_cta',
   covidVaccineUpdatesDisableAuth:
     'covid_vaccine_registration_frontend_hide_auth',


### PR DESCRIPTION
## Description

The `covid_vaccine_scheduling_frontend` flipper was never fully implemented, so the front-end code for it is good to remove.

## Original issue(s)

department-of-veterans-affairs/va.gov-cms#10656

## Testing done

Code search

## Acceptance criteria
- [ ] All references to `covid_vaccine_scheduling_frontend` are removed from the front-end without anything breaking.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
