### PR TITLE
[VA-11699] Add focus outline to Operating Status Alerts

### DIFF
--- a/src/platform/site-wide/sass/modules/facilities/_m-facilities-general.scss
+++ b/src/platform/site-wide/sass/modules/facilities/_m-facilities-general.scss
@@ -312,6 +312,7 @@
 a.operating-status-link {
   color: initial;
   text-decoration: none;
+  display: inline-block;
 }
 
 .operating-status-flag .fa-chevron-right {


### PR DESCRIPTION
## Summary

Operating Status alerts, specifically on VAMC pages, had no focus outlines. This is an accessibility bug since all keyboard interactive elements need a visual indicator when they have focus. The solution was to add `display: inline-block` to the operating status alert, since this gives the element the needed block styling to show a focus outline around it.

I work for the Facilities team but am also doing work to help the Public Websites team.

Closes [#11699](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11699)

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#11699](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11699)

## Testing done

I looked at an operating status alert locally and focused on it with my keyboard. There was no focus indicator visible. I made the CSS change in this pull request, tried again, and saw the focus indicator.

## Screenshots





| | Before | After |
| --- | --- | --- |
| Mobile | <img width="464" alt="Screen Shot 2022-12-13 at 10 20 21 AM" src="https://user-images.githubusercontent.com/10790736/207372921-84b8ca0f-c8bb-47b7-9a05-e0a0fdb72def.png"> | <img width="493" alt="Screen Shot 2022-12-13 at 10 20 31 AM" src="https://user-images.githubusercontent.com/10790736/207372918-d0254ea9-e094-4f49-8114-5ecaee38cb08.png"> |
| Desktop | <img width="678" alt="Screen Shot 2022-12-13 at 10 20 15 AM" src="https://user-images.githubusercontent.com/10790736/207372923-f1d3f313-bead-4d58-80f2-5855169b83c0.png"> | <img width="674" alt="Screen Shot 2022-12-13 at 10 08 50 AM" src="https://user-images.githubusercontent.com/10790736/207372247-5bb92b95-d943-4d89-9819-3a1151a3d860.png"> |

## What areas of the site does it impact?

All facility pages and likely any other pages that have a status alert component.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature
