### PR TITLE
ToE: Change Email Pre-fill Order to Prefer VA Profile Data

### DIFF
--- a/src/applications/toe/helpers.jsx
+++ b/src/applications/toe/helpers.jsx
@@ -162,8 +162,8 @@ export function prefillTransformer(pages, formData, metadata, state) {
   }
 
   const emailAddress =
-    profile?.email ||
     vapContactInfo.email?.emailAddress ||
+    profile?.email ||
     contactInfo.emailAddress ||
     undefined;
 


### PR DESCRIPTION
## Description
The order of preference/mapping logic was wrong when selecting which email to prefer for form pre-filling. `vapContactInfo` is being populated with the email address from the VA Profile and, if available, should be the first choice when pre-filling.

Sibling PR to #22804.