### PR TITLE
hide behind feature flag

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -292,8 +292,12 @@ const Dashboard = ({
                   />
                 </>
               ) : null}
-              <EducationAndTraining />
-              {isLOA3 ? <SavedApplications /> : <ApplyForBenefits />}
+              {shouldShowV2Dashboard ? <EducationAndTraining /> : null}
+              {isLOA3 && shouldShowV2Dashboard ? (
+                <SavedApplications />
+              ) : (
+                <ApplyForBenefits />
+              )}
             </div>
           </div>
         )}

--- a/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
@@ -9,6 +9,7 @@ import { makeMockUser } from '@@profile/tests/fixtures/users/user';
 import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
 import notInESR from '@@profile/tests/fixtures/enrollment-system/not-in-esr.json';
 import loa1User from '@@profile/tests/fixtures/users/user-loa1.json';
+import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import manifest from '~/applications/personalization/dashboard/manifest.json';
 
 import {
@@ -49,6 +50,17 @@ describe('The My VA Dashboard', () => {
       const user = makeMockUser();
       cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
       cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
+      cy.intercept('GET', '/v0/feature_toggles*', {
+        data: {
+          type: 'feature_toggles',
+          features: [
+            {
+              name: featureFlagNames.showMyVADashboardV2,
+              value: true,
+            },
+          ],
+        },
+      }).as('featuresB');
       cy.login(user);
       cy.visit(manifest.rootUrl);
     });

--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -2,7 +2,7 @@ import { mockUser } from '@@profile/tests/fixtures/users/user';
 import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-
+import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import manifest from 'applications/personalization/dashboard/manifest.json';
 
 describe('The My VA Dashboard', () => {
@@ -16,6 +16,17 @@ describe('The My VA Dashboard', () => {
       '/v0/disability_compensation_form/rating_info',
       disabilityRating,
     );
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          {
+            name: featureFlagNames.showMyVADashboardV2,
+            value: true,
+          },
+        ],
+      },
+    }).as('featuresB');
   });
   describe('when there are in-progress forms', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- Hide education and applications behind feature flag
Won't let me connect the issues for some reason, but it's https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/47520
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/47683

## Testing done

- Tests pass

## What areas of the site does it impact?
MyVA audit areas

## Acceptance criteria

- [ ]  Education and training and saved applications doesn't show unless flag is on
