### PR TITLE
Update 'View your payment history' link text

### DIFF
--- a/src/applications/personalization/dashboard/components/benefit-payments-v2/BenefitPaymentsV2.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-payments-v2/BenefitPaymentsV2.jsx
@@ -44,12 +44,12 @@ const PopularActionsForPayments = ({ showPaymentHistoryLink = false }) => {
         <IconCTALink
           href="/va-payment-history/payments/"
           icon="user-check"
-          text="View your payment history"
+          text="Review your payment history"
           /* eslint-disable react/jsx-no-bind */
           onClick={() => {
             recordEvent({
               event: 'nav-linkslist',
-              'links-list-header': 'View your payment history',
+              'links-list-header': 'Review your payment history',
               'links-list-section-header': 'Benefit payments',
             });
           }}


### PR DESCRIPTION
## Summary

As part of the 2022 My VA Audit, we're making many UX improvements. After QA, under the "Benefit Payments" card, we discovered that the "Review your payment history" link is incorrect - it is appearing as "View your payment history" instead of Review

This PR updates the link text to read "Review your payment history".

## Related issue(s)
- Ticket: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/54394](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54391)
- Epic: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934)

## Screenshots

| Before | After |
| --- | --- |
| ![review-payments-before](https://user-images.githubusercontent.com/534756/224382349-57a17215-6073-4bca-8d29-bb12c5ffacf2.png)| ![review-payments-after](https://user-images.githubusercontent.com/534756/224385196-c3fbd26b-4ad9-4a72-b097-99e05ab61778.png) |

- Visual 
- Local with mock data
- All unit and e2e tests pass

## What areas of the site does it impact?
MyVA

## Acceptance criteria

- [x]  Change text of link to read "Review your payment history"
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
