### PR TITLE
Added spacing between the privacy policy and finish this applicaton l…

### DIFF
--- a/src/applications/toe/components/preSubmitInfo.js
+++ b/src/applications/toe/components/preSubmitInfo.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default {
   required: false,
   notice: (
-    <div>
+    <div className="vads-u-margin-bottom--4">
       <strong>Note:</strong> According to federal law, there are criminal
       penalties, including a fine and/or imprisonment for up to 5 years, for
       withholding information or for providing incorrect information (See 18


### PR DESCRIPTION
## Summary
Gives spacing with class utilities to the preSubmitInfo component. Allows space between itself and the 
**Finish this application later** button


## Testing done
- [] Done

## Screenshots

## What areas of the site does it impact?
/education/survivor-dependent-benefits/apply-for-transferred-benefits-form-22-1990e/review-and-submit

