### PR TITLE
MHV-42095: Health history list page updated to latest designs

### DIFF
--- a/src/applications/mhv/medical-records/containers/HealthHistory.jsx
+++ b/src/applications/mhv/medical-records/containers/HealthHistory.jsx
@@ -21,68 +21,90 @@ const HealthHistory = () => {
   );
 
   return (
-    <>
-      <h1>Health history</h1>
+    <div className="health-history vads-u-padding-bottom--5">
+      <h1 className="vads-u-margin-bottom-3">Health history</h1>
       <p>Review, print, and download your personal health history.</p>
 
-      <h2 className="vads-u-margin-bottom--1">Vaccines</h2>
-      <va-link
-        className="section-link"
-        active
-        href="/my-health/medical-records/vaccines"
-        text="Review your vaccines"
-        data-testid="section-link"
-      />
-      <p>
-        Your VA immunizations/vaccinations list may not be complete. If you have
-        questions about your vaccinations, contact your VA health care team.
-      </p>
+      <ul className="unstyled-list">
+        <li>
+          <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
+            Allergies
+          </h2>
+          <va-link
+            className="section-link"
+            active
+            href="/my-health/medical-records/allergies"
+            text="Review your allergies"
+            data-testid="section-link"
+          />
+          <p className="vads-u-margin-top--1">[description of section]</p>
+        </li>
 
-      <h2 className="vads-u-margin-bottom--1">Clinical notes</h2>
-      <va-link
-        className="section-link"
-        active
-        href="/my-health/medical-records/notes"
-        text="Review your clinical notes"
-        data-testid="section-link"
-      />
-      <p>
-        VA Notes from January 1, 2013 forward are available thirty-six (36)
-        hours after they have been completed (except C&P Notes) and signed by
-        all required members of your VA health care team.
-      </p>
+        <li>
+          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+            Care summaries and notes
+          </h2>
+          <va-link
+            className="section-link"
+            active
+            href="/my-health/medical-records/notes"
+            text="Review your care summaries and notes"
+            data-testid="section-link"
+          />
+          <p className="vads-u-margin-top--1">
+            VA Notes from January 1, 2013 forward are available thirty-six (36)
+            hours after they have been completed (except C&P Notes) and signed
+            by all required members of your VA health care team.
+          </p>
+        </li>
 
-      <h2 className="vads-u-margin-bottom--1">Allergies</h2>
-      <va-link
-        className="section-link"
-        active
-        href="/my-health/medical-records/allergies"
-        text="Review your allergies"
-        data-testid="section-link"
-      />
-      <p>[description of section]</p>
+        <li>
+          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+            Health conditions
+          </h2>
+          <va-link
+            className="section-link"
+            active
+            href="/my-health/medical-records/health-conditions"
+            text="Review your health conditions"
+            data-testid="section-link"
+          />
+          <p className="vads-u-margin-top--1">[description of section]</p>
+        </li>
 
-      <h2 className="vads-u-margin-bottom--1">Health conditions</h2>
-      <va-link
-        className="section-link"
-        active
-        href="/my-health/medical-records/health-conditions"
-        text="Review your health conditions"
-        data-testid="section-link"
-      />
-      <p>[description of section]</p>
+        <li>
+          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+            Vaccines
+          </h2>
+          <va-link
+            className="section-link"
+            active
+            href="/my-health/medical-records/vaccines"
+            text="Review your vaccines"
+            data-testid="section-link"
+          />
+          <p className="vads-u-margin-top--1">
+            Your VA immunizations/vaccinations list may not be complete. If you
+            have questions about your vaccinations, contact your VA health care
+            team.
+          </p>
+        </li>
 
-      <h2 className="vads-u-margin-bottom--1">Vitals</h2>
-      <va-link
-        className="section-link"
-        active
-        href="/my-health/medical-records/vitals"
-        text="Review your vitals"
-        data-testid="section-link"
-      />
-      <p>[description of section]</p>
-      <div className="vads-u-margin-top--0 vads-u-margin-bottom--5" />
-    </>
+        <li>
+          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+            Vitals
+          </h2>
+          <va-link
+            className="section-link"
+            active
+            href="/my-health/medical-records/vitals"
+            text="Review your vitals"
+            data-testid="section-link"
+          />
+          <p className="vads-u-margin-top--1">[description of section]</p>
+        </li>
+      </ul>
+    </div>
   );
 };
 

--- a/src/applications/mhv/medical-records/sass/health-history.scss
+++ b/src/applications/mhv/medical-records/sass/health-history.scss
@@ -1,8 +1,19 @@
-.section-link {
+.health-history {
+  .unstyled-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    li {
+      margin: 0;
+      padding: 0;
+    }
+  }
+  .section-link {
     a {
-        color: $color-link-default;
+      color: $color-link-default;
     }
     a:visited {
-        color: $color-link-default;
+      color: $color-link-default;
     }
-    }
+  }
+}


### PR DESCRIPTION
## Summary
The health history list page has been updated to match the latest designs from UCD in sketch. Changes made to styling and ordering of categories. 

## Related issue(s)
https://vajira.max.gov/browse/MHV-42095

## Testing done
No content was changed that would require additional tests. 

## Screenshots
<img width="382" alt="Screenshot 2023-03-09 at 5 18 30 PM" src="https://user-images.githubusercontent.com/107576133/224190925-12dc8b67-d39b-4700-8940-0b5a0d85a481.png">
<img width="1097" alt="Screenshot 2023-03-09 at 5 19 31 PM" src="https://user-images.githubusercontent.com/107576133/224190928-e49e84a3-c81b-4e96-bcc5-cb05f8dd010e.png">

## What areas of the site does it impact?
Medical records health history list page

## Acceptance criteria
- [ ]  The List page for Health History has been complete and follows the latest design in Sketch
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
