### PR TITLE
[#MHV-40739] added link support to message history

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -13,9 +13,10 @@ import DeleteDraft from '../Draft/DeleteDraft';
 import { sendReply } from '../../actions/messages';
 import EmergencyNote from '../EmergencyNote';
 import HowToAttachFiles from '../HowToAttachFiles';
-import { dateFormat, urlRegex, httpRegex } from '../../util/helpers';
+import { dateFormat } from '../../util/helpers';
 import RouteLeavingGuard from '../shared/RouteLeavingGuard';
 import { draftAutoSaveTimeout } from '../../util/constants';
+import MessageThreadBody from '../MessageThread/MessageThreadBody';
 
 const ReplyForm = props => {
   const { draftToEdit, replyMessage } = props;
@@ -40,7 +41,6 @@ const ReplyForm = props => {
   const [userSaved, setUserSaved] = useState(false);
   const [navigationError, setNavigationError] = useState(null);
   const [saveError, setSaveError] = useState(null);
-  const words = replyMessage?.body.split(/\s/g);
 
   const isSaving = useSelector(state => state.sm.draftDetails.isSaving);
   const history = useHistory();
@@ -380,16 +380,7 @@ const ReplyForm = props => {
           </section>
 
           <section aria-label="Message body.">
-            <pre>
-              {words.map(word => {
-                return (word.match(urlRegex) || word.match(httpRegex)) &&
-                  words.length >= 1 ? (
-                  <a href={word}>{`${word} `}</a>
-                ) : (
-                  `${word} `
-                );
-              })}
-            </pre>
+            <MessageThreadBody text={replyMessage.body} />
           </section>
 
           {!!replyMessage.attachments &&

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -379,7 +379,7 @@ const ReplyForm = props => {
             </p>
           </section>
 
-          <section aria-label="Message body.">
+          <section aria-label="Message body." className="vads-u-margin-top--1">
             <MessageThreadBody text={replyMessage.body} />
           </section>
 

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -13,7 +13,7 @@ import DeleteDraft from '../Draft/DeleteDraft';
 import { sendReply } from '../../actions/messages';
 import EmergencyNote from '../EmergencyNote';
 import HowToAttachFiles from '../HowToAttachFiles';
-import { dateFormat } from '../../util/helpers';
+import { dateFormat, urlRegex, httpRegex } from '../../util/helpers';
 import RouteLeavingGuard from '../shared/RouteLeavingGuard';
 import { draftAutoSaveTimeout } from '../../util/constants';
 
@@ -40,6 +40,7 @@ const ReplyForm = props => {
   const [userSaved, setUserSaved] = useState(false);
   const [navigationError, setNavigationError] = useState(null);
   const [saveError, setSaveError] = useState(null);
+  const words = replyMessage?.body.split(/\s/g);
 
   const isSaving = useSelector(state => state.sm.draftDetails.isSaving);
   const history = useHistory();
@@ -379,7 +380,16 @@ const ReplyForm = props => {
           </section>
 
           <section aria-label="Message body.">
-            <pre>{replyMessage.body}</pre>
+            <pre>
+              {words.map(word => {
+                return (word.match(urlRegex) || word.match(httpRegex)) &&
+                  words.length >= 1 ? (
+                  <a href={word}>{`${word} `}</a>
+                ) : (
+                  `${word} `
+                );
+              })}
+            </pre>
           </section>
 
           {!!replyMessage.attachments &&

--- a/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
@@ -6,7 +6,8 @@ import MessageActionButtons from './MessageActionButtons';
 import AttachmentsList from './AttachmentsList';
 import PrintMessageThread from './PrintMessageThread';
 import { Categories } from '../util/constants';
-import { dateFormat, urlRegex, httpRegex } from '../util/helpers';
+import { dateFormat } from '../util/helpers';
+import MessageThreadBody from './MessageThread/MessageThreadBody';
 
 const MessageDetailBlock = props => {
   const {
@@ -52,7 +53,6 @@ const MessageDetailBlock = props => {
   };
 
   const categoryLabel = Categories[category];
-  const words = body.split(/\s/g);
 
   return (
     <section className="message-detail-block">
@@ -91,16 +91,7 @@ const MessageDetailBlock = props => {
         </section>
 
         <section className="message-body" aria-label="Message body.">
-          <pre>
-            {words.map(word => {
-              return (word.match(urlRegex) || word.match(httpRegex)) &&
-                words.length >= 1 ? (
-                <a href={word}>{`${word} `}</a>
-              ) : (
-                `${word} `
-              );
-            })}
-          </pre>
+          <MessageThreadBody text={body} />
         </section>
 
         {!!attachments &&

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -18,7 +18,7 @@ const MessageThreadBody = props => {
           {words.map(word => {
             return (word.match(urlRegex) || word.match(httpRegex)) &&
               words.length >= 1 ? (
-              <a href={word}>{`${word} `}</a>
+              <a href={word} target="_blank" rel="noreferrer">{`${word} `}</a>
             ) : (
               `${word} `
             );

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { urlRegex, httpRegex } from '../../util/helpers';
 
 const MessageThreadBody = props => {
+  const words = props.text.split(/\s/g);
+
   return (
     <div
       className={
@@ -11,7 +14,16 @@ const MessageThreadBody = props => {
       }
     >
       <>
-        <p>{props.text}</p>
+        <pre>
+          {words.map(word => {
+            return (word.match(urlRegex) || word.match(httpRegex)) &&
+              words.length >= 1 ? (
+              <a href={word}>{`${word} `}</a>
+            ) : (
+              `${word} `
+            );
+          })}
+        </pre>
       </>
     </div>
   );

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -14,7 +14,7 @@ const MessageThreadBody = props => {
       }
     >
       <>
-        <pre>
+        <pre className="vads-u-margin-y--0">
           {words.map(word => {
             return (word.match(urlRegex) || word.match(httpRegex)) &&
               words.length >= 1 ? (


### PR DESCRIPTION
## Summary
Fixes bug where links did not work in message previews.

## Related issue(s)
https://vajira.max.gov/browse/MHV-40739

## Testing done
Previously existing unit tests

## Screenshots
![Screen Shot 2023-02-02 at 5 04 48 PM](https://user-images.githubusercontent.com/108146636/216471061-2e597829-46f8-40d1-963c-8ea7bcb0cc84.png)

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
