### PR TITLE
#VFEP-306 #comment updated isUSSchool code to correctly identify the …

### DIFF
--- a/src/applications/gi/selectors/calculator.js
+++ b/src/applications/gi/selectors/calculator.js
@@ -531,7 +531,9 @@ const getDerivedValues = createSelector(
       inputs.classesOutsideUS;
 
     const isUSSchool = facilityCode => {
-      const digits = parseInt(facilityCode[5] + facilityCode[6], 10);
+      // the last two of the facility code is used to determine if the institution is foreign or domestic
+      const foreignDomesticInstituteFacilityCode = facilityCode.slice(-2);
+      const digits = parseInt(foreignDomesticInstituteFacilityCode, 10);
       return digits < 52 || (digits > 60 && digits < 67);
     };
 


### PR DESCRIPTION
## Summary
function within the comparison tool was incorrectly identifying the domestic/foreign status of institutions based on the Institution facility code. 

- *(Summarize the changes that have been made to the platform)*
Changes made tot he isUSSchool function within the calculator.js file located -> applications>gi>selectors now correctly takes the last two digits of the facility code. Prior to the change, the function took the two digits next to the last.

example of code:
facilityCode has a length of 8
old code took facilityCode[5] +facilityCode[6] 
new code now looks for the last two of the array with facilityCode.slice(-2)

- *(If bug, how to reproduce)*
for this example, without the update when a user would search Grand Canyon University, click into the institution, select the option NO to the filter "Will you be taking any classes in person?" the Housing allowance will revert to zero

- *(What is the solution, why is this the solution)*
With the solution mentioned above of correcting the function that will now correctly identify if the institution is domestic or foreign, when a user goes to Grand Canyon University, clicks into the institution, selects the option YES to the filter "Will you be taking any classes in person?" the Housing allowance will show the reduced amount.

- *(Which team do you work for, does your team own the maintenance of this component?)*
Work for GovCIO, we are the code owners of the comparison tool

- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
- N/A

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#0000
[Jira ticket](vajira.max.gov/browse/VFEP-306)

- *Link to ticket created in va.gov-team repo* N/A
- *Link to previous change of the code/bug (if applicable)* N/A
- *Link to epic if not included in ticket* N/A


## Testing done
manual testing done on local environment/Review environment - testing will be completed in staging as well

- *Describe what the old behavior was prior to the change*
See above for description

- *Describe the steps required to verify your changes are working as expected*
navigate to the comparison tool in review instance, search any domestic institution, click into the institution and filter NO on the question "Will you be taking any classes in person?". this should display an amount greater than 0

- *Describe the tests completed and the results*
navigated to several institutions at random. took the last two digits of the facility code and ran it through the logic of the isUSSchool logic. Compared all results with the expected results. All results passed as expected with the correct last two digits being pulled.

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before
![image](https://user-images.githubusercontent.com/88905347/207926475-e4da6f41-3bdc-4bfd-a843-aac9f97508d7.png)

 | After |
![image](https://user-images.githubusercontent.com/88905347/207926588-9746ec61-a6bb-486f-8586-450148469086.png)

| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
This impacts the comparison tool institution page

## Acceptance criteria
when selecting NO to the question "Will you be taking any classes in person?" for the Grand Canton University, the housing allowance is greater than $0 (shows the current national amount)

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback
NONE
