### PR TITLE
Mhv landing page/bug/mobile menu header link

### DIFF
--- a/src/platform/site-wide/mega-menu/constants/MY_HEALTH_LINK.js
+++ b/src/platform/site-wide/mega-menu/constants/MY_HEALTH_LINK.js
@@ -1,4 +1,4 @@
 export default {
   href: '/my-health/',
-  title: 'My Health',
+  title: 'My HealtheVet',
 };

--- a/src/platform/site-wide/user-nav/components/MyHealthLink.jsx
+++ b/src/platform/site-wide/user-nav/components/MyHealthLink.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { isLandingPageEnabledForUser } from 'applications/mhv/landing-page/utilities/feature-toggles';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
+import MY_HEALTH_LINK from 'platform/site-wide/mega-menu/constants/MY_HEALTH_LINK';
+
+const MyHealthLink = ({ isSSOe, onClick }) => {
+  const { featureToggles, user } = useSelector(state => state);
+  const newLandingPageEnabled = isLandingPageEnabledForUser(
+    featureToggles,
+    user?.profile?.signIn?.serviceName,
+  );
+  if (newLandingPageEnabled) {
+    return (
+      <li>
+        <a href={MY_HEALTH_LINK.href}>{MY_HEALTH_LINK.title}</a>
+      </li>
+    );
+  }
+  return (
+    <li>
+      <a href={mhvUrl(isSSOe, 'home')} onClick={onClick}>
+        My Health
+      </a>
+    </li>
+  );
+};
+
+export default MyHealthLink;

--- a/src/platform/site-wide/user-nav/components/MyHealthLink.jsx
+++ b/src/platform/site-wide/user-nav/components/MyHealthLink.jsx
@@ -13,13 +13,19 @@ const MyHealthLink = ({ isSSOe, onClick }) => {
   if (newLandingPageEnabled) {
     return (
       <li>
-        <a href={MY_HEALTH_LINK.href}>{MY_HEALTH_LINK.title}</a>
+        <a className="my-health-link" href={MY_HEALTH_LINK.href}>
+          {MY_HEALTH_LINK.title}
+        </a>
       </li>
     );
   }
   return (
     <li>
-      <a href={mhvUrl(isSSOe, 'home')} onClick={onClick}>
+      <a
+        className="my-health-link"
+        href={mhvUrl(isSSOe, 'home')}
+        onClick={onClick}
+      >
         My Health
       </a>
     </li>

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -8,8 +8,9 @@ import {
 } from 'platform/user/authentication/selectors';
 import { logoutUrl } from 'platform/user/authentication/utilities';
 import { logoutUrlSiS, logoutEvent } from 'platform/utilities/oauth/utilities';
-import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import recordEvent from 'platform/monitoring/record-event';
+
+import MyHealthLink from './MyHealthLink';
 
 const recordNavUserEvent = section => () => {
   recordEvent({ event: 'nav-user', 'nav-user-section': section });
@@ -41,11 +42,7 @@ export function PersonalizationDropdown(props) {
           My VA
         </a>
       </li>
-      <li>
-        <a href={mhvUrl(isSSOe, 'home')} onClick={recordMyHealthEvent}>
-          My Health
-        </a>
-      </li>
+      <MyHealthLink onClick={recordMyHealthEvent} isSSOe={isSSOe} />
       <li>
         <a href="/profile" onClick={recordProfileEvent}>
           Profile

--- a/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
 
 import { logoutUrl } from 'platform/user/authentication/utilities';
 import { logoutUrlSiS } from 'platform/utilities/oauth/utilities';
@@ -40,7 +43,18 @@ describe('<PersonalizationDropdown>', () => {
   });
 
   it('should report analytics when clicking My Health', () => {
-    const wrapper = shallow(<PersonalizationDropdown />);
+    const middleware = [];
+    const mockStore = configureStore(middleware);
+    const initState = {
+      featureToggles: {},
+      user: {},
+    };
+    const store = mockStore(initState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <PersonalizationDropdown />
+      </Provider>,
+    );
     wrapper
       .find('a')
       .at(1)
@@ -55,7 +69,7 @@ describe('<PersonalizationDropdown>', () => {
     const wrapper = shallow(<PersonalizationDropdown />);
     wrapper
       .find('a')
-      .at(2)
+      .at(1)
       .simulate('click');
     const recordedEvent = global.window.dataLayer[0];
     expect(recordedEvent.event).to.equal('nav-user');
@@ -65,7 +79,7 @@ describe('<PersonalizationDropdown>', () => {
 
   it('should use the logoutUrl if using SSOe', () => {
     const wrapper = shallow(<PersonalizationDropdown isSSOe />);
-    const signoutLink = wrapper.find('a').at(3);
+    const signoutLink = wrapper.find('a').at(2);
     const expectedUrl = logoutUrl();
     expect(signoutLink.prop('href')).to.equal(expectedUrl);
     wrapper.unmount();
@@ -73,7 +87,7 @@ describe('<PersonalizationDropdown>', () => {
 
   it('should use the logoutUrlSiS if using OAuth', () => {
     const wrapper = shallow(<PersonalizationDropdown />);
-    const signoutLink = wrapper.find('a').at(3);
+    const signoutLink = wrapper.find('a').at(2);
     const expectedUrl = logoutUrlSiS();
     expect(signoutLink.prop('href')).to.equal(expectedUrl);
     wrapper.unmount();

--- a/src/platform/site-wide/user-nav/tests/e2e/my-health-link/megu-menu.my-health.cypress.spec.js
+++ b/src/platform/site-wide/user-nav/tests/e2e/my-health-link/megu-menu.my-health.cypress.spec.js
@@ -1,0 +1,35 @@
+import { CSP_IDS } from '@department-of-veterans-affairs/platform-user/authentication/constants';
+import manifest from 'applications/mhv/landing-page/manifest.json';
+
+import ApiInitializer from 'applications/mhv/landing-page/tests/utilities/ApiInitializer';
+import LandingPage from 'applications/mhv/landing-page/tests/pages/LandingPage';
+
+describe(manifest.appName, () => {
+  it('shows the new link when enabled', () => {
+    ApiInitializer.initializeFeatureToggle.withCurrentFeatures();
+    ApiInitializer.initializeUserData.withDefaultUser();
+    LandingPage.visitPage({ serviceProvider: CSP_IDS.ID_ME });
+    cy.injectAxeThenAxeCheck();
+    cy.get('[data-e2e-id="my-health-4"]')
+      .should('be.visible')
+      .and('have.text', 'My Health');
+    cy.get('[data-e2e-id="my-health-4"]').should(
+      'have.attr',
+      'href',
+      '/my-health/',
+    );
+  });
+  it('shows the old link when disabled', () => {
+    ApiInitializer.initializeFeatureToggle.withAppDisabled();
+    ApiInitializer.initializeUserData.withDefaultUser();
+    cy.login();
+    cy.visit('/');
+    cy.injectAxeThenAxeCheck();
+    cy.get('[data-e2e-id="my-health-4"]')
+      .should('be.visible')
+      .and('have.text', 'My Health');
+    cy.get('[data-e2e-id="my-health-4"]')
+      .should('have.attr', 'href')
+      .and('include', 'mhv-portal-web/eauth');
+  });
+});

--- a/src/platform/site-wide/user-nav/tests/e2e/my-health-link/user-nav.my-health.cypress.spec.js
+++ b/src/platform/site-wide/user-nav/tests/e2e/my-health-link/user-nav.my-health.cypress.spec.js
@@ -10,14 +10,8 @@ describe(manifest.appName, () => {
     ApiInitializer.initializeUserData.withDefaultUser();
     LandingPage.visitPage({ serviceProvider: CSP_IDS.ID_ME });
     cy.injectAxeThenAxeCheck();
-    cy.get('[data-e2e-id="my-health-4"]')
-      .should('be.visible')
-      .and('have.text', 'My Health');
-    cy.get('[data-e2e-id="my-health-4"]').should(
-      'have.attr',
-      'href',
-      '/my-health/',
-    );
+    cy.viewportPreset('va-top-mobile-1');
+    cy.get('.my-health-link').should('have.attr', 'href', '/my-health/');
   });
   it('shows the old link when disabled', () => {
     ApiInitializer.initializeFeatureToggle.withAppDisabled();
@@ -25,11 +19,9 @@ describe(manifest.appName, () => {
     cy.login();
     cy.visit('/');
     cy.injectAxeThenAxeCheck();
-    cy.get('[data-e2e-id="my-health-4"]')
-      .should('be.visible')
-      .and('have.text', 'My Health');
-    cy.get('[data-e2e-id="my-health-4"]')
+    cy.viewportPreset('va-top-mobile-1');
+    cy.get('.my-health-link')
       .should('have.attr', 'href')
-      .and('include', 'mhv-portal-web/eauth');
+      .and('include', 'mhv-portal');
   });
 });


### PR DESCRIPTION
## Summary

- Update the mobile drop down nav menu to use the new toggle logic

### Old Behavior 
The `My Health` Link in the mobile drop down always linked to MHV

### New Behavior
The `My Health` Link in the mobile drop down should conditionally link to the new `/my-health` page. 

<img width="419" alt="image (1)" src="https://user-images.githubusercontent.com/1793923/224416140-e510eb6d-d6fc-4d5d-adf1-6908a8226be1.png">


## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-top-level-view-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/54025

## Testing done
- Added a cypress test

## Things I looked for

- This should reuse the same logic that is being used for the main navigation. 

## For testing

The toggle is enabled for all staging user, so any staging user shoudl see the new link. The link in both places (nav bar and drop down) should be the same. 

As `vets.gov.user+2@gmail.com` I should see the `My Health` link in the the desktop link to `/my-health/`
As `vets.gov.user+2@gmail.com` I should see the `My Health` link in the the mobile drop down link to `/my-health/`


