### PR TITLE
DDL: fix issue with initial value of requestStatus

### DIFF
--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -62,7 +62,7 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
   const totalItems = useRef(0);
   const totalPages = useRef(0);
   const paginatedItems = useRef([]);
-  const requestStatus = useRef(403);
+  const requestStatus = useRef(200);
 
   useEffect(() => {
     getClaimLetters()


### PR DESCRIPTION
## Description
 requestStatus should be 200

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Acceptance criteria
- [x] requestStatus initial value is 200

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
