### PR TITLE
Supplemental Claims | Fix issue decision date hint text

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^13.10.3",
+    "@department-of-veterans-affairs/component-library": "^13.11.1",
     "@department-of-veterans-affairs/formation": "^7.0.4",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/src/applications/appeals/995/components/AddIssue.jsx
+++ b/src/applications/appeals/995/components/AddIssue.jsx
@@ -166,6 +166,7 @@ const AddIssue = props => {
         <VaMemorableDate
           name="decision-date"
           label={content.date.label}
+          hint={content.date.hint}
           class="vads-u-margin-top--0"
           required
           onDateChange={handlers.onDateChange}
@@ -173,9 +174,7 @@ const AddIssue = props => {
           value={issueDate}
           error={((submitted || dateDirty) && dateErrorMessage[0]) || null}
           aria-describedby="decision-date-description"
-        >
-          {content.date.hint}
-        </VaMemorableDate>
+        />
         <p>
           <button
             type="button"

--- a/src/applications/appeals/995/content/addIssue.jsx
+++ b/src/applications/appeals/995/content/addIssue.jsx
@@ -20,11 +20,7 @@ export const content = {
   },
   date: {
     label: 'Date of decision',
-    hint: (
-      <p className="vads-u-font-weight--normal label-description">
-        Enter the date on your decision notice (the letter you received in the
-        mail from us).
-      </p>
-    ),
+    hint:
+      'Enter the date on your decision notice (the letter you received in the mail from us).',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,13 +2525,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^13.10.3":
-  version "13.10.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-13.10.3.tgz#7c99eb976b01eb65453a99d76c28fbfb4aa1f6ae"
-  integrity sha512-PoxATLH0dhmFEkmbuxscRGqdUBbQUU6pALIgSqrZLGSPAUylTuWdjiPlBPDKM/iI+ugcRE2wckxcQiQICtZz9w==
+"@department-of-veterans-affairs/component-library@^13.11.1":
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-13.11.1.tgz#d9b621c59c4b640e37e658598662aa3de8615c9f"
+  integrity sha512-+BXaW8TZ4mHpQnxaPO/CDfcr8r0DgB76bP+BZMOEKUcZsHD8Y813J10wAAPjoblDO3to0iAOB4e6fMRVxO55hQ==
   dependencies:
     "@department-of-veterans-affairs/react-components" "8.0.0"
-    "@department-of-veterans-affairs/web-components" "4.26.3"
+    "@department-of-veterans-affairs/web-components" "4.27.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2604,10 +2604,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.26.3":
-  version "4.26.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.26.3.tgz#92dd00784a669c0d6d13a3aa28bff4b9ec77eace"
-  integrity sha512-TNdT7TcWKvETkFQ/L+Je3dNCN0trPtMpWzqIyA+6BeLKxE8WslPn6bDk8x9ewU9VUPMjhefX+v1i3K78wI9yZQ==
+"@department-of-veterans-affairs/web-components@4.27.1":
+  version "4.27.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.27.1.tgz#d306cb6997ec5656084ac7dd7afc02daa2f4524b"
+  integrity sha512-tkDqCbGgJ++MaLBAU45ArxXOyMyZsT2hKfWb9OEU3cclzkX1oKPzfMzcebdd9g2E9HBNhmvpe7n/OD9ZZCd7OQ==
   dependencies:
     "@stencil/core" "^2.19.2"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > The decision date web component (`va-memorable-date`) includes hint text added as a child of the component, but adding content this way makes it not obvious to a screen reader user. A new `hint` property was added to the web component, and so this PR switches to use that property.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > `va-memorable-date` includes a hint text property which adds the hint text inside the `legend`, so it is read out by a screen reader along with the legend text
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews 
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#54215](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54215)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Screen readers would not read out the hint text
- *Describe the steps required to verify your changes are working as expected*
  > Test the work in this PR (locally or in a review instance) with a screen reader - get to the add contestable issue page
- *Describe the tests completed and the results*
  > All tests passing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

Screen reader including new hint text (added above the default hint text)

![Date of decision month input focused. Screen reader window is shown with "Month, edit text, Date of decision (*Required) Enter the date on your decision notice (the letter you received in the mail from us). Please enter two...](https://user-images.githubusercontent.com/136959/222226175-614e0f31-b7c4-4854-9535-efec6b53a4d0.png)

## What areas of the site does it impact?

All apps that use the `va-memorable-date` web component, but only if

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
