### PR TITLE
9078 Drupal Source of Truth for Health Care app widgets

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/vamc-ehr-static.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/vamc-ehr-static.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "nodeQuery": {
+      "count": 1,
+      "entities": [
+        {
+          "title": "Chalmers P. Wylie Veterans Outpatient Clinic",
+          "fieldFacilityLocatorApiId": "vha_757",
+          "fieldRegionPage": {
+            "entity": {
+              "title": "VA Central Ohio health care",
+              "fieldVamcEhrSystem": "cerner"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
-import { selectPatientFacilities } from 'platform/user/selectors';
 import { selectPatientFacilities as selectPatientFacilitiesDsot } from 'platform/user/cerner-dsot/selectors';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import PropTypes from 'prop-types';
@@ -49,9 +48,7 @@ App.propTypes = {
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   ehrDataByVhaId: selectEhrDataByVhaId(state),
-  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
-    ? selectPatientFacilitiesDsot(state)
-    : selectPatientFacilities(state),
+  facilities: selectPatientFacilitiesDsot(state),
   useSingleLogout: state?.featureToggles?.pwEhrCtaUseSlo,
 });
 

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
-import { selectPatientFacilities } from 'platform/user/selectors';
 import { selectPatientFacilities as selectPatientFacilitiesDsot } from 'platform/user/cerner-dsot/selectors';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import AuthContent from '../AuthContent';
@@ -49,9 +48,7 @@ App.propTypes = {
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   ehrDataByVhaId: selectEhrDataByVhaId(state),
-  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
-    ? selectPatientFacilitiesDsot(state)
-    : selectPatientFacilities(state),
+  facilities: selectPatientFacilitiesDsot(state),
   useSingleLogout: state?.featureToggles?.pwEhrCtaUseSlo,
 });
 

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
-import { selectPatientFacilities } from 'platform/user/selectors';
 import { selectPatientFacilities as selectPatientFacilitiesDsot } from 'platform/user/cerner-dsot/selectors';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import AuthContent from '../AuthContent';
@@ -40,9 +39,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   ehrDataByVhaId: selectEhrDataByVhaId(state),
-  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
-    ? selectPatientFacilitiesDsot(state)
-    : selectPatientFacilities(state),
+  facilities: selectPatientFacilitiesDsot(state),
   useSingleLogout: state?.featureToggles?.pwEhrCtaUseSlo,
 });
 

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/tests/index.cypress.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/tests/index.cypress.spec.js
@@ -2,12 +2,14 @@ import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import cernerUser from '../../fixtures/user/cerner.json';
 import notCernerUser from '../../fixtures/user/notCerner.json';
 import features from '../../fixtures/feature-toggles/enabled.json';
+import staticEhrData from '../../fixtures/vamc-ehr-static.json';
 
 const TEST_URL = '/health-care/schedule-view-va-appointments/';
 
 const setup = ({ authenticated, isCerner } = {}) => {
   // Mock feature toggles route.
   cy.intercept('GET', '/v0/feature_toggles*', features);
+  cy.intercept('GET', '/data/cms/vamc-ehr.json', staticEhrData);
 
   // Clear announcements.
   disableFTUXModals();

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
-import { selectPatientFacilities } from 'platform/user/selectors';
 import { selectPatientFacilities as selectPatientFacilitiesDsot } from 'platform/user/cerner-dsot/selectors';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
@@ -49,9 +48,7 @@ App.propTypes = {
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   ehrDataByVhaId: selectEhrDataByVhaId(state),
-  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
-    ? selectPatientFacilitiesDsot(state)
-    : selectPatientFacilities(state),
+  facilities: selectPatientFacilitiesDsot(state),
   useSingleLogout: state?.featureToggles?.pwEhrCtaUseSlo,
 });
 

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 // Relative imports.
-import { selectPatientFacilities } from 'platform/user/selectors';
 import { selectPatientFacilities as selectPatientFacilitiesDsot } from 'platform/user/cerner-dsot/selectors';
 import { selectEhrDataByVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
@@ -49,9 +48,7 @@ App.propTypes = {
 const mapStateToProps = state => ({
   authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   ehrDataByVhaId: selectEhrDataByVhaId(state),
-  facilities: state?.featureToggles?.pwEhrCtaDrupalSourceOfTruth
-    ? selectPatientFacilitiesDsot(state)
-    : selectPatientFacilities(state),
+  facilities: selectPatientFacilitiesDsot(state),
   useSingleLogout: state?.featureToggles?.pwEhrCtaUseSlo,
 });
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -94,7 +94,6 @@ export default Object.freeze({
   profileShowAppealStatusNotificationSetting: 'profile_show_appeal_status_notification_setting',
   profileUseVaosV2Api: 'profile_use_vaos_v2_api',
   profileUseVAFSC: 'profile_use_vafsc',
-  pwEhrCtaDrupalSourceOfTruth: 'pw_ehr_cta_drupal_source_of_truth',
   pwEhrCtaUseSlo: 'pw_ehr_cta_use_slo',
   ratedDisabilitiesSortAbTest: 'rated_disabilities_sort_ab_test',
   searchRepresentative: 'search_representative',


### PR DESCRIPTION
## Summary
This ticket is to:

Switch default behavior so that these widgets are "always on" to use Drupal data, and no longer need the feature toggle
Remove that feature flag
Remove references to the "Hard-coded API" within these 5 widgets
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9307 tracks completely removing the Hard-coded API from the code-base. 


## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#9078
- related: department-of-veterans-affairs/va.gov-cms/issues/9307
- Tracks completely removing the Hard-coded API from the code-base department-of-veterans-affairs/va.gov-cms/issues/9307

## Testing done
- Manual Testing by assuring each widget functions as it did previously, now using the Drupal source of truth.

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria
- [x] Drupal SSOT is still used for Cerner widgets (reading fetched vamc-ehr.json data in redux store)
- [x] Hard coded mechanism and feature toggle are removed from Cerner Widget code.
- [x] The feature toggle itself is removed, `pw_ehr_cta_drupal_source_of_truth`
- [x] Test all 5 Cerner-related widgets using Cerner test users
      - [x] [Refill and track your prescriptions](https://www.va.gov/health-care/refill-track-prescriptions)
      - [x] [Send a secure message to your health care team](https://www.va.gov/health-care/secure-messaging)
      - [x] [Schedule and manage health appointments](https://www.va.gov/health-care/schedule-view-va-appointments)
      - [x] [View your lab and test results](https://www.va.gov/health-care/view-test-and-lab-results)
      - [x] [Apply now for VA health care](https://www.va.gov/health-care/apply/application)
- [x]  No error nor warning in the console.
- [n/a ]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [n/a]  I added a screenshot of the developed feature

## Requested Feedback

- [ ] Test all 5 Cerner-related widgets using Cerner test users
    - [ ] [Refill and track your prescriptions](https://www.va.gov/health-care/refill-track-prescriptions)
    - [ ] [Send a secure message to your health care team](https://www.va.gov/health-care/secure-messaging)
    - [ ] [Schedule and manage health appointments](https://www.va.gov/health-care/schedule-view-va-appointments)
    - [ ] [View your lab and test results](https://www.va.gov/health-care/view-test-and-lab-results)
    - [ ] [Apply now for VA health care](https://www.va.gov/health-care/apply/application)