### PR TITLE
Provide error message for phone extension field

### DIFF
--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -15,7 +15,7 @@ export const phoneFormSchema = {
     },
     extension: {
       type: 'string',
-      pattern: '^\\s*[a-zA-Z0-9]{0,6}\\s*$',
+      pattern: '^\\s*[0-9-]{0,6}\\s*$',
       maxLength: 6,
     },
   },
@@ -37,7 +37,7 @@ export const phoneUiSchema = fieldName => {
     extension: {
       'ui:title': 'Extension (6 digits maximum)',
       'ui:errorMessages': {
-        pattern: 'Please enter a valid extension.',
+        pattern: 'Please enter a valid extension up to 6 digits.',
       },
     },
   };


### PR DESCRIPTION
## Summary

- Updates phone extension field to display an error in cases of letters being input instead of numbers

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/53541

## Testing done

- all tests passing
- manually tested validation as well


## Screenshots
![Screenshot 2023-02-27 at 9 37 41 PM](https://user-images.githubusercontent.com/8332986/221755230-7681a73c-abee-40fa-bad2-fc0fcac12b41.png)

## What areas of the site does it impact?
Profile and application that allow updating of user phone numbers

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature
