### PR TITLE
Add setFormData to CustomPage on review & submit page

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -257,6 +257,7 @@ class ReviewCollapsibleChapter extends React.Component {
           trackingPrefix={props.form.trackingPrefix}
           uploadFile={props.uploadFile}
           onReviewPage
+          setFormData={props.setData}
           data={props.form.data}
           updatePage={() => this.handleEdit(page.pageKey, false, page.index)}
           pagePerItemIndex={page.index}

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -1218,5 +1218,38 @@ describe('<ReviewCollapsibleChapter>', () => {
 
       expect(getByTestId('foo-value').innerHTML).to.equal('bar');
     });
+
+    it('should pass the setFormData function to the custom page component', () => {
+      const onSetData = sinon.spy();
+      const CustomPage = ({ setFormData }) => (
+        <div data-testid="custom-page-review">
+          <button
+            type="button"
+            onClick={setFormData}
+            data-testid="set-form-data-button"
+          >
+            setFormData
+          </button>
+        </div>
+      );
+      const { pages, chapterKey, chapter, form } = getProps();
+      form.pages.test.editMode = true;
+      pages[0].CustomPage = CustomPage;
+      form.pages.test.CustomPage = CustomPage;
+      const { getByTestId } = render(
+        <ReviewCollapsibleChapter
+          viewedPages={new Set()}
+          expandedPages={pages}
+          chapterKey={chapterKey}
+          chapterFormConfig={chapter}
+          form={form}
+          open
+          setData={onSetData}
+        />,
+      );
+
+      userEvent.click(getByTestId('set-form-data-button'));
+      expect(onSetData.callCount).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > The `ReviewCollapsibleChapter` component now renders the `CustomPage` component with a `setFormData` property
  > Added unit test
- *(If bug, how to reproduce)*
  > To reproduce, you'll need a `CustomPage` component that needs to update the form data and is rendered on the review & submit page (in edit mode). You'll get a `setFormData` is undefined error.
- *(What is the solution, why is this the solution)*
  > Pass `setFormData` to `CustomPage` within the `ReviewCollapsibleChapter` component
- *(Which team do you work for, does your team own the maintainence of this component?)*
  > Benefits Team 1, and no
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
  > N/A

## Related issue(s)
- [#50437](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50437)
- *Link to ticket created in va.gov-team repo*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- *Describe what the old behavior was prior to the change*
  > JavaScript error if `CustomPage` uses `setFormData` when it is rendered on the review & submit page in edit mode
- *Describe the steps required to verify your changes are working as expected*
  > Unit test checks that the `setFormData` property exists
- *Describe the tests completed and the results*
  > Passed

## Screenshots

N/A

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

> All `CustomPages` that use `setFormData`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
