### PR TITLE
[51697] Show correct date on COE status page when COE denied.

### DIFF
--- a/src/applications/lgy/coe/shared/components/StatusAlert/statuses/Denied.jsx
+++ b/src/applications/lgy/coe/shared/components/StatusAlert/statuses/Denied.jsx
@@ -28,7 +28,7 @@ const Denied = ({ origin, referenceNumber, requestDate, testUrl = '' }) => (
 Denied.propTypes = {
   origin: PropTypes.oneOf(['form', 'status']).isRequired,
   referenceNumber: PropTypes.string.isRequired,
-  requestDate: PropTypes.number,
+  requestDate: PropTypes.number.isRequired,
   testUrl: PropTypes.string,
 };
 

--- a/src/applications/lgy/coe/status/components/statuses/Denied.jsx
+++ b/src/applications/lgy/coe/status/components/statuses/Denied.jsx
@@ -48,7 +48,7 @@ export const Denied = ({ referenceNumber, requestDate }) => {
 
 Denied.propTypes = {
   referenceNumber: PropTypes.string.isRequired,
-  requestDate: PropTypes.number,
+  requestDate: PropTypes.number.isRequired,
 };
 
 export default Denied;

--- a/src/applications/lgy/coe/status/containers/App.jsx
+++ b/src/applications/lgy/coe/status/containers/App.jsx
@@ -83,7 +83,12 @@ const App = ({
         );
         break;
       case COE_ELIGIBILITY_STATUS.denied:
-        content = <Denied referenceNumber={coe.referenceNumber} />;
+        content = (
+          <Denied
+            referenceNumber={coe.referenceNumber}
+            requestDate={coe.applicationCreateDate}
+          />
+        );
         break;
       case COE_ELIGIBILITY_STATUS.pending:
         content = (


### PR DESCRIPTION
## Summary

- Previously, we were not passing `requestDate` as a prop to the `Denied` component. Consequently, in `formatDateLong`, `moment` was called with `undefined`. When `moment` is called with `undefined` it returns the current date -- which is the error we were seeing before for users with a denied COE.
- To reproduce the bug: 
  - Log in as any user with a denied COE (or hardcode status [here](https://github.com/department-of-veterans-affairs/vets-website/blob/bf129045b02299d7815f5980e66fd86632fadd17/src/applications/lgy/coe/status/containers/App.jsx#L72-L73) to `COE_ELIGIBILITY_STATUS.denied`)
  - Go to https://staging.va.gov/housing-assistance/home-loans/check-coe-status/your-coe
  - Open network tab in developer tools
  - Refresh page
  - Look at most recent status request, and identity data.attributes.applicationCreateDate therefrom.
  - Go to https://www.epochconverter.com/ and convert the integer to a human-readable date. This is the date we expect to be rendered.
  - The date rendered and the date returned from the backend do not match.
- To fix this bug, we just need to pass `requestDate` as a prop to the `Denied` component.
- I'm on Benefits Team 1, who is responsible for building and maintaining the COE form.
- This work is behind a feature toggle. We are aiming to launch a small pilot around 1/19.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#51697

## Testing done

- See "To reproduce the bug" above.
- Hardcoded coe status as denied and tested locally (see screenshots below). 
- Specs still pass

## Screenshots

![Screen Shot 2023-01-10 at 4 26 42 PM](https://user-images.githubusercontent.com/7520103/211667493-2eb3a102-f75a-45ca-9ee0-9c05b30966bf.png)

![Screen Shot 2023-01-10 at 4 26 55 PM](https://user-images.githubusercontent.com/7520103/211667501-822844ee-4d7a-44de-84fd-5d1861b1d41b.png)

![Screen Shot 2023-01-10 at 4 27 09 PM](https://user-images.githubusercontent.com/7520103/211667518-d7d3c129-f72a-4714-97ca-15e6a3346c15.png)

## What areas of the site does it impact?

COE form, which is currently behind a feature toggle.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
