### PR TITLE
Add error messaging for travelpay when check in fails

### DIFF
--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -94,7 +94,7 @@ const Error = () => {
       alerts = [
         {
           alertType: 'error',
-          messageText: t(
+          message: t(
             'were-sorry-we-couldnt-match-your-information-please-ask-for-help',
           ),
         },

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -22,7 +22,9 @@ const Error = () => {
     if (form.data['travel-question'] === 'no') {
       return (
         <>
-          <p>{t('travel-pay-reimbursement--info-message')}</p>
+          <p className="vads-u-margin-top--0">
+            {t('travel-pay-reimbursement--info-message')}
+          </p>
           <ExternalLink
             href="/health-care/get-reimbursed-for-travel-pay/"
             hrefLang="en"
@@ -36,8 +38,8 @@ const Error = () => {
     }
     if (
       form.data['travel-vehicle'] === 'no' ||
-      form.data.travelAddress === 'no' ||
-      form.data.travelMileage === 'no'
+      form.data['travel-address'] === 'no' ||
+      form.data['travel-mileage'] === 'no'
     ) {
       return (
         <>
@@ -63,7 +65,27 @@ const Error = () => {
         </>
       );
     }
-    return '';
+    // Answered yes to everything
+    return (
+      <>
+        <p className="vads-u-margin-top--0">
+          <Trans
+            i18nKey="were-sorry-cant-file-travel-file-later--info-message"
+            components={[
+              <span key="bold" className="vads-u-font-weight--bold" />,
+            ]}
+          />
+        </p>
+        <ExternalLink
+          href="/resources/how-to-file-a-va-travel-reimbursement-claim-online/"
+          hrefLang="en"
+          eventId="clicked-how-to-file-link-from-ineligible"
+          eventPrefix="nav"
+        >
+          {t('find-out-how-to-file--link')}
+        </ExternalLink>
+      </>
+    );
   };
 
   switch (error) {
@@ -112,7 +134,7 @@ const Error = () => {
           ),
         },
         {
-          type: 'warning',
+          type: form.data['travel-question'] === 'no' ? 'info' : 'warning',
           message: getTravelMessage(),
         },
       ];

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -2,64 +2,148 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation, Trans } from 'react-i18next';
 
-import { makeSelectError } from '../../selectors';
+import { makeSelectError, makeSelectForm } from '../../selectors';
 import Wrapper from '../../components/layout/Wrapper';
 import { phoneNumbers } from '../../utils/appConstants';
+import ExternalLink from '../../components/ExternalLink';
 
 const Error = () => {
   const { t } = useTranslation();
   const selectError = useMemo(makeSelectError, []);
   const { error } = useSelector(selectError);
 
-  let messageText = '';
-  let alertType = '';
+  const selectForm = useMemo(makeSelectForm, []);
+  const form = useSelector(selectForm);
+
+  let alerts = [];
   let header = '';
+
+  const getTravelMessage = () => {
+    if (form.data['travel-question'] === 'no') {
+      return (
+        <>
+          <p>{t('travel-pay-reimbursement--info-message')}</p>
+          <ExternalLink
+            href="/health-care/get-reimbursed-for-travel-pay/"
+            hrefLang="en"
+            eventId="request-travel-pay-reimbursement-from-confirmation-with-no-reimbursement--link-clicked"
+            eventPrefix="nav"
+          >
+            {t('find-out-if-youre-eligible--link')}
+          </ExternalLink>
+        </>
+      );
+    }
+    if (
+      form.data['travel-vehicle'] === 'no' ||
+      form.data.travelAddress === 'no' ||
+      form.data.travelMileage === 'no'
+    ) {
+      return (
+        <>
+          <p
+            className="vads-u-margin-top--0"
+            data-testid="travel-pay-not-eligible-message"
+          >
+            <Trans
+              i18nKey="travel-pay-cant-file-message"
+              components={[
+                <span key="bold" className="vads-u-font-weight--bold" />,
+              ]}
+            />
+          </p>
+          <ExternalLink
+            href="/resources/how-to-file-a-va-travel-reimbursement-claim-online/"
+            hrefLang="en"
+            eventId="clicked-how-to-file-link-from-ineligible"
+            eventPrefix="nav"
+          >
+            {t('find-out-how-to-file--link')}
+          </ExternalLink>
+        </>
+      );
+    }
+    return '';
+  };
 
   switch (error) {
     case 'max-validation':
-      alertType = 'error';
       header = t('we-couldnt-check-you-in');
-      messageText = t(
-        'were-sorry-we-couldnt-match-your-information-please-ask-for-help',
-      );
+      alerts = [
+        {
+          alertType: 'error',
+          messageText: t(
+            'were-sorry-we-couldnt-match-your-information-please-ask-for-help',
+          ),
+        },
+      ];
       break;
     case 'uuid-not-found':
       // Shown when POST sessions returns 404.
-      alertType = 'info';
       header = t('were-sorry-this-link-has-expired');
-      messageText = (
-        <Trans
-          i18nKey="trying-to-check-in-for-an-appointment--info-message"
-          components={[
-            <span key="bold" className="vads-u-font-weight--bold" />,
-            <va-telephone
-              key={phoneNumbers.textCheckIn}
-              data-testid="error-message-sms"
-              contact={phoneNumbers.textCheckIn}
-              sms
-            />,
-          ]}
-        />
-      );
+      alerts = [
+        {
+          type: 'info',
+          message: (
+            <Trans
+              i18nKey="trying-to-check-in-for-an-appointment--info-message"
+              components={[
+                <span key="bold" className="vads-u-font-weight--bold" />,
+                <va-telephone
+                  key={phoneNumbers.textCheckIn}
+                  data-testid="error-message-sms"
+                  contact={phoneNumbers.textCheckIn}
+                  sms
+                />,
+              ]}
+            />
+          ),
+        },
+      ];
+      break;
+    case 'check-in-post-error':
+    case 'error-completing-check-in':
+      header = t('we-couldnt-check-you-in');
+      alerts = [
+        {
+          type: 'warning',
+          message: t(
+            'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
+          ),
+        },
+        {
+          type: 'warning',
+          message: getTravelMessage(),
+        },
+      ];
       break;
     default:
-      alertType = 'info';
       header = t('we-couldnt-check-you-in');
-      messageText = t(
-        'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
-      );
+      alerts = [
+        {
+          type: 'info',
+          message: t(
+            'were-sorry-something-went-wrong-on-our-end-check-in-with-a-staff-member',
+          ),
+        },
+      ];
   }
 
   return (
     <Wrapper pageTitle={header}>
-      <va-alert
-        background-only
-        show-icon
-        status={alertType}
-        data-testid="error-message"
-      >
-        <div>{messageText}</div>
-      </va-alert>
+      {alerts.map((alert, index) => (
+        <div key={`alert-${index}`}>
+          <va-alert
+            background-only
+            show-icon
+            status={alert.type}
+            data-testid={`error-message-${index}`}
+            class={index !== 0 ? 'vads-u-margin-top--2' : ''}
+          >
+            <div>{alert.message}</div>
+          </va-alert>
+        </div>
+      ))}
     </Wrapper>
   );
 };

--- a/src/applications/check-in/day-of/pages/tests/Error.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/Error.test.unit.spec.jsx
@@ -36,8 +36,8 @@ describe('check-in', () => {
           </I18nextProvider>
         </Provider>,
       );
-      expect(component.getByTestId('error-message')).to.exist;
-      expect(component.getByTestId('error-message')).to.have.text(
+      expect(component.getByTestId('error-message-0')).to.exist;
+      expect(component.getByTestId('error-message-0')).to.have.text(
         'We’re sorry. Something went wrong on our end. Check in with a staff member.',
       );
     });
@@ -64,8 +64,8 @@ describe('check-in', () => {
         </I18nextProvider>
       </Provider>,
     );
-    expect(component.getByTestId('error-message')).to.exist;
-    expect(component.getByTestId('error-message')).to.have.text(
+    expect(component.getByTestId('error-message-0')).to.exist;
+    expect(component.getByTestId('error-message-0')).to.have.text(
       'Trying to check in for an appointment? Text check in to .',
     );
     expect(component.getByTestId('error-message-sms')).to.exist;

--- a/src/applications/check-in/day-of/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Error.js
@@ -3,13 +3,9 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 const titles = {
   default: {
     en: 'We couldn’t check you in',
-    es: 'No pudimos completar el registro.',
-    tl: 'Hindi ka namin mai-check in',
   },
   uuidNotFound: {
     en: 'We’re sorry. This link has expired.',
-    es: '',
-    tl: '',
   },
 };
 
@@ -17,57 +13,88 @@ const errorMessages = {
   default: {
     en:
       'We’re sorry. Something went wrong on our end. Check in with a staff member.',
-    es:
-      'Lo sentimos. Algo no funcionó de nuestra parte. Regístrese con un miembro del personal.',
-    tl:
-      'Paumanhin. May nangyaring mali sa aming panig. Mag-check in sa isang staff member.',
   },
   maxValidation: {
     en:
       'We’re sorry. We couldn’t match your information to our records. Please ask a staff member for help.',
-    es:
-      'Lo sentimos. No encontramos información en nuestros archivos que corresponda a esta información. Pídale asistencia a un miembro del personal.',
-    tl:
-      'Paumanhin. Hindi namin maitugma ang iyong impormasyon sa aming mga rekord. Mangyaring humingi ng tulong sa isang staff member.',
   },
   uuidNotFound: {
     en: 'Trying to check in for an appointment? Text check in to .',
-    es: '',
-    tl: '',
   },
-  checkInPostError: {
-    en: '',
+  checkInFailedCantFile: {
+    en:
+      'We’re sorry. We can’t file this type of travel reimbursement claim for you now. But you can still file within 30 days of the appointment.Find out how to file for travel reimbursement',
+  },
+  checkInFailedFindOut: {
+    en:
+      'VA travel pay reimbursement pays eligible Veterans and caregivers back for mileage and other travel expenses to and from approved health care appointments.Find out if you’re eligible and how to file for travel reimbursement',
+  },
+  checkInFailedFileLater: {
+    en:
+      'We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within 30 days of the appointment.Find out how to file for travel reimbursement',
   },
 };
 class Error {
   validatePageLoaded = (errorType = false, language = 'en') => {
-    let messageText = '';
-    let titleText = '';
     switch (errorType) {
       case 'max-validation':
-        titleText = titles.default[language];
-        messageText = errorMessages.maxValidation[language];
+        cy.get('h1', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', titles.default[language]);
+        cy.get('[data-testid="error-message-0"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.maxValidation[language]);
         break;
       case 'uuid-not-found':
-        titleText = titles.uuidNotFound[language];
-        messageText = errorMessages.uuidNotFound[language];
+        cy.get('h1', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', titles.uuidNotFound[language]);
+        cy.get('[data-testid="error-message-0"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.uuidNotFound[language]);
         break;
-      case 'check-in-post-error':
-      case 'error-completing-check-in':
-        titleText = titles.default[language];
-        messageText = errorMessages.uuidNotFound[language];
+      case 'check-in-failed-find-out':
+        cy.get('h1', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', titles.default[language]);
+        cy.get('[data-testid="error-message-0"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.default[language]);
+        cy.get('[data-testid="error-message-1"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.checkInFailedFindOut[language]);
+        break;
+      case 'check-in-failed-cant-file':
+        cy.get('h1', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', titles.default[language]);
+        cy.get('[data-testid="error-message-0"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.default[language]);
+        cy.get('[data-testid="error-message-1"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.checkInFailedCantFile[language]);
+        break;
+      case 'check-in-failed-file-later':
+        cy.get('h1', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', titles.default[language]);
+        cy.get('[data-testid="error-message-0"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.default[language]);
+        cy.get('[data-testid="error-message-1"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.checkInFailedFileLater[language]);
         break;
       default:
-        titleText = titles.default[language];
-        messageText = errorMessages.default[language];
+        cy.get('h1', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', titles.default[language]);
+        cy.get('[data-testid="error-message-0"]', { timeout: Timeouts.slow })
+          .should('be.visible')
+          .and('have.text', errorMessages.default[language]);
         break;
     }
-    cy.get('h1', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('have.text', titleText);
-    cy.get('[data-testid="error-message"]', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('have.text', messageText);
   };
 
   validateDatePreCheckInDateShows = () => {

--- a/src/applications/check-in/day-of/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Error.js
@@ -35,6 +35,9 @@ const errorMessages = {
     es: '',
     tl: '',
   },
+  checkInPostError: {
+    en: '',
+  },
 };
 class Error {
   validatePageLoaded = (errorType = false, language = 'en') => {
@@ -47,6 +50,11 @@ class Error {
         break;
       case 'uuid-not-found':
         titleText = titles.uuidNotFound[language];
+        messageText = errorMessages.uuidNotFound[language];
+        break;
+      case 'check-in-post-error':
+      case 'error-completing-check-in':
+        titleText = titles.default[language];
         messageText = errorMessages.uuidNotFound[language];
         break;
       default:

--- a/src/applications/check-in/day-of/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Error.js
@@ -3,6 +3,8 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 const titles = {
   default: {
     en: 'We couldn’t check you in',
+    es: 'No pudimos completar el registro.',
+    tl: 'Hindi ka namin mai-check in',
   },
   uuidNotFound: {
     en: 'We’re sorry. This link has expired.',
@@ -13,10 +15,18 @@ const errorMessages = {
   default: {
     en:
       'We’re sorry. Something went wrong on our end. Check in with a staff member.',
+    es:
+      'Lo sentimos. Algo no funcionó de nuestra parte. Regístrese con un miembro del personal.',
+    tl:
+      'Paumanhin. May nangyaring mali sa aming panig. Mag-check in sa isang staff member.',
   },
   maxValidation: {
     en:
       'We’re sorry. We couldn’t match your information to our records. Please ask a staff member for help.',
+    es:
+      'Lo sentimos. No encontramos información en nuestros archivos que corresponda a esta información. Pídale asistencia a un miembro del personal.',
+    tl:
+      'Paumanhin. Hindi namin maitugma ang iyong impormasyon sa aming mga rekord. Mangyaring humingi ng tulong sa isang staff member.',
   },
   uuidNotFound: {
     en: 'Trying to check in for an appointment? Text check in to .',

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec.js
@@ -1,0 +1,67 @@
+import '../../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
+import Demographics from '../../../../tests/e2e/pages/Demographics';
+import NextOfKin from '../../../../tests/e2e/pages/NextOfKin';
+import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
+import TravelPages from '../../../../tests/e2e/pages/TravelPages';
+import Appointments from '../pages/Appointments';
+import Error from '../pages/Error';
+
+describe('Check In Experience', () => {
+  describe('travel pay path', () => {
+    beforeEach(() => {
+      const appointments = [{ startTime: '2021-08-19T03:00:00' }];
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializeCheckInDataGet,
+        initializeCheckInDataPost,
+        initializeDemographicsPatch,
+      } = ApiInitializer;
+      initializeFeatureToggle.withTravelPay();
+      initializeSessionGet.withSuccessfulNewSession();
+      initializeSessionPost.withSuccess();
+      initializeDemographicsPatch.withSuccess();
+      initializeCheckInDataGet.withSuccess({
+        appointments,
+      });
+      initializeCheckInDataPost.withFailure(200);
+      cy.visitWithUUID();
+      ValidateVeteran.validatePage.dayOf();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Demographics.validatePageLoaded();
+      Demographics.attemptToGoToNextPage();
+      EmergencyContact.validatePageLoaded();
+      EmergencyContact.attemptToGoToNextPage();
+      NextOfKin.validatePageLoaded(
+        'Is this your current next of kin information?',
+      );
+      NextOfKin.attemptToGoToNextPage();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('shows the correct error message for generic api error.', () => {
+      TravelPages.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('vehicle');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+      Appointments.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      Appointments.attemptCheckIn(1);
+      Error.validatePageLoaded('check-in-post-error');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Day-of-check-in--travel-pay--check-in-error--no-vehicle',
+      );
+    });
+  });
+});

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec.js
@@ -47,7 +47,20 @@ describe('Check In Experience', () => {
         window.sessionStorage.clear();
       });
     });
-    it('shows the correct error message for generic api error.', () => {
+    it('shows the correct error message for check in failed no to travel claim', () => {
+      TravelPages.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+      Appointments.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      Appointments.attemptCheckIn(1);
+      Error.validatePageLoaded('check-in-failed-find-out');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Day-of-check-in--travel-pay--check-in-error--no-travel',
+      );
+    });
+    it('shows the correct error message for check in failed no to travel vehicle', () => {
       TravelPages.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       TravelPages.attemptToGoToNextPage();
@@ -57,11 +70,72 @@ describe('Check In Experience', () => {
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       Appointments.attemptCheckIn(1);
-      Error.validatePageLoaded('check-in-post-error');
+      Error.validatePageLoaded('check-in-failed-cant-file');
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots(
         'Day-of-check-in--travel-pay--check-in-error--no-vehicle',
       );
+    });
+    it('shows the correct error message for check in failed no to travel address', () => {
+      TravelPages.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('vehicle');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('address');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+      Appointments.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      Appointments.attemptCheckIn(1);
+      Error.validatePageLoaded('check-in-failed-cant-file');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Day-of-check-in--travel-pay--check-in-error--no-address',
+      );
+    });
+    it('shows the correct error message for check in failed no to travel mileage', () => {
+      TravelPages.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('vehicle');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('address');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('mileage');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+      Appointments.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      Appointments.attemptCheckIn(1);
+      Error.validatePageLoaded('check-in-failed-cant-file');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Day-of-check-in--travel-pay--check-in-error--no-mileage',
+      );
+    });
+    it('shows the correct error message for check in failed yes to all travel', () => {
+      TravelPages.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('vehicle');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('address');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded('mileage');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage();
+      Appointments.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      Appointments.attemptCheckIn(1);
+      Error.validatePageLoaded('check-in-failed-file-later');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Day-of-check-in--travel-pay--check-in-error');
     });
   });
 });

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -222,5 +222,6 @@
   "directions-to-location": "Directions to {{ location }}",
   "directions": "Directions",
   "were-sorry-this-link-has-expired": "We’re sorry. This link has expired.",
-  "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>."
+  "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>.",
+  "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment."
 }


### PR DESCRIPTION
## Summary

- Adds three different error scenarios and messages for travel pay when check in fails.

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#54280](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54280)


## Testing done

- Visual 
- Cypress

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._


### No Travel
![Day-of-check-in--travel-pay--check-in-error--no-travel](https://user-images.githubusercontent.com/2982977/223171335-b312381b-ce55-4cb9-abf5-2b95e88c1d1c.png)
### No to vehicle, Address, or mileage
![Day-of-check-in--travel-pay--check-in-error--no-vehicle](https://user-images.githubusercontent.com/2982977/223171377-f919c3ed-53a3-4516-b3f7-62702b6f0a06.png)
### Yes to all
![Day-of-check-in--travel-pay--check-in-error](https://user-images.githubusercontent.com/2982977/223183512-513d6ad9-700f-4a75-935a-3cb21249c503.png)

## What areas of the site does it impact?
Travel Pay Day of Check-in

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

