### PR TITLE
[FSR] Bug - 50564 - Feature Flag not updating

### DIFF
--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -29,6 +29,7 @@ const App = ({
   getFormStatus,
   isError,
   isLoggedIn,
+  isStartingOver,
   location,
   pending,
   router,
@@ -85,7 +86,7 @@ const App = ({
     },
     // Do not add formData to the dependency array, as it will cause an infinite loop. Linter warning will go away when feature flag is deprecated.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [showCombinedFSR, showEnhancedFSR, setFormData],
+    [showCombinedFSR, showEnhancedFSR, setFormData, isStartingOver],
   );
 
   if (pending) {
@@ -149,6 +150,7 @@ const mapStateToProps = state => ({
   showFSR: fsrFeatureToggle(state),
   showCombinedFSR: combinedFSRFeatureToggle(state),
   showEnhancedFSR: enhancedFSRFeatureToggle(state),
+  isStartingOver: state.form.isStartingOver,
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
## Summary
- Identified and fixed an issue where feature flags were not updating in the form data when "Start new Application" was selected when prompted. Form data resets, but the reset wasn't triggering the `useEffect` for the feature flags being added
- Added `isStartingOver` as dependency so feature flags are fetched if form is restarted.


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50564

## Testing done
To recreate the issue:
- Start FSR
- Select "Finish this request later"
- Select "Start new application"
- Note form system reset form data to prefill and feature flags have been lost

To verify the issue has been fixed:
- Start FSR
- Select "Finish this request later"
- Select "Start new application"
- Note feature flags are still present in form data.

## What areas of the site does it impact?
Financial Status Report (5655)
`/manage-va-debt/request-debt-help-form-5655/`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
