### PR TITLE
[#MHV-40916] fixed missing education category

### DIFF
--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -105,6 +105,7 @@ export const Categories = {
   APPOINTMENTS: 'Appointment',
   MEDICATIONS: 'Medication',
   TEST_RESULTS: 'Test',
+  EDUCATION: 'Education',
 };
 
 export const acceptedFileTypes = {


### PR DESCRIPTION
## Summary
Fixed bug when looking at "EDUCATION" messages in secure messaging. The category was blank.

## Related issue(s)
https://vajira.max.gov/browse/MHV-40916

## Testing done
All unit tests should still pass


## Screenshots
![Screen Shot 2023-02-02 at 12 57 06 PM](https://user-images.githubusercontent.com/108146636/216423074-11cefc7b-24e2-4832-9c79-1edd1b7cec71.png)

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
