### PR TITLE
Remove commented code since this is in a finalized, working state

### DIFF
--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -37,6 +37,11 @@ jobs:
             .cache/yarn
             node_modules
 
+      - name: Set UUID for Mochawesome reports
+        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+        #Actions for building docker image go here
+
       - name: Get Source Repo and Source Ref
         run: node ./script/github-actions/pe-deploy-source.js
         env:
@@ -49,6 +54,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
-          event-type: review_instance_run
+          event-type: deploy_review_instance
           repository: department-of-veterans-affairs/devops
           client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}" }'
+          # Once docker image is built, add the name of the image to this object as a new property.

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -6,16 +6,6 @@ on:
   push:
     branches:
       - '**'
-  # workflow_dispatch: # will remove this when finalized - leaving for testing purposes for now
-  #   inputs:
-  #     sourceRepo:
-  #       description: 'repo triggering deployment'
-  #       required: false
-  #       default: 'content-build'
-  #     sourceRef:
-  #       description: 'repo triggering deployment'
-  #       required: false
-  #       default: 'pe-deploy-cb'
 
 jobs:
   deploy-preview-environment:

--- a/script/github-actions/pe-deploy-source.js
+++ b/script/github-actions/pe-deploy-source.js
@@ -12,6 +12,6 @@ if (
   core.exportVariable('SOURCE_REPO', sourceRepo);
   core.exportVariable('SOURCE_REF', sourceRef);
 } else {
-  core.exportVariable('SOURCE_REPO', 'vets-website');
+  core.exportVariable('SOURCE_REPO', 'vets-api');
   core.exportVariable('SOURCE_REF', workflowRef);
 }


### PR DESCRIPTION
## Summary

As this workflow is finalized and working, the workflow_dispatch trigger that was being used to test this locally is no longer needed. Removing the commented out section.

## Related issue(s)
https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/50517


## Testing done
Tested by running this workflow both being triggered by a push in vets-website, and a repository_dispatch from content-build. Both successfully passed both the source_repo and source_ref to the devops repository.

## Screenshots
N/A

## What areas of the site does it impact?
Preview Environments (WIP, not live yet)

## Acceptance criteria

- [ ]  Comment is removed
- [ ]  Workflow runs as expected

