### PR TITLE
Supplemental Claims | Update subtask content

### DIFF
--- a/src/applications/appeals/995/subtask/SubTaskContainer.jsx
+++ b/src/applications/appeals/995/subtask/SubTaskContainer.jsx
@@ -24,13 +24,6 @@ export const SubTaskContainer = ({ show995, isLoadingFeatures }) => {
     <article data-page="start" className="row">
       <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
         <SubTask pages={pages} />
-        <p>
-          If you don’t think this is the right form for you, find out about
-          other decision review options.
-        </p>
-        <a href="/resources/choosing-a-decision-review-option/">
-          Learn about choosing a decision review option
-        </a>
       </div>
       <FormFooter formConfig={formConfig} />
     </article>

--- a/src/applications/appeals/995/subtask/pages/other.jsx
+++ b/src/applications/appeals/995/subtask/pages/other.jsx
@@ -40,6 +40,13 @@ const DecisionReviewPage = () => {
       <p className="vads-u-margin-bottom--0">
         <DownloadLink content="Download VA Form 20-0995" />
       </p>
+      <p>
+        If you don’t think this is the right form for you, find out about other
+        decision review options.
+      </p>
+      <a href="/resources/choosing-a-decision-review-option/">
+        Learn about choosing a decision review option
+      </a>
     </div>
   );
 };

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -70,11 +70,21 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
           You have new and relevant evidence to submit, <strong>or</strong>
         </li>
         <li>
-          You have a condition that we now consider presumptive (such as under
-          the <a href="/pact">PACT Act</a>
+          You would like VA to review your claim based on a new law (such as the{' '}
+          <a href="/pact">PACT Act</a>
           ).
         </li>
       </ul>
+      <va-additional-info trigger="What are other decision review options?">
+        <p className="vads-u-padding-bottom--1">
+          If you don’t think this is the right form for you, find out about
+          other decision review options.
+        </p>
+        <a href="/resources/choosing-a-decision-review-option/">
+          Learn about choosing a decision review option
+        </a>
+      </va-additional-info>
+
       <p>Answer this question to get started:</p>
       <VaRadio
         label={content.groupLabel}


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Move content below the subtask continue button to above it, and placed inside a `va-additional-info` so screen reader users will be aware of content that used to come after the continue button
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Moving content above the continue button ensures it is all accessible _before_ reaching the continue button
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#54006](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54006)

## Testing done

Checked unit & e2e tests. No changes needed since content was moved.

## Screenshots

Content is below the continue button

### Before

<details><summary>Not the right form content below the continue button</summary>

<!-- leave a blank line above -->
<img width="740" alt="Supplemental claim start page asking if this is the right form for you; but the context about if you think this isn't the right form for you is below the continue button" src="https://user-images.githubusercontent.com/136959/220688213-fdd9cab4-ed00-4832-9987-1787e924bac6.png"></details>

### After

<details><summary>Not the right form content is now above the navigation buttons</summary>

<!-- leave a blank line above -->
![Supplemental claim start page asking if this is the right form for you; and now the context about if you think this isn't the right form for you is above the continue button](https://user-images.githubusercontent.com/136959/220671472-93e0b892-b926-4102-88f7-56c69ae6a48f.png)
![Supplemental claim page shown after a compensation type of "other" is selected. The if you don't think this is the right form for you content is now above the back button](https://user-images.githubusercontent.com/136959/220671475-1c385206-de0c-4942-bc58-d3fb1f385170.png)</details>

## What areas of the site does it impact?

Supplemental Claim form (not yet released)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). No updates required
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
