### PR TITLE
MHV-39315: Compose form input widths fixed and component library upgraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^13.7.0",
+    "@department-of-veterans-affairs/component-library": "^13.8.0",
     "@department-of-veterans-affairs/formation": "^7.0.4",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/src/applications/mhv/secure-messaging/sass/compose.scss
+++ b/src/applications/mhv/secure-messaging/sass/compose.scss
@@ -38,6 +38,13 @@
     .compose-form-div {
       margin-bottom: 24px;
     }
+    va-text-input#message-subject::part(input) {
+      max-width: 100%;
+    }
+    va-textarea#message-body::part(textarea) {
+      max-width: 100%;
+      resize: vertical;
+    }
     .compose-form-header {
       border-radius: 4px 4px 0 0;
       background-color: $color-gray-lightest;
@@ -98,6 +105,13 @@
     }
     .compose-form-div {
       margin-bottom: 24px;
+    }
+    va-text-input#message-subject::part(input) {
+      max-width: 100%;
+      // background-color: $color-gray-dark;
+    }
+    va-textarea#message-body {
+      max-width: 100%;
     }
 
     .compose-inputs-container {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,13 +2525,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^13.7.0":
-  version "13.7.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-13.7.0.tgz#47297be96a2f075140426a92d3713d5e4bdf8084"
-  integrity sha512-M40PBy0YCuZxxbiB2Hu1haiX7c8hkGBQNfH1dvVB5oS//zR0J0uzU/oLnQ+NSi3MXxISuweYvM/ox86Q2JdMMA==
+"@department-of-veterans-affairs/component-library@^13.8.0":
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-13.8.0.tgz#558fb35de9ca3db452d183b9cbc29eee23428487"
+  integrity sha512-28/iUzRSNeBaoflf2Y8ffMPlXtNFat1SE5h3a8fQMxe0rjAw6rjvq2h/glDrz/wpYgoyt8Q0ISU2ZuhC6bxHfw==
   dependencies:
     "@department-of-veterans-affairs/react-components" "8.0.0"
-    "@department-of-veterans-affairs/web-components" "4.23.0"
+    "@department-of-veterans-affairs/web-components" "4.24.0"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2604,10 +2604,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.23.0.tgz#d2f6b96ce7a83022c70f73c4cae7e381a6d2cd41"
-  integrity sha512-buoTaxufVkmxevwN7gN6SsaA2lDucBgVVY4+ThepOqJm3nDPIKuXBUe+2OMyfdioqTajwH2oOwStCBvXviIzYA==
+"@department-of-veterans-affairs/web-components@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.24.0.tgz#d113e7dc70d364940c87e2d7992997b5cb71c261"
+  integrity sha512-bYHdEmB/RIONuKCOW7aCkHK40eD+xWhjSXLFTGwpStkWaU3doHNbqkOnHKg3t/ZUeXyLulFq3g06Qorl0437+A==
   dependencies:
     "@stencil/core" "^2.19.2"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Summary
The compose form subject field text input and message field textarea widths have been fixed to match the UCD requirement of being the full width of the form. In order to accomplish this UI change for the textarea component, the va.gov component library had to be upgraded to the latest version ([13.8.0](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v13.8.0)). This change was made for the VA.gov-SM-APR team. The mobile view is not affected by this change. 

## Related issue(s)
- Original issue: https://vajira.max.gov/browse/MHV-39315
- Epic: https://vajira.max.gov/browse/MHV-38503
- Component library version upgraded to: https://github.com/department-of-veterans-affairs/component-library/releases/tag/v13.8.0

## Testing done
Previous to this change, the subject and body fields in the compose form were different widths, both less than the full width of the form in desktop view. They should now be the full width of the form in desktop view. This change was manually tested. No relevant unit tests could be written. 

## Screenshots
Before:
<img width="773" alt="Screenshot 2023-01-31 at 10 28 05 AM" src="https://user-images.githubusercontent.com/107576133/215838630-72830b15-7e31-4f7b-9632-dc209bb46093.png">
After:
<img width="746" alt="Screenshot 2023-01-31 at 10 27 41 AM" src="https://user-images.githubusercontent.com/107576133/215838654-e2ee2e4a-cac2-4c4f-aa45-fa6b8075fe82.png">

## What areas of the site does it impact?
This change affects any areas of the app that use the component design library although there are no high risk changes in release 13.8.0. 

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
- [x]  Secure messaging compose form subject and message body fields should be the full width of the form in desktop view. 
