### PR TITLE
Updated logic to direct 1990E to new TOE app

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -12,7 +12,10 @@ import {
 } from 'applications/static-pages/wizard';
 import { connect } from 'react-redux';
 import VARadioButton from '../utils/VaRadioButton';
-import { showEduBenefits1990EZWizard } from '../selectors/educationWizard';
+import {
+  showEduBenefits1990EZWizard,
+  showMebDgi40Feature,
+} from '../selectors/educationWizard';
 
 const levels = [
   ['newBenefit'],
@@ -48,7 +51,7 @@ class EducationWizard extends React.Component {
     }
   }
 
-  getButton(form) {
+  getButton(form, featureFlag = false) {
     let url = '';
     switch (form) {
       case '0994':
@@ -60,7 +63,7 @@ class EducationWizard extends React.Component {
       case '22-1990':
         url = `/education/apply-for-benefits-form-22-1990`;
         break;
-      case '1990E':
+      case '1990E' && featureFlag:
         url = `/education/survivor-dependent-benefits/apply-for-transferred-benefits-form-22-1990e`;
         break;
       default:
@@ -161,7 +164,7 @@ class EducationWizard extends React.Component {
       applyForScholarship,
       post911GIBill,
     } = this.state;
-    const { showWizard } = this.props;
+    const { showWizard, showMEBFlag } = this.props;
 
     const buttonClasses = classNames('usa-button-primary', 'wizard-button', {
       'va-button-primary': !this.state.open,
@@ -460,7 +463,7 @@ class EducationWizard extends React.Component {
             {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'other' &&
               sponsorTransferredBenefits === 'yes' &&
-              this.getButton('1990E')}
+              this.getButton('1990E', showMEBFlag)}
             {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'other' &&
               sponsorTransferredBenefits === 'no' &&
@@ -475,6 +478,7 @@ class EducationWizard extends React.Component {
 
 const mapStateToProps = state => ({
   showWizard: showEduBenefits1990EZWizard(state),
+  showMEBFlag: showMebDgi40Feature(state),
 });
 
 export default connect(mapStateToProps)(EducationWizard);

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -61,7 +61,7 @@ class EducationWizard extends React.Component {
         url = `/education/apply-for-benefits-form-22-1990`;
         break;
       case '1990E':
-        if (this?.props['showMEBFlag']) {
+        if (this?.props['showMebDgi40Feature']) {
           url = `/education/survivor-dependent-benefits/apply-for-transferred-benefits-form-22-1990e`;
           break;
         }
@@ -165,7 +165,6 @@ class EducationWizard extends React.Component {
       applyForScholarship,
       post911GIBill,
     } = this.state;
-
     const buttonClasses = classNames('usa-button-primary', 'wizard-button', {
       'va-button-primary': !this.state.open,
     });
@@ -434,17 +433,14 @@ class EducationWizard extends React.Component {
                 </div>
               </div>
             )}
-            {post911GIBill === 'yes' &&
-              newBenefit === 'yes' &&
+            {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'own' &&
               vetTecBenefit === 'no' &&
+              post911GIBill === 'yes' &&
               this.getButton('22-1990')}
-            {post911GIBill === 'no' &&
-              newBenefit === 'yes' &&
-              vetTecBenefit === 'no' &&
-              this.getButton('1990')}
             {newBenefit === 'yes' &&
               vetTecBenefit === 'no' &&
+              post911GIBill === 'no' &&
               this.getButton('1990')}
             {newBenefit === 'yes' &&
               vetTecBenefit === 'yes' &&
@@ -473,7 +469,7 @@ class EducationWizard extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  showMEBFlag: showMebDgi40Feature(state),
+  showMebDgi40Feature: showMebDgi40Feature(state),
 });
 
 export default connect(mapStateToProps)(EducationWizard);

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -12,10 +12,7 @@ import {
 } from 'applications/static-pages/wizard';
 import { connect } from 'react-redux';
 import VARadioButton from '../utils/VaRadioButton';
-import {
-  showEduBenefits1990EZWizard,
-  showMebDgi40Feature,
-} from '../selectors/educationWizard';
+import { showMebDgi40Feature } from '../selectors/educationWizard';
 
 const levels = [
   ['newBenefit'],
@@ -51,7 +48,7 @@ class EducationWizard extends React.Component {
     }
   }
 
-  getButton(form, featureFlag = false) {
+  getButton(form) {
     let url = '';
     switch (form) {
       case '0994':
@@ -63,8 +60,12 @@ class EducationWizard extends React.Component {
       case '22-1990':
         url = `/education/apply-for-benefits-form-22-1990`;
         break;
-      case '1990E' && featureFlag:
-        url = `/education/survivor-dependent-benefits/apply-for-transferred-benefits-form-22-1990e`;
+      case '1990E':
+        if (this?.props['showMEBFlag']) {
+          url = `/education/survivor-dependent-benefits/apply-for-transferred-benefits-form-22-1990e`;
+          break;
+        }
+        url = `/education/apply-for-education-benefits/application/${form}`;
         break;
       default:
         url = `/education/apply-for-education-benefits/application/${form}`;
@@ -164,7 +165,6 @@ class EducationWizard extends React.Component {
       applyForScholarship,
       post911GIBill,
     } = this.state;
-    const { showWizard, showMEBFlag } = this.props;
 
     const buttonClasses = classNames('usa-button-primary', 'wizard-button', {
       'va-button-primary': !this.state.open,
@@ -318,8 +318,7 @@ class EducationWizard extends React.Component {
                   </div>
                 </div>
               )}
-            {showWizard &&
-              newBenefit === 'yes' &&
+            {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'own' &&
               vetTecBenefit === 'no' && (
                 <VARadioButton
@@ -435,19 +434,16 @@ class EducationWizard extends React.Component {
                 </div>
               </div>
             )}
-            {showWizard &&
-              (post911GIBill === 'yes' &&
-                newBenefit === 'yes' &&
-                serviceBenefitBasedOn === 'own' &&
-                vetTecBenefit === 'no' &&
-                this.getButton('22-1990'))}
-            {showWizard &&
-              (post911GIBill === 'no' &&
-                newBenefit === 'yes' &&
-                vetTecBenefit === 'no' &&
-                this.getButton('1990'))}
-            {!showWizard &&
+            {post911GIBill === 'yes' &&
               newBenefit === 'yes' &&
+              serviceBenefitBasedOn === 'own' &&
+              vetTecBenefit === 'no' &&
+              this.getButton('22-1990')}
+            {post911GIBill === 'no' &&
+              newBenefit === 'yes' &&
+              vetTecBenefit === 'no' &&
+              this.getButton('1990')}
+            {newBenefit === 'yes' &&
               vetTecBenefit === 'no' &&
               this.getButton('1990')}
             {newBenefit === 'yes' &&
@@ -463,7 +459,7 @@ class EducationWizard extends React.Component {
             {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'other' &&
               sponsorTransferredBenefits === 'yes' &&
-              this.getButton('1990E', showMEBFlag)}
+              this.getButton('1990E')}
             {newBenefit === 'yes' &&
               serviceBenefitBasedOn === 'other' &&
               sponsorTransferredBenefits === 'no' &&
@@ -477,7 +473,6 @@ class EducationWizard extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  showWizard: showEduBenefits1990EZWizard(state),
   showMEBFlag: showMebDgi40Feature(state),
 });
 

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -60,6 +60,9 @@ class EducationWizard extends React.Component {
       case '22-1990':
         url = `/education/apply-for-benefits-form-22-1990`;
         break;
+      case '1990E':
+        url = `/education/survivor-dependent-benefits/apply-for-transferred-benefits-form-22-1990e`;
+        break;
       default:
         url = `/education/apply-for-education-benefits/application/${form}`;
         break;

--- a/src/applications/edu-benefits/selectors/educationWizard.js
+++ b/src/applications/edu-benefits/selectors/educationWizard.js
@@ -25,3 +25,6 @@ export const showEduBenefits5495Wizard = state =>
 
 export const showEduBenefits1990EZWizard = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.showEduBenefits1990EZWizard];
+
+export const showMebDgi40Feature = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.showMebDgi40Features];

--- a/src/applications/edu-benefits/selectors/educationWizard.js
+++ b/src/applications/edu-benefits/selectors/educationWizard.js
@@ -23,8 +23,5 @@ export const showEduBenefits1990NWizard = state =>
 export const showEduBenefits5495Wizard = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.showEduBenefits5495Wizard];
 
-export const showEduBenefits1990EZWizard = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.showEduBenefits1990EZWizard];
-
 export const showMebDgi40Feature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.showMebDgi40Features];


### PR DESCRIPTION
## Summary
Updates the Education Wizard to redirect users to the new TOE app for 1990E forms via /education/how-to-apply/

## Testing done
- [] Done

## Screenshots

<img width="432" alt="image" src="https://user-images.githubusercontent.com/17830527/206534111-ade01154-72d8-4ced-9ea4-34129ec1f5d0.png">


## What areas of the site does it impact?
/education/how-to-apply/

## Acceptance criteria
