### PR TITLE
Adds `oauth` query parameter to Sign in CTAs and next

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -104,21 +104,13 @@ export class Main extends Component {
     return null;
   }
 
-  appendOrRemoveParameter({
-    url = 'loginModal',
-    pageTitle = '',
-    useSiS = true,
-  } = {}) {
+  appendOrRemoveParameter({ url = 'loginModal', pageTitle = '' } = {}) {
     if (url === 'loginModal' && this.getNextParameter()) {
       return null;
     }
     const location = window.location.toString();
-    const nextQuery = {
-      next: url,
-      ...(useSiS && this.props.useSignInService && { oauth: true }),
-    };
-    const path = useSiS ? location : location.replace('&oauth=true', '');
-    const nextPath = appendQuery(path, nextQuery);
+    const nextQuery = { next: url };
+    const nextPath = appendQuery(location, nextQuery);
     history.pushState({}, pageTitle, nextPath);
 
     return nextQuery;
@@ -166,7 +158,7 @@ export class Main extends Component {
           e.preventDefault();
           const linkHref = el.getAttribute('href');
           const pageTitle = el.textContent;
-          this.appendOrRemoveParameter({ linkHref, pageTitle });
+          this.appendOrRemoveParameter({ url: linkHref, pageTitle });
           this.openLoginModal();
         }
       });
@@ -185,7 +177,6 @@ export class Main extends Component {
 
   closeLoginModal = () => {
     this.props.toggleLoginModal(false);
-    this.appendOrRemoveParameter({ useSiS: false });
   };
 
   closeAccountTransitionModal = () => {
@@ -204,7 +195,6 @@ export class Main extends Component {
 
   openLoginModal = () => {
     this.props.toggleLoginModal(true);
-    this.appendOrRemoveParameter({});
   };
 
   signInSignUp = () => {

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -276,16 +276,6 @@ describe('<Main>', () => {
     wrapper.unmount();
   });
 
-  it('should append `&oauth=true` when the login modal is opened and signInServiceEnabled feature flag is true', () => {
-    const wrapper = shallow(<Main {...props} useSignInService />);
-    wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
-    const signInModalProps = wrapper.find('SignInModal').props();
-    expect(signInModalProps.useSiS).to.be.true;
-    expect(appendSpy.returnValues[0].next).to.equal('loginModal');
-    expect(appendSpy.returnValues[0].oauth).to.equal(true);
-    wrapper.unmount();
-  });
-
   it('should not append ?next=loginModal when the login modal is opened and a ?next parameter already exists', () => {
     global.window.location.search = { next: 'account' };
     const wrapper = shallow(<Main {...props} />);

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -18,17 +18,19 @@ export default function SignInModal({ onClose, visible }) {
       if (visible) {
         recordEvent({ event: `login-modal-opened${isOAuthEvent}` });
 
-        if (useSiS) {
-          url.searchParams.set('oauth', useSiS);
-        }
-
         if (!url.searchParams.get('next')) {
           url.searchParams.set('next', 'loginModal');
+        }
+
+        if (useSiS) {
+          url.searchParams.set('oauth', useSiS);
         }
       }
       window.history.pushState({}, '', url);
 
       return () => {
+        url.searchParams.delete('oauth');
+        window.history.pushState({}, '', url);
         recordEvent({ event: `login-modal-closed${isOAuthEvent}` });
       };
     },

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -1,34 +1,50 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { signInServiceEnabled } from 'platform/user/authentication/selectors';
 import { LoginContainer } from 'platform/user/authentication/components';
 
 import recordEvent from 'platform/monitoring/record-event';
 
-export default class SignInModal extends React.Component {
-  componentDidUpdate(prevProps) {
-    const isOAuthEvent = this.props.useSiS ? '-oauth' : '';
-    if (!prevProps.visible && this.props.visible) {
-      recordEvent({ event: `login-modal-opened${isOAuthEvent}` });
-    } else if (prevProps.visible && !this.props.visible) {
-      recordEvent({ event: `login-modal-closed${isOAuthEvent}` });
-    }
-  }
+export default function SignInModal({ onClose, visible }) {
+  const useSiS = useSelector(signInServiceEnabled);
 
-  render() {
-    return (
-      <Modal
-        cssClass="va-modal-large new-modal-design"
-        visible={this.props.visible}
-        focusSelector="button"
-        onClose={this.props.onClose}
-        id="signin-signup-modal"
-      >
-        <LoginContainer />
-      </Modal>
-    );
-  }
+  useEffect(
+    () => {
+      const isOAuthEvent = useSiS ? '-oauth' : '';
+      const url = new URL(window.location);
+      if (visible) {
+        recordEvent({ event: `login-modal-opened${isOAuthEvent}` });
+
+        if (useSiS) {
+          url.searchParams.set('oauth', useSiS);
+        }
+
+        if (!url.searchParams.get('next')) {
+          url.searchParams.set('next', 'loginModal');
+        }
+      }
+      window.history.pushState({}, '', url);
+
+      return () => {
+        recordEvent({ event: `login-modal-closed${isOAuthEvent}` });
+      };
+    },
+    [visible, useSiS],
+  );
+  return (
+    <Modal
+      cssClass="va-modal-large new-modal-design"
+      visible={visible}
+      focusSelector="button"
+      onClose={onClose}
+      id="signin-signup-modal"
+    >
+      <LoginContainer />
+    </Modal>
+  );
 }
 
 SignInModal.propTypes = {

--- a/src/platform/user/tests/authentication/components/SignInModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/SignInModal.unit.spec.js
@@ -1,22 +1,63 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { fireEvent } from '@testing-library/react';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 
-import { LoginContainer } from 'platform/user/authentication/components';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import SignInModal from 'platform/user/authentication/components/SignInModal';
 
-const defaultProps = {
-  visible: true,
-  onClose: () => {},
-  useSiS: false,
-};
+const generateStore = (enabled = false) => ({
+  featureToggles: {
+    // eslint-disable-next-line camelcase
+    sign_in_service_enabled: enabled,
+  },
+});
 
 describe('SignInModal', () => {
-  it('should render Modal and LoginContainer by default', () => {
-    const component = shallow(<SignInModal {...defaultProps} />);
-    expect(component.exists(Modal)).to.be.true;
-    expect(component.exists(LoginContainer)).to.be.true;
-    component.unmount();
+  const oldWindow = global.window;
+
+  after(() => {
+    global.window = oldWindow;
+  });
+
+  it('should NOT render if `visible` is set to false', () => {
+    const screen = renderInReduxProvider(<SignInModal />, {
+      initialState: generateStore(),
+    });
+    expect(screen.queryByText('Sign in')).to.be.null;
+  });
+
+  it('should render if `visible` is set to true', () => {
+    const screen = renderInReduxProvider(<SignInModal visible />, {
+      initialState: generateStore(),
+    });
+    const url = new URL(window.location);
+    expect(screen.queryByText('Sign in')).to.not.be.null;
+    expect(url.searchParams.get('next')).to.eql('loginModal');
+  });
+
+  it('should verify the close button works as expected', () => {
+    const onClose = sinon.spy();
+    const screen = renderInReduxProvider(
+      <SignInModal visible onClose={onClose} />,
+      {
+        initialState: generateStore(),
+      },
+    );
+
+    fireEvent.click(screen.queryByLabelText('close modal'));
+
+    expect(onClose.called).to.be.true;
+  });
+
+  it('should append the `oauth` query parameter', () => {
+    const screen = renderInReduxProvider(<SignInModal visible />, {
+      initialState: generateStore(true),
+    });
+
+    const url = new URL(window.location);
+    expect(screen.queryByText('Sign in')).to.not.be.null;
+    expect(url.searchParams.get('next')).to.eql('loginModal');
+    expect(url.searchParams.get('oauth')).to.eql('true');
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *(Summarize the changes that have been made to the platform)*
This PR changes the way the SignInModal component works to check if the `sign_in_service_enabled` feature toggle is enabled and optionally append the `oauth=true` query parameter.

- *(What is the solution, why is this the solution)*
The solution was to add a `useEffect` to determine if the `SignInModal` is visible and if it is then add some query parameters `oauth` and `next` and remove the `oauth` query parameter when the `SignInModal` is closed

- *(Which team do you work for, does your team own the maintenance of this component?)*
Identity. Yes it does

## Related issue(s)
- *Link to ticket created in va.gov-team repo*
Closes department-of-veterans-affairs/va.gov-team#48357

- *Link to epic if not included in ticket*
Closes department-of-veterans-affairs/va.gov-team#32749


## Testing done

- *Describe what the old behavior was prior to the change*
The old behavior is that any Call to Action (CTA) that toggles the SignInModal would not have the `oauth=true` query parameter open.  Additionally, any other links that pointed to `next=<some place>` would also not have the `oauth=true` query parameter appended even when Sign in Service (SiS) was enabled.

- *Describe the steps required to verify your changes are working as expected*
Manually tested by clicking the My VA link (`next=/my-va/`), clicked the Sign in button in the header, clicked the Sign in that was within a CTA `localhost:3001/health-care/apply/application/introduction`

- *Describe the tests completed and the results*
Manually tested above.  Additonally expanded the `SignInModal` unit tests to include the new functionality and removed deprecated functionality in the user-nav `Main.jsx`.

- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*


## Screenshots
n/a

## What areas of the site does it impact?
This will impact quite a bit of people as it's in the main VA.gov header as well as teamsites.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback
Most importantly I want feedback from teamsites
(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
