### PR TITLE
Test Fixes to Manage Delete Folder Error

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-inbox-message-sort.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-inbox-message-sort.cypress.spec.js
@@ -14,6 +14,8 @@ describe('Secure Messaging Inbox Message Sort', () => {
       .shadow()
       .find('select')
       .should('contain', 'Newest');
+    cy.injectAxe();
+    cy.axeCheck();
   });
 
   it('Sort Inbox Messages from Oldest to Newest', () => {
@@ -22,6 +24,8 @@ describe('Secure Messaging Inbox Message Sort', () => {
       .find('select')
       .select('asc', { force: true })
       .should('contain', 'newest');
+    cy.injectAxe();
+    cy.axeCheck();
   });
   it('Sort Inbox Messages from A to Z', () => {
     cy.get('#sort-order-dropdown')
@@ -29,6 +33,8 @@ describe('Secure Messaging Inbox Message Sort', () => {
       .find('select')
       .select('sender-alpha-asc', { force: true })
       .should('contain', 'A to Z');
+    cy.injectAxe();
+    cy.axeCheck();
   });
 
   it('Sort Inbox Messages from Z to A', () => {
@@ -37,11 +43,11 @@ describe('Secure Messaging Inbox Message Sort', () => {
       .find('select')
       .select('sender-alpha-desc', { force: true })
       .should('contain', 'Z to A');
+    cy.injectAxe();
+    cy.axeCheck();
   });
 
   afterEach(() => {
     cy.get('[data-testid="sort-button"]').click({ force: true });
-    cy.injectAxe();
-    cy.axeCheck();
   });
 });

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-manage-folder-delete-error.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-manage-folder-delete-error.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Secure Messaging Custom Folder Delete Error Message Validation', () =>
 
     cy.get('[class="modal hydrated"]')
       .shadow()
-      .find('[class="va-modal-inner"]');
+      .find('button');
 
     cy.get('[visible=""] > p');
     cy.injectAxe();


### PR DESCRIPTION


## Summary
Minor code change to fix the modal assertion error - added code using find() for the close button to cancel the modal. The test was flaky earlier.

## Testing done

Testing is complete and tests are passing consistently when performed locally.

## Acceptance criteria

- [ ]  No error nor warning in the console.
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
