### PR TITLE
Fix loading flash on Health care application introduction page

### DIFF
--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -46,35 +46,30 @@ const IntroductionPage = props => {
         appTitle="Application for VA health care"
         dependencies={[externalServices.es]}
       >
-        {showLoader ? (
+        {!showLOA3Content && (
+          <p>
+            VA health care covers care for your physical and mental health. This
+            includes a range of services from checkups to surgeries to home
+            health care. It also includes prescriptions and medical equipment.
+            Apply online now.
+          </p>
+        )}
+
+        {showLoader && (
           <va-loading-indicator
             label="Loading"
             message="Loading your application..."
           />
-        ) : (
-          <>
-            {!showLOA3Content && (
-              <p className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-line-height--3 vads-u-margin-bottom--5">
-                VA health care covers care for your physical and mental health.
-                This includes a range of services from checkups to surgeries to
-                home health care. It also includes prescriptions and medical
-                equipment. Apply online now.
-              </p>
-            )}
-
-            {showIdentityAlert && <IdentityVerificationAlert />}
-
-            {(showGetStartedContent || enrollmentOverrideEnabled) && (
-              <GetStartedContent
-                route={route}
-                showLoginAlert={showLoginAlert}
-              />
-            )}
-
-            {showLOA3Content &&
-              !enrollmentOverrideEnabled && <EnrollmentStatus route={route} />}
-          </>
         )}
+
+        {showIdentityAlert && <IdentityVerificationAlert />}
+
+        {(showGetStartedContent || enrollmentOverrideEnabled) && (
+          <GetStartedContent route={route} showLoginAlert={showLoginAlert} />
+        )}
+
+        {showLOA3Content &&
+          !enrollmentOverrideEnabled && <EnrollmentStatus route={route} />}
       </DowntimeNotification>
     </div>
   );


### PR DESCRIPTION
## Description
This PR updates the intro page to the HCA where there is a periodic flash of content when the application loading process takes an extended period of time to load. This may be staging issue only, but want to prevent any prod issues, should there be a slower response from vets-api.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#47733

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
