### PR TITLE
MyVA - minor copy update for Education and Training link 

### DIFF
--- a/src/applications/personalization/dashboard/components/education-and-training/EducationAndTraining.jsx
+++ b/src/applications/personalization/dashboard/components/education-and-training/EducationAndTraining.jsx
@@ -45,14 +45,14 @@ const EducationAndTraining = () => {
             }
           />
           <IconCTALink
-            text="Check your GI Bill Statement of Benefits"
+            text="Check your Post-9/11 GI Bill benefits"
             icon="dollar-sign"
             href="/education/gi-bill/post-9-11/ch-33-benefit/"
             testId="check-gi-bill-benefits-from-cta"
             onClick={() =>
               recordEvent({
                 event: 'nav-linkslist',
-                'links-list-header': 'Check your GI Bill Statement of Benefits',
+                'links-list-header': 'Check your Post-9/11 GI Bill benefits',
                 'links-list-section-header': 'Education and training',
               })
             }


### PR DESCRIPTION
## Summary
After a UX audit of the current MyVA, we decided to update one of the CTA links under Education and Training on MyVA for clarity. This PR changes the link copy from "**Check your GI Bill Statement of Benefits**" to "**Check your Post-9/11 GI Bill benefits**".

## Related issue(s)
- Ticket: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/52622](https://github.com/department-of-veterans-affairs/va.gov-team/issues/52622)
- Epic: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934)

## Testing done
- MyVA page still renders 
- All unit tests pass

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| Before | After |
|---|---|
| ![Screenshot 2023-02-08 at 9 59 46 AM](https://user-images.githubusercontent.com/8542413/217566997-adffcf0b-ab4d-4f93-88da-cd929aa5fc64.png) | ![Screenshot 2023-02-07 at 5 43 10 PM](https://user-images.githubusercontent.com/8542413/217566914-71adf677-d2a1-4bbd-8bf0-09f63ce9cd7f.png) |

## What areas of the site does it impact?
Just MyVA

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Documentation has been updated ([link](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/my-va/2022-audit/documentation/education-and-training-FE-documentation.md))
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature
