### PR TITLE
Update ApplicationInProgress component to use va-link component

### DIFF
--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import { recordDashboardClick } from '~/applications/personalization/dashboard/helpers';
 
-import CTALink from '../CTALink';
 import DashboardWidgetWrapper from '../DashboardWidgetWrapper';
 
 /**
@@ -59,12 +58,11 @@ const ApplicationInProgress = ({
               </div>
             </div>
           </div>
-          <CTALink
-            ariaLabel={`Continue your ${formTitle}`}
+          <va-link
+            active
             text="Continue your application"
             href={continueUrl}
             onClick={recordDashboardClick(formId, 'continue-button')}
-            showArrow
           />
         </div>
       </div>

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.unit.spec.jsx
@@ -41,8 +41,13 @@ describe('ApplicationInProgress component', () => {
         .to.exist;
     });
     it('renders the correct "continue" button', () => {
-      const continueButton = view.getByRole('link', { name: /continue/i });
-      expect(continueButton).to.have.attr('href', props.continueUrl);
+      const continueLink = view.container.querySelector('va-link');
+      expect(continueLink).to.exist;
+      expect(continueLink.getAttribute('text')).to.eql(
+        'Continue your application',
+      );
+      expect(continueLink.getAttribute('href')).to.eql(props.continueUrl);
+      expect(continueLink.getAttribute('active')).to.exist;
     });
   });
 });


### PR DESCRIPTION
## Summary

As part of the 2022 My VA Audit, we're making many UX improvements. After QA, we discovered that when the user has Applications in progress they see the draft application card. The link to "continue your application" should be the active link style as found in the design system.

This PR updates the `ApplicationsInProgress` component to use the design system's `va-link` component instead of the custom `CTALink` component.

## Related issue(s)
- Ticket: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/54394](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54394)
- Epic: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934)

## Screenshots

| Before | After |
| --- | --- |
| ![benefits-application-before](https://user-images.githubusercontent.com/534756/224368238-05799a41-eddb-4c70-9fff-1eb2f87c10fb.png)| ![benefits-application-after](https://user-images.githubusercontent.com/534756/224369212-68354cd3-3bf5-4b9d-b646-c0cc9f172805.png) |

- Visual 
- Local with mock data
- All unit and e2e tests pass

## What areas of the site does it impact?
MyVA

## Acceptance criteria

- [x] "Continue your application" link should be active link style
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
