### PR TITLE
Fixing res.json() being called incorrectly

### DIFF
--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -283,8 +283,9 @@ export function fetchInProgressForm(
     })
       .then(res => {
         if (res.ok) {
-          console.log("returning response: ", res.json());
-          return res.json();
+          const responseJSON = res.json();
+          console.log("returning response: ", responseJSON);
+          return responseJSON;
         }
 
         // Make me a switch?


### PR DESCRIPTION
A bug was discovered where fetchInProgressForm was calling res.json() inside of a console.log and then attempted to read it again as part of a return. Because res.json() only reads and outputs the json version of the response body 'once', the returned value was empty and calling errors.
