### PR TITLE
VFEP-388

### DIFF
--- a/src/applications/gi/components/profile/schoolRatings/RatingHeading.jsx
+++ b/src/applications/gi/components/profile/schoolRatings/RatingHeading.jsx
@@ -5,7 +5,7 @@ export const RatingHeading = ({ ratingCount, displayStars, ratingAverage }) => {
   return (
     <div className="vads-l-grid-container main-rating">
       <div className="vads-l-row">
-        <div className="vads-l-col--1 vads-u-margin-right--1p5 vads-u-margin-top--0p5 ratings-star-block">
+        <div className="vads-l-col--1 vads-u-margin-right--1p5 ratings-star-block">
           <RatingsStars rating={ratingAverage} />
         </div>
 

--- a/src/applications/gi/components/profile/schoolRatings/RatingsAccordion.jsx
+++ b/src/applications/gi/components/profile/schoolRatings/RatingsAccordion.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React, { useEffect, useState } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { getAvgCount } from '../../../utils/helpers';
@@ -20,8 +21,18 @@ export default function RatingsAccordion({
     values.forEach((_, index) => {
       const avgCount = getAvgCount(questionObj, index);
       const { question } = questionObj[index];
+      const ariaLabel =
+        avgCount > 0
+          ? `${question} with a rating of ${avgCount} out of 4.`
+          : `${question} This question has not been rated.`;
       tempQuestions.push(
-        <div key={index} className="vads-u-margin-top--1">
+        <div
+          key={index}
+          role="listitem"
+          tabIndex="0"
+          aria-label={ariaLabel}
+          className="vads-u-margin-top--1"
+        >
           <RenderBar label={question} avgRating={avgCount} />
         </div>,
       );
@@ -65,12 +76,14 @@ export default function RatingsAccordion({
   }, []);
 
   return (
-    <div className="vads-u-padding--1">
+    <div
+      aria-label={`${title} with a rating of ${categoryRating} out of 4.`}
+      className="vads-u-padding--1"
+    >
       <div className="star-heading">
         <RatingsStars rating={categoryRating} />
         <span className="vads-u-margin-left--1">{categoryRating}</span>
       </div>
-
       <va-accordion
         open-single
         headline={<h6 slot="headline">{title}</h6>}

--- a/src/applications/gi/components/profile/schoolRatings/RatingsAccordion.jsx
+++ b/src/applications/gi/components/profile/schoolRatings/RatingsAccordion.jsx
@@ -76,11 +76,8 @@ export default function RatingsAccordion({
   }, []);
 
   return (
-    <div
-      aria-label={`${title} with a rating of ${categoryRating} out of 4.`}
-      className="vads-u-padding--1"
-    >
-      <div className="star-heading">
+    <div className="vads-u-padding--1">
+      <div aria-hidden className="star-heading">
         <RatingsStars rating={categoryRating} />
         <span className="vads-u-margin-left--1">{categoryRating}</span>
       </div>
@@ -97,7 +94,9 @@ export default function RatingsAccordion({
 
         {!subHeader && (
           <va-accordion-item id={title}>
-            <h6 slot="headline">{title}</h6>
+            <h6 aria-labelledby="test" slot="headline">
+              {title}
+            </h6>
             <div>{getQuestions()}</div>
           </va-accordion-item>
         )}

--- a/src/applications/gi/constants.js
+++ b/src/applications/gi/constants.js
@@ -133,7 +133,7 @@ const CTRatingsQuestions = {
   q1Long: `Instructors' knowledge in the subject being taught`,
   q1: 'Instructor knowledge',
   q2Long: `Instructors' ability to engage with students around course content`,
-  q2: 'Instructor engagment',
+  q2: 'Instructor engagement',
   q3Long: `Support of course materials in meeting learning objectives`,
   q3: 'Course material support',
   q4Long: `Contribution of school-supplied technology and/or facilities to successful learning experience`,

--- a/src/applications/gi/containers/CompareLayout.jsx
+++ b/src/applications/gi/containers/CompareLayout.jsx
@@ -51,6 +51,9 @@ const CompareLayout = ({
     let institutionRatingIsNotNull = false;
     let institutionCountIsNotNull = false;
     let institutionOverallAvgIsNotNull = false;
+    const ratingsAriaLabel = `Overall rating for ${
+      institution.name
+    } has not yet been rated by veterans`;
     /** ***CHECK IF INSTITUTION.INSTITUTIONRATING IS NULL**** */
     if (institution.institutionRating != null) {
       institutionRatingIsNotNull = true;
@@ -86,7 +89,13 @@ const CompareLayout = ({
       const stars = convertRatingToStars(ratingAverage);
       return (
         <div>
-          <div>{stars.display} out of a possible 4 stars</div>
+          <div
+            aria-label={`Overall Rating for ${institution.name} is ${
+              stars.display
+            } out of 4.`}
+          >
+            {stars.display} out of a possible 4 stars
+          </div>
           <div>
             <RatingsStars rating={ratingAverage} />{' '}
           </div>
@@ -94,10 +103,16 @@ const CompareLayout = ({
       );
     }
     if (type.toUpperCase() === 'OJT') {
-      return 'N/A';
+      return (
+        <div
+          aria-label={`Overall rating not applicable for ${institution.name}`}
+        >
+          N/A
+        </div>
+      );
     }
 
-    return 'Not yet rated by Veterans';
+    return <div aria-label={ratingsAriaLabel}>Not yet rated by Veterans</div>;
   };
 
   const formatEstimate = ({ qualifier, value }) => {

--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -186,7 +186,7 @@ export function ResultCard({
       <div>
         <div className="vads-l-grid-container search-star-container">
           <div className="vads-u-margin-bottom--2 vads-l-row">
-            <div className="vads-u-margin-top--0p5 star-icons">
+            <div className="star-icons">
               <RatingsStars rating={ratingAverage} />
             </div>
             <div className="xsmall-screen:vads-l-col--12 medium-screen:vads-l-col--8">


### PR DESCRIPTION
## Summary
adding accessibility for the new ratings system allowing users to use screen assistance readers with tab and reading aria-labels.

- *(Summarize the changes that have been made to the platform)*
- -Added accessibility to new Ratings system for accessibility software
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution)*
- -The solution was to add aria-labels for sections that did not read correctly due to icons. The aria-label allows a screen reader to read a description in place of star icons
- *(Which team do you work for, does your team own the maintenance of this component?)*
-- GOVCIO, we are the code owners for this repo
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)* N/A

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#0000
- -[Jira ticket](https://vajira.max.gov/browse/VFEP-388)
- *Link to ticket created in va.gov-team repo*N/A
- *Link to previous change of the code/bug (if applicable)*
- -Link to Ratings system https://github.com/department-of-veterans-affairs/vets-website/pull/23284
- *Link to epic if not included in ticket* N/A


## Testing done testing
- *Describe what the old behavior was prior to the change*
- -Unable to tab through questions in ratings accordion component
- -Ratings were not read due to icon being used. aria-label added to read out actual value in place of icons
- *Describe the steps required to verify your changes are working as expected*
- -Using JAWS/NVDA/or Screen Reader, the user is able to tab through each question of the new ratings system and hear the question read out loud with the rating. This is true for the institution profile and the comparison tool.
- *Describe the tests completed and the results*
- -Test held on local machine using standard Screen reader on Linux OS. Will push to staging where the Ratings code currently is, for further testing with JAWS and NVDA
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)* N/A


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._
N/A
| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |


## What areas of the site does it impact?
This is for the ratings system within the EDU comparison tool. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_ N/A
