### PR TITLE
(fix) update codeowners for authd exp team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,10 +43,8 @@ script/github-actions/daily-product-scan/ @department-of-veterans-affairs/qa-sta
 
 # Authenticated Experience
 
-src/applications/personalization @department-of-veterans-affairs/vsa-authd-exp-frontend
-src/platform/user/profile/vap-svc @department-of-veterans-affairs/vsa-authd-exp-frontend
-src/applications/personalization @department-of-veterans-affairs/benefits-team-1-frontend
-src/platform/user/profile/vap-svc @department-of-veterans-affairs/benefits-team-1-frontend
+src/applications/personalization @department-of-veterans-affairs/vsa-authd-exp-frontend @department-of-veterans-affairs/benefits-team-1-frontend
+src/platform/user/profile/vap-svc @department-of-veterans-affairs/vsa-authd-exp-frontend @department-of-veterans-affairs/benefits-team-1-frontend
 
 # Claims & appeals (Benefits Team 1)
 


### PR DESCRIPTION
## Summary

The last time I updated the codeowners file, I made an error and put the teams on two different lines for the folder owners instead of the teams seperated by a space on the same line. This PR fixes the issue so both teams are codeowners over the two respective folders.

## Related issue(s)
- hotfix, no ticket

## Testing done

- Just updating codeowners to be correct

## Screenshots
No ui changes

## What areas of the site does it impact?
github codeowners and nothing else

## Acceptance criteria

- [ ]  updated codeowners to correct previous error

