### PR TITLE
Enrollment Verification: Fix Payment Paused and Verification Bugs

### DIFF
--- a/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationMonths.jsx
@@ -61,7 +61,7 @@ function EnrollmentVerificationMonths({ enrollmentVerification, status }) {
             information.
           </li>
         </ul>
-        <p>
+        <p className="vads-u-padding-top--2">
           If you notice a mistake, it’s best if you reach out to your SCO soon.
           The sooner VA knows about changes to your enrollment, the less likely
           you are to be overpaid and incur a debt.

--- a/src/applications/enrollment-verification/components/ReviewPausedInfo.jsx
+++ b/src/applications/enrollment-verification/components/ReviewPausedInfo.jsx
@@ -12,7 +12,10 @@ export default function ReviewPausedInfo({ onFinishVerifyingLater }) {
       status="warning"
       visible
     >
-      <va-additional-info trigger="If you submit this verification, we'll pause your monthly education payments">
+      <va-additional-info
+        trigger="If you submit this verification, we'll pause your monthly education payments"
+        disable-border="true"
+      >
         <p>
           If you submit this verification, we will pause your monthly payments
           until your enrollment information is corrected.

--- a/src/applications/enrollment-verification/constants/index.js
+++ b/src/applications/enrollment-verification/constants/index.js
@@ -26,4 +26,5 @@ export const VERIFICATION_RESPONSE = {
 };
 export const CERTIFICATION_METHOD = 'MEB';
 
+export const PAYMENT_PAUSED_NUMBER_OF_MONTHS = 2;
 export const PAYMENT_PAUSED_DAY_OF_MONTH = 25;

--- a/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
+++ b/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
@@ -367,12 +367,14 @@ export const VerifyEnrollmentsPage = ({
         required
       >
         <va-radio-option
+          checked={monthInformationCorrect === VERIFICATION_STATUS_CORRECT}
           class="vads-u-margin-y--2"
           label="Yes, this information is correct"
           name={VERIFICATION_STATUS_CORRECT}
           value={VERIFICATION_STATUS_CORRECT}
         />
         <va-radio-option
+          checked={monthInformationCorrect === VERIFICATION_STATUS_INCORRECT}
           class="vads-u-margin-y--2"
           label="No, this information isn’t correct"
           name={VERIFICATION_STATUS_INCORRECT}

--- a/src/applications/enrollment-verification/helpers/index.js
+++ b/src/applications/enrollment-verification/helpers/index.js
@@ -6,6 +6,7 @@ import {
 import {
   CERTIFICATION_METHOD,
   PAYMENT_PAUSED_DAY_OF_MONTH,
+  PAYMENT_PAUSED_NUMBER_OF_MONTHS,
   STATUS,
   VERIFICATION_RESPONSE,
 } from '../constants';
@@ -121,36 +122,46 @@ export const convertNumberToStringWithMinimumDigits = (n, minDigits) => {
  * Given a date in UTC format, determine if the current date is after
  * the "paused" day of the month following the given date.
  *
- * For example (given PAYMENT_PAUSED_DATE_OF_MONTH = 25):
- * * if today is 2022-02-24 and the given date is 2022-01-01,
+ * For example (given PAYMENT_PAUSED_NUMBER_OF_MONTHS is 2 and
+ * PAYMENT_PAUSED_DATE_OF_MONTH = 25):
+ * * if today is 2022-03-24 and the given date is 2022-01-01,
  *   return false;
- * * if today is 2022-02-25 and the given date is 2022-01-01,
+ * * if today is 2022-03-25 and the given date is 2022-01-01,
  *   return true;
- * * if today is 2022-02-25 and the given date is 2022-02-01,
+ * * if today is 2022-03-25 and the given date is 2022-02-01,
  *   return false;
  *
- * @param {string} date
+ * @param {string} lastCertifiedThroughDate The date through which
+ * enrollments have been verified.
  */
-export const monthlyPaymentsPaused = date => {
+export const monthlyPaymentsPaused = lastCertifiedThroughDate => {
   const now = new Date().toISOString();
 
-  if (now <= date) {
+  if (now <= lastCertifiedThroughDate) {
     return false;
   }
 
-  const dateSplit = date.split('-');
-  dateSplit[1] = (parseInt(dateSplit[1], 10) % 12) + 1;
-  if (dateSplit[1] === 1) {
-    // If we rolled over to a near year, increment the year.
-    dateSplit[0] += 1;
-  }
-  dateSplit[1] = convertNumberToStringWithMinimumDigits(dateSplit[1], 2);
-  dateSplit[2] = convertNumberToStringWithMinimumDigits(
-    PAYMENT_PAUSED_DAY_OF_MONTH,
-    2,
-  );
+  // Given the last certified-through date, generate the date
+  // when payments will paused and compare it with the current
+  // date.
+  const dateSplit = lastCertifiedThroughDate.split('-');
+  let year = parseInt(dateSplit[0], 10);
+  let month =
+    (parseInt(dateSplit[1], 10) + PAYMENT_PAUSED_NUMBER_OF_MONTHS) % 12;
+  let day = parseInt(dateSplit[2], 10);
 
-  return now >= dateSplit.join('-');
+  if (month <= PAYMENT_PAUSED_NUMBER_OF_MONTHS) {
+    // If we rolled over to a near year, increment the year.
+    year += 1;
+  }
+  month = convertNumberToStringWithMinimumDigits(month, 2);
+  day = convertNumberToStringWithMinimumDigits(PAYMENT_PAUSED_DAY_OF_MONTH, 2);
+
+  // If the current date is equal to or after this date, payments may
+  // be paused.
+  const paymentPausedDate = [year, month, day].join('-');
+
+  return now >= paymentPausedDate;
 };
 
 export const getEnrollmentVerificationStatus = enrollmentVerification => {


### PR DESCRIPTION
## Summary
- Fixes two issues with the Payment Paused alert: corrects business logic so the red, paused, alert shows after payments haven't been verified for two months, not one; and fix a JavaScript number vs. string date parsing bug that resulted in the red paused alert showing up after less than one month if the unverified enrollment period was in December.
- Also fixes an issue with radio buttons on the enrollment verification page not working properly. When we were forced to update from `RadioButtons` to `VaRadio` we didn't set the `checked` property for the `va-radio-option`s (#22864).
- Removes border from `additional-info` inside the `va-alert` on the verification review page. This change was made to match the mockups.
- Fix spacing issue in "What if I notice an error with my enrollment information?" additional info section.

## Related issue(s)
- #22864

## Testing done
- Verified that warning messages are (or are not) correctly displayed when the enrollment verification process is up-to-date, one month behind, and two or more months behind.

## Screenshots
### Before
<img width="729" alt="image" src="https://user-images.githubusercontent.com/112403/212926303-7c7f29bb-c451-4d8f-b963-bd9b9e957412.png">

### After
<img width="730" alt="image" src="https://user-images.githubusercontent.com/112403/212926066-a7abb251-a54b-46f4-b75b-1a3bba09a6f1.png">

## What areas of the site does it impact?
* EV enrollments and verification page.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature