### PR TITLE
Update vets-json-schema to v20.25.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0c8af6123cc4846b7239902ff7b81b66222ccf9e"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7f1b69f9b20f1b5dcd7ed92e0e8fc95af715ae82"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19055,9 +19055,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0c8af6123cc4846b7239902ff7b81b66222ccf9e":
-  version "20.25.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0c8af6123cc4846b7239902ff7b81b66222ccf9e"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#7f1b69f9b20f1b5dcd7ed92e0e8fc95af715ae82":
+  version "20.25.2"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7f1b69f9b20f1b5dcd7ed92e0e8fc95af715ae82"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
[DRAFT: DO NOT MERGE]


## Summary

- Package.json & yarn.lock change &mdash; **Upgrade vets-json-schema dependency** to v20.25.2
  - [not a bug]
  - v20.25.2 restores the required `privacyAgreementAccepted` definition & property that was accidentally deleted from the previous version.  That's it.
  - Team is VA.gov Product Teams - Forms
  - [not using feature-flag yet; still early days in development]

## Related issue(s)
- Dev ticket: department-of-veterans-affairs/va.gov-team-forms#16


## Testing done

- [n/a; not changing any app-code in vets-website]
- CI auto-checks should all Pass [will update here once checks are completed]
- *Describe the tests completed and the results*
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*


## Screenshots
[n/a; no UI changes involved]

## What areas of the site does it impact?
New VA Form 26-4555 &mdash; dev in-progress.  No other app affected.

## Acceptance criteria

- [x]  [unit-/e2e-tests coming soon &mdash; will be written later in team's [new dev-process](https://vfs.atlassian.net/wiki/spaces/VFT/pages/2492334104/Form+digitization+development+guide).  We're currently just on Step 3.]
- [x]  No error nor warning in the console.


## Requested Feedback

Just your regular code-review &mdash; literally JUST a package.json dependency update.  Thanks in advance!
