### PR TITLE
SM to VA.gov - Save Draft button styling on reply page

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -240,14 +240,12 @@ const ReplyForm = props => {
           </section>
           <div className="compose-form-actions vads-u-display--flex">
             <va-button
-              type="button"
               text="Send"
               class="vads-u-flex--1"
               data-testid="Send-Button"
               onClick={sendMessageHandler}
             />
             <va-button
-              type="button"
               text="Save draft"
               secondary
               class="vads-u-flex--1"


### PR DESCRIPTION
**Note**: Styling defect affected by previous PR while switching from `<button>` to `<va-button>`


## Screenshots
<img width="817" alt="Screenshot 2022-12-22 at 2 15 32 PM" src="https://user-images.githubusercontent.com/87077843/209209984-28b15112-e8c9-47c1-9c5c-8089c08d84fe.png">


