### PR TITLE
Change appointment cancelled behavior

### DIFF
--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -18,6 +18,7 @@ import {
 import {
   preCheckinExpired,
   appointmentWasCanceled,
+  allAppointmentsCanceled,
   preCheckinAlreadyCompleted,
   appointmentStartTimePast15,
 } from '../utils/appointment';
@@ -122,6 +123,11 @@ const useGetCheckInData = ({
               }
 
               if (appointmentWasCanceled(payload.appointments)) {
+                updateError('possible-canceled-appointment');
+                return;
+              }
+
+              if (allAppointmentsCanceled(payload.appointments)) {
                 updateError('appointment-canceled');
                 return;
               }

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -152,6 +152,8 @@ const Error = () => {
     case 'bad-token':
     case 'no-token':
     case 'reload-data-error':
+    case 'possible-canceled-appointment':
+      // This is considered our generic error message
       alertType = 'info';
       header = t('sorry-we-cant-complete-pre-check-in');
       messageText = mixedPhoneAndInPersonMessage;

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
@@ -6,6 +6,7 @@ import Error from '../../pages/Error';
 import Confirmation from '../../pages/Confirmation';
 
 describe('Pre-Check In Experience ', () => {
+  let apiData;
   beforeEach(() => {
     const {
       initializeFeatureToggle,
@@ -18,14 +19,14 @@ describe('Pre-Check In Experience ', () => {
 
     initializeSessionPost.withSuccess();
 
-    initializePreCheckInDataGet.withCanceledAppointment();
+    apiData = initializePreCheckInDataGet.withCanceledAppointment();
   });
   afterEach(() => {
     cy.window().then(window => {
       window.sessionStorage.clear();
     });
   });
-  it('Canceled Appointments are taken to Error Page', () => {
+  it('Every appointment is cancelled should result in an appointment cancelled Error Page', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
     ValidateVeteran.validatePage.preCheckIn();
@@ -37,6 +38,20 @@ describe('Pre-Check In Experience ', () => {
     Error.validateCanceledPageLoaded();
     cy.injectAxeThenAxeCheck();
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--canceled-error');
+    cy.createScreenshots('Pre-check-in--canceled-appointment');
+  });
+  it('Not every appointment is cancelled should result in a generic Error Page', () => {
+    apiData.payload.appointments[1].status = '';
+    cy.visitPreCheckInWithUUID();
+    // page: Validate
+    ValidateVeteran.validatePage.preCheckIn();
+    ValidateVeteran.validateVeteran();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    // UUID with canceled appointments should navigate to the error page.
+    Error.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Pre-check-in--possible-canceled-appointment');
   });
 });

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -33,7 +33,7 @@ const hasMoreAppointmentsToCheckInto = (appointments, currentAppointment) => {
 };
 
 /**
- * Check if any appointment was canceled.
+ * Check if any appointment was canceled but not every.
  *
  * @param {Array<Appointment>} appointments
  *
@@ -43,7 +43,30 @@ const appointmentWasCanceled = appointments => {
   const statusIsCanceled = appointment =>
     appointment.status?.startsWith('CANCELLED');
 
-  return Array.isArray(appointments) && appointments.some(statusIsCanceled);
+  return (
+    Array.isArray(appointments) &&
+    appointments.length > 0 &&
+    appointments.some(statusIsCanceled) &&
+    !appointments.every(statusIsCanceled)
+  );
+};
+
+/**
+ * Check if every appointment was canceled.
+ *
+ * @param {Array<Appointment>} appointments
+ *
+ * @returns {boolean}
+ */
+const allAppointmentsCanceled = appointments => {
+  const statusIsCanceled = appointment =>
+    appointment.status?.startsWith('CANCELLED');
+
+  return (
+    Array.isArray(appointments) &&
+    appointments.length > 0 &&
+    appointments.every(statusIsCanceled)
+  );
 };
 
 /**
@@ -225,6 +248,7 @@ const clinicName = appointment => {
 export {
   appointmentStartTimePast15,
   appointmentWasCanceled,
+  allAppointmentsCanceled,
   getFirstCanceledAppointment,
   hasMoreAppointmentsToCheckInto,
   intervalUntilNextAppointmentIneligibleForCheckin,


### PR DESCRIPTION
## Summary

Changes the behavior of the cancelled appointment error handling for pre check in. The cancelled appointment error should only be displayed if all appointments in the list are cancelled. If only some of the appointments are cancelled it should show the generic error.

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#51862](https://github.com/department-of-veterans-affairs/va.gov-team/issues/51862)


## Testing done

- Automated Unit and Cypress tests

## Screenshots
<img width="493" alt="Screen Shot 2023-01-13 at 2 53 43 PM" src="https://user-images.githubusercontent.com/2982977/212407170-ea8dcdf1-8a8d-493e-b421-e3a8dbf54b35.png">
<img width="488" alt="Screen Shot 2023-01-13 at 2 53 16 PM" src="https://user-images.githubusercontent.com/2982977/212407172-b0e8134b-198a-4b36-ac9b-aadcc56703a8.png">


## What areas of the site does it impact?
Pre Check In error page

## Acceptance criteria

- [ ]  The generic error message is displayed for when some of the appointments are canceled
- [ ]  The appointment cancelled error message is displayed when all appointments are canceled
- [ ]  Unit tests for new functionality
- [ ]  Cypress tests for new functionality