### PR TITLE
VACMS-11772: Replaces veterans-crisis-line number while 988 is out

### DIFF
--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,5 +1,6 @@
 const overlay = '#modal-crisisline';
-const firstModalItem = 'a[href="tel:988"]';
+// const firstModalItem = 'a[href="tel:988"]';
+const firstModalItem = 'a[href="tel:8772676030"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
 const firstOpenControl = '[data-show="#modal-crisisline"]';
 const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';

--- a/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
+++ b/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
@@ -37,9 +37,12 @@ export default function CrisisPanel() {
                 className="fa fa-phone va-crisis-panel-icon"
                 aria-hidden="true"
               />
-              <a href="tel:988">
-                Call <strong>988 and select 1</strong>
-              </a>
+              {
+                // eslint-disable-next-line @department-of-veterans-affairs/prefer-telephone-component
+                <a href="tel:8772676030">
+                  Call <strong>877-267-6030</strong>
+                </a>
+              }
             </li>
             <li>
               <i


### PR DESCRIPTION
## Description
Temporary change of emergency contact number.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11772


## Testing done
Visual; locally.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/205181282-3f432696-763f-4b77-8a68-ee7c71e5dc68.png)
![image](https://user-images.githubusercontent.com/6863534/205182050-5ff85a88-e50b-4a81-961f-1e6adc512bc9.png)
