### PR TITLE
Bumping vets-json-schema verstion for supplemental claims schema update

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae4fc20a545d9e30abc219356285f2ecb8a566bf"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1295d6003f181dfddf64bedaef074a8b41754d9a"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1295d6003f181dfddf64bedaef074a8b41754d9a"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#bde8b2b06006e2d72de819ef859da527f3df77c2"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19629,9 +19629,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae4fc20a545d9e30abc219356285f2ecb8a566bf":
-  version "20.24.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae4fc20a545d9e30abc219356285f2ecb8a566bf"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#1295d6003f181dfddf64bedaef074a8b41754d9a":
+  version "20.24.3"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1295d6003f181dfddf64bedaef074a8b41754d9a"
 
 vfile-message@^2.0.0:
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19629,9 +19629,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#1295d6003f181dfddf64bedaef074a8b41754d9a":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#bde8b2b06006e2d72de819ef859da527f3df77c2":
   version "20.24.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1295d6003f181dfddf64bedaef074a8b41754d9a"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#bde8b2b06006e2d72de819ef859da527f3df77c2"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION

## Summary

Bumps schema version for sc claims

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/739


## What areas of the site does it impact?
* schema

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

