### PR TITLE
ToE: Always Show Last 4 Digits of Bank Account Numbers

### DIFF
--- a/src/applications/toe/helpers.jsx
+++ b/src/applications/toe/helpers.jsx
@@ -28,13 +28,8 @@ export function obfuscate(str, numVisibleChars = 4, obfuscateChar = '●') {
     return '';
   }
 
-  if (str.length <= 2 * numVisibleChars) {
-    const visibileChars = Math.floor(str.length / 2);
-
-    return (
-      obfuscateChar.repeat(str.length - visibileChars) +
-      str.substring(str.length - visibileChars, str.length)
-    );
+  if (str.length <= numVisibleChars) {
+    return str;
   }
 
   return (


### PR DESCRIPTION
## Summary
Change the obfuscation code to always show the last four digits of bank account numbers, even if the account number is less than 8 digits.

## Related issue(s)
N/A

## Testing done
Verified that four digits are always displayed, even for short account numbers.

## Screenshots
| | Before | After |
| --- | --- | --- |
| Desktop | <img width="513" alt="image" src="https://user-images.githubusercontent.com/112403/208974496-31ec1b68-aa3c-4025-bbf8-3e346cdc3b10.png">|<img width="514" alt="image" src="https://user-images.githubusercontent.com/112403/208974258-70ffd7e2-b4ea-4afa-9159-530ea404799b.png">|

## What areas of the site does it impact?
ToE direct deposit page.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature