### PR TITLE
(chore) remove 'Source' from service_history api event

### DIFF
--- a/src/applications/personalization/profile/actions/index.js
+++ b/src/applications/personalization/profile/actions/index.js
@@ -55,7 +55,7 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
 
     const baseUrl = '/profile/service_history';
 
-    let apiEventName = `GET ${baseUrl}`;
+    const apiEventName = `GET ${baseUrl}`;
 
     try {
       recordAnalyticsEvent(
@@ -101,10 +101,6 @@ export function fetchMilitaryInformation(recordAnalyticsEvent = recordEvent) {
         });
         return;
       }
-
-      apiEventName = `${apiEventName}${
-        response?.dataSource ? ` Source: ${response.dataSource}` : ''
-      }`;
 
       recordAnalyticsEvent(
         createApiEvent({


### PR DESCRIPTION
## Summary

- Remove the `Source: ` template literal in GA events for the `service_history` api call within the Profile application. We were tracking the dataSource during a BE data provider transition, but are no longer needing this data within analytics events.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/51813


## Testing done

- Manually tested that analytics events fire without this data correctly. 

## Screenshots
No UI changes made

## What areas of the site does it impact?
Profile application - service_history ga events

## Acceptance criteria

- [x]  Updated event to remove `Source` from string
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs