### PR TITLE
(test) fix failing unit test assertion

### DIFF
--- a/src/applications/enrollment-verification/tests/unit/helpers.unit.spec.js
+++ b/src/applications/enrollment-verification/tests/unit/helpers.unit.spec.js
@@ -91,7 +91,7 @@ describe('helpers', () => {
 
       // Paused if we're past the payment paused date (the 25th)
       expect(paymentsPaused).to.eql(
-        now.getDate() > PAYMENT_PAUSED_DAY_OF_MONTH,
+        now.getDate() >= PAYMENT_PAUSED_DAY_OF_MONTH,
       );
     });
 


### PR DESCRIPTION
## Summary

There was a failing unit test assertion in the helper spec. I updated that to check for `>=` so that it doesn't fail on the 26th of the month. Spoke with @nathanielbuck and he said this was an appropriate fix.

## Related issue(s)
Hotfix

## Testing done

- Unit test passes

## Screenshots
No UI updates

## What areas of the site does it impact?
My Education Benefits

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).

