### PR TITLE
Enrollment Verification — Add API Error Handling and Loading Spinner

### DIFF
--- a/src/applications/enrollment-verification/components/EnrollmentVerificationAlert.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationAlert.jsx
@@ -2,10 +2,20 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import { getEVData } from '../selectors';
 import { STATUS } from '../constants';
 import { STATUS_PROP_TYPE } from '../helpers';
 import { UPDATE_VERIFICATION_STATUS_SUCCESS } from '../actions';
 import VerifyYourEnrollments from './VerifyYourEnrollments';
+
+const fetchFailureAlert = (
+  <va-alert status="error" visible>
+    <h3 slot="headline">
+      There was an error retrieving your enrollment verifications
+    </h3>
+    <p>Please try again later.</p>
+  </va-alert>
+);
 
 const successAlert = submissionResult => (
   <va-alert status="success" visible>
@@ -66,7 +76,15 @@ const pausedScoAlert = (
   </va-alert>
 );
 
-const EnrollmentVerificationAlert = ({ status, submissionResult }) => {
+const EnrollmentVerificationAlert = ({
+  enrollmentVerificationFetchFailure,
+  status,
+  submissionResult,
+}) => {
+  if (enrollmentVerificationFetchFailure) {
+    return fetchFailureAlert;
+  }
+
   switch (status) {
     case STATUS.ALL_VERIFIED:
       return successAlert(submissionResult);
@@ -83,11 +101,10 @@ const EnrollmentVerificationAlert = ({ status, submissionResult }) => {
 
 EnrollmentVerificationAlert.propTypes = {
   status: STATUS_PROP_TYPE.isRequired,
+  enrollmentVerificationFetchFailure: PropTypes.bool,
   submissionResult: PropTypes.string,
 };
 
-const mapStateToProps = state => ({
-  submissionResult: state?.data?.enrollmentVerificationSubmissionResult,
-});
+const mapStateToProps = state => getEVData(state);
 
 export default connect(mapStateToProps)(EnrollmentVerificationAlert);

--- a/src/applications/enrollment-verification/containers/EnrollmentVerificationIntroPage.jsx
+++ b/src/applications/enrollment-verification/containers/EnrollmentVerificationIntroPage.jsx
@@ -12,10 +12,13 @@ import {
   REVIEW_ENROLLMENTS_RELATIVE_URL,
   REVIEW_ENROLLMENTS_URL,
 } from '../constants';
+import { getEVData } from '../selectors';
 
 export function EnrollmentVerificationIntroPage({
-  loggedIn,
+  isLoggedIn,
   enrollmentVerification,
+  enrollmentVerificationFetchComplete,
+  enrollmentVerificationFetchFailure,
   hasCheckedKeepAlive,
   getPost911GiBillEligibility,
   post911GiBillEligibility,
@@ -48,6 +51,9 @@ export function EnrollmentVerificationIntroPage({
     [history],
   );
 
+  const enrollmentsLoadedOrFetchFailed =
+    enrollmentVerification || enrollmentVerificationFetchFailure;
+
   const verifyEnrollmentsButton = (
     <a
       type="button"
@@ -72,7 +78,7 @@ export function EnrollmentVerificationIntroPage({
     </va-alert>
   );
 
-  if (!loggedIn && !hasCheckedKeepAlive) {
+  if (!isLoggedIn && !hasCheckedKeepAlive) {
     return <EnrollmentVerificationLoadingIndicator />;
   }
 
@@ -84,9 +90,19 @@ export function EnrollmentVerificationIntroPage({
         continue getting paid.
       </p>
 
-      {!loggedIn ? <EnrollmentVerificationLogin /> : <></>}
-      {loggedIn && enrollmentVerification ? verifyEnrollmentsButton : <></>}
-      {loggedIn && !enrollmentVerification ? noPost911GiBillAlert : <></>}
+      {!isLoggedIn && <EnrollmentVerificationLogin />}
+      {isLoggedIn &&
+        !enrollmentVerificationFetchComplete && (
+          <EnrollmentVerificationLoadingIndicator message="Loading..." />
+        )}
+      {isLoggedIn &&
+        enrollmentVerificationFetchComplete &&
+        enrollmentsLoadedOrFetchFailed &&
+        verifyEnrollmentsButton}
+      {isLoggedIn &&
+        enrollmentVerificationFetchComplete &&
+        !enrollmentsLoadedOrFetchFailed &&
+        noPost911GiBillAlert}
 
       <h2>Who will need to verify their enrollment?</h2>
       <p>
@@ -185,11 +201,7 @@ export function EnrollmentVerificationIntroPage({
   );
 }
 
-const mapStateToProps = state => ({
-  loggedIn: state?.user?.login?.currentlyLoggedIn,
-  hasCheckedKeepAlive: state?.user?.login?.hasCheckedKeepAlive,
-  enrollmentVerification: state?.data?.enrollmentVerification,
-});
+const mapStateToProps = state => getEVData(state);
 
 const mapDispatchToProps = {
   getPost911GiBillEligibility: fetchPost911GiBillEligibility,

--- a/src/applications/enrollment-verification/containers/EnrollmentVerificationPage.jsx
+++ b/src/applications/enrollment-verification/containers/EnrollmentVerificationPage.jsx
@@ -12,37 +12,37 @@ import {
   ENROLLMENT_VERIFICATION_TYPE,
   getEnrollmentVerificationStatus,
 } from '../helpers';
+import { getEVData } from '../selectors';
 
 export const EnrollmentVerificationPage = ({
   enrollmentVerification,
+  enrollmentVerificationFetchComplete,
+  enrollmentVerificationFetchFailure,
   getPost911GiBillEligibility,
   hasCheckedKeepAlive,
-  loggedIn,
-  post911GiBillEligibility,
+  isLoggedIn,
 }) => {
   const history = useHistory();
 
   useEffect(
     () => {
-      if (hasCheckedKeepAlive && !loggedIn) {
+      if (hasCheckedKeepAlive && !isLoggedIn) {
         history.push('/');
       }
+    },
+    [hasCheckedKeepAlive, history, isLoggedIn],
+  );
 
+  useEffect(
+    () => {
       if (!enrollmentVerification) {
         getPost911GiBillEligibility();
       }
     },
-    [
-      hasCheckedKeepAlive,
-      history,
-      loggedIn,
-      post911GiBillEligibility,
-      getPost911GiBillEligibility,
-      enrollmentVerification,
-    ],
+    [getPost911GiBillEligibility, enrollmentVerification],
   );
 
-  if (!enrollmentVerification) {
+  if (!enrollmentVerificationFetchComplete) {
     return <EnrollmentVerificationLoadingIndicator />;
   }
 
@@ -62,12 +62,15 @@ export const EnrollmentVerificationPage = ({
 
       <EnrollmentVerificationAlert status={status} />
 
-      <EnrollmentVerificationMonths
-        status={status}
-        enrollmentVerification={enrollmentVerification}
-      />
+      {enrollmentVerificationFetchComplete &&
+        !enrollmentVerificationFetchFailure && (
+          <EnrollmentVerificationMonths
+            status={status}
+            enrollmentVerification={enrollmentVerification}
+          />
+        )}
 
-      <div className="ev-highlighted-content-container">
+      <div className="ev-highlighted-content-container vads-u-margin-top--3">
         <header className="ev-highlighted-content-container_header">
           <h1 className="ev-highlighted-content-container_title vads-u-font-size--h3">
             Related pages
@@ -92,18 +95,14 @@ export const EnrollmentVerificationPage = ({
 
 EnrollmentVerificationPage.propTypes = {
   enrollmentVerification: ENROLLMENT_VERIFICATION_TYPE,
+  enrollmentVerificationFetchComplete: PropTypes.bool,
+  enrollmentVerificationFetchFailure: PropTypes.bool,
   getPost911GiBillEligibility: PropTypes.func,
   hasCheckedKeepAlive: PropTypes.bool,
-  loggedIn: PropTypes.bool,
-  post911GiBillEligibility: PropTypes.object,
+  isLoggedIn: PropTypes.bool,
 };
 
-const mapStateToProps = state => ({
-  hasCheckedKeepAlive: state?.user?.login?.hasCheckedKeepAlive || false,
-  loggedIn: state?.user?.login?.currentlyLoggedIn || false,
-  enrollmentVerification: state?.data?.enrollmentVerification,
-  post911GiBillEligibility: state?.data?.post911GiBillEligibility,
-});
+const mapStateToProps = state => getEVData(state);
 
 const mapDispatchToProps = {
   getPost911GiBillEligibility: fetchPost911GiBillEligibility,

--- a/src/applications/enrollment-verification/reducers/index.js
+++ b/src/applications/enrollment-verification/reducers/index.js
@@ -21,9 +21,10 @@ export default {
   data: (state = initialState, action) => {
     switch (action.type) {
       case FETCH_POST_911_GI_BILL_ELIGIBILITY_SUCCESS:
-      case FETCH_POST_911_GI_BILL_ELIGIBILITY_FAILURE:
         return {
           ...state,
+          enrollmentVerificationFetchComplete: true,
+          enrollmentVerificationFetchFailure: false,
           enrollmentVerification: {
             ...action?.response?.data?.attributes,
             enrollmentVerifications: action?.response?.data?.attributes?.enrollmentVerifications?.filter(
@@ -31,6 +32,12 @@ export default {
                 ev.certifiedEndDate < new Date().toISOString().split('T')[0],
             ),
           },
+        };
+      case FETCH_POST_911_GI_BILL_ELIGIBILITY_FAILURE:
+        return {
+          ...state,
+          enrollmentVerificationFetchComplete: true,
+          enrollmentVerificationFetchFailure: true,
         };
       case UPDATE_VERIFICATION_STATUS_MONTHS:
         return {

--- a/src/applications/enrollment-verification/selectors.js
+++ b/src/applications/enrollment-verification/selectors.js
@@ -1,0 +1,12 @@
+export const getEVData = state => ({
+  isLoggedIn: state?.user?.login?.currentlyLoggedIn || false,
+  hasCheckedKeepAlive: state?.user?.login?.hasCheckedKeepAlive || false,
+  editMonthVerification: state?.data?.editMonthVerification,
+  enrollmentVerification: state?.data?.enrollmentVerification,
+  enrollmentVerificationFetchComplete:
+    state?.data?.enrollmentVerificationFetchComplete || false,
+  enrollmentVerificationFetchFailure:
+    state?.data?.enrollmentVerificationFetchFailure || false,
+  enrollmentVerificationSubmitted: state?.data?.enrollmentVerificationSubmitted,
+  submissionResult: state?.data?.enrollmentVerificationSubmissionResult,
+});


### PR DESCRIPTION
## Summary
- Add error handling for when the API call to retrieve enrollment verifications fails.
- Add a loading spinner to display while the API call is finishing.
- Update radio button component to the update Va Radio Button component as the previously used component was deprecated.

## Testing done

- Simulated the API call loading and failing, and verified that the interface behaved as expected.
- Verified that the interface behaved as expected when the API call is successful.
- Went through the verification 

## Screenshots
### Loading message
<img width="675" alt="image" src="https://user-images.githubusercontent.com/112403/205762689-f8505d81-f515-4def-829c-334b99800455.png">

### Error message
<img width="766" alt="image" src="https://user-images.githubusercontent.com/112403/205762969-81e415ad-bfcc-467b-8532-704a15b1937c.png">

### Verify enrollment
<img width="670" alt="image" src="https://user-images.githubusercontent.com/112403/205763346-2b0dda70-e069-479d-99ee-e5a0bbf54340.png">

## What areas of the site does it impact?
* Enrollment Verification app only 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
