### PR TITLE
VACMS-12012 typo fix in URL

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -249,7 +249,7 @@
     },
     {
       "column": "bottom_rail",
-      "href": "https://www.va.gov/accessibilty-at-va",
+      "href": "https://www.va.gov/accessibility-at-va",
       "order": 1,
       "target": null,
       "title": "Accessibility",


### PR DESCRIPTION
## Summary

https://github.com/department-of-veterans-affairs/vets-website/pull/22987/files#diff-6d5d7700b4a662263c2d00662044a5aa75b453ccb834fae61de7f1f1fba6bab8R252 merged with a typo, this PR fixes it. 
s/accessibility/accessiblty

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12012

