### PR TITLE
SM to VA.gov: MHV-39024 message body styling

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
@@ -38,7 +38,7 @@ const FolderHeader = props => {
         text = Folders.DELETED.desc;
         break;
       default:
-        text = ``;
+        text = `This is a folder you created. You can add conversations to this folder by moving them from your inbox or other folders.`;
         break;
     }
     return (

--- a/src/applications/mhv/secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/SearchForm.jsx
@@ -107,6 +107,7 @@ const SearchForm = props => {
     return (
       <label
         htmlFor="search-message-folder-input"
+        data-testid="search-message-folder-input-label"
         className={
           resultsCount === undefined
             ? 'keyword-search-label'

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -29,7 +29,7 @@
     }
     .message-list-body-expanded {
       white-space: pre-line;
-      word-break: break-all;
+      word-break: break-word;
     }
 
     .attachment {

--- a/src/applications/mhv/secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
@@ -40,10 +40,6 @@ describe('FolderHeader component in Inbox', () => {
     ).to.exist;
   });
 
-  it('must display valid folder description', () => {
-    const screen = setup(folders.inbox);
-    expect(screen.getByText(Folder.INBOX.desc)).to.exist;
-  });
   it('must display Compose message link', () => {
     const screen = setup(folders.inbox);
     expect(screen.getByText('Start a new message')).to.exist;

--- a/src/applications/mhv/secure-messaging/tests/containers/FolderListView.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/FolderListView.unit.spec.jsx
@@ -29,7 +29,7 @@ describe('FolderListView', () => {
 
   it('renders without errors', () => {
     const screen = setup();
-    expect(screen.getByText('Messages', { exact: true })).to.exist;
+    expect(screen.getByText('Inbox', { exact: true, selector: 'h1' })).to.exist;
   });
 
   it('displays loading indicator when messages are not yet loaded', () => {
@@ -51,15 +51,12 @@ describe('FolderListView', () => {
 
   it('displays the name of folder to be searched', async () => {
     const screen = setup();
-    const folderStatementStart = await screen.getByText('Search your', {
-      exact: false,
-    });
-    const folderName = await screen.getByText(folder.name);
-    const folderStatementEnd = await screen.getByText('messages folder', {
-      exact: false,
-    });
-    expect(folderStatementStart).to.exist;
-    expect(folderName).to.exist;
-    expect(folderStatementEnd).to.exist;
+    const folderStatementStart = await screen.getByTestId(
+      'search-message-folder-input-label',
+    );
+
+    expect(folderStatementStart.textContent).to.contain(
+      `Search your ${folder.name} messages folder`,
+    );
   });
 });

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-navigate-away-from-compose-message-modal.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-navigate-away-from-compose-message-modal.cypress.spec.js
@@ -22,7 +22,7 @@ describe('Secure Messaging Navigate Away From Compose Message', () => {
 
     composePage.selectSideBarMenuOption('Inbox');
     composePage.clickOnDeleteDraftButton();
-    composePage.verifyExpectedPageOpened('Messages');
+    composePage.verifyExpectedPageOpened('Inbox');
     cy.get('[data-testid="compose-message-link"]').should('be.visible');
   });
 

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -4,21 +4,19 @@ export const draftAutoSaveTimeout = 5000;
 export const DefaultFolders = {
   INBOX: {
     id: 0,
-    header: 'Messages',
-    desc:
-      'When you send a message to your care team, it can take up to 3 business days to get a response.',
+    header: 'Inbox',
+    desc: '',
   },
   SENT: {
     id: -1,
     header: 'Sent messages',
-    desc:
-      'When you send a message to your care team, it can take up to 3 business days to get a response.',
+    desc: '',
   },
   DRAFTS: { id: -2, header: 'Drafts', desc: '' },
   DELETED: {
     id: -3,
     header: 'Trash',
-    desc: `Here are the messages you deleted from other folders. You can't permanently delete messages.`,
+    desc: `These are the messages you moved to the trash from your inbox or folders. We won't permanently delete any messages.`,
   },
 };
 


### PR DESCRIPTION
## Summary

- proper word-break for main message body span
- Replacing 'Messages' with 'Inbox' on folder header. updating folder descriptions beneath headers

## Testing done

- Prior to the change, message body would break in a middle of a word, instead of carrying over entire word
- System folders would have description that now is moved to interstitial page and patient safety banners. Keeping description for Trash folder and all custom folders

## What areas of the site does it impact?
My Health - Secure Messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
