### PR TITLE
check-in/50083/Add info message and tests for pre checkin missed window

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -239,6 +239,15 @@ class ApiInitializer {
       });
       return data;
     },
+    withPast15MinuteWindow: () => {
+      const data = preCheckInData.get.createMockSuccessResponse(
+        preCheckInData.get.past15MinuteUUID,
+      );
+      cy.intercept('GET', '/check_in/v2/pre_check_ins/*', req => {
+        req.reply(data);
+      });
+      return data;
+    },
     withBadData: ({
       extraValidation = null,
       demographicsNeedsUpdate = true,

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -13,6 +13,7 @@ const canceledAppointmentUUID = '9d7b7c15-d539-4624-8d15-b740b84e8548';
 const canceledPhoneAppointmentUUID = '1448d690-fd5f-11ec-b939-0242ac120002';
 
 const expiredUUID = '354d5b3a-b7b7-4e5c-99e4-8d563f15c521';
+const past15MinuteUUID = 'f4167a0a-c74d-4e1e-9715-ca22ed7fab9e';
 const expiredPhoneUUID = '08ba56a7-68b7-4b9f-b779-53ba609140ef';
 
 const isoDateWithoutTimezoneFormat = "yyyy-LL-dd'T'HH:mm:ss";
@@ -26,10 +27,16 @@ const createMockSuccessResponse = (
   emergencyContactNeedsUpdate = false,
   emergencyContactConfirmedAt = null,
 ) => {
-  const mockTime =
-    token === expiredUUID || token === expiredPhoneUUID
-      ? new Date()
-      : dateFns.add(new Date(), { days: 1 });
+  const mockTime = (() => {
+    switch (token) {
+      case expiredUUID || expiredPhoneUUID:
+        return new Date();
+      case past15MinuteUUID:
+        return dateFns.sub(new Date(), { minutes: 15 });
+      default:
+        return dateFns.add(new Date(), { days: 1 });
+    }
+  })();
 
   let apptKind = 'clinic';
   let location = null;
@@ -121,4 +128,5 @@ module.exports = {
   createMockFailedResponse,
   defaultUUID,
   expiredUUID,
+  past15MinuteUUID,
 };

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -212,5 +212,6 @@
   "find-the-travel-contact-for-your-facility": "Find the travel contact for your facility",
   "or-call-our-BTSSS-toll-free-call-center": "Or call our BTSSS toll-free call center at <0></0> (<1></1>). We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.",
   "travel-pay-reimbursement--info-message": "VA travel pay reimbursement pays eligible Veterans and caregivers back for mileage and other travel expenses to and from approved health care appointments.",
-  "find-out-how-to-file--link": "Find out how to file for travel reimbursement"
+  "find-out-how-to-file--link": "Find out how to file for travel reimbursement",
+  "pre-check-in-no-longer-available--info-message": "We’re sorry. Pre-check-in is no longer available for your appointment time. Ask a staff member for help to check in."
 }

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -131,7 +131,11 @@ const Error = () => {
     } else if (appointmentStartTimePast15(appointments)) {
       // don't show sub message if we are 15 minutes past appointment start time
       header = t('sorry-pre-check-in-is-no-longer-available');
-      messages = [];
+      messages = [
+        {
+          text: t('pre-check-in-no-longer-available--info-message'),
+        },
+      ];
       accordion = appointmentAccordion(appointments);
       showHowToLink = false;
     } else if (error === 'pre-check-in-expired') {

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -247,7 +247,7 @@ describe('check-in', () => {
         };
         store = mockStore({ ...initState, ...scheduledDowntimeState });
       });
-      it('renders no sub message or how to link when appointment started more than 15 minutes ago', () => {
+      it('renders properly when appointment started more than 15 minutes ago', () => {
         const component = render(
           <Provider store={store}>
             <I18nextProvider i18n={i18n}>
@@ -255,7 +255,7 @@ describe('check-in', () => {
             </I18nextProvider>
           </Provider>,
         );
-        expect(component.queryByTestId('error-message')).to.be.null;
+        expect(component.queryByTestId('error-message')).to.exist;
         expect(component.queryByTestId('how-to-link')).to.not.exist;
       });
     });

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec.js
@@ -1,0 +1,43 @@
+import '../../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../../tests/e2e/pages/ValidateVeteran';
+import Error from '../../pages/Error';
+import Confirmation from '../../pages/Confirmation';
+
+describe('Pre-Check In Experience ', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializePreCheckInDataGet,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+
+    initializeSessionPost.withSuccess();
+
+    initializePreCheckInDataGet.withPast15MinuteWindow();
+  });
+  afterEach(() => {
+    cy.window().then(window => {
+      window.sessionStorage.clear();
+    });
+  });
+  it('Render Error pre check in past 15 minutes', () => {
+    cy.visitPreCheckInWithUUID();
+    // page: Validate
+    ValidateVeteran.validatePage.preCheckIn();
+    ValidateVeteran.validateVeteran();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    // Expired UUID should navigate to an error
+    Error.validatePast15MinutesPageLoaded();
+    Error.validateAccordionBlocks();
+    cy.injectAxeThenAxeCheck();
+    Confirmation.expandAllAccordions();
+    cy.createScreenshots('Pre-check-in--past-15-min');
+  });
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
@@ -70,6 +70,17 @@ class Error {
     }
   };
 
+  validatePast15MinutesPageLoaded = () => {
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('have.text', 'Sorry, pre-check-in is no longer available');
+    cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .contains(
+        'We’re sorry. Pre-check-in is no longer available for your appointment time. Ask a staff member for help to check in.',
+      );
+  };
+
   validateDatePreCheckInDateShows = () => {
     cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
       .should('be.visible')


### PR DESCRIPTION
Clarify Message when using Pre-Check-in on Day-of Appointment after Check-in Window

[wireframe](https://app.abstract.com/projects/d9d1d6b4-192b-4ee6-95ab-e7cf42a1ac03/branches/b5f64555-47bc-4a97-8465-ab617bbeecc3/commits/latest/files/db5cbb64-bed3-48f8-9512-2e2eef457dd1/layers/B524A666-420D-46D7-BD30-DCFD8DD22832?collectionId=71337211-25c1-41de-9efb-06e9acd1ea19&collectionLayerId=28e1acef-704c-45c2-af58-db3c1f046384&mode=design&selected=root-20856A1D-0D52-4F87-B79F-DF74267DCAB4)


![Screen Shot 2022-12-13 at 3 32 09 PM](https://user-images.githubusercontent.com/2982977/207437857-e58a94b9-e684-4478-8e78-e6879fb817b2.png)

## Summary

- Added a info message for pre check in no longer available
- Added item to translation

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#50083](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50083)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

