### PR TITLE
Update to Formation 7.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@department-of-veterans-affairs/component-library": "^13.3.0",
-    "@department-of-veterans-affairs/formation": "^7.0.3",
+    "@department-of-veterans-affairs/formation": "^7.0.4",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,10 +2544,10 @@
   dependencies:
     jsx-ast-utils "^3.3.3"
 
-"@department-of-veterans-affairs/formation@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.3.tgz#452206ad64000179cba8eb9f7dd7e852eb1ae7b3"
-  integrity sha512-VDS/PQLSwh2pe4zD9idlx5vg/xwEr8+5jlY4Xm9SMPMk9zcS2BXRSZBVq4aDP0CEWat3qpoiOBZWgAy+OeLJDQ==
+"@department-of-veterans-affairs/formation@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.4.tgz#897ae5dec1c63eb26d6398c556a6ea671f50ebc3"
+  integrity sha512-xgc+cWaGRNCcy1tipBzOwt9UoncH0RQKK3npnSm0uW68jTiBh3++7WlNkO7sKrxq4MqDmcgjhMt4Vnl5nT8w0A==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
This PR will update Formation to the latest published version. This version includes some minor updates to the radio button spacing: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/891

## Testing done
Local

## Acceptance criteria
- [ ] Formation v7.0.4 is used in vets-website.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
