### PR TITLE
My va/aw/51396/fix domo ga appointments v2 events

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -126,6 +126,12 @@ export function fetchConfirmedFutureAppointmentsV2() {
           'api-name': 'GET v2/appointments ',
           'api-status': 'failed',
         });
+      } else {
+        recordEvent({
+          event: `api_call`,
+          'api-name': 'GET v2/appointments ',
+          'api-status': 'successful',
+        });
       }
 
       const { data: appointments } = appointmentResponse;
@@ -243,7 +249,6 @@ export function fetchConfirmedFutureAppointments() {
       );
       recordEvent({
         event: `api_call`,
-        'error-key': `internal error`,
         'api-name': 'GET appointments',
         'api-status': 'successful',
       });


### PR DESCRIPTION
## Summary
Updates the analytics calls for the `v2/appointments` api request. There was no event fired for the success, and only failure.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/51396

## Testing done

- Tested locally, and ensured that GA event is firing
- Once in staging, will also test event firing

## Screenshots
No UI changes

## What areas of the site does it impact?
Google analytics and the Domo dashboard for this data

## Acceptance criteria

- [x]  Success event firing for appoints endpoint request
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
