### PR TITLE
Puts focus before skip-link on modal close without setTimeout

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -9,7 +9,9 @@ import recordEvent from 'platform/monitoring/record-event';
 
 function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
   const noscriptElements = document.getElementsByTagName('noscript');
-  const noScriptArray = Array.from(noscriptElements);
+  const ariaExcludeArray = Array.from(noscriptElements);
+  const skipLinkElement = document.getElementsByClassName('show-on-focus')[0];
+  ariaExcludeArray.push(skipLinkElement);
 
   return (
     <>
@@ -24,7 +26,7 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
           }}
           id="modal-announcement"
           modalTitle=""
-          ariaHiddenNodeExceptions={noScriptArray}
+          ariaHiddenNodeExceptions={ariaExcludeArray}
           aria-describedby="homepage-modal-description"
           aria-labelledby="homepage-modal-label-title"
           secondary-button-text="Not today, go to the current homepage"

--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -1,6 +1,6 @@
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
@@ -8,12 +8,8 @@ import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
 function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
-  // Ensures that there are no aria attributes on noscript elements to interfere with screenreader focus
-  useEffect(() => {
-    const noscriptElement = document.getElementsByTagName('noscript')[0];
-    noscriptElement.removeAttribute('aria-hidden');
-    noscriptElement.removeAttribute('data-aria-hidden');
-  }, []);
+  const noscriptElements = document.getElementsByTagName('noscript');
+  const noScriptArray = Array.from(noscriptElements);
 
   return (
     <>
@@ -28,6 +24,7 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
           }}
           id="modal-announcement"
           modalTitle=""
+          ariaHiddenNodeExceptions={noScriptArray}
           aria-describedby="homepage-modal-description"
           aria-labelledby="homepage-modal-label-title"
           secondary-button-text="Not today, go to the current homepage"

--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -1,7 +1,4 @@
-import {
-  VaButton,
-  VaModal,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import React from 'react';
 import { connect } from 'react-redux';
@@ -11,13 +8,6 @@ import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
 function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
-  const focusOnSkiplink = () => {
-    setTimeout(
-      () => document.getElementsByClassName('show-on-focus')[0].focus(),
-      0,
-    );
-  };
-
   return (
     <>
       {vaHomePreviewModal && (
@@ -28,12 +18,19 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
           onCloseEvent={() => {
             recordEvent({ event: 'new-homepage-modal-close' });
             dismiss();
-            focusOnSkiplink();
           }}
           id="modal-announcement"
           modalTitle=""
           aria-describedby="homepage-modal-description"
           aria-labelledby="homepage-modal-label-title"
+          secondary-button-text="Not today, go to the current homepage"
+          onSecondaryButtonClick={() => {
+            recordEvent({
+              event: 'new-homepage-modal-click',
+              'modal-secondary-link': 'go to current homepage',
+            });
+            dismiss();
+          }}
         >
           <img src="/img/design/logo/va-logo.png" alt="VA logo" width="300" />
           <h1
@@ -42,7 +39,10 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
           >
             Try our new VA.gov homepage
           </h1>
-          <div id="homepage-modal-description">
+          <div
+            id="homepage-modal-description"
+            className="vads-u-margin-bottom--2"
+          >
             <p>
               We're redesigning the VA.gov homepage to help you get the tools
               and information you need faster.
@@ -62,20 +62,6 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
             >
               Try the new home page
             </a>
-
-            <VaButton
-              secondary
-              text="Not today, go to the current homepage"
-              onClick={() => {
-                recordEvent({
-                  event: 'new-homepage-modal-click',
-                  'modal-secondary-link': 'go to current homepage',
-                });
-                dismiss();
-                focusOnSkiplink();
-              }}
-              className="vads-u-margin-top--2"
-            />
           </div>
         </VaModal>
       )}

--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -1,6 +1,6 @@
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
@@ -8,6 +8,13 @@ import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
 function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
+  // Ensures that there are no aria attributes on noscript elements to interfere with screenreader focus
+  useEffect(() => {
+    const noscriptElement = document.getElementsByTagName('noscript')[0];
+    noscriptElement.removeAttribute('aria-hidden');
+    noscriptElement.removeAttribute('data-aria-hidden');
+  }, []);
+
   return (
     <>
       {vaHomePreviewModal && (

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -11,6 +11,7 @@ const config = {
       component: HomepageRedesignModal,
       disabled: false,
       show: AnnouncementBehavior.SHOW_ONCE_PER_SESSION,
+      returnFocusToDefault: true,
     },
   ],
 };

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -11,7 +11,7 @@ const config = {
       component: HomepageRedesignModal,
       disabled: false,
       show: AnnouncementBehavior.SHOW_ONCE_PER_SESSION,
-      returnFocusToDefault: true,
+      returnFocusDivContent: 'Current Homepage',
     },
   ],
 };

--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -50,6 +50,18 @@ export class Announcement extends Component {
       .forEach(relatedAnnouncementName => {
         this.props.dismissAnnouncement(relatedAnnouncementName);
       });
+
+    // Manages focus on model close for screen reader accessibility
+    if (announcementName === 'new-homepage') {
+      const skipLinkParent = document.getElementsByClassName('merger')[0];
+      const skipLinkEl = document.getElementsByClassName('show-on-focus')[0];
+      const focusEl = document.createElement('div');
+      focusEl.innerHTML = 'Current Homepage';
+      focusEl.tabIndex = '-1';
+      focusEl.classList.add('sr-only', 'current-page-title');
+      skipLinkParent.insertBefore(focusEl, skipLinkEl);
+      focusEl.focus();
+    }
   };
 
   render() {

--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -16,7 +16,7 @@ export class Announcement extends Component {
       name: PropTypes.string.isRequired,
       show: PropTypes.oneOf(Object.keys(AnnouncementBehavior)),
       relatedAnnouncements: PropTypes.array,
-      returnFocusToDefault: PropTypes.bool,
+      returnFocusDivContent: PropTypes.string,
     }),
     dismissed: PropTypes.array,
     isLoggedIn: PropTypes.bool,
@@ -36,7 +36,7 @@ export class Announcement extends Component {
         name: announcementName,
         show = AnnouncementBehavior.SHOW_ONCE,
         relatedAnnouncements = [],
-        returnFocusToDefault,
+        returnFocusDivContent = '',
       },
       dismissed,
     } = this.props;
@@ -54,7 +54,7 @@ export class Announcement extends Component {
       });
 
     // Manages focus on modal close for screen reader accessibility
-    if (returnFocusToDefault) {
+    if (returnFocusDivContent) {
       const skipLinkParent = document.getElementsByClassName('merger')[0];
       const skipLinkEl = document.getElementsByClassName('show-on-focus')[0];
       const focusEl = document.createElement('div');

--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -16,6 +16,7 @@ export class Announcement extends Component {
       name: PropTypes.string.isRequired,
       show: PropTypes.oneOf(Object.keys(AnnouncementBehavior)),
       relatedAnnouncements: PropTypes.array,
+      returnFocusToDefault: PropTypes.bool,
     }),
     dismissed: PropTypes.array,
     isLoggedIn: PropTypes.bool,
@@ -35,6 +36,7 @@ export class Announcement extends Component {
         name: announcementName,
         show = AnnouncementBehavior.SHOW_ONCE,
         relatedAnnouncements = [],
+        returnFocusToDefault,
       },
       dismissed,
     } = this.props;
@@ -51,8 +53,8 @@ export class Announcement extends Component {
         this.props.dismissAnnouncement(relatedAnnouncementName);
       });
 
-    // Manages focus on model close for screen reader accessibility
-    if (announcementName === 'new-homepage') {
+    // Manages focus on modal close for screen reader accessibility
+    if (returnFocusToDefault) {
       const skipLinkParent = document.getElementsByClassName('merger')[0];
       const skipLinkEl = document.getElementsByClassName('show-on-focus')[0];
       const focusEl = document.createElement('div');


### PR DESCRIPTION
## Summary

- Updates homepage modal to no longer focus skip link directly on close
- Updates homepage dismiss logic for screen reader accessibility

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12008
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12045


## Testing done

- Local Visual testing

## What areas of the site does it impact?
Home page

## Acceptance criteria

- [ ]  When the modal is closed (using the X, the button or the ESC), the SR should announce the same element as what is visually focused - in this case the Skip to content link
- [ ]  Skip to content link is not made visible in front-end upon modal dismissal
- [ ] Focus is placed just ahead of skip link on a SR only visible div
