### PR TITLE
Update CODEOWNERS to include new forms team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,7 +126,7 @@ src/applications/mhv/secure-messaging @department-of-veterans-affairs/vfs-mhv-se
 
 # VA.gov Product Teams - Forms
 
-src/applications/simple-forms @department-of-veteran-affairs/platform-va-product-forms
+src/applications/simple-forms @department-of-veterans-affairs/platform-va-product-forms
 
 # Other
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,6 +124,10 @@ src/applications/toe @department-of-veterans-affairs/my-education-benefits
 src/applications/mhv/medical-records @department-of-veterans-affairs/vfs-mhv-medical-records
 src/applications/mhv/secure-messaging @department-of-veterans-affairs/vfs-mhv-secure-messaging
 
+# VA.gov Product Teams - Forms
+
+src/applications/simple-forms @department-of-veteran-affairs/platform-va-product-forms
+
 # Other
 
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe


### PR DESCRIPTION
This updates the CODEOWNERS file to include the new VA.gov Forms team. Our team will be building out multiple forms inside the `simple-forms` directory. We already have one merged pull request, https://github.com/department-of-veterans-affairs/vets-website/pull/23250, for our first VA Form 26-4555.

## Summary

- Updating the CODEOWNERS file to include the new VA.gov Forms team

## Related issue(s)
- department-of-veterans-affairs/VA.gov-team-forms#36
