### PR TITLE
Preneeds - replace fetch with apiRequest

### DIFF
--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1,10 +1,7 @@
 import merge from 'lodash/merge';
-// import * as Sentry from '@sentry/browser';
 
 import environment from 'platform/utilities/environment';
-// import localStorage from 'platform/utilities/storage/localStorage';
 import { apiRequest } from 'platform/utilities/api';
-// import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import { SET_UNAUTHORIZED } from '../actions/types';
 
 const evidenceGathering = 'Evidence gathering, review, and decision';

--- a/src/applications/pre-need/tests/00-all-fields.cypress.spec.js
+++ b/src/applications/pre-need/tests/00-all-fields.cypress.spec.js
@@ -4,7 +4,7 @@ import cemeteries from './fixtures/mocks/cemeteries.json';
 
 describe('Pre-need test', () => {
   // Test skipped to match Nightwatch
-  it.skip('fills the form and navigates accordingly', () => {
+  it('fills the form and navigates accordingly', () => {
     cy.intercept('POST', '/v0/preneeds/burial_forms', {
       data: {
         attributes: {
@@ -42,10 +42,10 @@ describe('Pre-need test', () => {
     cy.url().should('not.contain', '/introduction');
 
     cy.get('input[name="root_application_claimant_name_first"]');
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(1)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(1)')
+      .should('have.class', 'progress-segment-complete');
 
     // Application Information
     cy.fillName(
@@ -83,10 +83,10 @@ describe('Pre-need test', () => {
 
     // Veteran Information
     cy.get('input[name="root_application_veteran_currentName_first"]');
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(2)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(2)')
+      .should('have.class', 'progress-segment-complete');
 
     cy.fillName(
       'root_application_veteran_currentName',
@@ -183,10 +183,10 @@ describe('Pre-need test', () => {
       }
     });
 
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(3)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(3)')
+      .should('have.class', 'progress-segment-complete');
 
     cy.axeCheck();
     cy.get('.form-panel .usa-button-primary').click();
@@ -208,10 +208,10 @@ describe('Pre-need test', () => {
     cy.get('label[for="root_application_claimant_desiredCemetery"]').should(
       'be.visible',
     );
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(4)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(4)')
+      .should('have.class', 'progress-segment-complete');
     cy.fill(
       'input[name="root_application_claimant_desiredCemetery"]',
       testData.data.application.claimant.desiredCemetery.label,
@@ -253,19 +253,19 @@ describe('Pre-need test', () => {
     // Supporting Documents page
     cy.get('label[for="root_application_preneedAttachments"]');
 
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(5)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(5)')
+      .should('have.class', 'progress-segment-complete');
     cy.get('.form-panel .usa-button-primary').click();
     cy.url().should('not.contain', '/supporting-documents');
 
     // Applicant/Claimant Contact Information page
     cy.get('select[name="root_application_claimant_address_country"]');
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(6)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(6)')
+      .should('have.class', 'progress-segment-complete');
     cy.fillAddress(
       'root_application_claimant_address',
       testData.data.application.claimant.address,
@@ -281,10 +281,10 @@ describe('Pre-need test', () => {
 
     // Veteran Contact Information page
     cy.get('select[name="root_application_veteran_address_country"]');
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(6)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(6)')
+      .should('have.class', 'progress-segment-complete');
     cy.fillAddress(
       'root_application_veteran_address',
       testData.data.application.veteran.address,
@@ -296,10 +296,10 @@ describe('Pre-need test', () => {
     cy.get(
       'label[for="root_application_applicant_applicantRelationshipToClaimant_1"]',
     );
-    cy.get('.progress-bar-segmented div.progress-segment:nth-child(6)').should(
-      'have.class',
-      'progress-segment-complete',
-    );
+    cy.get('va-segmented-progress-bar')
+      .shadow()
+      .find('.progress-bar-segmented div.progress-segment:nth-child(6)')
+      .should('have.class', 'progress-segment-complete');
     cy.selectRadio(
       'root_application_applicant_applicantRelationshipToClaimant',
       testData.data.application.applicant.applicantRelationshipToClaimant,

--- a/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
@@ -9,27 +9,8 @@ import {
   selectRadio,
 } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
-import { mockFetch } from 'platform/testing/unit/helpers';
-
-const response = {
-  data: [
-    {
-      id: 915,
-      type: 'preneeds_cemeteries',
-      attributes: {
-        // eslint-disable-next-line camelcase
-        cemetery_id: '915',
-        name: 'ABRAHAM LINCOLN NATIONAL CEMETERY',
-        // eslint-disable-next-line camelcase
-        cemetery_type: 'N',
-        num: '915',
-      },
-    },
-  ],
-};
 
 describe('Pre-need burial benefits', () => {
-  beforeEach(() => mockFetch(response));
   const {
     schema,
     uiSchema,

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -1,20 +1,21 @@
 import React from 'react';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import PropTypes from 'prop-types';
-import get from 'platform/utilities/data/get';
-import omit from 'platform/utilities/data/omit';
 import * as Sentry from '@sentry/browser';
 
-import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
+import get from 'platform/utilities/data/get';
+import omit from 'platform/utilities/data/omit';
+import environment from 'platform/utilities/environment';
+import { apiRequest } from 'platform/utilities/api';
+
 import fullNameUI from 'platform/forms/definitions/fullName';
+import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import TextWidget from 'platform/forms-system/src/js/widgets/TextWidget';
 import {
   stringifyFormReplacer,
   filterViewFields,
 } from 'platform/forms-system/src/js/helpers';
-import environment from 'platform/utilities/environment';
-import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import * as autosuggest from 'platform/forms-system/src/js/definitions/autosuggest';
 import { serviceLabels } from './labels';
 import RaceEthnicityReviewField from '../components/RaceEthnicityReviewField';
@@ -460,20 +461,7 @@ export const militaryNameUI = {
 };
 
 export function getCemeteries() {
-  return fetch(`${environment.API_URL}/v0/preneeds/cemeteries`, {
-    credentials: 'include',
-    headers: {
-      'X-Key-Inflection': 'camel',
-      'Source-App-Name': window.appName,
-    },
-  })
-    .then(res => {
-      if (!res.ok) {
-        return Promise.reject(res);
-      }
-
-      return res.json();
-    })
+  return apiRequest(`${environment.API_URL}/v0/preneeds/cemeteries`)
     .then(res =>
       res.data.map(item => ({
         label: item.attributes.name,


### PR DESCRIPTION
## Summary

*(Summarize the changes that have been made to the platform)*
> Replaces `fetch` with `apiRequest` in the `preneed` application and updates the unit test & E2E tests associated with that app.

*(What is the solution, why is this the solution)*
> Replace `fetch` with `apiRequest` in the `getCemeteries` call and update all associated unit + E2E tests

*(Which team do you work for, does your team own the maintainence of this component?)*
> Identity. No.

## Related issue(s)
*Link to ticket created in va.gov-team repo*
> Close department-of-veterans-affairs/va.gov-team#48731

*Link to epic if not included in ticket*
> department-of-veterans-affairs/va.gov-team#48711


## Testing done

*Describe what the old behavior was prior to the change*
> The old behavior was for the `getCemeteries` function call to use the default `window.fetch` rather than `apiRequest`.

*Describe the steps required to verify your changes are working as expected*
> The call comes back as expected

*Describe the tests completed and the results*
> Unit tests worked as expcted.  Unit test `burialBenefits.unit.spec.jsx` was updated to remove `mockFetch` as it was not being used.  Additionally, the Pre-need eligibility form (#10007) was a previously skipped Cypress (E2E) test and it was additionally updated to appropriately check the `<va-segmented-progress-bar />` web component and verified to work as originally intended.

## Screenshots
> No updates to UI.

## What areas of the site does it impact?
> This will impact the `preneed` application specifically when the Pre-need eligibility form (#10007) is filled out and a cemetery is required.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
> 1. Verify that the `/v0/preneeds/cemeteries` call works as expected (returns list of cemeteries)
> 2. Verify filling out form 10007 (Pre-need eligibility form) works as expected
> 3. Commented out code is removed.
