### PR TITLE
Update Daily Product Scan example test apps

### DIFF
--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/service-member/01-yesHonorableDischarge.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/service-member/01-yesHonorableDischarge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { serviceMemberPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -8,29 +8,38 @@ const options = [
   { value: serviceMemberPathPageNames.noVaMemorandum, label: 'No' },
 ];
 
-const yesHonorableDischargeSM = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${serviceMemberPathPageNames.yesHonorableDischargeSM}-option`}
-    label={
-      <p>
-        Do you have a VA memorandum rating of
-        <strong> 20% or higher?</strong>
-      </p>
-    }
-    id={`${serviceMemberPathPageNames.yesHonorableDischargeSM}-option`}
-    options={options}
-    onValueChange={({ value }) =>
-      handleChangeAndPageSet(
-        setPageState,
-        value,
-        options,
-        'Do you have a VA memorandum rating of 20% or higher?',
-      )
-    }
-    value={{ value: state.selected }}
-    additionalFieldsetClass="vads-u-margin-top--0"
-  />
-);
+const yesHonorableDischargeSM = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
+    handleChangeAndPageSet(
+      setPageState,
+      value,
+      options,
+      'Do you have a VA memorandum rating of 20% or higher?',
+    );
+  };
+  return (
+    <VaRadio
+      id={serviceMemberPathPageNames.yesHonorableDischargeSM}
+      class="vads-u-margin-y--2"
+      label="Do you have a VA memorandum rating of 20% or higher?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="memorandum-rating"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
+  );
+};
 
 export default {
   name: serviceMemberPathPageNames.yesHonorableDischargeSM,

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/service-member/02-noVaMemorandum.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/service-member/02-noVaMemorandum.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { serviceMemberPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -8,29 +8,38 @@ const options = [
   { value: serviceMemberPathPageNames.noIDES, label: 'No' },
 ];
 
-const noVaMemorandum = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${serviceMemberPathPageNames.noVaMemorandum}-option`}
-    label={
-      <p>
-        Are you in the Integrated Disability Evaluation System (IDES){' '}
-        <strong>or</strong> going through the Physical Evaluation Board process?
-      </p>
-    }
-    id={`${serviceMemberPathPageNames.noVaMemorandum}-option`}
-    options={options}
-    onValueChange={({ value }) =>
-      handleChangeAndPageSet(
-        setPageState,
-        value,
-        options,
-        'Are you in the Integrated Disability Evaluation System (IDES)or going through Physical Evaluation Board process?',
-      )
-    }
-    value={{ value: state.selected }}
-    additionalFieldsetClass="vads-u-margin-top--0"
-  />
-);
+const noVaMemorandum = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
+    handleChangeAndPageSet(
+      setPageState,
+      value,
+      options,
+      'Are you in the Integrated Disability Evaluation System (IDES) or going through Physical Evaluation Board process?',
+    );
+  };
+  return (
+    <VaRadio
+      id={serviceMemberPathPageNames.noVaMemorandum}
+      class="vads-u-margin-y--2"
+      label="Are you in the Integrated Disability Evaluation System (IDES), or going through the Physical Evaluation Board process?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="ides-or-peb"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
+  );
+};
 
 export default {
   name: serviceMemberPathPageNames.noVaMemorandum,

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/service-member/isServiceMember.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/service-member/isServiceMember.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { serviceMemberPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -8,24 +8,38 @@ const options = [
   { value: serviceMemberPathPageNames.noHonorableDischargeSM, label: 'No' },
 ];
 
-const isServiceMember = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${serviceMemberPathPageNames.isServiceMember}-option`}
-    label="Do you expect to receive an honorable discharge?"
-    id={`${serviceMemberPathPageNames.isServiceMember}-option`}
-    options={options}
-    onValueChange={({ value }) =>
-      handleChangeAndPageSet(
-        setPageState,
-        value,
-        options,
-        'Do you expect to receive an honorable discharge?',
-      )
-    }
-    value={{ value: state.selected }}
-    additionalFieldsetClass="vads-u-margin-top--0"
-  />
-);
+const isServiceMember = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
+    handleChangeAndPageSet(
+      setPageState,
+      value,
+      options,
+      'Do you expect to receive an honorable discharge?',
+    );
+  };
+  return (
+    <VaRadio
+      id={serviceMemberPathPageNames.isServiceMember}
+      class="vads-u-margin-y--2"
+      label="Do you expect to receive an honorable discharge?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="honorable-discharge"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
+  );
+};
 
 export default {
   name: serviceMemberPathPageNames.isServiceMember,

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/start.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/start.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   startingPageName,
   veteranPathPageNames,
@@ -17,24 +17,37 @@ const options = [
   { value: otherPathPageNames.isOther, label: 'Neither of these' },
 ];
 
-const StartPage = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${startingPageName.start}-option`}
-    label="Which of these describes you?"
-    id={`${startingPageName.start}-option`}
-    options={options}
-    onValueChange={({ value }) =>
-      handleChangeAndPageSet(
-        setPageState,
-        value,
-        options,
-        'Which of these describes you?',
-      )
-    }
-    value={{ value: state.selected }}
-    additionalFieldsetClass="vads-u-margin-top--0"
-  />
-);
+const StartPage = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
+    handleChangeAndPageSet(
+      setPageState,
+      value,
+      options,
+      'Which of these describes you?',
+    );
+  };
+  return (
+    <VaRadio
+      class="vads-u-margin-y--2"
+      label="Which of these describes you?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="describes-you"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
+  );
+};
 
 export default {
   name: startingPageName.start,

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/veteran/01-yesHonorableDischarge.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/veteran/01-yesHonorableDischarge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { veteranPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -8,29 +8,38 @@ const options = [
   { value: veteranPathPageNames.noDisabilityRating, label: 'No' },
 ];
 
-const yesHonorableDischarge = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${veteranPathPageNames.yesHonorableDischarge}-option`}
-    label={
-      <p>
-        Do you have a service-connected disability rating of{' '}
-        <strong>10% or higher</strong>?
-      </p>
-    }
-    id={`${veteranPathPageNames.yesHonorableDischarge}-option`}
-    options={options}
-    onValueChange={({ value }) =>
-      handleChangeAndPageSet(
-        setPageState,
-        value,
-        options,
-        'Do you have a service-connected disability rating of 10% or higher',
-      )
-    }
-    value={{ value: state.selected }}
-    additionalFieldsetClass="vads-u-margin-top--0"
-  />
-);
+const yesHonorableDischarge = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
+    handleChangeAndPageSet(
+      setPageState,
+      value,
+      options,
+      'Do you have a service-connected disability rating of 10% or higher',
+    );
+  };
+  return (
+    <VaRadio
+      id={veteranPathPageNames.yesHonorableDischarge}
+      class="vads-u-margin-y--2"
+      label="Do you have a service-connected disability rating of 10% or higher?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="disability-rating"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
+  );
+};
 
 export default {
   name: veteranPathPageNames.yesHonorableDischarge,

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/veteran/isVeteran.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2a/wizard/pages/veteran/isVeteran.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { veteranPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -8,29 +8,38 @@ const options = [
   { value: veteranPathPageNames.noHonorableDischarge, label: 'No' },
 ];
 
-const isVeteran = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${veteranPathPageNames.isVeteran}-option`}
-    label={
-      <p>
-        Did you receive a discharge status <strong>other than</strong>{' '}
-        dishonorable?
-      </p>
-    }
-    id={`${veteranPathPageNames.isVeteran}-option`}
-    options={options}
-    onValueChange={({ value }) =>
-      handleChangeAndPageSet(
-        setPageState,
-        value,
-        options,
-        'Did you receive a discharge status other than  dishonorable?',
-      )
-    }
-    value={{ value: state.selected }}
-    additionalFieldsetClass="vads-u-margin-top--0"
-  />
-);
+const isVeteran = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
+    handleChangeAndPageSet(
+      setPageState,
+      value,
+      options,
+      'Did you receive a discharge status other than  dishonorable?',
+    );
+  };
+  return (
+    <VaRadio
+      id={veteranPathPageNames.isVeteran}
+      class="vads-u-margin-y--2"
+      label="Did you receive a discharge status other than dishonorable?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="discharge-status"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
+  );
+};
 
 export default {
   name: veteranPathPageNames.isVeteran,

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/BeginFormNow.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/BeginFormNow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
 import recordEvent from 'platform/monitoring/record-event';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -15,7 +16,8 @@ const options = [
 ];
 
 const BeginFormNow = ({ setPageState, state = {} }) => {
-  const handleValueChange = ({ value }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
     recordEvent({
       event: `howToWizard-formChange`,
       'form-field-type': 'form-radio-buttons',
@@ -26,14 +28,25 @@ const BeginFormNow = ({ setPageState, state = {} }) => {
     setPageState({ selected: value }, value);
   };
   return (
-    <RadioButtons
-      name="begin-form-now"
+    <VaRadio
+      id="beginFormNow"
+      class="vads-u-margin-y--2"
       label="Would you like to apply for career planning and guidance benefits now?"
-      options={options}
-      id="begin-form-now"
-      onValueChange={handleValueChange}
-      value={{ value: state.selected }}
-    />
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="begin-form-now"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
   );
 };
 

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/DischargeStatus.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/DischargeStatus.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
 import recordEvent from 'platform/monitoring/record-event';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -15,26 +16,38 @@ const options = [
 ];
 
 const DischargeStatus = ({ setPageState, state = {} }) => {
-  const handleValueChange = ({ value }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
     recordEvent({
       event: `howToWizard-formChange`,
       'form-field-type': 'form-radio-buttons',
       'form-field-label':
-        'Have you or your sponsor been discharged form active-duty service in the last year, or do you have less than 6 months until discharge?',
+        'Have you or your sponsor been discharged from active-duty service in the last year, or do you have less than 6 months until discharge?',
       'form-field-value': value,
     });
     setPageState({ selected: value }, value);
   };
 
   return (
-    <RadioButtons
-      name="discharge-status"
-      label="Have you or your sponsor been discharged form active-duty service in the last year, or do you have less than 6 months until discharge?"
-      options={options}
-      id="discharge-status"
-      onValueChange={handleValueChange}
-      value={{ value: state.selected }}
-    />
+    <VaRadio
+      id="dischargeStatus"
+      class="vads-u-margin-y--2"
+      label="Have you or your sponsor been discharged from active-duty service in the last year, or do you have less than 6 months until discharge?"
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="discharge-status"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
   );
 };
 

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/Start.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/Start.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
 import recordEvent from 'platform/monitoring/record-event';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
   {
     value: pageNames.isVeteran,
     label: 'Veteran',
+    page: 'VREBenefits',
   },
   {
     value: pageNames.isServiceMember,
     label: 'Service member',
+    page: 'VREBenefits',
   },
   {
     value: pageNames.VAEducationBenefits,
@@ -23,7 +26,8 @@ const options = [
 ];
 
 const StartPage = ({ setPageState, state = {} }) => {
-  const handleValueChange = ({ value }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
     recordEvent({
       event: `howToWizard-formChange`,
       'form-field-type': 'form-radio-buttons',
@@ -45,15 +49,25 @@ const StartPage = ({ setPageState, state = {} }) => {
   };
 
   return (
-    <RadioButtons
-      additionalFieldsetClass="vads-u-margin-top--1"
-      name="claimant-relationship"
+    <VaRadio
+      id="start"
+      class="vads-u-margin-y--2"
       label="Which of these best describes you?"
-      id="claimant-relationship"
-      options={options}
-      onValueChange={handleValueChange}
-      value={{ value: state.selected }}
-    />
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="claimant-relationship"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.page || option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
   );
 };
 

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/VREBenefits.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/VREBenefits.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
 import recordEvent from 'platform/monitoring/record-event';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -15,7 +16,8 @@ const options = [
 ];
 
 const VREBenefits = ({ setPageState, state = {} }) => {
-  const handleValueChange = ({ value }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
     recordEvent({
       event: `howToWizard-formChange`,
       'form-field-type': 'form-radio-buttons',
@@ -26,14 +28,25 @@ const VREBenefits = ({ setPageState, state = {} }) => {
     setPageState({ selected: value }, value);
   };
   return (
-    <RadioButtons
-      name="vre-benefits"
+    <VaRadio
+      id="VREBenefits"
+      class="vads-u-margin-y--2"
       label="Are you receiving Chapter 31 Veteran Readiness and Employment (VR&E) benefits?"
-      options={options}
-      id="vre-benefits"
-      onValueChange={value => handleValueChange(value)}
-      value={{ value: state.selected }}
-    />
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="vre-benefits"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
   );
 };
 

--- a/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/VaEducationBenefits.jsx
+++ b/script/github-actions/daily-product-scan/tests/mocks/applications/app-2/app-2b/wizard/pages/VaEducationBenefits.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
 import recordEvent from 'platform/monitoring/record-event';
-import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -15,7 +16,8 @@ const options = [
 ];
 
 const EducationBenefits = ({ setPageState, state = {} }) => {
-  const handleValueChange = ({ value }) => {
+  const handleValueChange = ({ detail } = {}) => {
+    const { value } = detail;
     recordEvent({
       event: `howToWizard-formChange`,
       'form-field-type': 'form-radio-buttons',
@@ -26,14 +28,25 @@ const EducationBenefits = ({ setPageState, state = {} }) => {
     setPageState({ selected: value }, value);
   };
   return (
-    <RadioButtons
-      name="education-benefits"
+    <VaRadio
+      id="VAEducationBenefits"
+      class="vads-u-margin-y--2"
       label="Are you using VA education benefits to go to school?"
-      options={options}
-      id="education-benefits"
-      onValueChange={handleValueChange}
-      value={{ value: state.selected }}
-    />
+      onVaValueChange={handleValueChange}
+    >
+      {options.map(option => (
+        <va-radio-option
+          key={option.value}
+          name="education-benefits"
+          label={option.label}
+          value={option.value}
+          checked={state.selected === option.value}
+          aria-describedby={
+            state.selected === option.value ? option.value : null
+          }
+        />
+      ))}
+    </VaRadio>
   );
 };
 


### PR DESCRIPTION
## Summary

This PR syncs the example apps used to test the daily product scan mechanism. The older versions of the apps contained RadioButtons that design system is removing support for.  

## Related issue(s)
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1310
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/54898

## Testing done

- The old version of the mock apps contained RadioButtons
- CI completes successfully
- Unit tests that use the mock apps are currently skipped. They were not passing previous to this PR's changes. They are still not passing.

## Screenshots
Not applicable -- no visual changes

## What areas of the site does it impact?
This does not impact the site.

## Acceptance criteria

- [x]  Unit tests and integration tests for this feature are currently skipped -- that status was kept.
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback
This change removes deprecated components from mock apps.
