### PR TITLE
[51471] Certificate of Eligibility | Fix notification letter titles and filenames on COE status page.

### DIFF
--- a/src/applications/lgy/coe/form/tests/fixtures/mocks/document-list.json
+++ b/src/applications/lgy/coe/form/tests/fixtures/mocks/document-list.json
@@ -3,19 +3,17 @@
     "attributes": [
       {
         "id": 23215740,
-        "documentType": "54",
+        "documentType": "COE Application First Returned Letter",
         "createDate": 1644869501000,
-        "description": "Example 1",
-        "mimeType": "IssueCOE1.pdf",
-        "title": "Example 1"
+        "description": "",
+        "mimeType": "IssueCOE1.pdf"
       },
       {
         "id": 23215741,
-        "documentType": "54",
+        "documentType": "Denial Letter",
         "createDate": 1646092800000,
         "description": "Example 2",
-        "mimeType": "IssueCOE2.pdf",
-        "title": "Example 2"
+        "mimeType": "IssueCOE2.pdf"
       }
     ]
   }

--- a/src/applications/lgy/coe/status/components/DocumentList/List.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/List.jsx
@@ -10,33 +10,26 @@ import ListItem from './ListItem';
 export const formatLabelDate = timestamp =>
   moment(timestamp).format('MM-DD-YYYY');
 
-// Example documentType: 'pdf', but the local mock data has '54'; this has been
-// updated to extract the file extension from the `mimeType` (e.g. `file.pdf`),
-// which really should contain the mime type (expecting `application/pdf`) -
-// still awaiting a response from LGY
-export const getDocumentType = fileName =>
-  fileName
-    .split('.')
-    .pop()
-    .toUpperCase();
-
 export const getDownloadLinkLabel = timestamp =>
   `Download Notification Letter ${formatLabelDate(timestamp)}`;
 
 const List = ({ documents }) =>
   documents.map((document, i) => {
-    const { createDate, description, mimeType, id } = document;
+    const { createDate, id, documentType, mimeType } = document;
     const downloadLinkLabel = getDownloadLinkLabel(createDate);
     const sentDate = formatDateLong(createDate);
 
+    // `documentType` represents what "kind" of Notification Letter this is
+    // (e.g. "COE Application First Returned Letter").
+    // Strangely, LGY represents a document's filename with `mimeType`.
     return (
       <ListItem
         key={i}
         downloadLinkLabel={downloadLinkLabel}
         downloadUrl={`${environment.API_URL}/v0/coe/document_download/${id}`}
-        fileType={getDocumentType(mimeType)}
         sentDate={sentDate}
-        title={description}
+        title={documentType}
+        fileName={mimeType}
       />
     );
   });

--- a/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/ListItem.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ListItem = ({ downloadUrl, downloadLinkLabel, sentDate, title }) => (
+const ListItem = ({
+  downloadUrl,
+  downloadLinkLabel,
+  fileName,
+  sentDate,
+  title,
+}) => (
   <div className="coe-list-item vads-u-border-bottom--1px vads-u-border-color--gray-lighter vads-u-margin-top--2p5 vads-u-padding-bottom--4">
     <h3 className="vads-u-font-family--serif vads-u-margin--0">{title}</h3>
     <p className="vads-u-margin-y--1p5">Date sent: {sentDate}</p>
@@ -9,7 +15,7 @@ const ListItem = ({ downloadUrl, downloadLinkLabel, sentDate, title }) => (
       download
       filetype="PDF"
       href={downloadUrl}
-      filename={downloadUrl}
+      filename={fileName}
       text={downloadLinkLabel}
     />
   </div>
@@ -18,6 +24,7 @@ const ListItem = ({ downloadUrl, downloadLinkLabel, sentDate, title }) => (
 ListItem.propTypes = {
   downloadLinkLabel: PropTypes.string,
   downloadUrl: PropTypes.string,
+  fileName: PropTypes.string,
   sentDate: PropTypes.string,
   title: PropTypes.string,
 };

--- a/src/applications/lgy/coe/status/tests/components/DocumentList/DocumentList.unit.spec.jsx
+++ b/src/applications/lgy/coe/status/tests/components/DocumentList/DocumentList.unit.spec.jsx
@@ -36,7 +36,7 @@ describe('DocumentList', () => {
       expect(h2.textContent).to.eq('You have letters about your COE request');
 
       $$('.coe-list-item', container).forEach((item, index) => {
-        expect($('h3', item).textContent).to.equal(data[index].title);
+        expect($('h3', item).textContent).to.equal(data[index].documentType);
         expect(item.textContent).to.contain(
           formatDateLong(data[index].createDate),
         );

--- a/src/applications/lgy/coe/status/tests/components/DocumentList/List.unit.spec.jsx
+++ b/src/applications/lgy/coe/status/tests/components/DocumentList/List.unit.spec.jsx
@@ -8,7 +8,6 @@ import { formatDateLong } from 'platform/utilities/date';
 
 import List, {
   formatLabelDate,
-  getDocumentType,
   getDownloadLinkLabel,
 } from '../../../components/DocumentList/List';
 import documentList from '../../../../form/tests/fixtures/mocks/document-list.json';
@@ -30,7 +29,7 @@ describe('List', () => {
 
     $$('.coe-list-item', container).forEach((item, index) => {
       const data = documents[index];
-      expect($('h3', item).textContent).to.equal(data.title);
+      expect($('h3', item).textContent).to.equal(data.documentType);
       const link = $('va-link', item);
       expect(link.getAttribute('text')).to.contain(
         'Download Notification Letter',
@@ -38,9 +37,7 @@ describe('List', () => {
       expect(link.getAttribute('href')).to.contain(
         `v0/coe/document_download/${data.id}`,
       );
-      expect(link.getAttribute('filename')).to.contain(
-        `v0/coe/document_download/${data.id}`,
-      );
+      expect(link.getAttribute('filename')).to.contain(data.mimeType);
 
       expect(item.textContent).to.contain(
         `Date sent: ${formatDateLong(data.createDate)}`,
@@ -53,18 +50,6 @@ describe('formatLabelDate', () => {
   it('should return a date in MMDDYYYY format', () => {
     expect(formatLabelDate(testDates[0].time)).to.equal(testDates[0].str);
     expect(formatLabelDate(testDates[1].time)).to.equal(testDates[1].str);
-  });
-});
-
-describe('getDocumentType', () => {
-  // assuming documentType matches `.{file-extension}`
-  // which isn't what is seen in the mock data
-  it('should return a PDF extension', () => {
-    expect(getDocumentType('some-file.pdf')).to.equal('PDF');
-    expect(getDocumentType('some.file.with.periods.pdf')).to.equal('PDF');
-  });
-  it('should return a jpeg extension', () => {
-    expect(getDocumentType('image.jpeg')).to.equal('JPEG');
   });
 });
 

--- a/src/applications/lgy/coe/status/tests/components/DocumentList/ListItem.unit.spec.jsx
+++ b/src/applications/lgy/coe/status/tests/components/DocumentList/ListItem.unit.spec.jsx
@@ -9,10 +9,11 @@ import ListItem from '../../../components/DocumentList/ListItem';
 describe('ListItem', () => {
   it('should render document list item', () => {
     const props = {
-      downloadUrl: 'doc-url.com/1234',
-      downloadLinkLabel: 'download test.pdf',
+      downloadUrl: 'http://example.com/v0/coe/document_download/12341234',
+      downloadLinkLabel: 'Download Notification Letter 11-22-2022',
       sentDate: 'July 10, 2022',
-      title: 'Test file',
+      title: 'COE Application First Returned Letter',
+      fileName: '12341234.pdf',
     };
     const { container } = render(
       <div>
@@ -25,7 +26,7 @@ describe('ListItem', () => {
     );
     const link = $('va-link', container);
     expect(link.getAttribute('href')).to.contain(props.downloadUrl);
-    expect(link.getAttribute('filename')).to.contain(props.downloadUrl);
+    expect(link.getAttribute('filename')).to.contain(props.fileName);
     expect(link.getAttribute('text')).to.contain(props.downloadLinkLabel);
   });
 });


### PR DESCRIPTION
## Summary

Fix notification letter titles and filenames on COE status page. 

After https://github.com/department-of-veterans-affairs/vets-api/pull/11338 and https://github.com/department-of-veterans-affairs/vets-api/pull/11335, we are now only showing notification letters on the COE status page, whereas before, we also showed vet-uploaded attachments. Notification letters are always PDFs, so we don't need to pass a `fileType` to `ListItem`. Besides, `filetype` was already hardcoded to `PDF` in `ListItem`.

We now know that LGY represents what "kind" of notification letter a document is through the `documentType` attribute (e.g. "COE Application First Returned Letter"). This means that we can begin setting `ListItem`s `title` to `documentType` rather than `description`. Before, titles would not be rendered for documents because `description` was always set to `null`. For context, `description` represents a vet's own freeform description of a document of type "other" that they uploaded to the COE form.

Strangely, LGY represents a document's filename as `mimeType` (e.g. "COE Application First Returned.pdf"). This means that we can set `ListItem`/`va-link`'s filename to `mimeType` instead of `downloadUrl`.

I am on the benefits team 1, which is responsible for the development and maintenance of the COE form.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/51471

## Testing done

Before, notification letters had no visible title on the COE status page. Now, they do.

This is a little difficult to test locally, but it is possible. To test:
- Log in as user 228, locally.
- Go to http://localhost:3001/housing-assistance/home-loans/check-coe-status/your-coe/
- Use react dev tools to find the `List` component under `DocumentList`. 
- Open the `documents` prop and remove all objects within it. 
- Add the following entry to the prop: `{ createDate: 1670353125000, description: null, documentType: "COE Application First Returned Letter", id: 23928901,
mimeType: "COE Application First Returned.pdf" }` (For context, this is what a COE notification letter will look like)
- Notice that the title of the `ListItem` is the `documentType`.

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

![Screen Shot 2023-01-03 at 3 31 10 PM](https://user-images.githubusercontent.com/7520103/210437015-31aa4fc1-5eca-412d-8138-95f3fde66b08.png)

![Screen Shot 2023-01-03 at 3 33 45 PM](https://user-images.githubusercontent.com/7520103/210437026-f19a9f1c-e85d-46cf-a813-8fd57a52476f.png)

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?

The COE form, which currently sits behind a feature flag.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
