### PR TITLE
Shouldn't check dates starting from the start of the day and statuses…

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -100,9 +100,7 @@ export function fetchConfirmedFutureAppointmentsV2() {
       type: FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
     });
 
-    const startOfToday = moment()
-      .startOf('day')
-      .toISOString();
+    const now = moment().toISOString();
 
     // Maximum number of days you can schedule an appointment in advance in VAOS
     const endDate = moment()
@@ -112,7 +110,7 @@ export function fetchConfirmedFutureAppointmentsV2() {
 
     try {
       const appointmentResponse = await apiRequest(
-        `/appointments?start=${startOfToday}&end=${endDate}&_include=facilities&status=booked`,
+        `/appointments?start=${now}&end=${endDate}&_include=facilities&statuses[]=booked`,
         { apiVersion: 'vaos/v2' },
       );
 

--- a/src/applications/personalization/dashboard/components/health-care-v2/AppointmentsV2.jsx
+++ b/src/applications/personalization/dashboard/components/health-care-v2/AppointmentsV2.jsx
@@ -9,8 +9,7 @@ export const AppointmentsCard = ({ appointments }) => {
   const start = moment.parseZone(nextAppointment?.startsAt);
   let locationName;
 
-  const timeZone =
-    nextAppointment?.timeZone ?? getAppointmentTimezone(nextAppointment);
+  const timeZone = getAppointmentTimezone(nextAppointment);
 
   if (nextAppointment?.isVideo) {
     locationName = 'VA Video Connect';

--- a/src/applications/personalization/dashboard/components/health-care/Appointments.jsx
+++ b/src/applications/personalization/dashboard/components/health-care/Appointments.jsx
@@ -8,8 +8,7 @@ export const Appointments = ({ appointments, hasError }) => {
   const nextAppointment = appointments?.[0];
   const start = moment.parseZone(nextAppointment?.startsAt);
   let locationName;
-  const timeZone =
-    nextAppointment?.timeZone ?? getAppointmentTimezone(nextAppointment);
+  const timeZone = getAppointmentTimezone(nextAppointment);
 
   if (nextAppointment?.isVideo) {
     locationName = 'VA Video Connect';

--- a/src/applications/personalization/dashboard/components/health-care/Appointments.jsx
+++ b/src/applications/personalization/dashboard/components/health-care/Appointments.jsx
@@ -51,7 +51,7 @@ export const Appointments = ({ appointments, hasError }) => {
           {start.format('dddd, MMMM Do, YYYY')}
         </p>
         <p className="vads-u-margin-bottom--1 vads-u-margin-top--1">
-          {`Time: ${start.format('h:mm a')} ${timeZone}`}
+          {`Time: ${start.format('h:mm a')} ${timeZone.abbreviation}`}
         </p>
         {locationName && <p className="vads-u-margin-top--1">{locationName}</p>}
         <CTALink

--- a/src/applications/personalization/dashboard/tests/e2e/vaos-v2-appointments/appointments-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/vaos-v2-appointments/appointments-v2.cypress.spec.js
@@ -20,7 +20,11 @@ describe('MyVA Dashboard - Appointments - v2', () => {
   });
   it('Has an appointment in the next 30 days', () => {
     cy.intercept('GET', '/vaos/v2/appointments*', req => {
-      expect(req.query.start).to.equal(
+      expect(
+        moment(req.query.start)
+          .startOf('day')
+          .toISOString(),
+      ).to.equal(
         moment()
           .startOf('day')
           .toISOString(),
@@ -33,7 +37,7 @@ describe('MyVA Dashboard - Appointments - v2', () => {
           .toISOString(),
       );
       expect(req.query._include).to.include('facilities');
-      expect(req.query.status).to.include('booked');
+      expect(req.query.statuses).to.include('booked');
       const rv = v2.createAppointmentSuccess();
       req.reply(rv);
     });
@@ -48,7 +52,7 @@ describe('MyVA Dashboard - Appointments - v2', () => {
     cy.findByRole('heading', { name: /next appointment/i }).should('exist');
   });
 
-  it('Has apppintments, but not in 30 days', () => {
+  it('Has appointments, but not in 30 days', () => {
     cy.intercept('GET', '/vaos/v2/appointments*', req => {
       // TODO: check for incoming params
       const rv = v2.createAppointmentSuccess({ startsInDays: [31] });

--- a/src/applications/personalization/dashboard/tests/e2e/vaos-v2-appointments/appointments-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/vaos-v2-appointments/appointments-v2.cypress.spec.js
@@ -37,7 +37,7 @@ describe('MyVA Dashboard - Appointments - v2', () => {
           .toISOString(),
       );
       expect(req.query._include).to.include('facilities');
-      expect(req.query.statuses).to.include('booked');
+      expect(req.query['statuses[]']).to.include('booked');
       const rv = v2.createAppointmentSuccess();
       req.reply(rv);
     });

--- a/src/applications/personalization/dashboard/utils/timezone.js
+++ b/src/applications/personalization/dashboard/utils/timezone.js
@@ -104,6 +104,14 @@ export function getUserTimezoneAbbr() {
  *   - description: The written out description (e.g. Eastern time)
  */
 export function getAppointmentTimezone(appointment) {
+  if (appointment?.timeZone) {
+    return {
+      identifier: appointment.timeZone,
+      abbreviation: appointment.timeZone,
+      description: getTimezoneNameFromAbbr(appointment.timeZone),
+    };
+  }
+
   // Most VA appointments will use this, since they're associated with a facility
   if (appointment?.location?.vistaId) {
     const locationId =


### PR DESCRIPTION
## Summary
- It no longer should be check dates starting from the start of the day and statuses is the only valid request for the api. Status was not valid. Timezone also had a bug that needed fixing that showed an undefined because it was looking for an attribute of an object that didn't exist in some cases

## Testing done

- Manual testing and tests pass

## What areas of the site does it impact?
MyVA Healthcare using VAOS 2.0 api

## Acceptance criteria

- [ ]  Timezone no longer shows undefined
- [ ]  Appointments are gathered from the api with the correct status
- [ ]  Appointments are gathered starting from the current time not the start of day
