### PR TITLE
Mhv 40510 add triage name to reply

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -224,7 +224,8 @@ const ReplyForm = props => {
                 To:{' '}
               </strong>
               {replyMessage.senderName}
-              <br />({replyMessage.triageGroupName})
+              <br />
+              (Team: {replyMessage.triageGroupName})
             </p>
             <va-textarea
               label="Message"

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -224,6 +224,7 @@ const ReplyForm = props => {
                 To:{' '}
               </strong>
               {replyMessage.senderName}
+              <br />({replyMessage.triageGroupName})
             </p>
             <va-textarea
               label="Message"


### PR DESCRIPTION
## Summary
Just adds the triage group associated with a message to the reply page.

## Related issue(s)
https://vajira.max.gov/browse/MHV-40510

## Testing done
Manual testing and unit tests

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
