### PR TITLE
[mhv-38981] changed 'Deleted' to 'Trash' in move modal

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
@@ -5,6 +5,7 @@ import {
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useDispatch, useSelector } from 'react-redux';
+import * as Constants from '../../util/constants';
 import { moveMessage } from '../../actions/messages';
 import { getFolders, newFolder } from '../../actions/folders';
 
@@ -89,7 +90,9 @@ const MoveMessageToFolderBtn = props => {
                       htmlFor={`radiobutton-${folder.name}`}
                     >
                       {/* checking if the folder is the trash folder, as the name on the backend is 'Deleted' instead of 'Trash'. */}
-                      {folder.id === -3 ? 'Trash' : folder.name}
+                      {folder.id === Constants.DefaultFolders.DELETED.id
+                        ? 'Trash'
+                        : folder.name}
                     </label>
                   </div>
                 ))}

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
@@ -88,7 +88,7 @@ const MoveMessageToFolderBtn = props => {
                       name="defaultName-0-label"
                       htmlFor={`radiobutton-${folder.name}`}
                     >
-                      {folder.name}
+                      {folder.name === 'Deleted' ? 'Trash' : folder.name}
                     </label>
                   </div>
                 ))}

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
@@ -88,7 +88,8 @@ const MoveMessageToFolderBtn = props => {
                       name="defaultName-0-label"
                       htmlFor={`radiobutton-${folder.name}`}
                     >
-                      {folder.name === 'Deleted' ? 'Trash' : folder.name}
+                      {/* checking if the folder is the trash folder, as the name on the backend is 'Deleted' instead of 'Trash'. */}
+                      {folder.id === -3 ? 'Trash' : folder.name}
                     </label>
                   </div>
                 ))}


### PR DESCRIPTION
## Description
Fixed a bug where in the move modal, the Trash folder shows up as Deleted.

## Original issue(s)
https://vajira.max.gov/browse/MHV-38981


## Testing done
Manual testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
