### PR TITLE
pdf cert flipper added

### DIFF
--- a/src/applications/search/selectors/index.js
+++ b/src/applications/search/selectors/index.js
@@ -1,0 +1,6 @@
+// import the toggleValues helper
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const showPdfWarningBanner = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.pdfWarningBanner];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -79,6 +79,7 @@ export default Object.freeze({
   mhvToLogingovAccountTransition: 'mhv_to_logingov_account_transition',
   mhvToLogingovAccountTransitionModal: 'mhv_to_logingov_account_transition_modal',
   omniChannelLink: 'omni_channel_link',
+  pdfWarningBanner: 'pdf_warning_banner',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',
   profileBlockForFiduciaryDeceasedOrIncompetent: 'profile_block_for_fiduciary_deceased_or_incompetent',
   profileNotificationSettings: 'profile_notification_settings',


### PR DESCRIPTION
## Description
adds flipper for pdf cert banner. corresponding vets-api PR: https://github.com/department-of-veterans-affairs/vets-api/pull/11249

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11023

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] Create flipper

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
