### PR TITLE
Save-in-progress text is not read out all at once

### DIFF
--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -139,20 +139,21 @@ export class ApplicationStatus extends React.Component {
 
         return (
           <div className="usa-alert usa-alert-info background-color-only sip-application-status vads-u-margin-bottom--2 vads-u-margin-top--0">
-            <h5 className="form-title saved">Your {appType} is in progress</h5>
+            <h5 className="form-title saved">
+              {`Your ${appType} is in progress`}
+            </h5>
             <span className="saved-form-item-metadata">
-              Your {formDescriptions[formId]} is in progress.
+              {`Your ${formDescriptions[formId]} is in progress.`}
             </span>
             <br />
             {lastSavedDateTime && (
               <span className="saved-form-item-metadata">
-                Your {appType} was last saved on {lastSavedDateTime}
+                {`Your ${appType} was last saved on ${lastSavedDateTime}`}
               </span>
             )}
             <br />
             <div className="expires-container">
-              You can continue {appAction} now, or come back later to finish
-              your {appType}. Your {appType}{' '}
+              {`You can continue ${appAction} now, or come back later to finish your ${appType}. Your ${appType} `}
               <span className="expires">
                 will expire on {format(expirationDate, 'MMMM d, yyyy')}.
               </span>
@@ -166,6 +167,7 @@ export class ApplicationStatus extends React.Component {
                 {continueAppButtonText}
               </a>
               <button
+                type="button"
                 className="usa-button-secondary"
                 onClick={this.toggleModal}
               >
@@ -174,9 +176,9 @@ export class ApplicationStatus extends React.Component {
             </p>
             {multipleForms && (
               <p className="no-bottom-margin">
-                You have more than one in-progress {formType} {appType}.{' '}
+                {`You have more than one in-progress ${formType} ${appType}. `}
                 <a href="/my-va">
-                  View and manage your {appType}s on your Account page
+                  {`View and manage your ${appType}s on your Account page`}
                 </a>
                 .
               </p>
@@ -205,10 +207,13 @@ export class ApplicationStatus extends React.Component {
       }
       return (
         <div className="usa-alert usa-alert-warning background-color-only sip-application-status vads-u-margin-bottom--2 vads-u-margin-top--0">
-          <h5 className="form-title saved">Your {appType} has expired</h5>
+          <h5 className="form-title saved">{`Your ${appType} has expired`}</h5>
           <span className="saved-form-item-metadata">
-            Your saved {formDescriptions[formId]} has expired. If you want to
-            apply for {formBenefits[formId]}, please start a new {appType}.
+            {`Your saved ${
+              formDescriptions[formId]
+            } has expired. If you want to apply for ${
+              formBenefits[formId]
+            }, please start a new ${appType}.`}
           </span>
           <br />
           <p>
@@ -218,7 +223,7 @@ export class ApplicationStatus extends React.Component {
           </p>
           {multipleForms && (
             <p className="no-bottom-margin">
-              You have more than one in-progress {formType} {appType}.{' '}
+              {`You have more than one in-progress ${formType} ${appType}. `}
               <a href="/my-va">
                 View and manage your {appType}s on your Account page
               </a>

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -119,19 +119,18 @@ class SaveInProgressIntro extends React.Component {
             <div className="usa-alert usa-alert-info background-color-only schemaform-sip-alert">
               <div className="schemaform-sip-alert-title">
                 <H className="usa-alert-heading vads-u-font-size--h3">
-                  {inProgressMessage} {savedAt && 'and was last saved on '}
-                  {lastSavedDateTime}
+                  {`${inProgressMessage} ${savedAt &&
+                    'and was last saved on '} ${lastSavedDateTime}`}
                 </H>
               </div>
               <div className="saved-form-metadata-container">
                 <div className="expires-container">
-                  You can continue {appAction} now
-                  {appContinuing && ` ${appContinuing}`}, or come back later to
-                  finish your {appType}.
+                  {`You can continue ${appAction} now ${appContinuing &&
+                    ` ${appContinuing}`}, or come back later to finish your ${appType}.`}
                   <p>
-                    Your {appType}{' '}
+                    {`Your ${appType} `}
                     <span className="expires">
-                      will expire on {expirationDate}.
+                      {`will expire on ${expirationDate}.`}
                     </span>
                   </p>
                 </div>
@@ -145,7 +144,7 @@ class SaveInProgressIntro extends React.Component {
             <div>
               <div className="usa-alert usa-alert-warning background-color-only schemaform-sip-alert">
                 <div className="schemaform-sip-alert-title">
-                  <strong>Your {appType} has expired</strong>
+                  <strong>{`Your ${appType} has expired`}</strong>
                 </div>
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-metadata">
@@ -163,10 +162,8 @@ class SaveInProgressIntro extends React.Component {
           <div>
             <div className="usa-alert usa-alert-info schemaform-sip-alert">
               <div className="usa-alert-body">
-                <strong>Note:</strong> Since you’re signed in to your account,
-                we can prefill part of your {appType} based on your account
-                details. You can also save your {appType} in progress and come
-                back later to finish filling it out.
+                <strong>Note: </strong>
+                {`Since you’re signed in to your account, we can prefill part of your ${appType} based on your account details. You can also save your ${appType} in progress and come back later to finish filling it out.`}
               </div>
             </div>
             <br />
@@ -179,8 +176,7 @@ class SaveInProgressIntro extends React.Component {
           <div>
             <div className="usa-alert usa-alert-info schemaform-sip-alert">
               <div className="usa-alert-body">
-                You can save this {appType} in progress, and come back later to
-                finish filling it out.
+                {`You can save this ${appType} in progress, and come back later to finish filling it out.`}
               </div>
             </div>
             <br />
@@ -224,28 +220,21 @@ class SaveInProgressIntro extends React.Component {
         <div className="usa-alert usa-alert-info schemaform-sip-alert">
           <div className="usa-alert-body">
             <H className="usa-alert-heading">
-              Save time—and save your work in progress—by signing in before
-              starting your {appType}
+              {`Save time—and save your work in progress—by signing in before starting your ${appType}`}
             </H>
             <div className="usa-alert-text">
               <p>When you’re signed in to your VA.gov account:</p>
               <ul>
                 <li>
-                  We can prefill part of your {appType} based on your account
-                  details.
+                  {`We can prefill part of your ${appType} based on your account details.`}
                 </li>
                 <li>
-                  You can save your {appType} in progress, and come back later
-                  to finish filling it out. You’ll have {retentionPeriod} from
-                  the date you start or update your {appType} to submit it.
-                  After {retentionPeriod}, we’ll delete the {appType} and you’ll
-                  need to start over.
+                  {`You can save your ${appType} in progress, and come back later to finish filling it out. You’ll have ${retentionPeriod} from the date you start or update your ${appType} to submit it. After ${retentionPeriod}, we’ll delete the ${appType} and you’ll need to start over.`}
                 </li>
               </ul>
               <p>
-                <strong>Note:</strong> If you sign in after you’ve started your{' '}
-                {appType}, you won’t be able to save the information you’ve
-                already filled in.
+                <strong>Note:</strong>
+                {` If you sign in after you’ve started your ${appType}, you won’t be able to save the information you’ve already filled in.`}
               </p>
               {unauthStartButton}
               {!this.props.hideUnauthedStartLink && (
@@ -257,7 +246,7 @@ class SaveInProgressIntro extends React.Component {
                     aria-label={ariaLabel}
                     aria-describedby={ariaDescribedby}
                   >
-                    Start your {appType} without signing in
+                    {`Start your ${appType} without signing in`}
                   </Link>
                 </p>
               )}
@@ -272,8 +261,7 @@ class SaveInProgressIntro extends React.Component {
         <div>
           <div className="usa-alert usa-alert-info schemaform-sip-alert">
             <div className="usa-alert-body">
-              You can save this {appType} in progress, and come back later to
-              finish filling it out.
+              {`You can save this ${appType} in progress, and come back later to finish filling it out.`}
               <br />
               <button
                 className="va-button-link"

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -125,7 +125,7 @@ class SaveInProgressIntro extends React.Component {
               </div>
               <div className="saved-form-metadata-container">
                 <div className="expires-container">
-                  {`You can continue ${appAction} now ${appContinuing &&
+                  {`You can continue ${appAction} now${appContinuing &&
                     ` ${appContinuing}`}, or come back later to finish your ${appType}.`}
                   <p>
                     {`Your ${appType} `}

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -84,7 +84,7 @@ function SaveStatus({
                   showLoginModal={showLoginModal}
                   toggleLoginModal={toggleLoginModal}
                 >
-                  Sign in to save your {appType} in progress
+                  {`Sign in to save your ${appType} in progress`}
                 </SignInLink>
                 .
               </span>

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -5,11 +5,11 @@ import SkinDeep from 'skin-deep';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { getFormDOM } from '../../../testing/unit/schemaform-utils';
 import { VA_FORM_IDS } from 'platform/forms/constants';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+import { getFormDOM } from '../../../testing/unit/schemaform-utils';
 
 import { ApplicationStatus } from '../../save-in-progress/ApplicationStatus';
-import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 describe('schemaform <ApplicationStatus>', () => {
   let formConfigDefaultData;
@@ -230,6 +230,7 @@ describe('schemaform <ApplicationStatus>', () => {
         }}
         showApplyButton
         applyText="Apply for benefit"
+        formType="application"
         profile={{
           loading: false,
           savedForms: [


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > When the in progress alert is shown on the screen, the text is broken into chunks making a screen reader break what should be a continuous sentence into smaller parts
  >
  > https://user-images.githubusercontent.com/136959/222552162-2c5fd512-9424-40c0-8b56-af1020d17c60.MP4
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Instead of adding text with variables inside JSX, we build the text using template strings
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

- See [#54518](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54518)
- Related [#1592](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1592)

## Testing done

- *Describe what the old behavior was prior to the change*
  > See the included video
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Screenreader testing & updated a failing unit test
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

### After

![VoiceOver text pane showing the following: heading level 2, Your application is in progress and was last saved on March 2, 2023, at 1:59 p.m. CST is read out all at once](https://user-images.githubusercontent.com/136959/222767689-156baea0-8449-4fab-97e0-28a727ed4dd3.png)
![VoiceOver text pane showing the following: You can continue applying now, or come back later to finish your application](https://user-images.githubusercontent.com/136959/222767741-93ac54bf-21cd-428f-82a5-73f5b1d74e99.png) (Note: extra space before the comma was removed after taking this screenshot)

## What areas of the site does it impact?

All apps that use save-in-progress

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
