### PR TITLE
Supplemental Claims | cleanup

### DIFF
--- a/src/applications/appeals/995/components/ContactInfoReview.jsx
+++ b/src/applications/appeals/995/components/ContactInfoReview.jsx
@@ -76,15 +76,16 @@ const ContactInfoReview = ({ data, editPage }) => {
         <h4 className="vads-u-font-size--h5 vads-u-margin--0">
           {content.title}
         </h4>
-        <va-button
+        <button
+          type="button"
           ref={editRef}
           id="confirmContactInformationEdit"
-          class="float-right edit-page"
-          secondary
+          className="float-right edit-page usa-button-secondary"
           onClick={handlers.onEditPage}
-          label={content.editLabel}
-          text={content.edit}
-        />
+          aria-label={content.editLabel}
+        >
+          {content.edit}
+        </button>
       </div>
       {list.length ? <dl className="review">{list}</dl> : null}
     </div>

--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -398,6 +398,7 @@ const EvidencePrivateRecords = ({
           onBlur={handlers.onBlur}
           // ignore submitted & dirty state when showing unique error
           error={showError('name') || errors.unique || null}
+          autocomplete="provider name"
         />
 
         <VaSelect
@@ -427,6 +428,7 @@ const EvidencePrivateRecords = ({
           onInput={handlers.onChange}
           onBlur={handlers.onBlur}
           error={showError('street')}
+          autocomplete="provider address-line1"
         />
         <VaTextInput
           id="street2"
@@ -435,6 +437,7 @@ const EvidencePrivateRecords = ({
           label={content.addressLabels.street2}
           value={currentData.providerFacilityAddress?.street2}
           onInput={handlers.onChange}
+          autocomplete="provider address-line2"
         />
         <VaTextInput
           id="city"
@@ -446,6 +449,7 @@ const EvidencePrivateRecords = ({
           onInput={handlers.onChange}
           onBlur={handlers.onBlur}
           error={showError('city')}
+          autocomplete="provider address-level2"
         />
         {hasStates.length ? (
           <VaSelect
@@ -489,6 +493,8 @@ const EvidencePrivateRecords = ({
           onInput={handlers.onChange}
           onBlur={handlers.onBlur}
           error={showError('postal')}
+          inputmode="numeric"
+          autocomplete="provider postal-code"
         />
 
         <br />

--- a/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
@@ -58,15 +58,16 @@ const EvidenceSummaryReview = ({ data, editPage }) => {
   return (
     <div className="form-review-panel-page">
       <div name="evidenceSummaryScrollElement" />
-      <va-button
+      <button
+        type="button"
         ref={editRef}
-        class="float-right edit-page"
-        secondary
+        className="float-right edit-page usa-button-secondary"
         onClick={handlers.onEditPage}
-        label="Update evidence summary page"
-        text={content.edit}
-        tabindex="0"
-      />
+        aria-label={content.editLabel}
+        tabIndex="0"
+      >
+        {content.edit}
+      </button>
       <h4 className="vads-u-font-size--h5 vads-u-display--inline-block">
         {content.reviewPageHeaderText}
       </h4>

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -350,6 +350,7 @@ const EvidenceVaRecords = ({
           onBlur={handlers.onBlur}
           // ignore submitted & dirty state when showing unique error
           error={showError('name') || errors.unique || null}
+          autocomplete="facility name"
         />
         <br />
         <VaCheckboxGroup

--- a/src/applications/appeals/995/components/PrimaryPhoneReview.jsx
+++ b/src/applications/appeals/995/components/PrimaryPhoneReview.jsx
@@ -13,13 +13,14 @@ const PrimaryPhoneReview = ({ data, editPage }) => {
         <h4 className="vads-u-font-size--h5 vads-u-margin--0">
           {content.reviewTitle}
         </h4>
-        <va-button
-          class="edit-page"
-          secondary
+        <button
+          type="button"
+          className="edit-page usa-button-secondary"
           onClick={editPage}
           aria-label={content.editLabel}
-          text={content.edit}
-        />
+        >
+          {content.edit}
+        </button>
       </div>
       <dl className="review">
         <div className="review-row">

--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -177,7 +177,7 @@ IntroductionPage.propTypes = {
   loggedIn: PropTypes.bool,
   route: PropTypes.shape({
     formConfig: PropTypes.shape({
-      downtime: PropTypes.array,
+      downtime: PropTypes.shape({}),
       formId: PropTypes.string,
       prefillEnabled: PropTypes.bool,
       rootUrl: PropTypes.string,

--- a/src/applications/appeals/995/content/evidenceSummary.jsx
+++ b/src/applications/appeals/995/content/evidenceSummary.jsx
@@ -5,6 +5,7 @@ import { EVIDENCE_VA_REQUEST } from '../constants';
 
 export const content = {
   edit: 'Edit',
+  editLabel: 'Edit evidence summary page',
   remove: 'Remove',
   update: 'Update page',
 

--- a/src/applications/appeals/995/content/evidenceWillUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceWillUpload.jsx
@@ -4,7 +4,9 @@ const evidenceWillUploadTitle =
   'Do you want to upload your records or other documents to support your claim?';
 
 export const evidenceWillUploadHeader = (
-  <h3 className="vads-u-margin-top--0">{evidenceWillUploadTitle}</h3>
+  <h3 className="vads-u-margin-top--0 vads-u-display--inline">
+    {evidenceWillUploadTitle}
+  </h3>
 );
 
 export const evidenceWillUploadInfo = (

--- a/src/applications/appeals/995/content/primaryPhone.js
+++ b/src/applications/appeals/995/content/primaryPhone.js
@@ -5,7 +5,7 @@ export const content = {
     'We may need to contact you to clarify issues related to your Supplemental Claim.',
   update: 'Update',
   edit: 'Edit',
-  editLabel: 'update primary phone',
+  editLabel: 'Edit primary phone',
   homeLabel: 'Home phone number',
   mobileLabel: 'Mobile phone number',
 };

--- a/src/applications/appeals/995/tests/components/ContactInfoReview.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ContactInfoReview.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+import sinon from 'sinon';
 
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
@@ -15,7 +16,7 @@ const getData = ({
   mobile = true,
   email = true,
   address = true,
-  editSpy = () => {},
+  editPage = () => {},
 } = {}) => ({
   data: {
     veteran: {
@@ -25,7 +26,7 @@ const getData = ({
       address: address ? vapProfile.mailingAddress : null,
     },
   },
-  editPage: editSpy,
+  editPage,
 });
 
 describe('<ContactInfoReview>', () => {
@@ -33,6 +34,7 @@ describe('<ContactInfoReview>', () => {
     const data = getData();
     const { container } = render(<ContactInfoReview {...data} />);
 
+    expect($('button.edit-page', container)).to.exist;
     expect($('h4', container).textContent).to.eq(content.title);
     expect($$('dt', container).length).to.eq(8);
     expect(container.innerHTML).to.contain('Home phone');
@@ -44,5 +46,15 @@ describe('<ContactInfoReview>', () => {
     expect($('h4', container).textContent).to.eq(content.title);
     expect($$('dt', container).length).to.eq(7);
     expect(container.innerHTML).to.not.contain('Home phone');
+  });
+
+  it('should call editPage callback', () => {
+    const editPageSpy = sinon.spy();
+    const data = getData({ editPage: editPageSpy });
+    const { container } = render(<ContactInfoReview {...data} />);
+
+    fireEvent.click($('button.edit-page', container));
+
+    expect(editPageSpy.called).to.be.true;
   });
 });

--- a/src/applications/appeals/995/tests/components/EvidencePrivateLimitation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidencePrivateLimitation.unit.spec.jsx
@@ -7,11 +7,6 @@ import EvidencePrivateLimitation from '../../components/EvidencePrivateLimitatio
 import { EVIDENCE_PRIVATE, EVIDENCE_PRIVATE_PATH } from '../../constants';
 import { $, $$ } from '../../utils/ui';
 
-const mouseClick = new MouseEvent('click', {
-  bubbles: true,
-  cancelable: true,
-});
-
 describe('<EvidencePrivateLimitation>', () => {
   it('should render', () => {
     const { container } = render(
@@ -33,7 +28,7 @@ describe('<EvidencePrivateLimitation>', () => {
       </div>,
     );
 
-    fireEvent($('button.usa-button-primary', container), mouseClick);
+    fireEvent.click($('button.usa-button-primary', container));
     expect(goSpy.called).to.be.true;
   });
 
@@ -61,7 +56,7 @@ describe('<EvidencePrivateLimitation>', () => {
       </div>,
     );
 
-    fireEvent($('button.usa-button-secondary', container), mouseClick);
+    fireEvent.click($('button.usa-button-secondary', container));
     expect(
       goSpy.calledWith(
         `/${EVIDENCE_PRIVATE_PATH}?index=${data.providerFacility.length - 1}`,

--- a/src/applications/appeals/995/tests/components/EvidenceSummaryReview.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummaryReview.unit.spec.jsx
@@ -8,11 +8,6 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import EvidenceSummaryReview from '../../components/EvidenceSummaryReview';
 import { EVIDENCE_PRIVATE, EVIDENCE_VA, EVIDENCE_OTHER } from '../../constants';
 
-const mouseClick = new MouseEvent('click', {
-  bubbles: true,
-  cancelable: true,
-});
-
 const providerFacilityAddress = {
   country: 'USA',
   street: '123 main',
@@ -93,7 +88,7 @@ describe('<EvidenceSummaryReview>', () => {
   it('should render', () => {
     const { container } = setupSummary();
 
-    expect($('va-button.edit-page', container)).to.exist;
+    expect($('button.edit-page', container)).to.exist;
     expect($$('h5', container).length).to.eq(3);
     expect($$('ul', container).length).to.eq(3);
     expect($$('a', container).length).to.eq(0);
@@ -127,11 +122,11 @@ describe('<EvidenceSummaryReview>', () => {
   });
 
   it('should call editPage callback', () => {
-    const editPage = sinon.spy();
-    const { container } = setupSummary({ editPage });
+    const editPageSpy = sinon.spy();
+    const { container } = setupSummary({ editPage: editPageSpy });
 
-    fireEvent.click($('va-button.edit-page', container), mouseClick);
+    fireEvent.click($('.edit-page', container));
 
-    expect(editPage.called).to.be.true;
+    expect(editPageSpy.called).to.be.true;
   });
 });

--- a/src/applications/appeals/995/tests/pages/noticeOfAcknowledgement.unit.spec.js
+++ b/src/applications/appeals/995/tests/pages/noticeOfAcknowledgement.unit.spec.js
@@ -8,11 +8,6 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 
-const mouseClick = new MouseEvent('click', {
-  bubbles: true,
-  cancelable: true,
-});
-
 describe('Supplemental Claims notice-of-acknowledgement page', () => {
   const { schema, uiSchema } = formConfig.chapters.evidence.pages.notice5103;
 
@@ -59,7 +54,7 @@ describe('Supplemental Claims notice-of-acknowledgement page', () => {
         onSubmit={onSubmit}
       />,
     );
-    fireEvent.click($('input[type="checkbox"]', container), mouseClick);
+    fireEvent.click($('input[type="checkbox"]', container));
     fireEvent.submit($('form', container));
     expect($('.usa-input-error', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;

--- a/src/applications/appeals/995/tests/pages/optIn.unit.spec.js
+++ b/src/applications/appeals/995/tests/pages/optIn.unit.spec.js
@@ -8,11 +8,6 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 
-const mouseClick = new MouseEvent('click', {
-  bubbles: true,
-  cancelable: true,
-});
-
 describe('Supplemental Claims opt-in page', () => {
   const { schema, uiSchema } = formConfig.chapters.issues.pages.optIn;
 
@@ -59,7 +54,7 @@ describe('Supplemental Claims opt-in page', () => {
         onSubmit={onSubmit}
       />,
     );
-    fireEvent.click($('input[type="checkbox"]', container), mouseClick);
+    fireEvent.click($('input[type="checkbox"]', container));
     fireEvent.submit($('form', container));
     expect($('.usa-input-error', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;

--- a/src/applications/appeals/995/tests/subtask/subtask.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/subtask/subtask.unit.spec.jsx
@@ -13,11 +13,6 @@ import SubTask, {
 import SubTaskContainer from '../../subtask/SubTaskContainer';
 import pages from '../../subtask/pages';
 
-const mouseClick = new MouseEvent('click', {
-  bubbles: true,
-  cancelable: true,
-});
-
 const mockStore = ({ data = {}, show995 = true, loading = false } = {}) => {
   setStoredSubTask(data);
   return {
@@ -92,11 +87,11 @@ describe('the Supplemental Claims Sub-task', () => {
 
     expect($('form[data-page="start"]', container)).to.exist;
 
-    fireEvent.click($('va-button[continue]', container), mouseClick);
+    fireEvent.click($('va-button[continue]', container));
     expect($('form[data-page="other"]', container)).to.exist;
     expect($('a[download]', container)).to.exist;
 
-    fireEvent.click($('va-button[back]', container), mouseClick);
+    fireEvent.click($('va-button[back]', container));
     expect($('form[data-page="start"]', container)).to.exist;
   });
   it.skip('should show an error when no selection is made', () => {
@@ -111,7 +106,7 @@ describe('the Supplemental Claims Sub-task', () => {
     expect(vaRadio).to.exist;
     expect(vaRadio.error).to.be.null;
 
-    fireEvent.click($('va-button[continue]', container), mouseClick);
+    fireEvent.click($('va-button[continue]', container));
     expect($('form[data-page="start"]', container)).to.exist;
     expect(vaRadio.error).to.contain('choose a claim type');
   });
@@ -127,7 +122,7 @@ describe('the Supplemental Claims Sub-task', () => {
 
     expect($('form[data-page="start"]', container)).to.exist;
 
-    fireEvent.click($('va-button[continue]', container), mouseClick);
+    fireEvent.click($('va-button[continue]', container));
     expect(router.push.args[0][0]).to.include('/introduction');
   });
 });


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > - Add `inputmode` to private evidence provider zip code input
  > - Add appropriate `autocomplete` settings to facility & provider inputs
  > - Change review & submit "Edit" `va-button` to `button` to improve focus management
  > - Code cleanup 
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
- *(Which team do you work for, does your team own the maintainence of this component?)*
  > Benefits Team 1
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#50125](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50125)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Zip code inputs previously would show a regular virtual keyboard on mobile, now shows number keyboard
  > Focus on the va-button targets the web component, so a `tabindex="0"` is needed, then the focus outline doubles. Without the tab index, using the platform focus will apply a `tabindex="-1"` and prevent focus inside the element
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Updated unit tests

## Screenshots

N/A - no visual changes

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
