### PR TITLE
[MHV 38987] VA.gov SM: Long, unbroken text in message body breaks responsive design

### DIFF
--- a/src/applications/mhv/secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv/secure-messaging/components/AttachmentsList.jsx
@@ -26,7 +26,7 @@ const AttachmentsList = props => {
               {editingEnabled && (
                 <>
                   <i className="fas fa-paperclip" aria-hidden="true" />
-                  <div className="editable-attachment">
+                  <div className="editable-attachment attachment">
                     <span>
                       {file.name} ({getSize(file.size || file.attachmentSize)})
                     </span>
@@ -42,7 +42,12 @@ const AttachmentsList = props => {
               {!editingEnabled && (
                 <>
                   <i className="fas fa-paperclip" aria-hidden="true" />
-                  <a href={file.link} target="_blank" rel="noreferrer">
+                  <a
+                    className="attachment"
+                    href={file.link}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     {file.name} ({getSize(file.size || file.attachmentSize)})
                   </a>
                 </>

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -1,6 +1,9 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 .message-detail-container {
+  max-width: 634.66px;
+  overflow-wrap: break-word;
+
   p {
     margin-top: 2px;
     margin-bottom: 1px;
@@ -41,6 +44,11 @@
     }
     .message-body {
       margin: 30px 0;
+    }
+
+    .attachment {
+      width: 96%;
+      overflow-wrap: break-word;
     }
 
     .message-attachments {


### PR DESCRIPTION
Changed 2 places where a string may be too long to fit into the container it's in. I added a word break style to the body and the attachments components in the message detail's view.

## Summary

## Related issue(s)
[VA.gov SM: Long, unbroken text in message body breaks responsive design](https://vajira.max.gov/browse/MHV-38987)

## Testing done
none

## Screenshots

| | Before | After |
| --- | --- | --- |
| Mobile |![image](https://user-images.githubusercontent.com/107279507/208486041-76793e25-c536-4e3b-8193-9adb0b14216a.png)|![image](https://user-images.githubusercontent.com/107279507/208486315-f2b96ef2-b78b-42a5-a889-19c19a767537.png)|
| Desktop |![image](https://user-images.githubusercontent.com/107279507/208485434-50757c6e-e43c-4171-8114-ea6a97dbe747.png)|![image](https://user-images.githubusercontent.com/107279507/208481944-d47134cc-d68b-4b2d-a094-59e7a4d9ee01.png)|

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback
