### PR TITLE
redirect to inbox on message send

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -76,10 +76,12 @@ const ComposeForm = props => {
           const sendData = new FormData();
           sendData.append('message', JSON.stringify(messageData));
           attachments.map(upload => sendData.append('uploads[]', upload));
-          dispatch(sendMessage(sendData, true)).then(() => history.push('/'));
+          dispatch(sendMessage(sendData, true)).then(() =>
+            history.push('/inbox'),
+          );
         } else {
           dispatch(sendMessage(JSON.stringify(messageData), false)).then(() =>
-            history.push('/'),
+            history.push('/inbox'),
           );
         }
       }


### PR DESCRIPTION
## Summary

- Resolving a bug related to introduction of a dashboard. 
- When a user is sending a message from Compose view, on successfull send, redirect back to `/inbox` instead of `/` where now dashboard resides


## Testing done

- Tested manually locally

## Screenshots
<img width="400" alt="image" src="https://user-images.githubusercontent.com/87077843/211393417-f8886755-8136-46b7-b4df-f22039b2c2aa.png">


| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
Secure Mesaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
