### PR TITLE
Remove use of ExpandingGroup component causing VAOS to fail in staging and production.

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-// import classNames from 'classnames';
+import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 // import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
-// import FacilityPhone from '../../../components/FacilityPhone';
+import FacilityPhone from '../../../components/FacilityPhone';
 import { GA_PREFIX } from '../../../utils/constants';
-// import State from '../../../components/State';
-// import NewTabAnchor from '../../../components/NewTabAnchor';
+import State from '../../../components/State';
+import NewTabAnchor from '../../../components/NewTabAnchor';
 import { isTypeOfCareSupported } from '../../../services/location';
 
 const UNSUPPORTED_FACILITY_RANGE = 100;
@@ -45,13 +45,13 @@ export default function FacilitiesNotShown({
     return null;
   }
 
-  /* const buttonClass = classNames(
+  const buttonClass = classNames(
     'additional-info-button',
     'va-button-link',
     'vads-u-display--block',
   );
 
-   const iconClass = classNames({
+  const iconClass = classNames({
     fas: true,
     'fa-angle-down': true,
     open: isOpen,
@@ -70,23 +70,24 @@ export default function FacilitiesNotShown({
         <i className={iconClass} />
       </span>
     </button>
-  ); */
+  );
 
   return (
     <div className="vads-u-margin-bottom--7">
-      {/* <ExpandingGroup
+      {/* Removing ExpandingGroup. Github ticket: #50602
+       <ExpandingGroup
         open={isOpen}
         expandedContentId="facilities-not-shown-content"
-      >
-        {trigger}
+      > */}
+      {trigger}
+      {isOpen && (
         <div className="additional-info-content">
           <p id="vaos-unsupported-label">
             The facilities below don’t offer online scheduling for this care.
-          </p> 
-      <ul
+          </p>
+          <ul
             aria-labelledby="vaos-unsupported-label"
             className="usa-unstyled-list"
-            role="list"
           >
             {nearbyUnsupportedFacilities.map(facility => (
               <li key={facility.id} className="vads-u-margin-top--2">
@@ -129,7 +130,8 @@ export default function FacilitiesNotShown({
             .
           </p>
         </div>
-      </ExpandingGroup> */}
+      )}
+      {/* </ExpandingGroup> */}
     </div>
   );
 }

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -476,7 +476,7 @@ describe('VAOS <VAFacilityPage>', () => {
         .exist;
     });
 
-    it.skip('should show additional info link if there are unsupported facilities within 100 miles', async () => {
+    it('should show additional info link if there are unsupported facilities within 100 miles', async () => {
       mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
       mockDirectBookingEligibilityCriteria(parentSiteIds, [
         getDirectBookingEligibilityCriteriaMock({
@@ -594,7 +594,7 @@ describe('VAOS <VAFacilityPage>', () => {
       ).to.have.attribute('href', '/find-locations');
     });
 
-    it.skip('should close additional info and re-sort unsupported facilities when sort method changes', async () => {
+    it('should close additional info and re-sort unsupported facilities when sort method changes', async () => {
       mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
       mockDirectBookingEligibilityCriteria(parentSiteIds, [
         getDirectBookingEligibilityCriteriaMock({
@@ -886,20 +886,20 @@ describe('VAOS <VAFacilityPage>', () => {
           .getAttribute('href'),
       ).to.contain('pages%2Fscheduling%2Fupcoming');
 
-      // userEvent.click(screen.getByText(/Why isn.t my facility listed/i));
-      // await waitFor(() => {
-      //   expect(screen.getByText(/Vista facility/i));
-      // });
+      userEvent.click(screen.getByText(/Why isn.t my facility listed/i));
+      await waitFor(() => {
+        expect(screen.getByText(/Vista facility/i));
+      });
 
-      // // Make sure Cerner facilities show up only once
-      // expect(screen.getAllByText(/Second Cerner facility/i)).to.have.length(1);
-      // userEvent.click(screen.getByLabelText(/First cerner facility/i));
-      // userEvent.click(screen.getByText(/Continue/));
-      // await waitFor(() =>
-      //   expect(screen.history.push.firstCall.args[0]).to.equal(
-      //     '/new-appointment/how-to-schedule',
-      //   ),
-      // );
+      // Make sure Cerner facilities show up only once
+      expect(screen.getAllByText(/Second Cerner facility/i)).to.have.length(1);
+      userEvent.click(screen.getByLabelText(/First cerner facility/i));
+      userEvent.click(screen.getByText(/Continue/));
+      await waitFor(() =>
+        expect(screen.history.push.firstCall.args[0]).to.equal(
+          '/new-appointment/how-to-schedule',
+        ),
+      );
     });
 
     it('should display a list of facilities with a show more button', async () => {


### PR DESCRIPTION
## Description

It's been determined that the ExpandingGroup component we are leveraging from the platform team is the root cause of the react errors we are seeing. I have commented out the component for now to temporarily fix staging & prod errors. We will likely need to wait for their component to get fixed before displaying the 'dropdown' style but the plan is to keep on displaying the exact info we have there but without the dropdown.


---

## Acceptance Criteria
The ''Why isn’t my facility listed?' section is displayed.
![Screen Shot 2022-12-11 at 10.04.49 PM.png](https://images.zenhubusercontent.com/62279c01c38e1718c9102bee/ad5b733f-dc3f-4b26-9628-86ed6d9a0af7)### Design Assets

## Definition of Done
- [ ] All acceptance criteria are met
- [ ] Documentation is updated

---