### PR TITLE
[VA-10656] Remove facility_locator_predictive_location_search flipper

### DIFF
--- a/src/applications/facility-locator/actions/mapbox/genBBoxFromAddress.js
+++ b/src/applications/facility-locator/actions/mapbox/genBBoxFromAddress.js
@@ -63,14 +63,7 @@ export const genBBoxFromAddress = (query, expandedRadius = false) => {
 
         dispatch({
           type: GEOCODE_COMPLETE,
-          payload: query.usePredictiveGeolocation
-            ? features.map(feature => ({
-                placeName: feature.place_name,
-                placeType: feature.place_type[0],
-                bbox: feature.bbox,
-                center: feature.center,
-              }))
-            : [],
+          payload: [],
         });
 
         const searchBoundingRadius = expandedRadius

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -25,7 +25,6 @@ import {
   facilitiesPpmsSuppressAll,
   facilitiesPpmsSuppressCommunityCare,
   facilitiesPpmsSuppressPharmacies,
-  facilityLocatorPredictiveLocationSearch,
   facilityLocatorLighthouseCovidVaccineQuery,
 } from '../utils/featureFlagSelectors';
 import ResultsList from '../components/ResultsList';
@@ -438,11 +437,8 @@ const FacilitiesMap = props => {
           <div id="search-result-emergency-care-info">
             <p className="search-result-emergency-care-subheader">
               <strong>Note:</strong> If you think your life or health is in
-              danger, call{' '}
-              <a aria-label="9 1 1" href="tel:911">
-                911
-              </a>{' '}
-              or go to the nearest emergency department right away.
+              danger, call <va-telephone contact="911" /> or go to the nearest
+              emergency department right away.
             </p>
           </div>
         )}
@@ -667,7 +663,6 @@ const mapStateToProps = state => ({
   suppressPPMS: facilitiesPpmsSuppressAll(state),
   suppressPharmacies: facilitiesPpmsSuppressPharmacies(state),
   suppressCCP: facilitiesPpmsSuppressCommunityCare(state),
-  usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),
   searchCovid19Vaccine: facilityLocatorLighthouseCovidVaccineQuery(state),
   results: state.searchResult.results,
   searchError: state.searchResult.error,

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -10,11 +10,6 @@ export const facilitiesPpmsSuppressPharmacies = state =>
 export const facilitiesPpmsSuppressCommunityCare = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressCommunityCare];
 
-export const facilityLocatorPredictiveLocationSearch = state =>
-  toggleValues(state)[
-    FEATURE_FLAG_NAMES.facilityLocatorPredictiveLocationSearch
-  ];
-
 export const facilityLocatorLighthouseCovidVaccineQuery = state =>
   toggleValues(state)[
     FEATURE_FLAG_NAMES.facilityLocatorLighthouseCovidVaccineQuery

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -53,8 +53,6 @@ export default Object.freeze({
   facilityLocatorLighthouseCovidVaccineQuery:
     'facility_locator_lighthouse_covid_vaccine_query',
   facilityLocatorShowHealthConnectNumber: 'facility_locator_show_health_connect_number',
-  facilityLocatorPredictiveLocationSearch:
-    'facility_locator_predictive_location_search',
   facilityLocatorRailsEngine: 'facility_locator_rails_engine',
   facilityLocatorRestoreCommunityCarePagination:
     'facility_locator_restore_community_care_pagination',


### PR DESCRIPTION
## Description

The `facility_locator_predictive_location_search` flipper was explored but never fully implemented, so the front-end code for it is good to remove.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10656

## Testing done

Code search

## Acceptance criteria
- [ ] All references to `facility_locator_predictive_location_search` are removed from the front-end without anything breaking.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
