### PR TITLE
Education Letters new copy updates for Has/NoLetters UI

### DIFF
--- a/src/applications/education-letters/components/LetterResults.jsx
+++ b/src/applications/education-letters/components/LetterResults.jsx
@@ -39,28 +39,10 @@ export const HasLetters = ({ claimStatus }) => {
         </div>
       </div>
 
-      <va-alert
-        close-btn-aria-label="Close notification"
-        status="warning"
-        visible
-      >
-        <div>
-          <p className="vads-u-margin-y--0">
-            The letter displayed here may not be the most recent decision letter
-            issued. If your claim requires further clarification, a follow-up
-            decision letter will be sent to you by mail. If you have additional
-            questions, you can contact us through{' '}
-            <a href="https://ask.va.gov/"> Ask VA.</a>
-          </p>
-        </div>
-      </va-alert>
-      <br />
-      <va-alert
-        background-only
-        close-btn-aria-label="Close notification"
-        status="warning"
-        visible
-      >
+      <va-alert close-btn-aria-label="Close notification" status="info" visible>
+        <h2 id="track-your-status-on-mobile" slot="headline">
+          COE Decision Letter Update
+        </h2>
         <div>
           <p className="vads-u-margin-y--0">
             The letter displayed here may not be the most recent decision letter

--- a/src/applications/education-letters/components/LetterResults.jsx
+++ b/src/applications/education-letters/components/LetterResults.jsx
@@ -7,7 +7,7 @@ export const LETTER_ENDPOINT = `${environment.API_URL}/meb_api/v0/claim_letter`;
 
 export const HasLetters = ({ claimStatus }) => {
   const receivedDate = () => {
-    const [year, month, day] = claimStatus?.receivedDate.split('-');
+    const [year, month, day] = claimStatus?.receivedDate?.split('-');
     return format(new Date(`${month}-${day}-${year}`), 'MMMM dd, yyyy');
   };
 
@@ -18,11 +18,12 @@ export const HasLetters = ({ claimStatus }) => {
         Download your VA education decision letter.
       </p>
       <h2>Letter available for you to download</h2>
-      <div className="edu-certi-eligibility">
+      <div className="edu-certi-eligibility vads-u-margin-bottom--4">
         <h3 className="vads-u-margin-top--2">Education decision letter</h3>
         <p>
-          This letter is proof of your eligibility for VA education benefits. It
-          shows details like which program you’re getting benefits through, the
+          The letter displayed is based on your most recent claim submission and
+          is proof of your eligibility for VA education benefits. It shows
+          details like which program you’re getting benefits through, the
           percentage of benefits you’re entitled to, and the time limit for
           using your benefits.
         </p>
@@ -37,6 +38,39 @@ export const HasLetters = ({ claimStatus }) => {
           <p>You applied for this on {receivedDate()}</p>
         </div>
       </div>
+
+      <va-alert
+        close-btn-aria-label="Close notification"
+        status="warning"
+        visible
+      >
+        <div>
+          <p className="vads-u-margin-y--0">
+            The letter displayed here may not be the most recent decision letter
+            issued. If your claim requires further clarification, a follow-up
+            decision letter will be sent to you by mail. If you have additional
+            questions, you can contact us through{' '}
+            <a href="https://ask.va.gov/"> Ask VA.</a>
+          </p>
+        </div>
+      </va-alert>
+      <br />
+      <va-alert
+        background-only
+        close-btn-aria-label="Close notification"
+        status="warning"
+        visible
+      >
+        <div>
+          <p className="vads-u-margin-y--0">
+            The letter displayed here may not be the most recent decision letter
+            issued. If your claim requires further clarification, a follow-up
+            decision letter will be sent to you by mail. If you have additional
+            questions, you can contact us through{' '}
+            <a href="https://ask.va.gov/"> Ask VA.</a>
+          </p>
+        </div>
+      </va-alert>
 
       <h2>How do I download and open a letter?</h2>
       <p>
@@ -103,17 +137,17 @@ export const NoLetters = () => {
       </p>
       <va-alert close-btn-aria-label="Close notification" status="info" visible>
         <h3 slot="headline">
-          We don’t have any letters available to you through this tool
+          Your letter is not available to you through this tool
         </h3>
         <div>
           <p>
-            At this time, we only have letters available here that you received
-            a decision on after August 20, 2022. To request a copy of an older
-            letter, you can contact us through Ask VA.
+            The letter displayed will be based on your most recent claim
+            submission. If your decision was prior to August 20, 2022 – or
+            you’re a family member or dependent – your decision letter will not
+            be listed here. You can contact us through Ask VA to request a copy
+            of your letter. Request your VA education letter through{' '}
+            <a href="https://ask.va.gov/"> Ask VA.</a>
           </p>
-          <a href="https://ask.va.gov/">
-            Request your VA education letter through Ask VA.
-          </a>
         </div>
       </va-alert>
     </>

--- a/src/applications/education-letters/containers/InboxPage.jsx
+++ b/src/applications/education-letters/containers/InboxPage.jsx
@@ -44,6 +44,10 @@ const InboxPage = ({
       );
     }
 
+    // let mockClaimStatus = {
+    //   claimStatus: 'ELIGIBLE',
+    //   receivedDate: '2020-12-12',
+    // };
     if (MEBClaimStatusFetchComplete || TOEClaimStatusFetchComplete) {
       if (['ELIGIBLE', 'DENIED'].includes(claimStatus?.claimStatus)) {
         return <HasLetters claimStatus={claimStatus} />;


### PR DESCRIPTION
## Summary
Updated styling and copy HasLetters UI and NoLetters UI, **need to confirm alert!**


## Testing done
- [] Done

## Screenshots
 
### /education/download-letters/letters - **NO LETTERS UI**
## <img width="480" alt="image" src="https://user-images.githubusercontent.com/17830527/206779211-c0729cc0-82aa-4052-8183-3c828f62d867.png">

### /education/download-letters/letters - **HAS LETTERS UI** 
<img width="497" alt="image" src="https://user-images.githubusercontent.com/17830527/207388958-a1d30a2b-5403-4042-a11b-53cfcdbe18ef.png">



## What areas of the site does it impact?
/education/download-letters/letters

## Acceptance criteria
Updated copy and text

