### PR TITLE
Fix undefined error

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -164,7 +164,7 @@ async function getAdditionalFacilityInfo(futureAppointments, useV2 = false) {
 function getAdditionalFacilityInfoV2(appointments) {
   // Facility information included with v2 appointment api call.
   return appointments
-    ?.map(appt => (appt.vaos.facilityData ? appt.vaos.facilityData : null))
+    ?.map(appt => appt?.vaos?.facilityData ?? null)
     .filter(n => n);
 }
 
@@ -354,7 +354,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
       if (
         data
           .flat()
-          ?.filter(appt => appt.videoData.kind === VIDEO_TYPES.clinic)
+          ?.filter(appt => appt?.videoData?.kind === VIDEO_TYPES.clinic)
           .some(appt => !appt.location?.stationId)
       ) {
         Sentry.captureMessage('VAOS clinic based appointment missing sta6aid');


### PR DESCRIPTION
## Summary
When toggle flag `vaOnlineSchedulingAppointmentList` is on and booked or pending appointments have community care appointments then will show the error "We're sorry. We've run into a problem". 

That's because CC appointments does NOT contain the object `appointment.vaos.facilityData` Adding optional chaining will fix the problem.


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#52542



## Testing done

Log into the RI using patient999@id.me

## Screenshots

<img width="1198" alt="Screenshot 2023-01-25 at 8 32 18 AM" src="https://user-images.githubusercontent.com/54327023/214626175-875eb113-ae94-4ed3-8f81-b60b791855d9.png">


| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ] The VAOS homepage displays the upcoming appointments whether the toggle flag vaOnlineSchedulingAppointmentList is on or off

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
