### PR TITLE
[#MHV-38996] Updated styling for folders page

### DIFF
--- a/src/applications/mhv/secure-messaging/components/FoldersList.jsx
+++ b/src/applications/mhv/secure-messaging/components/FoldersList.jsx
@@ -10,7 +10,7 @@ const FoldersList = props => {
       <ul className="folders-list">
         {!!folders.length &&
           folders.filter(folder => folder.id > 0).map(folder => (
-            <li key={folder.name}>
+            <li key={folder.name} className="folder-link">
               <Link to={`/folder/${folder.id}`}>
                 <i className="fas fa-folder" aria-hidden="true" />
                 {folder.name}

--- a/src/applications/mhv/secure-messaging/containers/Folders.jsx
+++ b/src/applications/mhv/secure-messaging/containers/Folders.jsx
@@ -87,7 +87,7 @@ const Folders = () => {
     }
     return (
       <>
-        <h1>My folders</h1>
+        <h1 className="vads-u-margin-bottom--2">My folders</h1>
         <AlertBackgroundBox closeable />
         <button type="button" className="modal-button" onClick={openNewModal}>
           Create new folder

--- a/src/applications/mhv/secure-messaging/sass/folders-list.scss
+++ b/src/applications/mhv/secure-messaging/sass/folders-list.scss
@@ -13,6 +13,15 @@
   }
 }
 
+.folder-link {
+  a {
+    color: $color-link-default;
+  }
+  a:visited {
+    color: $color-link-default;
+  }
+}
+
 .alert-box {
   p {
     margin: 0;


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Fixed some small styling on the folder management page for secure-messaging. 

## Related issue(s)
https://vajira.max.gov/browse/MHV-38996

## Testing done
Checked margins/padding on modal, checked links remain blue after visiting link.

## Screenshots

## What areas of the site does it impact?
secure-messages/folders

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
