### PR TITLE
FileField styling | Prevent long file name overflow

### DIFF
--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -340,6 +340,8 @@ fieldset.schemaform-field-template {
 .schemaform-file-list {
   list-style: none;
   padding-left: 0;
+  overflow-wrap: break-word;
+  word-break: break-all;
   > li {
     list-style: none;
   }


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > On a small (e.g. 320 pixel wide) screen, when uploading a long file the upload card will overflow and go off screen
- *(If bug, how to reproduce)*
  > 1. In staging, log into any of the [HLR users](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/staging-test-accounts-HLR.md)
  > 2. Go to [Supplemental Claims form](https://staging.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995)
  > 3. Navigate to the evidence upload page (choose yes)
  > 4. Upload a file name with a really long name
  > 5. Shrink browser width to cause the file name to overflow (depends on file name length)
- *(What is the solution, why is this the solution)*
  > Add CSS to force wrapping
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews; code owned by form team
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#54512](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54512)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Manual testing
- *Describe the steps required to verify your changes are working as expected*
  > Resize browser window to determine if long file names overflow
- *Describe the tests completed and the results*
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

### Before

![Long file name extends off the screen. This also causes the document type select](https://user-images.githubusercontent.com/136959/222539427-85db6c03-198b-46fa-9cfd-8e026ad84c66.png)

### After

![Long file name wraps and is completely visible with no overflow](https://user-images.githubusercontent.com/136959/222549829-1771ddf1-aed1-41da-a0ba-bf9b94c682d2.png)

## What areas of the site does it impact?

All apps that use the `FileField`

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

I did try to write a unit test to check of the file name overflows, but [this doesn't seem possible with testing library](https://stackoverflow.com/a/64393276).
