### PR TITLE
MEB: Fix Bank Account Error Message

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -1470,9 +1470,10 @@ const formConfig = {
               ...bankAccountUI,
               'ui:order': ['accountType', 'accountNumber', 'routingNumber'],
               accountNumber: {
-                'ui:title': 'Bank account number',
+                ...bankAccountUI.accountNumber,
                 'ui:validations': [validateAccountNumber],
                 'ui:errorMessages': {
+                  ...bankAccountUI.accountNumber['ui:errorMessages'],
                   pattern: 'Please enter only numbers',
                 },
               },


### PR DESCRIPTION
## Summary
- Fix error message for bank account number when the field is empty.

## Testing done
- Reviewed the error messages on the direct deposit page when no and invalid entries were made.
- Verified that valid inputs resulted in no errors being displayed and the form functioned as expected.

## Screenshots
### Empty bank account fields
<img width="488" alt="image" src="https://user-images.githubusercontent.com/112403/206788318-fe244cc6-451e-42ed-95cb-61ebde705723.png">

### Invalid bank account fields
<img width="485" alt="image" src="https://user-images.githubusercontent.com/112403/206788436-fd92cf8b-566b-4636-bdd2-ade97dc53d2c.png">

## What areas of the site does it impact?
* MEB direct deposit page only.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature