### PR TITLE
Roll phone icon back

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -50,9 +50,7 @@ const AppointmentBlock = props => {
                   <i
                     aria-label="Appointment type"
                     className={`fas ${
-                      appointment?.kind === 'phone'
-                        ? 'fa-phone-alt'
-                        : 'fa-building'
+                      appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'
                     }`}
                     aria-hidden="true"
                   />

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -147,7 +147,7 @@ const AppointmentDetails = props => {
                   <div data-testid="appointment-details--phone-value">
                     <i
                       aria-label="phone"
-                      className="fas fa-phone-alt vads-u-color--link-default vads-u-margin-right--1"
+                      className="fas fa-phone vads-u-color--link-default vads-u-margin-right--1"
                       aria-hidden="true"
                     />
                     <va-telephone contact={appointment.clinicPhoneNumber}>

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -436,9 +436,7 @@ describe('check in', () => {
         const appointment = createAppointment({ kind: 'phone' });
         const icon = render(appointmentIcon(appointment));
 
-        expect(icon.getByTestId('appointment-icon')).to.have.class(
-          'fa-phone-alt',
-        );
+        expect(icon.getByTestId('appointment-icon')).to.have.class('fa-phone');
       });
     });
     describe('clinicName', () => {

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -226,7 +226,7 @@ const appointmentIcon = (appointment, listMode = false) => {
       aria-label="Appointment type"
       className={`${
         listMode && appointment?.kind === 'clinic' ? 'far' : 'fas'
-      } ${appointment?.kind === 'phone' ? 'fa-phone-alt' : 'fa-building'}`}
+      } ${appointment?.kind === 'phone' ? 'fa-phone' : 'fa-building'}`}
       aria-hidden="true"
       data-testid="appointment-icon"
     />


### PR DESCRIPTION
## Summary
A quick hotfix to roll phone icon back to original after it was found to not work on stage. 

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#52075

## Screenshots

| Before | After |
| --- | --- |
| ![staging va gov_health-care_appointment-check-in_appointment-details_36899-530](https://user-images.githubusercontent.com/13967174/219101396-6817189a-e5c9-49f6-8275-6d8cbfc66ea1.png) | ![staging va gov_health-care_appointment-check-in_appointment-details_36899-530 (1)](https://user-images.githubusercontent.com/13967174/219101437-b4a33113-e827-4fe8-8224-2d823fb23829.png) | 


## What areas of the site does it impact?
Phone Icon in check-in applications

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

