### PR TITLE
Phone appointment GA tracking

### DIFF
--- a/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
 import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
+// eslint-disable-next-line import/no-unresolved
+import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 
 import AppointmentBlock from '../../../components/AppointmentBlock';
 
@@ -13,6 +15,8 @@ import { makeSelectVeteranData } from '../../../selectors';
 
 import ExternalLink from '../../../components/ExternalLink';
 import Wrapper from '../../../components/layout/Wrapper';
+import { hasPhoneAppointments } from '../../../utils/appointment';
+import { createAnalyticsSlug } from '../../../utils/analytics';
 
 const IntroductionDisplay = props => {
   const { router } = props;
@@ -55,6 +59,24 @@ const IntroductionDisplay = props => {
       ),
     },
   ];
+  const isPhone = hasPhoneAppointments(appointments);
+
+  const handleStart = useCallback(
+    e => {
+      if (e?.key && e.key !== ' ') {
+        return;
+      }
+      recordEvent({
+        event: createAnalyticsSlug(
+          `pre-check-in-started-${isPhone ? 'phone' : 'in-person'}`,
+          'nav',
+        ),
+      });
+      e.preventDefault();
+      goToNextPage();
+    },
+    [isPhone, goToNextPage],
+  );
 
   const StartButton = () => (
     <div
@@ -64,16 +86,8 @@ const IntroductionDisplay = props => {
       <a
         className="vads-c-action-link--green"
         href="#answer"
-        onKeyDown={useCallback(e => {
-          if (e.key === ' ') {
-            e.preventDefault();
-            goToNextPage();
-          }
-        }, [])}
-        onClick={useCallback(e => {
-          e.preventDefault();
-          goToNextPage();
-        }, [])}
+        onKeyDown={handleStart}
+        onClick={handleStart}
       >
         {t('answer-questions')}
       </a>

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -9,6 +9,7 @@ import {
   removeTimeZone,
   preCheckinExpired,
   locationShouldBeDisplayed,
+  hasPhoneAppointments,
 } from './index';
 
 import { get } from '../../api/local-mock-api/mocks/v2/shared';
@@ -370,6 +371,16 @@ describe('check in', () => {
           createAppointment({ preCheckInValid: true }),
         ];
         expect(preCheckinExpired(appointments)).to.be.false;
+      });
+    });
+    describe('hasPhoneAppointments', () => {
+      it('finds phone appointment', () => {
+        const appointments = [createAppointment({ kind: 'phone' })];
+        expect(hasPhoneAppointments(appointments)).to.be.true;
+      });
+      it("doesn't find phone appointment", () => {
+        const appointments = [createAppointment()];
+        expect(hasPhoneAppointments(appointments)).to.be.false;
       });
     });
   });

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -182,6 +182,12 @@ const appointmentStartTimePast15 = appointments => {
   });
 };
 
+const hasPhoneAppointments = appointments => {
+  return Object.values(appointments).some(appt => {
+    return appt?.kind === 'phone';
+  });
+};
+
 export {
   appointmentStartTimePast15,
   appointmentWasCanceled,
@@ -193,4 +199,5 @@ export {
   preCheckinAlreadyCompleted,
   removeTimeZone,
   preCheckinExpired,
+  hasPhoneAppointments,
 };


### PR DESCRIPTION


## Summary
Created phone appointment util and added event to pre-check-in start to record phone/in-person.

When a patient clicks the `Answer Questions` link a new nav event gets fired to record if there are phone appointments or just in-person. Event: ` nav-check-in-pre-check-in-started-phone` or ` nav-check-in-pre-check-in-started-in-person`

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#49746

## Testing done
Test for util to detect phone appointments.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
