### PR TITLE
VA-11864: Remove global downtime notification flipper

### DIFF
--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -83,10 +83,6 @@
         "value": true
       },
       {
-        "name": "vaGlobalDowntimeNotification",
-        "value": true
-      },
-      {
         "name": "eduBenefitsStemScholarship",
         "value": true
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -79,10 +79,6 @@
         "value": false
       },
       {
-        "name": "vaGlobalDowntimeNotification",
-        "value": false
-      },
-      {
         "name": "eduBenefitsStemScholarship",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -79,10 +79,6 @@
         "value": true
       },
       {
-        "name": "vaGlobalDowntimeNotification",
-        "value": true
-      },
-      {
         "name": "eduBenefitsStemScholarship",
         "value": true
       },

--- a/src/applications/static-pages/homepage/tests/mocks/features.js
+++ b/src/applications/static-pages/homepage/tests/mocks/features.js
@@ -20,7 +20,6 @@ const features = {
       { name: 'vaOnlineSchedulingVAOSServiceCCAppointments', value: false },
       { name: 'vaOnlineSchedulingVAOSServiceVAAppointments', value: false },
       { name: 'vaOnlineSchedulingVAOSServiceRequests', value: false },
-      { name: 'vaGlobalDowntimeNotification', value: false },
       { name: 'edu_section_103', value: true },
       { name: 'vaViewDependentsAccess', value: false },
       { name: 'gibctEybBottomSheet', value: true },

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -590,7 +590,6 @@ const responses = {
         { name: 'vaOnlineSchedulingExpressCare', value: true },
         { name: 'vaOnlineSchedulingFlatFacilityPage', value: true },
         { name: 'vaOnlineSchedulingUnenrolledVaccine', value: true },
-        { name: 'vaGlobalDowntimeNotification', value: false },
         { name: 'vaOnlineSchedulingVAOSServiceRequests', value: true },
         { name: 'vaOnlineSchedulingVAOSServiceVAAppointments', value: true },
         { name: 'vaOnlineSchedulingFacilitiesServiceV2', value: true },

--- a/src/applications/vaos/tests/e2e/vaos-cypress-v2-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-v2-helpers.js
@@ -253,11 +253,6 @@ export function mockFeatureToggles() {
           value: true,
         },
         {
-          name: 'vaGlobalDowntimeNotification',
-          value: false,
-        },
-
-        {
           name: 'vaOnlineSchedulingVAOSServiceRequests',
           value: true,
         },

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -83,7 +83,6 @@ const responses = {
         { name: 'vaOnlineSchedulingVAOSServiceCCAppointments', value: false },
         { name: 'vaOnlineSchedulingVAOSServiceVAAppointments', value: false },
         { name: 'vaOnlineSchedulingVAOSServiceRequests', value: false },
-        { name: 'vaGlobalDowntimeNotification', value: false },
         { name: 'edu_section_103', value: true },
         { name: 'vaViewDependentsAccess', value: false },
         { name: 'gibctEybBottomSheet', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -136,7 +136,6 @@ export default Object.freeze({
   subform89404192: 'subform_8940_4192',
   supplementalClaim: 'supplemental_claim',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
-  vaGlobalDowntimeNotification: 'va_global_downtime_notification',
   vaHomePreviewModal:
     'va_home_preview_modal',
   vaOnlineFacilitySelectionV22: 'va_online_scheduling_facility_selection_v2_2',


### PR DESCRIPTION
## Summary

This removes the Global Downtime Notification flipper. There are no references to it in the front end, so this only removes references to it in the feature flag and test/fixture data files. Afterward, the flipper can be removed from the `vets-api`, as it's confirmed to be off already.

## Related issue(s)
- department-of-veterans-affairs/va.gov-cms#11864

## Testing done

None needed.

## What areas of the site does it impact?

None, as the flipper is currently off.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
