### PR TITLE
[#MHV-40735] fixed bug when attaching file after removing it

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/FileInput.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/FileInput.jsx
@@ -16,6 +16,12 @@ const FileInput = ({ attachments, setAttachments }) => {
       return currentSize + item.size;
     }, 0);
     const selectedFile = event.target.files[0];
+
+    // eslint disabled here to clear the input's stored value to allow a user to remove and re-add the same attachment
+    // https://stackoverflow.com/questions/42192346/how-to-reset-reactjs-file-input
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = null;
+
     if (!selectedFile) return;
     const fileExtension =
       selectedFile.name && selectedFile.name.split('.').pop();


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Fixes a bug where you can't attach a file after removing it.

## Related issue(s)
https://vajira.max.gov/browse/MHV-40735

## Testing done
Can attach the same file after removing it

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
