### PR TITLE
My va/aw/50904/applications in progress content update

### DIFF
--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
@@ -62,7 +62,7 @@ const ApplicationsInProgress = ({ savedForms, hideH3 }) => {
           })}
         </div>
       ) : (
-        <p>You have no saved applications to show.</p>
+        <p>You have no applications in progress.</p>
       )}
     </>
   );

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -33,7 +33,7 @@ function oneYearFromNow() {
 }
 
 function noApplicationsInProgressShown(view, shown = true) {
-  const regex = /you have no saved applications to show/i;
+  const regex = /you have no applications in progress/i;
   if (shown) {
     view.getByText(regex);
   } else {

--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -158,7 +158,7 @@ describe('The My VA Dashboard', () => {
     it('should show fallback content when there are no benefit applications saved in progress', () => {
       cy.findByRole('heading', { name: /saved applications/i }).should('exist');
       cy.findAllByTestId('application-in-progress').should('have.length', 0);
-      cy.findByText(/you have no saved applications to show/i).should('exist');
+      cy.findByText(/you have no applications in progress/i).should('exist');
       cy.injectAxe();
       cy.axeCheck();
     });


### PR DESCRIPTION
## Summary
Minor _content only_ update for `ApplicationsInProgress` component when there are no applications in progress.


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/50904

## Testing done

- E2E and Unit tests are updated for the new content and are passing

## Screenshots

| Before | After |
| -------| ----- |
| ![Screenshot 2023-01-17 at 9 44 52 AM](https://user-images.githubusercontent.com/8332986/212960293-e80a38b7-4985-4326-ac7a-9d87b0bd843d.png) | ![Screenshot 2023-01-17 at 9 42 38 AM](https://user-images.githubusercontent.com/8332986/212960386-2d30b439-e5b2-4de9-8b47-4210fce95b23.png) |



## What areas of the site does it impact?
MyVa page when no application are in progress

## Acceptance criteria

- [x]  Updated content
- [x] Updated tests for new content
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature
