### PR TITLE
do not check country label for military overseas

### DIFF
--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -277,9 +277,7 @@ export function prefillTransformerV1(pages, formData, metadata, state) {
         postalCode: contactInfo?.zipcode,
         country: getSchemaCountryCode(contactInfo?.countryCode),
       },
-      livesOnMilitaryBase:
-        contactInfo?.countryCode !== 'US' &&
-        contactInfo?.addressType === 'MILITARY_OVERSEAS',
+      livesOnMilitaryBase: contactInfo?.addressType === 'MILITARY_OVERSEAS',
     },
     toursOfDuty: serviceData.map(transformServiceHistory),
   };
@@ -306,7 +304,6 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
   const claimant = state.data?.formData?.data?.attributes?.claimant || {};
   const serviceData = state.data?.formData?.data?.attributes?.serviceData || [];
   const contactInfo = claimant?.contactInfo || {};
-
   const stateUser = state.user || {};
 
   const profile = stateUser?.profile;
@@ -401,7 +398,6 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
         country: getSchemaCountryCode(address?.countryCode),
       },
       [formFields.livesOnMilitaryBase]:
-        address?.countryCode !== 'US' &&
         address?.addressType === 'MILITARY_OVERSEAS',
     },
     [formFields.bankAccount]: {

--- a/src/applications/my-education-benefits/tests/units/form-submit-transform.unit.spec.js
+++ b/src/applications/my-education-benefits/tests/units/form-submit-transform.unit.spec.js
@@ -165,21 +165,12 @@ describe('form submit transform', () => {
       );
       expect(addressType).to.eql('FOREIGN');
     });
-    it('should set addressType to MILITARY_OVERSEAS if livesOnMilitaryBase is true AND country is not USA', () => {
+    it('should set addressType to MILITARY_OVERSEAS if livesOnMilitaryBase is true', () => {
       mockSubmissionForm['view:mailingAddress'].livesOnMilitaryBase = true;
-      mockSubmissionForm['view:mailingAddress'].address.country = 'AFG';
       const addressType = getAddressType(
         mockSubmissionForm['view:mailingAddress'],
       );
       expect(addressType).to.eql('MILITARY_OVERSEAS');
-    });
-    it('should set addressType to DOMESTIC if livesOnMilitaryBase is true AND country is USA', () => {
-      mockSubmissionForm['view:mailingAddress'].livesOnMilitaryBase = true;
-      mockSubmissionForm['view:mailingAddress'].address.country = 'USA';
-      const addressType = getAddressType(
-        mockSubmissionForm['view:mailingAddress'],
-      );
-      expect(addressType).to.eql('DOMESTIC');
     });
   });
   describe('has a getLTSCountryCode method', () => {

--- a/src/applications/my-education-benefits/utils/form-submit-transform.js
+++ b/src/applications/my-education-benefits/utils/form-submit-transform.js
@@ -276,11 +276,7 @@ export function getAddressType(mailingAddress) {
     return null;
   }
 
-  if (
-    mailingAddress[formFields.address]?.country !==
-      DEFAULT_SCHEMA_COUNTRY_CODE &&
-    mailingAddress[formFields.livesOnMilitaryBase]
-  ) {
+  if (mailingAddress[formFields.livesOnMilitaryBase]) {
     return 'MILITARY_OVERSEAS';
   }
   if (


### PR DESCRIPTION
## Summary
Update if statement to not check for country label

## Related issue(s)
[department-of-veterans-affairs/va.gov-team#SA-44185
](https://jira.np.afsp.io/browse/SA-44185)- 


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

