### PR TITLE
Update focusElement behavior

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -1,5 +1,5 @@
 import Scroll from 'react-scroll';
-import { getScrollOptions } from 'platform/utilities/ui';
+import { focusElement, getScrollOptions } from 'platform/utilities/ui';
 
 export const $ = (selectorOrElement, root) =>
   typeof selectorOrElement === 'string'
@@ -10,19 +10,7 @@ export const $$ = (selector, root) => [
   ...(root || document).querySelectorAll(selector),
 ];
 
-export function focusElement(selectorOrElement, options) {
-  const el = $(selectorOrElement);
-
-  if (el) {
-    if (el.tabIndex === 0) {
-      el.setAttribute('tabindex', '0');
-    }
-    if (el.tabIndex < 0) {
-      el.setAttribute('tabindex', '-1');
-    }
-    el.focus(options);
-  }
-}
+export { focusElement };
 
 // List from https://html.spec.whatwg.org/dev/dom.html#interactive-content
 const focusableElements = [

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -11,31 +12,184 @@ import {
 } from '../../../src/js/utilities/ui';
 import { ReviewCollapsibleChapter } from '../../../src/js/review/ReviewCollapsibleChapter';
 
-describe('focus on element', () => {
-  it.skip('should focus on element based on selector string', () => {
-    const tree = ReactTestUtils.renderIntoDocument(
+describe('focusElement', () => {
+  it('should focus on header element using tabindex -1, and remove it on blur', async () => {
+    const screen = render(
       <div>
-        <button type="button" aria-label="button" />
+        <h2>test</h2>
       </div>,
     );
-    const dom = findDOMNode(tree);
-    global.document = dom;
-    const focused = sinon.stub(dom.querySelector('button'), 'focus');
-    focusElement('button', {});
-    expect(focused.calledOnce).to.be.true;
+    const h2 = screen.getByRole('heading', { levh2: 2 });
+
+    expect(h2.tabIndex).to.eq(-1);
+    expect(h2.getAttribute('tabindex')).to.be.null;
+
+    focusElement(h2);
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(h2);
+      expect(h2.tabIndex).to.eq(-1);
+      expect(h2.getAttribute('tabindex')).to.eq('-1');
+    });
+    fireEvent.blur(h2);
+    await waitFor(() => {
+      expect(h2.tabIndex).to.eq(-1);
+      expect(h2.getAttribute('tabindex')).to.be.null;
+    });
+  });
+  it('should focus on header string selector using tabindex -1, and remove it on blur', async () => {
+    const screen = render(
+      <div>
+        <h2>test</h2>
+      </div>,
+    );
+    const h2 = screen.getByRole('heading', { levh2: 2 });
+
+    expect(h2.tabIndex).to.eq(-1);
+    expect(h2.getAttribute('tabindex')).to.be.null;
+
+    focusElement('h2');
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(h2);
+      expect(h2.tabIndex).to.eq(-1);
+      expect(h2.getAttribute('tabindex')).to.eq('-1');
+    });
+    fireEvent.blur(h2);
+    await waitFor(() => {
+      expect(h2.tabIndex).to.eq(-1);
+      expect(h2.getAttribute('tabindex')).to.be.null;
+    });
+  });
+  it('should focus on div with tabindex 0, and not remove it on blur', async () => {
+    const screen = render(
+      <div>
+        <div role="button" tabIndex="0">
+          test
+        </div>
+      </div>,
+    );
+    const div = screen.getByRole('button');
+
+    expect(div.tabIndex).to.eq(0);
+    expect(div.getAttribute('tabindex')).to.eq('0');
+
+    focusElement('div[role]');
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(div);
+      expect(div.tabIndex).to.eq(0);
+      expect(div.getAttribute('tabindex')).to.eq('0');
+    });
+    fireEvent.blur(div);
+    await waitFor(() => {
+      expect(div.tabIndex).to.eq(0);
+      expect(div.getAttribute('tabindex')).to.eq('0');
+    });
   });
 
-  it('should focus on element passed to the function', () => {
-    const tree = ReactTestUtils.renderIntoDocument(
+  it('should focus on input element', async () => {
+    const screen = render(
       <div>
-        <button type="button" aria-label="button" />
+        <label htmlFor="name">Name</label>
+        <input id="name" type="text" />
       </div>,
     );
-    const dom = findDOMNode(tree);
-    const button = dom.querySelector('button');
-    const focused = sinon.stub(button, 'focus');
-    focusElement(button);
-    expect(focused.calledOnce).to.be.true;
+    const input = screen.getByLabelText('Name');
+
+    expect(input.tabIndex).to.eq(0);
+    expect(input.getAttribute('tabindex')).to.be.null;
+
+    focusElement(input);
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(input);
+      expect(input.tabIndex).to.eq(0);
+      expect(input.getAttribute('tabindex')).to.be.null;
+    });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(input.tabIndex).to.eq(0);
+      expect(input.getAttribute('tabindex')).to.be.null;
+    });
+  });
+  it('should focus on input element', async () => {
+    const screen = render(
+      <div>
+        <label htmlFor="name">Name</label>
+        <input id="name" type="text" />
+      </div>,
+    );
+    const input = screen.getByLabelText('Name');
+
+    expect(input.tabIndex).to.eq(0);
+    expect(input.getAttribute('tabindex')).to.be.null;
+
+    focusElement('input');
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(input);
+      expect(input.tabIndex).to.eq(0);
+      expect(input.getAttribute('tabindex')).to.be.null;
+    });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(input.tabIndex).to.eq(0);
+      expect(input.getAttribute('tabindex')).to.be.null;
+    });
+  });
+  it('should focus on va-alert element', async () => {
+    const screen = render(
+      <div>
+        <va-alert data-testid="test" status="info">
+          <h2 slot="headline">test</h2>
+        </va-alert>
+      </div>,
+    );
+    const alert = screen.getByTestId('test');
+
+    expect(alert.tabIndex).to.eq(-1);
+    expect(alert.getAttribute('tabindex')).to.be.null;
+
+    focusElement('va-alert');
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(alert);
+      expect(alert.tabIndex).to.eq(-1);
+      expect(alert.getAttribute('tabindex')).to.eq('-1');
+    });
+    fireEvent.blur(alert);
+    await waitFor(() => {
+      expect(alert.tabIndex).to.eq(-1);
+      expect(alert.getAttribute('tabindex')).to.be.null;
+    });
+  });
+  it('should focus on button in inside of container', async () => {
+    const screen = render(
+      <div>
+        <div>
+          <button type="button">test-1</button>
+        </div>
+        <div data-testid="container">
+          <button type="button" data-testid="button">
+            test-2
+          </button>
+        </div>
+      </div>,
+    );
+    const container = screen.getByTestId('container');
+    const button = screen.getByTestId('button');
+
+    expect(button.tabIndex).to.eq(0);
+    expect(button.getAttribute('tabindex')).to.be.null;
+
+    focusElement('button', {}, container);
+
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(button);
+      expect(button.tabIndex).to.eq(0);
+      expect(button.getAttribute('tabindex')).to.be.null;
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > - Replaced duplicate `focusElement` code with an import/export of main function
  > - Updated the `focusElement` function to check the internal `tabIndex` value and use that to determine if a `tabindex="-1"` needs to be set. Then on blur, the negative tab index is removed. Additionally, added a new `root` parameter to allow focusing on an element inside a web component if a web component shadow root is passed in.
- *(If bug, how to reproduce)*
  > - No need to log in
  > - Open a **new tab** and go to the [Supplemental Claims subtask page](https://staging.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start)
  > - Do not select either radio input
  > - <kbd>Tab</kbd> to and activate, or click, the "continue" button
  > - Note that the error message appears and the `va-radio` is focused (outlined)
  > - <kbd>Tab</kbd> to the "continue" button again (leave the `va-radio` web component)
  > - Now <kbd>Shift</kbd> + <kbd>Tab</kbd> backwards in the doc
  > - Note that the focus now skips the `va-radio` and goes directly to the breadcrumbs. The only way to get to the radio inputs now is by clicking!
- *(What is the solution, why is this the solution)*
  > - We can work-around this issue by adding a `tabindex="0"` to the `va-radio` but then tabbing through the page will now always include `va-radio`
  > - The best solution I could think of was to remove the `tabindex="-1"` once the component is blurred.
  > - Note: when the `va-radio-option` web component is focused, the outer `document.activeElement` will target the wrapping `va-radio`, never the elements inside the shadow dom. 
  > - Note2: Added a new `root` parameter to allow passing a web component shadow root so that the element inside can be focused
- *(Which team do you work for, does your team own the maintainence of this component?)*
  > Benefits Team 1. No, the design/form system team owns this code
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#50493](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50493)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Unable to use keyboard to focus on web component _after_ it was programmatically focused  (`tabindex="-1"` left intact)
- *Describe the steps required to verify your changes are working as expected*
  > `element.tabIndex` will always return either a -1 or 0 number, whereas the `element.getAttribute('tabindex')` will return `null` or a string. So we're using this to determine if `tabindex` was intentionally added. If a `tabindex` was not intentionally added, we add a blur callback to remove the `tabindex="-1"` for non-focusable elements.
- *Describe the tests completed and the results*
  > Added tests to check the described behavior. All tests passing

## Screenshots

Video showing the issue described above (no audio)

https://user-images.githubusercontent.com/136959/212379829-394e1b91-c92f-4953-bded-24ff0bb590de.mov

## What areas of the site does it impact?

Everything!

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot/video of the developed feature

## Requested Feedback

I included a lot of inline code comments, but please let me know if there is anything that isn't clear
