### PR TITLE
Education letters bug redirect non logged in users

### DIFF
--- a/src/applications/education-letters/containers/InboxPage.jsx
+++ b/src/applications/education-letters/containers/InboxPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Layout from '../components/Layout';
@@ -16,23 +16,39 @@ const InboxPage = ({
 }) => {
   const [fetchedClaimStatus, setFetchedClaimStatus] = useState(null);
 
+  const isLoggedIn = useRef(false);
+
   useEffect(
     () => {
-      if (!user?.login?.currentlyLoggedIn) {
-        return;
-      }
-
       if (!fetchedClaimStatus) {
         getClaimStatus('MEB');
         getClaimStatus('TOE');
         setFetchedClaimStatus(true);
       }
     },
-    [fetchedClaimStatus, getClaimStatus, user?.login?.currentlyLoggedIn],
+    [fetchedClaimStatus, getClaimStatus],
+  );
+
+  useEffect(
+    () => {
+      if (user?.login?.currentlyLoggedIn) {
+        isLoggedIn.current = true;
+      }
+      setTimeout(() => {
+        if (!isLoggedIn.current) {
+          window.location.href = '/education/download-letters/';
+        }
+      }, 2000);
+    },
+    [isLoggedIn, user?.login?.currentlyLoggedIn],
   );
 
   const renderInbox = () => {
-    if (MEBClaimStatusFetchInProgress || TOEClaimStatusFetchInProgress) {
+    if (
+      MEBClaimStatusFetchInProgress ||
+      TOEClaimStatusFetchInProgress ||
+      !isLoggedIn.current
+    ) {
       return (
         <div className="vads-u-margin-y--5">
           <va-loading-indicator

--- a/src/applications/education-letters/containers/InboxPage.jsx
+++ b/src/applications/education-letters/containers/InboxPage.jsx
@@ -15,7 +15,6 @@ const InboxPage = ({
   TOEClaimStatusFetchComplete,
 }) => {
   const [fetchedClaimStatus, setFetchedClaimStatus] = useState(null);
-
   const isLoggedIn = useRef(false);
 
   useEffect(
@@ -34,13 +33,17 @@ const InboxPage = ({
       if (user?.login?.currentlyLoggedIn) {
         isLoggedIn.current = true;
       }
-      setTimeout(() => {
-        if (!isLoggedIn.current) {
-          window.location.href = '/education/download-letters/';
-        }
-      }, 2000);
+      if (
+        (MEBClaimStatusFetchInProgress ||
+          TOEClaimStatusFetchInProgress ||
+          MEBClaimStatusFetchComplete ||
+          TOEClaimStatusFetchComplete) &&
+        !isLoggedIn.current
+      ) {
+        window.location.href = '/education/download-letters/';
+      }
     },
-    [isLoggedIn, user?.login?.currentlyLoggedIn],
+    [isLoggedIn, user?.login],
   );
 
   const renderInbox = () => {
@@ -71,11 +74,7 @@ const InboxPage = ({
       return <NoLetters />;
     }
 
-    if (
-      MEBClaimStatusFetchComplete &&
-      TOEClaimStatusFetchComplete &&
-      !claimStatus?.claimStatus
-    ) {
+    if (MEBClaimStatusFetchComplete && TOEClaimStatusFetchComplete) {
       return (
         <va-banner
           headline="There was an error in accessing your decision letters. We’re sorry we couldn’t display your letters.  Please try again later."


### PR DESCRIPTION
## Summary
Update InboxPage, Education Letters results page, to redirects visitors to the Education Letters landing page while rendering the correct UI for logged in users.


## Testing done
- [x] Done

## What areas of the site does it impact?
A change to the life cycle of InboxPage.jsx to redirect if everything is loaded minus the user.isLoggedIn bool.

/education/download-letters/letters

## Acceptance criteria
- [ ] Visitors should be redirected to the landing page if they go to /education/download-letters/letters,
- [ ] Logged in users remain in /education/download-letters/letters

