### PR TITLE
Fix action link styling

### DIFF
--- a/src/applications/check-in/pre-check-in/tests/e2e/intro-display/multiple.appointments.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/intro-display/multiple.appointments.display.cypress.spec.js
@@ -38,5 +38,9 @@ describe('Pre-Check In Experience', () => {
       Introduction.countAppointmentList(2);
       cy.injectAxeThenAxeCheck();
     });
+    it('start link styling is correct', () => {
+      Introduction.validateStartLinkStyling();
+      cy.injectAxeThenAxeCheck();
+    });
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
@@ -8,6 +8,17 @@ class Introduction {
       .and('have.text', 'Answer pre-check-in questions');
   };
 
+  validateStartLinkStyling = () => {
+    cy.get('[data-testid="start-button"] a').then($elements => {
+      // Cypress can't access pseudo-elements, so we need get the window
+      // object and assert against the element that way.
+      const window = $elements[0].ownerDocument.defaultView;
+      const before = window.getComputedStyle($elements[0], 'before');
+      const elementColor = before.getPropertyValue('color');
+      expect(elementColor).to.eq('rgb(46, 133, 64)');
+    });
+  };
+
   validateMultipleAppointmentIntroText = (
     appointmentDate = new Date().setDate(new Date().getDate() + 1),
   ) => {

--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -1,4 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 
 dt{
   font-weight: bold;


### PR DESCRIPTION
## Summary

- Directly import action link stylesheet to fix action link styling on pre-check-in introduction page
- to repro, view the introduction page on pre-checkin - the action link is not styled

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#53497

## Testing done

- Added e2e test

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
