### PR TITLE
SM to VA.gov: Defect - Print Preview attachment links

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
@@ -79,13 +79,17 @@ const PrintBtn = props => {
               <VaRadioOption
                 data-testid="radio-print-all-messages"
                 style={{ display: 'flex' }}
-                label={`Print all messages in this conversation (${
+                aria-label={`Print all messages in this conversation (${
                   messageThreadCount.current
                 } messages)`}
+                label="Print all messages in this conversation"
                 name="defaultName"
                 value="all messages"
               />
             </VaRadio>
+            <p>
+              <strong>{`(${messageThreadCount.current} messages)`}</strong>
+            </p>
           </div>
         </VaModal>
       </div>

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
@@ -53,7 +53,7 @@ const PrintBtn = props => {
         <VaModal
           id="print-modal"
           large
-          modalTitle="Print"
+          modalTitle="What do you want to print?"
           onCloseEvent={closeModal}
           onPrimaryButtonClick={handleConfirmPrint}
           onSecondaryButtonClick={closeModal}
@@ -63,26 +63,22 @@ const PrintBtn = props => {
           visible={isModalVisible}
         >
           <div className="modal-body">
-            <p>
-              Would you like to print this one message, or all messages in this
-              conversation?
-            </p>
             <VaRadio
               className="form-radio-buttons"
-              required
               enable-analytics
               // error={ // TODO: add error state}
               onRadioOptionSelected={handleOnChangePrintOption}
             >
               <VaRadioOption
                 data-testid="radio-print-one-message"
-                label="Only print this message"
+                label="Print only this message"
                 name="defaultName"
                 value="this message"
               />
 
               <VaRadioOption
                 data-testid="radio-print-all-messages"
+                style={{ display: 'flex' }}
                 label={`Print all messages in this conversation (${
                   messageThreadCount.current
                 } messages)`}

--- a/src/applications/mhv/secure-messaging/containers/Compose.jsx
+++ b/src/applications/mhv/secure-messaging/containers/Compose.jsx
@@ -66,7 +66,7 @@ const Compose = () => {
   useEffect(
     () => {
       return () => {
-        if (location.pathname) {
+        if (isDraftPage) {
           dispatch(closeAlert());
         }
       };

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -109,6 +109,9 @@
       text-decoration: none;
       color: inherit;
     }
+    va-alert {
+      display: none;
+    }
     .secure-messaging-navigation {
       display: none;
     }

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -64,7 +64,7 @@
     margin: 0px;
     padding: 0px;
     @media (max-width: $small-screen) {
-      li{
+      li {
         width: 100%;
       }
     }
@@ -87,10 +87,10 @@
         width: 102%;
       }
     }
-    :first-child button{
+    :first-child button {
       border-radius: 5px 0 0 5px;
     }
-    :last-child button{
+    :last-child button {
       border-radius: 0 5px 5px 0;
     }
   }
@@ -105,6 +105,10 @@
 
 @media print {
   body {
+    a {
+      text-decoration: none;
+      color: inherit;
+    }
     .secure-messaging-navigation {
       display: none;
     }

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-print-single-message.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-print-single-message.cypress.spec.js
@@ -18,18 +18,17 @@ describe('Secure Messaging - Print Functionality', () => {
     cy.get('[data-testid=radio-print-one-message]')
       .shadow()
       .find('label')
-      .should('have.text', 'Only print this message')
+      .should('have.text', 'Print only this message')
       .should('be.visible');
     cy.get('[data-testid=radio-print-all-messages]')
       .shadow()
       .find('label')
       .should('contain.text', 'Print all messages in this conversation')
       .should('be.visible');
-    cy.get('[data-testid=print-modal-popup] p')
-      .should(
-        'have.text',
-        'Would you like to print this one message, or all messages in this conversation?',
-      )
+    cy.get('[data-testid=print-modal-popup]')
+      .shadow()
+      .find('h1')
+      .should('have.text', 'What do you want to print?')
       .should('be.visible');
     cy.get('[data-testid=radio-print-all-messages]').click();
     cy.window().then(win => {


### PR DESCRIPTION
## Summary

Defect Print Preview shows attachments and URLs as clickable links. On legacy they are displayed as plain text

The text for the attachments in the print preview should be black to match the rest of the content and the underline should be removed so that the attachment doesn't look clickable in the print preview state. The icon and everything besides the two previously mentioned changes, should remain similar to the styling state when not in print preview.

Updating Print Modal per new designs

Hiding Alerts from Print Preview

## Related issue(s)
- [SM to VA.gov: Defect - Print Preview attachment links](https://vajira.max.gov/browse/MHV-41266)

## Testing done

- pending manual testing validation


## Screenshots
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/87077843/217643581-26933cc0-210d-4630-9bc6-9b254755c8a6.png">


## What areas of the site does it impact?
My Health - Secure Messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
