### PR TITLE
11918 / 11892 additional benefite.va.gov redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1145,6 +1145,31 @@
     "dest": "/education/benefit-rates/chapter-35-rates/past-rates/"
   },
   {
+    "domain": "www.benefits.va.gov",
+    "src": "/insurance/choose.asp",
+    "dest": "/life-insurance/manage-your-policy/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/insurance/OPA.asp",
+    "dest": "/life-insurance/manage-your-policy/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/INSURANCE/tsgli-claim-questionnaire.asp",
+    "dest": "/life-insurance/options-eligibility/tsgli/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/insurance/valife.asp",
+    "dest": "/life-insurance/options-eligibility/valife"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/insurance/valife-rates.asp",
+    "dest": "/life-insurance/options-eligibility/valife"
+  },
+  {
     "domain": "www.altoona.va.gov",
     "src": "/",
     "dest": "/altoona-health-care/",


### PR DESCRIPTION
## Summary

- This change adds 5 new client-side redirects from the old benefits.va.gov site to their new equivalent pages on va.gov.


## Related issue(s)

This PR batches two tickets:

- [department-of-veterans-affairs/va.gov-cms#11918](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11918)
- [department-of-veterans-affairs/va.gov-cms#11892](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11892)



## Testing done
Redirects need to be validated in production.


## What areas of the site does it impact?
These changes are redirects and effect their respective source urls.

## Acceptance criteria

- [n/a]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [n/a]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [n/a]  I added a screenshot of the developed feature

## Requested Feedback

- [ ] Validate that urls appear correct according to their respective tickets. 
- [ ] Validate redirects work in production.
