### PR TITLE
add basic dockerfile for just vets-website

### DIFF
--- a/src/platform/utilities/preview-environment/Dockerfile
+++ b/src/platform/utilities/preview-environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM public.ecr.aws/bitnami/node:14.15.5
+
+RUN mkdir vets-website
+
+COPY . ./vets-website
+
+EXPOSE 3001
+EXPOSE 3000
+
+CMD cd vets-website; yarn install;ls; yarn watch --port=3001 --host=0.0.0.0


### PR DESCRIPTION
## Summary
This work is being completed for the Preview Environment project being worked by the Platform Tech Team 4. This is an initial Dockerfile for the most barebones `vets-website` only instance of VA.gov that we can manage. The point is to have a workable image of the VA.gov frontend that we can use to test further pieces of a preview environment. Once we have a basic FE Dockerfile available a GHA workflow will build the image and push it to ECR.

## Related issue(s)
[Modify the Push-driven GHA Workflow to Tag and Store FE Image in ECR](https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/51983)

## Testing done

Tested locally with:
1.  `docker build -f src/platform/utilities/preview-environment/Dockerfile . -t barebones:latest`
2. `docker run -p 3001:3001 barebones`
3.  visited http://localhost:3001

## Screenshots
![image](https://user-images.githubusercontent.com/52456633/214464007-72df41cf-a684-48ac-b272-ccdec57a4d11.png)

## What areas of the site does it impact?
No area of the site should be impacted

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Give building and running the Dockerfile a whirl if you'd like!
