### PR TITLE
[VA-11591] Remove flipper facilities_ppms_suppress_pharmacies

### DIFF
--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -11,10 +11,6 @@
         "value": true
       },
       {
-        "name": "facilitiesPpmsSuppressPharmacies",
-        "value": false
-      },
-      {
         "name": "facilitiesPpmsSuppressCommunityCare",
         "value": true
       },

--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
-import ServiceTypeAhead from './ServiceTypeAhead';
 import recordEvent from 'platform/monitoring/record-event';
 import omit from 'platform/utilities/data/omit';
-import { LocationType } from '../constants';
+import { focusElement } from 'platform/utilities/ui';
+import classNames from 'classnames';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import {
   healthServices,
   benefitsServices,
@@ -11,9 +12,8 @@ import {
   emergencyCareServices,
   nonPPMSfacilityTypeOptions,
 } from '../config';
-import { focusElement } from 'platform/utilities/ui';
-import classNames from 'classnames';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { LocationType } from '../constants';
+import ServiceTypeAhead from './ServiceTypeAhead';
 import { setFocus } from '../utils/helpers';
 
 const SearchControls = props => {
@@ -216,16 +216,12 @@ const SearchControls = props => {
   };
 
   const renderFacilityTypeDropdown = () => {
-    const { suppressCCP, suppressPharmacies, suppressPPMS } = props;
+    const { suppressCCP, suppressPPMS } = props;
     const { facilityType, isValid, facilityTypeChanged } = currentQuery;
     const locationOptions = suppressPPMS
       ? nonPPMSfacilityTypeOptions
       : facilityTypesOptions;
     const showError = !isValid && facilityTypeChanged && !facilityType;
-
-    if (suppressPharmacies) {
-      delete locationOptions.pharmacy;
-    }
 
     if (suppressCCP) {
       delete locationOptions.provider;
@@ -398,7 +394,7 @@ const SearchControls = props => {
         }
       />
       <form id="facility-search-controls" onSubmit={handleSubmit}>
-        <div className={'columns'}>
+        <div className="columns">
           {renderLocationInputField()}
           <div id="search-controls-bottom-row">
             {renderFacilityTypeDropdown()}

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -24,7 +24,6 @@ import {
 import {
   facilitiesPpmsSuppressAll,
   facilitiesPpmsSuppressCommunityCare,
-  facilitiesPpmsSuppressPharmacies,
   facilityLocatorPredictiveLocationSearch,
   facilityLocatorLighthouseCovidVaccineQuery,
 } from '../utils/featureFlagSelectors';
@@ -430,7 +429,6 @@ const FacilitiesMap = props => {
           onSubmit={handleSearch}
           suppressPPMS={props.suppressPPMS}
           suppressCCP={props.suppressCCP}
-          suppressPharmacies={props.suppressPharmacies}
           searchCovid19Vaccine={props.searchCovid19Vaccine}
           clearSearchText={props.clearSearchText}
         />
@@ -438,11 +436,8 @@ const FacilitiesMap = props => {
           <div id="search-result-emergency-care-info">
             <p className="search-result-emergency-care-subheader">
               <strong>Note:</strong> If you think your life or health is in
-              danger, call{' '}
-              <a aria-label="9 1 1" href="tel:911">
-                911
-              </a>{' '}
-              or go to the nearest emergency department right away.
+              danger, call <va-telephone contact="911" /> or go to the nearest
+              emergency department right away.
             </p>
           </div>
         )}
@@ -665,7 +660,6 @@ const FacilitiesMap = props => {
 const mapStateToProps = state => ({
   currentQuery: state.searchQuery,
   suppressPPMS: facilitiesPpmsSuppressAll(state),
-  suppressPharmacies: facilitiesPpmsSuppressPharmacies(state),
   suppressCCP: facilitiesPpmsSuppressCommunityCare(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),
   searchCovid19Vaccine: facilityLocatorLighthouseCovidVaccineQuery(state),

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -4,9 +4,6 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 export const facilitiesPpmsSuppressAll = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressAll];
 
-export const facilitiesPpmsSuppressPharmacies = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressPharmacies];
-
 export const facilitiesPpmsSuppressCommunityCare = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressCommunityCare];
 

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -11,10 +11,6 @@
         "value": false
       },
       {
-        "name": "facilitiesPpmsSuppressPharmacies",
-        "value": false
-      },
-      {
         "name": "facilitiesPpmsSuppressCommunityCare",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -11,10 +11,6 @@
         "value": true
       },
       {
-        "name": "facilitiesPpmsSuppressPharmacies",
-        "value": true
-      },
-      {
         "name": "facilitiesPpmsSuppressCommunityCare",
         "value": true
       },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -49,7 +49,6 @@ export default Object.freeze({
   facilitiesPpmsSuppressAll: 'facilities_ppms_suppress_all',
   facilitiesPpmsSuppressCommunityCare:
     'facilities_ppms_suppress_community_care',
-  facilitiesPpmsSuppressPharmacies: 'facilities_ppms_suppress_pharmacies',
   facilityLocatorLatLongOnly: 'facility_locator_lat_long_only',
   facilityLocatorLighthouseCovidVaccineQuery:
     'facility_locator_lighthouse_covid_vaccine_query',


### PR DESCRIPTION
## Summary

This pull request removes the `facilities_ppms_suppress_pharmacies` flipper and related functionality from the front end. Pharmacies are no longer suppressed from the facility search as a result.

I am with the facilities team, which does work and maintenance over the component in question.

There is no known end date for this flipper as of yet.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#11591
- [*Link to epic if not included in ticket*](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10656)

## Testing done

Before the change, the flipper (when active) would suppress pharmacy data from the search by deleting it. These changes can be verified by going to the facility search and seeing pharmacy data included in the search. Testing done was visual and by visiting the facility search to ensure it still worked.

<img width="1152" alt="Screen Shot 2023-02-06 at 2 16 38 PM" src="https://user-images.githubusercontent.com/10790736/217064190-a2a23ea3-c118-49c4-8bf0-8d4115b3bcec.png">

## What areas of the site does it impact?

The facility locator.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
