### PR TITLE
FE feature toggle created for CST's migration to the Lighthouse API

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -36,6 +36,7 @@ import FeaturesWarning from '../components/FeaturesWarning';
 import MobileAppMessage from '../components/MobileAppMessage';
 import NoClaims from '../components/NoClaims';
 import StemClaimListItem from '../components/StemClaimListItem';
+import { cstUseLighthouse } from '../selectors';
 
 import { ITEMS_PER_PAGE } from '../constants';
 
@@ -299,10 +300,6 @@ function mapStateToProps(state) {
     FEATURE_FLAG_NAMES.stemAutomatedDecision
   ];
 
-  const useLighthouse = toggleValues(state)[
-    FEATURE_FLAG_NAMES.cstUseLighthouse
-  ];
-
   const stemClaims = stemAutomatedDecision ? claimsV2Root.stemClaims : [];
 
   // TO-DO: Implement with reselect to save cycles
@@ -319,7 +316,7 @@ function mapStateToProps(state) {
     canAccessClaims,
     claimsAvailable: claimsV2Root.claimsAvailability,
     claimsLoading: claimsV2Root.claimsLoading,
-    useLighthouse,
+    useLighthouse: cstUseLighthouse(state),
     fullName: state.user.profile.userFullName,
     list: sortedList,
     stemClaimsLoading: claimsV2Root.stemClaimsLoading,

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -61,6 +61,7 @@ class YourClaimsPageV2 extends React.Component {
     const {
       canAccessAppeals,
       canAccessClaims,
+      // useLighthouse,
       getAppealsV2,
       getClaimsV2,
       getStemClaims,
@@ -68,6 +69,7 @@ class YourClaimsPageV2 extends React.Component {
       appealsLoading,
       stemClaimsLoading,
     } = this.props;
+
     if (canAccessClaims) {
       getClaimsV2();
     }
@@ -280,6 +282,7 @@ YourClaimsPageV2.propTypes = {
     }),
   ),
   stemClaimsLoading: PropTypes.bool,
+  useLighthouse: PropTypes.bool,
 };
 
 function mapStateToProps(state) {
@@ -294,6 +297,10 @@ function mapStateToProps(state) {
   );
   const stemAutomatedDecision = toggleValues(state)[
     FEATURE_FLAG_NAMES.stemAutomatedDecision
+  ];
+
+  const useLighthouse = toggleValues(state)[
+    FEATURE_FLAG_NAMES.cstUseLighthouse
   ];
 
   const stemClaims = stemAutomatedDecision ? claimsV2Root.stemClaims : [];
@@ -312,6 +319,7 @@ function mapStateToProps(state) {
     canAccessClaims,
     claimsAvailable: claimsV2Root.claimsAvailability,
     claimsLoading: claimsV2Root.claimsLoading,
+    useLighthouse,
     fullName: state.user.profile.userFullName,
     list: sortedList,
     stemClaimsLoading: claimsV2Root.stemClaimsLoading,

--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -4,3 +4,5 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 export const isLoadingFeatures = state => toggleValues(state).loading;
 export const showClaimLettersFeature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.claimLettersAccess];
+export const cstUseLighthouse = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.cstUseLighthouse];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -38,6 +38,7 @@ export default Object.freeze({
   covidVolunteerIntakeBackendEnabled: 'covid_volunteer_intake_backend_enabled',
   covidVolunteerIntakeEnabled: 'covid_volunteer_intake_enabled',
   covidVolunteerUpdateEnabled: 'covid_volunteer_update_enabled',
+  cstUseLighthouse: 'cst_use_lighthouse',
   debtLettersShowLetters: 'debt_letters_show_letters',
   debtLettersShowLettersVBMS: 'debt_letters_show_letters_vbms',
   dependencyVerification: 'dependency_verification',


### PR DESCRIPTION
Added feature toggle that will be used to migrate CST from using EVSS API to the Lighthouse API.


## Summary

- created useLighthouse feature toggle
- useLighthouse/cst_use_lighthouse will be enabled until we successfully test the transition from the EVSS API to the Lighthouse API for CST

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/49863


## Testing done

- Tested feature toggle with console.log

