### PR TITLE
Show pci expired message on GET session 404

### DIFF
--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -25,6 +25,12 @@ const responses = {
   }),
   // v2
   'GET /check_in/v2/sessions/:uuid': (req, res) => {
+    const { uuid } = req.params;
+    if (uuid === missingUUID) {
+      return res
+        .status(404)
+        .json(sessions.post.createMockMissingUuidErrorResponse());
+    }
     return res.json(sessions.get.createMockSuccessResponse(req.params));
   },
   'POST /check_in/v2/sessions': (req, res) => {

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -92,10 +92,14 @@ const Index = props => {
                 }
               }
             })
-            .catch(() => {
+            .catch(e => {
               // @TODO move clear current session to hook or HOC
               clearCurrentSession(window);
-              updateError('session-error');
+              if (e?.errors[0]?.status === '404') {
+                updateError('uuid-not-found');
+              } else {
+                updateError('session-error');
+              }
             });
         }
       }


### PR DESCRIPTION
## Summary

This is a follow-on to #23281 - it adds the new title when `GET` sessions returns a 404.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#52492

## Testing done

- manual testing

## QA

Visit pre-check-in `missingUUID:` (`a5895713-ca42-4244-9f38-f8b5db020d04`)

## Screenshots

![Screenshot 2023-02-02 at 09 20 26](https://user-images.githubusercontent.com/101649/216381466-6349be4f-db3d-432a-98e8-e2bc243a6c39.png)

## What areas of the site does it impact?

Pre-check-in error page

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
