### PR TITLE
[FSR] Updating submit event data for tracking debt type

### DIFF
--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -15,12 +15,14 @@ import GrossMonthlyIncomeInput from '../components/GrossMonthlyIncomeInput';
 import PayrollDeductionChecklist from '../components/PayrollDeductionChecklist';
 import PayrollDeductionInputList from '../components/PayrollDeductionInputList';
 import EmploymentHistoryWidget from '../pages/income/employmentEnhanced/EmploymentHistoryWidget';
+import submitForm from './submitForm';
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   transformForSubmit: transform,
   submitUrl: `${environment.API_URL}/v0/financial_status_reports`,
+  submit: submitForm,
   submissionError: SubmissionAlert,
   trackingPrefix: 'fsr-5655-',
   wizardStorageKey: WIZARD_STATUS,

--- a/src/applications/financial-status-report/config/submitForm.js
+++ b/src/applications/financial-status-report/config/submitForm.js
@@ -1,0 +1,32 @@
+import { submitToUrl } from 'platform/forms-system/src/js/actions';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import { DEBT_TYPES } from '../utils/helpers';
+
+// Analytics event
+export const buildEventData = ({ selectedDebtsAndCopays }) => {
+  // Check types of debts and copays selected
+  const hasDebts = selectedDebtsAndCopays.some(
+    selected => selected.debtType === DEBT_TYPES.DEBT,
+  );
+  const hasCopays = selectedDebtsAndCopays.some(
+    selected => selected.debtType === DEBT_TYPES.COPAY,
+  );
+
+  return {
+    'request-includes-copay': hasCopays,
+    'request-includes-debt': hasDebts,
+  };
+};
+
+const submitForm = (form, formConfig) => {
+  const { submitUrl, trackingPrefix } = formConfig;
+  const body = formConfig.transformForSubmit
+    ? formConfig.transformForSubmit(formConfig, form)
+    : transformForSubmit(formConfig, form);
+
+  // eventData for analytics
+  const eventData = buildEventData(form.data);
+  return submitToUrl(body, submitUrl, trackingPrefix, eventData);
+};
+
+export default submitForm;

--- a/src/applications/financial-status-report/tests/unit/cfsr-5655-submit.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/cfsr-5655-submit.unit.spec.jsx
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import formConfig from '../../config/form';
+import maximal from './efsr-unit-maximal.json';
+
+import submitForm, { buildEventData } from '../../config/submitForm';
+
+const debtOnly = {
+  selectedDebtsAndCopays: [{ debtType: 'DEBT' }],
+};
+const copayOnly = {
+  selectedDebtsAndCopays: [{ debtType: 'COPAY' }],
+};
+const combined = {
+  selectedDebtsAndCopays: [{ debtType: 'COPAY' }, { debtType: 'DEBT' }],
+};
+
+describe('Submit event data', () => {
+  it('should build submit event data', () => {
+    expect(buildEventData(debtOnly)).to.deep.equal({
+      'request-includes-copay': false,
+      'request-includes-debt': true,
+    });
+    expect(buildEventData(copayOnly)).to.deep.equal({
+      'request-includes-copay': true,
+      'request-includes-debt': false,
+    });
+    expect(buildEventData(combined)).to.deep.equal({
+      'request-includes-copay': true,
+      'request-includes-debt': true,
+    });
+  });
+});
+
+describe('submitForm', () => {
+  let xhr;
+  let requests;
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = createdXhr => requests.push(createdXhr);
+  });
+
+  afterEach(() => {
+    global.XMLHttpRequest = window.XMLHttpRequest;
+    xhr.restore();
+  });
+
+  it('should submit at endpioint', done => {
+    submitForm(maximal, formConfig);
+    expect(requests[0].url).to.contain('/v0/financial_status_reports');
+    done();
+  });
+});


### PR DESCRIPTION
## Summary
Adding the following GA tags to `fsr-5655--submission-successful` event to track FSR type (Copay or Debt). 
`request-includes-copay`
`request-includes-debt`
Margining while analytics tracks, could update in the future to tweak tags as necessary

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#51650
- department-of-veterans-affairs/va.gov-team#47442

## What areas of the site does it impact?
FSR and related Google Analytics tracking

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
