### PR TITLE
Profile/50007/remove box security screen

### DIFF
--- a/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   isLOA3 as isLOA3Selector,
@@ -102,46 +101,6 @@ export const AccountSecurityContent = ({
         <NotInMPIError className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" />
       )}
       <ProfileInfoTable data={securitySections} fieldName="accountSecurity" />
-      <AlertBox
-        status="info"
-        headline="Have questions about signing in to VA.gov?"
-        className="medium-screen:vads-u-margin-top--4"
-        backgroundOnly
-        level={2}
-      >
-        <div className="vads-u-display--flex vads-u-flex-direction--column">
-          <p>
-            Get answers to frequently asked questions about how to sign in,
-            common issues with verifying your identity, and your privacy and
-            security on VA.gov.
-          </p>
-
-          <h3 className="vads-u-font-size--h4">
-            Go to FAQs about these topics:
-          </h3>
-          <a
-            href="/resources/signing-in-to-vagov/"
-            className="vads-u-margin-y--1"
-            onClick={handlers.vetsFAQ}
-          >
-            Signing in to VA.gov
-          </a>
-          <a
-            href="/resources/verifying-your-identity-on-vagov/"
-            className="vads-u-margin-y--1"
-            onClick={handlers.vetsFAQ}
-          >
-            Verifying your identity on VA.gov
-          </a>
-          <a
-            href="/resources/privacy-and-security-on-vagov/"
-            className="vads-u-margin-y--1"
-            onClick={handlers.vetsFAQ}
-          >
-            Privacy and security on VA.gov
-          </a>
-        </div>
-      </AlertBox>
     </>
   );
 };

--- a/src/applications/personalization/profile/tests/components/account-security/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/account-security/AccountSecurityContent.unit.spec.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-
 import {
   AccountSecurityContent,
   mapStateToProps,
@@ -110,30 +108,6 @@ describe('AccountSecurityContent', () => {
         wrapper.unmount();
       });
     });
-  });
-
-  it('should render a properly configured AlertBox as its second child', () => {
-    wrapper = shallow(<AccountSecurityContent {...makeDefaultProps()} />);
-    const alertBox = wrapper.childAt(1);
-    const alertBoxText = alertBox.find('p');
-    const firstAlertBoxLink = alertBox.find('a').first();
-    const secondAlertBoxLink = alertBox.find('a').at(1);
-    const thirdAlertBoxLink = alertBox.find('a').at(2);
-    const alertBoxSubtitle = alertBox.find('h3');
-    expect(alertBox.type()).to.equal(AlertBox);
-    expect(alertBox.prop('status')).to.equal('info');
-    expect(alertBox.prop('headline')).to.equal(
-      'Have questions about signing in to VA.gov?',
-    );
-    expect(alertBox.prop('backgroundOnly')).to.be.true;
-    expect(alertBoxText.text()).to.contain('Get answers');
-    expect(alertBoxSubtitle.text()).to.equal('Go to FAQs about these topics:');
-    expect(firstAlertBoxLink.text()).to.equal('Signing in to VA.gov');
-    expect(secondAlertBoxLink.text()).to.equal(
-      'Verifying your identity on VA.gov',
-    );
-    expect(thirdAlertBoxLink.text()).to.equal('Privacy and security on VA.gov');
-    wrapper.unmount();
   });
 });
 


### PR DESCRIPTION
## Summary

- Removed Alert at bottom of Account Security page in Profile
- Removed Unit tests corresponding to Alert

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50007


## Testing done

- e2e
- visual
- unit tests

## What areas of the site does it impact?
Account Security section of Profile no long has alert box at bottom

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
