### PR TITLE
Supplemental Claims | Hide bottom form start link when missing info

### DIFF
--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -152,11 +152,13 @@ class IntroductionPage extends React.Component {
             </va-additional-info>
           </li>
         </va-process-list>
-        {!showVerifyLink && (
-          <div className="sip-wrapper vads-u-margin-bottom--4">
-            <SaveInProgressIntro {...sipOptions} buttonOnly={loggedIn} />
-          </div>
-        )}
+        {loggedIn &&
+          !showVerifyLink &&
+          !showMissingInfo && (
+            <div className="sip-wrapper vads-u-margin-bottom--4">
+              <SaveInProgressIntro {...sipOptions} buttonOnly={loggedIn} />
+            </div>
+          )}
         <va-omb-info
           res-burden="15"
           omb-number="2900-0862"

--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -152,8 +152,7 @@ class IntroductionPage extends React.Component {
             </va-additional-info>
           </li>
         </va-process-list>
-        {loggedIn &&
-          !showVerifyLink &&
+        {!showVerifyLink &&
           !showMissingInfo && (
             <div className="sip-wrapper vads-u-margin-bottom--4">
               <SaveInProgressIntro {...sipOptions} buttonOnly={loggedIn} />

--- a/src/applications/appeals/995/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/IntroductionPage.unit.spec.jsx
@@ -99,6 +99,8 @@ describe('IntroductionPage', () => {
     );
     expect($('va-alert[status="continue"]', container)).to.exist;
     expect($('.schemaform-sip-alert', container)).to.not.exist;
+    expect($('.sip-wrapper .vads-c-action-link--green', container)).to.not
+      .exist;
   });
 
   it('should render missing SSN alert', () => {
@@ -113,6 +115,7 @@ describe('IntroductionPage', () => {
     expect(alert).to.exist;
     expect(alert.innerHTML).to.contain('your Social Security number.');
     expect($('.schemaform-sip-alert', container)).to.not.exist;
+    expect($('.vads-c-action-link--green', container)).to.not.exist;
   });
 
   it('should render missing DOB alert', () => {
@@ -127,6 +130,7 @@ describe('IntroductionPage', () => {
     expect(alert).to.exist;
     expect(alert.innerHTML).to.contain('your date of birth.');
     expect($('.schemaform-sip-alert', container)).to.not.exist;
+    expect($('.vads-c-action-link--green', container)).to.not.exist;
   });
 
   it('should render missing SSN and DOB alert', () => {


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > For Veterans missing either their SSN or DoB, the intro page replaces the top form start component with an alert; but currently, the bottom form start component still renders.
- *(If bug, how to reproduce)*
  > - Go to [Supplemental Claims on dev.va.gov](https://dev.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/introduction)
  > - Log in to user 233 (Cara)
  > - Note the "We’re missing some of your personal information" alert at the top of the page
  > - Bug: "Start your Claim" action link at the bottom of the page
- *(What is the solution, why is this the solution)*
  > Hide bottom action link when showing the alert
- *(Which team do you work for, does your team own the maintainence of this component?)*
  > Benefits Team 1
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#48159](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48159)

## Testing done

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

### Before

<details><summary>Missing SSN alert with bottom start form link 😞</summary>

<!-- leave a blank line above -->
![intro page with missing ssn alert, but showing a start your form action link at the bottom](https://user-images.githubusercontent.com/136959/212163877-92fed7e2-2bcc-4868-941c-a40cb5ee877b.png)
</details>

### After

<details><summary>Missing SSN alert with no form start link</summary>

<!-- leave a blank line above -->
![intro page with missing ssn alert and no way to start the form](https://user-images.githubusercontent.com/136959/212163871-7521ff1f-5d65-4eb2-8367-89b5c4bc6c6b.png)
</details>

## What areas of the site does it impact?

Supplemental Claims form (not yet in production)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
