### PR TITLE
11467 Adds Google Analytics events for new Homepage

### DIFF
--- a/src/applications/static-pages/homepage/HomepageSearch.jsx
+++ b/src/applications/static-pages/homepage/HomepageSearch.jsx
@@ -76,6 +76,7 @@ const HomepageSearch = () => {
     // Record the analytic event.
     recordEvent({
       event: 'view_search_results',
+      action: 'Homepage - Search',
       'search-page-path': searchUrl,
       'search-query': e.target.value,
       'search-results-total-count': null,

--- a/src/applications/static-pages/homepage/HomepageSearch.jsx
+++ b/src/applications/static-pages/homepage/HomepageSearch.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { VaSearchInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
-import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
-import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+import recordEvent from 'platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
 
 /**
  * Homepage redesign

--- a/src/applications/static-pages/homepage/HomepageSearch.jsx
+++ b/src/applications/static-pages/homepage/HomepageSearch.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { VaSearchInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
-
-import { apiRequest } from 'platform/utilities/api';
+import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 
 /**
  * Homepage redesign
@@ -72,6 +72,23 @@ const HomepageSearch = () => {
     const searchUrl = `https://www.va.gov/search/?query=${encodeURIComponent(
       e.target.value,
     )}&t=${false}`;
+
+    // Record the analytic event.
+    recordEvent({
+      event: 'view_search_results',
+      'search-page-path': searchUrl,
+      'search-query': e.target.value,
+      'search-results-total-count': null,
+      'search-results-total-pages': null,
+      'search-selection': 'All VA.gov',
+      'search-typeahead-enabled': false,
+      'search-location': 'Homepage Search',
+      'sitewide-search-app-used': false,
+      'type-ahead-option-keyword-selected': null,
+      'type-ahead-option-position': null,
+      'type-ahead-options-list': null,
+      'type-ahead-options-count': null,
+    });
 
     // relocate to search results, preserving history
     window.location.assign(searchUrl);


### PR DESCRIPTION
## Description
This PR adds a Google Analytics event for the submission of the Search form on the new Homepage, following the pattern established header Search component

## Original issue(s)
department-of-veterans-affairs/va.gov-cms/issues/11467

## Testing done
Local testing with the Google Analytics Chrome extension.


## Acceptance Criteria

- [x] Analytics team can help us test these once they are available in staging
- [x] Create an account events are tracked, distinctly from header sign-in events, such as `Homepage create an account CTA`
- [x] Events on Benefit promo are tracked by title and as initiated on the body of the homepage, such as `Homepage benefit promo > The PACT Act and your VA benefits` 
- [x] Search events are tracked and identifiable as interactions occurring on the body of the page, rather than from the header, such as `Homepage > Search`
- [x] Events on "Other search tools" are tracked by link label, such as `Other search tools  > Find a VA location`
- [x] Events on "Popular links menu" are tracked by link label, such as `Popular on VA.gov  > Check your claim or appeal status`
- [x] Events initiated via the VA news promo title link are tracked by name and as initiated on the body of the homepage, such as `Homepage news promo > title > Pathfinder`
- [x] Events initiated via the VA news promo CTA are tracked by name and as initiated on the body of the homepage, such as `Homepage news promo > CTA > Pathfinder`
- [x] Events on the More VA news link are identified as initiated on the body of the homepage, such as `Homepage news promo > More VA News`
- [x] Events on email signup are tracked, such as `Homepage email sign up`
- [x] Benefit hub events are tracked by Hub title, such a `Benefit hub > VA department`
- [x] Mega menu event tracking should be maintained
- [x] Header event tracking should be maintained
- [x] Footer event tracking should be maintained

## QA Steps
- [ ]  Verify in AdSwerve that the events are firing
- [ ]  Analytics team said they can assist via making sure the new event tagging/data layer works. Let @mmiddaugh know when changes are in PR and she'll ping Analytics for review, or can review herself


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
