### PR TITLE
#VFEP-102 #comment moved focusElement into own useEffect to fix acces…

### DIFF
--- a/src/applications/gi/containers/search/NameSearchResults.jsx
+++ b/src/applications/gi/containers/search/NameSearchResults.jsx
@@ -3,15 +3,15 @@ import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
+import { focusElement } from 'platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
 import { fetchSearchByNameResults } from '../../actions/index';
-import ResultCard from '../search/ResultCard';
+import ResultCard from './ResultCard';
 import FilterYourResults from '../FilterYourResults';
 import TuitionAndHousingEstimates from '../TuitionAndHousingEstimates';
 import { updateUrlParams } from '../../selectors/search';
 import { getFiltersChanged } from '../../selectors/filters';
 import MobileFilterControls from '../../components/MobileFilterControls';
-import { focusElement } from 'platform/utilities/ui';
-import recordEvent from 'platform/monitoring/record-event';
 
 export function NameSearchResults({
   dispatchFetchSearchByNameResults,
@@ -66,7 +66,6 @@ export function NameSearchResults({
 
   useEffect(
     () => {
-      focusElement('#name-search-results-count');
       // Avoid blank searches or double events
       if (name && count !== null) {
         recordEvent({
@@ -88,6 +87,7 @@ export function NameSearchResults({
     },
     [results, name, totalPages, count],
   );
+
   const fetchPage = page => {
     dispatchFetchSearchByNameResults(name, page, filters, version);
     updateUrlParams(
@@ -101,6 +101,13 @@ export function NameSearchResults({
       version,
     );
   };
+
+  useEffect(
+    () => {
+      focusElement('#name-search-results-count');
+    },
+    [results],
+  );
 
   return (
     <>


### PR DESCRIPTION
…sibility issue of search results not reading correctly

## Description
When searching for an institution while using JAWS, in the comparison tool, the feedback reads as "Contains Text". If the user preforms a second search, the feedback that is given is for the previous search and not the one just conducted.


## Original issue(s)
[Jira Ticket](https://vajira.max.gov/browse/VFEP-102)
On the screen titled “GI Bill Comparison Tool | Veterans Affairs,” under the “search by name” tab, after activating the Search button, assistive technology does not indicate that a search was executed. For example, when “12345” is entered into the search field, and the Search button is activated, assistive technology is reading “contains text,” but visually the text reads: “Showing 0 search results for 1234.” This does not indicate that a search was executed. (New: 07/29/2022)


## Testing done
manual testing on local environment / testing will be preformed in Review Instance and in Staging before going into Prod

## Screenshots
![image](https://user-images.githubusercontent.com/88905347/205144793-2df327eb-8f0f-4764-a934-6db4d6626f17.png)


## Acceptance criteria
- [ ] Accessibility reader, reads what is visually seen on screen

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating Jira issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
