### PR TITLE
MHV-39000: Anchor to top fix feature finished

### DIFF
--- a/src/applications/mhv/secure-messaging/components/shared/ScrollToTop.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/ScrollToTop.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+const ScrollToTop = props => {
+  const location = useLocation();
+  useEffect(
+    () => {
+      if (!location.hash) {
+        window.scrollTo(0, 0);
+      }
+    },
+    [location],
+  );
+
+  return <>{props.children}</>;
+};
+
+ScrollToTop.propTypes = {
+  children: PropTypes.any,
+};
+
+export default ScrollToTop;

--- a/src/applications/mhv/secure-messaging/containers/App.jsx
+++ b/src/applications/mhv/secure-messaging/containers/App.jsx
@@ -11,6 +11,7 @@ import LandingPageUnauth from './LandingPageUnauth';
 import MessageFAQs from './MessageFAQs';
 import SmBreadcrumbs from '../components/shared/SmBreadcrumbs';
 import Navigation from '../components/Navigation';
+import ScrollToTop from '../components/shared/ScrollToTop';
 
 const App = () => {
   const dispatch = useDispatch();
@@ -50,8 +51,8 @@ const App = () => {
               {/* toggle log in and out state without using va.gov sign in, to show the toggle button, comment out the visibility:hidden style */}
               <button
                 style={{
-                  // visibility: 'hidden',
-                  'z-index': '2',
+                  visibility: 'hidden',
+                  zIndex: '2',
                   width: '100px',
                   position: 'absolute',
                   top: '0',
@@ -62,6 +63,7 @@ const App = () => {
               >
                 {isLoggedIn ? <>log out</> : <>log in</>}
               </button>
+              <ScrollToTop />
               <Switch>
                 <Route path="/faq" key="MessageFAQ">
                   <MessageFAQs isLoggedIn={isLoggedIn} />

--- a/src/applications/mhv/secure-messaging/containers/App.jsx
+++ b/src/applications/mhv/secure-messaging/containers/App.jsx
@@ -52,7 +52,7 @@ const App = () => {
               <button
                 style={{
                   visibility: 'hidden',
-                  zIndex: '2',
+                  'z-index': '2',
                   width: '100px',
                   position: 'absolute',
                   top: '0',

--- a/src/applications/mhv/secure-messaging/containers/AuthorizedRoutes.jsx
+++ b/src/applications/mhv/secure-messaging/containers/AuthorizedRoutes.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
+import ScrollToTop from '../components/shared/ScrollToTop';
 import Compose from './Compose';
 import FolderListView from './FolderListView';
 import Folders from './Folders';
@@ -11,6 +12,7 @@ import SearchResults from './SearchResults';
 const AuthorizedRoutes = () => {
   return (
     <div className="vads-u-flex--fill">
+      <ScrollToTop />
       <Switch>
         <Route exact path="/" key="App">
           <LandingPageAuth />

--- a/src/applications/mhv/secure-messaging/containers/Compose.jsx
+++ b/src/applications/mhv/secure-messaging/containers/Compose.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams, useHistory } from 'react-router-dom';
-import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { clearDraft } from '../actions/draftDetails';
 import { retrieveMessage } from '../actions/messages';
 import { getTriageTeams } from '../actions/triageTeams';
@@ -54,13 +53,6 @@ const Compose = () => {
       }
     },
     [messageHistory],
-  );
-
-  useEffect(
-    () => {
-      focusElement(header.current);
-    },
-    [header],
   );
 
   let pageTitle;

--- a/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
+++ b/src/applications/mhv/secure-messaging/containers/SearchResults.jsx
@@ -15,10 +15,6 @@ const Search = () => {
   } = useSelector(state => state.sm.search);
   const history = useHistory();
 
-  useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-  }, []);
-
   useEffect(
     () => {
       if (!awaitingResults && !searchResults) {


### PR DESCRIPTION
## Summary
Navigating around the va.gov MHV SM app triggers scrolling to the top of the page so that the user is oriented to the top of the page. This change was made for the VA.gov-SM-APR team. 

## Related issue(s)
ticket: https://vajira.max.gov/browse/MHV-39000
epic: https://vajira.max.gov/browse/MHV-33470

## Testing done
This feature/fix cannot be tested by a unit test. To manually test this, scroll down and then use the left navigation panel. Visiting new pages should trigger the app to scroll to the top of the page. 

## Screenshots
This is a UX feature/fix, not UI. 

## What areas of the site does it impact?
This impacts every page of the va.gov MHV SM app. 

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  Display is anchored at the top of the page throughout application
