### PR TITLE
53550 - [FSR] - Include food and rent in total expenses calculation

### DIFF
--- a/src/applications/financial-status-report/tests/unit/efsr-transform.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/efsr-transform.unit.spec.jsx
@@ -170,7 +170,7 @@ describe('efsr-fsr transform helper functions', () => {
           },
         ],
       };
-      expect(getMonthlyExpenses(expenses)).to.equal(800);
+      expect(getMonthlyExpenses(expenses)).to.equal(1000);
     });
   });
 
@@ -761,7 +761,7 @@ describe('efsr-fsr transform information', () => {
       expect(
         submissionObj.expenses.expensesInstallmentContractsAndOtherDebts,
       ).to.equal('2000.64');
-      expect(submissionObj.expenses.totalMonthlyExpenses).to.equal('8203.44');
+      expect(submissionObj.expenses.totalMonthlyExpenses).to.equal('13404.35');
     });
     describe('efsr-other living expenses', () => {
       it('has valid structure', () => {
@@ -800,7 +800,7 @@ describe('efsr-fsr transform information', () => {
       const submissionObj = JSON.parse(transform(null, inputObject));
       expect(
         submissionObj.discretionaryIncome.netMonthlyIncomeLessExpenses,
-      ).to.equal('12394.41');
+      ).to.equal('7193.50');
       expect(
         submissionObj.discretionaryIncome.amountCanBePaidTowardDebt,
       ).to.equal('61.02');

--- a/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
+++ b/src/applications/financial-status-report/tests/unit/transform.unit.spec.jsx
@@ -169,7 +169,7 @@ describe('fsr transform helper functions', () => {
           },
         ],
       };
-      expect(getMonthlyExpenses(expenses)).to.equal(800);
+      expect(getMonthlyExpenses(expenses)).to.equal(1000);
     });
   });
 
@@ -771,7 +771,7 @@ describe('fsr transform information', () => {
       expect(
         submissionObj.expenses.expensesInstallmentContractsAndOtherDebts,
       ).to.equal('2000.64');
-      expect(submissionObj.expenses.totalMonthlyExpenses).to.equal('8203.44');
+      expect(submissionObj.expenses.totalMonthlyExpenses).to.equal('13404.35');
     });
     describe('other living expenses', () => {
       it('has valid structure', () => {
@@ -810,7 +810,7 @@ describe('fsr transform information', () => {
       const submissionObj = JSON.parse(transform(null, inputObject));
       expect(
         submissionObj.discretionaryIncome.netMonthlyIncomeLessExpenses,
-      ).to.equal('12394.41');
+      ).to.equal('7193.50');
       expect(
         submissionObj.discretionaryIncome.amountCanBePaidTowardDebt,
       ).to.equal('800.97');
@@ -1131,7 +1131,7 @@ describe('fsr transform information', () => {
         const submissionObj = JSON.parse(transform(null, cfsrInputObject));
         expect(
           submissionObj.discretionaryIncome.netMonthlyIncomeLessExpenses,
-        ).to.equal('12394.41');
+        ).to.equal('7193.50');
         expect(
           submissionObj.discretionaryIncome.amountCanBePaidTowardDebt,
         ).to.equal('61.02');

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { addDays, format, isValid } from 'date-fns';
+import { get } from 'lodash';
 import { deductionCodes } from '../constants/deduction-codes';
 
 export const fsrWizardFeatureToggle = state => {
@@ -263,6 +264,8 @@ export const getMonthlyExpenses = ({
   const installments = sumValues(installmentContracts, 'amountDueMonthly');
   const otherExp = sumValues(otherExpenses, 'amount');
   const expVals = Object.values(expenses).filter(Boolean);
+  const food = Number(get(expenses, 'food', 0));
+  const rentOrMortgage = Number(get(expenses, 'rentOrMortgage', 0));
 
   let totalExp = 0;
 
@@ -280,7 +283,7 @@ export const getMonthlyExpenses = ({
     );
   }
 
-  return utilities + installments + otherExp + totalExp;
+  return utilities + installments + otherExp + totalExp + food + rentOrMortgage;
 };
 
 export const getTotalAssets = ({


### PR DESCRIPTION
## Summary

- Bug with missing values in total expenses calculation
- Include food and mortgage values
- Used lodash for catching if these values are removed in the enhanced version and to default to `0`

## Related issue(s)
[- department-of-veterans-affairs/va.gov-team#53550
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/53550)

## Testing done
- Manual testing locally
- [ ] Unit tests passing


## Screenshots
<img width="378" alt="image" src="https://user-images.githubusercontent.com/20892803/218579103-0dca1129-82e4-4cc5-9fdd-3b8155939c63.png">


## What areas of the site does it impact?
FSR form and PDF

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

