### PR TITLE
Hotfix for alpha numeric station numbers

### DIFF
--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -269,9 +269,9 @@ const findAppointment = (appointmentId, appointments) => {
   const appointmentIdParts = appointmentId.split('-');
   return appointments.find(
     appointmentItem =>
-      Number(appointmentItem.appointmentIen) ===
-        Number(appointmentIdParts[0]) &&
-      Number(appointmentItem.stationNo) === Number(appointmentIdParts[1]),
+      String(appointmentItem.appointmentIen) ===
+        String(appointmentIdParts[0]) &&
+      String(appointmentItem.stationNo) === String(appointmentIdParts[1]),
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes issue where none numeric station numbers were causing a patient to not reach the check-in complete page.


## What areas of the site does it impact?
Day of check-in

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
