### PR TITLE
[51653] Add catch for missing fields resulting in NaN

### DIFF
--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -54,7 +54,7 @@ export const currency = amount => {
   const value =
     typeof amount === 'number'
       ? amount
-      : parseFloat(amount?.replaceAll(/[^0-9.-]/g, ''));
+      : parseFloat(amount?.replaceAll(/[^0-9.-]/g, '') ?? 0);
   return formatter.format(value);
 };
 
@@ -77,7 +77,8 @@ export const filterReduceByName = (deductions, filters) => {
   return deductions
     .filter(({ name = '' }) => filters.includes(name))
     .reduce(
-      (acc, curr) => acc + Number(curr.amount?.replaceAll(/[^0-9.-]/g, '')),
+      (acc, curr) =>
+        acc + Number(curr.amount?.replaceAll(/[^0-9.-]/g, '') ?? 0),
       0,
     );
 };
@@ -95,7 +96,8 @@ export const otherDeductionsAmt = (deductions, filters) => {
   return deductions
     .filter(({ name = '' }) => name && !filters.includes(name))
     .reduce(
-      (acc, curr) => acc + Number(curr.amount?.replaceAll(/[^0-9.-]/g, '')),
+      (acc, curr) =>
+        acc + Number(curr.amount?.replaceAll(/[^0-9.-]/g, '') ?? 0),
       0,
     );
 };
@@ -145,7 +147,8 @@ export const getAmountCanBePaidTowardDebt = (debts, combinedFSR) => {
         .filter(item => item.resolutionComment !== undefined)
         .reduce(
           (acc, debt) =>
-            acc + Number(debt.resolutionComment?.replaceAll(/[^0-9.-]/g, '')),
+            acc +
+            Number(debt.resolutionComment?.replaceAll(/[^0-9.-]/g, '') ?? 0),
           0,
         )
     : debts
@@ -153,7 +156,9 @@ export const getAmountCanBePaidTowardDebt = (debts, combinedFSR) => {
         .reduce(
           (acc, debt) =>
             acc +
-            Number(debt.resolution?.offerToPay?.replaceAll(/[^0-9.-]/g, '')),
+            Number(
+              debt.resolution?.offerToPay?.replaceAll(/[^0-9.-]/g, '') ?? 0,
+            ),
           0,
         );
 };
@@ -264,13 +269,13 @@ export const getMonthlyExpenses = ({
   if (expenses.expenseRecords && expenses.expenseRecords.length > 0) {
     totalExp = expenses.expenseRecords.reduce(
       (acc, expense) =>
-        acc + Number(expense.amount?.replaceAll(/[^0-9.-]/g, '')),
+        acc + Number((expense.amount || '0').replaceAll(/[^0-9.-]/g, '') ?? 0),
       0,
     );
   } else {
     totalExp = expVals.reduce(
       (acc, expense) =>
-        acc + Number(expense.amount?.replaceAll(/[^0-9.-]/g, '')),
+        acc + Number((expense.amount || '0').replaceAll(/[^0-9.-]/g, '') ?? 0),
       0,
     );
   }
@@ -287,14 +292,15 @@ export const getTotalAssets = ({
   const totOtherAssets = sumValues(assets.otherAssets, 'amount');
   const totRecVehicles = !combinedFSRActive
     ? sumValues(assets.recVehicles, 'recVehicleAmount')
-    : Number(assets?.recVehicleAmount?.replaceAll(/[^0-9.-]/g, ''));
+    : Number((assets?.recVehicleAmount).replaceAll(/[^0-9.-]/g, '') ?? 0);
   const totVehicles = sumValues(assets.automobiles, 'resaleValue');
   const realEstate = sumValues(realEstateRecords, 'realEstateAmount');
   const totAssets = !enhancedFSRActive
     ? Object.values(assets)
         .filter(item => item && !Array.isArray(item))
         .reduce(
-          (acc, amount) => acc + Number(amount?.replaceAll(/[^0-9.-]/g, '')),
+          (acc, amount) =>
+            acc + Number(amount?.replaceAll(/[^0-9.-]/g, '') ?? 0),
           0,
         )
     : sumValues(assets.monetaryAssets, 'amount');

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -269,13 +269,13 @@ export const getMonthlyExpenses = ({
   if (expenses.expenseRecords && expenses.expenseRecords.length > 0) {
     totalExp = expenses.expenseRecords.reduce(
       (acc, expense) =>
-        acc + Number((expense.amount || '0').replaceAll(/[^0-9.-]/g, '') ?? 0),
+        acc + Number(expense.amount?.replaceAll(/[^0-9.-]/g, '') ?? 0),
       0,
     );
   } else {
     totalExp = expVals.reduce(
       (acc, expense) =>
-        acc + Number((expense.amount || '0').replaceAll(/[^0-9.-]/g, '') ?? 0),
+        acc + Number(expense.amount?.replaceAll(/[^0-9.-]/g, '') ?? 0),
       0,
     );
   }
@@ -292,7 +292,7 @@ export const getTotalAssets = ({
   const totOtherAssets = sumValues(assets.otherAssets, 'amount');
   const totRecVehicles = !combinedFSRActive
     ? sumValues(assets.recVehicles, 'recVehicleAmount')
-    : Number((assets?.recVehicleAmount).replaceAll(/[^0-9.-]/g, '') ?? 0);
+    : Number(assets?.recVehicleAmount?.replaceAll(/[^0-9.-]/g, '') ?? 0);
   const totVehicles = sumValues(assets.automobiles, 'resaleValue');
   const realEstate = sumValues(realEstateRecords, 'realEstateAmount');
   const totAssets = !enhancedFSRActive


### PR DESCRIPTION
## Summary
- Add catch in `Number` casting for missing fields (`Number(undefined) -> NaN`)
- Default to 0 if monetary field is missing

## Related issue(s)
[- department-of-veterans-affairs/va.gov-team#51653](https://github.com/department-of-veterans-affairs/va.gov-team/issues/51653)

## Testing done

- Local testing on FSR submissions and validating against PDF

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

## What areas of the site does it impact?
FSR Submission

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
