### PR TITLE
Mbms 38319 bug/which category is required

### DIFF
--- a/src/applications/pre-need/tests/config/sponsorInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorInfo.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('Pre-need sponsor information', () => {
 
     form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error').length).to.equal(8);
+    expect(form.find('.usa-input-error').length).to.equal(7);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });

--- a/src/applications/pre-need/tests/config/veteranInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/veteranInfo.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('Pre-need veteran information', () => {
 
     form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error').length).to.equal(4);
+    expect(form.find('.usa-input-error').length).to.equal(3);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -353,7 +353,6 @@ export const veteranUI = {
     isWhite: {
       'ui:title': 'White',
     },
-    'ui:required': () => !environment.isProduction(),
     'ui:validations': [
       (errors, fields) => {
         if (

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -354,22 +354,7 @@ export const veteranUI = {
       'ui:title': 'White',
     },
     'ui:validations': [
-      (errors, fields) => {
-        if (
-          !environment.isProduction() &&
-          !(
-            fields.isSpanishHispanicLatino ||
-            fields.isAmericanIndianOrAlaskanNative ||
-            fields.isBlackOrAfricanAmerican ||
-            fields.isNativeHawaiianOrOtherPacificIslander ||
-            fields.notSpanishHispanicLatino ||
-            fields.isAsian ||
-            fields.isWhite
-          )
-        ) {
-          errors.addError('Choose at least one category');
-        }
-      },
+      /* (errors, fields) => {} */
     ],
     'ui:options': {
       showFieldLabel: true,


### PR DESCRIPTION
## Summary

- When filling out the pre-need form, when you reach the category that best describes you in staging, it is required. This is inconsistent with production. The expectation is that this field would not be required. 

## Related Issue
[Jira Link](https://vajira.max.gov/browse/MBMS-38319)

## Steps to reproduce bug before it was fixed:

- Begin the application signed in or without signing in
- On the first screen you fill out the required fields for Step 1 of 6: Applicant Information.
- Select any of the following for "Relationship to service member.":
                - I am the service member/Veteran
                - Spouse or Surviving Spouse
                - Unmarried adult child
                - Other.
- Select Continue
                - Note: When "I am the service member/Veteran" is selected it brings you to the next screen, Step 1 or 6: Applicant Information, where it ask "Which categories best describe you? (You may check more than one)(*Required)". 
                - When "Spouse or Surviving Spouse, Unmarried adult child, or Other" is selected it brings you to the next screen, Step 2 of 7: Sponsor's Information, where it ask "Which categories best describe you? (You may check more than one)(*Required)".

## Screenshots

### Desktop
https://user-images.githubusercontent.com/122034971/224124450-5d4373c4-4d89-49a8-82a0-23230f5a0244.mov

### Mobile
https://user-images.githubusercontent.com/122034971/224124590-7edeef7c-859c-4d5e-a8be-f65d50ab7f0d.mov

