### PR TITLE
Opens login modal on current page if not logged in for my-va link

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -180,6 +180,11 @@ const mapStateToProps = (state, ownProps) => {
   // Derive the default mega menu links (both auth + unauth).
   const defaultLinks = ownProps?.megaMenuData ? [...ownProps.megaMenuData] : [];
 
+  // If user is not logged in, open login modal on current page with a redirect param to my-va
+  if (!loggedIn) {
+    MY_VA_LINK.href = `${window.location.href.split('?')[0]}?next=%2Fmy-va%2F`;
+  }
+
   defaultLinks.push(MY_VA_LINK);
 
   const data = flagCurrentPageInTopLevelLinks(


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This change allows the user to click on the my-va link when they are not logged in and open the login modal on the current page they are on, without being sent back to the homepage should they close the login modal with actually logging in.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12195


## Testing done

-  Local testing with vets-website pointed at dev-api.va.gov
- Will test on staging with test user dashboard users before release to prod


## Screenshots
<img width="1289" alt="Screen Shot 2023-02-10 at 10 46 04 AM" src="https://user-images.githubusercontent.com/61624970/218137159-58019867-00f2-41e4-adbf-d861e4ca8eda.png">


## What areas of the site does it impact?
The my-va link in the header

## Acceptance criteria

- [ ]  Logged in user experience is not changed
- [ ]  Unauthed users are prompted with the login modal without being redirected to homepage
- [ ] If login is completed users are redirected to my-va dashboard
- [ ] If login modal is closed without sign in, users stay on current page
- [ ]  Injected header is not affected



## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
