### PR TITLE
New expired appt messaging

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -34,6 +34,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - canceledPhoneAppointmentUUID: `1448d690-fd5f-11ec-b939-0242ac120002`
   - expiredUUID: `354d5b3a-b7b7-4e5c-99e4-8d563f15c521`
   - expiredPhoneUUID: `08ba56a7-68b7-4b9f-b779-53ba609140ef`
+  - missingUUID: `a5895713-ca42-4244-9f38-f8b5db020d04`
 
 ## Design system
 99% of the styling comes from the VA design system [component library](https://design.va.gov/components/) and [utility classes](https://design.va.gov/foundation/utilities/). For the remaining 1% of styling there is an scss file in the `sass` directory in the project root.

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -15,6 +15,7 @@ const mockUser = Object.freeze({
   lastName: 'Smith',
   dob: '1989-03-15',
 });
+const missingUUID = 'a5895713-ca42-4244-9f38-f8b5db020d04';
 
 const responses = {
   ...commonResponses,
@@ -28,6 +29,11 @@ const responses = {
   },
   'POST /check_in/v2/sessions': (req, res) => {
     const { lastName, dob } = req.body?.session || {};
+    if (req.body?.session.uuid === missingUUID) {
+      return res
+        .status(404)
+        .json(sessions.post.createMockMissingUuidErrorResponse());
+    }
     if (!lastName) {
       return res.status(400).json(sessions.post.createMockFailedResponse());
     }

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
@@ -49,9 +49,9 @@ const mocks = {
       return {
         errors: [
           {
-            title: 'Data Not Found',
-            detail: 'Data Not Found',
-            code: 'CIE-VETS-API_404',
+            title: 'Not Found',
+            detail: 'Not Found',
+            code: 'CHIP-API_404',
             status: '404',
           },
         ],

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/sessions/index.js
@@ -45,6 +45,18 @@ const mocks = {
         ],
       };
     },
+    createMockMissingUuidErrorResponse: () => {
+      return {
+        errors: [
+          {
+            title: 'Data Not Found',
+            detail: 'Data Not Found',
+            code: 'CIE-VETS-API_404',
+            status: '404',
+          },
+        ],
+      };
+    },
     createMockMaxValidateErrorResponse: () => {
       return {
         errors: [

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -220,5 +220,6 @@
   "back-to-appointments": "Back to appointments",
   "click-to-see-details-for-your-time-appointment": "Click to see the details for your {{ time, time }} appointment",
   "directions-to-location": "Directions to {{ location }}",
-  "directions": "Directions"
+  "directions": "Directions",
+  "were-sorry-this-link-has-expired": "We’re sorry. This link has expired."
 }

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -148,6 +148,13 @@ const Error = () => {
       accordion = appointmentAccordion(appointments);
       showHowToLink = true;
       break;
+    case 'uuid-not-found':
+      // Shown when POST sessions returns 404.
+      alertType = 'info';
+      header = t('were-sorry-this-link-has-expired');
+      messageText = mixedPhoneAndInPersonMessage;
+      showHowToLink = false;
+      break;
     case 'session-error':
     case 'bad-token':
     case 'no-token':

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -54,6 +54,42 @@ describe('check-in', () => {
         );
       });
     });
+    describe('uuid-not-found error', () => {
+      let store;
+      beforeEach(() => {
+        const middleware = [];
+        const mockStore = configureStore(middleware);
+        const initState = {
+          checkInData: {
+            appointments: [],
+            veteranData: {},
+            form: {
+              pages: [],
+            },
+            error: 'uuid-not-found',
+          },
+        };
+        store = mockStore({ ...initState, ...scheduledDowntimeState });
+      });
+      it('renders correct message', () => {
+        const component = render(
+          <Provider store={store}>
+            <I18nextProvider i18n={i18n}>
+              <Error />
+            </I18nextProvider>
+          </Provider>,
+        );
+        expect(component.getByText('We’re sorry. This link has expired.')).to
+          .exist;
+        const expiredMessage = component.getByTestId('error-message');
+        expect(expiredMessage).to.exist;
+        expect(
+          within(expiredMessage).getByText(
+            'You can still check-in with your phone on the day of your appointment.',
+          ),
+        ).to.exist;
+      });
+    });
     describe('redux store with appointments but error-completing-pre-check-in', () => {
       let store;
       beforeEach(() => {

--- a/src/applications/check-in/utils/validateVeteran/index.js
+++ b/src/applications/check-in/utils/validateVeteran/index.js
@@ -71,6 +71,9 @@ const validateLogin = async (
     setIsLoading(false);
     if (e?.errors[0]?.status !== '401') {
       let errorType = 'lorota-fail';
+      if (e?.errors[0]?.status === '404') {
+        errorType = 'uuid-not-found';
+      }
       if (e?.errors[0]?.status === '410') {
         errorType = 'max-validation';
       }


### PR DESCRIPTION
## Summary

- This adds a new title when a user attempts to visit pre-checking with a UUID that's not in LoROTA

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#52492

## Testing done

- manual testing
- new e2e test
- new unit test

## QA

Visit pre-check-in and auth with `missingUUID:` (`a5895713-ca42-4244-9f38-f8b5db020d04`)

## Screenshots

![Screenshot 2023-02-02 at 09 20 26](https://user-images.githubusercontent.com/101649/216381466-6349be4f-db3d-432a-98e8-e2bc243a6c39.png)

## What areas of the site does it impact?

Pre-check-in error page

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
