### PR TITLE
ToE: Fix TTY Telephone Number

### DIFF
--- a/src/applications/toe/components/GetHelp.jsx
+++ b/src/applications/toe/components/GetHelp.jsx
@@ -14,8 +14,8 @@ export default function GetHelp() {
       <p className="vads-u-margin-bottom--0">
         If you have technical difficulties using this online application, call
         our MyVA411 main information line at{' '}
-        <va-telephone contact="8006982411" /> (TTY:{' '}
-        <va-telephone contact="711" />
+        <va-telephone contact="8006982411" /> (
+        <va-telephone contact="711" tty />
         ). We're here 24/7.
       </p>
     </div>


### PR DESCRIPTION
## Summary
Fix TTY phone number links. Move the TTY inside the link by adding the tty attribute in the <va-telephone> components.

## Related issue(s)
- #23001

## Testing done
Viewed link in footer and viewed source before and after making the change.

## Screenshots
| | Before | After |
| --- | --- | --- |
| Desktop |<img width="644" alt="image" src="https://user-images.githubusercontent.com/112403/208964823-46ff8e87-2200-4b5b-bb68-c1c2ed12d87d.png">|<img width="644" alt="image" src="https://user-images.githubusercontent.com/112403/208964508-6e49dbf5-686d-4e77-813e-0733f97a3cb7.png">|

## What areas of the site does it impact?
* ToE form footer.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature