### PR TITLE
Revert "10916 changes education wizard question order (#22620)"

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -1,3 +1,5 @@
+/* eslint @department-of-veterans-affairs/migrate-radio-buttons: 0 */
+
 import React from 'react';
 import dropWhile from 'lodash/dropWhile';
 import classNames from 'classnames';

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -1,7 +1,3 @@
-// Temporarily disablying migrate-radio-button rule
-// To be addressed in a later ticket, after audit https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11358
-/* eslint @department-of-veterans-affairs/migrate-radio-buttons: 0 */
-
 import React from 'react';
 import dropWhile from 'lodash/dropWhile';
 import classNames from 'classnames';
@@ -17,9 +13,9 @@ import { showEduBenefits1990EZWizard } from '../selectors/educationWizard';
 const levels = [
   ['newBenefit'],
   ['serviceBenefitBasedOn', 'transferredEduBenefits'],
-  ['sponsorTransferredBenefits'],
   ['sponsorDeceasedDisabledMIA'],
   ['vetTecBenefit'],
+  ['sponsorTransferredBenefits'],
   ['applyForScholarship'],
 ];
 
@@ -66,6 +62,7 @@ class EducationWizard extends React.Component {
 
   answerQuestion = (field, answer) => {
     const newState = { [field]: answer };
+
     if (field === 'newBenefit') {
       recordEvent({
         event: 'edu-howToApply-formChange',
@@ -267,21 +264,6 @@ class EducationWizard extends React.Component {
             )}
             {serviceBenefitBasedOn === 'other' && (
               <RadioButtons
-                name="sponsorTransferredBenefits"
-                id="sponsorTransferredBenefits"
-                options={[
-                  { label: 'Yes', value: 'yes' },
-                  { label: 'No', value: 'no' },
-                ]}
-                onValueChange={({ value }) =>
-                  this.answerQuestion('sponsorTransferredBenefits', value)
-                }
-                value={{ value: sponsorTransferredBenefits }}
-                label="Has your sponsor transferred their benefits to you?"
-              />
-            )}
-            {sponsorTransferredBenefits === 'no' && (
-              <RadioButtons
                 additionalFieldsetClass="wizard-fieldset"
                 name="sponsorDeceasedDisabledMIA"
                 id="sponsorDeceasedDisabledMIA"
@@ -294,6 +276,21 @@ class EducationWizard extends React.Component {
                 }
                 value={{ value: sponsorDeceasedDisabledMIA }}
                 label="Is your sponsor deceased, 100% permanently disabled, MIA, or a POW?"
+              />
+            )}
+            {sponsorDeceasedDisabledMIA === 'no' && (
+              <RadioButtons
+                name="sponsorTransferredBenefits"
+                id="sponsorTransferredBenefits"
+                options={[
+                  { label: 'Yes', value: 'yes' },
+                  { label: 'No', value: 'no' },
+                ]}
+                onValueChange={({ value }) =>
+                  this.answerQuestion('sponsorTransferredBenefits', value)
+                }
+                value={{ value: sponsorTransferredBenefits }}
+                label="Has your sponsor transferred their benefits to you?"
               />
             )}
             {newBenefit === 'yes' &&
@@ -470,12 +467,12 @@ class EducationWizard extends React.Component {
               this.getButton('5495')}
             {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'other' &&
-              sponsorTransferredBenefits === 'yes' &&
+              sponsorDeceasedDisabledMIA === 'yes' &&
               this.getButton('5490')}
             {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'other' &&
-              sponsorTransferredBenefits === 'no' &&
-              sponsorDeceasedDisabledMIA === 'yes' &&
+              sponsorDeceasedDisabledMIA === 'no' &&
+              sponsorTransferredBenefits !== null &&
               this.getButton('1990E')}
           </div>
         </div>

--- a/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx
@@ -101,7 +101,7 @@ describe('<EducationWizard>', () => {
 
     answerQuestion(tree, '#newBenefit-0', 'yes');
     answerQuestion(tree, '#serviceBenefitBasedOn-1', 'other');
-    answerQuestion(tree, '#sponsorTransferredBenefits-0', 'yes');
+    answerQuestion(tree, '#sponsorDeceasedDisabledMIA-0', 'yes');
     expect(
       tree
         .find('#apply-now-link')
@@ -115,8 +115,8 @@ describe('<EducationWizard>', () => {
 
     answerQuestion(tree, '#newBenefit-0', 'yes');
     answerQuestion(tree, '#serviceBenefitBasedOn-1', 'other');
-    answerQuestion(tree, '#sponsorTransferredBenefits-1', 'no');
-    answerQuestion(tree, '#sponsorDeceasedDisabledMIA-0', 'yes');
+    answerQuestion(tree, '#sponsorDeceasedDisabledMIA-1', 'no');
+    answerQuestion(tree, '#sponsorTransferredBenefits-0', 'yes');
     expect(
       tree
         .find('#apply-now-link')
@@ -130,8 +130,14 @@ describe('<EducationWizard>', () => {
 
     answerQuestion(tree, '#newBenefit-0', 'yes');
     answerQuestion(tree, '#serviceBenefitBasedOn-1', 'other');
-    answerQuestion(tree, '#sponsorTransferredBenefits-1', 'no');
     answerQuestion(tree, '#sponsorDeceasedDisabledMIA-1', 'no');
+    answerQuestion(tree, '#sponsorTransferredBenefits-1', 'no');
+    expect(
+      tree
+        .find('#apply-now-link')
+        .prop('href')
+        .endsWith('1990E'),
+    ).to.be.true;
     expect(tree.find('.usa-alert-warning')).not.be.be.false;
     tree.unmount();
   });

--- a/src/applications/edu-benefits/tests/edu-apply-wizard.cypress.spec.js
+++ b/src/applications/edu-benefits/tests/edu-apply-wizard.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Education Application Wizard', () => {
     // Create a new application
     cy.get('input[id="newBenefit-0"]')
       .click()
-      .get('label[for="serviceBenefitBasedOn-1"]')
+      .get('label[for="serviceBenefitBasedOn-0"]')
       .should('be.visible');
 
     // Select veteran
@@ -47,12 +47,12 @@ describe('Education Application Wizard', () => {
 
     cy.get('main .usa-alert-warning').should('not.exist');
 
-    cy.get('label[for="sponsorTransferredBenefits-0"]').should('be.visible');
+    cy.get('label[for="sponsorDeceasedDisabledMIA-0"]').should('be.visible');
 
     cy.injectAxeThenAxeCheck();
 
     // Select dependent
-    cy.get('#sponsorTransferredBenefits-0')
+    cy.get('#sponsorDeceasedDisabledMIA-0')
       .click()
       .get('#apply-now-link')
       .should('be.visible');
@@ -65,16 +65,16 @@ describe('Education Application Wizard', () => {
       );
 
     // Select non-dependant
-    cy.get('#sponsorTransferredBenefits-1').click();
+    cy.get('#sponsorDeceasedDisabledMIA-1').click();
     cy.get('#apply-now-link').should('not.exist');
 
-    cy.get('#sponsorTransferredBenefits-1')
-      .get('label[for="sponsorDeceasedDisabledMIA-0"]')
+    cy.get('#sponsorDeceasedDisabledMIA-1')
+      .get('label[for="sponsorTransferredBenefits-0"]')
       .should('be.visible');
     cy.axeCheck();
 
     // Select transfer
-    cy.get('#sponsorDeceasedDisabledMIA-0')
+    cy.get('#sponsorTransferredBenefits-0')
       .click()
       .get('#apply-now-link')
       .should('be.visible');
@@ -85,19 +85,24 @@ describe('Education Application Wizard', () => {
         'contain',
         '/education/apply-for-education-benefits/application/1990E',
       );
-
     // Select non-transfer
-    cy.get('#sponsorDeceasedDisabledMIA-1').click();
-    cy.get('main .usa-alert-warning').should('be.visible');
+    cy.get('#sponsorTransferredBenefits-1')
+      .click()
+      .get('#apply-now-link')
+      .should('be.visible');
 
+    cy.get('#apply-now-link')
+      .should('have.attr', 'href')
+      .and(
+        'contain',
+        '/education/apply-for-education-benefits/application/1990E',
+      );
     // Update an existing application
     cy.get('#newBenefit-1')
       .click()
       .get('label[for="transferredEduBenefits-0"]')
       .should('be.visible');
-
     cy.get('#apply-now-link').should('not.exist');
-
     // Select dependent
     cy.get('#transferredEduBenefits-2')
       .click()


### PR DESCRIPTION
## Description
This change rolls back https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10916 , reverts commit 548de054c634e5fbb690b7e02fb9b25a0a9d67f8.
This is a temporary measure until it can be properly configured after the Thanksgiving Holiday

## Testing done
Confirmed thru local testing of Education Wizard on /education/how-to-apply/

## Screenshots

<img width="743" alt="Screenshot 2022-11-23 at 3 12 32 PM" src="https://user-images.githubusercontent.com/732460/203646981-3402cf49-c379-415c-bff1-010992151303.png">


## Acceptance criteria
- [ ] Revert Wizard to previous working configuration.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
