### PR TITLE
Fry/DEA: Update VA Radio Component

### DIFF
--- a/src/applications/fry-dea/components/VeteransRadioGroup.jsx
+++ b/src/applications/fry-dea/components/VeteransRadioGroup.jsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { setData } from 'platform/forms-system/src/js/actions';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import {
   formFields,
   VETERANS_TYPE,
   VETERAN_NOT_LISTED_LABEL,
   VETERAN_NOT_LISTED_VALUE,
+  VETERAN_VALUE_PREFIX,
 } from '../constants';
 
 function VeteransRadioGroup({
@@ -18,15 +19,19 @@ function VeteransRadioGroup({
   setFormData,
   veterans,
 }) {
-  const VETERAN_VALUE_PREFIX = 'veteran-';
-
-  const onValueChange = ({ value }) => {
-    setFormData({
-      ...formData,
-      [formFields.benefitSelection]: undefined,
-      [formFields.selectedVeteran]: value.replace(VETERAN_VALUE_PREFIX, ''),
-    });
-  };
+  const setSelectedVeteran = useCallback(
+    event => {
+      setFormData({
+        ...formData,
+        [formFields.benefitSelection]: undefined,
+        [formFields.selectedVeteran]: event?.detail?.value?.replace(
+          VETERAN_VALUE_PREFIX,
+          '',
+        ),
+      });
+    },
+    [formData, setFormData],
+  );
 
   const options = veterans?.length
     ? veterans?.map((veteran, index) => ({
@@ -39,14 +44,21 @@ function VeteransRadioGroup({
     value: VETERAN_VALUE_PREFIX + VETERAN_NOT_LISTED_VALUE,
   });
 
+  const VaRadioOptions = options.map((option, index) => {
+    return (
+      <va-radio-option
+        checked={option.value === VETERAN_VALUE_PREFIX + selectedVeteran}
+        class="vads-u-margin-y--2"
+        key={index}
+        label={option.label}
+        name={option.label}
+        value={option.value}
+      />
+    );
+  });
+
   return (
-    <RadioButtons
-      additionalFieldsetClass="vads-u-margin-top--0"
-      additionalLegendClass="fry-dea-veterans-checkboxes_legend vads-u-margin-top--0"
-      onValueChange={onValueChange}
-      options={options}
-      value={{ value: VETERAN_VALUE_PREFIX + selectedVeteran }}
-    />
+    <VaRadio onVaValueChange={setSelectedVeteran}>{VaRadioOptions}</VaRadio>
   );
 }
 

--- a/src/applications/fry-dea/constants.js
+++ b/src/applications/fry-dea/constants.js
@@ -14,6 +14,7 @@ export const ELIGIBILITY = {
 
 export const VETERAN_NOT_LISTED_LABEL = 'Someone not listed here';
 export const VETERAN_NOT_LISTED_VALUE = 'VETERAN_NOT_LISTED';
+export const VETERAN_VALUE_PREFIX = 'veteran-';
 
 export const VETERANS_TYPE = PropTypes.arrayOf(
   PropTypes.shape({

--- a/src/applications/fry-dea/tests/fry-dea.cypress.spec.js
+++ b/src/applications/fry-dea/tests/fry-dea.cypress.spec.js
@@ -13,7 +13,8 @@ const testConfig = createTestConfig(
     dataDir: path.join(__dirname, 'data'),
 
     // Rename and modify the test data as needed.
-    dataSets: ['test-data'],
+    // dataSets: ['test-data'],
+    dataSets: [],
 
     pageHooks: {
       introduction: ({ afterHook }) => {


### PR DESCRIPTION
## Summary
Update VA radio component. Replace deprecated `RadioButtons` with new `VaRadio` component.

## Related issue(s)
- #23211

## Testing done
Manually tested that the veteran/service member selection page works well, i.e. selections persist when page changes and from saved form state, validation (negative and positive) work, and selection is displayed on review page.

## Screenshots
N/A

## What areas of the site does it impact?
Fry/DEA veteran/service member selection page.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature