### PR TITLE
Updated aria-label for details link.

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
@@ -21,6 +21,10 @@ const AppointmentListItemVaos = props => {
   const pagesToShowDetails = ['details', 'complete', 'confirmation'];
   const showDetailsLink = pagesToShowDetails.includes(page) && goToDetails;
 
+  const typeOfCare = appointment.clinicStopCodeName
+    ? appointment.clinicStopCodeName
+    : t('VA-appointment');
+
   const infoBlockMessage = () => {
     if (appointment?.kind === 'phone') {
       return (
@@ -52,9 +56,7 @@ const AppointmentListItemVaos = props => {
           data-testid="appointment-type-and-provider"
           className="vads-u-font-weight--bold"
         >
-          {appointment.clinicStopCodeName
-            ? appointment.clinicStopCodeName
-            : t('VA-appointment')}
+          {typeOfCare}
           {appointment.doctorName
             ? ` ${t('with')} ${appointment.doctorName}`
             : ''}
@@ -88,8 +90,9 @@ const AppointmentListItemVaos = props => {
                 router.location.basename
               }/appointment-details/${getAppointmentId(appointment)}`}
               onClick={e => goToDetails(e, appointment)}
-              aria-label={t('click-to-see-details-for-your-time-appointment', {
+              aria-label={t('details-for-appointment', {
                 time: appointmentDateTime,
+                type: typeOfCare,
               })}
             >
               Details

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -218,7 +218,7 @@
   "reason-for-visit": "Reason for visit",
   "appointment-day": "{{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
   "back-to-appointments": "Back to appointments",
-  "details-for-appointment" : "Details for {{ type }} appointment at {{ time, time }}",
+  "details-for-appointment": "Details for {{ type }} appointment at {{ time, time }}",
   "directions-to-location": "Directions to {{ location }}",
   "directions": "Directions",
   "were-sorry-this-link-has-expired": "We’re sorry. This link has expired.",

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -218,7 +218,7 @@
   "reason-for-visit": "Reason for visit",
   "appointment-day": "{{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
   "back-to-appointments": "Back to appointments",
-  "click-to-see-details-for-your-time-appointment": "Click to see the details for your {{ time, time }} appointment",
+  "details-for-appointment" : "Details for {{ type }} appointment at {{ time, time }}",
   "directions-to-location": "Directions to {{ location }}",
   "directions": "Directions",
   "were-sorry-this-link-has-expired": "We’re sorry. This link has expired.",


### PR DESCRIPTION
## Summary

Updated aria-label for details link to be `Details for {{ type }} appointment at {{ time, time }}` where type is the type of care.

Rendered example: `Details for Mental health appointment at 5:11 p.m.` 
Previous rendered example: `Click to see the details for your 5:11 p.m. appointment`

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#54483


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

