### PR TITLE
Remove anchor to nowhere and ignore eslint in favor of wave

### DIFF
--- a/src/applications/check-in/components/LanguagePicker.jsx
+++ b/src/applications/check-in/components/LanguagePicker.jsx
@@ -48,10 +48,11 @@ function LanguagePicker(props) {
               {link.label}
             </span>
           ) : (
+            // eslint-disable-next-line jsx-a11y/anchor-is-valid
             <a
               onClick={changeLanguage}
               data-testid={`translate-button-${link.lang}`}
-              href={`#${link.lang}`}
+              href="#"
               lang={link.lang}
             >
               {link.label}


### PR DESCRIPTION
## Summary

Wave was throwing a warning about the anchor links that were `#es`. This changes them to just a # sign and fixes that error. It also adds an ignore for eslint. The ideal solution would be to redesign using buttons since these links don't navigate anywhere. More information here:

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#52205](https://github.com/department-of-veterans-affairs/va.gov-team/issues/52205)


## Testing done

- Manual testing with wave and axe plugins on firefox

## Screenshots

![Screen Shot 2023-01-18 at 4 17 54 PM](https://user-images.githubusercontent.com/2982977/213749520-f81b1503-be90-42dd-ac90-3efb2fd06992.png)



## What areas of the site does it impact?
Check-in Experience

## Acceptance criteria

- [ ]  Wave plugin test passes
- [ ]  All other accessibility tests pass

