### PR TITLE
Remove Short Form feature flag conditionals from Health Care application

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/general.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/general.js
@@ -14,7 +14,7 @@ import {
   TricarePolicyDescription,
 } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisabilityOrNotCompensationTypeHigh } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { provider } = fullSchemaHca.definitions;
@@ -31,7 +31,7 @@ export default {
     'view:generalShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisabilityOrNotCompensationTypeHigh,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:healthInsuranceDescription': {

--- a/src/applications/hca/config/chapters/insuranceInformation/medicaid.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/medicaid.js
@@ -1,7 +1,7 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import { MedicaidDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisabilityOrNotCompensationTypeHigh } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { isMedicaidEligible } = fullSchemaHca.properties;
@@ -11,7 +11,7 @@ export default {
     'view:medicaidShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisabilityOrNotCompensationTypeHigh,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:medicaidDescription': {

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
@@ -1,13 +1,13 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import constants from 'vets-json-schema/dist/constants.json';
-import { statesWithoutService } from '../../../utils/constants';
+import { STATES_WITHOUT_MEDICAL } from '../../../utils/constants';
 import {
   EssentialCoverageDescription,
   FacilityLocatorDescription,
 } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
 import VaMedicalCenter from '../../../components/FormFields/VaMedicalCenter';
-import { NotHighDisabilityOrNotCompensationTypeHigh } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 // define default schema properties
@@ -18,7 +18,7 @@ const {
 
 // define states/territories with health care facilities
 const healthcareStates = constants.states.USA.filter(state => {
-  return !statesWithoutService.includes(state.value);
+  return !STATES_WITHOUT_MEDICAL.includes(state.value);
 });
 
 export default {
@@ -26,7 +26,7 @@ export default {
     'view:facilityShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisabilityOrNotCompensationTypeHigh,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:vaFacilityTitle': {

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility_json.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility_json.js
@@ -28,7 +28,7 @@ export default {
     'view:facilityShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: formData => isShortFormEligible(formData),
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:vaFacilityTitle': {

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility_json.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility_json.js
@@ -11,7 +11,7 @@ import {
 import { ShortFormAlert } from '../../../components/FormAlerts';
 import {
   medicalCentersByState,
-  NotHighDisabilityOrNotCompensationTypeHigh,
+  isShortFormEligible,
 } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
@@ -28,7 +28,7 @@ export default {
     'view:facilityShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisabilityOrNotCompensationTypeHigh,
+        hideIf: formData => isShortFormEligible(formData),
       },
     },
     'view:vaFacilityTitle': {

--- a/src/applications/hca/config/chapters/militaryService/serviceInformation.js
+++ b/src/applications/hca/config/chapters/militaryService/serviceInformation.js
@@ -4,8 +4,8 @@ import dateUI from 'platform/forms-system/src/js/definitions/date';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
 import {
-  dischargeTypeLabels,
-  lastServiceBranchLabels,
+  DISCHARGE_TYPE_LABELS,
+  SERVICE_BRANCH_LABELS,
 } from '../../../utils/constants';
 import { validateServiceDates } from '../../../utils/validation';
 
@@ -22,7 +22,7 @@ export default {
     lastServiceBranch: {
       'ui:title': 'Last branch of service',
       'ui:options': {
-        labels: lastServiceBranchLabels,
+        labels: SERVICE_BRANCH_LABELS,
       },
     },
     // TODO: this should really be a dateRange, but that requires a backend schema change. For now
@@ -32,7 +32,7 @@ export default {
     dischargeType: {
       'ui:title': 'Character of service',
       'ui:options': {
-        labels: dischargeTypeLabels,
+        labels: DISCHARGE_TYPE_LABELS,
       },
     },
     'ui:validations': [validateServiceDates],

--- a/src/applications/hca/config/chapters/veteranInformation/americanIndian.js
+++ b/src/applications/hca/config/chapters/veteranInformation/americanIndian.js
@@ -1,7 +1,7 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import { AmericanIndianDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { sigiIsAmericanIndian } = fullSchemaHca.properties;
@@ -11,7 +11,7 @@ export default {
     'view:aiqShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:aiqDescription': {

--- a/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthInformation.js
@@ -3,7 +3,7 @@ import constants from 'vets-json-schema/dist/constants.json';
 
 import AuthenticatedShortFormAlert from '../../../components/FormAlerts/AuthenticatedShortFormAlert';
 import { BirthInfoDescription } from '../../../components/FormDescriptions';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { cityOfBirth } = fullSchemaHca.properties;
@@ -14,7 +14,7 @@ export default {
     'view:authShortFormAlert': {
       'ui:field': AuthenticatedShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:placeOfBirth': {

--- a/src/applications/hca/config/chapters/veteranInformation/birthSex.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthSex.js
@@ -3,7 +3,7 @@ import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 import { genderLabels } from 'platform/static-data/labels';
 
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { gender } = fullSchemaHca.properties;
@@ -13,7 +13,7 @@ export default {
     'view:birthSexShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:prefillMessage': {

--- a/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
@@ -5,7 +5,7 @@ import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 
 import { ShortFormAlert } from '../../../components/FormAlerts';
 import { ContactInfoDescription } from '../../../components/FormDescriptions';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { email } = fullSchemaHca.properties;
@@ -16,7 +16,7 @@ export default {
     'view:contactShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:prefillMessage': {

--- a/src/applications/hca/config/chapters/veteranInformation/demographicInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/demographicInformation.js
@@ -4,7 +4,7 @@ import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 import DemographicField from '../../../components/FormFields/DemographicViewField';
 import { DemographicInfoDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const {
@@ -22,7 +22,7 @@ export default {
     'view:dmShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:prefillMessage': {

--- a/src/applications/hca/config/chapters/veteranInformation/maidenNameInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/maidenNameInformation.js
@@ -2,7 +2,7 @@ import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import set from 'platform/utilities/data/set';
 
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { mothersMaidenName } = fullSchemaHca.properties;
@@ -12,7 +12,7 @@ export default {
     'view:maidenNameShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     mothersMaidenName: {

--- a/src/applications/hca/config/chapters/veteranInformation/veteranAddress.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranAddress.js
@@ -8,7 +8,7 @@ import {
 
 import { MailingAddressDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 export default {
@@ -16,7 +16,7 @@ export default {
     'view:veteranAddressShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:prefillMessage': {

--- a/src/applications/hca/config/chapters/veteranInformation/veteranGender.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranGender.js
@@ -3,7 +3,7 @@ import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 
 import { SIGIGenderDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { sigiGenders } = fullSchemaHca.properties;
@@ -13,7 +13,7 @@ export default {
     'view:genderShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:prefillMessage': {

--- a/src/applications/hca/config/chapters/veteranInformation/veteranHomeAddress.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranHomeAddress.js
@@ -8,7 +8,7 @@ import {
 
 import { HomeAddressDescription } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { NotHighDisability } from '../../../utils/helpers';
+import { isShortFormEligible } from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 export default {
@@ -16,7 +16,7 @@ export default {
     'view:homeAddressShortFormMessage': {
       'ui:description': ShortFormAlert,
       'ui:options': {
-        hideIf: NotHighDisability,
+        hideIf: formData => !isShortFormEligible(formData),
       },
     },
     'view:prefillMessage': {

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // platform imports
 import environment from 'platform/utilities/environment';
 import preSubmitInfo from 'platform/forms/preSubmitInfo';

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // platform imports
 import environment from 'platform/utilities/environment';
 import preSubmitInfo from 'platform/forms/preSubmitInfo';
@@ -14,15 +15,12 @@ import GetHelp from '../components/GetHelp';
 import SubmissionErrorAlert from '../components/FormAlerts/SubmissionErrorAlert';
 import { DowntimeWarning } from '../components/FormAlerts';
 import IntroductionPage from '../containers/IntroductionPage';
-import { prefillTransformer, transform, formValue } from '../utils/helpers';
 import {
-  IS_LOGGED_IN,
-  USER_DOB,
-  IS_GTE_HIGH_DISABILITY,
-  IS_SHORT_FORM_ENABLED,
-  IS_COMPENSATION_TYPE_HIGH,
-  IS_VETERAN_IN_MVI,
-} from '../utils/constants';
+  prefillTransformer,
+  transform,
+  isShortFormEligible,
+} from '../utils/helpers';
+import { HIGH_DISABILITY_MINIMUM } from '../utils/constants';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { createDependentSchema } from '../definitions/dependent';
 
@@ -68,8 +66,7 @@ import general from './chapters/insuranceInformation/general';
 import ServiceConnectedPayConfirmation from '../components/FormAlerts/ServiceConnectedPayConfirmation';
 import CompensationTypeReviewPage from '../components/FormReview/CompensationTypeReviewPage';
 
-const dependentSchema = createDependentSchema(fullSchemaHca);
-
+// declare schema definitions
 const {
   date,
   fullName,
@@ -78,36 +75,12 @@ const {
   provider,
   ssn,
 } = fullSchemaHca.definitions;
+const dependentSchema = createDependentSchema(fullSchemaHca);
 
-// For which page should be shown on short form
-
-// show page when short form feature toggle is not enabled or
-// when compensation type high is not selected and veteran does not have high disability rating
-const notHighDisabilityNotSelfDisclosure = formData =>
-  !formValue(formData, IS_SHORT_FORM_ENABLED) ||
-  (!formValue(formData, IS_COMPENSATION_TYPE_HIGH) &&
-    !formValue(formData, IS_GTE_HIGH_DISABILITY));
-
-// show page when short form feature toggle is not enabled and veteran does not have data in MPI or
-// when compensation type high is not selected and veteran does not have data in MPI
-const notHighDisabilityAndNotInMvi = formData =>
-  (!formValue(formData, IS_SHORT_FORM_ENABLED) &&
-    !formValue(formData, IS_VETERAN_IN_MVI)) ||
-  (formValue(formData, IS_SHORT_FORM_ENABLED) &&
-    !formValue(formData, IS_COMPENSATION_TYPE_HIGH) &&
-    !formValue(formData, IS_VETERAN_IN_MVI));
-
-// show page when short form feature toggle is not enabled and is enrolled in medicare part A is selected or
-// when compensation type high is not selected and is enrolled in medicare part A is selected
-const notHighDisabilityEnrolledMedicarePartA = formData =>
-  (!formValue(formData, IS_SHORT_FORM_ENABLED) &&
-    formData.isEnrolledMedicarePartA) ||
-  (formValue(formData, IS_SHORT_FORM_ENABLED) &&
-    !formValue(formData, IS_COMPENSATION_TYPE_HIGH) &&
-    formData.isEnrolledMedicarePartA);
-
-// For which page needs prefill-message, check
-// vets-api/config/form_profile_mappings/1010ez.yml
+/**
+ * NOTE: Prefill message data values can be found in
+ * `vets-api/config/form_profile_mappings/1010ez.yml`
+ */
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
@@ -142,7 +115,7 @@ const formConfig = {
       path: 'id-form',
       component: IDPage,
       pageKey: 'id-form',
-      depends: formData => !formValue(formData, IS_LOGGED_IN),
+      depends: formData => !formData['view:isLoggedIn'],
     },
   ],
   confirmation: ConfirmationPage,
@@ -171,7 +144,7 @@ const formConfig = {
           CustomPage: PersonalAuthenticatedInformation,
           CustomPageReview: null,
           initialData: {},
-          depends: formData => formValue(formData, IS_LOGGED_IN),
+          depends: formData => formData['view:isLoggedIn'],
           uiSchema: {},
           schema: {
             type: 'object',
@@ -182,7 +155,7 @@ const formConfig = {
           path: 'veteran-information/profile-information',
           title: 'Veteran name',
           initialData: {},
-          depends: formData => !formValue(formData, IS_LOGGED_IN),
+          depends: formData => !formData['view:isLoggedIn'],
           uiSchema: veteranInformation.uiSchema,
           schema: veteranInformation.schema,
         },
@@ -190,7 +163,7 @@ const formConfig = {
           path: 'veteran-information/profile-information-ssn',
           title: 'Social Security number',
           initialData: {},
-          depends: formData => !formValue(formData, IS_LOGGED_IN),
+          depends: formData => !formData['view:isLoggedIn'],
           uiSchema: personalInformationSsn.uiSchema,
           schema: personalInformationSsn.schema,
         },
@@ -199,8 +172,7 @@ const formConfig = {
           title: 'Date of birth',
           initialData: {},
           depends: formData =>
-            !formValue(formData, IS_LOGGED_IN) ||
-            !formValue(formData, USER_DOB),
+            !formData['view:isLoggedIn'] || !formData['view:userDob'],
           uiSchema: personalInformationDOB.uiSchema,
           schema: personalInformationDOB.schema,
         },
@@ -284,8 +256,7 @@ const formConfig = {
           title: 'VA benefits',
           CustomPageReview: CompensationTypeReviewPage,
           depends: formData =>
-            !formValue(formData, IS_GTE_HIGH_DISABILITY) ||
-            !formValue(formData, IS_SHORT_FORM_ENABLED),
+            formData['view:totalDisabilityRating'] < HIGH_DISABILITY_MINIMUM,
           uiSchema: basicInformation.uiSchema,
           schema: basicInformation.schema,
         },
@@ -295,9 +266,7 @@ const formConfig = {
           CustomPage: ServiceConnectedPayConfirmation,
           CustomPageReview: null,
           initialData: {},
-          depends: formData =>
-            formData.vaCompensationType === 'highDisability' &&
-            formValue(formData, IS_SHORT_FORM_ENABLED),
+          depends: formData => formData.vaCompensationType === 'highDisability',
           uiSchema: {},
           schema: {
             type: 'object',
@@ -309,7 +278,7 @@ const formConfig = {
           title: 'VA pension',
           uiSchema: pensionInformation.uiSchema,
           schema: pensionInformation.schema,
-          depends: ({ vaCompensationType }) => vaCompensationType === 'none',
+          depends: formData => formData.vaCompensationType === 'none',
         },
       },
     },
@@ -319,21 +288,22 @@ const formConfig = {
         serviceInformation: {
           path: 'military-service/service-information',
           title: 'Service periods',
-          depends: notHighDisabilityNotSelfDisclosure,
+          depends: formData => !isShortFormEligible(formData),
           uiSchema: serviceInformation.uiSchema,
           schema: serviceInformation.schema,
         },
         additionalInformation: {
           path: 'military-service/additional-information',
           title: 'Service history',
-          depends: notHighDisabilityNotSelfDisclosure,
+          depends: formData => !isShortFormEligible(formData),
           uiSchema: additionalInformation.uiSchema,
           schema: additionalInformation.schema,
         },
         documentUpload: {
           title: 'Upload your discharge papers',
           path: 'military-service/documents',
-          depends: notHighDisabilityAndNotInMvi,
+          depends: formData =>
+            !isShortFormEligible(formData) && !formData['view:isUserInMvi'],
           editModeOnReviewPage: true,
           uiSchema: documentUpload.uiSchema,
           schema: documentUpload.schema,
@@ -346,14 +316,14 @@ const formConfig = {
         financialDisclosure: {
           path: 'household-information/financial-disclosure',
           title: 'Financial disclosure',
-          depends: notHighDisabilityNotSelfDisclosure,
+          depends: formData => !isShortFormEligible(formData),
           uiSchema: financialDisclosure.uiSchema,
           schema: financialDisclosure.schema,
         },
         maritalStatus: {
           path: 'household-information/marital-status',
           title: 'Marital status information',
-          depends: notHighDisabilityNotSelfDisclosure,
+          depends: formData => !isShortFormEligible(formData),
           initialData: {},
           uiSchema: maritalStatus.uiSchema,
           schema: maritalStatus.schema,
@@ -364,16 +334,15 @@ const formConfig = {
           initialData: {},
           depends: formData =>
             formData.discloseFinancialInformation &&
-            formData.maritalStatus &&
-            (formData.maritalStatus.toLowerCase() === 'married' ||
-              formData.maritalStatus.toLowerCase() === 'separated'),
+            (formData.maritalStatus?.toLowerCase() === 'married' ||
+              formData.maritalStatus?.toLowerCase() === 'separated'),
           uiSchema: spouseInformation.uiSchema,
           schema: spouseInformation.schema,
         },
         dependentInformation: {
           path: 'household-information/dependent-information',
           title: 'Dependent information',
-          depends: data => data.discloseFinancialInformation,
+          depends: formData => formData.discloseFinancialInformation,
           uiSchema: dependentInformation.uiSchema,
           schema: dependentInformation.schema,
         },
@@ -381,14 +350,14 @@ const formConfig = {
           path: 'household-information/annual-income',
           title: 'Annual income',
           initialData: {},
-          depends: data => data.discloseFinancialInformation,
+          depends: formData => formData.discloseFinancialInformation,
           uiSchema: annualIncome.uiSchema,
           schema: annualIncome.schema,
         },
         deductibleExpenses: {
           path: 'household-information/deductible-expenses',
           title: 'Deductible expenses',
-          depends: data => data.discloseFinancialInformation,
+          depends: formData => formData.discloseFinancialInformation,
           uiSchema: deductibleExpenses.uiSchema,
           schema: deductibleExpenses.schema,
         },
@@ -407,7 +376,7 @@ const formConfig = {
         medicare: {
           path: 'insurance-information/medicare',
           title: 'Medicare coverage',
-          depends: notHighDisabilityNotSelfDisclosure,
+          depends: formData => !isShortFormEligible(formData),
           initialData: {},
           uiSchema: medicare.uiSchema,
           schema: medicare.schema,
@@ -416,7 +385,8 @@ const formConfig = {
           path: 'insurance-information/medicare-part-a-effective-date',
           title: 'Medicare Part A effective date',
           initialData: {},
-          depends: notHighDisabilityEnrolledMedicarePartA,
+          depends: formData =>
+            !isShortFormEligible(formData) && formData.isEnrolledMedicarePartA,
           uiSchema: medicarePartAEffectiveDate.uiSchema,
           schema: medicarePartAEffectiveDate.schema,
         },

--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 
 import RoutedSavableApp from '@department-of-veterans-affairs/platform-forms/RoutedSavableApp';
 import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
-import { VA_FORM_IDS } from '@department-of-veterans-affairs/platform-forms/constants';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { fetchTotalDisabilityRating } from '../utils/actions';
@@ -17,12 +16,10 @@ const App = props => {
     children,
     setFormData,
     formData,
-    hasSavedForm,
     isAiqEnabled = false,
     isFacilitiesApiEnabled = false,
     isLoading = true,
     isLoggedIn,
-    isShortFormEnabled = false,
     isSigiEnabled = false,
     getTotalDisabilityRating,
     totalDisabilityRating,
@@ -71,10 +68,8 @@ const App = props => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       formData.veteranFullName,
-      hasSavedForm,
       isAiqEnabled,
       isLoggedIn,
-      isShortFormEnabled,
       isSigiEnabled,
       isFacilitiesApiEnabled,
       totalDisabilityRating,
@@ -121,12 +116,10 @@ App.propTypes = {
   ]),
   formData: PropTypes.object,
   getTotalDisabilityRating: PropTypes.func,
-  hasSavedForm: PropTypes.bool,
   isAiqEnabled: PropTypes.bool,
   isFacilitiesApiEnabled: PropTypes.bool,
   isLoading: PropTypes.bool,
   isLoggedIn: PropTypes.bool,
-  isShortFormEnabled: PropTypes.bool,
   isSigiEnabled: PropTypes.bool,
   location: PropTypes.object,
   setFormData: PropTypes.func,
@@ -136,14 +129,10 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   formData: state.form.data,
-  hasSavedForm: state.user.profile.savedForms.some(
-    form => form.form === VA_FORM_IDS.FORM_10_10EZ,
-  ),
   isAiqEnabled: state.featureToggles.hcaAmericanIndianEnabled,
   isFacilitiesApiEnabled: state.featureToggles.hcaUseFacilitiesApi,
   isLoading: state.featureToggles.loading,
   isLoggedIn: state.user.login.currentlyLoggedIn,
-  isShortFormEnabled: state.featureToggles.hcaShortFormEnabled,
   isSigiEnabled: state.featureToggles.caregiverSigiEnabled,
   totalDisabilityRating: state.totalRating.totalDisabilityRating,
   user: state.user.profile,

--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -43,10 +43,6 @@ const App = props => {
    * Set default view fields within the form data
    *
    * NOTE: we have included veteranFullName in the dependency list to reset view fields when starting a new application from save-in-progress.
-   *
-   * NOTE (2): to account for users with a form already in-progress at the time the short form is released, we need to check for that form
-   * using the "hasSavedForm" prop. The users will get their current in-progress form, instead of the short form option, to avoid any validation
-   * errors. This can be removed 90 days after hcaShortFormEnabled flipper toggle is fully enabled for all users.
    */
   useEffect(
     () => {
@@ -58,24 +54,16 @@ const App = props => {
         'view:totalDisabilityRating': totalDisabilityRating || 0,
       };
 
-      if (hasSavedForm || typeof hasSavedForm === 'undefined') {
+      if (isLoggedIn) {
         setFormData({
           ...formData,
           ...defaultViewFields,
           'view:userDob': user.dob,
-        });
-      } else if (isLoggedIn) {
-        setFormData({
-          ...formData,
-          ...defaultViewFields,
-          'view:userDob': user.dob,
-          'view:isShortFormEnabled': isShortFormEnabled,
         });
       } else {
         setFormData({
           ...formData,
           ...defaultViewFields,
-          'view:isShortFormEnabled': isShortFormEnabled,
         });
       }
     },

--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -39,7 +39,12 @@ const App = props => {
   /**
    * Set default view fields within the form data
    *
-   * NOTE: we have included veteranFullName in the dependency list to reset view fields when starting a new application from save-in-progress.
+   * NOTE: we have included veteranFullName in the dependency list to reset view fields when
+   * starting a new application from save-in-progress.
+   *
+   * NOTE 2: We also included the DOB value from profile for authenticated users to fix a bug
+   * where some profiles did not contain a DOB value. In this case we need to ask the user for
+   * that data for proper submission.
    */
   useEffect(
     () => {
@@ -48,7 +53,7 @@ const App = props => {
         'view:isSigiEnabled': isSigiEnabled,
         'view:isAiqEnabled': isAiqEnabled,
         'view:isFacilitiesApiEnabled': isFacilitiesApiEnabled,
-        'view:totalDisabilityRating': totalDisabilityRating || 0,
+        'view:totalDisabilityRating': parseInt(totalDisabilityRating, 10) || 0,
       };
 
       if (isLoggedIn) {

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-aiq.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-aiq.json
@@ -15,10 +15,6 @@
         "value": false
       },
       {
-        "name": "hcaShortFormEnabled",
-        "value": true
-      },
-      {
         "name": "hcaUseFacilitiesApi",
         "value": true
       }

--- a/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-shortForm.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/feature-toggles-shortForm.json
@@ -15,10 +15,6 @@
         "value": false
       },
       {
-        "name": "hcaShortFormEnabled",
-        "value": true
-      },
-      {
         "name": "hcaUseFacilitiesApi",
         "value": true
       }

--- a/src/applications/hca/tests/e2e/hca-identity-dob-data.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-identity-dob-data.cypress.spec.js
@@ -46,11 +46,6 @@ describe('HCA-User-Authenticated-Identity-Without-DOB', () => {
       .first()
       .should('exist');
 
-    // cy.findAllByText(/start.+application/i, { selector: 'button' })
-    //   .first()
-    //   .click();
-
-    // changed above to the following because of flaky test due to cy.findAllByText(/start.+application/i, { selector: 'button' })
     cy.get('#1-continueButton').click();
 
     cy.wait('@mockSip');

--- a/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
@@ -64,11 +64,6 @@ describe('HCA-Shortform-Authenticated-High-Disability', () => {
       .first()
       .should('exist');
 
-    // cy.findAllByText(/start.+application/i, { selector: 'button' })
-    //   .first()
-    //   .click();
-
-    // changed above to the following because of flaky test due to cy.findAllByText(/start.+application/i, { selector: 'button' })
     cy.get('#1-continueButton').click();
 
     cy.wait('@mockSip');
@@ -226,11 +221,6 @@ describe('HCA-Shortform-Authenticated-Low-Disability', () => {
       .first()
       .should('exist');
 
-    // cy.findAllByText(/start.+application/i, { selector: 'button' })
-    //   .first()
-    //   .click();
-
-    // changed above to the following because of flaky test due to cy.findAllByText(/start.+application/i, { selector: 'button' })
     cy.get('#1-continueButton').click();
 
     cy.wait('@mockSip');

--- a/src/applications/hca/tests/utils/selectors/feature-toggles.unit.spec.js
+++ b/src/applications/hca/tests/utils/selectors/feature-toggles.unit.spec.js
@@ -9,7 +9,6 @@ describe('HCA Selectors', () => {
       hca_american_indian_enabled: true,
       hca_browser_monitoring_enabled: true,
       hca_enrollment_status_override_enabled: false,
-      hca_short_form_enabled: true,
       hca_use_facilities_API: false,
       loading: false,
     },
@@ -24,7 +23,6 @@ describe('HCA Selectors', () => {
         isBrowserMonitoringEnabled: true,
         isESOverrideEnabled: false,
         isFacilitiesApiEnabled: false,
-        isShortFormEnabled: true,
         isSigiEnabled: false,
       });
     });

--- a/src/applications/hca/utils/constants.js
+++ b/src/applications/hca/utils/constants.js
@@ -1,3 +1,7 @@
+// declare the minimum percentage value to be considered high disability
+export const HIGH_DISABILITY_MINIMUM = 50;
+
+// declare enrollment status strings
 export const HCA_ENROLLMENT_STATUSES = Object.freeze({
   activeDuty: 'activeduty',
   canceledDeclined: 'canceled_declined',
@@ -37,20 +41,11 @@ export const DASHBOARD_ALERT_TYPES = Object.freeze({
   update: 'update', // Gold, exclamation
 });
 
-export const IS_LOGGED_IN = 'isVeteranLoggedIn';
-export const USER_DOB = 'veteranDOB';
-export const IS_GTE_HIGH_DISABILITY =
-  'isVetetanDisabilityRatingGreaterThanOrEqualToHighDisability';
-export const IS_COMPENSATION_TYPE_HIGH =
-  'isCompensationTypeHighDisabilitySelected';
-export const IS_VETERAN_IN_MVI = 'isVeteranDataInMPI';
-export const IS_SHORT_FORM_ENABLED = 'isShortFormFeatureToggleEnabled';
-
 // declare states without medical care serivces
-export const statesWithoutService = ['AA', 'AE', 'AP', 'FM', 'MH', 'PW'];
+export const STATES_WITHOUT_MEDICAL = ['AA', 'AE', 'AP', 'FM', 'MH', 'PW'];
 
 // declare labels for discharge type select box
-export const dischargeTypeLabels = {
+export const DISCHARGE_TYPE_LABELS = {
   honorable: 'Honorable',
   general: 'General',
   other: 'Other Than Honorable',
@@ -60,7 +55,7 @@ export const dischargeTypeLabels = {
 };
 
 // declare labels for last service branch select box
-export const lastServiceBranchLabels = {
+export const SERVICE_BRANCH_LABELS = {
   'air force': 'Air Force',
   army: 'Army',
   'coast guard': 'Coast Guard',

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -328,10 +328,10 @@ export function createLiteralMap(arrayToMap) {
 /**
  * Helper that determines if the user data contains values that allow them
  * to fill out the form using the short form flow
- * @param {Object} formData - an array of arrays that defines the keys/values to map
+ * @param {Object} formData - the current data object passed from the form
  * @returns {Boolean} - true if the total disability rating is greater than or equal
- * to the minimum percetage OR the user self-declares they have a rating higher than
- * that percentage
+ * to the minimum percetage OR the user self-declares they receive compensation equal to
+ * that of a high-disability-rated Veteran.
  */
 export function isShortFormEligible(formData) {
   const hasHighRating =

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -15,14 +15,7 @@ import {
 import { getInactivePages } from 'platform/forms/helpers';
 import { isInMPI } from 'platform/user/selectors';
 
-import {
-  IS_LOGGED_IN,
-  USER_DOB,
-  IS_GTE_HIGH_DISABILITY,
-  IS_SHORT_FORM_ENABLED,
-  IS_COMPENSATION_TYPE_HIGH,
-  IS_VETERAN_IN_MVI,
-} from './constants';
+import { HIGH_DISABILITY_MINIMUM } from './constants';
 
 // clean address so we only get address related properties then return the object
 const cleanAddressObject = address => {
@@ -317,42 +310,6 @@ export function didEnrollmentStatusChange(prevProps, props) {
   );
 }
 
-export function formValue(formData, value) {
-  const HIGH_DISABILITY = 50;
-
-  switch (value) {
-    case IS_LOGGED_IN:
-      return formData['view:isLoggedIn'];
-    case USER_DOB:
-      return formData['view:userDob'];
-    case IS_GTE_HIGH_DISABILITY:
-      return formData['view:totalDisabilityRating'] >= HIGH_DISABILITY;
-    case IS_SHORT_FORM_ENABLED:
-      return formData['view:isShortFormEnabled'];
-    case IS_COMPENSATION_TYPE_HIGH:
-      return formData.vaCompensationType === 'highDisability';
-    case IS_VETERAN_IN_MVI:
-      return formData['view:isUserInMvi'];
-    default:
-      return false;
-  }
-}
-
-export function NotHighDisabilityOrNotCompensationTypeHigh(formData) {
-  return !(
-    formValue(formData, IS_SHORT_FORM_ENABLED) &&
-    (formValue(formData, IS_COMPENSATION_TYPE_HIGH) ||
-      formValue(formData, IS_GTE_HIGH_DISABILITY))
-  );
-}
-
-export function NotHighDisability(formData) {
-  return !(
-    formValue(formData, IS_SHORT_FORM_ENABLED) &&
-    formValue(formData, IS_GTE_HIGH_DISABILITY)
-  );
-}
-
 /**
  * Helper that maps an array to an object literal to allow for
  * multiple keys to have the same value
@@ -366,4 +323,19 @@ export function createLiteralMap(arrayToMap) {
     }
     return obj;
   }, {});
+}
+
+/**
+ * Helper that determines if the user data contains values that allow them
+ * to fill out the form using the short form flow
+ * @param {Object} formData - an array of arrays that defines the keys/values to map
+ * @returns {Boolean} - true if the total disability rating is greater than or equal
+ * to the minimum percetage OR the user self-declares they have a rating higher than
+ * that percentage
+ */
+export function isShortFormEligible(formData) {
+  return (
+    formData['view:totalDisabilityRating'] >= HIGH_DISABILITY_MINIMUM ||
+    formData.vaCompensationType === 'highDisability'
+  );
 }

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -334,8 +334,8 @@ export function createLiteralMap(arrayToMap) {
  * that percentage
  */
 export function isShortFormEligible(formData) {
-  return (
-    formData['view:totalDisabilityRating'] >= HIGH_DISABILITY_MINIMUM ||
-    formData.vaCompensationType === 'highDisability'
-  );
+  const hasHighRating =
+    formData['view:totalDisabilityRating'] >= HIGH_DISABILITY_MINIMUM;
+  const hasHighCompensation = formData.vaCompensationType === 'highDisability';
+  return hasHighRating || hasHighCompensation;
 }

--- a/src/applications/hca/utils/selectors/feature-toggles.js
+++ b/src/applications/hca/utils/selectors/feature-toggles.js
@@ -17,9 +17,6 @@ const selectFeatureToggles = createSelector(
     isFacilitiesApiEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.hcaUseFacilitiesApi
     ],
-    isShortFormEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.hcaShortFormEnabled
-    ],
     isSigiEnabled: toggleValues(state)[FEATURE_FLAG_NAMES.caregiverSigiEnabled],
   }),
   toggles => toggles,


### PR DESCRIPTION
## Description
With the successful rollout of the Health Care application short form flow, we no longer need the heavy feature flag conditional logic bloating the application. This PR removes all of the conditional logic related to the feature flag and simplifies the conditions needed to enter the shorter flow.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#49177

## Testing done
- [x] Cypress tests
- [x] Unit testing

## Acceptance criteria
- [ ] Users can navigate through the correct flow based on their disability rating or declaration
- [ ] All appropriate alerts display within the form based on the form flow
