### PR TITLE
[MHV-38741] Removed 2nd Reply Button from Cannot Reply Alert

### DIFF
--- a/src/applications/mhv/secure-messaging/actions/messages.js
+++ b/src/applications/mhv/secure-messaging/actions/messages.js
@@ -88,7 +88,7 @@ export const retrieveMessage = (
   const today = new Date();
   const messageSentDate = format(new Date(sentDate), 'MM-dd-yyyy');
   const cannotReplyDate = addDays(new Date(messageSentDate), 45);
-  if (today > cannotReplyDate) {
+  if (!isDraft && today > cannotReplyDate) {
     dispatch(
       addAlert(
         Constants.ALERT_TYPE_INFO,

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons.jsx
@@ -11,7 +11,7 @@ import DeleteMessageModal from './Modals/DeleteMessageModal';
 import * as Constants from '../util/constants';
 
 const MessageActionButtons = props => {
-  const { id } = props;
+  const { id, hideReplyButton } = props;
   const dispatch = useDispatch();
   const history = useHistory();
   const folders = useSelector(state => state.sm.folders.folderList);
@@ -90,20 +90,23 @@ const MessageActionButtons = props => {
         <MoveMessageToFolderBtn messageId={id} allFolders={folders} />
       )}
 
-      <button
-        type="button"
-        className="message-action-button"
-        onClick={props.onReply}
-      >
-        <i className="fas fa-reply" aria-hidden="true" />
-        <span className="message-action-button-text">Reply</span>
-      </button>
+      {!hideReplyButton && (
+        <button
+          type="button"
+          className="message-action-button"
+          onClick={props.onReply}
+        >
+          <i className="fas fa-reply" aria-hidden="true" />
+          <span className="message-action-button-text">Reply</span>
+        </button>
+      )}
     </div>
   );
 };
 
 MessageActionButtons.propTypes = {
   handlePrintThreadStyleClass: PropTypes.func,
+  hideReplyButton: PropTypes.func,
   id: PropTypes.number,
   onReply: PropTypes.func,
 };

--- a/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
@@ -22,7 +22,7 @@ const MessageDetailBlock = props => {
 
   const history = useHistory();
   const sentReplyDate = format(new Date(sentDate), 'MM-dd-yyyy');
-  const CannotReplyDate = addDays(new Date(sentReplyDate), 45);
+  const cannotReplyDate = addDays(new Date(sentReplyDate), 45);
   const casedCategory = capitalize(category);
   const [printThread, setPrintThread] = useState('dont-print-thread');
   const [hideReplyButton, setReplyButton] = useState(false);
@@ -31,16 +31,16 @@ const MessageDetailBlock = props => {
     () => {
       history.push(`/reply/${messageId}`);
     },
-    [history],
+    [history, messageId],
   );
 
   useEffect(
     () => {
-      if (new Date() > CannotReplyDate) {
+      if (new Date() > cannotReplyDate) {
         setReplyButton(true);
       }
     },
-    [CannotReplyDate, hideReplyButton, sentReplyDate, sentDate],
+    [cannotReplyDate, hideReplyButton, sentReplyDate, sentDate],
   );
 
   const handlePrintThreadStyleClass = option => {
@@ -122,6 +122,7 @@ const MessageDetailBlock = props => {
           id={messageId}
           handlePrintThreadStyleClass={handlePrintThreadStyleClass}
           onReply={handleReplyButton}
+          hideReplyButton={hideReplyButton}
         />
       </main>
       <div className={printThread}>
@@ -130,7 +131,6 @@ const MessageDetailBlock = props => {
     </section>
   );
 };
-
 MessageDetailBlock.propTypes = {
   message: PropTypes.object,
 };


### PR DESCRIPTION
## Description

Updated logic so that the 2nd 'Reply' Button on the Message Details screen is removed during the 'Cannot Reply' 45 day alert action... Also included small code cleanup improvements.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

https://vajira.max.gov/browse/MHV-38741

## Testing done


## Screenshots

![Screenshot (207)](https://user-images.githubusercontent.com/59583325/205087535-cb202ae3-123e-43ff-90c0-6ff1778806b9.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
