### PR TITLE
replace with additional Info web component

### DIFF
--- a/src/applications/vaos/components/FacilityPhone.jsx
+++ b/src/applications/vaos/components/FacilityPhone.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-export default function FacilityPhone({ contact, className, level }) {
+export default function FacilityPhone({
+  contact,
+  className = 'vads-u-font-weight--bold',
+  level,
+}) {
   if (!contact) {
     return null;
   }

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import recordEvent from 'platform/monitoring/record-event';
+
+import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 // import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import FacilityPhone from '../../../components/FacilityPhone';
 import { GA_PREFIX } from '../../../utils/constants';
@@ -45,43 +45,13 @@ export default function FacilitiesNotShown({
     return null;
   }
 
-  const buttonClass = classNames(
-    'additional-info-button',
-    'va-button-link',
-    'vads-u-display--block',
-  );
-
-  const iconClass = classNames({
-    fas: true,
-    'fa-angle-down': true,
-    open: isOpen,
-  });
-
-  const trigger = (
-    <button
-      type="button"
-      className={buttonClass}
-      aria-expanded={isOpen ? 'true' : 'false'}
-      aria-controls="facilities-not-shown-content"
-      onClick={() => setIsOpen(!isOpen)}
-    >
-      <span className="additional-info-title">
-        Why isn’t my facility listed?
-        <i className={iconClass} />
-      </span>
-    </button>
-  );
-
   return (
     <div className="vads-u-margin-bottom--7">
-      {/* Removing ExpandingGroup. Github ticket: #50602
-       <ExpandingGroup
-        open={isOpen}
-        expandedContentId="facilities-not-shown-content"
-      > */}
-      {trigger}
-      {isOpen && (
-        <div className="additional-info-content">
+      <div className="additional-info-content">
+        <va-additional-info
+          data-testid="facility-not-listed"
+          trigger="Why isn't my facility listed?"
+        >
           <p id="vaos-unsupported-label">
             The facilities below don’t offer online scheduling for this care.
           </p>
@@ -111,6 +81,7 @@ export default function FacilitiesNotShown({
               </li>
             ))}
           </ul>
+          <br />
           <h3 className="vads-u-font-size--h4 vads-u-margin-top--2 vads-u-margin-bottom--1">
             What you can do
           </h3>
@@ -129,9 +100,8 @@ export default function FacilitiesNotShown({
             </NewTabAnchor>
             .
           </p>
-        </div>
-      )}
-      {/* </ExpandingGroup> */}
+        </va-additional-info>
+      </div>
     </div>
   );
 }

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -575,11 +575,7 @@ describe('VAOS <VAFacilityPage>', () => {
       });
       expect(await screen.findByLabelText(/Facility that is enabled/i)).to.be
         .ok;
-      expect(screen.queryByText(/Facility that is disabled/i)).not.to.be.ok;
-      const additionalInfoButton = screen.getByText(
-        /Why isn.t my facility listed/i,
-      );
-      userEvent.click(additionalInfoButton);
+      expect(screen.getByTestId('facility-not-listed')).to.exist;
       await screen.findByText(/Facility that is disabled/i);
       expect(screen.baseElement).to.contain.text('Bozeman, MontanaMT');
       expect(screen.getByText(/80\.4 miles/i)).to.be.ok;
@@ -588,7 +584,7 @@ describe('VAOS <VAFacilityPage>', () => {
         screen.queryByText(
           /Facility that is over 100 miles away and disabled/i,
         ),
-      ).not.to.be.ok;
+      ).to.be.null;
       expect(
         screen.getByRole('link', { name: /different VA location/i }),
       ).to.have.attribute('href', '/find-locations');
@@ -687,15 +683,12 @@ describe('VAOS <VAFacilityPage>', () => {
       });
       expect(await screen.findByLabelText(/Facility that is enabled/i)).to.be
         .ok;
-      let additionalInfoButton = screen.getByText(
-        /Why isn.t my facility listed/i,
-      );
-      userEvent.click(additionalInfoButton);
+      expect(screen.getByTestId('facility-not-listed')).to.exist;
       expect(
         await screen.findByText(/Disabled facility near residential address/i),
       ).to.be.ok;
-      expect(screen.queryByText(/Disabled facility near current location/i)).not
-        .to.be.ok;
+      expect(screen.queryByText(/Disabled facility near current location/i)).to
+        .be.null;
 
       const facilitiesSelect = await screen.findByTestId('facilitiesSelect');
       // call VaSelect custom event for onChange handling
@@ -706,13 +699,12 @@ describe('VAOS <VAFacilityPage>', () => {
       expect(await screen.findByLabelText(/Facility that is enabled/i)).to.be
         .ok;
 
-      additionalInfoButton = screen.getByText(/Why isn.t my facility listed/i);
-      userEvent.click(additionalInfoButton);
+      expect(screen.getByTestId('facility-not-listed')).to.exist;
       expect(
         await screen.findByText(/Disabled facility near current location/i),
       ).to.be.ok;
       expect(screen.queryByText(/Disabled facility near residential address/i))
-        .not.to.be.ok;
+        .to.be.null;
     });
 
     it.skip('should display correct facilities after changing type of care', async () => {
@@ -886,7 +878,7 @@ describe('VAOS <VAFacilityPage>', () => {
           .getAttribute('href'),
       ).to.contain('pages%2Fscheduling%2Fupcoming');
 
-      userEvent.click(screen.getByText(/Why isn.t my facility listed/i));
+      expect(screen.getByTestId('facility-not-listed')).to.exist;
       await waitFor(() => {
         expect(screen.getByText(/Vista facility/i));
       });


### PR DESCRIPTION
## Summary
We are replacing all ExpandingGroup with the `va-additional-info` web component.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#51131



## Testing done

To test locally, change the constant UNSUPPORTED_FACILITY_RANGE from 100 to 5000 on FacilitiesNotShown.jsx. 
Start the new appointment flow and select Social Work as type of care. On Choose VA Location page, you should see the link "Why isn't my facility listed" to expand.

## Screenshots
<img width="631" alt="Screenshot 2023-01-20 at 2 20 32 PM" src="https://user-images.githubusercontent.com/54327023/213830843-6cb583f2-a8cd-41a8-a183-d5f388f73693.png">


| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  Replace all expandingGroup with `va-additional-info` web component.


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
