### PR TITLE
[department-of-veterans-affairs/va-virtual-agent#776] Fix star rating clipping on tablet screens

### DIFF
--- a/src/applications/virtual-agent/components/page/Page.jsx
+++ b/src/applications/virtual-agent/components/page/Page.jsx
@@ -6,10 +6,10 @@ export default function Page() {
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
       <div className="vads-l-row vads-u-margin-x--neg2p5 vads-u-margin-y--4">
-        <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--7">
+        <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--5 small-desktop-screen:vads-l-col--7">
           <Disclaimer />
         </div>
-        <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--5">
+        <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--7 small-desktop-screen:vads-l-col--5">
           <Chatbox />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- There is a visual bug on tablet screens when a user submits the customer satisfication survey at the end of the conversation. The star rating is clipped so the user cannot select 4 or 5. This PR fixes the bug.
- This is work for VA Chatbot team. We own the modified components.

## Related issue(s)
- department-of-veterans-affairs/va-virtual-agent#776


## Testing done

- Manual testing completed

## What areas of the site does it impact?
VA Chatbot page
