### PR TITLE
[bug] Update spelling for statements prop to repopulate page

### DIFF
--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -193,7 +193,7 @@ const mapStateToProps = state => ({
   showCombinedFSR: combinedFSRFeatureToggle(state),
   showEnhancedFSR: enhancedFSRFeatureToggle(state),
   isStartingOver: state.form.isStartingOver,
-  statments: state.fsr.statments,
+  statements: state.fsr.statements,
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
## Summary
- Page was not being repopulated upon store statements being refreshed 


## Related issue(s)
[- department-of-veterans-affairs/va.gov-team#53757
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/53757)- 


## Testing done
- [x] Local testing
- [x] Cypress passing



## Screenshots
<img width="627" alt="image" src="https://user-images.githubusercontent.com/20892803/220747847-4d7530de-0986-4c3a-948d-abef4592ab68.png">

## What areas of the site does it impact?
FSR

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

