### PR TITLE
bugfix/SA-45575 education letters breadcrumb needs fixing

### DIFF
--- a/src/applications/education-letters/components/Layout.jsx
+++ b/src/applications/education-letters/components/Layout.jsx
@@ -12,7 +12,7 @@ const Layout = ({ children, clsName = '', breadCrumbs = {} }) => {
     <>
       <va-breadcrumbs>
         <a href="/">Home</a>
-        <a href="/education/">Eduction and training</a>
+        <a href="/education/">Education and training</a>
         {renderBreadCrumbs()}
       </va-breadcrumbs>
       <section id={`education-letters-${clsName}`} className={clsName}>


### PR DESCRIPTION
## Summary
Fixed typo in breadcrumbs, Eduction -> Education
