### PR TITLE
Tweak notification settings - mobile update link

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -23,7 +23,7 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
         ) : null}
         {mobilePhoneNumber ? (
           <li className="vads-u-margin-y--0p5">
-            <strong>Mobile number: </strong>
+            <strong>Mobile phone: </strong>
             <VaTelephone
               data-testid="mobile-phone-number-on-file"
               contact={`${mobilePhoneNumber.areaCode}${
@@ -34,9 +34,9 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
             <Link
               to={getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true)}
               className="small-screen:vads-u-display--block medium-screen:vads-u-display--inline"
+              aria-label="mobile number"
             >
               Update
-              <span className="sr-only"> mobile number</span>
             </Link>
           </li>
         ) : null}

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -33,10 +33,10 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
             />{' '}
             <Link
               to={getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true)}
-              className="small-screen:vads-u-display--inline vads-u-display--block"
+              className="small-screen:vads-u-display--block medium-screen:vads-u-display--inline"
             >
               Update
-              <span className="sr-only"> mobile phone number</span>
+              <span className="sr-only"> mobile number</span>
             </Link>
           </li>
         ) : null}

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
-
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
 import { FIELD_NAMES } from '@@vap-svc/constants';
+import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
   return (
@@ -24,7 +23,8 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
         ) : null}
         {mobilePhoneNumber ? (
           <li className="vads-u-margin-y--0p5">
-            <Telephone
+            <strong>Mobile number: </strong>
+            <VaTelephone
               contact={`${mobilePhoneNumber.areaCode}${
                 mobilePhoneNumber.phoneNumber
               }`}
@@ -32,8 +32,10 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
             />{' '}
             <Link
               to={getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true)}
+              className="small-screen:vads-u-display--inline vads-u-display--block"
             >
-              Update mobile phone
+              Update
+              <span className="sr-only"> mobile phone number</span>
             </Link>
           </li>
         ) : null}

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -25,6 +25,7 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
           <li className="vads-u-margin-y--0p5">
             <strong>Mobile number: </strong>
             <VaTelephone
+              data-testid="mobile-phone-number-on-file"
               contact={`${mobilePhoneNumber.areaCode}${
                 mobilePhoneNumber.phoneNumber
               }`}

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -45,7 +45,13 @@ describe('Notification Settings', () => {
 
         cy.loadingIndicatorWorks();
 
-        cy.findByText('503-555-1234').should('exist');
+        cy.findByTestId('mobile-phone-number-on-file').should('exist');
+
+        cy.findByTestId('mobile-phone-number-on-file')
+          .shadow()
+          .findByText(/503-555-1234/i)
+          .should('exist');
+
         // TODO: uncomment when email is a supported communication channel
         // cy.findByText('veteran@gmail.com').should('exist');
         cy.findAllByTestId('notification-group')
@@ -86,7 +92,10 @@ describe('Notification Settings', () => {
 
         cy.loadingIndicatorWorks();
 
-        cy.findByText('503-555-1234').should('exist');
+        cy.findByTestId('mobile-phone-number-on-file')
+          .shadow()
+          .findByText(/503-555-1234/i)
+          .should('exist');
         // TODO: uncomment when email is a supported communication channel
         // cy.findByText('veteran@gmail.com').should('exist');
         cy.findAllByTestId('notification-group')
@@ -125,7 +134,10 @@ describe('Notification Settings', () => {
 
         cy.loadingIndicatorWorks();
 
-        cy.findByText('503-555-1234').should('exist');
+        cy.findByTestId('mobile-phone-number-on-file')
+          .shadow()
+          .findByText(/503-555-1234/i)
+          .should('exist');
         // TODO: uncomment when email is a supported communication channel
         // cy.findByText('veteran@gmail.com').should('exist');
         cy.findAllByTestId('notification-group')
@@ -157,7 +169,10 @@ describe('Notification Settings', () => {
 
       cy.loadingIndicatorWorks();
 
-      cy.findByText('503-555-1234').should('exist');
+      cy.findByTestId('mobile-phone-number-on-file')
+        .shadow()
+        .findByText(/503-555-1234/i)
+        .should('exist');
       // uncomment when email is a supported communication channel
       // cy.findByText('veteran@gmail.com').should('exist');
       cy.findAllByTestId('notification-group')

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -194,7 +194,10 @@ describe('Notification Settings', () => {
 
           cy.loadingIndicatorWorks();
 
-          cy.findByText('503-555-1234').should('exist');
+          cy.findByTestId('mobile-phone-number-on-file')
+            .shadow()
+            .findByText(/503-555-1234/i)
+            .should('exist');
           cy.findByTestId('missing-contact-info-alert').should('not.exist');
           cy.findAllByTestId('notification-group').should('exist');
           cy.findByRole('link', { name: /add your mobile/i }).should(


### PR DESCRIPTION
## Description
After feedback from the first PR on this issue I have updated a few items.

- Updated the link to appear on its own line in mobile

I was unable to address the second item that Liz requested because the link is inside the main container so inherits that padding. I tried to add negative margin on it to push it out on the x axis, but it wasn’t displaying correctly.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/48753


## Testing done
Visual testing

## Screenshots
![Screen Shot 2022-11-29 at 9 11 46 AM](https://user-images.githubusercontent.com/8332986/204623796-50e2c357-91ee-4065-a63b-de66f3753642.png)

## Acceptance criteria
- [x] Update link moved to second line on mobile

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
