### PR TITLE
Bugfix HCA compensation type validation error

### DIFF
--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -46,14 +46,15 @@ const IntroductionPage = props => {
         appTitle="Application for VA health care"
         dependencies={[externalServices.es]}
       >
-        {!showLOA3Content && (
-          <p>
-            VA health care covers care for your physical and mental health. This
-            includes a range of services from checkups to surgeries to home
-            health care. It also includes prescriptions and medical equipment.
-            Apply online now.
-          </p>
-        )}
+        {!showLoader &&
+          !showLOA3Content && (
+            <p>
+              VA health care covers care for your physical and mental health.
+              This includes a range of services from checkups to surgeries to
+              home health care. It also includes prescriptions and medical
+              equipment. Apply online now.
+            </p>
+          )}
 
         {showLoader && (
           <va-loading-indicator

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -155,7 +155,10 @@ export function transform(formConfig, form) {
 
   // add back & double check compensation type because it could have been removed in filterInactivePages
   if (!withoutViewFields.vaCompensationType) {
-    const disabilityRating = form.data['view:totalDisabilityRating'];
+    const disabilityRating = parseInt(
+      form.data['view:totalDisabilityRating'],
+      10,
+    );
     const compensationType =
       disabilityRating >= 50 ? 'highDisability' : form.data.vaCompensationType;
     withoutViewFields = set(

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -155,12 +155,15 @@ export function transform(formConfig, form) {
 
   // add back & double check compensation type because it could have been removed in filterInactivePages
   if (!withoutViewFields.vaCompensationType) {
-    const disabilityRating = parseInt(
+    const highDisabilityRating = 50;
+    const userDisabilityRating = parseInt(
       form.data['view:totalDisabilityRating'],
       10,
     );
     const compensationType =
-      disabilityRating >= 50 ? 'highDisability' : form.data.vaCompensationType;
+      userDisabilityRating >= highDisabilityRating
+        ? 'highDisability'
+        : form.data.vaCompensationType;
     withoutViewFields = set(
       'vaCompensationType',
       compensationType,

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -153,6 +153,18 @@ export function transform(formConfig, form) {
     }
   });
 
+  // add back & double check compensation type because it could have been removed in filterInactivePages
+  if (!withoutViewFields.vaCompensationType) {
+    const disabilityRating = form.data['view:totalDisabilityRating'];
+    const compensationType =
+      disabilityRating >= 50 ? 'highDisability' : form.data.vaCompensationType;
+    withoutViewFields = set(
+      'vaCompensationType',
+      compensationType,
+      withoutViewFields,
+    );
+  }
+
   // add back dependents here, because it could have been removed in filterViewFields
   if (!withoutViewFields.dependents) {
     withoutViewFields = set('dependents', [], withoutViewFields);


### PR DESCRIPTION
## Description
The health care application occasionally runs into a validation mismatch between the front and backends when the backend is unable to retrieve an authenticated user's disability rating. This rating is used to determine the compensation type value that controls the short form flow of the application. The without the rating value the backend think the form has not provided the required data in order to submit.

This PR provides the appropriate compensation type in the frontend payload to allow the backend to skip the additional retrieval for the rating value when that was known to the front end.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#48528

## Acceptance criteria
- Form successfully submits with all provided data
- vaCompensationType value is included in the submission payload