### PR TITLE
[VA-11589] Remove flipper `facilities_ppms_suppress_all`

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -1,19 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
-import ServiceTypeAhead from './ServiceTypeAhead';
 import recordEvent from 'platform/monitoring/record-event';
 import omit from 'platform/utilities/data/omit';
-import { LocationType } from '../constants';
+import { focusElement } from 'platform/utilities/ui';
+import classNames from 'classnames';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import {
   healthServices,
   benefitsServices,
   urgentCareServices,
   facilityTypesOptions,
   emergencyCareServices,
-  nonPPMSfacilityTypeOptions,
 } from '../config';
-import { focusElement } from 'platform/utilities/ui';
-import classNames from 'classnames';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { LocationType } from '../constants';
+import ServiceTypeAhead from './ServiceTypeAhead';
 import { setFocus } from '../utils/helpers';
 
 const SearchControls = props => {
@@ -216,24 +215,21 @@ const SearchControls = props => {
   };
 
   const renderFacilityTypeDropdown = () => {
-    const { suppressCCP, suppressPharmacies, suppressPPMS } = props;
+    const { suppressCCP, suppressPharmacies } = props;
     const { facilityType, isValid, facilityTypeChanged } = currentQuery;
-    const locationOptions = suppressPPMS
-      ? nonPPMSfacilityTypeOptions
-      : facilityTypesOptions;
     const showError = !isValid && facilityTypeChanged && !facilityType;
 
     if (suppressPharmacies) {
-      delete locationOptions.pharmacy;
+      delete facilityTypesOptions.pharmacy;
     }
 
     if (suppressCCP) {
-      delete locationOptions.provider;
+      delete facilityTypesOptions.provider;
     }
 
-    const options = Object.keys(locationOptions).map(facility => (
+    const options = Object.keys(facilityTypesOptions).map(facility => (
       <option key={facility} value={facility}>
-        {locationOptions[facility]}
+        {facilityTypesOptions[facility]}
       </option>
     ));
 
@@ -398,7 +394,7 @@ const SearchControls = props => {
         }
       />
       <form id="facility-search-controls" onSubmit={handleSubmit}>
-        <div className={'columns'}>
+        <div className="columns">
           {renderLocationInputField()}
           <div id="search-controls-bottom-row">
             {renderFacilityTypeDropdown()}

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -58,7 +58,7 @@ export const resolveParamsWithUrl = ({
 
   let facility;
   let service;
-  let url = api.url;
+  let { url } = api;
   let roundRadius;
   const perPage = 10;
   let communityServiceType = false;
@@ -251,14 +251,6 @@ export const facilityTypesOptions = {
   [LocationType.CC_PROVIDER]: 'Community providers (in VA’s network)',
   [LocationType.URGENT_CARE_PHARMACIES]:
     'Community pharmacies (in VA’s network)',
-  [LocationType.BENEFITS]: 'VA benefits',
-  [LocationType.CEMETARY]: 'VA cemeteries',
-  [LocationType.VET_CENTER]: 'Vet Centers',
-};
-
-export const nonPPMSfacilityTypeOptions = {
-  [LocationType.NONE]: 'Choose a facility type',
-  [LocationType.HEALTH]: 'VA health',
   [LocationType.BENEFITS]: 'VA benefits',
   [LocationType.CEMETARY]: 'VA cemeteries',
   [LocationType.VET_CENTER]: 'Vet Centers',

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -22,7 +22,6 @@ import {
   clearGeocodeError,
 } from '../actions';
 import {
-  facilitiesPpmsSuppressAll,
   facilitiesPpmsSuppressCommunityCare,
   facilitiesPpmsSuppressPharmacies,
   facilityLocatorPredictiveLocationSearch,
@@ -48,7 +47,6 @@ import { recordZoomEvent, recordPanEvent } from '../utils/analytics';
 import { otherToolsLink, coronavirusUpdate } from '../utils/mapLinks';
 import SearchAreaControl from '../components/SearchAreaControl';
 import Covid19Result from '../components/search-results-items/Covid19Result';
-import Alert from '../components/Alert';
 
 let lastZoom = 3;
 
@@ -415,20 +413,12 @@ const FacilitiesMap = props => {
 
     return (
       <div className={!isMobile ? 'desktop-container' : undefined}>
-        {props.suppressPPMS && (
-          <Alert
-            displayType="warning"
-            title="Some search options aren’t working right now"
-            description="We’re sorry. Searches for non-VA facilities such as community providers and urgent care are currently unavailable. We’re working to fix this. Please check back soon."
-          />
-        )}
         <SearchControls
           geolocateUser={props.geolocateUser}
           clearGeocodeError={props.clearGeocodeError}
           currentQuery={currentQuery}
           onChange={props.updateSearchQuery}
           onSubmit={handleSearch}
-          suppressPPMS={props.suppressPPMS}
           suppressCCP={props.suppressCCP}
           suppressPharmacies={props.suppressPharmacies}
           searchCovid19Vaccine={props.searchCovid19Vaccine}
@@ -438,11 +428,8 @@ const FacilitiesMap = props => {
           <div id="search-result-emergency-care-info">
             <p className="search-result-emergency-care-subheader">
               <strong>Note:</strong> If you think your life or health is in
-              danger, call{' '}
-              <a aria-label="9 1 1" href="tel:911">
-                911
-              </a>{' '}
-              or go to the nearest emergency department right away.
+              danger, call <va-telephone contact="911" /> or go to the nearest
+              emergency department right away.
             </p>
           </div>
         )}
@@ -664,7 +651,6 @@ const FacilitiesMap = props => {
 
 const mapStateToProps = state => ({
   currentQuery: state.searchQuery,
-  suppressPPMS: facilitiesPpmsSuppressAll(state),
   suppressPharmacies: facilitiesPpmsSuppressPharmacies(state),
   suppressCCP: facilitiesPpmsSuppressCommunityCare(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -1,9 +1,6 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
-export const facilitiesPpmsSuppressAll = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressAll];
-
 export const facilitiesPpmsSuppressPharmacies = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressPharmacies];
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -46,7 +46,6 @@ export default Object.freeze({
   dhpConnectedDevicesFitbit: 'dhp_connected_devices_fitbit',
   dischargeWizardFeatures: 'discharge_wizard_features',
   enrollmentVerification: 'enrollment_verification',
-  facilitiesPpmsSuppressAll: 'facilities_ppms_suppress_all',
   facilitiesPpmsSuppressCommunityCare:
     'facilities_ppms_suppress_community_care',
   facilitiesPpmsSuppressPharmacies: 'facilities_ppms_suppress_pharmacies',


### PR DESCRIPTION
## Summary

This pull request removes the `facilities_ppms_suppress_all` flipper and related functionality from the front end. All facilities are no longer suppressed from the facility search as a result.

I am with the facilities team, which does work and maintenance over the component in question.

There is no known end date for this flipper as of yet.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#11589
- [*Link to epic if not included in ticket*](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10656)

## Testing done

Before the change, the flipper (when active) would suppress all facility data from the search by deleting it. These changes can be verified by going to the facility search and seeing all data included in the search. Testing done was visual and by visiting the facility search to ensure it still worked.

## What areas of the site does it impact?

The facility locator.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
