### PR TITLE
Clinic Patient Friendly Names Not Displaying Confirmation Page & Upcoming Appts Queue

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -328,7 +328,7 @@ export function transformVAOSAppointment(appt) {
       vistaId: appt.locationId?.substr(0, 3) || null,
       clinicId: appt.clinic,
       stationId: appt.locationId,
-      clinicName: appt.serviceName || null,
+      clinicName: appt.friendlyName || appt.serviceName || null,
     },
     comment:
       isVideo && !!appt.patientInstruction

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1252,6 +1252,84 @@
       }
     },
     {
+      "id": "147685",
+      "type": "appointments",
+      "attributes": {
+        "id": "147685",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
+            "value": "1081;20221214.080000"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "amputation",
+        "reasonCode": {
+          "text": "test"
+        },
+        "patientIcn": "1012845943V900681",
+        "locationId": "983GC",
+        "clinic": "1081",
+        "start": "2022-12-14T15:00:00Z",
+        "end": "2022-12-14T15:30:00Z",
+        "minutesDuration": 30,
+        "slot": {
+          "id": "3230323231323134313530303A323032323132313431353330",
+          "start": "2022-12-14T15:00:00Z",
+          "end": "2022-12-14T15:30:00Z"
+        },
+        "comment": "test",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "FUTURE"
+          ]
+        },
+        "serviceName": "FTC AMPUTATION",
+        "friendlyName": "Friendly Name FTC Amputation",
+        "location": {
+          "id": "983GC",
+          "type": "appointments",
+          "attributes": {
+            "id": "983GC",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Fort Collins VA Clinic",
+            "classification": "Multi-Specialty CBOC",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 40.553875,
+            "long": -105.08795,
+            "website": "https://www.cheyenne.va.gov/locations/Fort_Collins_VA_CBOC.asp",
+            "phone": {
+              "main": "970-224-1550"
+            },
+            "physicalAddress": {
+              "line": [
+                "2509 Research Boulevard"
+              ],
+              "city": "Fort Collins",
+              "state": "CO",
+              "postalCode": "80526-8108"
+            },
+            "healthService": [
+              "Audiology",
+              "EmergencyCare",
+              "MentalHealthCare",
+              "PrimaryCare",
+              "SpecialtyCare"
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "50096",
       "type": "appointments",
       "attributes": {
@@ -1278,6 +1356,7 @@
         "cancellationReason": {
           "code": "other"
         },
+        "friendlyName": "Friendly Name CHY PC KILPATRICK",
         "serviceName": "CHY PC KILPATRICK",
         "location": {
           "id": "983",


### PR DESCRIPTION
## Description
This PR maps clinic name in appointment details to the FriendlyName field.

## Original issue(s)
- https://app.zenhub.com/workspaces/vaos-team-603fdef281af6500110a1691/issues/department-of-veterans-affairs/va.gov-team/50597

## Testing done
- updated Mock file and tested that clinic name is mapped from the friendlyName field.

## Screenshots
<img width="600" alt="Screen Shot 2022-12-13 at 12 53 06 PM" src="https://user-images.githubusercontent.com/47654119/207408301-8c8dddaa-f654-4496-8273-5e26cab985f9.png">
<img width="600" alt="Screen Shot 2022-12-13 at 12 53 23 PM" src="https://user-images.githubusercontent.com/47654119/207408372-470d181a-2bf9-49bf-a8e9-a2d405fb7a81.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
