### PR TITLE
added level prop to FacilityPhone component

### DIFF
--- a/src/applications/vaos/components/FacilityPhone.jsx
+++ b/src/applications/vaos/components/FacilityPhone.jsx
@@ -28,7 +28,7 @@ export default function FacilityPhone({ contact, className, level }) {
 }
 
 FacilityPhone.propTypes = {
+  level: PropTypes.number.isRequired,
   className: PropTypes.string,
   contact: PropTypes.string,
-  level: PropTypes.number.isRequired,
 };

--- a/src/applications/vaos/components/FacilityPhone.jsx
+++ b/src/applications/vaos/components/FacilityPhone.jsx
@@ -30,5 +30,5 @@ export default function FacilityPhone({ contact, className, level }) {
 FacilityPhone.propTypes = {
   className: PropTypes.string,
   contact: PropTypes.string,
-  level: PropTypes.number,
+  level: PropTypes.number.isRequired,
 };

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import recordEvent from 'platform/monitoring/record-event';
+import ExpandingGroup from '~/platform/forms-system/src/js/components/ExpandingGroup';
 import FacilityPhone from '../../../components/FacilityPhone';
 import { GA_PREFIX } from '../../../utils/constants';
 import State from '../../../components/State';
@@ -105,6 +105,7 @@ export default function FacilitiesNotShown({
                   contact={
                     facility.telecom.find(t => t.system === 'phone')?.value
                   }
+                  level={3}
                 />
               </li>
             ))}

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 import ExpandingGroup from '~/platform/forms-system/src/js/components/ExpandingGroup';
@@ -133,3 +134,9 @@ export default function FacilitiesNotShown({
     </div>
   );
 }
+FacilitiesNotShown.propTypes = {
+  cernerSiteIds: PropTypes.object,
+  facilities: PropTypes.object,
+  sortMethod: PropTypes.string,
+  typeOfCareId: PropTypes.string,
+};

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
-import ExpandingGroup from '~/platform/forms-system/src/js/components/ExpandingGroup';
+import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import FacilityPhone from '../../../components/FacilityPhone';
 import { GA_PREFIX } from '../../../utils/constants';
 import State from '../../../components/State';


### PR DESCRIPTION
## Summary
In the `FacilitiesNotShown` component, there's a `FacilityPhone` component that is rendered anytime there's a nearby unsupported facility to a veteran. This `FacilityPhone` component expects a `level` prop. This level prop is used to determine what heading element to render, i.e `<h1></h1>,<h2></h2>`etc. This prop was missing and this was causing react to throw an error.

To prevent this from happening in the future, I've added `isRequired` prop validation.
## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50596
- https://app.zenhub.com/workspaces/vaos-team-603fdef281af6500110a1691/issues/department-of-veterans-affairs/va.gov-team/50596

## Testing done
- Tested Review instance with user - ola.e.edgecombe@id.me and bug appears to be fixed.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
