### PR TITLE
Profile/47841/fiduciary flag profile gate

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -260,7 +260,6 @@ Profile.propTypes = {
   shouldFetchCNPDirectDepositInformation: PropTypes.bool.isRequired,
   shouldFetchEDUDirectDepositInformation: PropTypes.bool.isRequired,
   shouldFetchTotalDisabilityRating: PropTypes.bool.isRequired,
-  shouldShowDirectDeposit: PropTypes.bool.isRequired,
   showLoader: PropTypes.bool.isRequired,
   user: PropTypes.object.isRequired,
 };

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -9,7 +9,10 @@ import {
   fetchHero as fetchHeroAction,
   fetchPersonalInformation as fetchPersonalInformationAction,
 } from '@@profile/actions';
-import { cnpDirectDepositInformation } from '@@profile/selectors';
+import {
+  cnpDirectDepositInformation,
+  selectIsBlocked,
+} from '@@profile/selectors';
 import {
   fetchCNPPaymentInformation as fetchCNPPaymentInformationAction,
   fetchEDUPaymentInformation as fetchEDUPaymentInformationAction,
@@ -156,13 +159,15 @@ class Profile extends Component {
             routes={routes}
             isInMVI={this.props.isInMVI}
             isLOA3={this.props.isLOA3}
+            isBlocked={this.props.isBlocked}
           >
             <Switch>
               {/* Redirect users to Account Security to upgrade their account if they need to */}
               {routes.map(route => {
                 if (
                   (route.requiresLOA3 && !this.props.isLOA3) ||
-                  (route.requiresMVI && !this.props.isInMVI)
+                  (route.requiresMVI && !this.props.isInMVI) ||
+                  (route.requiresLOA3 && this.props.isBlocked)
                 ) {
                   return (
                     <Redirect
@@ -248,6 +253,7 @@ Profile.propTypes = {
   fetchPersonalInformation: PropTypes.func.isRequired,
   fetchTotalDisabilityRating: PropTypes.func.isRequired,
   initializeDowntimeWarnings: PropTypes.func.isRequired,
+  isBlocked: PropTypes.bool.isRequired,
   isDowntimeWarningDismissed: PropTypes.bool.isRequired,
   isInMVI: PropTypes.bool.isRequired,
   isLOA3: PropTypes.bool.isRequired,
@@ -279,6 +285,9 @@ const mapStateToProps = state => {
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);
+
+  // 47841 block profile access for deceased, fiduciary flagged, and incompetent veterans
+  const isBlocked = selectIsBlocked(state);
 
   const shouldFetchTotalDisabilityRating = isLOA3 && isInMVI;
 
@@ -338,6 +347,7 @@ const mapStateToProps = state => {
     isDowntimeWarningDismissed: state.scheduledDowntime?.dismissedDowntimeWarnings?.includes(
       'profile',
     ),
+    isBlocked,
   };
 };
 

--- a/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
@@ -116,8 +116,14 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
 };
 
 ProfileMobileSubNav.propTypes = {
-  isLOA3: PropTypes.bool.isRequired,
   isInMVI: PropTypes.bool.isRequired,
+  isLOA3: PropTypes.bool.isRequired,
+  routes: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
 };
 
 export default ProfileMobileSubNav;

--- a/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import { NavLink } from 'react-router-dom';
+import { selectIsBlocked } from '../selectors';
 
 function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
-  // Filter out the routes the user cannot access due to not being in MVI/MPI or
-  // not having a high enough LOA
+  const isBlocked = useSelector(selectIsBlocked); // incompetent, fiduciary flag, deceased
+
+  // Filter out the routes the user cannot access due to
+  // not being in MVI/MPI, not having a high enough LOA,
+  // or having isBlocked state selector return true
   const filteredRoutes = routes.filter(route => {
-    let eligibleRoute = true;
-
-    if (route.requiresLOA3 && !isLOA3) {
-      eligibleRoute = false;
+    // loa3 check and isBlocked check
+    if (route.requiresLOA3 && (!isLOA3 || isBlocked)) {
+      return false;
     }
 
-    if (route.requiresMVI && !isInMVI) {
-      eligibleRoute = false;
-    }
-
-    return eligibleRoute;
+    // mvi check
+    return route.requiresMVI && !isInMVI;
   });
   return (
     <ul>

--- a/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
@@ -13,12 +13,12 @@ function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
   // or having isBlocked state selector return true
   const filteredRoutes = routes.filter(route => {
     // loa3 check and isBlocked check
-    if (route.requiresLOA3 && (!isLOA3 || isBlocked)) {
+    if ((route.requiresLOA3 && !isLOA3) || (route.requiresLOA3 && isBlocked)) {
       return false;
     }
 
     // mvi check
-    return route.requiresMVI && !isInMVI;
+    return !(route.requiresMVI && !isInMVI);
   });
   return (
     <ul>

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
@@ -21,6 +21,7 @@ import TwoFactorAuthorizationStatus from './TwoFactorAuthorizationStatus';
 import MHVTermsAndConditionsStatus from './MHVTermsAndConditionsStatus';
 import EmailAddressNotification from '../contact-information/email-addresses/EmailAddressNotification';
 import Verified from './Verified';
+import { selectIsBlocked } from '../../selectors';
 
 export const AccountSecurityContent = ({
   isIdentityVerified,
@@ -31,6 +32,7 @@ export const AccountSecurityContent = ({
   showMPIConnectionError,
   showNotInMPIError,
   signInServiceName,
+  isBlocked,
 }) => {
   const handlers = {
     learnMoreIdentity: () => {
@@ -83,6 +85,7 @@ export const AccountSecurityContent = ({
 
   return (
     <>
+      {isBlocked ? <p>Blocked</p> : null}
       {!isIdentityVerified && (
         <IdentityNotVerified
           additionalInfoClickHandler={handlers.learnMoreIdentity}
@@ -143,14 +146,15 @@ export const AccountSecurityContent = ({
 };
 
 AccountSecurityContent.propTypes = {
+  isBlocked: PropTypes.bool.isRequired,
   isIdentityVerified: PropTypes.bool.isRequired,
-  isInMPI: PropTypes.bool.isRequired,
   isMultifactorEnabled: PropTypes.bool.isRequired,
   showMHVTermsAndConditions: PropTypes.bool.isRequired,
   showMPIConnectionError: PropTypes.bool.isRequired,
   showNotInMPIError: PropTypes.bool.isRequired,
   showWeHaveVerifiedYourID: PropTypes.bool.isRequired,
   signInServiceName: PropTypes.string.isRequired,
+  isInMPI: PropTypes.bool,
   mhvAccount: PropTypes.shape({
     accountLevel: PropTypes.string,
     accountState: PropTypes.string,
@@ -172,6 +176,7 @@ export const mapStateToProps = state => {
   const showNotInMPIError =
     isIdentityVerified && !hasMPIConnectionError && !isInMPI;
   const showWeHaveVerifiedYourID = isInMPI && isIdentityVerified;
+  const isBlocked = selectIsBlocked(state);
 
   return {
     isIdentityVerified,
@@ -182,6 +187,7 @@ export const mapStateToProps = state => {
     showNotInMPIError,
     showMHVTermsAndConditions,
     signInServiceName: signInServiceNameSelector(state),
+    isBlocked,
   };
 };
 

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
@@ -22,6 +22,7 @@ import MHVTermsAndConditionsStatus from './MHVTermsAndConditionsStatus';
 import EmailAddressNotification from '../contact-information/email-addresses/EmailAddressNotification';
 import Verified from './Verified';
 import { selectIsBlocked } from '../../selectors';
+import { AccountBlocked } from '../alerts/AccountBlocked';
 
 export const AccountSecurityContent = ({
   isIdentityVerified,
@@ -85,7 +86,7 @@ export const AccountSecurityContent = ({
 
   return (
     <>
-      {isBlocked ? <p>Blocked</p> : null}
+      {isBlocked ? <AccountBlocked /> : null}
       {!isIdentityVerified && (
         <IdentityNotVerified
           additionalInfoClickHandler={handlers.learnMoreIdentity}

--- a/src/applications/personalization/profile/components/alerts/AccountBlocked.jsx
+++ b/src/applications/personalization/profile/components/alerts/AccountBlocked.jsx
@@ -1,3 +1,5 @@
+import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 import React from 'react';
 
 // this is used when the user is logged in, but they are flagged in one of three ways:
@@ -8,5 +10,21 @@ import React from 'react';
 // 3. they have a !notDeceasedIndicator
 
 export const AccountBlocked = () => {
-  return <div>AccountBlocked</div>;
+  return (
+    <div className="vads-u-margin-bottom--4">
+      <va-alert data-testid="account-blocked-alert" status="warning">
+        <h3 slot="headline">We can’t show your information</h3>
+        <p>
+          We’re sorry. Based on our records, we can’t show your information in
+          your VA.gov profile.
+        </p>
+        <p className="vads-u-margin-bottom--1">
+          If you think this is an error, you can call the VA.gov help desk at{' '}
+          <VaTelephone contact={CONTACTS.HELP_DESK} /> (
+          <VaTelephone contact={CONTACTS['711']} tty />
+          ). We’re here Monday &#8211; Friday, 8 a.m. &#8211; 8 p.m. ET.
+        </p>
+      </va-alert>
+    </div>
+  );
 };

--- a/src/applications/personalization/profile/components/alerts/AccountBlocked.jsx
+++ b/src/applications/personalization/profile/components/alerts/AccountBlocked.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+// this is used when the user is logged in, but they are flagged in one of three ways:
+
+// Criteria within the user state in the selector cnpDirectDepositIsBlocked
+// 1. they have a !isCompetentIndicator
+// 2. they have a !noFiduciaryAssignedIndicator
+// 3. they have a !notDeceasedIndicator
+
+export const AccountBlocked = () => {
+  return <div>AccountBlocked</div>;
+};

--- a/src/applications/personalization/profile/mocks/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/feature-toggles/index.js
@@ -15,6 +15,7 @@ const generateFeatureToggles = (toggles = {}) => {
     profileHideDirectDepositCompAndPen = false,
     profileShowPaymentsNotificationSetting = false,
     profileShowAppealStatusNotificationSetting = true,
+    profileBlockForFiduciaryDeceasedOrIncompetent = false,
   } = toggles;
 
   return {
@@ -68,6 +69,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'profile_show_appeal_status_notification_setting',
           value: profileShowAppealStatusNotificationSetting,
+        },
+        {
+          name: 'profile_block_for_fiduciary_deceased_or_incompetent',
+          value: profileBlockForFiduciaryDeceasedOrIncompetent,
         },
       ],
     },

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -46,7 +46,7 @@ const responses = {
     // This is a 'normal' payment history / control case data
     // payments.paymentHistory.simplePaymentHistory
 
-    return res.status(200).json(payments.paymentHistory.isDeceased);
+    return res.status(200).json(payments.paymentHistory.isNotCompetent);
   },
   'PUT /v0/ppiu/payment_information': (_req, res) => {
     return res

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -35,10 +35,18 @@ const responses = {
   'OPTIONS /v0/maintenance_windows': 'OK',
   'GET /v0/maintenance_windows': { data: [] },
   'GET /v0/feature_toggles': generateFeatureToggles({
-    profileHideDirectDepositCompAndPen: true,
+    profileBlockForFiduciaryDeceasedOrIncompetent: true,
   }),
   'GET /v0/ppiu/payment_information': (_req, res) => {
-    return res.status(200).json(payments.paymentHistory.simplePaymentHistory);
+    // 47841 - Below are the three cases where all of Profile should be gated off
+    // payments.paymentHistory.isFiduciary
+    // payments.paymentHistory.isDeceased
+    // payments.paymentHistory.isNotCompetent
+
+    // This is a 'normal' payment history / control case data
+    // payments.paymentHistory.simplePaymentHistory
+
+    return res.status(200).json(payments.paymentHistory.isDeceased);
   },
   'PUT /v0/ppiu/payment_information': (_req, res) => {
     return res

--- a/src/applications/personalization/profile/mocks/user.js
+++ b/src/applications/personalization/profile/mocks/user.js
@@ -1279,6 +1279,7 @@ const handleUserRequest = (req, res) => {
   // default user object
   // modify as needed for simulating varrious users
   // return res.json(mockUserData.badAddress);
+  // return res.json(mockUserData.loa3User);
   return res.json(mockUserData.user72Success);
 };
 

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -50,7 +50,6 @@ const getRoutes = () => {
       path: PROFILE_PATHS.ACCOUNT_SECURITY,
       requiresLOA3: false,
       requiresMVI: false,
-      requiresUserGuard: false,
     },
     {
       component: ConnectedApplications,

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -50,6 +50,7 @@ const getRoutes = () => {
       path: PROFILE_PATHS.ACCOUNT_SECURITY,
       requiresLOA3: false,
       requiresMVI: false,
+      requiresUserGuard: false,
     },
     {
       component: ConnectedApplications,

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -139,3 +139,14 @@ export const selectShowAppealStatusNotificationSetting = state =>
   toggleValues(state)?.[
     FEATURE_FLAG_NAMES.profileShowAppealStatusNotificationSetting
   ];
+
+// toggle used for 47841
+export const selectToggleProfileBlockForFiduciaryDeceasedOrIncompetent = state =>
+  toggleValues(state)?.[
+    FEATURE_FLAG_NAMES.profileBlockForFiduciaryDeceasedOrIncompetent
+  ];
+
+// remove the feature flag reliance once 47841 is live
+export const selectIsBlocked = state =>
+  cnpDirectDepositIsBlocked(state) &&
+  selectToggleProfileBlockForFiduciaryDeceasedOrIncompetent(state);

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -286,6 +286,7 @@ describe('mapStateToProps', () => {
       'shouldFetchEDUDirectDepositInformation',
       'shouldFetchTotalDisabilityRating',
       'isDowntimeWarningDismissed',
+      'isBlocked',
     ];
     expect(Object.keys(props)).to.deep.equal(expectedKeys);
   });

--- a/src/applications/personalization/profile/tests/components/account-security/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/account-security/AccountSecurityContent.unit.spec.jsx
@@ -9,11 +9,11 @@ import {
   mapStateToProps,
 } from '@@profile/components/account-security/AccountSecurityContent';
 import ProfileInfoTable from '@@profile/components/ProfileInfoTable';
-import IdentityNotVerified from '~/applications/personalization/components/IdentityNotVerified';
 import TwoFactorAuthorizationStatus from '@@profile/components/account-security/TwoFactorAuthorizationStatus';
 import MHVTermsAndConditionsStatus from '@@profile/components/account-security/MHVTermsAndConditionsStatus';
 import EmailAddressNotification from '@@profile/components/contact-information/email-addresses/EmailAddressNotification';
 import Verified from '@@profile/components/account-security/Verified';
+import IdentityNotVerified from '~/applications/personalization/components/IdentityNotVerified';
 
 describe('AccountSecurityContent', () => {
   let wrapper;
@@ -24,6 +24,7 @@ describe('AccountSecurityContent', () => {
     showMHVTermsAndConditions: true,
     useSSOe: true,
     showWeHaveVerifiedYourID: true,
+    isBlocked: false,
   });
 
   it('should render a ProfileInfoTable as its first child', () => {

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -129,7 +129,7 @@ describe('Profile "Not all data available" error', () => {
   });
   it('should not be shown if we can get data from all required endpoints', async () => {
     const initialState = createBasicInitialState();
-    const view = render(<Profile isLOA3 isInMVI />, {
+    const view = render(<Profile isLOA3 isInMVI isBlocked={false} />, {
       initialState,
     });
     const spinner = view.queryByRole('progressbar');

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/DirectDeposit.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/DirectDeposit.js
@@ -1,10 +1,12 @@
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '@@profile/constants';
+import { checkForLegacyLoadingIndicator } from 'applications/personalization/common/e2eHelpers';
 
 class DirectDepositPage {
   LINK_TEXT = 'Direct Deposit Information';
 
   visitPage = () => {
     cy.visit(PROFILE_PATHS.DIRECT_DEPOSIT);
+    checkForLegacyLoadingIndicator();
   };
 
   confirmDirectDepositIsAvailable = ({ visitPage = true } = {}) => {
@@ -24,7 +26,7 @@ class DirectDepositPage {
     }
   };
 
-  confirmDirectDepositIsNotAvailable = () => {
+  confirmDirectDepositIsNotAvailableInNav = () => {
     // the DD item should exist in the sub nav
     cy.findByText(this.LINK_TEXT).should('not.exist');
   };
@@ -48,6 +50,17 @@ class DirectDepositPage {
   confirmServiceIsDownMessageShows = () => {
     cy.findByTestId('direct-deposit-service-down-alert-headline').should(
       'exist',
+    );
+  };
+
+  confirmProfileIsBlocked = () => {
+    cy.findByTestId('account-blocked-alert').should('exist');
+  };
+
+  confirmRedirectToAccountSecurity = () => {
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
     );
   };
 }

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/display-consistently/direct.deposit.blocked.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/display-consistently/direct.deposit.blocked.cypress.spec.js
@@ -2,54 +2,124 @@ import DirectDeposit from '../DirectDeposit';
 import { paymentHistory } from '../../../../mocks/payment-history';
 import { anAccount } from '../../../../mocks/bank-accounts';
 import { user72Success } from '../../../../mocks/user';
+import { data } from '../../../../mocks/mhvAccount';
 
 import { generateFeatureToggles } from '../../../../mocks/feature-toggles';
 
 describe('Direct Deposit Consistently', () => {
-  beforeEach(() => {
-    cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles());
-    cy.login(user72Success);
+  describe('With profileBlockForFiduciaryDeceasedOrIncompetent feature toggle FALSE', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles());
+      cy.intercept('GET', '/v0/profile/ch33_bank_accounts', anAccount);
+      cy.intercept('GET', '/v0/mhv_account', { data });
+      cy.login(user72Success);
+    });
 
-    cy.intercept('GET', '/v0/profile/ch33_bank_accounts', anAccount);
+    it('happy path', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.simplePaymentHistory,
+      );
+      DirectDeposit.visitPage();
+
+      DirectDeposit.confirmDirectDepositIsAvailable();
+
+      cy.injectAxeThenAxeCheck();
+    });
+    it('shows blocked message for deceased veterans', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.isDeceased,
+      );
+      DirectDeposit.visitPage();
+      cy.injectAxeThenAxeCheck();
+      DirectDeposit.confirmDirectDepositIsBlocked();
+    });
+    it('shows blocked message for Fiduciary', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.isFiduciary,
+      );
+      DirectDeposit.visitPage();
+      cy.injectAxeThenAxeCheck();
+      DirectDeposit.confirmDirectDepositIsBlocked();
+    });
+    it('shows blocked message for Not Competent', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.isNotCompetent,
+      );
+      DirectDeposit.visitPage();
+      cy.injectAxeThenAxeCheck();
+      DirectDeposit.confirmDirectDepositIsBlocked();
+    });
   });
 
-  it('happy path', () => {
-    cy.intercept(
-      'GET',
-      'v0/ppiu/payment_information',
-      paymentHistory.simplePaymentHistory,
-    );
-    DirectDeposit.visitPage();
-    cy.injectAxeThenAxeCheck();
-  });
-  it('shows blocked message for deceased veterans', () => {
-    cy.intercept(
-      'GET',
-      'v0/ppiu/payment_information',
-      paymentHistory.isDeceased,
-    );
-    DirectDeposit.visitPage();
-    cy.injectAxeThenAxeCheck();
-    DirectDeposit.confirmDirectDepositIsBlocked();
-  });
-  it('shows blocked message for Fiduciary', () => {
-    cy.intercept(
-      'GET',
-      'v0/ppiu/payment_information',
-      paymentHistory.isFiduciary,
-    );
-    DirectDeposit.visitPage();
-    cy.injectAxeThenAxeCheck();
-    DirectDeposit.confirmDirectDepositIsBlocked();
-  });
-  it('shows blocked message for Not Competent', () => {
-    cy.intercept(
-      'GET',
-      'v0/ppiu/payment_information',
-      paymentHistory.isNotCompetent,
-    );
-    DirectDeposit.visitPage();
-    cy.injectAxeThenAxeCheck();
-    DirectDeposit.confirmDirectDepositIsBlocked();
+  describe('With profileBlockForFiduciaryDeceasedOrIncompetent feature toggle TRUE', () => {
+    beforeEach(() => {
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        generateFeatureToggles({
+          profileBlockForFiduciaryDeceasedOrIncompetent: true,
+        }),
+      );
+      cy.intercept('GET', '/v0/mhv_account', { data });
+      cy.intercept('GET', '/v0/profile/ch33_bank_accounts', anAccount);
+      cy.login(user72Success);
+    });
+
+    it('happy path', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.simplePaymentHistory,
+      );
+      DirectDeposit.visitPage();
+
+      DirectDeposit.confirmDirectDepositIsAvailable();
+
+      cy.injectAxeThenAxeCheck();
+    });
+    it('blocks profile for deceased veterans', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.isDeceased,
+      );
+      DirectDeposit.visitPage();
+      cy.injectAxeThenAxeCheck();
+      DirectDeposit.confirmDirectDepositIsNotAvailableInNav();
+      DirectDeposit.confirmRedirectToAccountSecurity();
+      DirectDeposit.confirmProfileIsBlocked();
+    });
+    it('shows blocked message for Fiduciary', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.isFiduciary,
+      );
+      DirectDeposit.visitPage();
+      cy.injectAxeThenAxeCheck();
+      DirectDeposit.confirmDirectDepositIsNotAvailableInNav();
+      DirectDeposit.confirmRedirectToAccountSecurity();
+      DirectDeposit.confirmProfileIsBlocked();
+    });
+    it('shows blocked message for Not Competent', () => {
+      cy.intercept(
+        'GET',
+        'v0/ppiu/payment_information',
+        paymentHistory.isNotCompetent,
+      );
+      DirectDeposit.visitPage();
+      cy.injectAxeThenAxeCheck();
+      DirectDeposit.confirmDirectDepositIsNotAvailableInNav();
+      DirectDeposit.confirmRedirectToAccountSecurity();
+      DirectDeposit.confirmProfileIsBlocked();
+    });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/display-consistently/menu.item.is.shown.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/display-consistently/menu.item.is.shown.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Direct Deposit Consistently', () => {
     cy.login(loa1User);
     DirectDeposit.visitPage();
     cy.injectAxeThenAxeCheck();
-    DirectDeposit.confirmDirectDepositIsNotAvailable();
+    DirectDeposit.confirmDirectDepositIsNotAvailableInNav();
   });
   it('should show the menu for deceased veteran', () => {
     cy.login(user72Success);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -80,6 +80,7 @@ export default Object.freeze({
   mhvToLogingovAccountTransitionModal: 'mhv_to_logingov_account_transition_modal',
   omniChannelLink: 'omni_channel_link',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',
+  profileBlockForFiduciaryDeceasedOrIncompetent: 'profile_block_for_fiduciary_deceased_or_incompetent',
   profileNotificationSettings: 'profile_notification_settings',
   profileHideDirectDepositCompAndPen: 'profile_hide_direct_deposit_comp_and_pen',
   profileDoNotRequireInternationalZipCode: 'profile_do_not_require_international_zip_code',


### PR DESCRIPTION
## Description
Adds guards for user access to the profile pages for 3 scenarios:

- Fiduciary flag
- Is deceased
- Is incompetent

These three conditions were previously gating just the access to the _Direct Deposit_ page content, but we have new guidance to gate all of profile for these cases. 

Behaviour for this will also initially be gated by the new feature toggle named `profile_block_for_fiduciary_deceased_or_incompetent` so that it can be tested fully before launching to production.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/47841

## Testing done
Updated unit tests for Profile component for new gating
Added E2E tests around this and also around it being active via feature toggle

## Screenshots
What a gated profile will look like

![Screen Shot 2022-11-23 at 10 43 52 AM](https://user-images.githubusercontent.com/8332986/203614161-acc0b289-dca3-4328-8b3e-78cd3edd1aa9.png)

## Acceptance criteria
- [x] Profile gated when needed, and lives behind feature toggle

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
