### PR TITLE
ToE: Fix a Typo in the Form's Original Routing Number Property

### DIFF
--- a/src/applications/toe/reducers.js
+++ b/src/applications/toe/reducers.js
@@ -13,6 +13,7 @@ import {
   FETCH_CLAIM_STATUS_SUCCESS,
   FETCH_CLAIM_STATUS_FAILURE,
 } from './actions';
+import { formFields } from './constants';
 
 const initialState = {
   formData: {
@@ -27,23 +28,18 @@ const initialState = {
 };
 
 const handleDirectDepositApi = action => {
-  if (action?.response?.data?.attributes) {
-    return {
-      ...action?.response?.data?.attributes,
-      originalAccountNumber: action?.response?.data?.attributes?.accountNumber,
-      originalRoutingNumer:
-        action?.response?.data?.attributes?.financialInstitutionRoutingNumber,
-      routingNumber:
-        action?.response?.data?.attributes?.financialInstitutionRoutingNumber,
-    };
+  if (!action?.response?.data?.attributes) {
+    return {};
   }
+
   return {
-    accountNumber: '******9891',
-    accountType: 'Checking',
-    financialInstitutionName: 'Wells Fargo',
-    originalAccountNumber: '******9891',
-    originalRoutingNumber: '*****0503',
-    routingNumber: '*****0503',
+    ...action?.response?.data?.attributes,
+    [formFields.originalAccountNumber]:
+      action?.response?.data?.attributes?.accountNumber,
+    [formFields.originalRoutingNumber]:
+      action?.response?.data?.attributes?.financialInstitutionRoutingNumber,
+    [formFields.routingNumber]:
+      action?.response?.data?.attributes?.financialInstitutionRoutingNumber,
   };
 };
 


### PR DESCRIPTION
## Summary
- Fix a typo in the form's original routing number property.
- Remove test data.

## Testing done
- Reproduced the bug and verified that this change allows the user to proceed with an un-edited, prefilled bank info as well as with updated bank info.

## Screenshots
N/A

## What areas of the site does it impact?
* The ToE direct deposit page.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature