### PR TITLE
Supplemental Claims | Add H2 to subtask va-radio question

### DIFF
--- a/src/applications/appeals/995/sass/995-supplemental-claim.scss
+++ b/src/applications/appeals/995/sass/995-supplemental-claim.scss
@@ -185,6 +185,7 @@ article[data-location="issue-summary"] {
   font-weight: 400;
 }
 
+article[data-location="start"],
 article[data-location="review-and-submit"],
 article[data-location="primary-phone-number"],
 article[data-location$="request-va-medical-records"],

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -91,6 +91,7 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
         error={error ? content.errorMessage : null}
         onVaValueChange={handlers.setBenefitType}
         required
+        label-header-level="3"
       >
         {options.map(({ value, label }) => (
           <VaRadioOption

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -91,7 +91,7 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
         error={error ? content.errorMessage : null}
         onVaValueChange={handlers.setBenefitType}
         required
-        label-header-level="3"
+        label-header-level="2"
       >
         {options.map(({ value, label }) => (
           <VaRadioOption

--- a/src/applications/appeals/995/subtask/pages/start.jsx
+++ b/src/applications/appeals/995/subtask/pages/start.jsx
@@ -85,7 +85,6 @@ const BenefitType = ({ data = {}, error, setPageData }) => {
         </a>
       </va-additional-info>
 
-      <p>Answer this question to get started:</p>
       <VaRadio
         label={content.groupLabel}
         error={error ? content.errorMessage : null}


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > To make the claim type question on the start page discoverable, we've set it to wrap the text in an H2. Currently, the font family defaults to a san-serif font, but will be [fixed when the css in the component library is updated](https://github.com/department-of-veterans-affairs/component-library/pull/632).
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Use `label-header-level` prop of `va-radio` to wrap the text in an `H2`
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

- [#54260](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54260)
- [Component-library #632](https://github.com/department-of-veterans-affairs/component-library/pull/632)

## Testing done

N/A - visual changes

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

### Before
<details><summary>Supplemental Claims claim type question - normal question text</summary>

<!-- leave a blank line above -->
<img width="810" alt="Is this the form I need page, with the va-radio question 'what type of claim are you filing a Supplemental Claim for?' question shown as normal text - it is hard to distinguish in all the text on the page" src="https://user-images.githubusercontent.com/136959/221702235-99a47e60-d4ae-4b0f-a1dc-0d03b4b0f73e.png"></details>

### After

<details><summary>Supplemental Claims claim type question - H2 question text</summary>

<!-- leave a blank line above -->
"Answer this question to get started:" text is also removed

![Is this the form I need page, with the va-radio question 'what type of claim are you filing a Supplemental Claim for?' question shown as an h2. It is much more obvious of this questions importance](https://user-images.githubusercontent.com/136959/221704268-6cf9c2a0-18c6-4ea9-929c-76258bfbf6f2.png)</details>

## What areas of the site does it impact?

Supplemental Claim (not yet released)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
