### PR TITLE
50123 - fix flaky cypress test (community-care.cypress.spec.js)

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -474,8 +474,8 @@ describe('VAOS community care flow', () => {
     cy.axeCheckBestPractice();
   });
 });
-// skipped due to failures around accurate test naming convention
-describe.skip('VAOS community care flow using VAOS service', () => {
+
+describe('VAOS community care flow using VAOS service', () => {
   beforeEach(() => {
     vaosSetup();
 


### PR DESCRIPTION
## Description
Fixes flaky Cypress e2e test. 

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#50123](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50123)


## Testing done
- e2e testing
- unit testing

## Screenshots


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
