### PR TITLE
[FSR] Tracking empty value issue 

### DIFF
--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -131,6 +131,7 @@ App.propTypes = {
   getFormStatus: PropTypes.func,
   isError: PropTypes.bool,
   isLoggedIn: PropTypes.bool,
+  isStartingOver: PropTypes.bool,
   location: PropTypes.object,
   pending: PropTypes.bool,
   router: PropTypes.object,


### PR DESCRIPTION
## Summary
Adding Sentry logging to track when `selectedDebtsAndCopays` is empty. This is caused from save in progress not containing updated feature flags. Forcing the flags to update mid form could cause additional issues, so the solution is to populate `selectedDebtsAndCopays` with the 'legacy' `selectedDebts`, and log when this occurs. We shouldn't see any more instances of this happening after any remaining save in progress forms expire after the fix applied on December 9 (see pr below). This logging can be removed after a few weeks after Feb 9 (60 days after patch), and we are no longer seeing any logs. 

- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
- *(Which team do you work for, does your team own the maintainence of this component?)*
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#51794
- Previous flag fix
  - #22901

## Testing done
Local testing: Starting an fsr with combined fsr feature flag set to false, selecting 'finish later'. Flipping flag to true, continuing the form, and submitting. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
