### PR TITLE
11892 - reverts prematurely merge benefits redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1160,16 +1160,6 @@
     "dest": "/life-insurance/options-eligibility/tsgli/"
   },
   {
-    "domain": "www.benefits.va.gov",
-    "src": "/insurance/valife.asp",
-    "dest": "/life-insurance/options-eligibility/valife"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/insurance/valife-rates.asp",
-    "dest": "/life-insurance/options-eligibility/valife"
-  },
-  {
     "domain": "www.altoona.va.gov",
     "src": "/",
     "dest": "/altoona-health-care/",


### PR DESCRIPTION
## Summary

- This PR reverts changes added to the cross domain redirects that was merged in error.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#11892
 

## Testing done

None, Will need to be verified in production.

## Screenshots
n/a

## What areas of the site does it impact?
None, this reverts a non-deployed PR sitting on staging. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [n/a]  I added a screenshot of the developed feature

## Requested Feedback

Verification of redirects in production environment. 
