### PR TITLE
ToE: Update VA Radio Component

### DIFF
--- a/src/applications/toe/components/FirstSponsorRadioGroup.jsx
+++ b/src/applications/toe/components/FirstSponsorRadioGroup.jsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
-import { setData } from 'platform/forms-system/src/js/actions';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import {
   IM_NOT_SURE_LABEL,
   IM_NOT_SURE_VALUE,
+  SPONSORS_TYPE,
   SPONSOR_NOT_LISTED_VALUE,
 } from '../constants';
 
@@ -16,12 +18,15 @@ function FirstSponsorRadioGroup({
   setFormData,
   sponsors,
 }) {
-  const onValueChange = ({ value }) => {
-    setFormData({
-      ...formData,
-      firstSponsor: value.replace('sponsor-', ''),
-    });
-  };
+  const setSelectedFirstSponsor = useCallback(
+    event => {
+      setFormData({
+        ...formData,
+        firstSponsor: event?.detail?.value?.replace('sponsor-', ''),
+      });
+    },
+    [formData, setFormData],
+  );
 
   const options = sponsors?.sponsors.length
     ? sponsors?.sponsors?.flatMap(
@@ -54,16 +59,32 @@ function FirstSponsorRadioGroup({
     value: `sponsor-${IM_NOT_SURE_VALUE}`,
   });
 
+  const VaRadioOptions = options.map((option, index) => {
+    return (
+      <va-radio-option
+        checked={option.value === `sponsor-${firstSponsor}`}
+        class="vads-u-margin-y--2"
+        key={index}
+        label={option.label}
+        name={option.label}
+        value={option.value}
+      />
+    );
+  });
+
   return (
-    <RadioButtons
-      additionalFieldsetClass="vads-u-margin-top--0"
-      additionalLegendClass="toe-sponsors-checkboxes_legend vads-u-margin-top--0"
-      onValueChange={onValueChange}
-      options={options}
-      value={{ value: `sponsor-${firstSponsor}` }}
-    />
+    <VaRadio onVaValueChange={setSelectedFirstSponsor}>
+      {VaRadioOptions}
+    </VaRadio>
   );
 }
+
+FirstSponsorRadioGroup.propTypes = {
+  firstSponsor: PropTypes.string,
+  formData: PropTypes.object,
+  setFormData: PropTypes.func,
+  sponsors: SPONSORS_TYPE,
+};
 
 const mapStateToProps = state => ({
   firstSponsor: state.form?.data?.firstSponsor,


### PR DESCRIPTION
## Summary
Update VA radio component. Replace deprecated `RadioButtons` with new `VaRadio` component.

## Related issue(s)
- #23212

## Testing done
Manually tested that the first sponsor form page works well, i.e. selections persist when page changes and from saved form state, validation (negative and positive) work, and selection is displayed on review page.

## Screenshots
N/A

## What areas of the site does it impact?
ToE first sponsor page.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature