### PR TITLE
[VA-11862] Remove Mega Menu V2 Flipper

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -67,7 +67,6 @@ export class Main extends Component {
     ).isRequired,
     display: PropTypes.object,
     loggedIn: PropTypes.bool.isRequired,
-    isMegaMenuMobileV2Enabled: PropTypes.bool,
   };
 
   toggleDropDown = currentDropdown => {

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -76,7 +76,6 @@ export default Object.freeze({
   hcaUseFacilitiesApi: 'hca_use_facilities_API',
   loopPages: 'loop_pages',
   manageDependents: 'dependents_management',
-  megaMenuMobileV2: 'mega_menu_mobile_v2',
   medicalCopaysHtmlMedicalStatementsViewEnabled: 'medical_copays_html_medical_statements_view_enabled',
   mhvSecureMessagingToVaGovRelease: 'mhv_secure_messaging_to_va_gov_release',
   mhvToLogingovAccountTransition: 'mhv_to_logingov_account_transition',


### PR DESCRIPTION
## Summary

This removes the Mega Menu V2 flipper. This removes all traces of it from the front-end, but there's nothing that affects the UI. Afterwards the flipper can be removed from the `vets-api`, as it's confirmed to already be off.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#11862

## Testing done

None needed.

## What areas of the site does it impact?

None, as the flipper is currently off.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
