### PR TITLE
fix to read appt details on details link

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestAppointmentLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestAppointmentLayout.jsx
@@ -88,10 +88,11 @@ export default function RequestAppointmentLayout({ appointment }) {
               className="vaos-hide-for-print"
               padding="0"
               size="1"
+              aria-label={detailAriaLabel}
             >
               <va-link
                 className="vaos-appts__focus--hide-outline"
-                aria-label={detailAriaLabel}
+                aria-describedby="vaos-appts__detail"
                 href={link}
                 onClick={e => e.preventDefault()}
                 text="Details"


### PR DESCRIPTION
## Summary
This PR fixes the issue of VoiceOver not reading the appointment information when tabbing to the details link. See ticket for how to reproduce.


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#54098


## Testing done
VoiceOver testing


## Screenshots

https://user-images.githubusercontent.com/3587066/223194270-8fc3a9cc-32c3-4a43-975e-b163903f1620.mov



## What areas of the site does it impact?


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
