### PR TITLE
11831 Switch background colors for new homepage search section

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-homepage-preview.scss
+++ b/src/platform/site-wide/sass/modules/_m-homepage-preview.scss
@@ -1,4 +1,3 @@
-
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 .homepage-hero {
@@ -19,7 +18,7 @@
   &__welcome-headline {
     max-width: 100%;
     @media (min-width: $small-desktop-screen) {
-       max-width: 50%;
+      max-width: 50%;
     }
   }
 
@@ -57,8 +56,8 @@
   &__wrapper {
     background: linear-gradient(
       to bottom,
-      $color-primary-alt-lightest 0 50%,
-      $color-white 50% 100%
+      $color-white 0 40%,
+      $color-primary-alt-lightest 40% 100%
     );
   }
 
@@ -70,8 +69,8 @@
     &__wrapper {
       background: linear-gradient(
         to right,
-        $color-primary-alt-lightest 0 50%,
-        $color-white 50% 100%
+        $color-white 0 50%,
+        $color-primary-alt-lightest 50% 100%
       );
     }
     &__list {
@@ -80,7 +79,6 @@
       -moz-columns: 2;
     }
   }
-
 
   &__search-tools {
     ul {


### PR DESCRIPTION
## Summary

This PR swaps the background colors of the Search / Top links section of the new homepage design.

Sibling PR:  https://github.com/department-of-veterans-affairs/content-build/pull/1401

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11831)

## Testing done
Visual comparison to the screenshots in the ticket.

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

Before: 
![image](https://user-images.githubusercontent.com/55411834/206761332-527f2a1c-f8a5-429b-b3ca-c8a8b55e0926.png)

After:
<img width="1214" alt="Screenshot 2022-12-14 at 11 58 17 AM" src="https://user-images.githubusercontent.com/732460/207674372-1d1884ce-1d9c-4f61-9fdf-697937cc5681.png">
<img width="491" alt="Screenshot 2022-12-14 at 11 58 37 AM" src="https://user-images.githubusercontent.com/732460/207674389-a44ea023-036b-4825-8dfb-b52a0342fb6d.png">

## What areas of the site does it impact?
The new homepage, currently located at `/new-home-page`

## Acceptance criteria

- [n/a]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [n/a]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback
In both mobile and desktop, 
- [x] Search block has white background
- [x] Menu of links has light blue background