### PR TITLE
MEB 5.0 — Fix TTY Telephone Numbers

### DIFF
--- a/src/applications/my-education-benefits/components/GetFormHelp.jsx
+++ b/src/applications/my-education-benefits/components/GetFormHelp.jsx
@@ -18,8 +18,8 @@ function GetFormHelp({ showMebDgi40Features }) {
           <p className="vads-u-margin-bottom--0">
             If you have technical difficulties using this online application,
             call our MyVA411 main information line at{' '}
-            <va-telephone contact="8006982411" /> (TTY:{' '}
-            <va-telephone contact="711" />
+            <va-telephone contact="8006982411" /> (
+            <va-telephone contact="711" tty />
             ). We're here 24/7.
           </p>
         </>
@@ -35,8 +35,8 @@ function GetFormHelp({ showMebDgi40Features }) {
           <p className="vads-u-margin-bottom--0">
             If you have technical difficulties using this online application,
             call our MyVA411 main information line at{' '}
-            <va-telephone contact="8006982411" /> (TTY:{' '}
-            <va-telephone contact="711" />
+            <va-telephone contact="8006982411" /> (
+            <va-telephone contact="711" tty />
             ). We're here 24/7.
           </p>
         </>


### PR DESCRIPTION
## Summary
- Fix TTY phone number links. Move the TTY inside the link by adding the `tty` attribute in the `<va-telephone>` components.

## Related issue(s)
* #23002

## Testing done
- Viewed link in footer and viewed source.

## Screenshots
<img width="647" alt="image" src="https://user-images.githubusercontent.com/112403/208962564-ce1f9009-f288-447c-8054-e62213fb1fc7.png">

## What areas of the site does it impact?
* MEB form footer.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature