### PR TITLE
MHV-42348 - Announce "load more messages" to screen readers

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import PropType from 'prop-types';
 import HorizontalRule from '../shared/HorizontalRule';
@@ -22,6 +22,26 @@ const MessageThread = props => {
   const handleLoadMoreMessages = () => {
     setViewCount(viewCount + 5);
   };
+
+  const handleKeyPress = e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      // prevent from scrolling to the footer
+      e.preventDefault();
+      handleLoadMoreMessages();
+    }
+  };
+
+  // value for screen readers to indicate how many messages are being loaded
+  const messagesLoaded = useMemo(
+    () => {
+      if (messageHistory?.length)
+        return messageHistory?.length > viewCount
+          ? 5
+          : messageHistory.length - viewCount + 5;
+      return null;
+    },
+    [viewCount, messageHistory],
+  );
 
   return (
     <>
@@ -47,12 +67,27 @@ const MessageThread = props => {
 
             {viewCount < messageHistory?.length && (
               <div className="vads-u-margin-top--1 vads-l-row vads-u-justify-content--flex-start">
-                <va-link
-                  secondary
-                  text="+ 5 more messages"
+                {/* Per design decision it was determined to use a link instead of a button */}
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                <a
+                  aria-label="Load 5 more messages"
+                  role="button"
+                  tabIndex="0"
+                  onKeyPress={handleKeyPress}
                   onClick={handleLoadMoreMessages}
-                />
+                >
+                  + 5 more messages
+                </a>
               </div>
+            )}
+            {viewCount > 6 && (
+              <div
+                // announce to screen readers that more messages have been loaded
+                aria-live="polite"
+                aria-label={`${messagesLoaded} more message${
+                  messagesLoaded > 1 ? 's are' : ' is'
+                } loaded. Press Tab to navigate to the next message`}
+              />
             )}
           </div>
         )}

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
@@ -84,6 +84,7 @@ const MessageThread = props => {
               <div
                 // announce to screen readers that more messages have been loaded
                 aria-live="polite"
+                role="alert"
                 aria-label={`${messagesLoaded} more message${
                   messagesLoaded > 1 ? 's are' : ' is'
                 } loaded. Press Tab to navigate to the next message`}

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -15,10 +15,12 @@ const MessageThreadBody = props => {
     >
       <>
         <span className="vads-u-margin-y--0">
-          {words?.map(word => {
+          {words?.map((word, i) => {
             return (word.match(urlRegex) || word.match(httpRegex)) &&
               words.length >= 1 ? (
-              <a href={word} target="_blank" rel="noreferrer">{`${word} `}</a>
+              <a key={i} href={word} target="_blank" rel="noreferrer">
+                {`${word} `}
+              </a>
             ) : (
               `${word} `
             );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- adding aria-live to announce loading more messages actions to screen readers

## Related issue(s)
- [SM to VA.gov: MUST - Update 'load more messages' to include announcement for accessibility](https://vajira.max.gov/browse/MHV-42348)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/51913


## Testing done

- Before this change, non-sighted user would not receive a feedback from screen reader if more messages were loaded on the screen on button click


## Screenshots
<img src="https://user-images.githubusercontent.com/87077843/224066722-7051327f-070b-43df-8581-8ac526eae7d8.png" width=350px />
<img src="https://user-images.githubusercontent.com/87077843/224066760-3242f762-84fd-4003-8abc-67589bca14ad.png" width=350px />
<img src="https://user-images.githubusercontent.com/87077843/224066783-c9535ccb-1b91-4962-a7f7-49de1312ca08.png" width=350px />



## What areas of the site does it impact?
My Health - Secure Messaging - Thread Preview

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

