### PR TITLE
MHV-40415: Send and save message bug fixed

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -205,9 +205,7 @@ const ComposeForm = props => {
       category,
       debouncedMessageBody,
       debouncedSubject,
-      saveDraftHandler,
       selectedRecipient,
-      sendMessageFlag,
     ],
   );
 
@@ -239,7 +237,7 @@ const ComposeForm = props => {
               error={recipientError}
             >
               {sortRecipients(recipientsList)?.map(item => (
-                <option key={item.id} value={item.name}>
+                <option key={item.id} value={item.id}>
                   {item.name}
                 </option>
               ))}


### PR DESCRIPTION
## Summary
The send and save message functionality has been fixed. They were broken due to the value of the recipient selector being changed from the recipient ID to the name of the recipient. 

## Related issue(s)
https://vajira.max.gov/browse/MHV-40415

## Testing done
This has been manually tested. This is not testable through unit tests. 

## Screenshots
No UI changes made

## What areas of the site does it impact?
This impacts the compose and reply pages for the va.gov MHV SM app. 

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

