### PR TITLE
MHV-38008: Single day search fixed

### DIFF
--- a/src/applications/mhv/secure-messaging/actions/search.js
+++ b/src/applications/mhv/secure-messaging/actions/search.js
@@ -50,14 +50,21 @@ export const runAdvancedSearch = (folder, query) => async dispatch => {
     });
   } catch (error) {
     const err = error.errors[0];
-    dispatch({
-      type: Actions.Alerts.ADD_ALERT,
-      payload: {
-        alertType: 'error',
-        header: err.title,
-        content: err.detail,
-        response: err,
-      },
-    });
+    if (err.code === 'SM99' && err.status === '502') {
+      dispatch({
+        type: Actions.Search.RUN_ADVANCED,
+        response: { folder, query, data: [] },
+      });
+    } else {
+      dispatch({
+        type: Actions.Alerts.ADD_ALERT,
+        payload: {
+          alertType: 'error',
+          header: err.title,
+          content: err.detail,
+          response: err,
+        },
+      });
+    }
   }
 };

--- a/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
@@ -101,16 +101,23 @@ const SearchMessagesForm = props => {
     const formInvalid = testingSubmit || checkFormValidity();
     if (formInvalid) return;
 
+    const todayDateTime = moment(new Date()).format();
+    const offset = todayDateTime.substring(todayDateTime.length - 6);
     let relativeToDate;
     let relativeFromDate;
+    let fromDateTime;
+    let toDateTime;
 
     if (
       dateRange === DateRangeValues.LAST3 ||
       dateRange === DateRangeValues.LAST6 ||
       dateRange === DateRangeValues.LAST12
     ) {
-      relativeToDate = dateFormat(new Date(), 'yyyy-MM-DD');
+      relativeToDate = moment(new Date());
       relativeFromDate = getRelativeDate(dateRange);
+    } else if (dateRange === DateRangeValues.CUSTOM && fromDate === toDate) {
+      fromDateTime = `${toDate}T00:00:00${offset}`;
+      toDateTime = `${toDate}T23:59:59${offset}`;
     }
 
     const folderData = folders.find(item => +item.id === +folder);
@@ -121,8 +128,8 @@ const SearchMessagesForm = props => {
         sender: senderName,
         subject,
         category,
-        fromDate: relativeFromDate || fromDate,
-        toDate: relativeToDate || toDate,
+        fromDate: relativeFromDate || fromDateTime || fromDate,
+        toDate: relativeToDate || toDateTime || toDate,
       }),
     );
     history.push('/search/results');

--- a/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
@@ -115,8 +115,8 @@ const SearchMessagesForm = props => {
     ) {
       relativeToDate = moment(new Date());
       relativeFromDate = getRelativeDate(dateRange);
-    } else if (dateRange === DateRangeValues.CUSTOM && fromDate === toDate) {
-      fromDateTime = `${toDate}T00:00:00${offset}`;
+    } else if (dateRange === DateRangeValues.CUSTOM) {
+      fromDateTime = `${fromDate}T00:00:00${offset}`;
       toDateTime = `${toDate}T23:59:59${offset}`;
     }
 
@@ -128,8 +128,8 @@ const SearchMessagesForm = props => {
         sender: senderName,
         subject,
         category,
-        fromDate: relativeFromDate || fromDateTime || fromDate,
-        toDate: relativeToDate || toDateTime || toDate,
+        fromDate: relativeFromDate || fromDateTime,
+        toDate: relativeToDate || toDateTime,
       }),
     );
     history.push('/search/results');

--- a/src/applications/mhv/secure-messaging/containers/SearchMessages.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchMessages.jsx
@@ -14,6 +14,10 @@ const Search = () => {
 
   const { pathname } = location;
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }, []);
+
   useEffect(
     () => {
       if (pathname === '/search/advanced') {

--- a/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
@@ -11,6 +11,10 @@ const Search = () => {
   );
   const history = useHistory();
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }, []);
+
   useEffect(
     () => {
       if (!awaitingResults && !searchResults) {


### PR DESCRIPTION
## Description
Performing an advanced search for messages using the same "toDate" and "fromDate" now returns messages from the entirety of that day. Previously it would return an error. This is fixed by setting a time as the start of the day for fromDate and a time as the end of the day for toDate. Thus the dates are not the exact same and always request a range of time. 

## Original issue(s)
https://vajira.max.gov/browse/MHV-38008

## Testing done
No relevant tests. 

## Screenshots
No UI changes. 

## Acceptance criteria
- [ ] Doing an advanced search for a single day as the date range must return relevant results. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
