### PR TITLE
10307  show events until they end - alt branch 

### DIFF
--- a/src/applications/static-pages/events/helpers/index.js
+++ b/src/applications/static-pages/events/helpers/index.js
@@ -180,7 +180,7 @@ export const filterEvents = (
       return events
         .filter(event => {
           return moment(
-            event?.fieldDatetimeRangeTimezone[0]?.value * 1000,
+            event?.fieldDatetimeRangeTimezone[0]?.endValue * 1000,
           ).isAfter(now.clone());
         })
         .reduce(keepUniqueEventsFromList, []);
@@ -190,7 +190,9 @@ export const filterEvents = (
     case 'next-week': {
       return events
         ?.filter(event =>
-          moment(event?.fieldDatetimeRangeTimezone[0]?.value * 1000).isBetween(
+          moment(
+            event?.fieldDatetimeRangeTimezone[0]?.endValue * 1000,
+          ).isBetween(
             now
               .clone()
               .add('7', 'days')
@@ -208,7 +210,9 @@ export const filterEvents = (
     case 'next-month': {
       return events
         ?.filter(event =>
-          moment(event?.fieldDatetimeRangeTimezone[0]?.value * 1000).isBetween(
+          moment(
+            event?.fieldDatetimeRangeTimezone[0]?.endValue * 1000,
+          ).isBetween(
             now
               .clone()
               .add('1', 'month')


### PR DESCRIPTION
## Summary

- This change effect the duration of which Events are displayed on the Event Listing page (/outreach-and-events/events) 
- Previously events would display in "All Upcoming" up until their start time, which inconveniently hid them from Veterans who might need to find the event location, etc as it was starting. This change causes events to display in Upcoming, Next Week and Next Month until their end time has passed.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#10307
 
## Testing done
- Manual testing against live data.

## What areas of the site does it impact?
the Event Listing page (/outreach-and-events/events)

## Acceptance criteria
- [x] Events should appear in Upcoming until the end time has passed, then move to Past Events.
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [n/a]  Events are being sent to the appropriate logging solution
- [n/a]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [n/a]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [n/a]  I added a screenshot of the developed feature

## Requested Feedback

Assure events still display after they've started,
