### PR TITLE
[#MHV-41305] added back to top va component

### DIFF
--- a/src/applications/mhv/secure-messaging/containers/AuthorizedRoutes.jsx
+++ b/src/applications/mhv/secure-messaging/containers/AuthorizedRoutes.jsx
@@ -48,6 +48,7 @@ const AuthorizedRoutes = () => {
           <FolderListView />
         </Route>
       </Switch>
+      <va-back-to-top />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Adds a back to top button to mhv/secure-messaging

## Related issue(s)
https://vajira.max.gov/browse/MHV-41305

## Testing done
existing unit tests

## Screenshots
![Screen Shot 2023-02-09 at 3 28 33 PM](https://user-images.githubusercontent.com/108146636/217943197-ca8cfe66-b2d2-4171-86db-e16c9fcf3346.png)

![Screen Shot 2023-02-09 at 3 29 06 PM](https://user-images.githubusercontent.com/108146636/217943306-1cead9e5-d631-4e4f-84a6-65549dad141a.png)

## What areas of the site does it impact?
mhv/secure-messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed