### PR TITLE
Supplemental Claim | Skip form element focus when forceEditView is set

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditView.jsx
@@ -254,6 +254,10 @@ export class ProfileInformationEditView extends Component {
   }
 
   focusOnFirstFormElement() {
+    if (this.props.forceEditView) {
+      // Showing the edit view on its own page, so let the app handle focus
+      return;
+    }
     const focusableElement = this.editForm?.querySelector(
       'button, input, select, a, textarea',
     );
@@ -388,6 +392,7 @@ ProfileInformationEditView.propTypes = {
     formSchema: PropTypes.object,
     uiSchema: PropTypes.object,
   }),
+  forceEditView: PropTypes.bool,
   title: PropTypes.string,
   transaction: PropTypes.object,
   transactionRequest: PropTypes.object,

--- a/src/applications/personalization/profile/components/ProfileInformationEditViewVAFSC.jsx
+++ b/src/applications/personalization/profile/components/ProfileInformationEditViewVAFSC.jsx
@@ -23,10 +23,14 @@ const renderActiveField = (fieldName, props) => {
 export const ProfileInformationEditViewVAFSC = props => {
   const formRef = useRef();
 
-  const { fieldName } = props;
+  const { fieldName, forceEditView } = props;
 
   const focusOnFirstFormElement = useCallback(
     () => {
+      if (forceEditView) {
+        // Showing the edit view on its own page, so let the app handle focus
+        return;
+      }
       // TODO: is there a better way to ensure focus inside a web comp on render?
       // setting timeout for event so that input in web component can get focus,
       // otherwise web component will not render by time querySelector is fired
@@ -68,6 +72,7 @@ ProfileInformationEditViewVAFSC.propTypes = {
   fieldName: PropTypes.oneOf(Object.values(VAP_SERVICE.FIELD_NAMES)).isRequired,
   getInitialFormValues: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  forceEditView: PropTypes.bool,
   title: PropTypes.string,
 };
 

--- a/src/applications/personalization/profile/tests/components/ContactInformationEditView.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ContactInformationEditView.unit.spec.jsx
@@ -43,6 +43,7 @@ describe('<ProfileInformationEditView/> - Email Address', () => {
       data: null,
       editViewData: null,
       fieldName: 'email',
+      forceEditView: false,
       formSchema: {},
       getInitialFormValues() {},
       field: {

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -411,6 +411,7 @@ class ProfileInformationFieldController extends React.Component {
               this.props.formSchema,
             )}
             title={title}
+            forceEditView={forceEditView}
           />
         </>
       ) : (
@@ -432,6 +433,7 @@ class ProfileInformationFieldController extends React.Component {
           )}
           title={title}
           recordCustomProfileEvent={recordCustomProfileEvent}
+          forceEditView={forceEditView}
         />
       );
     }


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > In our Supplemental Claim form, when returning to edit an empty contact field after previously canceling, the field error is shown immediately instead of on blur. Within the `ProfileInformationEditView` component, focus is immediately set on the first field element. But in our app, we move focus to the `h3`, which happens after the field is focused, thus causing a field error to appear.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > To fix the problem, we pass the `forceEditView` property, already passed to the `ProfileInformationFieldController` to show the form fields, in edit mode. Passing along this value allows us to skip the initial form element focus, since we're only showing edit view on a separate page.
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#53475](https://github.com/department-of-veterans-affairs/va.gov-team/issues/53475)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Updated unit test with prop, but I didn't find any previous testing of focus, so I didn't add it
- *Describe the steps required to verify your changes are working as expected*
  > Manual testing locally
- *Describe the tests completed and the results*
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

### After

Focus on `H3` and no initial focus on input, so no input error message showing
![Edit mobile phone number h3 is focused, and the phone input below does not show any errors](https://user-images.githubusercontent.com/136959/221009661-60aada38-71c2-47ea-b6ca-cbab35fdbd1a.png)

## What areas of the site does it impact?

* Supplemental Claims (not yet released)
* Notice of Disagreement (focus remains on `H2`)
* Higher-Level Review (Edit still opens a modal, focus on close modal button)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
