### PR TITLE
[CST] Make app wait to load components until feature flags are loaded

### DIFF
--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -15,9 +15,9 @@ import { isLoadingFeatures } from '../selectors';
 function AppContent({ children, featureFlagsLoading, isDataAvailable }) {
   const canUseApp =
     isDataAvailable === true || typeof isDataAvailable === 'undefined';
-  const shouldUseApp = canUseApp && !featureFlagsLoading;
+  const isAppReady = canUseApp && !featureFlagsLoading;
 
-  if (!shouldUseApp) {
+  if (!isAppReady) {
     return (
       <div className="vads-u-margin-y--5">
         <va-loading-indicator message="Loading your information..." />
@@ -28,7 +28,7 @@ function AppContent({ children, featureFlagsLoading, isDataAvailable }) {
   return (
     <div className="claims-status-content">
       {!canUseApp && <ClaimsAppealsUnavailable />}
-      {shouldUseApp && <>{children}</>}
+      {isAppReady && <>{children}</>}
     </div>
   );
 }

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -5,23 +5,47 @@ import PropTypes from 'prop-types';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { RequiredLoginView } from 'platform/user/authorization/components/RequiredLoginView';
+
 import { setLastPage } from '../actions';
 import ClaimsAppealsUnavailable from '../components/ClaimsAppealsUnavailable';
+import { isLoadingFeatures } from '../selectors';
 
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
-function AppContent({ children, isDataAvailable }) {
+function AppContent({ children, featureFlagsLoading, isDataAvailable }) {
   const canUseApp =
     isDataAvailable === true || typeof isDataAvailable === 'undefined';
+  const shouldUseApp = canUseApp && !featureFlagsLoading;
+
+  if (canUseApp && featureFlagsLoading) {
+    return (
+      <div className="vads-u-margin-y--5">
+        <va-loading-indicator message="Loading your information..." />
+      </div>
+    );
+  }
+
   return (
     <div className="claims-status-content">
       {!canUseApp && <ClaimsAppealsUnavailable />}
-      {canUseApp && <>{children}</>}
+      {shouldUseApp && <>{children}</>}
     </div>
   );
 }
 
-function ClaimsStatusApp({ children, dispatchSetLastPage, router, user }) {
+AppContent.propTypes = {
+  children: PropTypes.node,
+  featureFlagsLoading: PropTypes.bool,
+  isDataAvailable: PropTypes.bool,
+};
+
+function ClaimsStatusApp({
+  children,
+  dispatchSetLastPage,
+  featureFlagsLoading,
+  router,
+  user,
+}) {
   useEffect(() => {
     router.listen(location => {
       dispatchSetLastPage(location.pathname);
@@ -37,7 +61,9 @@ function ClaimsStatusApp({ children, dispatchSetLastPage, router, user }) {
       ]}
       user={user}
     >
-      <AppContent>{children}</AppContent>
+      <AppContent featureFlagsLoading={featureFlagsLoading}>
+        {children}
+      </AppContent>
     </RequiredLoginView>
   );
 }
@@ -45,12 +71,18 @@ function ClaimsStatusApp({ children, dispatchSetLastPage, router, user }) {
 ClaimsStatusApp.propTypes = {
   children: PropTypes.object,
   dispatchSetLastPage: PropTypes.func,
+  featureFlagsLoading: PropTypes.bool,
   router: PropTypes.object,
   user: PropTypes.object,
 };
 
 function mapStateToProps(state) {
-  return { user: state.user };
+  const featureFlagsLoading = isLoadingFeatures(state);
+
+  return {
+    featureFlagsLoading,
+    user: state.user,
+  };
 }
 
 const mapDispatchToProps = {

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -20,7 +20,10 @@ function AppContent({ children, featureFlagsLoading, isDataAvailable }) {
   if (!isAppReady) {
     return (
       <div className="vads-u-margin-y--5">
-        <va-loading-indicator message="Loading your information..." />
+        <va-loading-indicator
+          data-testid="feature-flags-loading"
+          message="Loading your information..."
+        />
       </div>
     );
   }

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -17,7 +17,7 @@ function AppContent({ children, featureFlagsLoading, isDataAvailable }) {
     isDataAvailable === true || typeof isDataAvailable === 'undefined';
   const shouldUseApp = canUseApp && !featureFlagsLoading;
 
-  if (canUseApp && featureFlagsLoading) {
+  if (!shouldUseApp) {
     return (
       <div className="vads-u-margin-y--5">
         <va-loading-indicator message="Loading your information..." />

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { render } from '@testing-library/react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
@@ -22,6 +23,7 @@ describe('<ClaimsStatusApp>', () => {
     ]);
     expect(tree.subTree('RequiredLoginView').props.verify).to.be.true;
   });
+
   it('should render children', () => {
     const tree = SkinDeep.shallowRender(
       <AppContent available authorized>
@@ -31,5 +33,27 @@ describe('<ClaimsStatusApp>', () => {
 
     expect(tree.everySubTree('.test-child')).not.to.be.empty;
     expect(tree.everySubTree('ClaimsUnavailable')).to.be.empty;
+  });
+
+  it('should render loading indicator if feature toggles are not available', () => {
+    const screen = render(
+      <AppContent featureFlagsLoading>
+        <div data-testid="children" />
+      </AppContent>,
+    );
+
+    expect(screen.getByTestId('feature-flags-loading')).to.exist;
+    expect(screen.queryByTestId('children')).to.not.exist;
+  });
+
+  it('should render children if feature toggles are available', () => {
+    const screen = render(
+      <AppContent featureFlagsLoading={false}>
+        <div data-testid="children" />
+      </AppContent>,
+    );
+
+    expect(screen.queryByTestId('feature-flags-loading')).to.not.exist;
+    expect(screen.queryByTestId('children')).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-disabled.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-disabled.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "type": "feature_toggles",
+    "features": [
+      {
+        "name": "cst_use_lighthouse",
+        "value": false
+      }
+    ]
+  }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-enabled.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-enabled.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "type": "feature_toggles",
+    "features": [
+      {
+        "name": "cst_use_lighthouse",
+        "value": true
+      }
+    ]
+  }
+}

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims/phase3.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims/phase3.json
@@ -83,6 +83,16 @@
           "date": "2021-09-22"
         },
         {
+          "trackedItemId": 50,
+          "fileType": "Correspondence",
+          "documentType": "L023",
+          "filename": "Large_BDD_STR_Test_part_2_of_3.pdf",
+          "uploadDate": "2021-09-22",
+          "status": "NEEDED",
+          "type": "still_need_from_you_list",
+          "date": "2021-09-22"
+        },
+        {
           "trackedItemId": null,
           "fileType": "Correspondence",
           "documentType": "L023",

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims/phase3.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/claims/phase3.json
@@ -83,16 +83,6 @@
           "date": "2021-09-22"
         },
         {
-          "trackedItemId": 50,
-          "fileType": "Correspondence",
-          "documentType": "L023",
-          "filename": "Large_BDD_STR_Test_part_2_of_3.pdf",
-          "uploadDate": "2021-09-22",
-          "status": "NEEDED",
-          "type": "still_need_from_you_list",
-          "date": "2021-09-22"
-        },
-        {
           "trackedItemId": null,
           "fileType": "Correspondence",
           "documentType": "L023",

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -1,3 +1,7 @@
+// START lighthouse_migration
+import featureToggleDisabled from '../fixtures/mocks/lighthouse/feature-toggle-disabled.json';
+// END lighthouse_migration
+
 const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 /* eslint-disable class-methods-use-this */
@@ -15,6 +19,11 @@ class TrackClaimsPage {
     }
     cy.intercept('GET', '/v0/evss_claims_async', claimsList);
     cy.login();
+
+    // START lighthouse_migration
+    cy.intercept('GET', '/v0/feature_toggles?*', featureToggleDisabled);
+    // END lighthouse_migration
+
     cy.visit('/track-claims');
     cy.title().should(
       'eq',


### PR DESCRIPTION
## Summary

We are using a feature toggle to determine which endpoints need to be called when certain components load. In order for the feature toggle to work properly and make the right API call, we need the feature toggle values to be loaded before the components are loaded.

- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
    * The app has a root-level wrapper component that renders all of the content. I am checking to see if feature toggles are loaded before rendering the normal content
    * If the feature toggles are not loaded the app will render a loading indicator
    * If the feature toggles are loaded and the user is properly authenticated, then the normal content is rendered
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#50036
- *Link to ticket created in va.gov-team repo*

## Testing done
Tests still pass as expected
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
