### PR TITLE
Supplemental Claims - Update Content

### DIFF
--- a/src/applications/appeals/995/content/evidenceUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceUpload.jsx
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { MAX_FILE_SIZE_MB, SUPPORTED_UPLOAD_TYPES } from '../constants';
 import { readableList } from '../utils/helpers';
 
-export const uploadTitle = <h3>Upload your supporting evidence</h3>;
-
 export const UploadDescription = () => {
   const types = SUPPORTED_UPLOAD_TYPES.map(text => text.toUpperCase());
   const list = readableList(types, 'or');

--- a/src/applications/appeals/995/content/evidenceUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceUpload.jsx
@@ -4,11 +4,7 @@ import PropTypes from 'prop-types';
 import { MAX_FILE_SIZE_MB, SUPPORTED_UPLOAD_TYPES } from '../constants';
 import { readableList } from '../utils/helpers';
 
-export const uploadTitle = (
-  <h3 className="vads-u-margin-top--0 vads-u-display--inline">
-    Upload your supporting evidence
-  </h3>
-);
+export const uploadTitle = <h3>Upload your supporting evidence</h3>;
 
 export const UploadDescription = () => {
   const types = SUPPORTED_UPLOAD_TYPES.map(text => text.toUpperCase());
@@ -58,12 +54,11 @@ UploadDescription.propTypes = {
   uploadTitle: PropTypes.string,
 };
 
-export const evidencePrivateText = {
-  label: 'Upload your private medical records',
-  description: ' ',
-};
-
 export const evidenceOtherText = {
-  label: 'Supporting (lay) statements or other evidence',
+  label: (
+    <h3 className="vads-u-margin-top--0 vads-u-display--inline">
+      Upload your supporting evidence
+    </h3>
+  ),
   description: 'You’re adding this evidence:',
 };

--- a/src/applications/appeals/995/pages/evidenceUpload.js
+++ b/src/applications/appeals/995/pages/evidenceUpload.js
@@ -1,5 +1,4 @@
 import {
-  uploadTitle,
   UploadDescription,
   evidenceOtherText,
 } from '../content/evidenceUpload';
@@ -8,10 +7,6 @@ import { ATTACHMENTS_OTHER } from '../constants';
 
 export default {
   uiSchema: {
-    'view:uploadTitle': {
-      'ui:title': ' ',
-      'ui:description': uploadTitle,
-    },
     additionalDocuments: {
       ...ancillaryFormUploadUi(evidenceOtherText),
       'ui:description': UploadDescription,
@@ -22,10 +17,6 @@ export default {
     type: 'object',
     required: ['additionalDocuments'],
     properties: {
-      'view:uploadTitle': {
-        type: 'object',
-        properties: {},
-      },
       additionalDocuments: {
         type: 'array',
         items: {

--- a/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
+++ b/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
@@ -119,8 +119,8 @@ export const uiSchema = {
       showFieldLabel: true,
     },
     'ui:errorMessages': {
-      required: 'Please upload a file',
-      minItems: 'Please upload at least one file',
+      required: 'You must upload a file',
+      minItems: 'You must upload at least one file',
     },
     'ui:validations': [validateFileField, validateDocumentDescription],
   },

--- a/src/platform/forms-system/src/js/definitions/file.js
+++ b/src/platform/forms-system/src/js/definitions/file.js
@@ -32,8 +32,8 @@ export default function fileUiSchema(label, userOptions = {}) {
       ...userOptions,
     },
     'ui:errorMessages': {
-      required: 'Please upload a file',
-      minItems: 'Please upload at least one file',
+      required: 'You must upload a file',
+      minItems: 'You must upload at least one file',
     },
     'ui:validations': [validateFileField],
   };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *(Summarize the changes that have been made to the platform)*
  > -removed uploadTitle and replaced with evidenceOtherText
  > -updated evidenceOtherText to be required
  > -updated 'Please' to 'You must'

## Related issue(s)

[#49541](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49541)


## Testing done

 > No behavior change, just content updates
  > Tested locally at: http://localhost:3001/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/supporting-evidence/upload-evidence

## Screenshots

### Upload your supporting evidence

<details><summary>Before</summary>

<!-- leave a blank line above -->
<img width="653" alt="upload evidence page showing extra subtext, and required on the wrong title" src="https://user-images.githubusercontent.com/37054305/211407172-344d0685-6263-4ae6-8b40-5ec5846b19f6.png"></details>

<details><summary>After</summary>

<!-- leave a blank line above -->
<img width="653" alt="upload evidence page with subtext removed, required asterisk moved and error message updated" src="https://user-images.githubusercontent.com/37054305/211407440-99b4c45c-da13-464a-86ac-184c404f54fa.png"></details>

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
