### PR TITLE
Supplemental Claims | Fix bottom SiP not showing

### DIFF
--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -31,7 +31,7 @@ class IntroductionPage extends React.Component {
     // Without being LOA3 (verified), the prefill & contestable issues won't load
     const showVerifyLink = loggedIn && !isVerified;
     // Missing SSN or DOB
-    const showMissingInfo = !canApply || !hasDob;
+    const showMissingInfo = loggedIn && (!canApply || !hasDob);
     const pathname = location.basename;
 
     const sipOptions = {

--- a/src/applications/appeals/995/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/IntroductionPage.unit.spec.jsx
@@ -76,6 +76,7 @@ describe('IntroductionPage', () => {
     expect($('.va-introtext', container)).to.exist;
     expect($('va-process-list', container)).to.exist;
     expect($('va-omb-info', container)).to.exist;
+    expect($('.sip-wrapper', container)).to.exist;
   });
 
   it('should render one SIP alert when not logged in', () => {
@@ -99,8 +100,7 @@ describe('IntroductionPage', () => {
     );
     expect($('va-alert[status="continue"]', container)).to.exist;
     expect($('.schemaform-sip-alert', container)).to.not.exist;
-    expect($('.sip-wrapper .vads-c-action-link--green', container)).to.not
-      .exist;
+    expect($('.sip-wrapper', container)).to.not.exist;
   });
 
   it('should render missing SSN alert', () => {
@@ -147,6 +147,7 @@ describe('IntroductionPage', () => {
       'your Social Security number and date of birth.',
     );
     expect($('.schemaform-sip-alert', container)).to.not.exist;
+    expect($('.sip-wrapper', container)).to.not.exist;
   });
 
   it('should render top SIP alert with action links', () => {


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > After making the bottom save-in-progress component not show if there was a missing SSN or DoB alert, the render did not account for the not-logged in state
- *(If bug, how to reproduce)*
  > While logged out, check the Supplemental Claims form on staging - there is no log in button within the page content
- *(What is the solution, why is this the solution)*
  > Check logged in state
- *(Which team do you work for, does your team own the maintainence of this component?)*
  > Benefits Team 1
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#48159](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48159)

## Testing done

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Updated unit tests, all passing

## Screenshots

<details><summary>No save-in-progress component</summary>

<!-- leave a blank line above -->
<img width="724" alt="No box titled saving your work in progress" src="https://user-images.githubusercontent.com/136959/212365407-c610ca22-972d-41ba-9e0a-5b14665aa2e8.png"></details>

## What areas of the site does it impact?

Supplemental Claims (not released)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
