### PR TITLE
Supplemental Claims | Fix evidence header wrap

### DIFF
--- a/src/applications/appeals/995/components/ContactInfo.jsx
+++ b/src/applications/appeals/995/components/ContactInfo.jsx
@@ -76,7 +76,7 @@ const ContactInfo = ({
 
   const MainHeader = onReviewPage ? 'h4' : 'h3';
   const Headers = onReviewPage ? 'h5' : 'h4';
-  const headerClassNames = ['vads-u-font-size--h3', 'vads-u-width--auto'].join(
+  const headerClassNames = ['vads-u-font-size--h4', 'vads-u-width--auto'].join(
     ' ',
   );
 

--- a/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
@@ -65,7 +65,7 @@ const EvidenceSummaryReview = ({ data, editPage }) => {
         <button
           type="button"
           ref={editRef}
-          className="edit-btn primary-outline"
+          className="edit-page usa-button-secondary"
           onClick={handlers.onEditPage}
           aria-label={content.editLabel}
         >

--- a/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
@@ -58,18 +58,20 @@ const EvidenceSummaryReview = ({ data, editPage }) => {
   return (
     <div className="form-review-panel-page">
       <div name="evidenceSummaryScrollElement" />
-      <button
-        type="button"
-        ref={editRef}
-        className="float-right edit-page usa-button-secondary"
-        onClick={handlers.onEditPage}
-        aria-label={content.editLabel}
-      >
-        {content.edit}
-      </button>
-      <h4 className="vads-u-font-size--h5 vads-u-display--inline-block">
-        {content.summaryTitle}
-      </h4>
+      <div className="form-review-panel-page-header-row">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
+          {content.summaryTitle}
+        </h4>
+        <button
+          type="button"
+          ref={editRef}
+          className="edit-btn primary-outline"
+          onClick={handlers.onEditPage}
+          aria-label={content.editLabel}
+        >
+          {content.edit}
+        </button>
+      </div>
 
       {noEvidence ? (
         <dl className="review">

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -123,7 +123,7 @@ const formConfig = {
           schema: contactInfo.schema,
         },
         editHomePhone: {
-          title: 'Edit phone number',
+          title: 'Edit home phone number',
           path: 'edit-home-phone',
           CustomPage: EditHomePhone,
           CustomPageReview: EditHomePhone,
@@ -132,7 +132,7 @@ const formConfig = {
           schema: blankSchema,
         },
         editMobilePhone: {
-          title: 'Edit phone number',
+          title: 'Edit mobile phone number',
           path: 'edit-mobile-phone',
           CustomPage: EditMobilePhone,
           CustomPageReview: EditMobilePhone,

--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -115,7 +115,7 @@ describe('995 contact info loop', () => {
 
     // Mobile phone
     cy.get('a[href$="mobile-phone"]').click();
-    cy.contains('Edit phone number').should('be.visible');
+    cy.contains('Edit mobile phone number').should('be.visible');
     cy.location('pathname').should('eq', `${BASE_URL}/edit-mobile-phone`);
 
     cy.findByLabelText(/mobile phone/i)


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Fix contact info entry header sizes
  > Fix evidence summary review & submit header not wrapping 
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Use same class names as other review & submit page headers
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefit decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#50493](https://github.com/department-of-veterans-affairs/va.gov-team/issues/50493)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Evidence summary header would shift to the next line


- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*


## Screenshots

### Before

Header shifts below the edit
![confirm or edit your evidence header shifted below the edit button on 320 pixel wide screen](https://user-images.githubusercontent.com/136959/220207269-6e999ab2-6b50-4607-93c0-816eb54ee1bd.png)

Info headers are all h3-sized
![home, mobile, email and address headers are h4s but the same size as the contact information h3](https://user-images.githubusercontent.com/136959/220207788-c164c687-684d-4114-a42b-300ee2ccc39e.png)

### After

Header wraps and stays to the left of the edit button
![confirm or edit your evidence header now wraps to the left of the edit button on 320 pixel wide screen](https://user-images.githubusercontent.com/136959/220207338-9d787ae6-935e-4856-a0ff-541417cf5cac.png)

Info headers are now h4 sized
![home, mobile, email and address headers are h4 sizede and the contact information header is h3 sized](https://user-images.githubusercontent.com/136959/220207619-6b7c992d-957a-4bc7-ac87-d927fb178295.png)

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
