### PR TITLE
Enrollment Verification: Remove Alert and Add Radio Option Description

### DIFF
--- a/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
+++ b/src/applications/enrollment-verification/containers/VerifyEnrollmentsPage.jsx
@@ -370,21 +370,6 @@ export const VerifyEnrollmentsPage = ({
         onVaValueChange={updateMonthInformationCorrect}
         required
       >
-        <va-alert
-          class="vads-u-margin-top--2"
-          close-btn-aria-label="Close notification"
-          id="information-incorrect-warning"
-          status="warning"
-          visible
-        >
-          If you select “<em>No, this information isn’t correct</em>”{' '}
-          <strong>
-            we will pause your monthly payment until your information is updated
-          </strong>
-          . Work with your School Certifying Official (SCO) to ensure your
-          enrollment information is updated with VA.
-        </va-alert>
-
         <va-radio-option
           aria-describedby="information-incorrect-warning"
           checked={monthInformationCorrect === VERIFICATION_STATUS_CORRECT}
@@ -397,6 +382,7 @@ export const VerifyEnrollmentsPage = ({
           aria-describedby="information-incorrect-warning"
           checked={monthInformationCorrect === VERIFICATION_STATUS_INCORRECT}
           class="vads-u-margin-y--2"
+          description="If you select “No, this information isn’t correct” we will pause your monthly payment until your information is updated. Work with your School Certifying Official (SCO) to ensure your enrollment information is updated with VA."
           label="No, this information isn’t correct"
           name={VERIFICATION_STATUS_INCORRECT}
           value={VERIFICATION_STATUS_INCORRECT}


### PR DESCRIPTION
## Summary
Remove alert and add alert text to the `va-radio-option`'s `description` so screen readers can read the alert.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/52089
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/52076

## Testing done
Used VoiceOver to verify that the alert text is read.

## Screenshots
 | Before | After |
| --- | --- |
|<img width="660" alt="image" src="https://user-images.githubusercontent.com/112403/214658281-f5fd4325-9d66-4c1e-b885-d3ea21579f43.png">| <img width="410" alt="Screen Shot 2023-01-25 at 1 51 17 PM" src="https://user-images.githubusercontent.com/112403/214658146-e0ba69d6-f7d4-40f5-901a-333700d7dcd6.png">|

## What areas of the site does it impact?
Enrollment Verification verify flow radio buttons.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature