### PR TITLE
StopCodeName bug

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -86,7 +86,9 @@ const AppointmentBlock = props => {
                   {t('type-of-care')}:
                 </div>
                 <div className="check-in--value" data-testid="type-of-care">
-                  {appointment.clinicStopCodeName ?? t('VA-appointment')}
+                  {appointment.clinicStopCodeName
+                    ? appointment.clinicStopCodeName
+                    : t('VA-appointment')}
                 </div>
                 {appointment.doctorName && (
                   <>

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentConfirmationListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentConfirmationListItem.jsx
@@ -29,7 +29,9 @@ const AppointmentConfirmationListItem = props => {
           {t('type-of-care')}:
         </div>
         <div className="check-in--value" data-testid="type-of-care">
-          {appointment.clinicStopCodeName ?? t('VA-appointment')}
+          {appointment.clinicStopCodeName
+            ? appointment.clinicStopCodeName
+            : t('VA-appointment')}
         </div>
         {appointment.doctorName && (
           <>

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -24,7 +24,9 @@ const AppointmentListItem = props => {
             {t('type-of-care')}:{' '}
           </span>
           <span className="item-value" data-testid="type-of-care">
-            {appointment.clinicStopCodeName ?? t('VA-appointment')}
+            {appointment.clinicStopCodeName
+              ? appointment.clinicStopCodeName
+              : t('VA-appointment')}
           </span>
           {appointment.doctorName && (
             <>

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
@@ -38,7 +38,9 @@ const AppointmentListItemVaos = props => {
           data-testid="appointment-type-and-provider"
           className="vads-u-font-weight--bold"
         >
-          {appointment.clinicStopCodeName ?? t('VA-appointment')}
+          {appointment.clinicStopCodeName
+            ? appointment.clinicStopCodeName
+            : t('VA-appointment')}
           {appointment.doctorName
             ? ` ${t('with')} ${appointment.doctorName}`
             : ''}

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItemVaos.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItemVaos.unit.spec.jsx
@@ -25,8 +25,8 @@ const appointments = [
     clinicName: 'LOM ACC CLINIC TEST',
     appointmentIen: 'some-ien',
     startTime: '2021-11-16T21:39:36',
-    doctorName: 'Dr. Green',
-    clinicStopCodeName: 'Primary care',
+    doctorName: '',
+    clinicStopCodeName: '',
     kind: 'phone',
   },
 ];
@@ -61,7 +61,7 @@ describe('AppointmentListItemVaos', () => {
       });
     });
     describe('Phone appointment context', () => {
-      it('Renders appointment details', () => {
+      it('Renders appointment details with no stopCodeName or provider', () => {
         const screen = render(
           <I18nextProvider i18n={i18n}>
             <AppointmentListItemVaos
@@ -75,7 +75,7 @@ describe('AppointmentListItemVaos', () => {
         );
         expect(
           screen.getByTestId('appointment-type-and-provider'),
-        ).to.have.text('Primary care with Dr. Green');
+        ).to.have.text('VA Appointment');
         expect(
           screen.getByTestId('appointment-kind-and-location'),
         ).to.have.text('Phone');

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -41,6 +41,7 @@ describe('check-in experience', () => {
       startTime: now,
       checkInWindowEnd: add(now, { minutes: 30 }),
       stationNo: '230',
+      clinicStopCodeName: '',
     };
     initAppointments[3] = {
       ...initAppointments[3],
@@ -221,6 +222,26 @@ describe('check-in experience', () => {
             <Provider store={notExistStore}>
               <I18nextProvider i18n={i18n}>
                 <AppointmentDetails router={mockRouter} />
+              </I18nextProvider>
+            </Provider>,
+          );
+          expect(
+            getByTestId('appointment-details--appointment-value'),
+          ).to.have.text('VA Appointment');
+        });
+        it('renders generic appointment if stopCodeName is empty string', () => {
+          const stopCodeRouter = {
+            params: {
+              appointmentId: '3333-230',
+            },
+            location: {
+              pathname: '/appointment',
+            },
+          };
+          const { getByTestId } = render(
+            <Provider store={notExistStore}>
+              <I18nextProvider i18n={i18n}>
+                <AppointmentDetails router={stopCodeRouter} />
               </I18nextProvider>
             </Provider>,
           );

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -112,7 +112,9 @@ const AppointmentDetails = props => {
               <div data-testid="appointment-details--what">
                 <h2 className="vads-u-font-size--sm">{t('what')}</h2>
                 <div data-testid="appointment-details--appointment-value">
-                  {appointment.clinicStopCodeName ?? t('VA-appointment')}
+                  {appointment.clinicStopCodeName
+                    ? appointment.clinicStopCodeName
+                    : t('VA-appointment')}
                 </div>
               </div>
               {appointment.doctorName && (


### PR DESCRIPTION
## Summary
Updated `??` syntax where the value could be an empty string and added tests for newer VAOS work. The ?? syntax only works if the key is completely missing or null, and empty string is truthy with `??`. 

This PR updates our usage of `??` where it is possible to encounter an empty string. This updates both newer VAOS design display and our older usage. Tests were added to the VAOS work to test empty string values.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#53780

## Testing done
Updates unit tests

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

