### PR TITLE
Mhv 40892 move message with attachment

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/pages/PatientInboxPage.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/pages/PatientInboxPage.js
@@ -376,6 +376,11 @@ class PatientInboxPage {
     cy.contains('Message was successfully sent.').should('be.visible');
   };
 
+  verifyMoveMessagewithAttachmentSuccessMessage = () => {
+    cy.get('[data-testid="expired-alert-message"]').contains('Success');
+    cy.get('p').contains('Message was successfully moved');
+  };
+
   loadComposeMessagePage = () => {
     cy.get('[data-testid="compose-message-link"]').click();
   };

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
@@ -48,7 +48,9 @@ describe('Secure Messaging - Move Message with Attachment', () => {
     cy.get('@moveMessagewithAttachment')
       .its('response')
       .then(response => {
+        cy.log(JSON.stringify(response));
         expect(response.body.data.id).to.include('7192838');
+        expect(response.statusCode).to.eq(200);
       });
   });
 });

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
@@ -1,0 +1,54 @@
+import PatientInboxPage from './pages/PatientInboxPage';
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import mockMessagewithAttachment from './fixtures/message-response-withattachments.json';
+import mockMessages from './fixtures/messages-response.json';
+
+describe('Secure Messaging - Move Message with Attachment', () => {
+  it('can move with attachment', () => {
+    const site = new SecureMessagingSite();
+    const landingPage = new PatientInboxPage();
+    site.login();
+    site.loadPage();
+    cy.intercept(
+      'GET',
+      '/my_health/v1/messaging/folders/0/messages?per_page=-1&useCache=false',
+      mockMessages,
+    ).as('messagesFolder');
+    cy.intercept(
+      'PATCH',
+      '/my_health/v1/messaging/messages/7192838/move?folder_id=-3',
+      mockMessagewithAttachment,
+    ).as('moveMessagewithAttachment');
+
+    cy.get('[data-testid="inbox-sidebar"] > a').click();
+    cy.wait('@messagesFolder');
+    mockMessagewithAttachment.data.id = '7192838';
+    mockMessagewithAttachment.data.attributes.attachment = true;
+    mockMessagewithAttachment.data.attributes.body = 'attachment';
+
+    landingPage.loadMessagewithAttachments(mockMessagewithAttachment);
+
+    cy.contains('General:').click();
+    cy.get('[data-testid="move-button-text"]').click({ force: true });
+    cy.get('[data-testid="move-to-modal"]')
+      .find('[class = "form-radio-buttons hydrated"]', {
+        includeShadowDom: true,
+      })
+      .find('[id = "radiobutton-Deleted"]', { includeShadowDom: true })
+      .click();
+    cy.get('[data-testid="move-to-modal"]')
+      .shadow()
+      .find('button')
+      .contains('Confirm')
+      .click();
+    cy.wait('@moveMessagewithAttachment');
+    cy.injectAxe();
+    cy.axeCheck();
+    landingPage.verifyMoveMessagewithAttachmentSuccessMessage();
+    cy.get('@moveMessagewithAttachment')
+      .its('response')
+      .then(response => {
+        expect(response.body.data.id).to.include('7192838');
+      });
+  });
+});

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
@@ -25,9 +25,7 @@ describe('Secure Messaging - Move Message with Attachment', () => {
     mockMessagewithAttachment.data.id = '7192838';
     mockMessagewithAttachment.data.attributes.attachment = true;
     mockMessagewithAttachment.data.attributes.body = 'attachment';
-
     landingPage.loadMessagewithAttachments(mockMessagewithAttachment);
-
     cy.contains('General:').click();
     cy.get('[data-testid="move-button-text"]').click({ force: true });
     cy.get('[data-testid="move-to-modal"]')


### PR DESCRIPTION
## Summary

Test scripts have been added to validate move messages with attachment to a different folder. 

## Testing done

Testing is complete and tests are passing consistently when local testing was performed.


## Acceptance criteria

- [ ]  No error nor warning in the console.
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
