### PR TITLE
Migrate downtime components to use web components

### DIFF
--- a/src/applications/check-in/utils/defineWebComponents.js
+++ b/src/applications/check-in/utils/defineWebComponents.js
@@ -5,6 +5,7 @@ import {
   defineCustomElementVaAlert,
   defineCustomElementVaLoadingIndicator,
   defineCustomElementVaMemorableDate,
+  defineCustomElementVaModal, // For global DowntimeApproaching notification
   defineCustomElementVaTelephone,
   defineCustomElementVaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/components';
@@ -14,5 +15,6 @@ defineCustomElementVaAccordionItem();
 defineCustomElementVaAlert();
 defineCustomElementVaLoadingIndicator();
 defineCustomElementVaMemorableDate();
+defineCustomElementVaModal();
 defineCustomElementVaTelephone();
 defineCustomElementVaTextInput();

--- a/src/applications/facility-locator/tests/e2e/DowntimeNotification.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/DowntimeNotification.cypress.spec.js
@@ -19,7 +19,7 @@ const endTime = moment()
 
 const selectors = {
   app: '.facility-locator',
-  statusDown: '.usa-alert-heading',
+  statusDown: '[slot="headline"]',
   statusDownApproachingModal:
     '[data-status="downtimeApproaching"] #downtime-approaching-modal',
 };

--- a/src/platform/monitoring/DowntimeNotification/components/Down.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Down.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 // eslint-disable-next-line no-unused-vars
 export function DownMessaging({ endTime, appTitle }) {
@@ -13,17 +12,13 @@ export function DownMessaging({ endTime, appTitle }) {
 
 export default function Down() {
   return (
-    <AlertBox
-      className="vads-u-margin-bottom--4"
-      headline={`This tool is down for maintenance.`}
-      isVisible
-      status="warning"
-    >
+    <va-alert class="vads-u-margin-bottom--4" visible status="warning">
+      <h3 slot="headline">This tool is down for maintenance</h3>
       <p>
         We’re making some updates to this tool to help make it even better for
         Veterans, service members, and family members like you. We’re sorry it’s
         not working right now. Please check back soon.
       </p>
-    </AlertBox>
+    </va-alert>
   );
 }

--- a/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import externalServiceStatus from '../config/externalServiceStatus';
 import DowntimeNotificationWrapper from './Wrapper';
 
@@ -7,6 +7,7 @@ class DowntimeApproaching extends React.Component {
   componentDidMount() {
     this.props.initializeDowntimeWarnings();
   }
+
   render() {
     const {
       startTime,
@@ -20,19 +21,21 @@ class DowntimeApproaching extends React.Component {
       className = 'row-padded',
     } = this.props;
     const close = () => dismissDowntimeWarning(appTitle);
+    const modalTitle =
+      messaging.title || `The ${appTitle} will be down for maintenance soon`;
     return (
       <DowntimeNotificationWrapper
         status={externalServiceStatus.downtimeApproaching}
         className={className}
       >
-        <Modal
+        <VaModal
           id="downtime-approaching-modal"
-          onClose={close}
+          onCloseEvent={close}
+          onSecondaryButtonClick={close}
           visible={!isDowntimeWarningDismissed}
+          secondaryButtonText="Dismiss"
+          modalTitle={modalTitle}
         >
-          {messaging.title || (
-            <h3>The {appTitle} will be down for maintenance soon</h3>
-          )}
           {messaging.content || (
             <p>
               We’ll be doing some work on the {appTitle} on{' '}
@@ -41,14 +44,7 @@ class DowntimeApproaching extends React.Component {
               that time, please check back soon.
             </p>
           )}
-          <button
-            type="button"
-            className="usa-button-secondary"
-            onClick={close}
-          >
-            Dismiss
-          </button>
-        </Modal>
+        </VaModal>
         {children || content}
       </DowntimeNotificationWrapper>
     );

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { formatDowntime } from 'platform/utilities/date';
 
@@ -89,7 +87,7 @@ class DowntimeNotification extends React.Component {
     if (!this.props.isReady) {
       return (
         this.props.loadingIndicator || (
-          <LoadingIndicator
+          <va-loading-indicator
             message={`Checking the ${this.props.appTitle} status...`}
           />
         )

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import { VA_FORM_IDS } from 'platform/forms/constants';
@@ -67,18 +66,14 @@ class DowntimeNotification extends React.Component {
     const endTime = formatDowntime(this.props.globalDowntime.endTIme);
 
     return (
-      <AlertBox
-        className="vads-u-margin-bottom--4"
-        headline={`This ${appType} is down for maintenance`}
-        isVisible
-        status="warning"
-      >
+      <va-alert class="vads-u-margin-bottom--4" visible status="warning">
+        <h3 slot="headline">This {{ appType }} is down for maintenance</h3>
         <p>
           We’re making some updates to this {appType}. We’re sorry it’s not
           working right now and we hope to be finished by {endTime}. Please
           check back soon.
         </p>
-      </AlertBox>
+      </va-alert>
     );
   };
 

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -67,7 +67,7 @@ class DowntimeNotification extends React.Component {
 
     return (
       <va-alert class="vads-u-margin-bottom--4" visible status="warning">
-        <h3 slot="headline">This {{ appType }} is down for maintenance</h3>
+        <h3 slot="headline">This {appType} is down for maintenance</h3>
         <p>
           We’re making some updates to this {appType}. We’re sorry it’s not
           working right now and we hope to be finished by {endTime}. Please

--- a/src/platform/monitoring/DowntimeNotification/tests/DowntimeNotification.unit.spec.jsx
+++ b/src/platform/monitoring/DowntimeNotification/tests/DowntimeNotification.unit.spec.jsx
@@ -3,6 +3,7 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import moment from 'moment';
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { createServiceMap } from '../util/helpers';
 import { externalServices, externalServiceStatus } from '../index';
@@ -132,7 +133,7 @@ describe('<DowntimeNotification/>', () => {
           `[data-status="${externalServiceStatus.downtimeApproaching}"]`,
         ),
       ).to.have.lengthOf(1, 'The correct status was rendered');
-      expect(innerWrapper.find('Modal')).to.have.lengthOf(
+      expect(innerWrapper.find(VaModal)).to.have.lengthOf(
         1,
         'Authenticated users will see a modal',
       );


### PR DESCRIPTION
## Summary

The React components in the `platform/monitoring` directory have been changed to use Design System Web Components instead of the deprecated React components from the `component-library`. This is happening because:

1. The `pre-check-in` app uses the platform `DowntimeNotification` component
1. The `DowntimeNotification` component uses the `AlertBox` component from the Design System
1. The `AlertBox` component uses the `usa-alert` CSS class provided in `formation`
1. The `pre-check-in` app is opting out of the site-wide stylesheet in order to have a smaller bundle and improved performance
1. The `usa-alert` styles are not included in the minimal stylesheet now used by `pre-check-in`

A relevant slack thread can be found [here in the check-in teams engineering channel](https://dsva.slack.com/archives/C02G6AB3ZRS/p1670370991946549).

I'm from the @department-of-veterans-affairs/platform-design-system-team.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1211
- https://github.com/department-of-veterans-affairs/content-build/pull/1391


## Testing done

Prior to this change, the `component-library` React components used in `DowntimeNotification` would not display properly on the `pre-check-in` application since the CSS they relied on wasn't present on the page.

To verify the changes I forced the downtime notification to appear, including the notification for when a downtime is approaching. The correct visual was achieved.

## Screenshots

### DowntimeApproaching

| | Before | After |
| --- | --- | --- |
| Mobile | ![image](https://user-images.githubusercontent.com/2008881/206332687-aaeb65df-07ab-44ab-b6da-1b95913fd849.png) | ![image](https://user-images.githubusercontent.com/2008881/206332434-9183a953-1c8d-4db1-8b39-eaf15247df21.png) |
| Desktop | ![image](https://user-images.githubusercontent.com/2008881/206332813-05e2c2d7-f5c5-4467-bd9f-cfb36ee27530.png) | ![image](https://user-images.githubusercontent.com/2008881/206332321-fcba46d1-2b78-45e4-9094-15c026597f33.png) |

### Active Downtime

| | Before | After |
| --- | --- | --- |
| Mobile | ![image](https://user-images.githubusercontent.com/2008881/206333619-50241e9e-adcb-4031-a756-826167ff2955.png)| ![image](https://user-images.githubusercontent.com/2008881/206333836-6e579f55-e94d-4c9c-ba1e-0e770fc1bce0.png) |
| Desktop | ![image](https://user-images.githubusercontent.com/2008881/206333545-fb8a7ca3-d06a-4411-9ea8-0782e14a6fb1.png) | ![image](https://user-images.githubusercontent.com/2008881/206333943-4fa4e9f3-ca36-40ae-b406-7b7ba739faf7.png)|

### Active global downtime

| | Before | After |
| --- | --- | --- |
| Mobile | ![image](https://user-images.githubusercontent.com/2008881/206339048-b2907574-7098-4578-a084-9fa7abfe7f36.png) | ![image](https://user-images.githubusercontent.com/2008881/206338894-7239b9f1-9af4-4cf2-a7a8-1a8d81f07449.png)|
| Desktop | ![image](https://user-images.githubusercontent.com/2008881/206339186-6cfcab50-aa5b-46e0-aba5-9038ac5ddfe6.png) | ![image](https://user-images.githubusercontent.com/2008881/206338778-58581f0d-a6a3-4d1d-9876-5752777dcede.png) |

### Checking external services loading state

| | Before | After |
| --- | --- | --- |
| Mobile | ![image](https://user-images.githubusercontent.com/2008881/206339883-710162f4-c7b7-46b8-8ec3-73a009ce04bf.png) | ![image](https://user-images.githubusercontent.com/2008881/206339677-df681e47-8864-4f06-b803-41144214f7cc.png) |
| Desktop | ![image](https://user-images.githubusercontent.com/2008881/206339984-f37c8acf-af37-4c7d-8abd-accef40165ba.png) | ![image](https://user-images.githubusercontent.com/2008881/206339566-d44051b2-f4d0-48df-85f8-fd115e366b4e.png) |


## What areas of the site does it impact?
This will impact any application or page using the `DowntimeNotification` component.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

As we allow for more applications to opt out of site-wide assets such as the web component definition script, how can we make sure that those teams define the web components that might be used by one of the platform components that they import?
