### PR TITLE
Removes default Content-Type from default headers for apiRequest.

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -75,7 +75,6 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
     method: 'GET',
     credentials: 'include',
     headers: {
-      'Content-Type': 'application/json',
       'X-Key-Inflection': 'camel',
       'Source-App-Name': window.appName,
       'X-CSRF-Token': csrfTokenStored,


### PR DESCRIPTION
## Summary
Removes the default Content-Type in the headers of apiRequest utility. This change of adding the default Content-Type broke functionality in vets-api for the pre-check-in application.

To reproduce the bug, create a pre-check-in appointment in stage and attempt to validate with lorota in pre-check-in. You will see the error page.

The solution is to remove the recently added default Content-Type in the header which is not correct for a GET request.

I work with the check-in team which does not own maintenance for this component.

no flipper applicable.

## Testing done

none

## Screenshots
none

## What areas of the site does it impact?
pre-check-in and reporting for day of check-in

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
