### PR TITLE
Fix facility address line

### DIFF
--- a/src/applications/vaos/components/FacilityAddress.jsx
+++ b/src/applications/vaos/components/FacilityAddress.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import FacilityDirectionsLink from '../components/FacilityDirectionsLink';
+import FacilityDirectionsLink from './FacilityDirectionsLink';
 import FacilityPhone from './FacilityPhone';
 import State from './State';
 import { hasValidCovidPhoneNumber } from '../services/appointment';
@@ -37,12 +38,9 @@ export default function FacilityAddress({
       )}
       {!!address && (
         <>
-          {address?.line?.map(line => (
-            <React.Fragment key={line}>
-              {line}
-              <br />
-            </React.Fragment>
-          ))}
+          {/* removes falsy values from address array */}
+          {address?.line.filter(Boolean).join(', ')}
+          <br />
           {address.city}, <State state={address.state} /> {address.postalCode}
           <br />
         </>
@@ -73,3 +71,13 @@ export default function FacilityAddress({
     </>
   );
 }
+
+FacilityAddress.propTypes = {
+  facility: PropTypes.object.isRequired,
+  clinicName: PropTypes.string,
+  level: PropTypes.number,
+  name: PropTypes.string,
+  showCovidPhone: PropTypes.bool,
+  showDirectionsLink: PropTypes.bool,
+  showPhone: PropTypes.bool,
+};

--- a/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
@@ -72,12 +72,9 @@ export default function ReviewPage() {
             <h3 className="vaos-appts__block-label">{facility.name}</h3>
             {clinic.serviceName}
             <br />
-            {facility.address?.line?.map(line => (
-              <React.Fragment key={line}>
-                {line}
-                <br />
-              </React.Fragment>
-            ))}
+            {/* removes falsy value from address array */}
+            {facility.address?.line?.filter(Boolean).join(', ')}
+            <br />
             {facility.address?.city}, <State state={facility.address?.state} />
           </div>
         </div>

--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -276,9 +276,9 @@ export function formatFacilityAddress(facility) {
     facility?.address?.state &&
     facility?.address?.postalCode
   ) {
-    return `${facility.address.line.join(', ')}, ${facility.address.city}, ${
-      facility.address.state
-    } ${facility.address.postalCode}`;
+    return `${facility.address.line.filter(Boolean).join(', ')}, ${
+      facility.address.city
+    }, ${facility.address.state} ${facility.address.postalCode}`;
   }
 
   return '';

--- a/src/applications/vaos/services/mocks/v2/facilities.json
+++ b/src/applications/vaos/services/mocks/v2/facilities.json
@@ -27,7 +27,7 @@
         "mailingAddress": null,
         "physicalAddress": {
           "type": "physical",
-          "line": ["2360 East Pershing Boulevard"],
+          "line": ["2360 East Pershing Boulevard",null,"Suite 10"],
           "city": "Cheyenne",
           "state": "WY",
           "postalCode": "82001-5356"

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -253,7 +253,7 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
                 postalCode: '82001-5356',
                 city: 'Cheyenne',
                 state: 'WY',
-                line: ['2360 East Pershing Boulevard'],
+                line: ['2360 East Pershing Boulevard', null, 'Suite 10'],
               },
             },
           ],
@@ -298,6 +298,7 @@ describe('VAOS vaccine flow with VAOS service <ReviewPage>', () => {
     expect(screen.baseElement).to.contain.text(
       'Make sure the information is correct. Then confirm your appointment.',
     );
+    expect(screen.getByText(/2360 East Pershing Boulevard, Suite 10/i)).to.be;
 
     // When the user confirms their appointment
     userEvent.click(screen.getByText(/Confirm appointment/i));

--- a/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.unit.spec.jsx
@@ -75,7 +75,7 @@ const store = createTestStore({
             postalCode: '82001-5356',
             city: 'Cheyenne',
             state: 'WY',
-            line: ['2360 East Pershing Boulevard'],
+            line: ['2360 East Pershing Boulevard', undefined, 'Suite 10'],
           },
           telecom: [{ system: 'phone', value: '307-778-7550' }],
         },
@@ -99,7 +99,8 @@ describe('VAOS <ConfirmationDirectScheduleInfoV2>', () => {
     ).to.be.ok;
     expect(screen.getByText('Primary care')).to.be.ok;
     expect(screen.getByText(/Cheyenne VA Medical Center/i)).to.be.ok;
-    expect(screen.getByText(/2360 East Pershing Boulevard/i)).to.be.ok;
+    expect(screen.getByText(/2360 East Pershing Boulevard, Suite 10/i)).to.be
+      .ok;
     expect(screen.baseElement).to.contain.text(
       'Cheyenne, WyomingWY 82001-5356',
     );
@@ -163,18 +164,19 @@ describe('VAOS <ConfirmationDirectScheduleInfoV2>', () => {
     // with a tab character
     let description = tokens.get('DESCRIPTION');
     description = description.split(/(?=\t)/g); // look ahead include the split character in the results
-
     expect(description[0]).to.equal(
       'You have a health care appointment at CHY PC CASSIDY',
     );
     expect(description[1]).to.equal('\t\\n\\n2360 East Pershing Boulevard\\n');
-    expect(description[2]).to.equal('\tCheyenne\\, WY 82001-5356\\n');
+    expect(description[2]).to.equal(
+      '\tSuite 10\\, Cheyenne\\, WY 82001-5356\\n',
+    );
     expect(description[3]).to.equal('\t307-778-7550\\n');
     expect(description[4]).to.equal(
       '\t\\nSign in to VA.gov to get details about this appointment\\n',
     );
     expect(tokens.get('LOCATION')).to.equal(
-      '2360 East Pershing Boulevard\\, Cheyenne\\, WY 82001-5356',
+      '2360 East Pershing Boulevard\\, Suite 10\\, Cheyenne\\, WY 82001-5356',
     );
     expect(tokens.get('DTSTAMP')).to.equal(
       `${moment(start)


### PR DESCRIPTION
The facility address displays all the values from the address line array. In most instance the address line contains just one value, the street name. In rare instance, the address will also contain the floor or suite number which are stored in the second or third index array. When address line array contains a null or empty value, it will create a blank line in place of the falsey value. This PR removes the null or empty values and displays the address line in a single line.
## Summary

- When facility/clinic with an address with more than 2 or 3 lines, displayed display them in a single line
- Ensure the Add to calendar ICS file also reflect the same fix where there is no gap line

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50776


## Testing done

- Unit test

## Screenshots
<img width="282" alt="Screenshot 2023-01-06 at 1 59 02 PM" src="https://user-images.githubusercontent.com/54327023/211107375-cfc876af-8be6-4905-8e13-ab75454cb6c7.png">

_____
<img width="295" alt="Screenshot 2023-01-06 at 11 39 34 AM" src="https://user-images.githubusercontent.com/54327023/211105180-e54143d1-7d56-4901-a76f-8e4501ec811d.png">

_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  Remove the address gap.



