### PR TITLE
Added claims-list.json for issue #50755

### DIFF
--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims/claims-list.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims/claims-list.json
@@ -67,6 +67,28 @@
       }
     },
     {
+      "id": "phase3-decision-mailed",
+      "type": "evss_claims",
+      "attributes": {
+        "evssId": 18968500,
+        "dateFiled": "2021-09-16",
+        "minEstDate": null,
+        "maxEstDate": null,
+        "phaseChangeDate": "2021-09-19",
+        "open": true,
+        "waiverSubmitted": false,
+        "documentsNeeded": false,
+        "developmentLetterSent": false,
+        "decisionLetterSent": true,
+        "phase": 3,
+        "everPhaseBack": false,
+        "currentPhaseBack": false,
+        "requestedDecision": false,
+        "claimType": "Compensation",
+        "updatedAt": "2022-06-08T03:34:10.967Z"
+      }
+    },
+    {
       "id": "decision-mailed",
       "type": "evss_claims",
       "attributes": {


### PR DESCRIPTION
## Summary

- Added phase3-decision-mailed.json to claims-list.json array, and set `"decisionLetterSent": true`

## Related issue(s)
- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50755)

## Requested Feedback

_Is there anything I'm missing to recreate this scenario other than adding it to claims-list and setting the "decisionLetterSent" flag to true (which I did)?_
