### PR TITLE
Temporary change for homepage search GA event

### DIFF
--- a/src/applications/static-pages/homepage/HomepageSearch.jsx
+++ b/src/applications/static-pages/homepage/HomepageSearch.jsx
@@ -74,9 +74,27 @@ const HomepageSearch = () => {
     )}&t=${false}`;
 
     // Record the analytic event.
+
+    // Uncomment this event and delete unlabled event when analytics implements our custom GA events
+    // recordEvent({
+    //   event: 'view_search_results',
+    //   action: 'Homepage - Search',
+    //   'search-page-path': searchUrl,
+    //   'search-query': e.target.value,
+    //   'search-results-total-count': null,
+    //   'search-results-total-pages': null,
+    //   'search-selection': 'All VA.gov',
+    //   'search-typeahead-enabled': false,
+    //   'search-location': 'Homepage Search',
+    //   'sitewide-search-app-used': false,
+    //   'type-ahead-option-keyword-selected': null,
+    //   'type-ahead-option-position': null,
+    //   'type-ahead-options-list': null,
+    //   'type-ahead-options-count': null,
+    // });
+
     recordEvent({
       event: 'view_search_results',
-      action: 'Homepage - Search',
       'search-page-path': searchUrl,
       'search-query': e.target.value,
       'search-results-total-count': null,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Removes label from the new homepage search,  leaves old recordEvent function commented out for when we switch back to custom events

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12065


## Testing done

Local testing using AdSwerve

## Screenshots
<img width="1033" alt="Screen Shot 2023-01-06 at 11 02 41 AM" src="https://user-images.githubusercontent.com/61624970/211050955-9f5f58ee-ccac-4d3d-9a65-789769b7cfb1.png">


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  Search input in-page gets same GA event as header search, e.g. ec: Search ea: Search Results Returned ~ Type Ahead Enabled ~ All VA.gov ~ [search term input] el: view_search_resultsexpected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
