### PR TITLE
EV: Hide Alert and Fix Pagination Message for No Enrollments

### DIFF
--- a/src/applications/enrollment-verification/components/EnrollmentVerificationMonth.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationMonth.jsx
@@ -81,7 +81,7 @@ export default function EnrollmentVerificationMonth({
 
   return (
     <div className="ev-enrollment-month vads-u-margin-y--3">
-      <h1 className="vads-u-font-size--h4 vads-u-font-weight--bold">
+      <h1 className="vads-u-font-size--h4 vads-u-font-weight--bold vads-u-margin-top--3">
         {month.verificationMonth}
       </h1>
       {monthStatusMessage}

--- a/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
@@ -34,7 +34,9 @@ function EnrollmentVerificationMonths({ enrollmentVerification, status }) {
     [setCurrentPage],
   );
 
-  const lowerDisplayedRange = MONTHS_PER_PAGE * (currentPage - 1) + 1;
+  const lowerDisplayedRange = months?.length
+    ? MONTHS_PER_PAGE * (currentPage - 1) + 1
+    : 0;
   const upperDisplayedRange = Math.min(
     currentPage * MONTHS_PER_PAGE,
     months?.length,

--- a/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
@@ -34,13 +34,14 @@ function EnrollmentVerificationMonths({ enrollmentVerification, status }) {
     [setCurrentPage],
   );
 
-  const lowerDisplayedRange = months?.length
-    ? MONTHS_PER_PAGE * (currentPage - 1) + 1
-    : 0;
+  const lowerDisplayedRange = MONTHS_PER_PAGE * (currentPage - 1) + 1;
   const upperDisplayedRange = Math.min(
     currentPage * MONTHS_PER_PAGE,
     months?.length,
   );
+  const showingPages = months?.length
+    ? `${lowerDisplayedRange} - ${upperDisplayedRange}`
+    : '0';
   const numPages = Math.ceil(months?.length / MONTHS_PER_PAGE);
   const minMonth = (currentPage - 1) * MONTHS_PER_PAGE;
   const maxMonth = currentPage * MONTHS_PER_PAGE;
@@ -67,12 +68,10 @@ function EnrollmentVerificationMonths({ enrollmentVerification, status }) {
         </p>
       </va-additional-info>
 
-      {enrollmentVerification?.enrollmentVerifications && (
-        <p>
-          Showing {lowerDisplayedRange}-{upperDisplayedRange} of{' '}
-          {months?.length} monthly enrollments listed by most recent
-        </p>
-      )}
+      <p>
+        Showing {showingPages} of {months?.length || '0'} monthly enrollments
+        listed by most recent
+      </p>
 
       {months?.slice(minMonth, maxMonth)}
 

--- a/src/applications/enrollment-verification/containers/EnrollmentVerificationPage.jsx
+++ b/src/applications/enrollment-verification/containers/EnrollmentVerificationPage.jsx
@@ -17,7 +17,7 @@ import { getEVData } from '../selectors';
 export const EnrollmentVerificationPage = ({
   enrollmentVerification,
   enrollmentVerificationFetchComplete,
-  enrollmentVerificationFetchFailure,
+  // enrollmentVerificationFetchFailure,
   getPost911GiBillEligibility,
   hasCheckedKeepAlive,
   isLoggedIn,
@@ -60,15 +60,17 @@ export const EnrollmentVerificationPage = ({
         education payments.
       </p>
 
-      <EnrollmentVerificationAlert status={status} />
+      {enrollmentVerification?.enrollmentVerifications?.length > 0 && (
+        <EnrollmentVerificationAlert status={status} />
+      )}
 
-      {enrollmentVerificationFetchComplete &&
-        !enrollmentVerificationFetchFailure && (
-          <EnrollmentVerificationMonths
-            status={status}
-            enrollmentVerification={enrollmentVerification}
-          />
-        )}
+      {enrollmentVerificationFetchComplete && (
+        // !enrollmentVerificationFetchFailure && (
+        <EnrollmentVerificationMonths
+          status={status}
+          enrollmentVerification={enrollmentVerification}
+        />
+      )}
 
       <div className="ev-highlighted-content-container vads-u-margin-top--3">
         <header className="ev-highlighted-content-container_header">
@@ -96,7 +98,7 @@ export const EnrollmentVerificationPage = ({
 EnrollmentVerificationPage.propTypes = {
   enrollmentVerification: ENROLLMENT_VERIFICATION_TYPE,
   enrollmentVerificationFetchComplete: PropTypes.bool,
-  enrollmentVerificationFetchFailure: PropTypes.bool,
+  // enrollmentVerificationFetchFailure: PropTypes.bool,
   getPost911GiBillEligibility: PropTypes.func,
   hasCheckedKeepAlive: PropTypes.bool,
   isLoggedIn: PropTypes.bool,


### PR DESCRIPTION
## Summary

- Hide alert message when there are no enrollments.
- Fix pagination message to display "0-0 of 0" when there are no enrollments.

## Testing done
- Verified that no alert and correct pagination message displays when there are no enrollments or the back-end call fails.
- Verified that alert displays and pagination message is correct when there are enrollment verifications.

## Screenshots
<img width="737" alt="image" src="https://user-images.githubusercontent.com/112403/206627462-5074c67d-f50a-468b-bc3a-496bd54b093a.png">

## What areas of the site does it impact?
*Enrollment Verification application only.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
