### PR TITLE
MBMS-38442 Remove Codeowners from Memorials Self Service GitHub Repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,7 +52,6 @@ src/applications/letters @department-of-veterans-affairs/benefits-team-1-fronten
 src/applications/disability-benefits @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/claims-status @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/appeals @department-of-veterans-affairs/benefits-team-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
-src/applications/pre-need @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/vre @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/lgy @department-of-veterans-affairs/benefits-team-1-frontend
 src/applications/sah @department-of-veterans-affairs/benefits-team-1-frontend


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Removing `benefits-team-1-frontend` from code reviewers for preneed

## Related issue(s)
https://vajira.max.gov/browse/MBMS-38442
## Testing done
NA

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
