### PR TITLE
VA-11358: Discharge wizard: transition to design system radios

### DIFF
--- a/src/applications/discharge-wizard/components/AnswerReview.jsx
+++ b/src/applications/discharge-wizard/components/AnswerReview.jsx
@@ -7,7 +7,7 @@ import Scroll from 'react-scroll';
 // Relative Imports
 import { answerReview, shouldShowQuestion } from '../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const AnswerReview = ({ formValues, handleScrollTo }) => {
   if (!formValues) {
@@ -19,9 +19,9 @@ const AnswerReview = ({ formValues, handleScrollTo }) => {
   }
 
   return (
-    <div className="review-answers">
+    <div>
       <Element name="END" />
-      <h4>Review your answers</h4>
+      <h2>Review your answers</h2>
       <div className="va-introtext">
         <p>
           If any information below is incorrect, update your answers to get the
@@ -45,6 +45,7 @@ const AnswerReview = ({ formValues, handleScrollTo }) => {
                     <p>{reviewLabel}</p>
                   </td>
                   <td>
+                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                     <a
                       href="#"
                       onClick={handleScrollTo}

--- a/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
+++ b/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
@@ -47,7 +47,7 @@ const BranchOfServiceQuestion = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
+++ b/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const BranchOfServiceQuestion = ({
   formValues,
@@ -24,11 +24,6 @@ const BranchOfServiceQuestion = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      In which branch of service did you serve?
-    </h4>
-  );
   const options = [
     { label: 'Army', value: 'army' },
     { label: 'Navy', value: 'navy' },
@@ -39,25 +34,31 @@ const BranchOfServiceQuestion = ({
 
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label: 'In which branch of service did you serve?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
+++ b/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
@@ -56,6 +56,7 @@ const BranchOfServiceQuestion = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
+++ b/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
@@ -54,7 +54,7 @@ const BranchOfServiceQuestion = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
+++ b/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
@@ -66,6 +66,7 @@ const CourtMartial = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
+++ b/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const CourtMartial = ({
   formValues,
@@ -29,12 +29,6 @@ const CourtMartial = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      Was your discharge the outcome of a <strong>general</strong>{' '}
-      court-martial?
-    </h4>
-  );
   const options = [
     {
       label: 'Yes, my discharge was the outcome of a general court-martial.',
@@ -47,27 +41,34 @@ const CourtMartial = ({
     },
     { label: "I'm not sure.", value: '3' },
   ];
+
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label: 'Was your discharge the outcome of a general court-martial?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
+++ b/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
@@ -64,7 +64,7 @@ const CourtMartial = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
+++ b/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
@@ -57,7 +57,7 @@ const CourtMartial = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/DischargeMonth.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeMonth.jsx
@@ -7,7 +7,7 @@ import { months } from 'platform/static-data/options-for-select.js';
 import Select from '@department-of-veterans-affairs/component-library/Select';
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const DischargeMonthQuestion = ({
   formValues,
@@ -26,8 +26,8 @@ const DischargeMonthQuestion = ({
   }
 
   const monthLabel = (
-    <legend className="legend-label">
-      <h4 className={`${key}_header`}>What month were you discharged?</h4>
+    <legend className={`${key}_header legend-label`}>
+      What month were you discharged?
     </legend>
   );
 

--- a/src/applications/discharge-wizard/components/questions/DischargeType.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeType.jsx
@@ -52,7 +52,7 @@ const DischargeType = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/DischargeType.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeType.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 import { questionLabels } from '../../constants';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const DischargeType = ({
   formValues,
@@ -25,36 +25,38 @@ const DischargeType = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      Which of the following categories best describes you?
-    </h4>
-  );
   const options = [
     { label: questionLabels[key][1], value: '1' },
     { label: questionLabels[key][2], value: '2' },
   ];
+
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label: 'Which of the following categories best describes you?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/DischargeType.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeType.jsx
@@ -54,6 +54,7 @@ const DischargeType = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/DischargeType.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeType.jsx
@@ -45,7 +45,7 @@ const DischargeType = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/DischargeYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeYear.jsx
@@ -7,7 +7,7 @@ import Scroll from 'react-scroll';
 import Select from '@department-of-veterans-affairs/component-library/Select';
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const DischargeYearQuestion = ({
   formValues,
@@ -35,10 +35,8 @@ const DischargeYearQuestion = ({
   yearOptions.push({ label: 'Before 1992', value: '1991' });
 
   const label = (
-    <legend className="legend-label">
-      <h4 className={`${key}_header`}>
-        What year were you discharged from the military?
-      </h4>
+    <legend className={`${key}_header legend-label`}>
+      What year were you discharged from the military?
     </legend>
   );
 

--- a/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
+++ b/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
@@ -56,7 +56,7 @@ const FailureToExhaust = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
+++ b/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
@@ -65,6 +65,7 @@ const FailureToExhaust = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
+++ b/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
@@ -63,7 +63,7 @@ const FailureToExhaust = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
+++ b/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const FailureToExhaust = ({
   formValues,
@@ -23,14 +23,6 @@ const FailureToExhaust = ({
   if (!shouldShowQuestion(key, formValues.questions)) {
     return null;
   }
-
-  const label = (
-    <h4 className={`${key}_header`}>
-      Was your application denied due to “failure to exhaust other remedies”?
-      Note: “Failure to exhaust other remedies” generally means you applied to
-      the wrong board.
-    </h4>
-  );
 
   let boardLabel = 'BCMR';
   if (['navy', 'marines'].includes(formValues['1_branchOfService'])) {
@@ -50,25 +42,32 @@ const FailureToExhaust = ({
 
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label:
+      'Was your application denied due to "failure to exhaust other remedies"? Note: "Failure to exhaust other remedies" generally means you applied to the wrong board.',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/Intention.jsx
+++ b/src/applications/discharge-wizard/components/questions/Intention.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 import { questionLabels } from '../../constants';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const Intention = ({
   formValues,
@@ -25,37 +25,39 @@ const Intention = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      Do you want to change your name, discharge date, or anything written in
-      the “other remarks” section of your DD214?
-    </h4>
-  );
   const options = [
     { label: `Yes, ${questionLabels[key][1]}`, value: '1' },
     { label: `No, ${questionLabels[key][2]}`, value: '2' },
   ];
+
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label:
+      'Do you want to change your name, discharge date, or anything written in the “other remarks” section of your DD214?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/Intention.jsx
+++ b/src/applications/discharge-wizard/components/questions/Intention.jsx
@@ -46,7 +46,7 @@ const Intention = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/Intention.jsx
+++ b/src/applications/discharge-wizard/components/questions/Intention.jsx
@@ -53,7 +53,7 @@ const Intention = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/Intention.jsx
+++ b/src/applications/discharge-wizard/components/questions/Intention.jsx
@@ -55,6 +55,7 @@ const Intention = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
@@ -57,6 +57,7 @@ const PrevApplication = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
@@ -48,7 +48,7 @@ const PrevApplication = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const PrevApplication = ({
   formValues,
@@ -29,35 +29,37 @@ const PrevApplication = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      Have you previously applied for and been denied a discharge upgrade for
-      this period of service? Note: You can still apply. Your answer to this
-      question simply changes where you send your application.
-    </h4>
-  );
   const options = [{ label: 'Yes', value: '1' }, { label: 'No', value: '2' }];
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label:
+      'Have you previously applied for and been denied a discharge upgrade for this period of service?',
+    hint:
+      'Note: You can still apply. Your answer to this question simply changes where you send your application.',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
@@ -55,7 +55,7 @@ const PrevApplication = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
@@ -69,7 +69,7 @@ const PrevApplicationType = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
@@ -62,7 +62,7 @@ const PrevApplicationType = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const PrevApplicationType = ({
   formValues,
@@ -23,13 +23,6 @@ const PrevApplicationType = ({
   if (!shouldShowQuestion(key, formValues.questions)) {
     return null;
   }
-
-  const label = (
-    <h4 className={`${key}_header`}>
-      What type of application did you make to upgrade your discharge
-      previously?
-    </h4>
-  );
 
   let boardLabel =
     'I applied to a Board for Correction of Military Records (BCMR)';
@@ -55,25 +48,32 @@ const PrevApplicationType = ({
 
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label:
+      'What type of application did you make to upgrade your discharge previously?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
@@ -71,6 +71,7 @@ const PrevApplicationType = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
@@ -59,7 +59,7 @@ const PrevApplicationYear = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { prevApplicationYearCutoff } from '../../constants';
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const PrevApplicationYear = ({
   formValues,
@@ -30,12 +30,6 @@ const PrevApplicationYear = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      What year did you apply for a discharge upgrade?
-    </h4>
-  );
-
   const labelYear = prevApplicationYearCutoff[formValues['4_reason']];
 
   const options = [
@@ -45,25 +39,31 @@ const PrevApplicationYear = ({
 
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label: 'What year did you apply for a discharge upgrade?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
@@ -61,6 +61,7 @@ const PrevApplicationYear = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
@@ -52,7 +52,7 @@ const PrevApplicationYear = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/PriorService.jsx
+++ b/src/applications/discharge-wizard/components/questions/PriorService.jsx
@@ -69,7 +69,7 @@ const PriorService = ({
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/PriorService.jsx
+++ b/src/applications/discharge-wizard/components/questions/PriorService.jsx
@@ -71,6 +71,7 @@ const PriorService = ({
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/PriorService.jsx
+++ b/src/applications/discharge-wizard/components/questions/PriorService.jsx
@@ -62,7 +62,7 @@ const PriorService = ({
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/components/questions/PriorService.jsx
+++ b/src/applications/discharge-wizard/components/questions/PriorService.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const PriorService = ({
   formValues,
@@ -29,13 +29,6 @@ const PriorService = ({
     return null;
   }
 
-  const label = (
-    <h4 className={`${key}_header`}>
-      Did you complete a period of service in which your character of service
-      was Honorable or General Under Honorable Conditions?
-    </h4>
-  );
-
   const options = [
     {
       label:
@@ -55,25 +48,32 @@ const PriorService = ({
 
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label:
+      'Did you complete a period of service in which your character of service was Honorable or General Under Honorable Conditions?',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/questions/Reason.jsx
@@ -59,6 +59,7 @@ const Reason = ({ formValues, handleKeyDown, scrollToLast, updateField }) => {
             label={option.label}
             name={option.value}
             value={option.value}
+            checked={formValues[key] === option.value}
           />
         ))}
       </VaRadio>

--- a/src/applications/discharge-wizard/components/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/questions/Reason.jsx
@@ -57,7 +57,7 @@ const Reason = ({ formValues, handleKeyDown, scrollToLast, updateField }) => {
           <va-radio-option
             key={index}
             label={option.label}
-            name={option.value}
+            name={key}
             value={option.value}
             checked={formValues[key] === option.value}
           />

--- a/src/applications/discharge-wizard/components/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/questions/Reason.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // Relative Imports
 import { shouldShowQuestion } from '../../helpers';
 import { questionLabels } from '../../constants';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 const Reason = ({ formValues, handleKeyDown, scrollToLast, updateField }) => {
   const key = '4_reason';
@@ -32,41 +32,36 @@ const Reason = ({ formValues, handleKeyDown, scrollToLast, updateField }) => {
     { label: questionLabels[key]['7'], value: '7' },
   ];
 
-  const label = (
-    <div>
-      <h4 className={`${key}_header`}>
-        Which of the following best describes why you want to change your
-        discharge paperwork? Choose the one that’s closest to your situation.
-      </h4>
-      <p>
-        <strong>Note:</strong> If more than one of these fits your situation,
-        choose the one that started the events leading to your discharge. For
-        example, if you experienced sexual assault and have posttraumatic stress
-        disorder (PTSD) resulting from that experience, choose sexual assault.
-      </p>
-    </div>
-  );
   const radioButtonProps = {
     name: key,
-    label,
-    options,
+    label:
+      'Which of the following best describes why you want to change your discharge paperwork? Choose the one that’s closest to your situation.',
+    hint:
+      'Note: If more than one of these fits your situation, choose the one that started the events leading to your discharge. For example, if you experienced sexual assault and have posttraumatic stress disorder (PTSD) resulting from that experience, choose sexual assault.',
     key,
-    onValueChange: v => {
-      if (v.dirty) {
-        updateField(key, v.value);
+    value: formValues[key],
+    onVaValueChange: e => {
+      if (e.returnValue) {
+        updateField(key, e.detail.value);
       }
     },
     onMouseDown: scrollToLast,
     onKeyDown: handleKeyDown,
-    value: {
-      value: formValues[key],
-    },
   };
 
   return (
-    <div>
+    <div className="vads-u-margin-top--4">
       <Element name={key} />
-      <RadioButtons {...radioButtonProps} />
+      <VaRadio {...radioButtonProps}>
+        {options.map((option, index) => (
+          <va-radio-option
+            key={index}
+            label={option.label}
+            name={option.value}
+            value={option.value}
+          />
+        ))}
+      </VaRadio>
     </div>
   );
 };

--- a/src/applications/discharge-wizard/components/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/questions/Reason.jsx
@@ -50,7 +50,7 @@ const Reason = ({ formValues, handleKeyDown, scrollToLast, updateField }) => {
   };
 
   return (
-    <div className="vads-u-margin-top--4">
+    <div className="vads-u-margin-top--6">
       <Element name={key} />
       <VaRadio {...radioButtonProps}>
         {options.map((option, index) => (

--- a/src/applications/discharge-wizard/sass/discharge-wizard.scss
+++ b/src/applications/discharge-wizard/sass/discharge-wizard.scss
@@ -16,7 +16,6 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 
   fieldset {
     margin: 0;
-    padding: 0 1.5em;
     margin-top: 2em;
 
     &.dischargeMonth,

--- a/src/applications/discharge-wizard/tests/components/FormQuestions.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/components/FormQuestions.unit.spec.js
@@ -55,10 +55,13 @@ describe('Discharge Wizard <FormQuestions />', () => {
       'Do you want to change your name, discharge date, or anything written in the “other remarks” section of your DD214?',
     );
     expect(html).to.include(
-      `Was your discharge the outcome of a <strong>general</strong> court-martial?`,
+      `Was your discharge the outcome of a general court-martial?`,
     );
     expect(html).to.include(
-      'Have you previously applied for and been denied a discharge upgrade for this period of service? Note: You can still apply. Your answer to this question simply changes where you send your application.',
+      'Have you previously applied for and been denied a discharge upgrade for this period of service?',
+    );
+    expect(html).to.include(
+      'Note: You can still apply. Your answer to this question simply changes where you send your application.',
     );
     expect(html).to.include('What year did you apply for a discharge upgrade?');
     expect(html).to.include(
@@ -112,7 +115,9 @@ describe('Discharge Wizard <FormQuestions />', () => {
       />,
     );
 
-    expect(wrapper.find('input[name="1_branchOfService"]')).to.have.lengthOf(5);
+    expect(
+      wrapper.find('va-radio[name="1_branchOfService"] va-radio-option'),
+    ).to.have.lengthOf(5);
     expect(wrapper.find('select[name="2_dischargeYear"]')).to.have.lengthOf(1);
     expect(wrapper.find('select[name="4_reason"]')).to.have.lengthOf(0);
 

--- a/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
+++ b/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
@@ -19,32 +19,32 @@ describe('functionality of discharge wizard', () => {
     // questions page | fill out form
     cy.get('.main .usa-button-primary').click();
 
-    cy.get('input[name="1_branchOfService"]')
+    cy.get('va-radio[name="1_branchOfService"] va-radio-option')
       .first()
       .click();
 
     cy.get('select[name="2_dischargeYear"]').select('2016');
-    cy.get('input[name="4_reason"]')
+    cy.get('va-radio[name="4_reason"] va-radio-option')
       .first()
       .click();
 
-    cy.get('input[name="6_intention"]')
+    cy.get('va-radio[name="6_intention"] va-radio-option')
       .first()
       .click();
 
-    cy.get('input[name="7_courtMartial"]')
+    cy.get('va-radio[name="7_courtMartial"] va-radio-option')
       .first()
       .click();
 
-    cy.get('input[name="8_prevApplication"]')
+    cy.get('va-radio[name="8_prevApplication"] va-radio-option')
       .first()
       .click();
 
-    cy.get('input[name="9_prevApplicationYear"]')
+    cy.get('va-radio[name="9_prevApplicationYear"] va-radio-option')
       .first()
       .click();
 
-    cy.get('input[name="12_priorService"]')
+    cy.get('va-radio[name="12_priorService"] va-radio-option')
       .first()
       .click();
 


### PR DESCRIPTION
## Summary

The Discharge Wizard page uses the old React component for radio answers. This changes them over to the design system's radio components while retaining the same functionality and updating a few styles for consistency and accessibility.

## Related issue(s)

- Closes department-of-veterans-affairs/va.gov-cms#11358


## Testing done

Clicked through the discharge wizard questions to confirm the same functionality and alignment carried over. Also confirmed that the labels no longer contain headers, for both radio and non-radio questions.

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | <img width="469" alt="Screen Shot 2022-12-14 at 12 59 46 PM" src="https://user-images.githubusercontent.com/10790736/207671840-91a09ea6-1a79-4128-a4ac-e752e55af06d.png"><img width="472" alt="Screen Shot 2022-12-14 at 12 59 58 PM" src="https://user-images.githubusercontent.com/10790736/207671836-940c134a-e606-4aa3-8951-28de5480d7c2.png"> | <img width="472" alt="Screen Shot 2022-12-14 at 12 56 28 PM" src="https://user-images.githubusercontent.com/10790736/207671119-76d81e3f-4c15-4180-8839-9547333c6c24.png"><img width="471" alt="Screen Shot 2022-12-14 at 12 56 34 PM" src="https://user-images.githubusercontent.com/10790736/207671115-c3450dab-5ea9-4874-845a-61f2e262feb6.png"> |
| Desktop | <img width="1537" alt="Screen Shot 2022-12-14 at 1 00 25 PM" src="https://user-images.githubusercontent.com/10790736/207671844-a4044666-f382-4629-9d57-285766e5a4ba.png"><img width="1531" alt="Screen Shot 2022-12-14 at 1 00 17 PM" src="https://user-images.githubusercontent.com/10790736/207671842-864d4f83-6dd6-4147-a550-ce8c90866b17.png"> | <img width="1380" alt="Screen Shot 2022-12-14 at 12 56 04 PM" src="https://user-images.githubusercontent.com/10790736/207671125-b3fa3767-9fec-4fc1-8d41-3f315aafe04a.png"><img width="1378" alt="Screen Shot 2022-12-14 at 12 56 12 PM" src="https://user-images.githubusercontent.com/10790736/207671121-e0b506f0-e8e1-479b-a7d1-bb1de6997a90.png"> |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Check for consistency, no broken functionality, and no remaining old radio components.
