### PR TITLE
Add page unit tests for 26-4555 [F/E test]

### DIFF
--- a/src/applications/simple-forms/26-4555/tests/pages/contactInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/contactInformation1.unit.spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.contactInformationChapter.pages.contactInformation1;
+
+describe('contact information page 1', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(8);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(getByRole('combobox', { name: /country/i }).value).to.exist;
+    expect(errors).to.have.lengthOf(4);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/contactInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/contactInformation2.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.contactInformationChapter.pages.contactInformation2;
+
+describe('contact information page 2', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(3);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(1);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/livingSituation1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/livingSituation1.unit.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.livingSituationChapter.pages.livingSituation1;
+
+describe('living situation page 1', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          livingSituation: {
+            isInCareFacility: false,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(2);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(1);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/livingSituation2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/livingSituation2.unit.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.livingSituationChapter.pages.livingSituation2;
+
+describe('living situation page 2', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          livingSituation: {
+            isInCareFacility: true,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(7);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          livingSituation: {
+            isInCareFacility: true,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(4);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/personalInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/personalInformation1.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.personalInformationChapter.pages.personalInformation1;
+
+describe('personal information page 1', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(7);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(2);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/personalInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/personalInformation2.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.personalInformationChapter.pages.personalInformation2;
+
+describe('personal information page 2', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(2);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(1);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication1.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.previousApplicationsChapter.pages.previousShaApplication1;
+
+describe('previous HI information page 1', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, selected')).to.have.lengthOf(2);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(1);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication2.unit.spec.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.previousApplicationsChapter.pages.previousShaApplication2;
+
+describe('previous HI information page 2', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          previousHiApplication: {
+            hasPreviousHiApplication: false,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(9);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          previousHiApplication: {
+            hasPreviousHiApplication: true,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(getByRole('combobox', { name: /country/i }).value).to.exist;
+    expect(errors).to.have.lengthOf(4);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication1.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.previousApplicationsChapter.pages.previousSahApplication1;
+
+describe('previous SAH application 1', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(2);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(1);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication2.unit.spec.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.previousApplicationsChapter.pages.previousSahApplication2;
+
+describe('previous SAH information page 2', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          previousSahApplication: {
+            hasPreviousSahApplication: false,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    expect(container.querySelectorAll('input, select')).to.have.lengthOf(9);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          previousSahApplication: {
+            hasPreviousSahApplication: true,
+          },
+        }}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(getByRole('combobox', { name: /country/i }).value).to.exist;
+    expect(errors).to.have.lengthOf(4);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/pages/remarks.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/remarks.unit.spec.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.additionalInformationChapter.pages.remarks;
+
+describe('remarks page', () => {
+  it('should have appropriate number of fields', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(
+      container.querySelectorAll('input, select, textarea'),
+    ).to.have.lengthOf(1);
+  });
+
+  it('should show the correct number of errors on submit', () => {
+    const { getByRole, queryAllByRole } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const errors = queryAllByRole('alert');
+    expect(errors).to.have.lengthOf(0);
+  });
+});

--- a/src/applications/simple-forms/26-4555/tests/routes.unit.spec.js
+++ b/src/applications/simple-forms/26-4555/tests/routes.unit.spec.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import routes from '../routes';
+
+describe('Form route test', () => {
+  const { onEnter } = routes.indexRoute;
+  it('should redirect from the root to /introduction', () => {
+    const replace = sinon.spy();
+    onEnter(null, replace);
+    expect(replace.calledWith('/introduction')).to.be.true;
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Unit tests for `pages` for form 26-4555 - Specially Adapted Housing
E2E tests and container tests not included.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#23

## Testing done
- Browser testing combined with unit tests.
- Verify correct number of inputs are shown
- Verify correct number of errors on page are shown when trying to submit

## Screenshots
N/A

## What areas of the site does it impact?
N/A - new app being developed not deployed yet

## Acceptance criteria

- [x]  I added unit tests the feature
- [x]  No error nor warning in the console.

## Requested Feedback
First time doing a unit test in this project, so any feedback is welcome.
