### PR TITLE
MHV-38769: Search results summary updated

### DIFF
--- a/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
@@ -114,7 +114,7 @@ const SearchMessagesForm = props => {
       dateRange === DateRangeValues.LAST12
     ) {
       relativeToDate = moment(new Date());
-      relativeFromDate = getRelativeDate(dateRange);
+      relativeFromDate = `${getRelativeDate(dateRange)}T00:00:00${offset}`;
     } else if (dateRange === DateRangeValues.CUSTOM) {
       fromDateTime = `${fromDate}T00:00:00${offset}`;
       toDateTime = `${toDate}T23:59:59${offset}`;

--- a/src/applications/mhv/secure-messaging/components/Search/CondensedSearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/CondensedSearchForm.jsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link, useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import moment from 'moment';
 import { runBasicSearch } from '../../actions/search';
 
 const CondensedSearchForm = props => {
-  const { folder, keyword, resultsView } = props;
+  const { folder, keyword, resultsCount, query } = props;
   const dispatch = useDispatch();
   const history = useHistory();
   const [searchTerm, setSearchTerm] = useState('');
@@ -19,15 +20,64 @@ const CondensedSearchForm = props => {
 
   const handleSearch = e => {
     dispatch(runBasicSearch(folder.folderId, e.target.value.toLowerCase()));
-    if (!resultsView) {
+    if (!resultsCount) {
       history.push('/search/results');
     }
   };
 
+  const queryItem = (key, value) => {
+    return (
+      <li>
+        {key && `${key}: `}"<strong>{value}</strong>"
+      </li>
+    );
+  };
+
+  const dateRange = () => {
+    if (query.fromDate && query.toDate) {
+      return queryItem(
+        null,
+        `${moment(query.fromDate).format('MMMM Do YYYY')} to ${moment(
+          query.toDate,
+        ).format('MMMM Do YYYY')}`,
+      );
+    }
+    return null;
+  };
+
+  const displayQuery = () => {
+    if (keyword) {
+      return (
+        <>
+          for "<strong>{keyword}</strong>" in <strong>{folder.name}</strong>
+        </>
+      );
+    }
+    return (
+      <>
+        in <strong>{folder.name}</strong> for
+        <ul>
+          {query.messageId && queryItem('Message ID', query.messageId)}
+          {query.sender && queryItem('From', query.sender)}
+          {query.subject && queryItem('Subject', query.subject)}
+          {query.category && queryItem('Category', query.category)}
+          {dateRange()}
+        </ul>
+      </>
+    );
+  };
+
   const label = () => {
-    const labelString = resultsView
-      ? folder.name
-      : `Search the ${folder.name} messages folder`;
+    const labelString = resultsCount ? (
+      <>
+        <strong className="search-results-count">
+          {resultsCount.toLocaleString()}
+        </strong>{' '}
+        results {displayQuery()}
+      </>
+    ) : (
+      `Search the ${folder.name} messages folder`
+    );
     return (
       <label
         htmlFor="search-message-folder-input"
@@ -49,7 +99,7 @@ const CondensedSearchForm = props => {
         label="search-message-folder-input"
       />
 
-      {resultsView && (
+      {resultsCount && (
         <div className="condensed-advanced-search-button">
           <Link to="/search/advanced">Advanced search</Link>
         </div>
@@ -61,7 +111,8 @@ const CondensedSearchForm = props => {
 CondensedSearchForm.propTypes = {
   folder: PropTypes.object,
   keyword: PropTypes.string,
-  resultsView: PropTypes.bool,
+  query: PropTypes.object,
+  resultsCount: PropTypes.number,
 };
 
 export default CondensedSearchForm;

--- a/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
@@ -6,9 +6,13 @@ import MessageList from '../components/MessageList/MessageList';
 import CondensedSearchForm from '../components/Search/CondensedSearchForm';
 
 const Search = () => {
-  const { awaitingResults, searchResults, folder, keyword } = useSelector(
-    state => state.sm.search,
-  );
+  const {
+    awaitingResults,
+    searchResults,
+    folder,
+    keyword,
+    query,
+  } = useSelector(state => state.sm.search);
   const history = useHistory();
 
   useEffect(() => {
@@ -50,7 +54,12 @@ const Search = () => {
       );
     }
     return (
-      <CondensedSearchForm folder={folder} keyword={keyword} resultsView />
+      <CondensedSearchForm
+        folder={folder}
+        keyword={keyword}
+        resultsCount={searchResults.length}
+        query={query}
+      />
     );
   };
 

--- a/src/applications/mhv/secure-messaging/sass/search-messages.scss
+++ b/src/applications/mhv/secure-messaging/sass/search-messages.scss
@@ -126,7 +126,7 @@
   .search-in-description {
     margin-bottom: 6px;
     @media (min-width: $medium-screen) {
-      margin-bottom: 11px;
+      margin-bottom: 24px;
     }
   }
   va-search-input {

--- a/src/applications/mhv/secure-messaging/tests/components/Search/CondensedSearchForm.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Search/CondensedSearchForm.unit.spec.jsx
@@ -1,28 +1,108 @@
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
-import { searchResults } from '../../fixtures/search-response.json';
-import { folder } from '../../fixtures/folder-inbox-metadata.json';
+import searchResults from '../../fixtures/search-response.json';
+import folder from '../../fixtures/folder-inbox-metadata.json';
 import reducer from '../../../reducers';
-import SearchResults from '../../../containers/SearchResults';
+import CondensedSearchForm from '../../../components/Search/CondensedSearchForm';
 
 describe('Condensed search form', () => {
-  const initialState = {
-    sm: {
-      search: {
-        searchResults,
-        folder,
-        keyword: 'covid',
-      },
-    },
-  };
+  const initialState = {};
 
   it('renders without errors', () => {
-    const screen = renderWithStoreAndRouter(<SearchResults />, {
-      initialState,
-      reducers: reducer,
-      path: `/search/results`,
-    });
+    const screen = renderWithStoreAndRouter(
+      <CondensedSearchForm
+        folder={folder}
+        keyword="test"
+        resultsCount={searchResults.length}
+      />,
+      {
+        initialState,
+        reducers: reducer,
+        path: `/search/results`,
+      },
+    );
+    expect(screen);
+  });
+
+  it('renders displays a query summary containing the number of results, searched keyword, and folder', async () => {
+    const screen = renderWithStoreAndRouter(
+      <CondensedSearchForm
+        folder={folder}
+        keyword="test"
+        resultsCount={searchResults.length}
+      />,
+      {
+        initialState,
+        reducers: reducer,
+        path: `/search/results`,
+      },
+    );
+
+    const count = await screen.findByText('5', { exact: true });
+    const statement = await screen.findByText('results for', { exact: false });
+    const keyword = await screen.findByText('test', { exact: true });
+    const statementFolder = await screen.findByText('Inbox', { exact: true });
+
+    expect(count).to.exist;
+    expect(statement).to.exist;
+    expect(keyword).to.exist;
+    expect(statementFolder).to.exist;
+  });
+
+  it('renders displays a query summary containing the number of results, folder, and query fields', async () => {
+    const query = {
+      messageId: '7232799',
+      sender: 'islam',
+      subject: 'mess',
+      category: 'other',
+      fromDate: '2022-09-19T00:00:00-07:00',
+      toDate: '2022-12-19T21:55:17.766Z',
+    };
+    const screen = renderWithStoreAndRouter(
+      <CondensedSearchForm
+        folder={folder}
+        resultsCount={searchResults.length}
+        query={query}
+      />,
+      {
+        initialState,
+        reducers: reducer,
+        path: `/search/results`,
+      },
+    );
+
+    const queryItems = await screen.getAllByRole('listitem');
+    const messageId = await screen.findByText('7232799', { exact: true });
+    const sender = await screen.findByText('islam', { exact: true });
+    const subject = await screen.findByText('mess', { exact: true });
+    const category = await screen.findByText('other', { exact: true });
+    const dateRange = await screen.findByText(
+      'September 19th 2022 to December 19th 2022',
+      { exact: true },
+    );
+
+    expect(queryItems.length).to.equal(5);
+    expect(messageId).to.exist;
+    expect(sender).to.exist;
+    expect(subject).to.exist;
+    expect(category).to.exist;
+    expect(dateRange).to.exist;
+  });
+
+  it('displays a link to the advanced search page', () => {
+    const screen = renderWithStoreAndRouter(
+      <CondensedSearchForm
+        folder={folder}
+        keyword="test"
+        resultsCount={searchResults.length}
+      />,
+      {
+        initialState,
+        reducers: reducer,
+        path: `/search/results`,
+      },
+    );
     expect(screen.findByText('Advanced search', { exact: true }));
   });
 });


### PR DESCRIPTION
## Summary
The MHV secure messaging search results header has been changed to display a summary of the search performed. For a basic search, you will see the number of search results, the keyword used for the search, and the name of the searched folder. For an advanced search, you will see the number of search results, the name of the folder that was searched, and a list of fields that were searched along with the value for each field. 

## Related issue(s)
https://vajira.max.gov/browse/MHV-38769

## Testing done
Previous to this change, only the folder that was searched was shown where the search summary is now. To verify this change, I implemented tests that supplied search results and metadata to the condensedSearchForm component and then verified that the proper text was being displayed based on the newly implemented summary statements and metadata provided. 

## Screenshots
Before:
<img width="793" alt="Screenshot 2022-12-15 at 2 56 43 PM" src="https://user-images.githubusercontent.com/107576133/208580561-a11a72c3-8ce4-4e21-81ed-006dc7781b5f.png">
After:
Basic search:
<img width="983" alt="Screenshot 2022-12-19 at 1 30 27 PM" src="https://user-images.githubusercontent.com/107576133/208580605-24b7e520-fd36-4022-9ba8-fa520b080986.png">
Advanced search:
<img width="981" alt="Screenshot 2022-12-19 at 2 55 43 PM" src="https://user-images.githubusercontent.com/107576133/208580619-d9c851f2-bc3f-471a-b4ed-e2b870bac14b.png">

## What areas of the site does it impact?
This impacts pages that use the condensedSearchForm component which includes the folder messages view and the search results view. 

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  Search Results Include Count, Term, and Folder Name

