### PR TITLE
Clean up Caregiver signature checkbox name string rendering

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -18,11 +18,14 @@ const SignatureCheckbox = ({
   const [hasError, setError] = useState(null);
   const [isChecked, setIsChecked] = useState(false);
   const hasSubmittedForm = !!submission.status;
+  const normalizedFullName = `${fullName?.first} ${fullName?.middle || ''} ${
+    fullName?.last
+  }`.replace(/ +(?= )/g, '');
   const representativeLabelId = isRepresentative
     ? `${label}-signature-label`
     : undefined;
   const ariaDescribedbyMessage = isRepresentative
-    ? `on behalf of ${fullName.first} ${fullName.middle} ${fullName.last}`
+    ? `on behalf of ${normalizedFullName}`
     : undefined;
 
   useEffect(
@@ -44,7 +47,7 @@ const SignatureCheckbox = ({
       <SignatureInput
         ariaDescribedBy={ariaDescribedbyMessage}
         label={label}
-        fullName={fullName}
+        fullName={normalizedFullName}
         required={isRequired}
         showError={showError}
         hasSubmittedForm={hasSubmittedForm}
@@ -56,9 +59,7 @@ const SignatureCheckbox = ({
       {isRepresentative && (
         <p className="signature-box--representative" id={representativeLabelId}>
           On behalf of
-          <strong className="vads-u-font-size--lg">
-            {fullName.first} {fullName.middle} {fullName.last}
-          </strong>
+          <strong className="vads-u-font-size--lg">{normalizedFullName}</strong>
         </p>
       )}
 

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -3,67 +3,49 @@ import PropTypes from 'prop-types';
 
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-const SignatureInput = ({
-  fullName,
-  required,
-  label,
-  showError,
-  hasSubmittedForm,
-  isRepresentative,
-  setSignatures,
-  isChecked,
-  ariaDescribedBy,
-}) => {
-  const [error, setError] = useState();
-  const firstName = fullName.first || '';
-  const lastName = fullName.last || '';
-  const middleName = fullName.middle || '';
+const SignatureInput = props => {
+  const {
+    fullName,
+    required,
+    label,
+    showError,
+    hasSubmittedForm,
+    isRepresentative,
+    setSignatures,
+    isChecked,
+    ariaDescribedBy,
+  } = props;
 
+  const [error, setError] = useState();
   const [signature, setSignature] = useState({
     value: '',
     dirty: false,
   });
 
-  const createInputLabel = inputLabel =>
-    isRepresentative
-      ? `Enter your name to sign as the Veteran\u2019s representative`
-      : `${inputLabel} full name`;
-
-  const firstLetterOfMiddleName =
-    middleName === undefined ? '' : middleName.charAt(0);
-
-  const removeSpaces = string =>
-    string
-      .split(' ')
-      .join('')
-      .toLocaleLowerCase();
-
-  const getName = (middle = '') =>
-    removeSpaces(
-      `${firstName?.toLowerCase()}${middle?.toLowerCase()}${lastName?.toLowerCase()}`,
-    );
+  // set label and error message strings
+  const textInputLabel = isRepresentative
+    ? `Enter your name to sign as the Veteran\u2019s representative`
+    : `${label} full name`;
 
   const errorMessage = isRepresentative
     ? 'You must sign as representative.'
-    : `Your signature must match previously entered name: ${firstName} ${middleName} ${lastName}`;
+    : `Your signature must match previously entered name: ${fullName}`;
 
-  const normalizedSignature = removeSpaces(signature.value);
-
-  // first and last
-  const firstAndLastMatches = getName() === normalizedSignature;
-
-  // middle initial
-  const middleInitialMatches =
-    getName(firstLetterOfMiddleName) === normalizedSignature;
-
-  // middle name
-  const withMiddleNameMatches = getName(middleName) === normalizedSignature;
+  /*
+   * validate input string against the desired value
+   *
+   * normalizedSignature: the current state value with extra whitespaces trimmed
+   * signatureMatches: compare the normalizedSignature string again the desired value
+   * isSignatureComplete: complete if the value & desired string match and the parent checkbox is checked
+   */
+  const normalizedSignature = signature.value.replace(/ +(?= )/g, '');
 
   const signatureMatches =
-    firstAndLastMatches || middleInitialMatches || withMiddleNameMatches;
+    normalizedSignature.toLocaleLowerCase() === fullName.toLocaleLowerCase();
 
   const isSignatureComplete = signatureMatches && isChecked;
 
+  // set blur event for the input
   const onBlur = useCallback(
     event => {
       setSignature({ value: event.target.value, dirty: true });
@@ -71,6 +53,7 @@ const SignatureInput = ({
     [setSignature],
   );
 
+  // set signature value if all checks pass
   useEffect(
     () => {
       if (!isSignatureComplete) return;
@@ -83,12 +66,15 @@ const SignatureInput = ({
     [isSignatureComplete, label, setSignatures, signature.value],
   );
 
+  // validate input on dirty/value change
   useEffect(
     () => {
       const isDirty = signature.dirty;
 
-      /* show error if user has touched input and signature does not match
-         show error if there is a form error and has not been submitted */
+      /* 
+       * show error if the user has touched input and the value does not match OR 
+       * if there is a form error and the form has not been submitted
+       */
       if ((isDirty && !signatureMatches) || (showError && !hasSubmittedForm)) {
         setSignatures(prevState => {
           return { ...prevState, [label]: '' };
@@ -96,11 +82,11 @@ const SignatureInput = ({
         setError(errorMessage);
       }
 
-      /* if input has been touched and signature matches allow submission
-         if input is dirty and representative is signing skip validation and make sure signature is present
-         all signature matching logic is with spaces removed
-      */
-
+      /* 
+       * allow submission if we need to validate the input and the value matches the 
+       * desired string OR if the user is a filling out as a third party and no string 
+       * validation is necessary
+       */
       if (
         (isDirty && signatureMatches) ||
         (isDirty && isRepresentative && !!normalizedSignature)
@@ -128,7 +114,7 @@ const SignatureInput = ({
     <VaTextInput
       messageAriaDescribedby={ariaDescribedBy}
       class="signature-input"
-      label={createInputLabel(label)}
+      label={textInputLabel}
       required={required}
       value={signature.value}
       error={error}
@@ -138,7 +124,7 @@ const SignatureInput = ({
 };
 
 SignatureInput.propTypes = {
-  fullName: PropTypes.object.isRequired,
+  fullName: PropTypes.string.isRequired,
   hasSubmittedForm: PropTypes.bool.isRequired,
   isChecked: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,

--- a/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureCheckbox.unit.spec.js
+++ b/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureCheckbox.unit.spec.js
@@ -8,7 +8,7 @@ const getData = ({ isRepresentative = false, label } = {}) => ({
     children: undefined,
     fullName: {
       first: 'John',
-      middle: 'William',
+      middle: '',
       last: 'Smith',
     },
     label,
@@ -20,33 +20,31 @@ const getData = ({ isRepresentative = false, label } = {}) => ({
   },
 });
 
-describe('10-10CG', () => {
-  describe('SignatureCheckbox', () => {
-    it('should render message-aria-describedby attribute when "isRepresentative" is true', () => {
-      const label = 'test-label';
-      const { mockProps } = getData({
-        isRepresentative: true,
-        label,
-      });
-      const view = render(<SignatureCheckbox {...mockProps} />);
-      const inputComponent = view.container.querySelector('.signature-input');
-
-      expect(inputComponent).to.have.attribute(
-        'message-aria-describedby',
-        'on behalf of John William Smith',
-      );
+describe('CG <SignatureCheckbox>', () => {
+  it('should render message-aria-describedby attribute when "isRepresentative" is true', () => {
+    const label = 'test-label';
+    const { mockProps } = getData({
+      isRepresentative: true,
+      label,
     });
+    const view = render(<SignatureCheckbox {...mockProps} />);
+    const inputComponent = view.container.querySelector('.signature-input');
 
-    it('should not render message-aria-describedby attribute when "isRepresentative" is false', () => {
-      const label = 'test-label';
-      const { mockProps } = getData({
-        isRepresentative: false,
-        label,
-      });
-      const view = render(<SignatureCheckbox {...mockProps} />);
-      const inputComponent = view.container.querySelector('.signature-input');
+    expect(inputComponent).to.have.attribute(
+      'message-aria-describedby',
+      'on behalf of John Smith',
+    );
+  });
 
-      expect(inputComponent).to.not.have.attribute('message-aria-describedby');
+  it('should not render message-aria-describedby attribute when "isRepresentative" is false', () => {
+    const label = 'test-label';
+    const { mockProps } = getData({
+      isRepresentative: false,
+      label,
     });
+    const view = render(<SignatureCheckbox {...mockProps} />);
+    const inputComponent = view.container.querySelector('.signature-input');
+
+    expect(inputComponent).to.not.have.attribute('message-aria-describedby');
   });
 });

--- a/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureInput.unit.spec.js
+++ b/src/applications/caregivers/tests/components/PreSubmitInfo/SignatureInput.unit.spec.js
@@ -6,11 +6,7 @@ import { expect } from 'chai';
 import SignatureInput from '../../../components/PreSubmitInfo/SignatureInput';
 
 describe('CG <SignatureInput>', () => {
-  const fullName = {
-    first: 'John',
-    middle: '',
-    last: 'Smith',
-  };
+  const fullName = 'John Smith';
 
   it('should render Signature Input for representative', () => {
     const view = render(
@@ -90,14 +86,10 @@ describe('CG <SignatureInput>', () => {
       'Mary Jane',
     );
 
-    // Note: when testing, the literal string seems to put an extra space for no middleName,
-    // hence John  Smith in the test and not John Smith.
-    // When running the application it shows with only one space.
-
     await waitFor(() => {
       expect(view.container.querySelector('va-text-input')).to.have.attribute(
         'error',
-        'Your signature must match previously entered name: John  Smith',
+        `Your signature must match previously entered name: ${fullName}`,
       );
     });
   });


### PR DESCRIPTION
## Description
During screenreader testing, it was discovered that when a user does not input a middle name, and they give focus to the text input in the signature validation on the review page, that the middle name is actually read as `undefined` (i.e. "on behalf of John undefined Smith"). This PR cleans up how the name string is utilized and rendered for both screenreader and input validation purposes.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#24502

## Testing done
- [x] Unit tests

## Acceptance criteria
- [ ]  Input validation continues to behave as expected
- [ ]  aria-describedby message and value read by the screenreader does not contain "undefined"