### PR TITLE
MyVA - updated GA event and action labels for links in the Claims and appeals section

### DIFF
--- a/src/applications/personalization/dashboard/components/claims-and-appeals-v2/ClaimsAndAppealsV2.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals-v2/ClaimsAndAppealsV2.jsx
@@ -64,9 +64,9 @@ const PopularActionsForClaimsAndAppeals = ({ showLearnLink = false }) => {
           icon="file"
           onClick={() => {
             recordEvent({
-              event: 'profile-navigation',
-              'profile-action': 'view-link',
-              'profile-section': 'view-how-to-file-a-claim',
+              event: 'nav-linkslist',
+              'links-list-header': 'Learn how to file a claim',
+              'links-list-section-header': 'Claims and appeals',
             });
           }}
           testId="file-claims-and-appeals-link-v2"
@@ -78,9 +78,9 @@ const PopularActionsForClaimsAndAppeals = ({ showLearnLink = false }) => {
         icon="clipboard-check"
         onClick={() => {
           recordEvent({
-            event: 'profile-navigation',
-            'profile-action': 'view-link',
-            'profile-section': 'view-manage-claims-and-appeals',
+            event: 'nav-linkslist',
+            'links-list-header': 'Manage all claims and appeals',
+            'links-list-section-header': 'Claims and appeals',
           });
         }}
         testId="manage-claims-and-appeals-link-v2"


### PR DESCRIPTION
## Summary
After an [audit of MyVA by the Analytics team](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/my-va/2022-audit/Product/audit-analytics-request.md), we discovered that the links under Claims and appeals section were using the incorrect GA event labels. This PR corrects it so that it can be logged correctly on GA.

## Related issue(s)
[https://github.com/department-of-veterans-affairs/va.gov-team/issues/53744](https://github.com/department-of-veterans-affairs/va.gov-team/issues/53744)

## Testing done
- locally with Adswerve
- all unit and e2e tests pass

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| Before | After |
| --- | --- |
| ![Screenshot 2023-02-17 at 5 56 30 PM](https://user-images.githubusercontent.com/8542413/219813203-a0f2eb38-b75c-41d3-b8ca-3df72c4cb98a.png) | ![Screenshot 2023-02-17 at 5 54 01 PM](https://user-images.githubusercontent.com/8542413/219813233-1444b509-968b-4b7b-9d02-a95ec85835b0.png) |

## What areas of the site does it impact?
MyVA

## Acceptance criteria
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs