### PR TITLE
Prevents modal from showing when next param is present

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -13,64 +13,69 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
   const skipLinkElement = document.getElementsByClassName('show-on-focus')[0];
   ariaExcludeArray.push(skipLinkElement);
 
+  // Prevents modal from showing when redirected to homepage for auth
+  const searchParams = new URLSearchParams(window.location.search);
+  const hasRedirectParam = searchParams.has('next');
+
   return (
     <>
-      {vaHomePreviewModal && (
-        <VaModal
-          role="dialog"
-          cssClass="va-modal announcement-brand-consolidation"
-          visible
-          onCloseEvent={() => {
-            recordEvent({ event: 'new-homepage-modal-close' });
-            dismiss();
-          }}
-          id="modal-announcement"
-          modalTitle=""
-          ariaHiddenNodeExceptions={ariaExcludeArray}
-          aria-describedby="homepage-modal-description"
-          aria-labelledby="homepage-modal-label-title"
-          secondary-button-text="Not today, go to the current homepage"
-          onSecondaryButtonClick={() => {
-            recordEvent({
-              event: 'new-homepage-modal-click',
-              'modal-secondary-link': 'go to current homepage',
-            });
-            dismiss();
-          }}
-        >
-          <img src="/img/design/logo/va-logo.png" alt="VA logo" width="300" />
-          <h1
-            id="homepage-modal-label-title"
-            className="vads-u-font-size--lg vads-u-margin-top--2p5"
+      {vaHomePreviewModal &&
+        !hasRedirectParam && (
+          <VaModal
+            role="dialog"
+            cssClass="va-modal announcement-brand-consolidation"
+            visible
+            onCloseEvent={() => {
+              recordEvent({ event: 'new-homepage-modal-close' });
+              dismiss();
+            }}
+            id="modal-announcement"
+            modalTitle=""
+            ariaHiddenNodeExceptions={ariaExcludeArray}
+            aria-describedby="homepage-modal-description"
+            aria-labelledby="homepage-modal-label-title"
+            secondary-button-text="Not today, go to the current homepage"
+            onSecondaryButtonClick={() => {
+              recordEvent({
+                event: 'new-homepage-modal-click',
+                'modal-secondary-link': 'go to current homepage',
+              });
+              dismiss();
+            }}
           >
-            Try our new VA.gov homepage
-          </h1>
-          <div
-            id="homepage-modal-description"
-            className="vads-u-margin-bottom--2"
-          >
-            <p>
-              We're redesigning the VA.gov homepage to help you get the tools
-              and information you need faster.
-            </p>
-            <p>And we want your feedback to help us make it even better.</p>
-
-            <a
-              className="vads-c-action-link--green"
-              href="/new-home-page"
-              onClick={() => {
-                dismiss();
-                recordEvent({
-                  event: 'new-homepage-modal-click',
-                  'modal-primaryButton-text': 'try the new homepage',
-                });
-              }}
+            <img src="/img/design/logo/va-logo.png" alt="VA logo" width="300" />
+            <h1
+              id="homepage-modal-label-title"
+              className="vads-u-font-size--lg vads-u-margin-top--2p5"
             >
-              Try the new home page
-            </a>
-          </div>
-        </VaModal>
-      )}
+              Try our new VA.gov homepage
+            </h1>
+            <div
+              id="homepage-modal-description"
+              className="vads-u-margin-bottom--2"
+            >
+              <p>
+                We're redesigning the VA.gov homepage to help you get the tools
+                and information you need faster.
+              </p>
+              <p>And we want your feedback to help us make it even better.</p>
+
+              <a
+                className="vads-c-action-link--green"
+                href="/new-home-page"
+                onClick={() => {
+                  dismiss();
+                  recordEvent({
+                    event: 'new-homepage-modal-click',
+                    'modal-primaryButton-text': 'try the new homepage',
+                  });
+                }}
+              >
+                Try the new home page
+              </a>
+            </div>
+          </VaModal>
+        )}
     </>
   );
 }

--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -14,8 +14,11 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
   ariaExcludeArray.push(skipLinkElement);
 
   // Prevents modal from showing when redirected to homepage for auth
-  const searchParams = new URLSearchParams(window.location.search);
-  const hasRedirectParam = searchParams.has('next');
+  let hasRedirectParam = false;
+  if (window.location.search) {
+    const searchParams = new URLSearchParams(window.location.search);
+    hasRedirectParam = searchParams.has('next');
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Prevents the new homepage modal from displaying when there is a param present for redirecting to authed experience

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12099


## Testing done

- Local testing

## Screenshots
<img width="1155" alt="Screen Shot 2022-12-28 at 3 10 27 PM" src="https://user-images.githubusercontent.com/61624970/209867008-59a378ea-5777-4a13-bcd9-6337e9a29293.png">
<img width="1155" alt="Screen Shot 2022-12-28 at 3 10 12 PM" src="https://user-images.githubusercontent.com/61624970/209867012-bfcf98be-bfce-4b70-8098-28a36c2f38db.png">


| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  Modal works as expected without clashing with login

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
