### PR TITLE
Supplemental Claims | Move edit contact info link inline with values

### DIFF
--- a/src/applications/appeals/995/components/ContactInfo.jsx
+++ b/src/applications/appeals/995/components/ContactInfo.jsx
@@ -76,11 +76,9 @@ const ContactInfo = ({
 
   const MainHeader = onReviewPage ? 'h4' : 'h3';
   const Headers = onReviewPage ? 'h5' : 'h4';
-  const headerClassNames = [
-    'vads-u-font-size--h3',
-    'vads-u-width--auto',
-    'vads-u-display--inline-block',
-  ].join(' ');
+  const headerClassNames = ['vads-u-font-size--h3', 'vads-u-width--auto'].join(
+    ' ',
+  );
 
   // Loop to separate pages when editing
   // Each Link includes an ID for focus managements on the review & submit page
@@ -89,6 +87,7 @@ const ContactInfo = ({
       <Headers className={`${headerClassNames} vads-u-margin-top--0p5`}>
         Home phone number
       </Headers>
+      <span>{getFormattedPhone(homePhone)}</span>
       <Link
         id="edit-home-phone"
         to="/edit-home-phone"
@@ -97,9 +96,9 @@ const ContactInfo = ({
       >
         edit
       </Link>
-      <div>{getFormattedPhone(homePhone)}</div>
 
       <Headers className={headerClassNames}>Mobile phone number</Headers>
+      <span>{getFormattedPhone(mobilePhone)}</span>
       <Link
         id="edit-mobile-phone"
         to="/edit-mobile-phone"
@@ -108,9 +107,9 @@ const ContactInfo = ({
       >
         edit
       </Link>
-      <div>{getFormattedPhone(mobilePhone)}</div>
 
       <Headers className={headerClassNames}>Email address</Headers>
+      <span>{email || ''}</span>
       <Link
         id="edit-email"
         to="/edit-email-address"
@@ -119,19 +118,18 @@ const ContactInfo = ({
       >
         edit
       </Link>
-      <div>{email || ''}</div>
 
       <Headers className={headerClassNames}>Mailing address</Headers>
-      <Link
-        id="edit-address"
-        to="/edit-mailing-address"
-        aria-label="Edit mailing address"
-        className="vads-u-margin-left--2"
-      >
-        edit
-      </Link>
-      <div>
+      <div className="vads-u-display--flex">
         <AddressView data={address} />
+        <Link
+          id="edit-address"
+          to="/edit-mailing-address"
+          aria-label="Edit mailing address"
+          className="vads-u-margin-left--2"
+        >
+          edit
+        </Link>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Moved the edit contact info link from inline of the header to inline of the value. This was done so that screenreaders will read the header, then value, then edit.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#53448](https://github.com/department-of-veterans-affairs/va.gov-team/issues/53448)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Previously screenreaders would read header, then edit, then the contact info value forcing the user to navigate backwards to use the edit link
- *Describe the steps required to verify your changes are working as expected*
  > Re-order DOM elements
- *Describe the tests completed and the results*
  > No test changes needed; manual screenreader test revealed that the new DOM order is as expected 
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

### Before
<img width="286" alt="contact info page showing home & mobile phone, email and mailing address. Each header has an edit link to its right and the contact info value is below the header" src="https://user-images.githubusercontent.com/136959/217951813-f6b7e8f0-5275-4b75-a949-e14800c13946.png">

### After
<img width="658" alt="contact info page showing home & mobile phone, email and mailing address. Under each header is the value and to its right is now the edit link" src="https://user-images.githubusercontent.com/136959/217951908-485d1e72-9b0c-4069-bc5a-28fe5d79c870.png">

## What areas of the site does it impact?

Supplemental Claim form (not yet released)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
