### PR TITLE
Update Caregiver signature box wrapping element

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import recordEvent from 'platform/monitoring/record-event';
+import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import SignatureInput from './SignatureInput';
 
 const SignatureCheckbox = ({
@@ -32,34 +32,32 @@ const SignatureCheckbox = ({
   );
 
   return (
-    <article
+    <fieldset
       data-testid={label}
-      className="signature-box vads-u-background-color--gray-lightest vads-u-padding-bottom--6 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--7"
+      className="signature-box vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--5"
     >
-      {children && <header>{children}</header>}
+      {!!children && <>{children}</>}
 
-      <section>
-        <SignatureInput
-          ariaDescribedBy={representativeLabelId}
-          label={label}
-          fullName={fullName}
-          required={isRequired}
-          showError={showError}
-          hasSubmittedForm={hasSubmittedForm}
-          isRepresentative={isRepresentative}
-          setSignatures={setSignatures}
-          isChecked={isChecked}
-        />
+      <SignatureInput
+        ariaDescribedBy={representativeLabelId}
+        label={label}
+        fullName={fullName}
+        required={isRequired}
+        showError={showError}
+        hasSubmittedForm={hasSubmittedForm}
+        isRepresentative={isRepresentative}
+        setSignatures={setSignatures}
+        isChecked={isChecked}
+      />
 
-        {isRepresentative && (
-          <p className="on-behalf-representative" id={representativeLabelId}>
-            On behalf of
-            <strong className="vads-u-font-size--lg">
-              {fullName.first} {fullName.middle} {fullName.last}
-            </strong>
-          </p>
-        )}
-      </section>
+      {isRepresentative && (
+        <p className="signature-box--representative" id={representativeLabelId}>
+          On behalf of
+          <strong className="vads-u-font-size--lg">
+            {fullName.first} {fullName.middle} {fullName.last}
+          </strong>
+        </p>
+      )}
 
       <Checkbox
         onValueChange={value => {
@@ -75,7 +73,7 @@ const SignatureCheckbox = ({
         errorMessage={hasError && 'Must certify by checking box'}
         required={isRequired}
       />
-    </article>
+    </fieldset>
   );
 };
 

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
+import recordEvent from 'platform/monitoring/record-event';
 import SignatureInput from './SignatureInput';
 
 const SignatureCheckbox = ({

--- a/src/applications/caregivers/components/PreSubmitInfo/StatementOfTruth.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/StatementOfTruth.jsx
@@ -6,7 +6,9 @@ const StatementOfTruth = ({ content }) => {
   const { label = '', text = [] } = content;
   return (
     <>
-      <h3 className="vads-u-margin-top--4">{`${label} statement of truth`}</h3>
+      <legend className="signature-box--legend vads-u-display--block vads-u-width--full vads-u-font-family--serif vads-u-font-size--h3 vads-u-font-weight--bold">
+        {`${label} statement of truth`}
+      </legend>
 
       {text.map((copy, idx) => {
         return <p key={`${label}-${idx}`}>{copy}</p>;

--- a/src/applications/caregivers/sass/_signatureBox.scss
+++ b/src/applications/caregivers/sass/_signatureBox.scss
@@ -1,15 +1,14 @@
 .signature-box {
-  .on-behalf-representative {
+  .signature-box--representative {
     display: flex;
     flex-direction: column;
     align-self: flex-start;
     margin: 10px 0 0 0;
   }
 
-  header {
-    p + p {
-      margin-bottom: 0;
-    }
+  .signature-box--legend {
+    color: inherit;
+    float: left;
   }
 
   label:first-child {


### PR DESCRIPTION
## Description
The sign as veteran/representative fields on the Caregiver application are incorrectly wrapped in `article` tags. Using the `article` element to contain the signatures will suggest to screen reader users scanning through their elements list or rotor that there are independent, self-contained sections on the page. This isn't the case as the signatures are directly related to the other elements on the review page. Furthermore, since none of the `articles` are uniquely labelled, they will simply appear as a list of generic articles in a rotor or elements list.

This PR updates the markup of the containers to migrate from `article` to `fieldset` to allow for correct semantics.  

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#24503

## Acceptance criteria
- [ ] The signature components are semantically correct in wrapping and implementation.
