### PR TITLE
Add sanitization of branch names to PE deploy script

### DIFF
--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -56,5 +56,5 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           event-type: deploy_review_instance
           repository: department-of-veterans-affairs/devops
-          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}" }'
+          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}", "source_ref_sanitized": "${{ env.SOURCE_REF_SANITIZED }}" }'
           # Once docker image is built, add the name of the image to this object as a new property.

--- a/script/github-actions/pe-deploy-source.js
+++ b/script/github-actions/pe-deploy-source.js
@@ -11,7 +11,15 @@ if (
 ) {
   core.exportVariable('SOURCE_REPO', sourceRepo);
   core.exportVariable('SOURCE_REF', sourceRef);
+  core.exportVariable(
+    'SOURCE_REF_SANITIZED',
+    sourceRef.replace(/[^a-zA-Z0-9-_]/g, ''),
+  );
 } else {
   core.exportVariable('SOURCE_REPO', 'vets-api');
   core.exportVariable('SOURCE_REF', workflowRef);
+  core.exportVariable(
+    'SOURCE_REF_SANITIZED',
+    workflowRef.replace(/[^a-zA-Z0-9-_]/g, ''),
+  );
 }

--- a/script/github-actions/pe-deploy-source.js
+++ b/script/github-actions/pe-deploy-source.js
@@ -20,6 +20,6 @@ if (
   core.exportVariable('SOURCE_REF', workflowRef);
   core.exportVariable(
     'SOURCE_REF_SANITIZED',
-    workflowRef.replace(/[^a-zA-Z0-9-_]/g, ''),
+    workflowRef.replace(/[^a-zA-Z0-9-_]/g, '-'),
   );
 }


### PR DESCRIPTION
## Summary

- Adds a branch name that is sanitized for safe usage in URLs to the workflow for preview environments deployments.

## Related issue(s)
https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/50987


## Testing done
Branch name is sanitized as expected on workflow runs and is passed to the devops repo in the repository dispatch step.

## Acceptance criteria

- [ ] A URL-friendly branch name is passed to the devops repo alongside the regular branch name in the PE deployment workflow.
