### PR TITLE
DDL: Fix issue with response status tracking

### DIFF
--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -26,7 +26,9 @@ const docTypeToDescription = {
 };
 
 const getDescription = docType => {
-  return docTypeToDescription[docType];
+  const defaultDescription = 'Notification Letter';
+
+  return docTypeToDescription[docType] || defaultDescription;
 };
 
 const filename = 'ClaimLetter.pdf';

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -54,7 +54,7 @@ const ClaimLetterListItem = ({ letter }) => {
         filetype="PDF"
         href={downloadUrl(letter.documentId)}
         onClick={downloadHandler}
-        text={`Download ${formattedDate} Dateletter`}
+        text={`Download ${formattedDate} letter`}
       />
     </li>
   );

--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -21,6 +21,14 @@ const formatDate = date => {
   return format(withOffset, 'MMMM dd, yyyy');
 };
 
+const docTypeToDescription = {
+  184: 'Notification Letter',
+};
+
+const getDescription = docType => {
+  return docTypeToDescription[docType];
+};
+
 const filename = 'ClaimLetter.pdf';
 
 const downloadHandler = () => {
@@ -31,13 +39,14 @@ const downloadHandler = () => {
 };
 
 const ClaimLetterListItem = ({ letter }) => {
-  const heading = `Letter dated ${formatDate(letter.receivedAt)}`;
+  const formattedDate = formatDate(letter.receivedAt);
+  const heading = `Letter dated ${formattedDate}`;
 
   return (
     <li className="vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-padding-bottom--2">
       <h2 className="vads-u-font-size--h4">{heading}</h2>
       <div className="vads-u-color--gray-warm-dark vads-u-margin-bottom--0p5">
-        {letter.typeDescription}
+        {getDescription(letter.docType)}
       </div>
       <va-link
         download
@@ -45,7 +54,7 @@ const ClaimLetterListItem = ({ letter }) => {
         filetype="PDF"
         href={downloadUrl(letter.documentId)}
         onClick={downloadHandler}
-        text="Download letter"
+        text={`Download ${formattedDate} Dateletter`}
       />
     </li>
   );

--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -43,7 +43,7 @@ const ServerErrorContent = () => (
 );
 
 const paginateItems = items => {
-  return items.length ? chunk(items, ITEMS_PER_PAGE) : [[]];
+  return items?.length ? chunk(items, ITEMS_PER_PAGE) : [[]];
 };
 
 // const getFromToNums = (page, total) => {
@@ -68,14 +68,18 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
     getClaimLetters()
       .then(data => {
         paginatedItems.current = paginateItems(data);
-        totalItems.current = data.length;
+        totalItems.current = data?.length || 0;
         totalPages.current = paginatedItems.current.length;
 
         setCurrentItems(paginatedItems.current[currentPage - 1]);
         requestStatus.current = 200;
       })
       .catch(error => {
-        requestStatus.current = Number(error.errors[0].code);
+        if (error.errors) {
+          requestStatus.current = Number(error?.errors[0].code);
+        } else {
+          requestStatus.current = error.status;
+        }
       })
       .then(() => {
         setLettersLoading(false);

--- a/src/applications/claims-status/containers/YourClaimLetters.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters.jsx
@@ -72,10 +72,12 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
         totalPages.current = paginatedItems.current.length;
 
         setCurrentItems(paginatedItems.current[currentPage - 1]);
-        setLettersLoading(false);
+        requestStatus.current = 200;
       })
       .catch(error => {
-        requestStatus.current = error.status;
+        requestStatus.current = Number(error.errors[0].code);
+      })
+      .then(() => {
         setLettersLoading(false);
       });
 

--- a/src/applications/claims-status/tests/e2e/08.claim-letters.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/08.claim-letters.cypress.spec.js
@@ -1,6 +1,12 @@
 import claimLetters from './fixtures/mocks/claim-letters.json';
 import featureToggles from './fixtures/mocks/feature-toggles.json';
 
+const generateErrorContent = (title, code) => {
+  return {
+    errors: [{ title, detail: title, code, status: code }],
+  };
+};
+
 describe('Claim Letters Page', () => {
   beforeEach(() => {
     cy.intercept('GET', '/v0/claim_letters', claimLetters.data);
@@ -12,7 +18,6 @@ describe('Claim Letters Page', () => {
   });
 
   it('Displays a list of letters', () => {
-    // cy.intercept('GET', '/v0/claim_letters', claimLetters.data.slice(0, 8));
     cy.get('h1').should('have.text', 'Your VA claim letters');
     cy.get('ol').should.exist;
     cy.get('ol > li').should('have.length', 10);
@@ -77,9 +82,7 @@ describe('Claim Letters Page', () => {
   it('Displays a "No letters to show" message if there are no letters', () => {
     cy.intercept('GET', '/v0/claim_letters', []);
 
-    cy.get('h2.vads-u-font-size--h3')
-      .first()
-      .should('have.text', 'No letters to show');
+    cy.findByText(/No letters to show/i);
 
     // List shouldn't show
     cy.get('ol').should('not.exist');
@@ -88,40 +91,37 @@ describe('Claim Letters Page', () => {
   });
 
   it('Displays a server error message when status code is 500', () => {
-    cy.intercept('GET', '/v0/claim_letters', { statusCode: 500 });
+    cy.intercept('GET', '/v0/claim_letters', {
+      statusCode: 500,
+      body: generateErrorContent('Internal server error', '500'),
+    });
 
-    cy.get('h2.vads-u-font-size--h3')
-      .first()
-      .should('have.text', 'We can’t load this page');
-    cy.get('h2.vads-u-font-size--h3 + div').contains(
-      'Please refresh this page or try again later',
-    );
+    cy.findByText(/We can’t load this page/i);
+    cy.findByText(/Please refresh this page or try again later/i);
 
     cy.axeCheck();
   });
 
-  it('Displays an unauthenticated error message when status code is 403', () => {
-    cy.intercept('GET', '/v0/claim_letters', { statusCode: 403 });
+  it('Displays a forbidden error message when status code is 403', () => {
+    cy.intercept('GET', '/v0/claim_letters', {
+      statusCode: 403,
+      body: generateErrorContent('Forbidden', '403'),
+    });
 
-    cy.get('h2.vads-u-font-size--h3')
-      .first()
-      .should('have.text', 'We can’t load this page');
-    cy.get('h2.vads-u-font-size--h3 + div').contains(
-      'Please double check the URL',
-    );
+    cy.findByText(/We can’t load this page/i);
+    cy.findByText(/Please double check the URL/i);
 
     cy.axeCheck();
   });
 
   it('Displays an unauthenticated error message when status code is 401', () => {
-    cy.intercept('GET', '/v0/claim_letters', { statusCode: 401 });
+    cy.intercept('GET', '/v0/claim_letters', {
+      statusCode: 401,
+      body: generateErrorContent('Not authorized', '401'),
+    });
 
-    cy.get('h2.vads-u-font-size--h3')
-      .first()
-      .should('have.text', 'We can’t load this page');
-    cy.get('h2.vads-u-font-size--h3 + div').contains(
-      'Please double check the URL',
-    );
+    cy.findByText(/We can’t load this page/i);
+    cy.findByText(/Please double check the URL/i);
 
     cy.axeCheck();
   });

--- a/src/applications/claims-status/tests/e2e/08.claim-letters.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/08.claim-letters.cypress.spec.js
@@ -19,10 +19,10 @@ describe('Claim Letters Page', () => {
 
   it('Displays a list of letters', () => {
     cy.get('h1').should('have.text', 'Your VA claim letters');
-    cy.get('ol').should.exist;
+    cy.get('ol').should('exist');
     cy.get('ol > li').should('have.length', 10);
 
-    cy.get('va-pagination').should.exist;
+    cy.get('va-pagination').should('exist');
 
     cy.axeCheck();
   });
@@ -32,7 +32,7 @@ describe('Claim Letters Page', () => {
 
     // TODO: Check the number of pages in the va-pagination component
     // We should know ahead of time how many pages should appear
-    cy.get('va-pagination').should.exist;
+    cy.get('va-pagination').should('exist');
 
     cy.axeCheck();
   });
@@ -82,7 +82,7 @@ describe('Claim Letters Page', () => {
   it('Displays a "No letters to show" message if there are no letters', () => {
     cy.intercept('GET', '/v0/claim_letters', []);
 
-    cy.findByText(/No letters to show/i);
+    cy.findByText(/No letters to show/i).should('exist');
 
     // List shouldn't show
     cy.get('ol').should('not.exist');
@@ -96,8 +96,10 @@ describe('Claim Letters Page', () => {
       body: generateErrorContent('Internal server error', '500'),
     });
 
-    cy.findByText(/We can’t load this page/i);
-    cy.findByText(/Please refresh this page or try again later/i);
+    cy.findByText(/We can’t load this page/i).should('exist');
+    cy.findByText(/Please refresh this page or try again later/i).should(
+      'exist',
+    );
 
     cy.axeCheck();
   });
@@ -108,8 +110,8 @@ describe('Claim Letters Page', () => {
       body: generateErrorContent('Forbidden', '403'),
     });
 
-    cy.findByText(/We can’t load this page/i);
-    cy.findByText(/Please double check the URL/i);
+    cy.findByText(/We can’t load this page/i).should('exist');
+    cy.findByText(/Please double check the URL/i).should('exist');
 
     cy.axeCheck();
   });
@@ -120,8 +122,8 @@ describe('Claim Letters Page', () => {
       body: generateErrorContent('Not authorized', '401'),
     });
 
-    cy.findByText(/We can’t load this page/i);
-    cy.findByText(/Please double check the URL/i);
+    cy.findByText(/We can’t load this page/i).should('exist');
+    cy.findByText(/Please double check the URL/i).should('exist');
 
     cy.axeCheck();
   });


### PR DESCRIPTION
## Description
Updating the way that response status is tracked to get it from the `errors` array
Updated some of the content to reflect desired changes

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#49795

## Testing done
* Tests updated to pass body with `errors` array on intercepts
* Using `findByText` instead of fragile selectors

## Screenshots
<details><summary>Before</summary>

![Screen Shot 2022-12-05 at 11 11 01 AM](https://user-images.githubusercontent.com/13838621/205699460-bc9abc7c-39c8-4fcb-82e6-7215867235f2.png)
</details>

<details><summary>After</summary>

![Screen Shot 2022-12-05 at 11 09 47 AM](https://user-images.githubusercontent.com/13838621/205699299-0792ecc7-8cac-4f4e-8d83-94b14bce56e2.png)
</details>

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
