### PR TITLE
[#MHV-38992] fixed pagination of message lists

### DIFF
--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -96,7 +96,7 @@ export const getMessageCategoryList = () => {
  */
 export const getMessageList = folderId => {
   return apiRequest(
-    `${apiBasePath}/messaging/folders/${folderId}/messages?useCache=false`,
+    `${apiBasePath}/messaging/folders/${folderId}/messages?per_page=-1&useCache=false`,
     {
       headers: {
         'Content-Type': 'application/json',

--- a/src/applications/mhv/secure-messaging/components/MessageList/MessageList.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/MessageList.jsx
@@ -36,7 +36,7 @@ const MAX_PAGE_LIST_LENGTH = 5;
 let sortOrderSelection;
 const MessageList = props => {
   const location = useLocation();
-  const { messages, folder, keyword } = props;
+  const { messages, folder, keyword, isSearch } = props;
   // const perPage = messages.meta.pagination.per_page;
   const perPage = 10;
   // const totalEntries = messages.meta.pagination.total_entries;
@@ -188,15 +188,21 @@ const MessageList = props => {
           keyword={keyword}
         />
       ))}
-      {currentMessages && (
-        <VaPagination
-          onPageSelect={e => onPageChange(e.detail.page)}
-          page={currentPage}
-          pages={paginatedMessages.current.length}
-          maxPageListLength={MAX_PAGE_LIST_LENGTH}
-          showLastPage
-        />
+      {currentPage === paginatedMessages.current.length && (
+        <p className="vads-u-margin-y--3 vads-u-color--gray-medium">
+          End of {!isSearch ? 'messages in this folder' : 'search results'}
+        </p>
       )}
+      {currentMessages &&
+        paginatedMessages.current.length > 1 && (
+          <VaPagination
+            onPageSelect={e => onPageChange(e.detail.page)}
+            page={currentPage}
+            pages={paginatedMessages.current.length}
+            maxPageListLength={MAX_PAGE_LIST_LENGTH}
+            showLastPage
+          />
+        )}
     </div>
   );
 };
@@ -205,6 +211,7 @@ export default MessageList;
 
 MessageList.propTypes = {
   folder: PropTypes.object,
+  isSearch: PropTypes.bool,
   keyword: PropTypes.string,
   messages: PropTypes.array,
 };

--- a/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
@@ -85,6 +85,7 @@ const Search = () => {
             messages={searchResults}
             folder={folder}
             keyword={keyword}
+            isSearch
           />
         )}
     </div>


### PR DESCRIPTION
## Summary
Fixed pagination on all pages in va sm. Pagination now renders on any page showing more than 10 messages. This includes the folder pages and search/advance search pages.

## Related issue(s)
https://vajira.max.gov/browse/MHV-38992

## Testing done
Used to not show up as there was a bug with the api call to retrieve messages.

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
Secure-messaging on Va.gov

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
