### PR TITLE
 SM to VA.gov: Defect - Message attachments url

### DIFF
--- a/src/applications/mhv/secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv/secure-messaging/components/AttachmentsList.jsx
@@ -1,6 +1,5 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import environment from 'platform/utilities/environment';
 
 const AttachmentsList = props => {
   const { attachments, setAttachments, editingEnabled } = props;
@@ -43,15 +42,7 @@ const AttachmentsList = props => {
               {!editingEnabled && (
                 <>
                   <i className="fas fa-paperclip" aria-hidden="true" />
-                  <a
-                    href={`${
-                      environment.API_URL
-                    }/my_health/v1/messaging/messages/${
-                      file.messageId
-                    }/attachments/${file.attachmentId}`}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
+                  <a href={file.link} target="_blank" rel="noreferrer">
                     {file.name} ({getSize(file.size || file.attachmentSize)})
                   </a>
                 </>


### PR DESCRIPTION
## Description
On Message Details view, attachments were not opening up using a link. It appears that backend handles env parsing in attachment url that are returned back in the response. With this fix, just passing link from the response to open an attachment. 

## Original issue(s)
[MHV-38410 SM to VA.gov: Defect - Message attachments](https://vajira.max.gov/browse/MHV-38410)


## Testing done
Need to test this in a higher env. 

## Screenshots
![image-2022-11-17-09-48-17-287](https://user-images.githubusercontent.com/87077843/204821234-7bf5e5fa-02b1-4979-9e34-9149652826a9.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
