### PR TITLE
ToE: Fix Direct Deposit Error Messages and Labels

### DIFF
--- a/src/applications/toe/components/DirectDepositViewField.jsx
+++ b/src/applications/toe/components/DirectDepositViewField.jsx
@@ -23,14 +23,14 @@ export default function DirectDepositViewField({ formData }) {
           <dd>{financialInstitutionName}</dd> */}
 
           <dt className="toe-definition-list_term toe-definition-list_term--normal">
-            Account Number:
+            Bank account number:
           </dt>
           <dd className="toe-definition-list_definition">
             {obfuscate(accountNumber)}
           </dd>
 
           <dt className="toe-definition-list_term toe-definition-list_term--normal">
-            Routing Number:
+            Bank routing number:
           </dt>
           <dd className="toe-definition-list_definition">
             {obfuscate(routingNumber)}

--- a/src/applications/toe/config/form.js
+++ b/src/applications/toe/config/form.js
@@ -1232,21 +1232,18 @@ const formConfig = {
               ...bankAccountUI,
               'ui:order': ['accountType', 'accountNumber', 'routingNumber'],
               accountNumber: {
+                ...bankAccountUI.accountNumber,
                 'ui:errorMessages': {
-                  pattern: 'Please enter a valid account number',
-                  required: 'Please enter a valid account number',
+                  ...bankAccountUI.accountNumber['ui:errorMessages'],
+                  pattern: 'Please enter only numbers',
                 },
                 'ui:reviewField': ObfuscateReviewField,
                 'ui:title': 'Bank account number',
                 'ui:validations': [validateAccountNumber],
               },
               routingNumber: {
-                'ui:errorMessages': {
-                  pattern: 'Please enter a valid routing number',
-                  required: 'Please enter a valid routing number',
-                },
+                ...bankAccountUI.routingNumber,
                 'ui:reviewField': ObfuscateReviewField,
-                'ui:title': 'Routing number',
                 'ui:validations': [validateRoutingNumber],
               },
             },


### PR DESCRIPTION
## Summary

- Correct/standardize direct deposit error messages.
- Correct direct deposit labels.

## Related issue(s)
N/A

## Testing done
- Tested view and edit mode for ToE's direct deposit page.
- Verified that error messages and labels match requirements.

## Screenshots
### Error Messages when empty
<img width="529" alt="image" src="https://user-images.githubusercontent.com/112403/207703794-a79f3027-0335-43b2-8f78-2677e5b4532e.png">

### Invalid routing number
<img width="527" alt="image" src="https://user-images.githubusercontent.com/112403/207704226-8af38770-038f-4502-a615-c1bb42ae8454.png">

### Direct deposit view mode
<img width="521" alt="image" src="https://user-images.githubusercontent.com/112403/207704374-26b50bd5-9405-4f4c-8c16-a8e0e9f14a47.png">


## What areas of the site does it impact?
* ToE Direct deposit page only.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
