### PR TITLE
Create a Reusable VA Radio Button component in order to replace the RadioButton component in TuitionAndHousingEstimates page

### DIFF
--- a/src/applications/gi/components/VARadioButton.jsx
+++ b/src/applications/gi/components/VARadioButton.jsx
@@ -14,33 +14,22 @@ import {
  * @param {Function} onRadioOptionSelected - updates subtask options
  * @returns {JSX.Element}
  */
-const VARadioButton = ({
-  radioLabel,
-  initialValue,
-  options,
-  onRadioOptionSelected,
-}) => (
+const VARadioButton = ({ radioLabel, options, onRadioOptionSelected }) => (
   <VaRadio
     enable-analytics
     label={radioLabel}
     onRadioOptionSelected={onRadioOptionSelected}
   >
     {options.map(({ value, label }) => (
-      <VaRadioOption
-        key={value}
-        id={value}
-        value={value}
-        label={label}
-        checked={value === initialValue}
-      />
+      <VaRadioOption key={value} id={value} value={value} label={label} />
     ))}
   </VaRadio>
 );
 
 VARadioButton.propTypes = {
   initialValue: PropTypes.string.isRequired,
-  onRadioOptionSelected: PropTypes.func.isRequired,
   radioLabel: PropTypes.string.isRequired,
+  onRadioOptionSelected: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.string,

--- a/src/applications/gi/components/VARadioButton.jsx
+++ b/src/applications/gi/components/VARadioButton.jsx
@@ -6,7 +6,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 /**
- * Benefit type page
+ * VA Radio button with VA Radio Option component.
  *
  * @param {String} radioLabel - Text Displayed at the top of the radio buttons.
  * @param {String} initialValue - initial value of the radio button

--- a/src/applications/gi/components/VARadioButton.jsx
+++ b/src/applications/gi/components/VARadioButton.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  VaRadio,
+  VaRadioOption,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+/**
+ * Benefit type page
+ *
+ * @param {String} radioLabel - Text Displayed at the top of the radio buttons.
+ * @param {String} initialValue - initial value of the radio button
+ * @param {Object} options - subtask options
+ * @param {Function} onRadioOptionSelected - updates subtask options
+ * @returns {JSX.Element}
+ */
+const VARadioButton = ({
+  radioLabel,
+  initialValue,
+  options,
+  onRadioOptionSelected,
+}) => (
+  <VaRadio
+    enable-analytics
+    label={radioLabel}
+    onRadioOptionSelected={onRadioOptionSelected}
+  >
+    {options.map(({ value, label }) => (
+      <VaRadioOption
+        key={value}
+        id={value}
+        value={value}
+        label={label}
+        checked={value === initialValue}
+      />
+    ))}
+  </VaRadio>
+);
+
+VARadioButton.propTypes = {
+  initialValue: PropTypes.string.isRequired,
+  onRadioOptionSelected: PropTypes.func.isRequired,
+  radioLabel: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    }),
+  ),
+};
+
+export default VARadioButton;

--- a/src/applications/gi/components/VARadioButton.jsx
+++ b/src/applications/gi/components/VARadioButton.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  VaRadio,
-  VaRadioOption,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 /**
  * VA Radio button with VA Radio Option component.
@@ -11,17 +8,28 @@ import {
  * @param {String} radioLabel - Text Displayed at the top of the radio buttons.
  * @param {String} initialValue - initial value of the radio button
  * @param {Object} options - subtask options
- * @param {Function} onRadioOptionSelected - updates subtask options
+ * @param {Function} onVaValueChange - updates subtask options
  * @returns {JSX.Element}
  */
-const VARadioButton = ({ radioLabel, options, onRadioOptionSelected }) => (
+const VARadioButton = ({
+  radioLabel,
+  initialValue,
+  options,
+  onVaValueChange,
+}) => (
   <VaRadio
     enable-analytics
     label={radioLabel}
-    onRadioOptionSelected={onRadioOptionSelected}
+    onVaValueChange={onVaValueChange}
   >
     {options.map(({ value, label }) => (
-      <VaRadioOption key={value} id={value} value={value} label={label} />
+      <va-radio-option
+        key={value}
+        id={value}
+        value={value}
+        label={label}
+        checked={value === initialValue}
+      />
     ))}
   </VaRadio>
 );
@@ -29,7 +37,7 @@ const VARadioButton = ({ radioLabel, options, onRadioOptionSelected }) => (
 VARadioButton.propTypes = {
   initialValue: PropTypes.string.isRequired,
   radioLabel: PropTypes.string.isRequired,
-  onRadioOptionSelected: PropTypes.func.isRequired,
+  onVaValueChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.string,

--- a/src/applications/gi/containers/TuitionAndHousingEstimates.jsx
+++ b/src/applications/gi/containers/TuitionAndHousingEstimates.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import recordEvent from 'platform/monitoring/record-event';
 import SearchAccordion from '../components/SearchAccordion';
 import SearchBenefits from '../components/SearchBenefits';
-import RadioButtons from '../components/RadioButtons';
+import VARadioButton from '../components/VARadioButton';
 import LearnMoreLabel from '../components/LearnMoreLabel';
 import { showModal, eligibilityChange } from '../actions';
-import { connect } from 'react-redux';
 import { createId } from '../utils/helpers';
-import recordEvent from 'platform/monitoring/record-event';
 
 export function TuitionAndHousingEstimates({
   eligibility,
@@ -83,27 +83,26 @@ export function TuitionAndHousingEstimates({
         setMilitaryStatus={setMilitaryStatus}
         setSpouseActiveDuty={setSpouseActiveDuty}
       />
-      <RadioButtons
-        label={
-          <LearnMoreLabel
-            text="Will you be taking any classes in person?"
-            onClick={() => {
-              dispatchShowModal('onlineOnlyDistanceLearning');
-            }}
-            ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
-            butttonId="classes-in-person-learn-more"
-          />
-        }
-        name="inPersonClasses"
+      <LearnMoreLabel
+        text="Will you be taking any classes in person?"
+        onClick={() => {
+          dispatchShowModal('onlineOnlyDistanceLearning');
+        }}
+        ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
+        butttonId="classes-in-person-learn-more"
+      />
+      <VARadioButton
+        radioLabel=""
+        initialValue="no"
         options={[{ value: 'no', label: 'Yes' }, { value: 'yes', label: 'No' }]}
-        value={onlineClasses}
-        onChange={e => {
+        onRadioOptionSelected={target => {
+          const { value } = target;
           recordEvent({
             event: 'gibct-form-change',
             'gibct-form-field': 'Will you be taking any classes in person ?',
-            'gibct-form-value': e.target.value,
+            'gibct-form-value': value,
           });
-          setOnlineClasses(e.target.value);
+          setOnlineClasses(value);
         }}
       />
       <div id="note" className="vads-u-padding-top--2">

--- a/src/applications/gi/containers/TuitionAndHousingEstimates.jsx
+++ b/src/applications/gi/containers/TuitionAndHousingEstimates.jsx
@@ -95,7 +95,7 @@ export function TuitionAndHousingEstimates({
         radioLabel=""
         initialValue="no"
         options={[{ value: 'no', label: 'Yes' }, { value: 'yes', label: 'No' }]}
-        onRadioOptionSelected={target => {
+        onVaValueChange={target => {
           const { value } = target;
           recordEvent({
             event: 'gibct-form-change',


### PR DESCRIPTION
Create a Reusable VA Radio Button component in order to replace the RadioButton component in TuitionAndHousingEstimates page

## Description


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
