### PR TITLE
MHV-38375: Enable non-paginated folder results for basic search

### DIFF
--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -112,7 +112,7 @@ export const getMessageList = folderId => {
  */
 export const getMessageListAll = folderId => {
   return apiRequest(
-    `${apiBasePath}/messaging/folders/${folderId}/messages?per_page=9999`,
+    `${apiBasePath}/messaging/folders/${folderId}/messages?per_page=-1`,
     {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Description
The front end can now get more than 100 results without making multiple calls so that results can be searched by keyword on the front end. This is necessary because the keyword search needs to get all messages from a folder to search multiple fields for keyword matches. This is a temporary fix until the MHV API implements keyword search functionality.

## Original issue(s)
https://vajira.max.gov/browse/MHV-38375

## Testing done
No additional testing required

## Screenshots
No UI changes made

## Acceptance criteria
- [ ] Front end can get all messages in a folder with one call

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
