### PR TITLE
Remove V0 call to get email preferences.

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -26,8 +26,6 @@ import {
   getCCEType,
 } from './selectors';
 import {
-  getPreferences,
-  updatePreferences,
   submitRequest,
   submitAppointment,
   sendRequestMessage,
@@ -51,7 +49,6 @@ import {
   FLOW_TYPES,
   GA_PREFIX,
 } from '../../utils/constants';
-import { createPreferenceBody } from '../../utils/data';
 import {
   transformFormToVARequest,
   transformFormToCCRequest,
@@ -752,12 +749,6 @@ export function checkCommunityCareEligibility() {
   };
 }
 
-async function buildPreferencesDataAndUpdate(email) {
-  const preferenceData = await getPreferences();
-  const preferenceBody = createPreferenceBody(preferenceData, email);
-  return updatePreferences(preferenceBody);
-}
-
 export function submitAppointmentOrRequest(history) {
   return async (dispatch, getState) => {
     const state = getState();
@@ -799,17 +790,6 @@ export function submitAppointmentOrRequest(history) {
         } else {
           const appointmentBody = transformFormToAppointment(getState());
           await submitAppointment(appointmentBody);
-        }
-
-        // BG 3/29/2022: This logic is to resolve issue:
-        // https://app.zenhub.com/workspaces/vaos-team-603fdef281af6500110a1691/issues/department-of-veterans-affairs/va.gov-team/39301
-        // This will need to be removed once var resources is sunset.
-        try {
-          await buildPreferencesDataAndUpdate(data.email);
-        } catch (error) {
-          // These are ancillary updates, the request went through if the first submit
-          // succeeded
-          captureError(error);
         }
 
         dispatch({
@@ -921,7 +901,6 @@ export function submitAppointmentOrRequest(history) {
             if (requestMessage) {
               await sendRequestMessage(requestData.id, requestMessage);
             }
-            await buildPreferencesDataAndUpdate(data.email);
           } catch (error) {
             // These are ancillary updates, the request went through if the first submit
             // succeeded
@@ -934,17 +913,6 @@ export function submitAppointmentOrRequest(history) {
                 '\n',
               ),
             });
-          }
-        } else {
-          // // BG 3/29/2022: This logic is to resolve issue:
-          // // https://app.zenhub.com/workspaces/vaos-team-603fdef281af6500110a1691/issues/department-of-veterans-affairs/va.gov-team/39301
-          // // This will need to be removed once var resources is sunset.
-          try {
-            await buildPreferencesDataAndUpdate(data.email);
-          } catch (error) {
-            // These are ancillary updates, the request went through if the first submit
-            // succeeded
-            captureError(error);
           }
         }
 

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -159,7 +159,6 @@ const responses = {
   'GET /vaos/v0/facilities/:id/cancel_reasons': cancelReasons,
   'GET /vaos/v0/request_eligibility_criteria': requestEligibilityCriteria,
   'GET /vaos/v0/direct_booking_eligibility_criteria': directBookingEligibilityCriteria,
-  'GET /vaos/v0/preferences': { data: { attributes: { emailAllowed: true } } },
   'PUT /vaos/v0/appointments/cancel': {},
   'POST /vaos/v0/appointment_requests': {
     data: {
@@ -189,7 +188,6 @@ const responses = {
       attributes: {},
     },
   },
-  'PUT /vaos/v0/preferences': { data: { attributes: {} } },
   'POST /vaos/v2/appointments': (req, res) => {
     const submittedAppt = {
       id: `mock${currentMockId}`,

--- a/src/applications/vaos/services/var/index.js
+++ b/src/applications/vaos/services/var/index.js
@@ -247,18 +247,6 @@ export function sendRequestMessage(id, messageText) {
   }).then(parseApiObject);
 }
 
-export function getPreferences() {
-  return apiRequestWithUrl(`/vaos/v0/preferences`).then(parseApiObject);
-}
-
-export function updatePreferences(data) {
-  return apiRequestWithUrl(`/vaos/v0/preferences`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  }).then(parseApiObject);
-}
-
 export function getRequestEligibilityCriteria(sites) {
   return apiRequestWithUrl(
     `/vaos/v0/request_eligibility_criteria?${sites

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -2,7 +2,6 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 import {
   mockFeatureToggles,
   vaosSetup,
-  mockPreferencesApi,
   mockAppointmentsApi,
   mockAppointmentRequestsApi,
   mockLoginApi,
@@ -27,7 +26,6 @@ describe('VAOS community care flow', () => {
     mockFacilitiesApi({ apiVersion: 0 });
     mockFacilitiesApi({ apiVersion: 1 });
     mockFeatureToggles();
-    mockPreferencesApi();
     mockSupportedSitesApi();
   });
 
@@ -502,7 +500,6 @@ describe('VAOS community care flow using VAOS service', () => {
     mockFacilityApi({ id: 'vha_442', apiVersion: 1 });
     mockFeatureToggles({ v2Requests: true, v2Facilities: true });
     mockLoginApi();
-    mockPreferencesApi();
     mockSchedulingConfigurationApi();
 
     cy.visit('health-care/schedule-view-va-appointments/appointments/');

--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -7,7 +7,6 @@ import {
   mockFacilityApi,
   mockFeatureToggles,
   mockLoginApi,
-  mockPreferencesApi,
   mockSchedulingConfigurationApi,
   mockAppointmentsApi,
   vaosSetup,
@@ -43,14 +42,12 @@ describe('VAOS direct schedule flow', () => {
     mockFacilitiesApi({ apiVersion: 0 });
     mockFacilitiesApi({ apiVersion: 1 });
     mockFeatureToggles();
-    mockPreferencesApi();
     mockSupportedSitesApi();
     mockRequestEligibilityCriteriaApi();
     mockDirectBookingEligibilityCriteriaApi();
     mockRequestLimitsApi();
     mockClinicApi({ facilityId: '983', apiVersion: 0 });
     mockDirectScheduleSlotsApi({ start, end, apiVersion: 0 });
-    mockPreferencesApi();
     mockVisitsApi();
   });
 
@@ -109,11 +106,6 @@ describe('VAOS direct schedule flow', () => {
       expect(body).to.have.property('dateTime');
       expect(body).to.have.property('bookingNotes', fullReason);
       expect(body).to.have.property('preferredEmail', 'veteran@gmail.com');
-    });
-    // TODO: Not needed since check is in the mock
-    cy.wait('@v0:update:preferences').should(xhr => {
-      const { body } = xhr.request;
-      expect(body.emailAddress).to.eq('veteran@gmail.com');
     });
 
     // Confirmation page
@@ -289,7 +281,6 @@ describe('VAOS direct schedule flow using VAOS service', () => {
       v2DirectSchedule: true,
     });
     mockLoginApi();
-    mockPreferencesApi();
     mockSchedulingConfigurationApi();
   });
 
@@ -345,10 +336,6 @@ describe('VAOS direct schedule flow using VAOS service', () => {
         `${start.format('YYYY-MM-DD')}T00:00:00+00:00`,
       );
       expect(request.status).to.eq('booked');
-    });
-    cy.wait('@v0:update:preferences').should(xhr => {
-      const request = xhr.request.body;
-      expect(request.emailAddress).to.eq('veteran@gmail.com');
     });
 
     // Confirmation page

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -6,7 +6,6 @@ import {
   mockAppointmentsApi,
   mockCCProvidersApi,
   mockFacilitiesApi,
-  mockPreferencesApi,
   mockSupportedSitesApi,
   mockRequestEligibilityCriteriaApi,
   mockDirectBookingEligibilityCriteriaApi,
@@ -34,14 +33,12 @@ describe('VAOS VA request flow', () => {
     mockFacilitiesApi({ apiVersion: 0 });
     mockFacilitiesApi({ apiVersion: 1 });
     mockFeatureToggles();
-    mockPreferencesApi();
     mockSupportedSitesApi();
     mockRequestEligibilityCriteriaApi();
     mockDirectBookingEligibilityCriteriaApi();
     mockRequestLimitsApi();
     mockClinicApi({ facilityId: '983', apiVersion: 0 });
     mockDirectScheduleSlotsApi({ apiVersion: 0 });
-    mockPreferencesApi();
     mockVisitsApi({ facilityId: '983GB' });
   });
 
@@ -190,7 +187,6 @@ describe('VAOS VA request flow using VAOS service', () => {
       v2DirectSchedule: true,
     });
     mockLoginApi();
-    mockPreferencesApi();
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
     cy.injectAxe();
 

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -1032,22 +1032,6 @@ export function mockLoginApi({
   }
 }
 
-export function mockPreferencesApi() {
-  cy.intercept({ method: 'GET', pathname: '/vaos/v0/preferences' }, req =>
-    req.reply({ data: {} }),
-  ).as('v0:get:preferences');
-
-  cy.intercept({ method: 'PUT', pathname: '/vaos/v0/preferences' }, req => {
-    expect(req.body).to.have.property('emailAddress', 'veteran@gmail.com');
-    expect(req.body).to.have.property('emailAllowed', true);
-    expect(req.body).to.have.property(
-      'notificationFrequency',
-      'Each new message',
-    );
-    req.reply({ data: {} });
-  }).as('v0:update:preferences');
-}
-
 export function vaosSetup() {
   Cypress.Commands.add('axeCheckBestPractice', (context = 'main') => {
     cy.axeCheck(context, {

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -793,30 +793,6 @@ export function mockFacilitiesPageFetches(
 }
 
 /**
- * Mocks the api call that sets or retrieves preferences in var-resources
- *
- * @export
- * @param {string} emailAddress The email address to return in the mock
- */
-export function mockPreferences(emailAddress) {
-  setFetchJSONResponse(
-    global.fetch.withArgs(`${environment.API_URL}/vaos/v0/preferences`),
-    {
-      data: {
-        id: '3071ca1783954ec19170f3c4bdfd0c95',
-        type: 'preferences',
-        attributes: {
-          notificationFrequency: 'Each new message',
-          emailAllowed: true,
-          emailAddress,
-          textMsgAllowed: false,
-        },
-      },
-    },
-  );
-}
-
-/**
  * Mock the api calls used to set up Express Care windows
  *
  * @export

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -20,11 +20,7 @@ import {
   onCalendarChange,
   startRequestAppointmentFlow,
 } from '../../../../new-appointment/redux/actions';
-import {
-  mockMessagesFetch,
-  mockPreferences,
-  mockRequestSubmit,
-} from '../../../mocks/helpers';
+import { mockMessagesFetch, mockRequestSubmit } from '../../../mocks/helpers';
 
 import { mockAppointmentSubmitV2 } from '../../../mocks/helpers.v2';
 import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
@@ -119,7 +115,6 @@ describe('VAOS <ReviewPage> CC request', () => {
     mockRequestSubmit('cc', {
       id: 'fake_id',
     });
-    mockPreferences(null);
     mockMessagesFetch('fake_id', {});
 
     const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
@@ -392,7 +387,6 @@ describe('VAOS <ReviewPage> CC request with provider selection', () => {
     mockRequestSubmit('cc', {
       id: 'fake_id',
     });
-    mockPreferences(null);
     mockMessagesFetch('fake_id', {});
 
     const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
@@ -424,9 +418,6 @@ describe('VAOS <ReviewPage> CC request with provider selection', () => {
 
     const messageData = JSON.parse(global.fetch.getCall(1).args[1].body);
     expect(messageData.messageText).to.equal('I need an appt');
-
-    const preferences = JSON.parse(global.fetch.getCall(3).args[1].body);
-    expect(preferences.emailAddress).to.equal('joeblow@gmail.com');
   });
 
   it('should show error message on failure', async () => {
@@ -564,7 +555,6 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
         reasonCode: {},
       },
     });
-    mockPreferences(null);
 
     const screen = renderWithStoreAndRouter(<ReviewPage />, {
       store,
@@ -655,7 +645,6 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
         reasonCode: {},
       },
     });
-    mockPreferences(null);
 
     const screen = renderWithStoreAndRouter(<ReviewPage />, {
       store,

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -18,7 +18,7 @@ import {
   onCalendarChange,
   startDirectScheduleFlow,
 } from '../../../../new-appointment/redux/actions';
-import { mockAppointmentSubmit, mockPreferences } from '../../../mocks/helpers';
+import { mockAppointmentSubmit } from '../../../mocks/helpers';
 import { mockAppointmentSubmitV2 } from '../../../mocks/helpers.v2';
 import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
 import { mockFacilityFetchByVersion } from '../../../mocks/fetch';
@@ -170,7 +170,6 @@ describe('VAOS <ReviewPage> direct scheduling', () => {
 
   it('should submit successfully', async () => {
     mockAppointmentSubmit({});
-    mockPreferences('test@va.gov');
 
     const screen = renderWithStoreAndRouter(<ReviewPage />, {
       store,

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -20,11 +20,7 @@ import {
   onCalendarChange,
   startRequestAppointmentFlow,
 } from '../../../../new-appointment/redux/actions';
-import {
-  mockMessagesFetch,
-  mockPreferences,
-  mockRequestSubmit,
-} from '../../../mocks/helpers';
+import { mockMessagesFetch, mockRequestSubmit } from '../../../mocks/helpers';
 import { mockAppointmentSubmitV2 } from '../../../mocks/helpers.v2';
 import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
 import { mockFacilityFetchByVersion } from '../../../mocks/fetch';
@@ -249,7 +245,6 @@ describe('VAOS <ReviewPage> VA request', () => {
     mockRequestSubmit('va', {
       id: 'fake_id',
     });
-    mockPreferences(null);
     mockMessagesFetch('fake_id', {});
 
     const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
@@ -465,7 +460,6 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
         reasonCode: {},
       },
     });
-    mockPreferences(null);
 
     const screen = renderWithStoreAndRouter(<ReviewPage />, {
       store,

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -1,19 +1,4 @@
 /**
- * Data utility methods
- * @module utils/data
- *
- */
-
-export function createPreferenceBody(preferences, emailAddress) {
-  return {
-    ...preferences,
-    emailAddress,
-    notificationFrequency: 'Each new message',
-    emailAllowed: true,
-  };
-}
-
-/**
  * Converts an array of items into an object with item.id as
  * the key, and item as the value
  *


### PR DESCRIPTION
We were previously making a call to /vaos/v0/preferences to get the notification preferences of a veteran when scheduling an appointment in scheduling manager. This is no longer needed since we now handle scheduling appointments in Vista.

This PR removes any reference to that endpoint in our repo.