### PR TITLE
fix: increase CI timeout-minutes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -534,7 +534,7 @@ jobs:
   stress-test-cypress-tests:
     name: Stress Test Cypress Tests
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: [build, cypress-tests-prep]
     if: |
       needs.build.result == 'success' &&
@@ -602,7 +602,7 @@ jobs:
       - name: Run Cypress tests
         if: needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'
         run: node script/github-actions/run-cypress-tests.js
-        timeout-minutes: 40
+        timeout-minutes: 90
         env:
           CYPRESS_CI: true
           STEP: ${{ matrix.ci_node_index }}


### PR DESCRIPTION
## Summary
- Increases timeout on E2E Stress Test Workflow for CI
- I was having timeout issues because I had changed 18 tests, and since the Stress Test runs each set of tests 25x, the 40 minute timeout was getting reached.

## Related issue(s)
Support thread since this is a hotfix issue
https://dsva.slack.com/archives/CBU0KDSB1/p1678120587261509
