### PR TITLE
Removed vsa-debt-frontend as codeowners from unrelated sources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,9 +51,9 @@ src/platform/user/profile/vap-svc @department-of-veterans-affairs/vsa-authd-exp-
 
 src/applications/letters @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/disability-benefits @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
-src/applications/claims-status @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-debt-frontend
-src/applications/appeals @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-debt-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
-src/applications/pre-need @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-debt-frontend
+src/applications/claims-status @department-of-veterans-affairs/benefits-team-1-frontend
+src/applications/appeals @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
+src/applications/pre-need @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/vre @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/lgy @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/sah @department-of-veterans-affairs/benefits-team-1-frontend


### PR DESCRIPTION
## Summary
Removed `vsa-debt-frontend` from CODEOWNERS for claims and `benefits-team-1-frontend` related sources to help clarify work and responsibilities. 

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50169
  - Adding as a part of documentation and cleanup

## Testing done
- Not super applicable, but `benefits-team-1-frontend` is still listed as owners so there will be no gaps in coverage. 

## What areas of the site does it impact?
`vsa-debt-frontend` will no longer be required for unrelated PRs. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
