### PR TITLE
11021 pdf warning search page

### DIFF
--- a/src/applications/edu-benefits/1990s/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/1990s/containers/PreSubmitInfo.jsx
@@ -1,9 +1,15 @@
+/* eslint @department-of-veterans-affairs/migrate-radio-buttons: 0 */
+// added until testing of new radio buttons is completed
+
 import React from 'react';
 import { connect } from 'react-redux';
 
 // platform - form-system actions
 import { setPreSubmit as setPreSubmitAction } from 'platform/forms-system/src/js/actions';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import {
+  VaRadio,
+  VaRadioOption,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PreSubmitInfo from '../../containers/PreSubmitInfo';
 
 function PreSubmitNotice({
@@ -12,49 +18,64 @@ function PreSubmitNotice({
   onSectionComplete,
   setPreSubmit,
 }) {
-  const vrrapConfirmation = formData.vrrapConfirmation;
+  const { vrrapConfirmation } = formData;
+
+  const options = [
+    { label: 'Yes', value: true },
+    { label: 'No', value: false },
+  ];
+
+  const handlers = {
+    onSelection: event => {
+      setPreSubmit('vrrapConfirmation', event.detail.value === 'true');
+    },
+  };
 
   const confirmEligibilityNote = (
     <div>
       <div>
-        <h4 id="confirmEligibility_title">Confirm you're eligible for VRRAP</h4>
+        <h4 id="confirmEligibility_title">Confirm you’re eligible for VRRAP</h4>
         <div>
           <p>
             To be eligible for VRRAP, the 3 following statements must be true:
           </p>
           <ul>
             <li>
-              As of the date of this application, you're currently unemployed
+              As of the date of this application, you’re currently unemployed
               due to the COVID-19 pandemic.
             </li>
             <li>
-              You're not currently enrolled in a federal or state jobs program,
-              and you don't expect to be enrolled in one while using VRRAP.
+              You’re not currently enrolled in a federal or state jobs program,
+              and you don’t expect to be enrolled in one while using VRRAP.
             </li>
             <li>
-              You won't receive unemployment compensation, including any cash
+              You won’t receive unemployment compensation, including any cash
               benefit received under the CARES Act, while training using VRRAP.
             </li>
           </ul>
         </div>
       </div>
-      <div>
-        <RadioButtons
-          name={'confirmEligibility_options'}
-          label={
-            'The statements above are true and accurate to the best of my knowledge and belief.'
-          }
-          id={'confirmEligibility_options'}
-          options={[
-            { label: 'Yes', value: true },
-            { label: 'No', value: false },
-          ]}
-          onValueChange={({ value }) =>
-            setPreSubmit('vrrapConfirmation', value === 'true')
-          }
-          value={{ value: vrrapConfirmation }}
-        />
-      </div>
+      <VaRadio
+        class="vads-u-margin-y--4"
+        name="confirmEligibility"
+        error={null}
+        label="The statements above are true and accurate to the best of my knowledge and belief."
+        onVaValueChange={handlers.onSelection}
+        ariaDescribedby="confirmEligibility"
+      >
+        {options.map(({ value, label }) => (
+          <VaRadioOption
+            key={value}
+            class="vads-u-margin-y--3"
+            name="confirmEligibility_options"
+            label={label}
+            id={`confirmEligibility_options ${value}`}
+            value={value}
+            checked={vrrapConfirmation === value}
+            ariaDescribedby="confirmEligibility_options"
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 

--- a/src/applications/edu-benefits/1990s/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/edu-benefits/1990s/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import PreSubmitInfo from '../../containers/PreSubmitInfo';
 import { Provider } from 'react-redux';
 import { combineReducers, createStore } from 'redux';
 import { commonReducer } from 'platform/startup/store';
+import PreSubmitInfo from '../../containers/PreSubmitInfo';
 
 const fakeStore = createStore(
   combineReducers({
@@ -26,9 +26,8 @@ describe('<PreSubmitInfo>', () => {
       </Provider>,
     );
     expect(tree).to.not.be.undefined;
-    expect(tree.text()).to.contain("Confirm you're eligible for VRRAP");
+    expect(tree.text()).to.include('Confirm you’re eligible for VRRAP');
     expect(tree.text()).to.contain('privacy policy');
-
     tree.unmount();
   });
 });

--- a/src/applications/edu-benefits/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import PreSubmitInfo from '../../containers/PreSubmitInfo';
 import { Provider } from 'react-redux';
 import { combineReducers, createStore } from 'redux';
 import { commonReducer } from 'platform/startup/store';
+import PreSubmitInfo from '../../containers/PreSubmitInfo';
 
 const fakeStore = createStore(
   combineReducers({
@@ -25,9 +25,9 @@ describe('<PreSubmitInfo>', () => {
         />
       </Provider>,
     );
-    expect(tree).to.not.be.undefined;
-    expect(tree.text()).to.contain('privacy policy');
 
+    expect(tree).to.not.be.undefined;
+    expect(tree.text()).to.include('privacy policy');
     tree.unmount();
   });
 });

--- a/src/applications/find-forms/components/FindVaForms.jsx
+++ b/src/applications/find-forms/components/FindVaForms.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/no-redundant-roles */
 // Node modules.
-import React from 'react';
+import React, { useEffect } from 'react';
+
 // Relative imports.
 import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
@@ -19,18 +20,24 @@ const onFeaturedContentClick = header => () => {
 };
 
 export const FindVaForms = ({ showPdfWarningBanner }) => {
-  if (showPdfWarningBanner) {
-    const PDFAlertContent = `<va-alert>
-      <h2 slot="headline" className="vads-u-font-size--h3">
-        We’re updating our forms
-      </h2>
-      <p>After January 7, 2023, you won't be able to use VA forms that have a “last updated” date before March 2022. If you downloaded any of these older VA forms, you may need to download new copies in January.</p>
-      </va-alert>`;
+  useEffect(
+    () => {
+      if (showPdfWarningBanner) {
+        const PDFAlertContent = `<va-alert>
+        <h2 slot="headline" className="vads-u-font-size--h3">
+          We’re updating our forms
+        </h2>
+        <p>After January 7, 2023, you won't be able to use VA forms that have a “last updated” date before March 2022. If you downloaded any of these older VA forms, you may need to download new copies in January.</p>
+        </va-alert>`;
 
-    document
-      .getElementsByClassName('va-introtext')[0]
-      .insertAdjacentHTML('beforebegin', `${PDFAlertContent}`);
-  }
+        document
+          .getElementsByClassName('va-introtext')[0]
+          .insertAdjacentHTML('beforebegin', `${PDFAlertContent}`);
+      }
+    },
+    [showPdfWarningBanner],
+  );
+
   return (
     <>
       <SearchForm />

--- a/src/applications/find-forms/components/FindVaForms.jsx
+++ b/src/applications/find-forms/components/FindVaForms.jsx
@@ -2,9 +2,14 @@
 // Node modules.
 import React from 'react';
 // Relative imports.
+import { connect } from 'react-redux';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+import recordEvent from 'platform/monitoring/record-event';
+import PropTypes from 'prop-types';
 import SearchForm from '../containers/SearchForm';
 import SearchResults from '../containers/SearchResults';
-import recordEvent from 'platform/monitoring/record-event';
 
 const onFeaturedContentClick = header => () => {
   recordEvent({
@@ -13,111 +18,141 @@ const onFeaturedContentClick = header => () => {
   });
 };
 
-export default () => (
-  <>
-    <SearchForm />
-    <SearchResults />
-    <h2>Frequently used VA forms</h2>
-    <p>
-      You can now do many form-based tasks online, like filing a disability
-      claim and applying for the GI Bill or VA health care. We&apos;ll walk you
-      through the process step-by-step.
-    </p>
-    {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-    <ul
-      className="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row"
-      role="list"
-    >
-      <li className="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
-        <h3 className="vads-u-font-size--base vads-u-margin--0">
-          File a VA disability claim
-        </h3>
-        <hr
-          aria-hidden="true"
-          role="presentation"
-          className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"
-        />
-        <p className="va-nav-linkslist-description">
-          Equal to VA Form 21-526EZ
-        </p>
-        <a
-          className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
-          href="/disability/file-disability-claim-form-21-526ez/"
-          onClick={onFeaturedContentClick('File a VA disability claim')}
-        >
-          <span>
-            Apply online
-            <span className="vads-u-visibility--screen-reader">
-              about filing a VA disability claim
+export const FindVaForms = ({ showPdfWarningBanner }) => {
+  if (showPdfWarningBanner) {
+    const PDFAlertContent = `<va-alert>
+      <h2 slot="headline" className="vads-u-font-size--h3">
+        We’re updating our forms
+      </h2>
+      <p>After January 7, 2023, you won't be able to use VA forms that have a “last updated” date before March 2022. If you downloaded any of these older VA forms, you may need to download new copies in January.</p>
+      </va-alert>`;
+
+    document
+      .getElementsByClassName('va-introtext')[0]
+      .insertAdjacentHTML('beforebegin', `${PDFAlertContent}`);
+  }
+  return (
+    <>
+      <SearchForm />
+      <SearchResults />
+      <h2>Frequently used VA forms</h2>
+      <p>
+        You can now do many form-based tasks online, like filing a disability
+        claim and applying for the GI Bill or VA health care. We’ll walk you
+        through the process step-by-step.
+      </p>
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+      <ul
+        className="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row"
+        role="list"
+      >
+        <li className="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
+          <h3 className="vads-u-font-size--base vads-u-margin--0">
+            File a VA disability claim
+          </h3>
+          <hr
+            aria-hidden="true"
+            role="presentation"
+            className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"
+          />
+          <p className="va-nav-linkslist-description">
+            Equal to VA Form 21-526EZ
+          </p>
+          <a
+            className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
+            href="/disability/file-disability-claim-form-21-526ez/"
+            onClick={onFeaturedContentClick('File a VA disability claim')}
+          >
+            <span>
+              Apply online
+              <span className="vads-u-visibility--screen-reader">
+                about filing a VA disability claim
+              </span>
+              <i
+                aria-hidden="true"
+                className="fa fa-chevron-right vads-facility-hub-cta-arrow"
+                role="presentation"
+              />
             </span>
-            <i
-              aria-hidden="true"
-              className="fa fa-chevron-right vads-facility-hub-cta-arrow"
-              role="presentation"
-            />
-          </span>
-        </a>
-      </li>
-      <li className="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
-        <h3 className="vads-u-font-size--base vads-u-margin--0">
-          Apply for the GI Bill and other education benefits
-        </h3>
-        <hr
-          aria-hidden="true"
-          role="presentation"
-          className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"
-        />
-        <p className="va-nav-linkslist-description">
-          Includes VA Forms 22-1990 and 22-1995
-        </p>
-        <a
-          className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
-          href="/education/how-to-apply/"
-          onClick={onFeaturedContentClick(
-            'Apply for the GI Bill and other education benefits',
-          )}
-        >
-          <span>
-            Learn how to apply online
-            <span className="vads-u-visibility--screen-reader">
-              about applying for the GI Bill and other education benefits
+          </a>
+        </li>
+        <li className="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
+          <h3 className="vads-u-font-size--base vads-u-margin--0">
+            Apply for the GI Bill and other education benefits
+          </h3>
+          <hr
+            aria-hidden="true"
+            role="presentation"
+            className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"
+          />
+          <p className="va-nav-linkslist-description">
+            Includes VA Forms 22-1990 and 22-1995
+          </p>
+          <a
+            className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
+            href="/education/how-to-apply/"
+            onClick={onFeaturedContentClick(
+              'Apply for the GI Bill and other education benefits',
+            )}
+          >
+            <span>
+              Learn how to apply online
+              <span className="vads-u-visibility--screen-reader">
+                about applying for the GI Bill and other education benefits
+              </span>
+              <i
+                aria-hidden="true"
+                className="fa fa-chevron-right vads-facility-hub-cta-arrow"
+                role="presentation"
+              />
             </span>
-            <i
-              aria-hidden="true"
-              className="fa fa-chevron-right vads-facility-hub-cta-arrow"
-              role="presentation"
-            />
-          </span>
-        </a>
-      </li>
-      <li className="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
-        <h3 className="vads-u-font-size--base vads-u-margin--0">
-          Apply for VA health care
-        </h3>
-        <hr
-          aria-hidden="true"
-          role="presentation"
-          className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"
-        />
-        <p className="va-nav-linkslist-description">Equal to VA Form 10-10EZ</p>
-        <a
-          className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
-          href="/health-care/apply/application/"
-          onClick={onFeaturedContentClick('Apply for VA health care benefits')}
-        >
-          <span>
-            Apply online
-            <span className="vads-u-visibility--screen-reader">
-              about applying for VA health care benefits
+          </a>
+        </li>
+        <li className="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
+          <h3 className="vads-u-font-size--base vads-u-margin--0">
+            Apply for VA health care
+          </h3>
+          <hr
+            aria-hidden="true"
+            role="presentation"
+            className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"
+          />
+          <p className="va-nav-linkslist-description">
+            Equal to VA Form 10-10EZ
+          </p>
+          <a
+            className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
+            href="/health-care/apply/application/"
+            onClick={onFeaturedContentClick(
+              'Apply for VA health care benefits',
+            )}
+          >
+            <span>
+              Apply online
+              <span className="vads-u-visibility--screen-reader">
+                about applying for VA health care benefits
+              </span>
+              <i
+                aria-hidden="true"
+                className="fa fa-chevron-right vads-facility-hub-cta-arrow"
+                role="presentation"
+              />
             </span>
-            <i
-              aria-hidden="true"
-              className="fa fa-chevron-right vads-facility-hub-cta-arrow"
-              role="presentation"
-            />
-          </span>
-        </a>
-      </li>
-    </ul>
-  </>
-);
+          </a>
+        </li>
+      </ul>
+    </>
+  );
+};
+
+FindVaForms.propTypes = {
+  showPdfWarningBanner: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  showPdfWarningBanner: toggleValues(state)[
+    FEATURE_FLAG_NAMES.pdfWarningBanner || false
+  ],
+});
+
+export default connect(mapStateToProps)(FindVaForms);

--- a/src/applications/find-forms/tests/components/FindVaForms.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/FindVaForms.unit.spec.jsx
@@ -2,12 +2,44 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
 // Relative imports.
 import FindVaForms from '../../components/FindVaForms';
 
+const getData = ({
+  showNod = true,
+  isLoading = false,
+  loggedIn = true,
+} = {}) => ({
+  props: {
+    isLoading,
+    loggedIn,
+  },
+  mockStore: {
+    getState: () => ({
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        form10182_nod: showNod,
+      },
+      user: {
+        login: {
+          currentlyLoggedIn: loggedIn,
+        },
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  },
+});
+
 describe('Find VA Forms <FindVaForms>', () => {
   it('should render', () => {
-    const tree = shallow(<FindVaForms />);
+    const { mockStore } = getData();
+    const tree = shallow(
+      <Provider store={mockStore}>
+        <FindVaForms />
+      </Provider>,
+    );
 
     expect(tree.find('SearchForm')).to.exist;
     tree.unmount();

--- a/src/applications/gi/components/VARadioButton.jsx
+++ b/src/applications/gi/components/VARadioButton.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+/**
+ * VA Radio button with VA Radio Option component.
+ *
+ * @param {String} radioLabel - Text Displayed at the top of the radio buttons.
+ * @param {String} initialValue - initial value of the radio button
+ * @param {Object} options - subtask options
+ * @param {Function} onVaValueChange - updates subtask options
+ * @returns {JSX.Element}
+ */
+const VARadioButton = ({
+  radioLabel,
+  initialValue,
+  options,
+  onVaValueChange,
+}) => (
+  <VaRadio
+    enable-analytics
+    label={radioLabel}
+    onVaValueChange={onVaValueChange}
+  >
+    {options.map(({ value, label }) => (
+      <va-radio-option
+        key={value}
+        id={value}
+        value={value}
+        label={label}
+        checked={value === initialValue}
+      />
+    ))}
+  </VaRadio>
+);
+
+VARadioButton.propTypes = {
+  initialValue: PropTypes.string.isRequired,
+  radioLabel: PropTypes.string.isRequired,
+  onVaValueChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    }),
+  ),
+};
+
+export default VARadioButton;

--- a/src/applications/gi/containers/TuitionAndHousingEstimates.jsx
+++ b/src/applications/gi/containers/TuitionAndHousingEstimates.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import recordEvent from 'platform/monitoring/record-event';
 import SearchAccordion from '../components/SearchAccordion';
 import SearchBenefits from '../components/SearchBenefits';
-import RadioButtons from '../components/RadioButtons';
+import VARadioButton from '../components/VARadioButton';
 import LearnMoreLabel from '../components/LearnMoreLabel';
 import { showModal, eligibilityChange } from '../actions';
-import { connect } from 'react-redux';
 import { createId } from '../utils/helpers';
-import recordEvent from 'platform/monitoring/record-event';
 
 export function TuitionAndHousingEstimates({
   eligibility,
@@ -83,27 +83,26 @@ export function TuitionAndHousingEstimates({
         setMilitaryStatus={setMilitaryStatus}
         setSpouseActiveDuty={setSpouseActiveDuty}
       />
-      <RadioButtons
-        label={
-          <LearnMoreLabel
-            text="Will you be taking any classes in person?"
-            onClick={() => {
-              dispatchShowModal('onlineOnlyDistanceLearning');
-            }}
-            ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
-            butttonId="classes-in-person-learn-more"
-          />
-        }
-        name="inPersonClasses"
+      <LearnMoreLabel
+        text="Will you be taking any classes in person?"
+        onClick={() => {
+          dispatchShowModal('onlineOnlyDistanceLearning');
+        }}
+        ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
+        butttonId="classes-in-person-learn-more"
+      />
+      <VARadioButton
+        radioLabel=""
+        initialValue="no"
         options={[{ value: 'no', label: 'Yes' }, { value: 'yes', label: 'No' }]}
-        value={onlineClasses}
-        onChange={e => {
+        onVaValueChange={target => {
+          const { value } = target;
           recordEvent({
             event: 'gibct-form-change',
             'gibct-form-field': 'Will you be taking any classes in person ?',
-            'gibct-form-value': e.target.value,
+            'gibct-form-value': value,
           });
-          setOnlineClasses(e.target.value);
+          setOnlineClasses(value);
         }}
       />
       <div id="note" className="vads-u-padding-top--2">

--- a/src/applications/search/selectors/index.js
+++ b/src/applications/search/selectors/index.js
@@ -1,6 +1,0 @@
-// import the toggleValues helper
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
-export const showPdfWarningBanner = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.pdfWarningBanner];

--- a/src/applications/toe/helpers.jsx
+++ b/src/applications/toe/helpers.jsx
@@ -162,8 +162,8 @@ export function prefillTransformer(pages, formData, metadata, state) {
   }
 
   const emailAddress =
-    profile?.email ||
     vapContactInfo.email?.emailAddress ||
+    profile?.email ||
     contactInfo.emailAddress ||
     undefined;
 


### PR DESCRIPTION
## Description
Adds an info banner to the find-a-form search page

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11021


## Testing done
Tested locally both pointed at staging and prod to test flipper logic functionality

QA Steps: 
1: Point local api to prod to verify that the alert does not render, to staging to see that it does
2. Navigate to /find-forms/
3. Verify that the alert renders above the va-introtext


## Screenshots
![image](https://user-images.githubusercontent.com/61624970/204899317-e54e2168-e935-42fe-af55-ba517e80388c.png)


## Acceptance Criteria
- [x] Environment flag/Flipper prevents from showing in Prod
- [x] Text is exactly what appears above in description
- [x] Only shows if Flipper is set to true in the environment
- [x] Alert displays under H1 when user lands on Form Search page
- [x] Alert persists when user executes a search
- [x] Alert is not dismissible
- [ ] Screen reader reads the alert only once on the Search page while the user remains there (without navigating away), even as the user executes one or more searches
- [ ] Requires design review
- [ ] Requires accessibility review

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
