### PR TITLE
[MHV-40917] Updated Draft Save Manual and Auto Alert

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -443,6 +443,7 @@ const ComposeForm = props => {
             setAttachments={setAttachments}
           />
         </section>
+        <DraftSavedInfo userSaved={userSaved} />
         <div className="compose-form-actions vads-u-display--flex">
           <va-button
             text="Send"
@@ -451,6 +452,7 @@ const ComposeForm = props => {
             onClick={sendMessageHandler}
           />
           <va-button
+            id="save-draft-button"
             text="Save draft"
             secondary
             class="vads-u-flex--1 save-draft-button"
@@ -462,7 +464,6 @@ const ComposeForm = props => {
           </div>
         </div>
       </div>
-      <DraftSavedInfo userSaved={userSaved} />
     </form>
   );
 };

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/DraftSavedInfo.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/DraftSavedInfo.jsx
@@ -40,19 +40,17 @@ const DraftSavedInfo = props => {
   if (lastSaveTime) {
     return (
       <>
-        {
-          <va-alert
-            background-only
-            class="last-save-time"
-            full-width="false"
-            show-icon
-            status="success"
-            visible={userSaved}
-            aria-describedby="save-draft-button"
-          >
-            <p className="vads-u-margin-y--0">{content()}</p>
-          </va-alert>
-        }
+        <va-alert
+          background-only
+          class="last-save-time"
+          full-width="false"
+          show-icon
+          status="success"
+          visible={userSaved}
+          aria-describedby="save-draft-button"
+        >
+          <p className="vads-u-margin-y--0">{content()}</p>
+        </va-alert>
         {userSaved === false && (
           <va-alert
             background-only

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/DraftSavedInfo.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/DraftSavedInfo.jsx
@@ -40,17 +40,31 @@ const DraftSavedInfo = props => {
   if (lastSaveTime) {
     return (
       <>
-        <va-alert
-          background-only
-          class="last-save-time"
-          full-width="false"
-          show-icon
-          status="success"
-          visible={userSaved}
-        >
-          <p className="vads-u-margin-y--0">{content()}</p>
-        </va-alert>
-        {userSaved === false && <p>{content()}</p>}
+        {
+          <va-alert
+            background-only
+            class="last-save-time"
+            full-width="false"
+            show-icon
+            status="success"
+            visible={userSaved}
+            aria-describedby="save-draft-button"
+          >
+            <p className="vads-u-margin-y--0">{content()}</p>
+          </va-alert>
+        }
+        {userSaved === false && (
+          <va-alert
+            background-only
+            class="last-save-time"
+            full-width="false"
+            show-icon
+            status="success"
+            visible
+          >
+            <p className="vads-u-margin-y--0">{content()}</p>
+          </va-alert>
+        )}
       </>
     );
   }

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -1,5 +1,5 @@
 /** time to wait (in ms) after the user stops typing before initiating draft auto-save */
-export const draftAutoSaveTimeout = 15000;
+export const draftAutoSaveTimeout = 5000;
 
 export const DefaultFolders = {
   INBOX: {


### PR DESCRIPTION
## Summary

- *Moved position of alert to appear above action buttons*
- *Updated auto-save alert timeout to appear after 5 seconds*
- *Updated auto-save alert styling to match manual save design: (green background with checkmark)*
- *Updated va-alert to have aria-describedby info when invoked by the Save Draft button*
- *MHV- Secure Messaging - Va.gov*

## Related issue(s)
- department-of-veterans-affairs/vets-website
- *vajira.max.gov/browse/MHV-40917*

## Testing done

- *Manual and 508 testing*
-*To Reproduce:  Login to Va.gov - Secure Messages, Navigate to Drafts folder and select a message to view, Make a text change to the draft.  Wait 5 sec. to view the auto-save alert, and to view the manual-save alert, make another text change and press 'Save Draft' button*

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

DESKTOP: 
<img width="629" alt="Screenshot 2023-02-23 at 10 02 14 AM" src="https://user-images.githubusercontent.com/59583325/220965215-cd0a241d-de40-4036-bfca-161ab4ab0950.png">

MOBILE: 
<img width="381" alt="image" src="https://user-images.githubusercontent.com/59583325/220964850-e3839f83-06a3-4a42-b3c1-5ace0c99d967.png">


## What areas of the site does it impact?
*Va.gov - Secure Messaging - Drafts Inbox - Drafts Compose Message*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
