### PR TITLE
[eFSR-48747] Content start your request

### DIFF
--- a/src/applications/financial-status-report/components/Alerts.jsx
+++ b/src/applications/financial-status-report/components/Alerts.jsx
@@ -67,3 +67,36 @@ export const ErrorAlert = () => (
     </p>
   </va-alert>
 );
+
+export const ZeroDebtAlert = () => (
+  <va-alert close-btn-aria-label="Close notification" status="info" visible>
+    <h2 id="all-zero-alert" className="vads-u-font-size--h3" slot="headline">
+      You don’t have any current VA debt or copay bills
+    </h2>
+    <div>
+      <p className="vads-u-font-size--base vads-u-font-family--sans">
+        Our records show you don’t have any current VA benefit debt and you
+        haven’t received a copay bill in the past 6 months.
+      </p>
+    </div>
+    <div>
+      <h3 className="vads-u-font-size--h4">
+        What to do if you think you have a VA debt or copay bill
+      </h3>
+      <ul>
+        <li className="vads-u-font-family--sans">
+          <strong>For benefit debts</strong>, call the Debt Management Center
+          (DMC) at <va-telephone contact="8008270648" /> (TTY:{' '}
+          <va-telephone contact="711" />
+          ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+        </li>
+        <li className="vads-u-font-family--sans">
+          <strong>For health care copay bills</strong>, call the VA Health
+          Resource Center at <va-telephone contact="8664001238" /> (TTY:{' '}
+          <va-telephone contact="711" />
+          ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+        </li>
+      </ul>
+    </div>
+  </va-alert>
+);

--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -107,7 +107,7 @@ const App = ({
     return <ErrorAlert />;
   }
 
-  if (!isLoggedIn && !debts.length && !statementsByUniqueFacility.length) {
+  if (isLoggedIn && !debts.length && !statementsByUniqueFacility.length) {
     return (
       <div className="row vads-u-margin-bottom--5">
         <div className="medium-9 columns">

--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import MetaTags from 'react-meta-tags';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import {
   WIZARD_STATUS_NOT_STARTED,
@@ -13,9 +13,10 @@ import {
   restartShouldRedirect,
 } from 'platform/site-wide/wizard';
 import formConfig from '../config/form';
+import { fetchDebts, fetchFormStatus } from '../actions';
+import { getStatements } from '../actions/copays';
 import { ZeroDebtAlert, ErrorAlert } from '../components/Alerts';
 import WizardContainer from '../wizard/WizardContainer';
-import { fetchFormStatus } from '../actions/index';
 import { WIZARD_STATUS } from '../wizard/constants';
 import {
   fsrWizardFeatureToggle,
@@ -93,6 +94,17 @@ const App = ({
     [showCombinedFSR, showEnhancedFSR, setFormData, isStartingOver],
   );
 
+  const dispatch = useDispatch();
+  useEffect(
+    () => {
+      if (showCombinedFSR) {
+        fetchDebts(dispatch);
+        getStatements(dispatch);
+      }
+    },
+    [dispatch, showCombinedFSR],
+  );
+
   if (pending) {
     return (
       <va-loading-indicator
@@ -107,7 +119,12 @@ const App = ({
     return <ErrorAlert />;
   }
 
-  if (isLoggedIn && !debts.length && !statementsByUniqueFacility.length) {
+  if (
+    isLoggedIn &&
+    showCombinedFSR &&
+    !debts.length &&
+    !statementsByUniqueFacility.length
+  ) {
     return (
       <div className="row vads-u-margin-bottom--5">
         <div className="medium-9 columns">


### PR DESCRIPTION
## Summary
Users who do not have debt should receive an info box that matches the [UX pin](https://preview.uxpin.com/552e9ad135f7d7ee943a92576feab45190b069f4#/pages/145021573/specification/sitemap?mode=i) provided from the design team. 

- Add info box that displays a customized message for users who are authenticated, and do not have debt 
- The solution implemented by adding a new info box with custom messaging that displays when a user is logged in and does not own debt. The following conditions need to be met in order to see the info box.

- `isLoggedIn`
- `!debts.length`  found in `state.fsr`
- `!statementsByUniqueFacility.length`  found in `state.fsr`
- Owned by VSA-Debt Front End
- No Flipper required.

## Related issue(s)
-   https://github.com/department-of-veterans-affairs/va.gov-team/issues/48747



## Testing done

- Verified that the alert box is not shown when user is not authenticated. 
- Confirmed that the alert box is not shown when user has debt


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._




| | Before | After |
| --- | --- | --- |
| Desktop | |<img width="1122" alt="Screenshot 2023-01-19 at 2 03 32 PM" src="https://user-images.githubusercontent.com/3916436/214127071-a29284b0-1a4c-4c2e-993d-5b7f8b995a39.png"> |



## What areas of the site does it impact?


[Entry to FSR](http://va.gov/manage-va-debt/request-debt-help-form-5655/introduction)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
