### PR TITLE
Vfep 279

### DIFF
--- a/src/applications/edu-benefits/utils/VaRadioButton.jsx
+++ b/src/applications/edu-benefits/utils/VaRadioButton.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+/**
+ * VA Radio button with VA Radio Option component.
+ *
+ * @param {String} radioLabel - Text Displayed at the top of the radio buttons.
+ * @param {String} initialValue - initial value of the radio button
+ * @param {Object} options - subtask options
+ * @param {Function} onVaValueChange - updates subtask options
+ * @returns {JSX.Element}
+ */
+const VARadioButton = ({
+  radioLabel,
+  initialValue,
+  options,
+  onVaValueChange,
+}) => (
+  <VaRadio
+    enable-analytics
+    label={radioLabel}
+    onVaValueChange={onVaValueChange}
+  >
+    {options.map(({ value, label }) => (
+      <va-radio-option
+        key={value}
+        id={value}
+        value={value}
+        label={label}
+        checked={value === initialValue}
+      />
+    ))}
+  </VaRadio>
+);
+
+VARadioButton.propTypes = {
+  initialValue: PropTypes.string.isRequired,
+  radioLabel: PropTypes.string.isRequired,
+  onVaValueChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    }),
+  ),
+};
+
+export default VARadioButton;

--- a/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
+++ b/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
 import { pageNames } from './pageList';
-import VARadioButton from '../../../gi/components/VARadioButton';
+import VARadioButton from '../../utils/VaRadioButton';
 
 const claimingBenefitOwnServiceOptions = [
   { label: 'Yes', value: 'yes' },

--- a/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
+++ b/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { pageNames } from './pageList';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
+import { pageNames } from './pageList';
+import VARadioButton from '../../../gi/components/VARadioButton';
 
 const claimingBenefitOwnServiceOptions = [
   { label: 'Yes', value: 'yes' },
@@ -10,17 +10,15 @@ const claimingBenefitOwnServiceOptions = [
 const ClaimingBenefitOwnService = ({
   setPageState,
   getPageStateFromPageName,
-  state = {},
   setReferredBenefit,
 }) => (
   <div>
-    <RadioButtons
-      name={`${pageNames.claimingBenefitOwnService}`}
-      label="Are you a Veteran or service member claiming a benefit based on your own service?"
-      id={`${pageNames.claimingBenefitOwnService}`}
-      additionalFieldsetClass="wizard-fieldset"
+    <VARadioButton
+      radioLabel="Are you a Veteran or service member claiming a benefit based on your own service?"
+      initialValue=""
       options={claimingBenefitOwnServiceOptions}
-      onValueChange={({ value }) => {
+      onVaValueChange={event => {
+        const { value } = event.detail;
         const newBenefitAnswer = getPageStateFromPageName(pageNames.newBenefit)
           ?.selected;
         const sponsorDeceasedAnswer = getPageStateFromPageName(
@@ -29,16 +27,14 @@ const ClaimingBenefitOwnService = ({
         const transferredBenefitsAnswer = getPageStateFromPageName(
           pageNames.transferredBenefits,
         )?.selected;
-        const nationalCallToServiceAnswer = getPageStateFromPageName(
-          pageNames.nationalCallToService,
-        )?.selected;
         if (
           newBenefitAnswer === 'new' &&
           value === 'no' &&
           transferredBenefitsAnswer === 'no'
         ) {
           return setPageState({ selected: value }, pageNames.sponsorDeceased);
-        } else if (
+        }
+        if (
           newBenefitAnswer === 'new' &&
           value === 'no' &&
           sponsorDeceasedAnswer === 'yes'
@@ -46,24 +42,15 @@ const ClaimingBenefitOwnService = ({
           const { FORM_ID_5490 } = formIdSuffixes;
           setReferredBenefit(FORM_ID_5490);
           return setPageState({ selected: value }, pageNames.applyNow);
-        } else if (
-          newBenefitAnswer === 'new' &&
-          nationalCallToServiceAnswer === 'no' &&
-          value === 'yes'
-        ) {
-          return setPageState({ selected: value }, pageNames.vetTec);
-        } else if (newBenefitAnswer === 'new' && value === 'yes') {
-          return setPageState(
-            { selected: value },
-            pageNames.nationalCallToService,
-          );
-        } else if (newBenefitAnswer === 'new' && value === 'no') {
-          return setPageState({ selected: value }, pageNames.sponsorDeceased);
-        } else {
-          return setPageState({ selected: value });
         }
+        if (newBenefitAnswer === 'new' && value === 'yes') {
+          return setPageState({ selected: value }, pageNames.vetTec);
+        }
+        if (newBenefitAnswer === 'new' && value === 'no') {
+          return setPageState({ selected: value }, pageNames.sponsorDeceased);
+        }
+        return setPageState({ selected: value });
       }}
-      value={{ value: state.selected }}
     />
   </div>
 );


### PR DESCRIPTION
## Summary

**THIS ONLY AFFECTS STAGING / NO CHANGES TO PRODUCTION**

A secondary education wizard was discovered in the code base, and a "are you sure this is the right form" page is currently in staging. After discussions with Education and Cinda Quattrini, it was agreed the wizard and the page are not needed and will be  deleted.  

- *(Summarize the changes that have been made to the platform)*
The following files have been deleted

Files location vets-website/src/applications/edu-benefits/wizard

inside folder "containers":
WizardContainer.jsx

inside folder "pages":
ApplyNow.jsx
CLaiminigBenefitOwnService.jsx
NationalCallToService.jsx
NewBenefit.jsx
Index.js
pageList.js
SponsorDeceased.jsx
STEMScholarship.jsx
TransferredBenefits.jsx
VetTec.jsx
WarningAlert.jsx

The following files have been updated to account for the above deleted files.

files location vets-website/src/applications/edu-benefits/

0994/containers/IntroductionPage.js
1990/containers/IntroductionPage.js
1990e/containers/IntroductionPage.js
1990n/containers/IntroductionPage.js
1995/containers/IntroductionPage.js
5490/containers/IntroductionPage.js
5495/containers/IntroductionPage.js

- *Not a bug*
- *(The solution is removing duplicated and unwanted files from Va.Gov Education section)*
- *(Work for GovCio, we are the code owners of this folder)*
- *(Target date to remove flipper is 27 Dec 2022)*

## Related issue(s)
- *Jira Story - [Click Me](url)
- *Link to previous change of the code/bug (if applicable)* NA
- *Link to epic if not included in ticket* Link to Jira story above


## Testing done

- The old behavior is seen when a user goes to this url https://staging.va.gov/education/change-gi-bill-benefits/ and clicks on either link ( [Complete VA Form 22-1995 online](https://staging.va.gov/education/apply-for-education-benefits/application/1995/introduction) / [Complete VA Form 22-5495 online](https://staging.va.gov/education/apply-for-education-benefits/application/5495/) ), they are then taken to a page that presents another education wizard for the user to use. Or there is a link at the bottom of the page that the user can continue to the form previously selected.

- EDU no longer wants to work on this feature and would like it removed
- Manual testing completed on local host and review instance. Testing consist of visiting each page involved with this ticket to ensure all pages that are still remaining work correctly. Each page has its own unit test spec as well that will not be modified.

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._
Page to be removed
![image](https://user-images.githubusercontent.com/88905347/206517674-38c2387e-13f1-4600-9222-e842a598c8ef.png)
Within this page, the wizard is also to be removed as it is a duplication of the education wizard. 
| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
There is no impact to Production. This code only lives in Staging and was never pushed to production. Currently the code is hidden behind a toggle that will only be removed once this PR is merged.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). N/A
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution N/A
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable) N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A

## Requested Feedback
N/A
