### PR TITLE
12012 changes Accessibilty footer link to point to new page.

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -249,7 +249,7 @@
     },
     {
       "column": "bottom_rail",
-      "href": "https://www.section508.va.gov",
+      "href": "https://www.va.gov/accessibilty-at-va",
       "order": 1,
       "target": null,
       "title": "Accessibility",


### PR DESCRIPTION
BLOCKED: This PR is awaiting the publishing of the new page at `/accessibility-at-va`

## Summary

- This changes the Accessibility link in the footer's bottom rail of links to point to `/accessibility-at-va`

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#12012

## Testing done

- Previously the link pointed to https://www.section508.va.gov/
- The link should now point to `https://www.va.gov/accesibility-at-va`


## What areas of the site does it impact?
This change has a site-wide impact on the Accessibility link in the global footer.

## Acceptance criteria
- [ ]  Footer Accessibility link points correctly to https://www.va.gov/accessibilty-at-va in production
- [n/a]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [n/a]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [n/a]  I added a screenshot of the developed feature

## Requested Feedback
Assure the link points to https://www.va.gov/accessibilty-at-va in production
