### PR TITLE
VACMS-11794: Updates Facility Locator Covid Status Display

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationCovidStatus.jsx
@@ -43,19 +43,15 @@ const LocationCovidStatus = ({ supplementalStatus, staticCovidStatuses }) => {
   }
 
   return (
-    <va-alert-expandable
-      class="vads-u-margin-x--0"
+    <va-alert
+      background-only
+      show-icon
       status="info"
-      trigger={covidStatus.name}
       data-testid={`${covidStatus.status_id.toLowerCase()}-message`}
+      class="vads-u-margin-x--0"
     >
-      {/* eslint-disable react/no-danger */}
-      <div
-        dangerouslySetInnerHTML={{
-          __html: covidStatus.description,
-        }}
-      />
-    </va-alert-expandable>
+      <div>{covidStatus.name}</div>
+    </va-alert>
   );
 };
 

--- a/src/applications/facility-locator/tests/components/search-results/common/LocationCovidStatus.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/common/LocationCovidStatus.unit.spec.jsx
@@ -45,7 +45,7 @@ describe('LocationCovidStatus', () => {
       />,
     );
 
-    expect(wrapper.find('va-alert-expandable').props()['data-testid']).to.eq(
+    expect(wrapper.find('va-alert').props()['data-testid']).to.eq(
       covidStatus.dataID,
     );
     wrapper.unmount();


### PR DESCRIPTION
## Summary

- On the Facility Locator app, the Covid facility status has been displayed as an expandable alert with more in-depth information visible when expanded. This information has proven confusing, though, and not flexible enough, so we're removing it. This PR replaces that expandable alert with a standard (non-expandable) alert.
- This work is done by the Facilities team on a product under its ownership.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11794

## Testing done

- Before change, alert was expandable.
- After change, alert is not expandable.
- To confirm, navigate to /find-locations and fill out form. On result, find a facility with a Covid status alert and confirm it is not expandable.

## Screenshots
| | Before | After |
| --- | --- | --- |
| Mobile | ![image](https://user-images.githubusercontent.com/6863534/208195182-eef99e15-514e-48d2-a06d-56b396822fdf.png)
 | |
| Desktop | ![image](https://user-images.githubusercontent.com/6863534/208195030-91f26b8c-10d4-4b14-9693-bef8b7afeaf0.png) | ![image](https://user-images.githubusercontent.com/6863534/208195373-2e7b8009-844d-411f-874a-21e9fd1996b6.png) |

## What areas of the site does it impact?
* Facility Locator

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [n/a]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback