### PR TITLE
Check in/50993/pre check in details

### DIFF
--- a/src/applications/check-in/actions/universal/index.js
+++ b/src/applications/check-in/actions/universal/index.js
@@ -33,3 +33,12 @@ export const setForm = form => {
     payload: { form },
   };
 };
+
+export const SET_ACTIVE_APPOINTMENT = 'SET_ACTIVE_APPOINTMENT';
+
+export const setActiveAppointment = appointmentIen => {
+  return {
+    type: SET_ACTIVE_APPOINTMENT,
+    payload: { activeAppointment: appointmentIen },
+  };
+};

--- a/src/applications/check-in/actions/universal/index.js
+++ b/src/applications/check-in/actions/universal/index.js
@@ -39,6 +39,6 @@ export const SET_ACTIVE_APPOINTMENT = 'SET_ACTIVE_APPOINTMENT';
 export const setActiveAppointment = appointmentIen => {
   return {
     type: SET_ACTIVE_APPOINTMENT,
-    payload: { activeAppointment: appointmentIen },
+    payload: appointmentIen,
   };
 };

--- a/src/applications/check-in/actions/universal/universal.actions.unit.spec.js
+++ b/src/applications/check-in/actions/universal/universal.actions.unit.spec.js
@@ -7,6 +7,8 @@ import {
   RECORD_ANSWER,
   setError,
   SET_ERROR,
+  setActiveAppointment,
+  SET_ACTIVE_APPOINTMENT,
 } from './index';
 
 describe('check-in', () => {
@@ -41,6 +43,17 @@ describe('check-in', () => {
       it('should return correct structure', () => {
         const action = setError('max-validation');
         expect(action.payload.error).equal('max-validation');
+      });
+    });
+
+    describe('setActiveAppointment', () => {
+      it('should return correct action', () => {
+        const action = setActiveAppointment({});
+        expect(action.type).to.equal(SET_ACTIVE_APPOINTMENT);
+      });
+      it('should return correct structure', () => {
+        const action = setActiveAppointment(1111);
+        expect(action.payload.activeAppointment).equal(1111);
       });
     });
   });

--- a/src/applications/check-in/actions/universal/universal.actions.unit.spec.js
+++ b/src/applications/check-in/actions/universal/universal.actions.unit.spec.js
@@ -53,7 +53,7 @@ describe('check-in', () => {
       });
       it('should return correct structure', () => {
         const action = setActiveAppointment(1111);
-        expect(action.payload.activeAppointment).equal(1111);
+        expect(action.payload).equal(1111);
       });
     });
   });

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -88,6 +88,19 @@ class ApiInitializer {
         }),
       );
     },
+    withDetailsPage: () => {
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        featureToggles.generateFeatureToggles({
+          checkInExperienceEnabled: true,
+          preCheckInEnabled: true,
+          emergencyContactEnabled: true,
+          checkInExperienceTravelReimbursement: false,
+          checkInExperienceUpdatedApptPresentation: true,
+        }),
+      );
+    },
   };
 
   initializeSessionGet = {

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -94,6 +94,7 @@ const createMockSuccessResponse = (
           startTime: mockTime,
           checkInSteps,
           preCheckInValid: true,
+          appointmentIen: 1111,
         }),
         createAppointment({
           clinicLocation: location ?? 'SECOND FLOOR ROOM 2',

--- a/src/applications/check-in/components/AppointmentBlockVaos.jsx
+++ b/src/applications/check-in/components/AppointmentBlockVaos.jsx
@@ -3,15 +3,16 @@ import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
+import AppointmentListItem from './AppointmentListItem';
 import { setActiveAppointment } from '../actions/universal';
 import { useFormRouting } from '../hooks/useFormRouting';
-import { appointmentIcon, clinicName } from '../utils/appointment';
 
 const AppointmentBlockVaos = props => {
   const { appointments, page, router } = props;
   const { t } = useTranslation();
-  const dispatch = useDispatch();
   const appointmentsDateTime = new Date(appointments[0].startTime);
+
+  const dispatch = useDispatch();
   const { jumpToPage } = useFormRouting(router);
 
   const handleDetailClick = (appointmentIen, e) => {
@@ -35,55 +36,13 @@ const AppointmentBlockVaos = props => {
         className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list"
         data-testid="appointment-list"
       >
-        {appointments.map((appointment, index) => {
-          const appointmentDateTime = new Date(appointment.startTime);
-          const clinic = clinicName(appointment);
+        {appointments.map(appointment => {
           return (
-            <li
-              key={index}
-              className="vads-u-border-bottom--1px check-in--appointment-item"
-              data-testid="appointment-list-item"
-            >
-              <div className="check-in--appointment-summary vads-u-margin-bottom--2 vads-u-margin-top--2">
-                <div className="vads-u-font-size--h2 vads-u-font-family--serif">
-                  {t('date-time', { date: appointmentDateTime })}
-                </div>
-                <div className="vads-u-font-weight--bold">
-                  {appointment.clinicStopCodeName ?? t('VA-appointment')}
-                  {appointment.doctorName
-                    ? ` ${t('with')} ${appointment.doctorName}`
-                    : ''}
-                </div>
-                <div>
-                  <div className="vads-u-margin-right--1 check-in--label">
-                    {appointmentIcon(appointment)}
-                  </div>
-                  <div className="vads-u-display--inline">
-                    {appointment?.kind === 'phone' ? (
-                      t('phone')
-                    ) : (
-                      <>
-                        {`${t('in-person')} at ${appointment.facility}`} <br />{' '}
-                        Clinic: {clinic}
-                      </>
-                    )}
-                  </div>
-                  {page === 'confirmation' && (
-                    <div>
-                      <a
-                        data-testid="details-link"
-                        href="#details"
-                        onClick={e =>
-                          handleDetailClick(appointment.appointmentIen, e)
-                        }
-                      >
-                        Details
-                      </a>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </li>
+            <AppointmentListItem
+              key={`${appointment.appointmentIen}-${appointment.stationNo}`}
+              appointment={appointment}
+              goToDetails={page === 'confirmation' ? handleDetailClick : null}
+            />
           );
         })}
       </ol>

--- a/src/applications/check-in/components/AppointmentBlockVaos.jsx
+++ b/src/applications/check-in/components/AppointmentBlockVaos.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { setActiveAppointment } from '../actions/universal';
 import { useFormRouting } from '../hooks/useFormRouting';
-import { appointmentIcon } from '../utils/appointment';
+import { appointmentIcon, clinicName } from '../utils/appointment';
 
 const AppointmentBlockVaos = props => {
   const { appointments, page, router } = props;
@@ -37,9 +37,7 @@ const AppointmentBlockVaos = props => {
       >
         {appointments.map((appointment, index) => {
           const appointmentDateTime = new Date(appointment.startTime);
-          const clinic = appointment.clinicFriendlyName
-            ? appointment.clinicFriendlyName
-            : appointment.clinicName;
+          const clinic = clinicName(appointment);
           return (
             <li
               key={index}

--- a/src/applications/check-in/components/AppointmentBlockVaos.jsx
+++ b/src/applications/check-in/components/AppointmentBlockVaos.jsx
@@ -80,6 +80,7 @@ const AppointmentBlockVaos = props => {
                   {page === 'confirmation' && (
                     <div>
                       <a
+                        data-testid="details-link"
                         href="#details"
                         onClick={e =>
                           handleDetailClick(appointment.appointmentIen, e)

--- a/src/applications/check-in/components/AppointmentBlockVaos.jsx
+++ b/src/applications/check-in/components/AppointmentBlockVaos.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { setActiveAppointment } from '../actions/universal';
 import { useFormRouting } from '../hooks/useFormRouting';
+import { appointmentIcon } from '../utils/appointment';
 
 const AppointmentBlockVaos = props => {
   const { appointments, page, router } = props;
@@ -57,15 +58,7 @@ const AppointmentBlockVaos = props => {
                 </div>
                 <div>
                   <div className="vads-u-margin-right--1 check-in--label">
-                    <i
-                      aria-label="Appointment type"
-                      className={`fas ${
-                        appointment?.kind === 'phone'
-                          ? 'fa-phone'
-                          : 'fa-building'
-                      }`}
-                      aria-hidden="true"
-                    />
+                    {appointmentIcon(appointment)}
                   </div>
                   <div className="vads-u-display--inline">
                     {appointment?.kind === 'phone' ? (

--- a/src/applications/check-in/components/AppointmentBlockVaos.jsx
+++ b/src/applications/check-in/components/AppointmentBlockVaos.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+const AppointmentBlockVaos = props => {
+  const { appointments, page } = props;
+  const { t } = useTranslation();
+
+  const appointmentsDateTime = new Date(appointments[0].startTime);
+
+  return (
+    <div>
+      <p
+        className="vads-u-font-family--serif"
+        data-testid="appointment-day-location"
+      >
+        {t('your-appointments-on-day', {
+          count: appointments.length,
+          day: appointmentsDateTime,
+        })}
+      </p>
+      <ol
+        className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list"
+        data-testid="appointment-list"
+      >
+        {appointments.map((appointment, index) => {
+          const appointmentDateTime = new Date(appointment.startTime);
+          const clinic = appointment.clinicFriendlyName
+            ? appointment.clinicFriendlyName
+            : appointment.clinicName;
+          return (
+            <li
+              key={index}
+              className="vads-u-border-bottom--1px check-in--appointment-item"
+              data-testid="appointment-list-item"
+            >
+              <div className="check-in--appointment-summary vads-u-margin-bottom--2 vads-u-margin-top--2">
+                <div className="vads-u-font-size--h2 vads-u-font-family--serif">
+                  {t('date-time', { date: appointmentDateTime })}
+                </div>
+                <div className="vads-u-font-weight--bold">
+                  {appointment.clinicStopCodeName ?? t('VA-appointment')}
+                  {appointment.doctorName
+                    ? ` ${t('with')} ${appointment.doctorName}`
+                    : ''}
+                </div>
+                <div>
+                  <div className="vads-u-margin-right--1 check-in--label">
+                    <i
+                      aria-label="Appointment type"
+                      className={`fas ${
+                        appointment?.kind === 'phone'
+                          ? 'fa-phone'
+                          : 'fa-building'
+                      }`}
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="vads-u-display--inline">
+                    {appointment?.kind === 'phone' ? (
+                      t('phone')
+                    ) : (
+                      <>
+                        {`${t('in-person')} at ${appointment.facility}`} <br />{' '}
+                        Clinic: {clinic}
+                      </>
+                    )}
+                  </div>
+                  {page === 'confirmation' && (
+                    <div>
+                      <a href="#details">Details</a>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+AppointmentBlockVaos.propTypes = {
+  appointments: PropTypes.array.isRequired,
+  page: PropTypes.string.isRequired,
+};
+
+export default AppointmentBlockVaos;

--- a/src/applications/check-in/components/AppointmentBlockVaos.jsx
+++ b/src/applications/check-in/components/AppointmentBlockVaos.jsx
@@ -1,12 +1,23 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
-const AppointmentBlockVaos = props => {
-  const { appointments, page } = props;
-  const { t } = useTranslation();
+import { setActiveAppointment } from '../actions/universal';
+import { useFormRouting } from '../hooks/useFormRouting';
 
+const AppointmentBlockVaos = props => {
+  const { appointments, page, router } = props;
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
   const appointmentsDateTime = new Date(appointments[0].startTime);
+  const { jumpToPage } = useFormRouting(router);
+
+  const handleDetailClick = (appointmentIen, e) => {
+    e.preventDefault();
+    dispatch(setActiveAppointment(appointmentIen));
+    jumpToPage('appointment-details');
+  };
 
   return (
     <div>
@@ -68,7 +79,14 @@ const AppointmentBlockVaos = props => {
                   </div>
                   {page === 'confirmation' && (
                     <div>
-                      <a href="#details">Details</a>
+                      <a
+                        href="#details"
+                        onClick={e =>
+                          handleDetailClick(appointment.appointmentIen, e)
+                        }
+                      >
+                        Details
+                      </a>
                     </div>
                   )}
                 </div>
@@ -84,6 +102,7 @@ const AppointmentBlockVaos = props => {
 AppointmentBlockVaos.propTypes = {
   appointments: PropTypes.array.isRequired,
   page: PropTypes.string.isRequired,
+  router: PropTypes.object,
 };
 
 export default AppointmentBlockVaos;

--- a/src/applications/check-in/components/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentListItem.jsx
@@ -16,20 +16,32 @@ const AppointmentListItem = props => {
       data-testid="appointment-list-item"
     >
       <div className="check-in--appointment-summary vads-u-margin-bottom--2 vads-u-margin-top--2">
-        <div className="vads-u-font-size--h2 vads-u-font-family--serif">
+        <div
+          data-testid="appointment-time"
+          className="vads-u-font-size--h2 vads-u-font-family--serif"
+        >
           {t('date-time', { date: appointmentDateTime })}
         </div>
-        <div className="vads-u-font-weight--bold">
+        <div
+          data-testid="appointment-type-and-provider"
+          className="vads-u-font-weight--bold"
+        >
           {appointment.clinicStopCodeName ?? t('VA-appointment')}
           {appointment.doctorName
             ? ` ${t('with')} ${appointment.doctorName}`
             : ''}
         </div>
         <div>
-          <div className="vads-u-margin-right--1 check-in--label">
+          <div
+            data-testid="appointment-kind-icon"
+            className="vads-u-margin-right--1 check-in--label"
+          >
             {appointmentIcon(appointment)}
           </div>
-          <div className="vads-u-display--inline">
+          <div
+            data-testid="appointment-kind-and-location"
+            className="vads-u-display--inline"
+          >
             {appointment?.kind === 'phone' ? (
               t('phone')
             ) : (

--- a/src/applications/check-in/components/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentListItem.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+import { appointmentIcon, clinicName } from '../utils/appointment';
+
+const AppointmentListItem = props => {
+  const { appointment, goToDetails } = props;
+  const { t } = useTranslation();
+
+  const appointmentDateTime = new Date(appointment.startTime);
+  const clinic = clinicName(appointment);
+  return (
+    <li
+      className="vads-u-border-bottom--1px check-in--appointment-item"
+      data-testid="appointment-list-item"
+    >
+      <div className="check-in--appointment-summary vads-u-margin-bottom--2 vads-u-margin-top--2">
+        <div className="vads-u-font-size--h2 vads-u-font-family--serif">
+          {t('date-time', { date: appointmentDateTime })}
+        </div>
+        <div className="vads-u-font-weight--bold">
+          {appointment.clinicStopCodeName ?? t('VA-appointment')}
+          {appointment.doctorName
+            ? ` ${t('with')} ${appointment.doctorName}`
+            : ''}
+        </div>
+        <div>
+          <div className="vads-u-margin-right--1 check-in--label">
+            {appointmentIcon(appointment)}
+          </div>
+          <div className="vads-u-display--inline">
+            {appointment?.kind === 'phone' ? (
+              t('phone')
+            ) : (
+              <>
+                {`${t('in-person')} at ${appointment.facility}`} <br /> Clinic:{' '}
+                {clinic}
+              </>
+            )}
+          </div>
+          {goToDetails && (
+            <div>
+              <a
+                data-testid="details-link"
+                href="#details"
+                onClick={e => goToDetails(appointment.appointmentIen, e)}
+              >
+                Details
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+};
+
+AppointmentListItem.propTypes = {
+  appointment: PropTypes.object.isRequired,
+  goToDetails: PropTypes.func,
+};
+
+export default AppointmentListItem;

--- a/src/applications/check-in/components/BackButton.jsx
+++ b/src/applications/check-in/components/BackButton.jsx
@@ -10,7 +10,7 @@ import { useFormRouting } from '../hooks/useFormRouting';
 import { URLS } from '../utils/navigation';
 
 const BackButton = props => {
-  const { action, router, text = false } = props;
+  const { action, router, text = null } = props;
   const {
     getCurrentPageFromRouter,
     getPreviousPageFromRouter,
@@ -57,7 +57,7 @@ const BackButton = props => {
 BackButton.propTypes = {
   action: PropTypes.func,
   router: PropTypes.object,
-  text: PropTypes.bool,
+  text: PropTypes.string,
 };
 
 export default BackButton;

--- a/src/applications/check-in/components/BackButton.jsx
+++ b/src/applications/check-in/components/BackButton.jsx
@@ -10,7 +10,7 @@ import { useFormRouting } from '../hooks/useFormRouting';
 import { URLS } from '../utils/navigation';
 
 const BackButton = props => {
-  const { action, router } = props;
+  const { action, router, text = false } = props;
   const {
     getCurrentPageFromRouter,
     getPreviousPageFromRouter,
@@ -45,7 +45,7 @@ const BackButton = props => {
         <ul className="row va-nav-breadcrumbs-list columns">
           <li>
             <a onClick={handleClick} href="#back" data-testid="back-button">
-              {t('back-to-last-screen')}
+              {text || t('back-to-last-screen')}
             </a>
           </li>
         </ul>
@@ -57,6 +57,7 @@ const BackButton = props => {
 BackButton.propTypes = {
   action: PropTypes.func,
   router: PropTypes.object,
+  text: PropTypes.bool,
 };
 
 export default BackButton;

--- a/src/applications/check-in/components/PreCheckinConfirmation.jsx
+++ b/src/applications/check-in/components/PreCheckinConfirmation.jsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
+import { makeSelectFeatureToggles } from '../utils/selectors/feature-toggles';
+
 import AppointmentBlock from './AppointmentBlock';
+import AppointmentBlockVaos from './AppointmentBlockVaos';
 import ExternalLink from './ExternalLink';
 import PreCheckInAccordionBlock from './PreCheckInAccordionBlock';
 import HowToLink from './HowToLink';
@@ -16,10 +20,16 @@ const PreCheckinConfirmation = props => {
     nextOfKinUpToDate,
   } = formData;
   const { t } = useTranslation();
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+
+  const { isUpdatedApptPresentationEnabled } = useSelector(
+    selectFeatureToggles,
+  );
 
   if (appointments.length === 0) {
     return <></>;
   }
+
   const apptType = appointments[0]?.kind ?? 'clinic';
   const renderLoadingMessage = () => {
     return (
@@ -40,7 +50,14 @@ const PreCheckinConfirmation = props => {
         pageTitle={t('youve-completed-pre-check-in')}
         testID="confirmation-wrapper"
       >
-        <AppointmentBlock appointments={appointments} page="confirmation" />
+        {isUpdatedApptPresentationEnabled ? (
+          <AppointmentBlockVaos
+            appointments={appointments}
+            page="confirmation"
+          />
+        ) : (
+          <AppointmentBlock appointments={appointments} page="confirmation" />
+        )}
         <HowToLink apptType={apptType} />
         <p className="vads-u-margin-bottom--4">
           <ExternalLink

--- a/src/applications/check-in/components/PreCheckinConfirmation.jsx
+++ b/src/applications/check-in/components/PreCheckinConfirmation.jsx
@@ -13,7 +13,7 @@ import HowToLink from './HowToLink';
 import Wrapper from './layout/Wrapper';
 
 const PreCheckinConfirmation = props => {
-  const { appointments, isLoading, formData } = props;
+  const { appointments, isLoading, formData, router } = props;
   const {
     demographicsUpToDate,
     emergencyContactUpToDate,
@@ -54,6 +54,7 @@ const PreCheckinConfirmation = props => {
           <AppointmentBlockVaos
             appointments={appointments}
             page="confirmation"
+            router={router}
           />
         ) : (
           <AppointmentBlock appointments={appointments} page="confirmation" />
@@ -85,6 +86,7 @@ PreCheckinConfirmation.propTypes = {
   appointments: PropTypes.array,
   formData: PropTypes.object,
   isLoading: PropTypes.bool,
+  router: PropTypes.object,
 };
 
 export default PreCheckinConfirmation;

--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -46,9 +46,11 @@ const Wrapper = props => {
       >
         <MixedLanguageDisclaimer />
         <LanguagePicker withTopMargin={!withBackButton} />
-        <h1 tabIndex="-1" data-testid="header">
-          {pageTitle}
-        </h1>
+        {pageTitle && (
+          <h1 tabIndex="-1" data-testid="header">
+            {pageTitle}
+          </h1>
+        )}
         <DowntimeNotification
           appTitle={appTitle}
           dependencies={[downtimeDependency]}
@@ -62,7 +64,7 @@ const Wrapper = props => {
 };
 
 Wrapper.propTypes = {
-  pageTitle: PropTypes.string.isRequired,
+  pageTitle: PropTypes.string,
   children: PropTypes.node,
   classNames: PropTypes.string,
   testID: PropTypes.string,

--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -64,9 +64,9 @@ const Wrapper = props => {
 };
 
 Wrapper.propTypes = {
-  pageTitle: PropTypes.string,
   children: PropTypes.node,
   classNames: PropTypes.string,
+  pageTitle: PropTypes.string,
   testID: PropTypes.string,
   withBackButton: PropTypes.bool,
 };

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -1,0 +1,205 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { I18nextProvider } from 'react-i18next';
+import { scheduledDowntimeState } from '../../../tests/unit/utils/initState';
+import AppointmentDetails from './index';
+import i18n from '../../../utils/i18n/i18n';
+import { multipleAppointments } from '../../../tests/unit/mocks/mock-appointments';
+
+describe('check-in experience', () => {
+  describe('shared components', () => {
+    const middleware = [];
+    const mockStore = configureStore(middleware);
+    const initAppointments = [...multipleAppointments];
+
+    initAppointments[0] = {
+      ...initAppointments[0],
+      kind: 'phone',
+      appointmentIen: 1111,
+    };
+    initAppointments[1] = {
+      ...initAppointments[0],
+      kind: 'clinic',
+      appointmentIen: 2222,
+      clinicStopCodeName: 'stop code test',
+      doctorName: 'test doc',
+    };
+    delete initAppointments[0].clinicPhoneNumber;
+
+    const initState = {
+      checkInData: {
+        context: {
+          token: '',
+        },
+        appointments: initAppointments,
+        veteranData: {
+          demographics: {},
+        },
+        form: {
+          pages: [],
+        },
+      },
+    };
+    const phoneState = {
+      ...JSON.parse(JSON.stringify(initState)),
+      ...scheduledDowntimeState,
+    };
+    phoneState.checkInData.activeAppointment = 1111;
+    const inPersonState = {
+      ...JSON.parse(JSON.stringify(initState)),
+      ...scheduledDowntimeState,
+    };
+    inPersonState.checkInData.activeAppointment = 2222;
+    describe('AppointmentDetails', () => {
+      describe('Phone appointment', () => {
+        const phoneStore = mockStore(phoneState);
+        it('renders correct heading for appointment type', () => {
+          const { getByTestId } = render(
+            <Provider store={phoneStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByTestId('header')).to.have.text('Phone appointment');
+        });
+        it('renders correct subtitle', () => {
+          const { getByTestId } = render(
+            <Provider store={phoneStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByTestId('phone-appointment-subtitle')).to.exist;
+        });
+        it('renders clinic instead of where to attend', () => {
+          const { getByRole } = render(
+            <Provider store={phoneStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByRole('heading', { name: 'Clinic', level: 2 })).to.exist;
+        });
+      });
+      describe('In person appointment', () => {
+        const inPersonStore = mockStore(inPersonState);
+        it('renders correct heading for appointment type', () => {
+          const { getByTestId } = render(
+            <Provider store={inPersonStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByTestId('header')).to.have.text('In person appointment');
+        });
+        it('renders correct subtitle', () => {
+          const { getByTestId } = render(
+            <Provider store={inPersonStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByTestId('in-person-appointment-subtitle')).to.exist;
+        });
+        it('renders where to attend instead of clinic', () => {
+          const { getByRole } = render(
+            <Provider store={inPersonStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByRole('heading', { name: 'Where to attend', level: 2 })).to
+            .exist;
+        });
+      });
+      describe('All appointments - data exists', () => {
+        const existStore = mockStore(inPersonState);
+        it('renders stopcode if exists', () => {
+          const { getByTestId } = render(
+            <Provider store={existStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(
+            getByTestId('appointment-details--appointment-value'),
+          ).to.have.text('stop code test');
+        });
+        it('renders doctor name if exists', () => {
+          const { getByTestId } = render(
+            <Provider store={existStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByTestId('appointment-details--provider')).to.exist;
+        });
+        it('renders phone number if available', () => {
+          const { getByTestId } = render(
+            <Provider store={existStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(getByTestId('appointment-details--phone')).to.exist;
+        });
+        // TBD
+        // it('renders reason for visit if available', () => {
+
+        // });
+      });
+      describe("All appointments - data doesn't exist", () => {
+        const notExistStore = mockStore(phoneState);
+        it('renders VA appointment when no stopcode', () => {
+          const { getByTestId } = render(
+            <Provider store={notExistStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(
+            getByTestId('appointment-details--appointment-value'),
+          ).to.have.text('VA Appointment');
+        });
+        it('does not render doctor name if missing', () => {
+          const { queryByTestId } = render(
+            <Provider store={notExistStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(queryByTestId('appointment-details--provider')).to.not.exist;
+        });
+        it('does not render phone number', () => {
+          const { queryByTestId } = render(
+            <Provider store={notExistStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(queryByTestId('appointment-details--phone')).to.not.exist;
+        });
+        // TBD
+        // it('does not render reason for visit', () => {
+
+        // });
+      });
+    });
+  });
+});

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -48,12 +48,12 @@ describe('check-in experience', () => {
       ...JSON.parse(JSON.stringify(initState)),
       ...scheduledDowntimeState,
     };
-    phoneState.checkInData.activeAppointment = 1111;
+    phoneState.checkInData.form.activeAppointment = 1111;
     const inPersonState = {
       ...JSON.parse(JSON.stringify(initState)),
       ...scheduledDowntimeState,
     };
-    inPersonState.checkInData.activeAppointment = 2222;
+    inPersonState.checkInData.form.activeAppointment = 2222;
     describe('AppointmentDetails', () => {
       describe('Phone appointment', () => {
         const phoneStore = mockStore(phoneState);

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -72,13 +72,23 @@ const AppointmentDetails = props => {
               'appointment',
             )}`}
           </h1>
-          <p className="vads-u-margin--0">
-            {isPhoneAppointment
-              ? t('your-provider-will-call-you-at-your-appointment-time')
-              : t(
-                  'please-bring-your-insurance-cards-with-you-to-your-appointment',
-                )}
-          </p>
+          {isPhoneAppointment ? (
+            <p
+              data-testid="phone-appointment-subtitle"
+              className="vads-u-margin--0"
+            >
+              {t('your-provider-will-call-you-at-your-appointment-time')}
+            </p>
+          ) : (
+            <p
+              data-testid="in-person-appointment-subtitle"
+              className="vads-u-margin--0"
+            >
+              {t(
+                'please-bring-your-insurance-cards-with-you-to-your-appointment',
+              )}
+            </p>
+          )}
           <div data-testid="appointment-details--when">
             <h2 className="vads-u-font-size--sm">{t('when')}</h2>
             <div data-testid="appointment-details--date-value">

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -23,134 +23,150 @@ const AppointmentDetails = props => {
   const { activeAppointment } = useSelector(selectActiveAppointment);
   const [appointment, setAppointment] = useState([]);
 
-  const appointmentDay = new Date(appointment.startTime);
+  const appointmentDay = new Date(appointment?.startTime);
   const isPhoneAppointment = appointment?.kind === 'phone';
 
   useEffect(
     () => {
       if (activeAppointment) {
-        setAppointment(
-          appointments.find(
-            appointmentItem =>
-              appointmentItem.appointmentIen === activeAppointment,
-          ),
+        const activeAppointmentDetails = appointments.find(
+          appointmentItem =>
+            appointmentItem.appointmentIen === activeAppointment,
         );
-      } else {
-        jumpToPage('complete');
+        if (activeAppointmentDetails) {
+          setAppointment(
+            appointments.find(
+              appointmentItem =>
+                appointmentItem.appointmentIen === activeAppointment,
+            ),
+          );
+          return;
+        }
       }
+      // Go back to complete page if no activeAppointment or not in list.
+      jumpToPage('complete');
     },
     [activeAppointment, appointments, jumpToPage],
   );
 
-  const clinic = appointment.clinicFriendlyName
-    ? appointment.clinicFriendlyName
-    : appointment.clinicName;
+  const clinic = appointment?.clinicFriendlyName
+    ? appointment?.clinicFriendlyName
+    : appointment?.clinicName;
+
   return (
     <>
-      <BackButton
-        router={router}
-        action={goToPreviousPage}
-        text={t('back-to-appointments')}
-      />
-      <Wrapper classNames="appointment-details-page" withBackButton>
-        <div className="appointment-details--container vads-u-margin-top--2 vads-u-border--2px vads-u-border-color--gray-lighter vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2">
-          <div className="appointment-details--icon">
-            <i
-              aria-label="Appointment type"
-              className={`fas ${
-                appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'
-              }`}
-              aria-hidden="true"
-            />
-          </div>
-          <h1
-            tabIndex="-1"
-            data-testid="header"
-            className="vads-u-font-size--h3"
-          >
-            {`${isPhoneAppointment ? t('phone') : t('in-person')} ${t(
-              'appointment',
-            )}`}
-          </h1>
-          {isPhoneAppointment ? (
-            <p
-              data-testid="phone-appointment-subtitle"
-              className="vads-u-margin--0"
-            >
-              {t('your-provider-will-call-you-at-your-appointment-time')}
-            </p>
-          ) : (
-            <p
-              data-testid="in-person-appointment-subtitle"
-              className="vads-u-margin--0"
-            >
-              {t(
-                'please-bring-your-insurance-cards-with-you-to-your-appointment',
-              )}
-            </p>
-          )}
-          <div data-testid="appointment-details--when">
-            <h2 className="vads-u-font-size--sm">{t('when')}</h2>
-            <div data-testid="appointment-details--date-value">
-              {isValid(appointmentDay) &&
-                t('appointment-day', { date: appointmentDay })}
-            </div>
-          </div>
-          <div data-testid="appointment-details--what">
-            <h2 className="vads-u-font-size--sm">{t('what')}</h2>
-            <div data-testid="appointment-details--appointment-value">
-              {appointment.clinicStopCodeName ?? t('VA-appointment')}
-            </div>
-          </div>
-          {appointment.doctorName && (
-            <div data-testid="appointment-details--provider">
-              <h2 className="vads-u-font-size--sm">{t('Provider')}</h2>
-              <div data-testid="appointment-details--provider-value">
-                {appointment.doctorName}
-              </div>
-            </div>
-          )}
-          <div data-testid="appointment-details--where">
-            <h2 className="vads-u-font-size--sm">
-              {isPhoneAppointment ? t('clinic') : t('where-to-attend')}
-            </h2>
-            {/* TODO add address for in person appointments */}
-            <div data-testid="appointment-details--clinic-value">
-              {isPhoneAppointment ? '' : t('clinic')}: {clinic}
-            </div>
-            {isPhoneAppointment ? (
-              ''
-            ) : (
-              <div data-testid="appointment-details--location-value">
-                {`${t('location')}: ${appointment.clinicLocation}`}
-              </div>
-            )}
-          </div>
-          {appointment.clinicPhoneNumber && (
-            <div data-testid="appointment-details--phone">
-              <h2 className="vads-u-font-size--sm">{t('phone')}</h2>
-              <div data-testid="appointment-details--phone-value">
+      {appointment ? (
+        <>
+          <BackButton
+            router={router}
+            action={goToPreviousPage}
+            text={t('back-to-appointments')}
+          />
+          <Wrapper classNames="appointment-details-page" withBackButton>
+            <div className="appointment-details--container vads-u-margin-top--2 vads-u-border--2px vads-u-border-color--gray-lighter vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2">
+              <div className="appointment-details--icon">
                 <i
-                  aria-label="phone"
-                  className="fas fa-phone vads-u-color--link-default vads-u-margin-right--1"
+                  aria-label="Appointment type"
+                  className={`fas ${
+                    appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'
+                  }`}
                   aria-hidden="true"
                 />
-                <va-telephone contact={appointment.clinicPhoneNumber}>
-                  {appointment.clinicPhoneNumber}
-                </va-telephone>
               </div>
-            </div>
-          )}
-          {appointment.reasonForVisit && (
-            <div data-testid="appointment-details--reason">
-              <h2 className="vads-u-font-size--sm">{t('reason-for-visit')}</h2>
-              <div data-testid="appointment-details--reason-value">
-                {appointment.reasonForVisit}
+              <h1
+                tabIndex="-1"
+                data-testid="header"
+                className="vads-u-font-size--h3"
+              >
+                {`${isPhoneAppointment ? t('phone') : t('in-person')} ${t(
+                  'appointment',
+                )}`}
+              </h1>
+              {isPhoneAppointment ? (
+                <p
+                  data-testid="phone-appointment-subtitle"
+                  className="vads-u-margin--0"
+                >
+                  {t('your-provider-will-call-you-at-your-appointment-time')}
+                </p>
+              ) : (
+                <p
+                  data-testid="in-person-appointment-subtitle"
+                  className="vads-u-margin--0"
+                >
+                  {t(
+                    'please-bring-your-insurance-cards-with-you-to-your-appointment',
+                  )}
+                </p>
+              )}
+              <div data-testid="appointment-details--when">
+                <h2 className="vads-u-font-size--sm">{t('when')}</h2>
+                <div data-testid="appointment-details--date-value">
+                  {isValid(appointmentDay) &&
+                    t('appointment-day', { date: appointmentDay })}
+                </div>
               </div>
+              <div data-testid="appointment-details--what">
+                <h2 className="vads-u-font-size--sm">{t('what')}</h2>
+                <div data-testid="appointment-details--appointment-value">
+                  {appointment.clinicStopCodeName ?? t('VA-appointment')}
+                </div>
+              </div>
+              {appointment.doctorName && (
+                <div data-testid="appointment-details--provider">
+                  <h2 className="vads-u-font-size--sm">{t('Provider')}</h2>
+                  <div data-testid="appointment-details--provider-value">
+                    {appointment.doctorName}
+                  </div>
+                </div>
+              )}
+              <div data-testid="appointment-details--where">
+                <h2 className="vads-u-font-size--sm">
+                  {isPhoneAppointment ? t('clinic') : t('where-to-attend')}
+                </h2>
+                {/* TODO add address for in person appointments */}
+                <div data-testid="appointment-details--clinic-value">
+                  {isPhoneAppointment ? '' : t('clinic')}: {clinic}
+                </div>
+                {isPhoneAppointment ? (
+                  ''
+                ) : (
+                  <div data-testid="appointment-details--location-value">
+                    {`${t('location')}: ${appointment.clinicLocation}`}
+                  </div>
+                )}
+              </div>
+              {appointment.clinicPhoneNumber && (
+                <div data-testid="appointment-details--phone">
+                  <h2 className="vads-u-font-size--sm">{t('phone')}</h2>
+                  <div data-testid="appointment-details--phone-value">
+                    <i
+                      aria-label="phone"
+                      className="fas fa-phone vads-u-color--link-default vads-u-margin-right--1"
+                      aria-hidden="true"
+                    />
+                    <va-telephone contact={appointment.clinicPhoneNumber}>
+                      {appointment.clinicPhoneNumber}
+                    </va-telephone>
+                  </div>
+                </div>
+              )}
+              {appointment.reasonForVisit && (
+                <div data-testid="appointment-details--reason">
+                  <h2 className="vads-u-font-size--sm">
+                    {t('reason-for-visit')}
+                  </h2>
+                  <div data-testid="appointment-details--reason-value">
+                    {appointment.reasonForVisit}
+                  </div>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      </Wrapper>
+          </Wrapper>
+        </>
+      ) : (
+        <va-loading-indicator message={t('loading')} />
+      )}
     </>
   );
 };

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -10,6 +10,7 @@ import {
   makeSelectVeteranData,
 } from '../../../selectors';
 
+import { appointmentIcon } from '../../../utils/appointment';
 import Wrapper from '../../layout/Wrapper';
 import BackButton from '../../BackButton';
 
@@ -65,13 +66,7 @@ const AppointmentDetails = props => {
           <Wrapper classNames="appointment-details-page" withBackButton>
             <div className="appointment-details--container vads-u-margin-top--2 vads-u-border--2px vads-u-border-color--gray-lighter vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2">
               <div className="appointment-details--icon">
-                <i
-                  aria-label="Appointment type"
-                  className={`fas ${
-                    appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'
-                  }`}
-                  aria-hidden="true"
-                />
+                {appointmentIcon(appointment)}
               </div>
               <h1
                 tabIndex="-1"

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -35,12 +35,7 @@ const AppointmentDetails = props => {
             appointmentItem.appointmentIen === activeAppointment,
         );
         if (activeAppointmentDetails) {
-          setAppointment(
-            appointments.find(
-              appointmentItem =>
-                appointmentItem.appointmentIen === activeAppointment,
-            ),
-          );
+          setAppointment(activeAppointmentDetails);
           return;
         }
       }

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -126,7 +126,7 @@ const AppointmentDetails = props => {
                 </h2>
                 {/* TODO add address for in person appointments */}
                 <div data-testid="appointment-details--clinic-value">
-                  {isPhoneAppointment ? '' : t('clinic')}: {clinic}
+                  {isPhoneAppointment ? '' : `${t('clinic')}:`} {clinic}
                 </div>
                 {isPhoneAppointment ? (
                   ''

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -114,7 +114,7 @@ const AppointmentDetails = props => {
               </div>
               {appointment.doctorName && (
                 <div data-testid="appointment-details--provider">
-                  <h2 className="vads-u-font-size--sm">{t('Provider')}</h2>
+                  <h2 className="vads-u-font-size--sm">{t('provider')}</h2>
                   <div data-testid="appointment-details--provider-value">
                     {appointment.doctorName}
                   </div>

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -10,7 +10,7 @@ import {
   makeSelectVeteranData,
 } from '../../../selectors';
 
-import { appointmentIcon } from '../../../utils/appointment';
+import { appointmentIcon, clinicName } from '../../../utils/appointment';
 import Wrapper from '../../layout/Wrapper';
 import BackButton from '../../BackButton';
 
@@ -45,9 +45,7 @@ const AppointmentDetails = props => {
     [activeAppointment, appointments, jumpToPage],
   );
 
-  const clinic = appointment?.clinicFriendlyName
-    ? appointment?.clinicFriendlyName
-    : appointment?.clinicName;
+  const clinic = appointment && clinicName(appointment);
 
   return (
     <>

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -48,10 +48,16 @@ const AppointmentDetails = props => {
         text={t('back-to-appointments')}
       />
       <Wrapper classNames="appointment-details-page" withBackButton>
-        <div
-          className="vads-u-border--2px vads-u-border-color--gray-lighter vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2"
-          style={{ borderRadius: '20px' }}
-        >
+        <div className="appointment-details--container vads-u-margin-top--2 vads-u-border--2px vads-u-border-color--gray-lighter vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2">
+          <div className="appointment-details--icon">
+            <i
+              aria-label="Appointment type"
+              className={`fas ${
+                appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'
+              }`}
+              aria-hidden="true"
+            />
+          </div>
           <h1
             tabIndex="-1"
             data-testid="header"
@@ -61,7 +67,7 @@ const AppointmentDetails = props => {
               'appointment',
             )}`}
           </h1>
-          <p>
+          <p className="vads-u-margin--0">
             {isPhoneAppointment
               ? t('your-provider-will-call-you-at-your-appointment-time')
               : t(

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -1,0 +1,111 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import isValid from 'date-fns/isValid';
+
+import { useFormRouting } from '../../../hooks/useFormRouting';
+import {
+  makeSelectActiveAppointment,
+  makeSelectVeteranData,
+} from '../../../selectors';
+
+import Wrapper from '../../layout/Wrapper';
+import BackButton from '../../BackButton';
+
+const AppointmentDetails = props => {
+  const { router } = props;
+  const { t } = useTranslation();
+  const { goToPreviousPage, jumpToPage } = useFormRouting(router);
+  const selectVeteranData = useMemo(makeSelectVeteranData, []);
+  const selectActiveAppointment = useMemo(makeSelectActiveAppointment, []);
+  const { appointments } = useSelector(selectVeteranData);
+  const { activeAppointment } = useSelector(selectActiveAppointment);
+  const [appointment, setAppointment] = useState([]);
+
+  const appointmentDay = new Date(appointment.startTime);
+  const isPhoneAppointment = appointment?.kind === 'phone';
+
+  useEffect(
+    () => {
+      if (activeAppointment) {
+        setAppointment(
+          appointments.find(
+            appointmentItem =>
+              appointmentItem.appointmentIen === activeAppointment,
+          ),
+        );
+      } else {
+        jumpToPage('complete');
+      }
+    },
+    [activeAppointment, appointments, jumpToPage],
+  );
+  return (
+    <>
+      <BackButton
+        router={router}
+        action={goToPreviousPage}
+        text={t('back-to-appointments')}
+      />
+      <Wrapper classNames="appointment-details-page" withBackButton>
+        <div
+          className="vads-u-border--2px vads-u-border-color--gray-lighter vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2"
+          style={{ borderRadius: '20px' }}
+        >
+          <h1
+            tabIndex="-1"
+            data-testid="header"
+            className="vads-u-font-size--h3"
+          >
+            {`${isPhoneAppointment ? t('phone') : t('in-person')} ${t(
+              'appointment',
+            )}`}
+          </h1>
+          <p>
+            {isPhoneAppointment
+              ? t('your-provider-will-call-you-at-your-appointment-time')
+              : t(
+                  'please-bring-your-insurance-cards-with-you-to-your-appointment',
+                )}
+          </p>
+          <div className="appointment-details--when">
+            <h2 className="vads-u-font-size--sm">{t('when')}</h2>
+            {isValid(appointmentDay) &&
+              t('appointment-day', { date: appointmentDay })}
+          </div>
+          <div className="appointment-details--what">
+            <h2 className="vads-u-font-size--sm">{t('what')}</h2>
+            {appointment.clinicStopCodeName ?? t('VA-appointment')}
+          </div>
+          {appointment.doctorName && (
+            <div className="appointment-details--provider">
+              <h2 className="vads-u-font-size--sm">{t('Provider')}</h2>
+              {appointment.doctorName}
+            </div>
+          )}
+          <div className="appointment-details--where">
+            <h2 className="vads-u-font-size--sm">
+              {isPhoneAppointment ? t('clinic') : t('where-to-attend')}
+            </h2>
+          </div>
+          {appointment.clinicPhoneNumber && (
+            <div className="appointment-details--phone">
+              <h2 className="vads-u-font-size--sm">{t('phone')}</h2>
+              <va-telephone contact={appointment.clinicPhoneNumber}>
+                {appointment.clinicPhoneNumber}
+              </va-telephone>
+            </div>
+          )}
+          {appointment.reasonForVisit && (
+            <div className="appointment-details--reason">
+              <h2 className="vads-u-font-size--sm">{t('reason-for-visit')}</h2>
+              {appointment.reasonForVisit}
+            </div>
+          )}
+        </div>
+      </Wrapper>
+    </>
+  );
+};
+
+export default AppointmentDetails;

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import isValid from 'date-fns/isValid';
+import PropTypes from 'prop-types';
 
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import {
@@ -40,6 +41,10 @@ const AppointmentDetails = props => {
     },
     [activeAppointment, appointments, jumpToPage],
   );
+
+  const clinic = appointment.clinicFriendlyName
+    ? appointment.clinicFriendlyName
+    : appointment.clinicName;
   return (
     <>
       <BackButton
@@ -74,44 +79,74 @@ const AppointmentDetails = props => {
                   'please-bring-your-insurance-cards-with-you-to-your-appointment',
                 )}
           </p>
-          <div className="appointment-details--when">
+          <div data-testid="appointment-details--when">
             <h2 className="vads-u-font-size--sm">{t('when')}</h2>
-            {isValid(appointmentDay) &&
-              t('appointment-day', { date: appointmentDay })}
+            <div data-testid="appointment-details--date-value">
+              {isValid(appointmentDay) &&
+                t('appointment-day', { date: appointmentDay })}
+            </div>
           </div>
-          <div className="appointment-details--what">
+          <div data-testid="appointment-details--what">
             <h2 className="vads-u-font-size--sm">{t('what')}</h2>
-            {appointment.clinicStopCodeName ?? t('VA-appointment')}
+            <div data-testid="appointment-details--appointment-value">
+              {appointment.clinicStopCodeName ?? t('VA-appointment')}
+            </div>
           </div>
           {appointment.doctorName && (
-            <div className="appointment-details--provider">
+            <div data-testid="appointment-details--provider">
               <h2 className="vads-u-font-size--sm">{t('Provider')}</h2>
-              {appointment.doctorName}
+              <div data-testid="appointment-details--provider-value">
+                {appointment.doctorName}
+              </div>
             </div>
           )}
-          <div className="appointment-details--where">
+          <div data-testid="appointment-details--where">
             <h2 className="vads-u-font-size--sm">
               {isPhoneAppointment ? t('clinic') : t('where-to-attend')}
             </h2>
+            {/* TODO add address for in person appointments */}
+            <div data-testid="appointment-details--clinic-value">
+              {isPhoneAppointment ? '' : t('clinic')}: {clinic}
+            </div>
+            {isPhoneAppointment ? (
+              ''
+            ) : (
+              <div data-testid="appointment-details--location-value">
+                {`${t('location')}: ${appointment.clinicLocation}`}
+              </div>
+            )}
           </div>
           {appointment.clinicPhoneNumber && (
-            <div className="appointment-details--phone">
+            <div data-testid="appointment-details--phone">
               <h2 className="vads-u-font-size--sm">{t('phone')}</h2>
-              <va-telephone contact={appointment.clinicPhoneNumber}>
-                {appointment.clinicPhoneNumber}
-              </va-telephone>
+              <div data-testid="appointment-details--phone-value">
+                <i
+                  aria-label="phone"
+                  className="fas fa-phone vads-u-color--link-default vads-u-margin-right--1"
+                  aria-hidden="true"
+                />
+                <va-telephone contact={appointment.clinicPhoneNumber}>
+                  {appointment.clinicPhoneNumber}
+                </va-telephone>
+              </div>
             </div>
           )}
           {appointment.reasonForVisit && (
-            <div className="appointment-details--reason">
+            <div data-testid="appointment-details--reason">
               <h2 className="vads-u-font-size--sm">{t('reason-for-visit')}</h2>
-              {appointment.reasonForVisit}
+              <div data-testid="appointment-details--reason-value">
+                {appointment.reasonForVisit}
+              </div>
             </div>
           )}
         </div>
       </Wrapper>
     </>
   );
+};
+
+AppointmentDetails.propTypes = {
+  router: PropTypes.object,
 };
 
 export default AppointmentDetails;

--- a/src/applications/check-in/components/tests/AppointmentBlockVaos.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlockVaos.unit.spec.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
 import { I18nextProvider } from 'react-i18next';
+import configureStore from 'redux-mock-store';
 import i18n from '../../utils/i18n/i18n';
-import AppointmentBlock from '../AppointmentBlock';
+
+import AppointmentBlockVaos from '../AppointmentBlockVaos';
 
 const appointments = [
   {
@@ -28,23 +31,45 @@ const appointments = [
   },
 ];
 describe('pre-check-in', () => {
+  let mockRouter;
+  let store;
+  beforeEach(() => {
+    const middleware = [];
+    const mockStore = configureStore(middleware);
+    const initState = {
+      checkInData: {
+        context: {
+          token: '',
+        },
+        form: {
+          pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
+        },
+      },
+    };
+    store = mockStore(initState);
+
+    mockRouter = {
+      params: {
+        token: 'token-123',
+      },
+      location: {
+        pathname: '/third-page',
+      },
+    };
+  });
   describe('AppointmentBlock', () => {
     describe('In person appointment context', () => {
-      it('Renders appointment type label', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={appointments} page="confirmation" />
-          </I18nextProvider>,
-        );
-        expect(screen.getAllByTestId('appointment-type-label')[0]).to.have.text(
-          'In person',
-        );
-      });
       it('Renders appointment day for multiple appointments', () => {
         const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={appointments} page="intro" />
-          </I18nextProvider>,
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <AppointmentBlockVaos
+                appointments={appointments}
+                page="intro"
+                router={mockRouter}
+              />
+            </I18nextProvider>
+          </Provider>,
         );
         expect(screen.getByTestId('appointment-day-location')).to.have.text(
           'Your appointments are on November 16, 2021.',
@@ -56,12 +81,15 @@ describe('pre-check-in', () => {
       it('Renders appointment day and facility for single appointment', () => {
         const updateAppointments = [...appointments];
         const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock
-              appointments={[updateAppointments.shift()]}
-              page="intro"
-            />
-          </I18nextProvider>,
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <AppointmentBlockVaos
+                appointments={[updateAppointments.shift()]}
+                page="intro"
+                router={mockRouter}
+              />
+            </I18nextProvider>
+          </Provider>,
         );
         expect(screen.getByTestId('appointment-day-location')).to.have.text(
           'Your appointment is on November 16, 2021.',
@@ -71,160 +99,27 @@ describe('pre-check-in', () => {
           1,
         );
       });
-      it('Renders appointment facility, time, and clinic', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={appointments} page="intro" />
-          </I18nextProvider>,
-        );
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[0]
-            .querySelector('[data-testid="facility-name"]'),
-        ).to.have.text('LOMA LINDA VA CLINIC');
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[0]
-            .querySelector('[data-testid="appointment-time"]'),
-        ).to.have.text('9:39 p.m.');
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[0]
-            .querySelector('[data-testid="appointment-clinic"]'),
-        ).to.have.text('TEST CLINIC');
-      });
-      it('Renders clinicName if no clinicFriendlyName', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={appointments} page="intro" />
-          </I18nextProvider>,
-        );
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[1]
-            .querySelector('[data-testid="appointment-clinic"]'),
-        ).to.have.text('LOM ACC CLINIC TEST');
-      });
-      it('should render the appointment location for in person appointments when available', () => {
-        const locationAppointments = JSON.parse(JSON.stringify(appointments));
-        locationAppointments[0].clinicLocation = 'Test location';
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={locationAppointments} />
-          </I18nextProvider>,
-        );
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[0]
-            .querySelector('[data-testid="clinic-location"]'),
-        ).to.have.text('Test location');
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[1]
-            .querySelector('[data-testid="clinic-location"]'),
-        ).to.not.exist;
-      });
     });
     describe('Phone appointment context', () => {
       const phoneAppointments = JSON.parse(JSON.stringify(appointments));
       phoneAppointments[0].kind = 'phone';
       phoneAppointments[1].kind = 'phone';
-      it('Renders appointment type label', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock
-              appointments={phoneAppointments}
-              page="confirmation"
-            />
-          </I18nextProvider>,
-        );
-        expect(screen.getAllByTestId('appointment-type-label')[0]).to.have.text(
-          'Phone Call',
-        );
-      });
+
       it('Renders appointment time with no clinic for phone appointments', () => {
         const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock
-              appointments={phoneAppointments}
-              page="confirmation"
-            />
-          </I18nextProvider>,
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <AppointmentBlockVaos
+                appointments={phoneAppointments}
+                page="confirmation"
+                router={mockRouter}
+              />
+            </I18nextProvider>
+          </Provider>,
         );
         expect(screen.getByTestId('appointment-day-location')).to.have.text(
           'Your appointments are on November 16, 2021.',
         );
-      });
-      it('Renders phone message with appointment on confirmation page', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock
-              appointments={phoneAppointments}
-              page="confirmation"
-            />
-          </I18nextProvider>,
-        );
-        expect(screen.getAllByTestId('appointment-message')[0]).to.have.text(
-          'Your provider will call you at your appointment time. You may need to wait about 15 minutes for their call. Thanks for your patience.',
-        );
-      });
-      it('Renders phone message with appointment on intro page', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={phoneAppointments} page="intro" />
-          </I18nextProvider>,
-        );
-        expect(screen.getAllByTestId('appointment-message')[0]).to.have.text(
-          'Your provider will call you.',
-        );
-      });
-      it('Does not render facility name', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={phoneAppointments} page="intro" />
-          </I18nextProvider>,
-        );
-        expect(screen.queryByTestId('facility-name')).to.not.exist;
-      });
-      it('should render the type of care when available or default', () => {
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={appointments} />
-          </I18nextProvider>,
-        );
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[0]
-            .querySelector('[data-testid="type-of-care"]'),
-        ).to.have.text('Primary care');
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[1]
-            .querySelector('[data-testid="type-of-care"]'),
-        ).to.have.text('VA Appointment');
-      });
-      it('should not render the appointment location for phone appointments even when available', () => {
-        const phoneLocationAppointments = JSON.parse(
-          JSON.stringify(appointments),
-        );
-        phoneLocationAppointments[0].clinicLocation = 'Test location';
-        phoneLocationAppointments[0].kind = 'phone';
-        phoneLocationAppointments[1].kind = 'phone';
-        const screen = render(
-          <I18nextProvider i18n={i18n}>
-            <AppointmentBlock appointments={phoneLocationAppointments} />
-          </I18nextProvider>,
-        );
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[0]
-            .querySelector('[data-testid="clinic-location"]'),
-        ).to.not.exist;
-        expect(
-          screen
-            .getAllByTestId('appointment-list-item')[1]
-            .querySelector('[data-testid="clinic-location"]'),
-        ).to.not.exist;
       });
     });
   });

--- a/src/applications/check-in/components/tests/AppointmentBlockVaos.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlockVaos.unit.spec.jsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../utils/i18n/i18n';
+import AppointmentBlock from '../AppointmentBlock';
+
+const appointments = [
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien',
+    startTime: '2021-11-16T21:39:36',
+    doctorName: 'Dr. Green',
+    clinicStopCodeName: 'Primary care',
+    kind: 'clinic',
+  },
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: '',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien2',
+    startTime: '2021-11-16T23:00:00',
+    kind: 'clinic',
+  },
+];
+describe('pre-check-in', () => {
+  describe('AppointmentBlock', () => {
+    describe('In person appointment context', () => {
+      it('Renders appointment type label', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={appointments} page="confirmation" />
+          </I18nextProvider>,
+        );
+        expect(screen.getAllByTestId('appointment-type-label')[0]).to.have.text(
+          'In person',
+        );
+      });
+      it('Renders appointment day for multiple appointments', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={appointments} page="intro" />
+          </I18nextProvider>,
+        );
+        expect(screen.getByTestId('appointment-day-location')).to.have.text(
+          'Your appointments are on November 16, 2021.',
+        );
+        expect(screen.getAllByTestId('appointment-list-item').length).to.equal(
+          2,
+        );
+      });
+      it('Renders appointment day and facility for single appointment', () => {
+        const updateAppointments = [...appointments];
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock
+              appointments={[updateAppointments.shift()]}
+              page="intro"
+            />
+          </I18nextProvider>,
+        );
+        expect(screen.getByTestId('appointment-day-location')).to.have.text(
+          'Your appointment is on November 16, 2021.',
+        );
+
+        expect(screen.getAllByTestId('appointment-list-item').length).to.equal(
+          1,
+        );
+      });
+      it('Renders appointment facility, time, and clinic', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={appointments} page="intro" />
+          </I18nextProvider>,
+        );
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="facility-name"]'),
+        ).to.have.text('LOMA LINDA VA CLINIC');
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="appointment-time"]'),
+        ).to.have.text('9:39 p.m.');
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="appointment-clinic"]'),
+        ).to.have.text('TEST CLINIC');
+      });
+      it('Renders clinicName if no clinicFriendlyName', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={appointments} page="intro" />
+          </I18nextProvider>,
+        );
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[1]
+            .querySelector('[data-testid="appointment-clinic"]'),
+        ).to.have.text('LOM ACC CLINIC TEST');
+      });
+      it('should render the appointment location for in person appointments when available', () => {
+        const locationAppointments = JSON.parse(JSON.stringify(appointments));
+        locationAppointments[0].clinicLocation = 'Test location';
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={locationAppointments} />
+          </I18nextProvider>,
+        );
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="clinic-location"]'),
+        ).to.have.text('Test location');
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[1]
+            .querySelector('[data-testid="clinic-location"]'),
+        ).to.not.exist;
+      });
+    });
+    describe('Phone appointment context', () => {
+      const phoneAppointments = JSON.parse(JSON.stringify(appointments));
+      phoneAppointments[0].kind = 'phone';
+      phoneAppointments[1].kind = 'phone';
+      it('Renders appointment type label', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock
+              appointments={phoneAppointments}
+              page="confirmation"
+            />
+          </I18nextProvider>,
+        );
+        expect(screen.getAllByTestId('appointment-type-label')[0]).to.have.text(
+          'Phone Call',
+        );
+      });
+      it('Renders appointment time with no clinic for phone appointments', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock
+              appointments={phoneAppointments}
+              page="confirmation"
+            />
+          </I18nextProvider>,
+        );
+        expect(screen.getByTestId('appointment-day-location')).to.have.text(
+          'Your appointments are on November 16, 2021.',
+        );
+      });
+      it('Renders phone message with appointment on confirmation page', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock
+              appointments={phoneAppointments}
+              page="confirmation"
+            />
+          </I18nextProvider>,
+        );
+        expect(screen.getAllByTestId('appointment-message')[0]).to.have.text(
+          'Your provider will call you at your appointment time. You may need to wait about 15 minutes for their call. Thanks for your patience.',
+        );
+      });
+      it('Renders phone message with appointment on intro page', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={phoneAppointments} page="intro" />
+          </I18nextProvider>,
+        );
+        expect(screen.getAllByTestId('appointment-message')[0]).to.have.text(
+          'Your provider will call you.',
+        );
+      });
+      it('Does not render facility name', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={phoneAppointments} page="intro" />
+          </I18nextProvider>,
+        );
+        expect(screen.queryByTestId('facility-name')).to.not.exist;
+      });
+      it('should render the type of care when available or default', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={appointments} />
+          </I18nextProvider>,
+        );
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="type-of-care"]'),
+        ).to.have.text('Primary care');
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[1]
+            .querySelector('[data-testid="type-of-care"]'),
+        ).to.have.text('VA Appointment');
+      });
+      it('should not render the appointment location for phone appointments even when available', () => {
+        const phoneLocationAppointments = JSON.parse(
+          JSON.stringify(appointments),
+        );
+        phoneLocationAppointments[0].clinicLocation = 'Test location';
+        phoneLocationAppointments[0].kind = 'phone';
+        phoneLocationAppointments[1].kind = 'phone';
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentBlock appointments={phoneLocationAppointments} />
+          </I18nextProvider>,
+        );
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[0]
+            .querySelector('[data-testid="clinic-location"]'),
+        ).to.not.exist;
+        expect(
+          screen
+            .getAllByTestId('appointment-list-item')[1]
+            .querySelector('[data-testid="clinic-location"]'),
+        ).to.not.exist;
+      });
+    });
+  });
+});

--- a/src/applications/check-in/components/tests/AppointmentListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentListItem.unit.spec.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import sinon from 'sinon';
+import i18n from '../../utils/i18n/i18n';
+import AppointmentListItem from '../AppointmentListItem';
+
+const appointments = [
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien',
+    startTime: '2021-11-16T21:39:36',
+    doctorName: 'Dr. Green',
+    clinicStopCodeName: 'Primary care',
+    kind: 'clinic',
+  },
+  {
+    facility: 'LOMA LINDA VA CLINIC',
+    clinicPhoneNumber: '5551234567',
+    clinicFriendlyName: 'TEST CLINIC',
+    clinicName: 'LOM ACC CLINIC TEST',
+    appointmentIen: 'some-ien',
+    startTime: '2021-11-16T21:39:36',
+    doctorName: 'Dr. Green',
+    clinicStopCodeName: 'Primary care',
+    kind: 'phone',
+  },
+];
+describe('pre-check-in', () => {
+  describe('AppointmentListItem', () => {
+    describe('In person appointment context', () => {
+      it('Renders appointment details', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentListItem appointment={appointments[0]} />
+          </I18nextProvider>,
+        );
+        expect(screen.getByTestId('appointment-time')).to.have.text(
+          '9:39 p.m.',
+        );
+        expect(
+          screen.getByTestId('appointment-type-and-provider'),
+        ).to.have.text('Primary care with Dr. Green');
+        expect(
+          screen.getByTestId('appointment-kind-and-location'),
+        ).to.have.text(
+          'In person at LOMA LINDA VA CLINIC  Clinic: TEST CLINIC',
+        );
+      });
+    });
+    describe('Phone appointment context', () => {
+      it('Renders appointment details', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentListItem appointment={appointments[1]} />
+          </I18nextProvider>,
+        );
+        expect(screen.getByTestId('appointment-time')).to.have.text(
+          '9:39 p.m.',
+        );
+        expect(
+          screen.getByTestId('appointment-type-and-provider'),
+        ).to.have.text('Primary care with Dr. Green');
+        expect(
+          screen.getByTestId('appointment-kind-and-location'),
+        ).to.have.text('Phone');
+      });
+    });
+    describe('Details link', () => {
+      it("Doesn't show if no function", () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentListItem appointment={appointments[0]} />
+          </I18nextProvider>,
+        );
+        expect(screen.queryByTestId('details-link')).to.not.exist;
+      });
+      it('Does show if function', () => {
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentListItem
+              appointment={appointments[0]}
+              goToDetails={() => {}}
+            />
+          </I18nextProvider>,
+        );
+        expect(screen.queryByTestId('details-link')).to.exist;
+      });
+      it('Fires go to details function', () => {
+        const goToDetails = sinon.spy();
+        const screen = render(
+          <I18nextProvider i18n={i18n}>
+            <AppointmentListItem
+              appointment={appointments[0]}
+              goToDetails={goToDetails}
+            />
+          </I18nextProvider>,
+        );
+        fireEvent.click(screen.getByTestId('details-link'));
+        expect(goToDetails.calledOnce).to.be.true;
+      });
+    });
+  });
+});

--- a/src/applications/check-in/components/tests/BackButton.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/BackButton.unit.spec.jsx
@@ -81,5 +81,19 @@ describe('check-in', () => {
       );
       expect(screen.queryByTestId('back-button')).to.not.exist;
     });
+    it('renders custom text', () => {
+      const screen = render(
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <BackButton
+              action={() => {}}
+              router={() => {}}
+              text="go back test"
+            />
+          </I18nextProvider>
+        </Provider>,
+      );
+      expect(screen.getByTestId('back-button')).to.have.text('go back test');
+    });
   });
 });

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -214,7 +214,6 @@
   "appointment": "appointment",
   "when": "When",
   "what": "What",
-  "Provider": "Provider",
   "where-to-attend": "Where to attend",
   "reason-for-visit": "Reason for visit",
   "appointment-day": "{{ date, day }}, {{ date, monthDay }} at {{ date, time }}",

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -210,5 +210,13 @@
   "travel-pay-reimbursement--info-message": "VA travel pay reimbursement pays eligible Veterans and caregivers back for mileage and other travel expenses to and from approved health care appointments.",
   "find-out-how-to-file--link": "Find out how to file for travel reimbursement",
   "pre-check-in-no-longer-available--info-message": "We’re sorry. Pre-check-in is no longer available for your appointment time. Ask a staff member for help to check in.",
-  "with": "with"
+  "with": "with",
+  "appointment": "appointment",
+  "when": "When",
+  "what": "What",
+  "Provider": "Provider",
+  "where-to-attend": "Where to attend",
+  "reason-for-visit": "Reason for visit",
+  "appointment-day": "{{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
+  "back-to-appointments": "Back to appointments"
 }

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -209,5 +209,6 @@
   "or-call-our-BTSSS-toll-free-call-center": "Or call our BTSSS toll-free call center at <0></0> (<1></1>). We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.",
   "travel-pay-reimbursement--info-message": "VA travel pay reimbursement pays eligible Veterans and caregivers back for mileage and other travel expenses to and from approved health care appointments.",
   "find-out-how-to-file--link": "Find out how to file for travel reimbursement",
-  "pre-check-in-no-longer-available--info-message": "We’re sorry. Pre-check-in is no longer available for your appointment time. Ask a staff member for help to check in."
+  "pre-check-in-no-longer-available--info-message": "We’re sorry. Pre-check-in is no longer available for your appointment time. Ask a staff member for help to check in.",
+  "with": "with"
 }

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -16,7 +16,8 @@ import {
   makeSelectVeteranData,
 } from '../../../selectors';
 
-const Confirmation = () => {
+const Confirmation = props => {
+  const { router } = props;
   const [isLoading, setIsLoading] = useState(false);
   const { getPreCheckinComplete, setPreCheckinComplete } = useSessionStorage();
 
@@ -94,6 +95,7 @@ const Confirmation = () => {
       appointments={appointments}
       isLoading={isLoading}
       formData={formData}
+      router={router}
     />
   );
 };

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import { focusElement } from 'platform/utilities/ui';
 
@@ -98,6 +99,10 @@ const Confirmation = props => {
       router={router}
     />
   );
+};
+
+Confirmation.propTypes = {
+  router: PropTypes.object,
 };
 
 export default Confirmation;

--- a/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
@@ -8,10 +8,12 @@ import { VaModal } from '@department-of-veterans-affairs/web-components/react-bi
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 
 import AppointmentBlock from '../../../components/AppointmentBlock';
+import AppointmentBlockVaos from '../../../components/AppointmentBlockVaos';
 
 import { useFormRouting } from '../../../hooks/useFormRouting';
 
 import { makeSelectVeteranData } from '../../../selectors';
+import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
 
 import ExternalLink from '../../../components/ExternalLink';
 import Wrapper from '../../../components/layout/Wrapper';
@@ -23,7 +25,12 @@ const IntroductionDisplay = props => {
   const { t } = useTranslation();
   const { goToNextPage } = useFormRouting(router);
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+
   const { appointments } = useSelector(selectVeteranData);
+  const { isUpdatedApptPresentationEnabled } = useSelector(
+    selectFeatureToggles,
+  );
 
   const [privacyActModalOpen, setPrivacyActModalOpen] = useState(false);
 
@@ -101,7 +108,11 @@ const IntroductionDisplay = props => {
       <p className="vads-u-font-family--serif">
         {t('your-answers-will-help-us-better-prepare-for-your-needs')}
       </p>
-      <AppointmentBlock appointments={appointments} page="intro" />
+      {isUpdatedApptPresentationEnabled ? (
+        <AppointmentBlockVaos appointments={appointments} page="intro" />
+      ) : (
+        <AppointmentBlock appointments={appointments} page="intro" />
+      )}
 
       <h2 className="vads-u-margin-top--6">{t('start-here')}</h2>
       <StartButton />

--- a/src/applications/check-in/pre-check-in/routes.jsx
+++ b/src/applications/check-in/pre-check-in/routes.jsx
@@ -10,6 +10,7 @@ import Confirmation from './pages/Confirmation';
 import Landing from './pages/Landing';
 import Error from './pages/Error';
 import ErrorTest from './pages/ErrorTest';
+import AppointmentDetails from '../components/pages/AppointmentDetails';
 import { URLS } from '../utils/navigation';
 
 import withFeatureFlip from '../containers/withFeatureFlip';
@@ -80,6 +81,15 @@ const routes = [
   {
     path: URLS.ERROR,
     component: Error,
+  },
+  {
+    path: URLS.APPOINTMENT_DETAILS,
+    component: AppointmentDetails,
+    permissions: {
+      requiresForm: true,
+      requireAuthorization: true,
+    },
+    reloadable: true,
   },
 ];
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -1,0 +1,110 @@
+import '../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
+import Introduction from '../pages/Introduction';
+import Demographics from '../../../../tests/e2e/pages/Demographics';
+import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
+import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
+import Confirmation from '../pages/Confirmation';
+import AppointmentDetails from '../../../../tests/e2e/pages/AppointmentDetails';
+
+describe('Pre-Check In Experience', () => {
+  describe('Appointment details in person', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializePreCheckInDataGet,
+        initializePreCheckInDataPost,
+      } = ApiInitializer;
+      initializeFeatureToggle.withDetailsPage();
+      initializeSessionGet.withSuccessfulNewSession();
+
+      initializeSessionPost.withSuccess();
+      initializePreCheckInDataGet.withSuccess();
+
+      initializePreCheckInDataPost.withSuccess();
+
+      cy.visitPreCheckInWithUUID();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Introduction.validatePageLoaded();
+      Introduction.attemptToGoToNextPage();
+      Demographics.validatePageLoaded();
+      Demographics.attemptToGoToNextPage();
+      EmergencyContact.validatePageLoaded();
+      EmergencyContact.attemptToGoToNextPage();
+      NextOfKin.validatePageLoaded();
+      NextOfKin.attemptToGoToNextPage();
+      Confirmation.validatePageContent();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('Appointment details page content loads for in person appointment', () => {
+      Confirmation.clickDetails();
+      AppointmentDetails.validatePageLoadedInPerson();
+      AppointmentDetails.validateSubtitleInPerson();
+      AppointmentDetails.validateWhen();
+      AppointmentDetails.validateWhat();
+      AppointmentDetails.validateProvider();
+      AppointmentDetails.validateWhere();
+      AppointmentDetails.validatePhone();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  describe('Appointment details in phone', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializePreCheckInDataGet,
+        initializePreCheckInDataPost,
+      } = ApiInitializer;
+      initializeFeatureToggle.withDetailsPage();
+      initializeSessionGet.withSuccessfulNewSession();
+
+      initializeSessionPost.withSuccess();
+      initializePreCheckInDataGet.withSuccess({
+        uuid: '258d753c-262a-4ab2-b618-64b645884daf',
+      });
+
+      initializePreCheckInDataPost.withSuccess();
+
+      cy.visitPreCheckInWithUUID('258d753c-262a-4ab2-b618-64b645884daf');
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Introduction.validatePageLoaded();
+      Introduction.attemptToGoToNextPage();
+      Demographics.validatePageLoaded();
+      Demographics.attemptToGoToNextPage();
+      EmergencyContact.validatePageLoaded();
+      EmergencyContact.attemptToGoToNextPage();
+      NextOfKin.validatePageLoaded();
+      NextOfKin.attemptToGoToNextPage();
+      Confirmation.validatePageContent();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('Appointment details page content loads for phone appointment', () => {
+      Confirmation.clickDetails();
+      AppointmentDetails.validatePageLoadedPhone();
+      AppointmentDetails.validateSubtitlePhone();
+      AppointmentDetails.validateWhen();
+      AppointmentDetails.validateWhat();
+      AppointmentDetails.validateProvider();
+      AppointmentDetails.validateWhere('phone');
+      AppointmentDetails.validatePhone();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
@@ -107,6 +107,12 @@ class Confirmation {
       });
     }
   };
+
+  clickDetails = (appointment = 1) => {
+    cy.get(`li:nth-child(${appointment}) [data-testid="details-link"]`).click({
+      waitForAnimations: true,
+    });
+  };
 }
 
 export default new Confirmation();

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -7,10 +7,10 @@ const initialState = {
   form: {
     pages: [],
     data: {},
+    activeAppointment: null,
   },
   app: '',
   error: '',
-  activeAppointment: null,
 };
 
 import {

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -10,6 +10,7 @@ const initialState = {
   },
   app: '',
   error: '',
+  activeAppointment: null,
 };
 
 import {
@@ -36,7 +37,12 @@ import {
   seeStaffMessageUpdatedHandler,
 } from './day-of';
 
-import { setAppHandler, setErrorHandler, setFormHandler } from './universal';
+import {
+  setAppHandler,
+  setErrorHandler,
+  setFormHandler,
+  setActiveAppointmentHandler,
+} from './universal';
 
 import { INIT_FORM } from '../actions/navigation';
 
@@ -51,6 +57,7 @@ import {
   RECORD_ANSWER,
   SET_ERROR,
   SET_FORM,
+  SET_ACTIVE_APPOINTMENT,
 } from '../actions/universal';
 
 const handler = Object.freeze({
@@ -68,6 +75,7 @@ const handler = Object.freeze({
   [SET_APP]: setAppHandler,
   [SET_ERROR]: setErrorHandler,
   [SET_FORM]: setFormHandler,
+  [SET_ACTIVE_APPOINTMENT]: setActiveAppointmentHandler,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/reducers/pre-check-in/pre-check-in.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/pre-check-in/pre-check-in.reducers.unit.spec.js
@@ -135,6 +135,7 @@ describe('check in', () => {
             'emergency-contact',
             'next-of-kin',
             'complete',
+            'appointment-details',
           ]);
         });
       });

--- a/src/applications/check-in/reducers/reducer.unit.spec.js
+++ b/src/applications/check-in/reducers/reducer.unit.spec.js
@@ -17,6 +17,7 @@ describe('check in', () => {
           form: {
             pages: [],
             data: {},
+            activeAppointment: null,
           },
           error: '',
         });

--- a/src/applications/check-in/reducers/universal/index.js
+++ b/src/applications/check-in/reducers/universal/index.js
@@ -9,4 +9,13 @@ const setErrorHandler = (state, action) => {
 const setFormHandler = (state, action) => {
   return { ...state, ...action.payload };
 };
-export { setAppHandler, setErrorHandler, setFormHandler };
+
+const setActiveAppointmentHandler = (state, action) => {
+  return { ...state, ...action.payload };
+};
+export {
+  setAppHandler,
+  setErrorHandler,
+  setFormHandler,
+  setActiveAppointmentHandler,
+};

--- a/src/applications/check-in/reducers/universal/index.js
+++ b/src/applications/check-in/reducers/universal/index.js
@@ -9,9 +9,14 @@ const setErrorHandler = (state, action) => {
 const setFormHandler = (state, action) => {
   return { ...state, ...action.payload };
 };
-
 const setActiveAppointmentHandler = (state, action) => {
-  return { ...state, ...action.payload };
+  return {
+    ...state,
+    form: {
+      ...state.form,
+      activeAppointment: action.payload,
+    },
+  };
 };
 export {
   setAppHandler,

--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -80,7 +80,7 @@ va-text-input[error]:not([error=""])::part(span)  {
 .appointment-details--icon {
   height: 40px;
   width: 40px;
-  background: $color-black;
+  background: $color-gray-dark;
   border-radius: 20px;
   display: flex;
   align-items: center;

--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -73,3 +73,21 @@ va-text-input[error]:not([error=""])::part(label) ,
 va-text-input[error]:not([error=""])::part(span)  {
   margin-top: 3rem;
 }
+.appointment-details--container {
+  position: relative;
+  border-radius: 15px;
+}
+.appointment-details--icon {
+  height: 40px;
+  width: 40px;
+  background: $color-black;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $color-white;
+  font-size: 20px;
+  position: absolute;
+  top: -20px;
+  left: calc(50% - 20px);
+}

--- a/src/applications/check-in/selectors/index.js
+++ b/src/applications/check-in/selectors/index.js
@@ -69,6 +69,17 @@ const selectError = createSelector(
 
 const makeSelectError = () => selectError;
 
+const selectActiveAppointment = createSelector(
+  state => {
+    return {
+      activeAppointment: state?.checkInData?.activeAppointment,
+    };
+  },
+  activeAppointment => activeAppointment,
+);
+
+const makeSelectActiveAppointment = () => selectActiveAppointment;
+
 export {
   makeSelectCurrentContext,
   makeSelectForm,
@@ -77,4 +88,5 @@ export {
   makeSelectSeeStaffMessage,
   makeSelectApp,
   makeSelectError,
+  makeSelectActiveAppointment,
 };

--- a/src/applications/check-in/selectors/index.js
+++ b/src/applications/check-in/selectors/index.js
@@ -72,7 +72,7 @@ const makeSelectError = () => selectError;
 const selectActiveAppointment = createSelector(
   state => {
     return {
-      activeAppointment: state?.checkInData?.activeAppointment,
+      activeAppointment: state?.checkInData?.form?.activeAppointment,
     };
   },
   activeAppointment => activeAppointment,

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -1,0 +1,79 @@
+import Timeouts from 'platform/testing/e2e/timeouts';
+
+class AppointmentDetails {
+  validatePageLoadedInPerson = () => {
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('include.text', 'In person appointment');
+  };
+
+  validatePageLoadedPhone = () => {
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('include.text', 'Phone appointment');
+  };
+
+  validateSubtitleInPerson = () => {
+    cy.get('p[data-testid="in-person-appointment-subtitle"]').should(
+      'be.visible',
+    );
+  };
+
+  validateSubtitlePhone = () => {
+    cy.get('p[data-testid="phone-appointment-subtitle"]').should('be.visible');
+  };
+
+  validateWhen = () => {
+    cy.get('div[data-testid="appointment-details--when"]').should('be.visible');
+    cy.get('div[data-testid="appointment-details--date-value"]').should(
+      'be.visible',
+    );
+  };
+
+  validateWhat = () => {
+    cy.get('div[data-testid="appointment-details--what"]').should('be.visible');
+    cy.get('div[data-testid="appointment-details--appointment-value"]').should(
+      'be.visible',
+    );
+  };
+
+  validateProvider = () => {
+    cy.get('div[data-testid="appointment-details--provider"]').should(
+      'be.visible',
+    );
+    cy.get('div[data-testid="appointment-details--provider-value"]').should(
+      'be.visible',
+    );
+  };
+
+  validateWhere = (type = 'in-person') => {
+    cy.get('div[data-testid="appointment-details--where"]').should(
+      'be.visible',
+    );
+    cy.get('div[data-testid="appointment-details--clinic-value"]').should(
+      'be.visible',
+    );
+    if (type === 'in-person') {
+      cy.get('div[data-testid="appointment-details--location-value"]').should(
+        'be.visible',
+      );
+    }
+  };
+
+  validatePhone = () => {
+    cy.get('div[data-testid="appointment-details--phone"]').should(
+      'be.visible',
+    );
+    cy.get('div[data-testid="appointment-details--phone-value"]').should(
+      'be.visible',
+    );
+  };
+
+  returnToAppointmentsPage = () => {
+    cy.get('button[data-testid="back-button"]').click({
+      waitForAnimations: true,
+    });
+  };
+}
+
+export default new AppointmentDetails();

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
 import MockDate from 'mockdate';
 import {
   appointmentWasCanceled,
@@ -10,6 +11,7 @@ import {
   preCheckinExpired,
   locationShouldBeDisplayed,
   hasPhoneAppointments,
+  appointmentIcon,
 } from './index';
 
 import { get } from '../../api/local-mock-api/mocks/v2/shared';
@@ -381,6 +383,14 @@ describe('check in', () => {
       it("doesn't find phone appointment", () => {
         const appointments = [createAppointment()];
         expect(hasPhoneAppointments(appointments)).to.be.false;
+      });
+    });
+    describe('appointmentIcon', () => {
+      it('finds phone appointment', () => {
+        const appointment = createAppointment({ kind: 'phone' });
+        const icon = render(appointmentIcon(appointment));
+
+        expect(icon.getByTestId('appointment-icon')).to.have.class('fa-phone');
       });
     });
   });

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -12,6 +12,7 @@ import {
   locationShouldBeDisplayed,
   hasPhoneAppointments,
   appointmentIcon,
+  clinicName,
 } from './index';
 
 import { get } from '../../api/local-mock-api/mocks/v2/shared';
@@ -391,6 +392,18 @@ describe('check in', () => {
         const icon = render(appointmentIcon(appointment));
 
         expect(icon.getByTestId('appointment-icon')).to.have.class('fa-phone');
+      });
+    });
+    describe('clinicName', () => {
+      it('returns clinic friendly name', () => {
+        const appointment = createAppointment({
+          clinicFriendlyName: 'test clinic',
+        });
+        expect(clinicName(appointment)).to.equal('test clinic');
+      });
+      it('returns the fallback if friendly name missing', () => {
+        const appointment = createAppointment({ clinicFriendlyName: '' });
+        expect(clinicName(appointment)).to.equal('LOM ACC CLINIC TEST');
       });
     });
   });

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { parseISO, startOfDay } from 'date-fns';
 import { ELIGIBILITY } from './eligibility';
 import { VISTA_CHECK_IN_STATUS_IENS } from '../appConstants';
@@ -188,6 +189,26 @@ const hasPhoneAppointments = appointments => {
   });
 };
 
+/**
+ * Render the appointment type icon
+ *
+ * @param {Appointment} appointment
+ * @returns {Node}
+ */
+
+const appointmentIcon = appointment => {
+  return (
+    <i
+      aria-label="Appointment type"
+      className={`fas ${
+        appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'
+      }`}
+      aria-hidden="true"
+      data-testid="appointment-icon"
+    />
+  );
+};
+
 export {
   appointmentStartTimePast15,
   appointmentWasCanceled,
@@ -200,4 +221,5 @@ export {
   removeTimeZone,
   preCheckinExpired,
   hasPhoneAppointments,
+  appointmentIcon,
 };

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -209,6 +209,19 @@ const appointmentIcon = appointment => {
   );
 };
 
+/**
+ * Return the name to use for appointment clinic.
+ *
+ * @param {Appointment} appointment
+ * @returns {string}
+ */
+
+const clinicName = appointment => {
+  return appointment.clinicFriendlyName
+    ? appointment.clinicFriendlyName
+    : appointment.clinicName;
+};
+
 export {
   appointmentStartTimePast15,
   appointmentWasCanceled,
@@ -222,4 +235,5 @@ export {
   preCheckinExpired,
   hasPhoneAppointments,
   appointmentIcon,
+  clinicName,
 };

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -59,6 +59,12 @@ i18n
           if (format === 'time') {
             return formatDate(value, 'h:mm aaaa', { locale });
           }
+          if (format === 'day') {
+            return formatDate(value, 'iiii', { locale });
+          }
+          if (format === 'monthDay') {
+            return formatDate(value, "MMMM' 'dd", { locale });
+          }
           return formatDate(value, format, { locale });
         }
         return value;

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -90,6 +90,7 @@ const URLS = Object.freeze({
   TRAVEL_VEHICLE: 'travel-vehicle',
   TRAVEL_ADDRESS: 'travel-address',
   TRAVEL_MILEAGE: 'travel-mileage',
+  APPOINTMENT_DETAILS: 'appointment-details',
 });
 
 export { updateFormPages, URLS };

--- a/src/applications/check-in/utils/navigation/pre-check-in/index.js
+++ b/src/applications/check-in/utils/navigation/pre-check-in/index.js
@@ -33,6 +33,10 @@ const PRE_CHECK_IN_FORM_PAGES = Object.freeze([
     url: URLS.CONFIRMATION,
     order: 5,
   },
+  {
+    url: URLS.APPOINTMENT_DETAILS,
+    order: 6,
+  },
 ]);
 
 const getPagesInOrder = () =>


### PR DESCRIPTION
## Summary
Adds new appointment block layout and details page behind feature flag `check_in_experience_updated_appt_presentation`

Updates routing and redux store to control and show the selected appointment.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50993

## Testing done

Adds unit and cypress tests


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

