### PR TITLE
MHV-40732, 38993, 39024 SM to VA.gov styling fixes

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -17,7 +17,11 @@ import { sortRecipients } from '../../util/helpers';
 import { sendMessage } from '../../actions/messages';
 import RouteLeavingGuard from '../shared/RouteLeavingGuard';
 import HowToAttachFiles from '../HowToAttachFiles';
-import { draftAutoSaveTimeout, Categories } from '../../util/constants';
+import {
+  draftAutoSaveTimeout,
+  Categories,
+  Prompts,
+} from '../../util/constants';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 
@@ -360,27 +364,24 @@ const ComposeForm = props => {
 
             <VaModal
               id="edit-list"
-              modalTitle="You'll need to edit your list of recipients on My HealtheVet"
+              modalTitle={Prompts.Compose.EDIT_LIST_TITLE}
               name="edit-list"
               visible={editListModal}
-              onPrimaryButtonClick={() => {
-                const editListURL = mhvUrl(
-                  isAuthenticatedWithSSOe(fullState),
-                  'preferences',
-                );
-                window.open(editListURL, '_blank');
-              }}
-              onSecondaryButtonClick={() => setEditListModal(false)}
               onCloseEvent={() => setEditListModal(false)}
-              primaryButtonText="Continue"
-              secondaryButtonText="Cancel"
               status="warning"
             >
-              <p>
-                You’ll be asked to sign in to My HealtheVet in another tab.
-                After you edit your list, you can refresh this page to see your
-                changes.
-              </p>
+              <p>{Prompts.Compose.EDIT_LIST_CONTENT}</p>
+              <a
+                className="vads-c-action-link--green"
+                href={mhvUrl(isAuthenticatedWithSSOe(fullState), 'preferences')}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => {
+                  setEditListModal(false);
+                }}
+              >
+                Edit your contact list on the My HealtheVet website
+              </a>
             </VaModal>
 
             <button

--- a/src/applications/mhv/secure-messaging/components/FrequentlyAskedQuestions.jsx
+++ b/src/applications/mhv/secure-messaging/components/FrequentlyAskedQuestions.jsx
@@ -4,7 +4,7 @@ import { openCrisisModal } from '../util/helpers';
 
 const FrequentlyAskedQuestions = ({ prefLink }) => {
   return (
-    <div className="secure-messaging-faq vads-u-padding-bottom--9">
+    <div className="secure-messaging-faq">
       <h2 className="vads-u-margin-top--1">Questions about using messages</h2>
 
       <va-accordion open-single>

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
@@ -31,7 +31,7 @@ const MessageThread = props => {
 
       {messageHistory?.length > 0 &&
         viewCount && (
-          <div className="older-messages vads-u-margin-y--3 vads-u-padding-left--0p5">
+          <div className="older-messages vads-u-margin-top--3 vads-u-padding-left--0p5">
             <h3 className="vads-u-font-weight--bold">
               Messages in this conversation
             </h3>

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -14,7 +14,7 @@ const MessageThreadBody = props => {
       }
     >
       <>
-        <pre className="vads-u-margin-y--0">
+        <span className="vads-u-margin-y--0">
           {words?.map(word => {
             return (word.match(urlRegex) || word.match(httpRegex)) &&
               words.length >= 1 ? (
@@ -23,7 +23,7 @@ const MessageThreadBody = props => {
               `${word} `
             );
           })}
-        </pre>
+        </span>
       </>
     </div>
   );

--- a/src/applications/mhv/secure-messaging/components/Navigation.jsx
+++ b/src/applications/mhv/secure-messaging/components/Navigation.jsx
@@ -123,7 +123,7 @@ const Navigation = () => {
   };
 
   return (
-    <div className="secure-messaging-navigation vads-u-flex--auto">
+    <div className="secure-messaging-navigation vads-u-flex--auto vads-u-padding-bottom--7 medium-screen:vads-u-padding-bottom--0">
       {openNavigationBurgerButton()}
       {(isNavigationOpen && isMobile) || isMobile === false ? (
         <div className="sidebar-navigation">

--- a/src/applications/mhv/secure-messaging/components/Navigation.jsx
+++ b/src/applications/mhv/secure-messaging/components/Navigation.jsx
@@ -123,7 +123,7 @@ const Navigation = () => {
   };
 
   return (
-    <div className="secure-messaging-navigation vads-u-padding-bottom--7 vads-u-flex--auto">
+    <div className="secure-messaging-navigation vads-u-flex--auto">
       {openNavigationBurgerButton()}
       {(isNavigationOpen && isMobile) || isMobile === false ? (
         <div className="sidebar-navigation">

--- a/src/applications/mhv/secure-messaging/containers/App.jsx
+++ b/src/applications/mhv/secure-messaging/containers/App.jsx
@@ -58,6 +58,9 @@ const App = () => {
         {mhvSecureMessagingToVaGovRelease === false &&
           window.location.replace('/health-care/secure-messaging')}
       </div>
+      <div className="vads-u-padding-right--1">
+        <va-back-to-top />
+      </div>
     </RequiredLoginView>
   );
 };

--- a/src/applications/mhv/secure-messaging/containers/AuthorizedRoutes.jsx
+++ b/src/applications/mhv/secure-messaging/containers/AuthorizedRoutes.jsx
@@ -51,7 +51,6 @@ const AuthorizedRoutes = () => {
           <FolderListView />
         </Route>
       </Switch>
-      <va-back-to-top />
     </div>
   );
 };

--- a/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
+++ b/src/applications/mhv/secure-messaging/containers/FolderListView.jsx
@@ -102,7 +102,7 @@ const FolderListView = props => {
           <div className="vads-u-padding-y--1p5 vads-l-row vads-u-margin-top--2 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light">
             Displaying 0 of 0 messages
           </div>
-          <div className="vads-u-margin-top--3 vads-u-margin-bottom--4">
+          <div className="vads-u-margin-top--3">
             <va-alert
               background-only="true"
               status="info"

--- a/src/applications/mhv/secure-messaging/sass/compose.scss
+++ b/src/applications/mhv/secure-messaging/sass/compose.scss
@@ -30,7 +30,7 @@
     width: fit-content;
   }
   .compose-form {
-    margin: 2rem 0 4rem 0;
+    margin-top: 2rem;
     background-color: $color-white;
     .required {
       color: $color-secondary-dark;

--- a/src/applications/mhv/secure-messaging/sass/folders-list.scss
+++ b/src/applications/mhv/secure-messaging/sass/folders-list.scss
@@ -31,7 +31,6 @@
 
 .folders-container {
   padding: 0px;
-  margin-bottom: 38px;
 }
 
 .folder-title {

--- a/src/applications/mhv/secure-messaging/sass/message-thread.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-thread.scss
@@ -19,12 +19,12 @@
 
   .message-list-body-expanded {
     white-space: pre-line;
-    word-break: break-all;
+    word-break: break-word;
   }
   .message-list-body-collapsed {
     text-overflow: ellipsis;
     overflow: hidden;
-    word-break: break-all;
+    word-break: break-word;
     display: -webkit-box !important;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -3,10 +3,6 @@
 @import "./folders-list";
 @forward "usa-button-group";
 
-#marginWrapper {
-  margin-top: 10px !important;
-}
-
 .secure-messaging-container {
   display: flex;
   flex-direction: row;

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -3,6 +3,10 @@
 @import "./folders-list";
 @forward "usa-button-group";
 
+#marginWrapper {
+  margin-top: 10px !important;
+}
+
 .secure-messaging-container {
   display: flex;
   flex-direction: row;

--- a/src/applications/mhv/secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
@@ -7,6 +7,7 @@ import categories from '../../fixtures/categories-response.json';
 import draftMessage from '../../fixtures/message-draft-response.json';
 import reducer from '../../../reducers';
 import ComposeForm from '../../../components/ComposeForm/ComposeForm';
+import { Prompts } from '../../../util/constants';
 
 describe('Compose form component', () => {
   const initialState = {
@@ -59,6 +60,38 @@ describe('Compose form component', () => {
     expect(categoryRadioButtons.length).to.equal(6);
     expect(subject).to.exist;
     expect(body).to.exist;
+  });
+
+  it('displays Edit List modal if path is /compose', async () => {
+    const screen = renderWithStoreAndRouter(
+      <ComposeForm recipients={triageTeams} />,
+      {
+        initialState,
+        reducers: reducer,
+        path: `/compose`,
+      },
+    );
+
+    const editListLink = await screen.getByText('Edit List', {
+      selector: 'button',
+      exact: true,
+    });
+    expect(
+      document.querySelector('#edit-list').getAttribute('visible'),
+    ).to.equal('false');
+
+    fireEvent.click(editListLink);
+    const modalContent = await screen.getByText(
+      Prompts.Compose.EDIT_LIST_CONTENT,
+    );
+    screen.debug();
+    expect(
+      document.querySelector('#edit-list').getAttribute('visible'),
+    ).to.equal('true');
+    expect(
+      document.querySelector('.vads-c-action-link--green').getAttribute('href'),
+    ).to.equal('https://mhv-syst.myhealth.va.gov/mhv-portal-web/preferences');
+    expect(modalContent).to.exist;
   });
 
   it('displays compose action buttons if path is /compose', async () => {

--- a/src/applications/mhv/secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
@@ -84,7 +84,7 @@ describe('Compose form component', () => {
     const modalContent = await screen.getByText(
       Prompts.Compose.EDIT_LIST_CONTENT,
     );
-    screen.debug();
+
     expect(
       document.querySelector('#edit-list').getAttribute('visible'),
     ).to.equal('true');

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-specialcharacter-search.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-specialcharacter-search.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Secure Messaging - Search Special Characters', () => {
     mockSpeciaCharMessage.data.attributes.messageId = '2585370';
     mockSpeciaCharMessage.data.attributes.body = 'special %$#';
     landingPage.loadMessageDetailsWithData(mockSpeciaCharMessage);
-    cy.get('pre').should('contain', 'special %$#');
+    cy.get('span').should('contain', 'special %$#');
     cy.injectAxe();
     cy.axeCheck();
   });

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -78,6 +78,11 @@ export const Links = {
 };
 
 export const Prompts = {
+  Compose: {
+    EDIT_LIST_TITLE: 'Edit your contact list',
+    EDIT_LIST_CONTENT:
+      'You can edit your contact list on the My HealtheVet website. Then refresh this page to review your updated list.',
+  },
   Message: {
     DELETE_MESSAGE_CONFIRM:
       'Are you sure you want to move this message to the trash?',


### PR DESCRIPTION
## Summary

- MHV-40732 - On Compose page, when user clicks on Edit List link, modal content is updated, Cancel button removed, Continue button replaces with an Action Link, handling closing modal when navigating through a link
- MHV-38993 - Removing excess bottom padding and margin on all containers and views in Secure Messaging to conform to designs
- MHV-39024 - fixing a word break styling in messages in thread, back to 2 line preview when collapsing a body

## Related issue(s)
- https://vajira.max.gov/browse/MHV-40732
- https://vajira.max.gov/browse/MHV-38993
- https://vajira.max.gov/browse/MHV-39024


## Screenshots
![image](https://user-images.githubusercontent.com/87077843/222801562-7e6eefda-3f99-4845-bdce-222b2d03fe10.png)
![image](https://user-images.githubusercontent.com/87077843/222801583-e09eb383-0ad1-4f8d-bd1b-dedfb5e1bfe1.png)
![image](https://user-images.githubusercontent.com/87077843/222801688-1b175d30-ba3d-4595-93b1-0be5b54a8e58.png)


## What areas of the site does it impact?
My Health - Secure Messaging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

