### PR TITLE
11662 - redirect to subdomain redirect match destination

### DIFF
--- a/src/applications/proxy-rewrite/redirects/index.js
+++ b/src/applications/proxy-rewrite/redirects/index.js
@@ -67,14 +67,15 @@ const redirectIfNecessary = currentWindow => {
   const toSubdomainRedirectMatch = toSubdomainRedirects?.find(redirect => {
     const isHostMatch = deriveIsHostMatch(redirect, currentWindow);
     const currentPathMatchesSubdomainSrc =
-      currentWindow.location.pathname === redirect.src.toLowerCase();
+      currentWindow.location.pathname.toLowerCase() ===
+      redirect.src.toLowerCase();
     return isHostMatch && currentPathMatchesSubdomainSrc;
   });
 
   // Redirect if there is a to subdomain match
   if (toSubdomainRedirectMatch) {
     // eslint-disable-next-line no-param-reassign
-    currentWindow.location.href = `${catchAllRedirectMatch.dest}`;
+    currentWindow.location.href = `${toSubdomainRedirectMatch.dest}`;
   }
 };
 


### PR DESCRIPTION
## Summary
This PR makes adjustments to client-side redirect logic to ensure subdomain redirects go to their intended destination

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms/issues/11662

## Testing done
None, will need to be validated in production.

## What areas of the site does it impact?
- This will only effect redirects between two subdomains.

## Acceptance criteria

- [n/a]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [n/a]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [n/a]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [n/a]  I added a screenshot of the developed feature

## Requested Feedback

Needs to be validated in production.
