### PR TITLE
[#MHV-40743] text.split ignores newlines

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { urlRegex, httpRegex } from '../../util/helpers';
 
 const MessageThreadBody = props => {
-  const words = props.text.split(/\s/g);
+  const words = props.text.split(/[^\S\r\n]+/g);
 
   return (
     <div


### PR DESCRIPTION
## Summary
Adds newline support for received messages. 

## Related issue(s)
https://vajira.max.gov/browse/MHV-40743

## Testing done
Existing unit tests

## Screenshots
![Screen Shot 2023-02-06 at 2 29 06 PM](https://user-images.githubusercontent.com/108146636/217078223-4dae916c-394c-4c0f-b79b-7836577cc3b1.png)

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
