### PR TITLE
revert auto-refresh

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -1,15 +1,9 @@
 import * as Sentry from '@sentry/browser';
 import merge from 'lodash/merge';
-import isomorphicFetch from 'isomorphic-fetch';
-import retryFetch from 'fetch-retry';
 
 import environment from '../environment';
 import localStorage from '../storage/localStorage';
-import {
-  infoTokenExists,
-  checkOrSetSessionExpiration,
-  refresh,
-} from '../oauth/utilities';
+import { checkOrSetSessionExpiration } from '../oauth/utilities';
 import { checkAndUpdateSSOeSession } from '../sso';
 
 export function fetchAndUpdateSessionExpiration(url, settings) {
@@ -18,31 +12,9 @@ export function fetchAndUpdateSessionExpiration(url, settings) {
     return fetch(url, settings);
   }
 
-  const originalFetch = isomorphicFetch;
-  const mergedSettings = {
-    ...settings,
-    async retryOn(attempt, error, response) {
-      if (error) return false;
-      const atError = await response.clone().json();
-
-      if (
-        atError.errors === 'Access token has expired' &&
-        infoTokenExists() &&
-        attempt < 1
-      ) {
-        await refresh({
-          type: sessionStorage.getItem('serviceName'),
-        });
-
-        return true;
-      }
-      return false;
-    },
-  };
-
   // Only replace with custom fetch if not stubbed for unit testing
-  const _fetch = retryFetch(originalFetch);
-  return _fetch(url, mergedSettings).then(response => {
+  const _fetch = fetch;
+  return _fetch(url, settings).then(response => {
     const apiURL = environment.API_URL;
 
     if (response.url.includes(apiURL)) {

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -13,8 +13,7 @@ export function fetchAndUpdateSessionExpiration(url, settings) {
   }
 
   // Only replace with custom fetch if not stubbed for unit testing
-  const _fetch = fetch;
-  return _fetch(url, settings).then(response => {
+  return fetch(url, settings).then(response => {
     const apiURL = environment.API_URL;
 
     if (response.url.includes(apiURL)) {


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
Revert the automatic refresh in the `fetchAndUpdateSessionExpiration` function.

- *(If bug, how to reproduce)*
There is a bug in the `retryOn` method in the `apiRequest` utility function in which the `.json()` clone is throwing an error. See more about replicating here: https://dsva.slack.com/archives/C5AGLBNRK/p1675352034193369 (Attempt to download a letter)

- *(What is the solution, why is this the solution)*
Revert. Requested by Chris J.
- *(Which team do you work for, does your team own the maintenance of this component?)*
Identity
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
N/A

## Related issue(s)
References department-of-veterans-affairs/va.gov-team#53009

## Testing done

- *Describe what the old behavior was prior to the change*
The `retryOn` function was breaking a lot of things: Downloading letters, MHV secure messages, etc.

- *Describe the steps required to verify your changes are working as expected*
Run unit tests & build vets-website from scratch

- *Describe the tests completed and the results*
Reverted to old unit tests suite

## Screenshots
n/a

## What areas of the site does it impact?
The `fetchAndUpdateSessionExpiration` is used by `apiRequest` which is used throughout vets-website.  It will affect everyone

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected


## Requested Feedback
### Confirm the following
#### Local setup of download PDF file
1. Set up vets-api following these instructions: https://dsva.slack.com/archives/C5AGLBNRK/p1675374081359829?thread_ts=1675352034.193369&cid=C5AGLBNRK
2. Start the Frontend using `yarn watch`
3. Sign in `oauth=false` using ID.me (user+228)
4. After authenticating navigate to `http://localhost:3001/records/download-va-letters/letters/letter-list`
5. Chose any letter in the letter list and click Download
6. Confirm the PDF downloads to the users computer

#### Unit tests + E2E tests
1. Unit tests work as expected
2. Cypress tests work as expected
