### PR TITLE
Certificate of Eligibility | Add intent value to review

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -15,14 +15,13 @@ import {
   validateVALoanNumber,
   validateUniqueVALoanNumber,
 } from '../../../validations';
-import { LOAN_INTENT, LOAN_INTENT_SCHEMA } from '../../../constants';
+import { LOAN_INTENT_SCHEMA } from '../../../constants';
+import { getLoanIntent } from '../../helpers';
 
 const stateLabels = createUSAStateLabels(states);
 
 const PreviousLoanView = ({ formData }) => {
-  const intent = Object.values(LOAN_INTENT).find(
-    type => type.value === formData.intent,
-  );
+  const intent = getLoanIntent(formData.intent);
   const {
     propertyAddress1,
     propertyCity,

--- a/src/applications/lgy/coe/form/config/helpers.js
+++ b/src/applications/lgy/coe/form/config/helpers.js
@@ -1,6 +1,6 @@
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
-import { NON_DIGIT_REGEX } from '../constants';
+import { NON_DIGIT_REGEX, LOAN_INTENT } from '../constants';
 
 export const replaceNonDigits = number =>
   (number || '').replace(NON_DIGIT_REGEX, '');
@@ -51,3 +51,6 @@ export const customCOEsubmit = (formConfig, form) => {
     },
   });
 };
+
+export const getLoanIntent = value =>
+  Object.values(LOAN_INTENT).find(type => type.value === value);

--- a/src/applications/lgy/coe/form/constants.js
+++ b/src/applications/lgy/coe/form/constants.js
@@ -47,7 +47,7 @@ export const LOAN_INTENT = {
     value: 'INQUIRY',
     label: (
       <>
-        An <strong>entitlement inqury only</strong>
+        An <strong>entitlement inquiry only</strong>
       </>
     ),
     shortLabel: 'An inquiry only',

--- a/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
@@ -21,7 +21,9 @@ const ConfirmationPage = ({ form }) => {
 
   const { data, submission } = form;
   const name = data?.fullName || {};
-  const fullName = `${name.first} ${name.middle || ''} ${name.last}`;
+  const fullName = [name.first || '', name.middle || '', name.last || '']
+    .join(' ')
+    .trim();
 
   const submitDate = moment(submission?.timestamp || Date.now());
   const { referenceNumber = '' } = submission?.response?.attributes || {};
@@ -44,9 +46,10 @@ const ConfirmationPage = ({ form }) => {
           <span className="additional">(VA Form 26-1880)</span>
         </h2>
 
-        {name && (
+        {fullName && (
           <span>
-            For: {fullName} {name.suffix && `, ${name.suffix}`}
+            For: {fullName}
+            {name.suffix && `, ${name.suffix}`}
           </span>
         )}
 

--- a/src/applications/lgy/coe/form/content/loanHistory.js
+++ b/src/applications/lgy/coe/form/content/loanHistory.js
@@ -1,6 +1,8 @@
 import { formatReviewDate } from 'platform/forms-system/src/js/helpers';
 import get from 'platform/utilities/data/get';
 
+import { getLoanIntent } from '../config/helpers';
+
 export default {
   loanClose: {
     title: 'Closing date of your loan',
@@ -48,5 +50,9 @@ export default {
   owned: {
     title: 'Do you still own this property?',
     value: data => (get('propertyOwned', data, '') ? 'Yes' : 'No'),
+  },
+  intent: {
+    title: 'How will you use your Certificate of Eligibility?',
+    value: data => getLoanIntent(get('intent', data, ''))?.shortLabel || '',
   },
 };

--- a/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/config/helpers.unit.spec.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as helpers from 'platform/forms-system/src/js/helpers';
-import { customCOEsubmit } from '../../config/helpers';
+import { customCOEsubmit, getLoanIntent } from '../../config/helpers';
+import { LOAN_INTENT } from '../../constants';
 
 const form = {
   data: {
@@ -54,5 +55,14 @@ describe('customCOEsubmit', () => {
   it('should correctly format the form data', () => {
     sandbox.stub(helpers, 'transformForSubmit').returns(formattedProperties);
     expect(customCOEsubmit({}, form)).to.equal(result);
+  });
+});
+
+describe('getLoanIntent', () => {
+  it('should return the loan intent object based on the value', () => {
+    Object.keys(LOAN_INTENT).forEach(type => {
+      const obj = getLoanIntent(LOAN_INTENT[type].value);
+      expect(obj).to.deep.equal(LOAN_INTENT[type]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > During COE testing, we noticed 3 issues:
  > - Loan intent ("How will you use your Certificate of Eligibility?") was missing on the review & submit page
  > - "Inquiry" was misspelled
  > - When reloading the confirmation page, the name of "undefined undefined" is displayed 
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > - Add loan intent to review & submit page
  > - Fix typo
  > - Prevent "undefined" from showing on the confirmation page
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews (previously Benefits team 1, squad 2)
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#52015](https://github.com/department-of-veterans-affairs/va.gov-team/issues/52015)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Missing loan intent
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Added unit tests, all passing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*


## Screenshots

<details><summary>Loan intent included on review & submit</summary>

<!-- leave a blank line above -->
![loan intent showing on review and submit](https://user-images.githubusercontent.com/136959/216152911-1400d9d5-d065-4dda-8dd8-546e9b784ccb.png)</details>

<details><summary>Inquiry typo</summary>

<!-- leave a blank line above -->
<img width="472" alt="Loan intent list with inquiry misspelled" src="https://user-images.githubusercontent.com/136959/216152905-f37571ce-a0da-45a2-8a04-114968c91612.png"></details>

<details><summary>Confirmation page name</summary>

<!-- leave a blank line above -->
Confirmation page (normal view)
<img width="687" alt="confirmation page name showing Mark Webb, Jr" src="https://user-images.githubusercontent.com/136959/216152908-019af175-2e97-4aba-9240-73803d48950a.png">

Reloaded confirmation page
<img width="693" alt="confirmation page with no name - happens after reloading the confirmation page" src="https://user-images.githubusercontent.com/136959/216152910-a56df952-91e6-42f7-9a34-7d2d8e3c41d1.png"></details>

## What areas of the site does it impact?

Certificate of Eligibility (not yet released)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
