### PR TITLE
 Added directions ability to address component.

### DIFF
--- a/src/applications/check-in/components/AddressBlock.jsx
+++ b/src/applications/check-in/components/AddressBlock.jsx
@@ -51,7 +51,10 @@ const AddressBlock = ({ address, showDirections = false, placeName }) => {
       {showDirections &&
         placeName && (
           <div data-testid="directions-link-wrapper">
-            <i className="fas fa-road vads-u-color--link-default vads-u-margin-right--0p5" />
+            <i
+              className="fas fa-road vads-u-color--link-default vads-u-margin-right--0p5"
+              aria-hidden="true"
+            />
             <a
               data-testid="directions-link"
               href={`https://maps.google.com?addr=Current+Location&daddr=${fullAddress(

--- a/src/applications/check-in/components/AddressBlock.jsx
+++ b/src/applications/check-in/components/AddressBlock.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
-const AddressBlock = ({ address }) => {
+const AddressBlock = ({ address, showDirections = false, placeName }) => {
   const { t } = useTranslation();
   const requiredFields = ['street1', 'city', 'state', 'zip'];
   const isValidAddress = requiredFields.every(
@@ -25,6 +25,20 @@ const AddressBlock = ({ address }) => {
   const lineTwo = formatAddressLine('street2');
   const lineThree = formatAddressLine('street3');
 
+  const fullAddress = addressObject => {
+    let addressString = addressObject.street1;
+    if (addressObject.street2) {
+      addressString = `${addressString}, ${addressObject.street2}`;
+    }
+    if (addressObject.street3) {
+      addressString = `${addressString}, ${addressObject.street3}`;
+    }
+    addressString = `${addressString}, ${addressObject.city}, ${
+      addressObject.state
+    }, ${addressObject.zip}`;
+    return addressString;
+  };
+
   return (
     <>
       <span data-testid="address-line-street1">{address.street1}</span>
@@ -34,11 +48,30 @@ const AddressBlock = ({ address }) => {
       <span data-testid="address-city-state-and-zip">
         {`${address.city}, ${address.state} ${address.zip.substring(0, 5)}`}
       </span>
+      {showDirections &&
+        placeName && (
+          <div data-testid="directions-link-wrapper">
+            <i className="fas fa-road vads-u-color--link-default vads-u-margin-right--0p5" />
+            <a
+              data-testid="directions-link"
+              href={`https://maps.google.com?addr=Current+Location&daddr=${fullAddress(
+                address,
+              )}`}
+              aria-label={t('directions-to-location', { location: placeName })}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t('directions')}
+            </a>
+          </div>
+        )}
     </>
   );
 };
 AddressBlock.propTypes = {
   address: PropTypes.object,
+  placeName: PropTypes.string,
+  showDirections: PropTypes.bool,
 };
 
 export default AddressBlock;

--- a/src/applications/check-in/components/tests/AddressBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AddressBlock.unit.spec.jsx
@@ -101,5 +101,51 @@ describe('check-in', () => {
       const component = render(<AddressBlock address={addressMissingZip} />);
       expect(component.getByText('Not available')).to.exist;
     });
+    it('Does not display directions link when false', () => {
+      const component = render(
+        <AddressBlock
+          address={oneLineAddress}
+          showDirections={false}
+          placeName="test place"
+        />,
+      );
+      expect(component.queryByTestId('directions-link')).to.not.exist;
+    });
+    it('Displays directions link when true', () => {
+      const component = render(
+        <AddressBlock
+          address={oneLineAddress}
+          showDirections
+          placeName="test place"
+        />,
+      );
+      expect(component.getByTestId('directions-link')).to.exist;
+    });
+    it('Builds the link with all address parts', () => {
+      const component = render(
+        <AddressBlock
+          address={fullAddress}
+          showDirections
+          placeName="test place"
+        />,
+      );
+      expect(component.getByTestId('directions-link')).to.have.attribute(
+        'href',
+        'https://maps.google.com?addr=Current+Location&daddr=line 1, line 2, line 3, city, state, 000001234',
+      );
+    });
+    it('Builds the link with some missing address parts', () => {
+      const component = render(
+        <AddressBlock
+          address={oneLineAddress}
+          showDirections
+          placeName="test place"
+        />,
+      );
+      expect(component.getByTestId('directions-link')).to.have.attribute(
+        'href',
+        'https://maps.google.com?addr=Current+Location&daddr=line 1, city, state, 00000',
+      );
+    });
   });
 });

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -218,5 +218,7 @@
   "reason-for-visit": "Reason for visit",
   "appointment-day": "{{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
   "back-to-appointments": "Back to appointments",
-  "click-to-see-details-for-your-time-appointment": "Click to see the details for your {{ time, time }} appointment"
+  "click-to-see-details-for-your-time-appointment": "Click to see the details for your {{ time, time }} appointment",
+  "directions-to-location": "Directions to {{ location }}",
+  "directions": "Directions"
 }


### PR DESCRIPTION
## Summary
Modifies AddressBlock component to be able to display a directions link.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50825

## Testing done
Adds additional unit tests, no e2e tests since this is not in use yet.

## Acceptance criteria

- [ ]  Able to generate a link to google maps directions for a given valid address
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
