### PR TITLE
Deprecate check_in_experience_lorota_deletion_enabled Feature Flag

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -26,7 +26,6 @@ class ApiInitializer {
           preCheckInEnabled: true,
           emergencyContactEnabled: true,
           checkInExperienceLorotaSecurityUpdatesEnabled: false,
-          checkInExperienceLorotaDeletionEnabled: true,
           checkInExperienceTravelReimbursement: false,
         }),
       );
@@ -65,7 +64,6 @@ class ApiInitializer {
           preCheckInEnabled: true,
           checkInExperienceTranslationDisclaimerSpanishEnabled: true,
           checkInExperienceLorotaSecurityUpdatesEnabled: false,
-          checkInExperienceLorotaDeletionEnabled: false,
           checkInExperienceTravelReimbursement: true,
         }),
       );

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -5,7 +5,6 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceTranslationDisclaimerSpanishEnabled = true,
     checkInExperienceTranslationDislaimerTagalogEnabled = true,
     checkInExperienceLorotaSecurityUpdatesEnabled = false,
-    checkInExperienceLorotaDeletionEnabled = false,
     checkInExperienceTravelReimbursement = false,
     checkInExperienceBrowserMonitoring = false,
   } = toggles;
@@ -33,10 +32,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'check_in_experience_lorota_security_updates_enabled',
           value: checkInExperienceLorotaSecurityUpdatesEnabled,
-        },
-        {
-          name: 'check_in_experience_lorota_deletion_enabled',
-          value: checkInExperienceLorotaDeletionEnabled,
         },
         {
           name: 'check_in_experience_travel_reimbursement',

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -141,7 +141,6 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: when we are in a situation where new content is not added to the site until it is translated into spanish
 - `check_in_experience_lorota_security_updates_enabled` : Enables or disables DOB log in instead of last 4 of SSN
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
-- `check_in_experience_lorota_deletion_enabled`: Enables tracking validation attempts on the server side. When toggle is on, the backend will count the attempts, then delete the entry in LoRota when it reaches the max amount of attempts, and send the frontend a status 410. When it is off, attempts are tracked in local storage.
 - `check_in_experience_travel_reimbursement`: Enables travel reimbursement workflow for day-of check-in.
 - `check_in_experience_browser_monitoring`: Enables browser monitoring for check-in applications.
 

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -10,23 +10,19 @@ const Error = () => {
   const selectError = useMemo(makeSelectError, []);
   const { error } = useSelector(selectError);
 
-  const validationError = error === 'max-validation';
-
-  const maxValidateMessage = t(
-    'were-sorry-we-couldnt-match-your-information-please-ask-for-help',
-  );
-  const message = validationError
-    ? maxValidateMessage
-    : t(
-        'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
-      );
+  const message =
+    error === 'max-validation'
+      ? 'were-sorry-we-couldnt-match-your-information-please-ask-for-help'
+      : t(
+          'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
+        );
 
   return (
     <Wrapper pageTitle={t('we-couldnt-check-you-in')}>
       <va-alert
         background-only
         show-icon
-        status={validationError ? 'error' : 'info'}
+        status={error === 'max-validation' ? 'error' : 'info'}
         data-testid="error-message"
       >
         <div>{message}</div>

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -3,17 +3,14 @@ import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { makeSelectError } from '../../selectors';
-import { useSessionStorage } from '../../hooks/useSessionStorage';
 import Wrapper from '../../components/layout/Wrapper';
 
 const Error = () => {
   const { t } = useTranslation();
-  const { getValidateAttempts } = useSessionStorage(false);
   const selectError = useMemo(makeSelectError, []);
   const { error } = useSelector(selectError);
-  const { isMaxValidateAttempts } = getValidateAttempts(window);
 
-  const validationError = isMaxValidateAttempts || error === 'max-validation';
+  const validationError = error === 'max-validation';
 
   const maxValidateMessage = t(
     'were-sorry-we-couldnt-match-your-information-please-ask-for-help',

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -12,7 +12,7 @@ const Error = () => {
 
   const message =
     error === 'max-validation'
-      ? 'were-sorry-we-couldnt-match-your-information-please-ask-for-help'
+      ? t('were-sorry-we-couldnt-match-your-information-please-ask-for-help')
       : t(
           'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
         );

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -19,12 +19,7 @@ const ValidateVeteran = props => {
   const { router } = props;
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const {
-    getValidateAttempts,
-    incrementValidateAttempts,
-    resetAttempts,
-    setPermissions,
-  } = useSessionStorage(false);
+  const { setPermissions } = useSessionStorage(false);
 
   const { updateError } = useUpdateError();
 
@@ -52,12 +47,8 @@ const ValidateVeteran = props => {
   const { token } = useSelector(selectCurrentContext);
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const {
-    isLorotaSecurityUpdatesEnabled,
-    isLorotaDeletionEnabled,
-  } = useSelector(selectFeatureToggles);
+  const { isLorotaSecurityUpdatesEnabled } = useSelector(selectFeatureToggles);
 
-  const { isMaxValidateAttempts } = getValidateAttempts(window);
   const [showValidateError, setShowValidateError] = useState(false);
   const app = '';
   const onClick = useCallback(
@@ -74,29 +65,21 @@ const ValidateVeteran = props => {
         setShowValidateError,
         isLorotaSecurityUpdatesEnabled,
         goToNextPage,
-        incrementValidateAttempts,
-        isMaxValidateAttempts,
         token,
         setSession,
         app,
-        resetAttempts,
-        isLorotaDeletionEnabled,
         updateError,
       );
     },
     [
       app,
       goToNextPage,
-      incrementValidateAttempts,
-      isMaxValidateAttempts,
       last4Ssn,
       lastName,
       dob,
       dobError,
-      resetAttempts,
       setSession,
       token,
-      isLorotaDeletionEnabled,
       isLorotaSecurityUpdatesEnabled,
       updateError,
     ],

--- a/src/applications/check-in/hooks/tests/useSessionStorage/TestComponent.jsx
+++ b/src/applications/check-in/hooks/tests/useSessionStorage/TestComponent.jsx
@@ -7,7 +7,6 @@ export default function TestComponent({ window, isPreCheckIn, token }) {
     clearCurrentSession,
     getCurrentToken,
     setCurrentToken,
-    resetAttempts,
   } = useSessionStorage(isPreCheckIn);
   const [fromSession, setFromSession] = useState();
   return (
@@ -49,18 +48,6 @@ export default function TestComponent({ window, isPreCheckIn, token }) {
         type="button"
       >
         set
-      </button>
-      <button
-        onClick={useCallback(
-          () => {
-            resetAttempts(window, token, true);
-          },
-          [resetAttempts, window, token],
-        )}
-        data-testid="reset-button"
-        type="button"
-      >
-        reset
       </button>
       <div data-testid="from-session">
         {fromSession && JSON.stringify(fromSession)}

--- a/src/applications/check-in/hooks/tests/useSessionStorage/useSessionStorage.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useSessionStorage/useSessionStorage.unit.spec.jsx
@@ -119,26 +119,5 @@ describe('check-in', () => {
         ).to.be.true;
       });
     });
-    describe('reset validation attempts', () => {
-      it('calls removeItem on reset', () => {
-        const removeItem = sinon.spy();
-        const window = {
-          sessionStorage: {
-            removeItem,
-          },
-        };
-
-        const testToken = 'testToken';
-        const component = render(
-          <TestComponent window={window} token={testToken} />,
-        );
-        const button = component.getByTestId('reset-button');
-        fireEvent.click(button);
-        expect(removeItem.called).to.be.true;
-        expect(
-          removeItem.calledWith('health.care.pre.check.in.validate.attempts'),
-        ).to.be.true;
-      });
-    });
   });
 });

--- a/src/applications/check-in/hooks/useSessionStorage.jsx
+++ b/src/applications/check-in/hooks/useSessionStorage.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { createSessionStorageKeys } from '../utils/session-storage';
 
-const useSessionStorage = (isPreCheckIn = true, maxValidateAttempts = 3) => {
+const useSessionStorage = (isPreCheckIn = true) => {
   const SESSION_STORAGE_KEYS = useMemo(
     () => {
       return createSessionStorageKeys({ isPreCheckIn });
@@ -32,29 +32,11 @@ const useSessionStorage = (isPreCheckIn = true, maxValidateAttempts = 3) => {
     return data ? JSON.parse(data) : null;
   };
 
-  const resetAttempts = useCallback(
-    (window, uuid, complete = false) => {
-      if (uuid !== SESSION_STORAGE_KEYS.CURRENT_UUID || complete === true) {
-        window.sessionStorage.removeItem(
-          SESSION_STORAGE_KEYS.VALIDATE_ATTEMPTS,
-        );
-      }
-    },
-    [SESSION_STORAGE_KEYS],
-  );
-
   const setCurrentToken = useCallback(
     (window, token) => {
-      const lastToken = JSON.parse(
-        sessionStorage.getItem(SESSION_STORAGE_KEYS.CURRENT_UUID),
-      );
-
-      if (lastToken && lastToken.token !== token) {
-        resetAttempts(window, token);
-      }
       setSessionKey(window, SESSION_STORAGE_KEYS.CURRENT_UUID, { token });
     },
-    [SESSION_STORAGE_KEYS, resetAttempts],
+    [SESSION_STORAGE_KEYS],
   );
 
   const getCurrentToken = useCallback(
@@ -77,27 +59,6 @@ const useSessionStorage = (isPreCheckIn = true, maxValidateAttempts = 3) => {
     },
     [SESSION_STORAGE_KEYS],
   );
-
-  const incrementValidateAttempts = window => {
-    const validateAttempts =
-      getSessionKey(window, SESSION_STORAGE_KEYS.VALIDATE_ATTEMPTS) ?? 0;
-    setSessionKey(
-      window,
-      SESSION_STORAGE_KEYS.VALIDATE_ATTEMPTS,
-      validateAttempts + 1,
-    );
-  };
-
-  const getValidateAttempts = window => {
-    const validateAttempts =
-      getSessionKey(window, SESSION_STORAGE_KEYS.VALIDATE_ATTEMPTS) ?? 0;
-    const isMaxValidateAttempts = validateAttempts >= maxValidateAttempts - 1;
-    const remainingValidateAttempts = maxValidateAttempts - validateAttempts;
-    return {
-      isMaxValidateAttempts,
-      remainingValidateAttempts,
-    };
-  };
 
   const setShouldSendDemographicsFlags = useCallback(
     (window, value) => {
@@ -179,13 +140,10 @@ const useSessionStorage = (isPreCheckIn = true, maxValidateAttempts = 3) => {
     getCurrentToken,
     setPreCheckinComplete,
     getPreCheckinComplete,
-    incrementValidateAttempts,
-    getValidateAttempts,
     setShouldSendDemographicsFlags,
     getShouldSendDemographicsFlags,
     setShouldSendTravelPayClaim,
     getShouldSendTravelPayClaim,
-    resetAttempts,
     setProgressState,
     getProgressState,
     setPermissions,

--- a/src/applications/check-in/pre-check-in/README.md
+++ b/src/applications/check-in/pre-check-in/README.md
@@ -95,7 +95,6 @@ Though we have the HOC, its now considered best practice to query redux using th
   - when to sunset: when we are in a situation where new content is not added to the site until it is translated into spanish
 - `check_in_experience_lorota_security_updates_enabled` : Enables or disables DOB log in instead of last 4 of SSN
   - when to sunset: once we have successfully tested this feature in production with users and the backend has fully switched over
-- `check_in_experience_lorota_deletion_enabled`: Enables tracking validation attempts on the server side. When toggle is on, the backend will count the attempts, then delete the entry in LoRota when it reaches the max amount of attempts, and send the frontend a status 410. When it is off, attempts are tracked in local storage.
 - `check_in_experience_browser_monitoring`: Enables browser monitoring for check-in applications.
 
 ### How to test this?

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -18,12 +18,7 @@ import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggl
 import { validateLogin } from '../../../utils/validateVeteran';
 
 const Index = ({ router }) => {
-  const {
-    getValidateAttempts,
-    incrementValidateAttempts,
-    resetAttempts,
-    setPermissions,
-  } = useSessionStorage(true);
+  const { setPermissions } = useSessionStorage(true);
   const { goToNextPage } = useFormRouting(router);
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -44,10 +39,7 @@ const Index = ({ router }) => {
   const { app } = useSelector(selectApp);
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const {
-    isLorotaSecurityUpdatesEnabled,
-    isLorotaDeletionEnabled,
-  } = useSelector(selectFeatureToggles);
+  const { isLorotaSecurityUpdatesEnabled } = useSelector(selectFeatureToggles);
 
   const [isLoading, setIsLoading] = useState(false);
   const [lastName, setLastName] = useState('');
@@ -58,7 +50,6 @@ const Index = ({ router }) => {
   const [lastNameErrorMessage, setLastNameErrorMessage] = useState();
   const [last4ErrorMessage, setLast4ErrorMessage] = useState();
 
-  const { isMaxValidateAttempts } = getValidateAttempts(window);
   const [showValidateError, setShowValidateError] = useState(false);
 
   const validateHandler = useCallback(
@@ -74,29 +65,21 @@ const Index = ({ router }) => {
         setShowValidateError,
         isLorotaSecurityUpdatesEnabled,
         goToNextPage,
-        incrementValidateAttempts,
-        isMaxValidateAttempts,
         token,
         setSession,
         app,
-        resetAttempts,
-        isLorotaDeletionEnabled,
         updateError,
       );
     },
     [
       app,
       goToNextPage,
-      incrementValidateAttempts,
-      isMaxValidateAttempts,
       last4Ssn,
       lastName,
       dob,
       dobError,
-      resetAttempts,
       setSession,
       token,
-      isLorotaDeletionEnabled,
       isLorotaSecurityUpdatesEnabled,
       updateError,
     ],

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.phone.appointments.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.phone.appointments.cypress.spec.js
@@ -3,7 +3,6 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
-import Error from '../pages/Error';
 
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
@@ -25,25 +24,6 @@ describe('Pre-Check In Experience', () => {
       cy.window().then(window => {
         window.sessionStorage.clear();
       });
-    });
-    it('validation failed with failed response from server. redirect to error page after max validate limit reached', () => {
-      cy.injectAxeThenAxeCheck();
-      // First Attempt
-      ValidateVeteran.validateVeteran('Sith', '4321');
-      ValidateVeteran.attemptToGoToNextPage();
-      ValidateVeteran.validateErrorAlert();
-
-      // Second Attempt
-      ValidateVeteran.validateVeteran('Sith', '4321');
-      ValidateVeteran.attemptToGoToNextPage();
-      ValidateVeteran.validateErrorAlert();
-
-      // Third/Final attempt
-      ValidateVeteran.validateVeteran('Sith', '4321');
-      ValidateVeteran.validateErrorAlert();
-      ValidateVeteran.attemptToGoToNextPage();
-
-      Error.validatePageLoaded(true, true);
     });
     it('fails validation once and then succeeds on the second attempt', () => {
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/utils/selectors/feature-toggles.js
+++ b/src/applications/check-in/utils/selectors/feature-toggles.js
@@ -21,9 +21,6 @@ const selectFeatureToggles = createSelector(
     isLorotaSecurityUpdatesEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.checkInExperienceLorotaSecurityUpdatesEnabled
     ],
-    isLorotaDeletionEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.checkInExperienceLorotaDeletionEnabled
-    ],
     isTravelReimbursementEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.checkInExperienceTravelReimbursement
     ],

--- a/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
+++ b/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
@@ -15,7 +15,6 @@ describe('check-in', () => {
         check_in_experience_translation_disclaimer_spanish_enabled: false,
         check_in_experience_translation_disclaimer_tagalog_enabled: false,
         check_in_experience_lorota_security_updates_enabled: false,
-        check_in_experience_lorota_deletion_enabled: false,
         check_in_experience_travel_reimbursement: false,
         check_in_experience_browser_monitoring: false,
         loading: false,
@@ -32,7 +31,6 @@ describe('check-in', () => {
           isTranslationDisclaimerSpanishEnabled: false,
           isTranslationDisclaimerTagalogEnabled: false,
           isLorotaSecurityUpdatesEnabled: false,
-          isLorotaDeletionEnabled: false,
           isTravelReimbursementEnabled: false,
           isBrowserMonitoringEnabled: false,
         });

--- a/src/applications/check-in/utils/session-storage/index.js
+++ b/src/applications/check-in/utils/session-storage/index.js
@@ -4,7 +4,6 @@ const createSessionStorageKeys = ({ isPreCheckIn = true }) => {
     : 'health.care.check-in';
   const sessionStorageKeys = {
     CURRENT_UUID: `${namespace}.current.uuid`,
-    VALIDATE_ATTEMPTS: `${namespace}.validate.attempts`,
     COMPLETE: `${namespace}.complete`,
     SHOULD_SEND_DEMOGRAPHICS_FLAGS: `${namespace}.should.send.demographics.flags`,
     PROGRESS_STATE: `${namespace}.progress`,

--- a/src/applications/check-in/utils/session-storage/sessions.storage.unit.spec.js
+++ b/src/applications/check-in/utils/session-storage/sessions.storage.unit.spec.js
@@ -8,7 +8,6 @@ describe('check in', () => {
         const keys = createSessionStorageKeys({ isPreCheckIn: true });
         expect(keys).to.deep.equal({
           CURRENT_UUID: 'health.care.pre.check.in.current.uuid',
-          VALIDATE_ATTEMPTS: 'health.care.pre.check.in.validate.attempts',
           COMPLETE: 'health.care.pre.check.in.complete',
           SHOULD_SEND_DEMOGRAPHICS_FLAGS:
             'health.care.pre.check.in.should.send.demographics.flags',
@@ -20,7 +19,6 @@ describe('check in', () => {
         const keys = createSessionStorageKeys({ isPreCheckIn: false });
         expect(keys).to.deep.equal({
           CURRENT_UUID: 'health.care.check-in.current.uuid',
-          VALIDATE_ATTEMPTS: 'health.care.check-in.validate.attempts',
           COMPLETE: 'health.care.check-in.complete',
           SHOULD_SEND_DEMOGRAPHICS_FLAGS:
             'health.care.check-in.should.send.demographics.flags',

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -13,13 +13,9 @@ import { api } from '../../api';
  * @param {function} [setShowValidateError]
  * @param {boolean} [isLorotaSecurityUpdatesEnabled]
  * @param {function} [goToNextPage]
- * @param {function} [incrementValidateAttempts]
- * @param {boolean} [isMaxValidateAttempts]
  * @param {string} [token]
  * @param {function} [setSession]
  * @param {string} [app]
- * @param {function} [resetAttempts]
- * @param {boolean} [isLorotaDeletionEnabled]
  * @param {function} [updateError]
  */
 
@@ -34,13 +30,9 @@ const validateLogin = async (
   setShowValidateError,
   isLorotaSecurityUpdatesEnabled,
   goToNextPage,
-  incrementValidateAttempts,
-  isMaxValidateAttempts,
   token,
   setSession,
   app,
-  resetAttempts,
-  isLorotaDeletionEnabled,
   updateError,
 ) => {
   setLastNameErrorMessage();
@@ -97,24 +89,18 @@ const validateLogin = async (
       updateError('session-error');
     } else {
       setSession(token, resp.permissions);
-      if (!isLorotaDeletionEnabled) {
-        resetAttempts(window, token, true);
-      }
       goToNextPage();
     }
   } catch (e) {
     setIsLoading(false);
-    if (e?.errors[0]?.status !== '401' || isMaxValidateAttempts) {
+    if (e?.errors[0]?.status !== '401') {
       let errorType = 'lorota-fail';
-      if (e?.errors[0]?.status === '410' || isMaxValidateAttempts) {
+      if (e?.errors[0]?.status === '410') {
         errorType = 'max-validation';
       }
       updateError(errorType);
     } else {
       setShowValidateError(true);
-      if (!isLorotaDeletionEnabled) {
-        incrementValidateAttempts(window);
-      }
     }
   }
 };


### PR DESCRIPTION
## Summary
Removed checkInExperienceLorotaDeletionEnabled flag and validation attempts handling in session storage.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50855

## Testing done
updates tests and removes testing of removed functionality surrounding feature flag.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
