### PR TITLE
Restores 988 text and appropriate tests

### DIFF
--- a/src/applications/virtual-agent/components/chatbox/ChatboxDisclaimer.jsx
+++ b/src/applications/virtual-agent/components/chatbox/ChatboxDisclaimer.jsx
@@ -15,8 +15,8 @@ export const ChatboxDisclaimer = () => {
           <li>
             Our chatbot can’t help you if you’re experiencing a personal,
             medical, or mental health emergency. Go to the nearest emergency
-            room, dial 1-800-273-8255 and press 1 for mental health support, or
-            call 911 to get medical care right away.
+            room, dial 988 and press 1 for mental health support, or call 911 to
+            get medical care right away.
             <br />
             <a href="/health-care/health-needs-conditions/mental-health/">
               Learn more about VA mental health services

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -32,7 +32,7 @@ import {
 export const CHATBOT_ERROR_MESSAGE = /We’re making some updates to the Virtual Agent. We’re sorry it’s not working right now. Please check back soon. If you require immediate assistance please call the VA.gov help desk/i;
 
 const disclaimerText =
-  'Our chatbot can’t help you if you’re experiencing a personal, medical, or mental health emergency. Go to the nearest emergency room, dial 1-800-273-8255 and press 1 for mental health support, or call 911 to get medical care right away.';
+  'Our chatbot can’t help you if you’re experiencing a personal, medical, or mental health emergency. Go to the nearest emergency room, dial 988 and press 1 for mental health support, or call 911 to get medical care right away.';
 
 /**
  * @testing-library/dom


### PR DESCRIPTION
## Summary
Restores 988 text in chat disclaimer before user is able to interact with the chatbot

## Related issue(s)
- department-of-veterans-affairs/va-virtual-agent#748


## Testing done
- Unit testing