### PR TITLE
49844 debts side by side

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -251,7 +251,7 @@ const Dashboard = ({
               {props.showHealthCare && !shouldShowV2Dashboard ? (
                 <HealthCare />
               ) : null}
-              {shouldShowV2Dashboard ? (
+              {isLOA3 && shouldShowV2Dashboard ? (
                 <HealthCareV2 isVAPatient={isVAPatient} />
               ) : null}
 
@@ -272,7 +272,9 @@ const Dashboard = ({
                   />
                 </>
               ) : null}
-              {shouldShowV2Dashboard ? <EducationAndTraining /> : null}
+              {isLOA3 && shouldShowV2Dashboard ? (
+                <EducationAndTraining />
+              ) : null}
               {isLOA3 && shouldShowV2Dashboard ? (
                 <SavedApplications />
               ) : (

--- a/src/applications/personalization/dashboard/components/debts-v2/CopaysCardV2.jsx
+++ b/src/applications/personalization/dashboard/components/debts-v2/CopaysCardV2.jsx
@@ -23,9 +23,9 @@ export const CopaysV2 = ({ copays }) => {
   }
 
   return (
-    <div className="vads-u-display--flex vads-u-flex-direction--column large-screen:vads-u-flex--1 vads-u-margin-bottom--2p5">
+    <div className="vads-u-display--flex vads-u-margin-bottom--3">
       <div
-        className="vads-u-background-color--gray-lightest vads-u-padding-y--2p5 vads-u-padding-x--2p5"
+        className="vads-u-display--flex vads-u-width--full vads-u-flex-direction--column vads-u-justify-content--space-between vads-u-align-items--flex-start vads-u-background-color--gray-lightest vads-u-padding--2p5"
         data-testid="copay-card-v2"
       >
         <h3 className="vads-u-margin-top--0" data-testid="copay-due-header-v2">

--- a/src/applications/personalization/dashboard/components/debts-v2/DebtsCardV2.jsx
+++ b/src/applications/personalization/dashboard/components/debts-v2/DebtsCardV2.jsx
@@ -40,9 +40,9 @@ export const DebtsV2 = ({ debts }) => {
   }
 
   return (
-    <div className="vads-u-display--flex vads-u-flex-direction--column large-screen:vads-u-flex--1 vads-u-margin-bottom--2p5">
+    <div className="vads-u-display--flex vads-u-margin-bottom--3">
       <div
-        className="vads-u-background-color--gray-lightest vads-u-padding-y--2p5 vads-u-padding-x--2p5"
+        className="vads-u-display--flex vads-u-width--full vads-u-flex-direction--column vads-u-justify-content--space-between vads-u-align-items--flex-start vads-u-background-color--gray-lightest vads-u-padding--2p5"
         data-testid="debt-card-v2"
       >
         <h3 className="vads-u-margin-top--0" data-testid="debt-total-header-v2">

--- a/src/applications/personalization/dashboard/components/health-care-v2/HealthCareCTAV2.jsx
+++ b/src/applications/personalization/dashboard/components/health-care-v2/HealthCareCTAV2.jsx
@@ -20,7 +20,7 @@ const HealthCareCTAV2 = ({
           text="Apply for VA health care"
           icon="file-medical"
           newTab
-          href="/apply/application"
+          href="/health-care/apply/application/introduction"
           testId="apply-va-healthcare-link-from-cta"
           onClick={() =>
             recordEvent({

--- a/src/applications/personalization/dashboard/components/health-care-v2/HealthCareCTAV2.jsx
+++ b/src/applications/personalization/dashboard/components/health-care-v2/HealthCareCTAV2.jsx
@@ -20,7 +20,7 @@ const HealthCareCTAV2 = ({
           text="Apply for VA health care"
           icon="file-medical"
           newTab
-          href="/apply/application/introduction"
+          href="/apply/application"
           testId="apply-va-healthcare-link-from-cta"
           onClick={() =>
             recordEvent({

--- a/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2.cypress.spec.js
@@ -166,32 +166,32 @@ describe('The My VA Dashboard - Outstanding Debts', () => {
         });
       });
 
-      describe('and no copays', () => {
-        it('shows debt card and no copays - C20882', () => {
-          cy.intercept('/v0/medical_copays', copaysSuccessEmpty()).as(
-            'emptyCopays1',
-          );
-          cy.visit('my-va/');
-          cy.wait([
-            '@featuresB',
-            '@noPaymentsB',
-            '@recentDebts1',
-            '@emptyCopays1',
-          ]);
-          cy.findByTestId('dashboard-section-debts-v2').should('exist');
+      // describe('and no copays', () => {
+      //   it('shows debt card and no copays - C20882', () => {
+      //     cy.intercept('/v0/medical_copays', copaysSuccessEmpty()).as(
+      //       'emptyCopays1',
+      //     );
+      //     cy.visit('my-va/');
+      //     cy.wait([
+      //       '@featuresB',
+      //       '@noPaymentsB',
+      //       '@recentDebts1',
+      //       '@emptyCopays1',
+      //     ]);
+      //     cy.findByTestId('dashboard-section-debts-v2').should('exist');
 
-          cy.findByTestId('copay-card-v2').should('not.exist');
-          cy.findByTestId('debt-card-v2').should('exist');
-          cy.findByTestId('copay-due-header-v2').should('not.exist');
-          cy.findByTestId('debt-total-header-v2').should('exist');
-          cy.findByTestId('learn-va-debt-link-v2').should('not.exist');
+      //     cy.findByTestId('copay-card-v2').should('not.exist');
+      //     cy.findByTestId('debt-card-v2').should('exist');
+      //     cy.findByTestId('copay-due-header-v2').should('not.exist');
+      //     cy.findByTestId('debt-total-header-v2').should('exist');
+      //     cy.findByTestId('learn-va-debt-link-v2').should('not.exist');
 
-          // make the a11y check
-          cy.injectAxeThenAxeCheck(
-            '[data-testid="dashboard-section-debts-v2"]',
-          );
-        });
-      });
+      //     // make the a11y check
+      //     cy.injectAxeThenAxeCheck(
+      //       '[data-testid="dashboard-section-debts-v2"]',
+      //     );
+      //   });
+      // });
     });
   });
 });

--- a/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2.cypress.spec.js
@@ -166,32 +166,32 @@ describe('The My VA Dashboard - Outstanding Debts', () => {
         });
       });
 
-      // describe('and no copays', () => {
-      //   it('shows debt card and no copays - C20882', () => {
-      //     cy.intercept('/v0/medical_copays', copaysSuccessEmpty()).as(
-      //       'emptyCopays1',
-      //     );
-      //     cy.visit('my-va/');
-      //     cy.wait([
-      //       '@featuresB',
-      //       '@noPaymentsB',
-      //       '@recentDebts1',
-      //       '@emptyCopays1',
-      //     ]);
-      //     cy.findByTestId('dashboard-section-debts-v2').should('exist');
+      describe('and no copays', () => {
+        it('shows debt card and no copays - C20882', () => {
+          cy.intercept('/v0/medical_copays', copaysSuccessEmpty()).as(
+            'emptyCopays1',
+          );
+          cy.visit('my-va/');
+          cy.wait([
+            '@featuresB',
+            '@noPaymentsB',
+            '@recentDebts1',
+            '@emptyCopays1',
+          ]);
+          cy.findByTestId('dashboard-section-debts-v2').should('exist');
 
-      //     cy.findByTestId('copay-card-v2').should('not.exist');
-      //     cy.findByTestId('debt-card-v2').should('exist');
-      //     cy.findByTestId('copay-due-header-v2').should('not.exist');
-      //     cy.findByTestId('debt-total-header-v2').should('exist');
-      //     cy.findByTestId('learn-va-debt-link-v2').should('not.exist');
+          cy.findByTestId('copay-card-v2').should('not.exist');
+          cy.findByTestId('debt-card-v2').should('exist');
+          cy.findByTestId('copay-due-header-v2').should('not.exist');
+          cy.findByTestId('debt-total-header-v2').should('exist');
+          cy.findByTestId('learn-va-debt-link-v2').should('not.exist');
 
-      //     // make the a11y check
-      //     cy.injectAxeThenAxeCheck(
-      //       '[data-testid="dashboard-section-debts-v2"]',
-      //     );
-      //   });
-      // });
+          // make the a11y check
+          cy.injectAxeThenAxeCheck(
+            '[data-testid="dashboard-section-debts-v2"]',
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- show debt section in one row not 2

## Testing done

- manual and tests pass

## Screenshots
### no flag
![Screenshot 2022-12-09 002717](https://user-images.githubusercontent.com/84803567/206631541-aeed3a60-95b6-4f46-9840-82b327e3b932.png)
### flag
![Screenshot 2022-12-09 003013](https://user-images.githubusercontent.com/84803567/206631553-0ac6f6e2-2828-4d8a-913c-f7ffbde61556.png)


## What areas of the site does it impact?
MyVA Debt Section

## Acceptance criteria

- [ ] A flag will turn on debt cards being in the same row
