### PR TITLE
526 | Hide PTSD questions in BDD flow

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -43,6 +43,7 @@ import {
   showSeparationLocation,
   isExpired,
   truncateDescriptions,
+  hasNewPtsdDisability,
   showPtsdCombat,
   showPtsdNonCombat,
   skip781,
@@ -1201,6 +1202,30 @@ describe('skip PTSD questions', () => {
     },
     skip781ForCombatReason: skipCombat,
     skip781ForNonCombatReason: skipNonCombat,
+  });
+
+  describe('hasNewPtsdDisability', () => {
+    const getPtsdData = (date, bddState = true) => ({
+      'view:isBddData': bddState,
+      serviceInformation: {
+        servicePeriods: [{ dateRange: { to: date } }],
+      },
+      'view:claimType': { 'view:claimingnew': true },
+      newDisabilities: [{ condition: 'PTSD' }],
+    });
+
+    it('should return true for PTSD in non-BDD flow', () => {
+      expect(hasNewPtsdDisability(getPtsdData('2020-01-01', false))).to.be.true;
+      // invalid BDD separation date negates BDD flow
+      const today = moment().format('YYYY-MM-DD');
+      expect(hasNewPtsdDisability(getPtsdData(today, true))).to.be.true;
+    });
+    it('should return false for PTSD in BDD flow', () => {
+      const date = moment()
+        .add(90, 'days')
+        .format('YYYY-MM-DD');
+      expect(hasNewPtsdDisability(getPtsdData(date, true))).to.be.false;
+    });
   });
 
   describe('showPtsdCombat', () => {

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -417,6 +417,26 @@ describe('526 helpers', () => {
         }),
       ).to.be.false;
     });
+    it('should return false if in BDD flow', () => {
+      expect(
+        needsToEnter781({
+          'view:isBddData': true,
+          serviceInformation: {
+            servicePeriods: [
+              {
+                dateRange: {
+                  to: moment()
+                    .add(90, 'days')
+                    .format('YYYY-MM-DD'),
+                },
+              },
+            ],
+          },
+          'view:claimType': { 'view:claimingnew': true },
+          newDisabilities: [{ condition: 'PTSD' }],
+        }),
+      ).to.be.false;
+    });
   });
 
   describe('needsToEnter781a', () => {

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -414,6 +414,7 @@ export const isBDD = formData => {
 };
 
 export const hasNewPtsdDisability = formData =>
+  !isBDD(formData) &&
   isClaimingNew(formData) &&
   _.get('newDisabilities', formData, []).some(disability =>
     isDisabilityPtsd(disability.condition),
@@ -434,6 +435,7 @@ export const skip781 = formData =>
   _.get('skip781ForNonCombatReason', formData) === true;
 
 export const needsToEnter781 = formData =>
+  hasNewPtsdDisability(formData) &&
   (showPtsdCombat(formData) || showPtsdNonCombat(formData)) &&
   !skip781(formData);
 


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > While form 526EZ is in the Benefits Delivery at Discharge (BDD) flow, all PTSD questions should be hidden. Previous work hid the PTSD (form 781/781a) questions, but not the PTSD intro and PTSD type pages.
  >
  > Note: the [BDD flow diagram](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/526-overall-flow.md#main-flow) was already showing the expected flow, it just wanted implemented that way
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Updated 526 form config so that the `hasNewPtsdDisability` utility function will return false if the BDD flow is set. Also the `needsToEnter781` needed to include the new PTSD check; this solution was the simplest, otherwise a `isBDD` check would need to be added to multiple utility functions & made the logic more difficult to work out
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits Team 1
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#49301](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49301)

## Testing done

- *Describe what the old behavior was prior to the change*
  > While in the BDD flow (separation date within 90-180 days), if a service member added "PTSD" as a new condition, the online form would have shown these pages:
  > - PTSD intro page (`/new-disabilities/ptsd-intro`); uses `hasNewPtsdDisability`
  > - PTSD type page (`/new-disabilities/ptsd-type`), uses `hasNewPtsdDisability`
  > - PTSD 781 walkthrough page (`/new-disabilities/walkthrough-781-choice`); uses `needsToEnter781` if "combat" type is selected (upload or answer questions online)
  > - PTSD upload 781 page (`/new-disabilities/ptsd-781-upload`); uses `needsToEnter781`
- *Describe the steps required to verify your changes are working as expected*
  > This work will jump from the last followup question (`/new-disabilities/follow-up/#`) for any non-PTSD new conditions, or  the add new disability page if only PTSD is added to the additional disability benefits page (`/additional-disability-benefits`)
- *Describe the tests completed and the results*
  > Added unit tests for `hasNewPtsdDisability` and `needsToEnter781` changes; all passing

## Screenshots

N/A - pages hidden from flow

## What areas of the site does it impact?

Form 526EZ when filing a Benefits Delivery at Discharge form (active service members with a separation date between 90 and 180 days in the future)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
