### PR TITLE
Correct 508 screenreader defect on Caregiver Sign as Representive field

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -23,7 +23,7 @@ const SignatureCheckbox = ({
     : undefined;
   const ariaDescribedbyMessage = isRepresentative
     ? `on behalf of ${fullName.first} ${fullName.middle} ${fullName.last}`
-    : '';
+    : undefined;
 
   useEffect(
     () => {

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -21,6 +21,9 @@ const SignatureCheckbox = ({
   const representativeLabelId = isRepresentative
     ? `${label}-signature-label`
     : undefined;
+  const ariaDescribedbyMessage = isRepresentative
+    ? `on behalf of ${fullName.first} ${fullName.middle} ${fullName.last}`
+    : '';
 
   useEffect(
     () => {
@@ -39,7 +42,7 @@ const SignatureCheckbox = ({
       {!!children && <>{children}</>}
 
       <SignatureInput
-        ariaDescribedBy={representativeLabelId}
+        ariaDescribedBy={ariaDescribedbyMessage}
         label={label}
         fullName={fullName}
         required={isRequired}

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -126,7 +126,7 @@ const SignatureInput = ({
 
   return (
     <VaTextInput
-      ariaDescribedbyMessage={ariaDescribedBy}
+      messageAriaDescribedby={ariaDescribedBy}
       class="signature-input"
       label={createInputLabel(label)}
       required={required}

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -126,7 +126,7 @@ const SignatureInput = ({
 
   return (
     <VaTextInput
-      aria-describedby={ariaDescribedBy}
+      ariaDescribedbyMessage={ariaDescribedBy}
       class="signature-input"
       label={createInputLabel(label)}
       required={required}

--- a/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureCheckbox.unit.spec.js
+++ b/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureCheckbox.unit.spec.js
@@ -6,7 +6,11 @@ import SignatureCheckbox from '../../../components/PreSubmitInfo/SignatureCheckb
 const getData = ({ isRepresentative = false, label } = {}) => ({
   mockProps: {
     children: undefined,
-    fullName: '',
+    fullName: {
+      first: 'John',
+      middle: 'William',
+      last: 'Smith',
+    },
     label,
     setSignatures: () => {},
     showError: false,
@@ -20,7 +24,6 @@ describe('10-10CG', () => {
   describe('SignatureCheckbox', () => {
     it('should render aria-describedby attribute when "isRepresentative" is true', () => {
       const label = 'test-label';
-      const labelId = `${label}-signature-label`;
       const { mockProps } = getData({
         isRepresentative: true,
         label,
@@ -28,7 +31,10 @@ describe('10-10CG', () => {
       const view = render(<SignatureCheckbox {...mockProps} />);
       const inputComponent = view.container.querySelector('.signature-input');
 
-      expect(inputComponent).to.have.attribute('aria-describedby', labelId);
+      expect(inputComponent).to.have.attribute(
+        'ariadescribedbymessage',
+        'on behalf of John William Smith',
+      );
     });
 
     it('should not render aria-describedby attribute when "isRepresentative" is false', () => {
@@ -40,7 +46,7 @@ describe('10-10CG', () => {
       const view = render(<SignatureCheckbox {...mockProps} />);
       const inputComponent = view.container.querySelector('.signature-input');
 
-      expect(inputComponent).to.not.have.attribute('aria-describedby');
+      expect(inputComponent).to.not.have.attribute('ariadescribedbymessage');
     });
   });
 });

--- a/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureCheckbox.unit.spec.js
+++ b/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureCheckbox.unit.spec.js
@@ -22,7 +22,7 @@ const getData = ({ isRepresentative = false, label } = {}) => ({
 
 describe('10-10CG', () => {
   describe('SignatureCheckbox', () => {
-    it('should render aria-describedby attribute when "isRepresentative" is true', () => {
+    it('should render message-aria-describedby attribute when "isRepresentative" is true', () => {
       const label = 'test-label';
       const { mockProps } = getData({
         isRepresentative: true,
@@ -32,12 +32,12 @@ describe('10-10CG', () => {
       const inputComponent = view.container.querySelector('.signature-input');
 
       expect(inputComponent).to.have.attribute(
-        'ariadescribedbymessage',
+        'message-aria-describedby',
         'on behalf of John William Smith',
       );
     });
 
-    it('should not render aria-describedby attribute when "isRepresentative" is false', () => {
+    it('should not render message-aria-describedby attribute when "isRepresentative" is false', () => {
       const label = 'test-label';
       const { mockProps } = getData({
         isRepresentative: false,
@@ -46,7 +46,7 @@ describe('10-10CG', () => {
       const view = render(<SignatureCheckbox {...mockProps} />);
       const inputComponent = view.container.querySelector('.signature-input');
 
-      expect(inputComponent).to.not.have.attribute('ariadescribedbymessage');
+      expect(inputComponent).to.not.have.attribute('message-aria-describedby');
     });
   });
 });


### PR DESCRIPTION
## Description
A 508-defect-2 [SCREENREADER] issue within the Sign as a Representative section of the Caregiver application was discovered where the string "On behalf of [Veteran name]" was being skipped by most screen readers. It was discovered that when switching from the React text input component to the text input web component that the `aria-describedby` attribute was removed as unnecessary by the Design System Team. 

After consultation with the DST, they have created a workaround attribute and made it available for this component. This PR updates the attributes to successfully pass the aria-describedby message to the web component.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#24502

## Testing done
- [x] Voiceover on Mac
- [x] Unit tests

## Acceptance criteria

- [ ]  Screenreaders can successfully read the `aria-describedby` message in the context of the text input