### PR TITLE
[VA-11863] Remove shift-vets-banner flipper

### DIFF
--- a/src/applications/static-pages/shifted-vets-banner/components/App/index.js
+++ b/src/applications/static-pages/shifted-vets-banner/components/App/index.js
@@ -1,18 +1,10 @@
 // Node modules.
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
-import { hideDefaultBanner, showDefaultBanner } from '../../helpers';
+import { hideDefaultBanner } from '../../helpers';
 
-export const App = ({ show }) => {
-  // If the feature toggle is disabled, do not render.
-  if (!show) {
-    // Ensure the default banner is rendered & escape early.
-    showDefaultBanner();
-    return null;
-  }
-
+export const App = () => {
   // Hide the default location banner image.
   hideDefaultBanner();
 
@@ -41,16 +33,4 @@ export const App = ({ show }) => {
   );
 };
 
-App.propTypes = {
-  // From mapStateToProps.
-  show: PropTypes.bool,
-};
-
-const mapStateToProps = state => ({
-  show: state?.featureToggles?.shiftVetsBanner,
-});
-
-export default connect(
-  mapStateToProps,
-  null,
-)(App);
+export default connect()(App);

--- a/src/applications/static-pages/shifted-vets-banner/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/shifted-vets-banner/components/App/index.unit.spec.js
@@ -6,18 +6,7 @@ import { shallow } from 'enzyme';
 import { App } from '.';
 
 describe('Shifted Veteran Banner <App>', () => {
-  it('does not render when feature toggle disabled', () => {
-    // Set up.
-    const wrapper = shallow(<App />);
-
-    // Assertions.
-    expect(wrapper.type()).to.equal(null);
-
-    // Clean up.
-    wrapper.unmount();
-  });
-
-  it('renders what we expect with feature toggle enabled', () => {
+  it('renders the new banner', () => {
     // Set up.
     const wrapper = shallow(<App show />);
 

--- a/src/applications/static-pages/shifted-vets-banner/helpers/index.js
+++ b/src/applications/static-pages/shifted-vets-banner/helpers/index.js
@@ -12,18 +12,3 @@ export const hideDefaultBanner = () => {
     defaultBanner.classList.add('vads-u-display--none');
   }
 };
-
-export const showDefaultBanner = () => {
-  // Derive the default banner on the page.
-  const defaultBanner = document.querySelector('div[id="vets-banner-1"]');
-
-  // Escape early if the default banner doesn't exist.
-  if (!defaultBanner) {
-    return;
-  }
-
-  // Add `vads-u-display--none` class to the default banner if it doesn't already exist.
-  if (defaultBanner.classList.contains('vads-u-display--none')) {
-    defaultBanner.classList.remove('vads-u-display--none');
-  }
-};

--- a/src/applications/static-pages/shifted-vets-banner/helpers/index.unit.spec.js
+++ b/src/applications/static-pages/shifted-vets-banner/helpers/index.unit.spec.js
@@ -1,16 +1,10 @@
 // Node modules.
 import { expect } from 'chai';
 // Relative imports.
-import { hideDefaultBanner, showDefaultBanner } from '.';
+import { hideDefaultBanner } from '.';
 
 describe('hideDefaultBanner', () => {
   it('returns what we expect with no arguments', () => {
     expect(hideDefaultBanner()).to.equal(undefined);
-  });
-});
-
-describe('showDefaultBanner', () => {
-  it('returns what we expect with no arguments', () => {
-    expect(showDefaultBanner()).to.equal(undefined);
   });
 });

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -200,7 +200,7 @@ createManageVADebtCTA(store, widgetTypes.MANAGE_VA_DEBT_CTA);
 createHomepageHeroRandomizer(store, widgetTypes.HOMEPAGE_HERO_RANDOMIZER);
 createHomepageSearch(store, widgetTypes.HOMEPAGE_SEARCH);
 create1095BDownloadCTA(store, widgetTypes.DOWNLOAD_1095B_CTA);
-createShiftedVetsBanner(store, widgetTypes.SHIFTED_VETS_BANNER);
+createShiftedVetsBanner(store);
 createNodCTA(store, widgetTypes.FORM_10182_CTA);
 createSupplementalClaim(store, widgetTypes.SUPPLEMENTAL_CLAIM);
 createEnrollmentVerificationLoginWidget(

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -99,7 +99,6 @@ export default Object.freeze({
   ratedDisabilitiesSortAbTest: 'rated_disabilities_sort_ab_test',
   searchRepresentative: 'search_representative',
   searchDropdownComponentEnabled: 'search_dropdown_component_enabled',
-  shiftVetsBanner: 'shift_vets_banner',
   show526Wizard: 'show526_wizard',
   showPaymentAndDebtSection: 'show_payment_and_debt_section',
   showContactChatbot: 'show_contact_chatbot',


### PR DESCRIPTION
## Summary

This removes the Shift Vets Banner flipper. This removes all traces of it from the front end, but nothing affects the UI since the flipper is off. Afterward, the flipper can be removed from the `vets-api`, as it's confirmed to be off already.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#11863

## Testing done

None needed.

## What areas of the site does it impact?

None, as the flipper is currently off.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
