### PR TITLE
DDL: Adding error content

### DIFF
--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -57,14 +57,7 @@ const CAN_USE_MOCKS = environment.isLocalhost() && !window.Cypress;
 const USE_MOCKS = CAN_USE_MOCKS && SHOULD_USE_MOCKS;
 
 export const getClaimLetters = async () => {
-  try {
-    return await apiRequest('/claim_letters');
-    // return new Promise(res => {
-    //   setTimeout(() => res(letters), 500);
-    // });
-  } catch (err) {
-    throw new Error('error.unknown');
-  }
+  return apiRequest('/claim_letters');
 };
 
 export function setNotification(message) {

--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -12,6 +12,36 @@ import WIP from '../components/WIP';
 import { ITEMS_PER_PAGE } from '../constants';
 import { isLoadingFeatures, showClaimLettersFeature } from '../selectors';
 
+const NoLettersContent = () => (
+  <>
+    <h2 className="vads-u-font-size--h3">No letters to show</h2>
+    <div className="vads-u-font-size--lg">
+      It looks like you don’t have any letters from the VA at the moment. Check
+      back when you’re notified about letters.
+    </div>
+  </>
+);
+
+const UnauthenticatedContent = () => (
+  <div className="vads-u-text-align--center">
+    <h2 className="vads-u-font-size--h3">We can’t load this page</h2>
+    <div className="vads-u-font-size--lg">
+      Something went wrong on our end. Please double check the URL and make sure
+      you are signed in.
+    </div>
+  </div>
+);
+
+const ServerErrorContent = () => (
+  <div className="vads-u-text-align--center">
+    <h2 className="vads-u-font-size--h3">We can’t load this page</h2>
+    <div className="vads-u-font-size--lg">
+      We’re sorry. Something went wrong on our end. Please refresh this page or
+      try again later.
+    </div>
+  </div>
+);
+
 const paginateItems = items => {
   return items.length ? chunk(items, ITEMS_PER_PAGE) : [[]];
 };
@@ -23,16 +53,6 @@ const paginateItems = items => {
 //   return [from, to];
 // };
 
-const NoLettersContent = () => (
-  <>
-    <h2 className="vads-u-font-size--h3">No letters to show</h2>
-    <div className="vads-u-font-size--lg">
-      It looks like you don’t have any letters from the VA at the moment. Check
-      back when you’re notified about letters.
-    </div>
-  </>
-);
-
 export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
   const [currentItems, setCurrentItems] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
@@ -42,16 +62,22 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
   const totalItems = useRef(0);
   const totalPages = useRef(0);
   const paginatedItems = useRef([]);
+  const requestStatus = useRef(403);
 
   useEffect(() => {
-    getClaimLetters().then(data => {
-      paginatedItems.current = paginateItems(data);
-      totalItems.current = data.length;
-      totalPages.current = paginatedItems.current.length;
+    getClaimLetters()
+      .then(data => {
+        paginatedItems.current = paginateItems(data);
+        totalItems.current = data.length;
+        totalPages.current = paginatedItems.current.length;
 
-      setCurrentItems(paginatedItems.current[currentPage - 1]);
-      setLettersLoading(false);
-    });
+        setCurrentItems(paginatedItems.current[currentPage - 1]);
+        setLettersLoading(false);
+      })
+      .catch(error => {
+        requestStatus.current = error.status;
+        setLettersLoading(false);
+      });
 
     document.title = 'Your VA Claim Letters | Veterans Affairs';
   }, []);
@@ -59,6 +85,38 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
   const onPageChange = page => {
     setCurrentItems(paginatedItems.current[page - 1]);
     setCurrentPage(page);
+  };
+
+  const getSectionBodyContent = statusCode => {
+    if (statusCode === 500) {
+      return <ServerErrorContent />;
+    }
+
+    if (statusCode === 401 || statusCode === 403) {
+      return <UnauthenticatedContent />;
+    }
+
+    return (
+      <>
+        {/* <p className="vads-u-font-size--lg vads-u-font-family--serif">
+        Showing {fromToNums[0]} - {fromToNums[1]} of {totalItems.current}{' '}
+        claim letters
+      </p> */}
+        {currentItems?.length ? (
+          <ClaimLetterList letters={currentItems} />
+        ) : (
+          <NoLettersContent />
+        )}
+        {totalPages.current > 1 && (
+          <VaPagination
+            onPageSelect={e => onPageChange(e.detail.page)}
+            page={currentPage}
+            pages={totalPages.current}
+            maxPageListLength={ITEMS_PER_PAGE}
+          />
+        )}
+      </>
+    );
   };
 
   if (isLoading) {
@@ -81,25 +139,7 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
         {lettersLoading ? (
           <va-loading-indicator message="Loading your claim letters..." />
         ) : (
-          <>
-            {/* <p className="vads-u-font-size--lg vads-u-font-family--serif">
-              Showing {fromToNums[0]} - {fromToNums[1]} of {totalItems.current}{' '}
-              claim letters
-            </p> */}
-            {currentItems?.length ? (
-              <ClaimLetterList letters={currentItems} />
-            ) : (
-              <NoLettersContent />
-            )}
-            {totalPages.current > 1 && (
-              <VaPagination
-                onPageSelect={e => onPageChange(e.detail.page)}
-                page={currentPage}
-                pages={totalPages.current}
-                maxPageListLength={ITEMS_PER_PAGE}
-              />
-            )}
-          </>
+          getSectionBodyContent(requestStatus.current)
         )}
       </>
     );


### PR DESCRIPTION
## Description
Adding error content to show the user when the request to get claim letters results in an HTTP status code of 401, 403 or 500

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Mockups
[401](https://www.sketch.com/s/8b025901-295d-4929-95cc-8dbeb28454b3/a/dlL1L52)
[403](https://www.sketch.com/s/8b025901-295d-4929-95cc-8dbeb28454b3/a/jg8o8Ya)
[500](https://www.sketch.com/s/8b025901-295d-4929-95cc-8dbeb28454b3/a/DPg0gDW)

## Testing done
Tests still pass

## Screenshots
<details><summary>401</summary>

![Screen Shot 2022-12-01 at 11 59 43 AM](https://user-images.githubusercontent.com/13838621/205127297-66855897-7bb6-46b1-bb0b-990ad159dfd8.png)
</details>

<details><summary>403</summary>

![Screen Shot 2022-12-01 at 11 59 43 AM](https://user-images.githubusercontent.com/13838621/205127297-66855897-7bb6-46b1-bb0b-990ad159dfd8.png)
</details>

<details><summary>500</summary>

![Screen Shot 2022-12-01 at 11 59 03 AM](https://user-images.githubusercontent.com/13838621/205127412-6f88eb83-4a2c-44b5-956a-8979cdc5498d.png)
</details>

## Acceptance criteria
- [x] Content is added for 401, 403, and 500 HTTP status code scenarios

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
