### PR TITLE
Mhv 40736 attachment instructions errors

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/FileInput.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/FileInput.jsx
@@ -16,6 +16,12 @@ const FileInput = ({ attachments, setAttachments }) => {
       return currentSize + item.size;
     }, 0);
     const selectedFile = event.target.files[0];
+
+    // eslint disabled here to clear the input's stored value to allow a user to remove and re-add the same attachment
+    // https://stackoverflow.com/questions/42192346/how-to-reset-reactjs-file-input
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = null;
+
     if (!selectedFile) return;
     const fileExtension =
       selectedFile.name && selectedFile.name.split('.').pop();

--- a/src/applications/mhv/secure-messaging/components/HowToAttachFiles.jsx
+++ b/src/applications/mhv/secure-messaging/components/HowToAttachFiles.jsx
@@ -9,7 +9,7 @@ const HowToAttachFiles = () => {
       disable-border={false}
     >
       <section className="how-to-attach-files">
-        <ul>
+        <ul className="vads-u-margin-y--0">
           <li>You may attach up to 4 files to each message</li>
           <li>
             You can attach only these file types: doc, docx, gif, jpg, pdf, png,

--- a/src/applications/mhv/secure-messaging/components/HowToAttachFiles.jsx
+++ b/src/applications/mhv/secure-messaging/components/HowToAttachFiles.jsx
@@ -4,41 +4,20 @@ import { VaAdditionalInfo } from '@department-of-veterans-affairs/component-libr
 const HowToAttachFiles = () => {
   return (
     <VaAdditionalInfo
-      trigger="How to attach a file"
+      trigger="What to know about attaching files"
       disable-analytics={false}
       disable-border={false}
     >
       <section className="how-to-attach-files">
         <ul>
-          <li>Select the 'Attach files' link on the message you are editing</li>
-          <li>Select the file you would like to attach</li>
-          <li>Select the 'Attach' button</li>
-        </ul>
-
-        <h5>Attachment Requirements</h5>
-        <ul>
-          <li>You may attach up to 4 files.</li>
+          <li>You may attach up to 4 files to each message</li>
           <li>
-            Files supported: doc, docx, gif, jpg, pdf, png, rtf, txt, xls, xlsx
+            You can attach only these file types: doc, docx, gif, jpg, pdf, png,
+            rtf, txt, xls, xlsx
           </li>
+          <li>The maximum size for each file is 6 MB</li>
           <li>
-            File size for a single attachment cannot exceed 6MB and the total
-            size of all attachments cannot exceed 10MB.
-          </li>
-        </ul>
-
-        <h5>
-          Note: If you are unable to attach a document to a Secure Message:
-        </h5>
-        <ul>
-          <li>
-            Confirm that your document meets the requirements for size and type
-          </li>
-          <li>Check your browser settings to be sure JavaScript is enabled</li>
-          <li>Use a browser such as Chrome or Firefox</li>
-          <li>
-            If your problem persists, please contact the My HealtheVet{' '}
-            <a href="https://www.va.gov/contact-us/">Help Desk</a>
+            The maximum total size for all files attached to 1 message is 10 MB
           </li>
         </ul>
       </section>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Fixes a bug where you can't attach a file after removing it.

## Related issue(s)
https://vajira.max.gov/browse/MHV-40735


## Testing done
Can attach the same file after removing it

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
