### PR TITLE
MHV-42347 SM to VA.gov: Expand thread, accessibility review remidiations

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThread.jsx
@@ -52,9 +52,9 @@ const MessageThread = props => {
       {messageHistory?.length > 0 &&
         viewCount && (
           <div className="older-messages vads-u-margin-top--3 vads-u-padding-left--0p5">
-            <h3 className="vads-u-font-weight--bold">
+            <h2 className="vads-u-font-weight--bold">
               Messages in this conversation
-            </h3>
+            </h2>
             <HorizontalRule />
 
             {messageHistory.map((m, i) => {

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { urlRegex, httpRegex } from '../../util/helpers';
 
 const MessageThreadBody = props => {
-  const words = props.text?.split(/[^\S\r\n]+/g);
+  const { expanded, text } = props;
+  const words = text?.split(/[^\S\r\n]+/g);
 
   return (
     <div
       className={
-        props.expanded
+        expanded
           ? 'message-list-body-expanded vads-u-margin-bottom--2'
           : 'message-list-body-collapsed'
       }
@@ -18,7 +19,13 @@ const MessageThreadBody = props => {
           {words?.map((word, i) => {
             return (word.match(urlRegex) || word.match(httpRegex)) &&
               words.length >= 1 ? (
-              <a key={i} href={word} target="_blank" rel="noreferrer">
+              <a
+                tabIndex={!expanded ? -1 : 0}
+                key={i}
+                href={word}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {`${word} `}
               </a>
             ) : (

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import HorizontalRule from '../shared/HorizontalRule';
@@ -6,6 +6,7 @@ import MessageThreadMeta from './MessageThreadMeta';
 import MessageThreadBody from './MessageThreadBody';
 import MessageThreadAttachments from './MessageThreadAttachments';
 import { markMessageAsReadInThread } from '../../actions/messages';
+import { dateFormat } from '../../util/helpers';
 
 const MessageThreadItem = props => {
   const dispatch = useDispatch();
@@ -25,19 +26,50 @@ const MessageThreadItem = props => {
   );
 
   const handleExpand = e => {
-    if (e.keyCode === 32) {
-      e.preventDefault(); // prevent from scrolling to the footer
-    }
-    if (!e.shiftKey && e.key !== 'Tab') {
-      // prevent from expanding/collapsing on Tab key press for accessibility
-      setIsExpanded(!isExpanded);
-    }
-    if (!isExpanded) {
-      // TODO replace line above with a line below once readReceipt is fixed in the backend
-      // if (!isRead && !isExpanded) {
-      dispatch(markMessageAsReadInThread(message.messageId));
+    // prevent messaage to expand/collapse when user is selecting text
+    if (window.getSelection().toString().length === 0) {
+      if (e.keyCode === 32) {
+        e.preventDefault(); // prevent from scrolling to the footer
+      }
+
+      // expanding/collapsing on Enter or Space key press for accessibility
+      if (
+        (e.key === 'Enter' || e.key === ' ' || e.type === 'click') &&
+        e.target.tagName !== 'a' // prevent from collapsing when user clicks on a link in the message
+      ) {
+        setIsExpanded(!isExpanded);
+      }
+
+      if (!isExpanded) {
+        // TODO replace line above with a line below once readReceipt is fixed in the backend
+        // if (!isRead && !isExpanded) {
+        dispatch(markMessageAsReadInThread(message.messageId));
+      }
     }
   };
+
+  const hasAttachments = useMemo(
+    () => {
+      return (
+        message.attachment ||
+        message.hasAttachments ||
+        message.attachments?.length
+      );
+    },
+    [message.attachment, message.hasAttachments, message.attachments],
+  );
+
+  const ariaLabel = useMemo(
+    () => {
+      return `${!isRead ? 'New' : ''} message ${
+        hasAttachments ? 'with attachment' : ''
+      } from ${message.senderName}, ${dateFormat(
+        message.sentDate,
+        'MMMM D, YYYY [at] h:mm a z',
+      )}. Click to ${isExpanded ? 'Collapse message' : 'Expand message'}`;
+    },
+    [hasAttachments, isExpanded, isRead, message],
+  );
 
   return (
     message && (
@@ -61,10 +93,11 @@ const MessageThreadItem = props => {
           <div className="vads-u-flex--fill " data-testid={message.messageId}>
             <div
               role="button"
+              tabIndex={0}
               data-testid="expand-message-button"
               aria-expanded={isExpanded}
-              tabIndex={0}
-              onClick={e => {
+              aria-label={!isExpanded ? ariaLabel : ''}
+              onClickCapture={e => {
                 handleExpand(e);
               }}
               onKeyDown={e => {
@@ -75,6 +108,7 @@ const MessageThreadItem = props => {
                 expanded={isExpanded}
                 message={message}
                 isRead={isRead}
+                hasAttachments={hasAttachments}
               />
               <MessageThreadBody expanded={isExpanded} text={message.body} />
             </div>
@@ -87,32 +121,6 @@ const MessageThreadItem = props => {
                   attachments={message.attachments}
                 />
               )}
-          </div>
-
-          <div className="vads-u-flex--auto">
-            <div
-              role="button"
-              tabIndex={0}
-              aria-label={isExpanded ? 'Collapse message' : 'Expand message'}
-              onClick={e => {
-                handleExpand(e);
-              }}
-              onKeyDown={e => {
-                handleExpand(e);
-              }}
-            >
-              {isExpanded ? (
-                <i
-                  className="fas fa-angle-up vads-u-margin--0p5"
-                  aria-hidden="true"
-                />
-              ) : (
-                <i
-                  className="fas fa-angle-down vads-u-margin--0p5"
-                  aria-hidden="true"
-                />
-              )}
-            </div>
           </div>
         </div>
         <HorizontalRule />

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -74,10 +74,7 @@ const MessageThreadItem = props => {
   return (
     message && (
       <>
-        <div
-          className="older-message vads-u-padding-top--0p5 vads-u-padding-bottom--2 vads-u-display--flex vads-u-flex-direction--row"
-          data-testid="expand-message-button-parent"
-        >
+        <div className="older-message vads-u-padding-top--0p5 vads-u-padding-bottom--2 vads-u-display--flex vads-u-flex-direction--row">
           <div
             className="vads-u-flex--auto"
             role="img"
@@ -90,29 +87,27 @@ const MessageThreadItem = props => {
             />
           </div>
 
-          <div className="vads-u-flex--fill " data-testid={message.messageId}>
-            <div
-              role="button"
-              tabIndex={0}
-              data-testid="expand-message-button"
-              aria-expanded={isExpanded}
-              aria-label={!isExpanded ? ariaLabel : ''}
-              onClickCapture={e => {
-                handleExpand(e);
-              }}
-              onKeyDown={e => {
-                handleExpand(e);
-              }}
-            >
-              <MessageThreadMeta
-                expanded={isExpanded}
-                message={message}
-                isRead={isRead}
-                hasAttachments={hasAttachments}
-              />
-              <MessageThreadBody expanded={isExpanded} text={message.body} />
-            </div>
-
+          <div
+            className="vads-u-flex--fill "
+            role="button"
+            tabIndex={0}
+            data-testid={`expand-message-button-${message.messageId}`}
+            aria-expanded={isExpanded}
+            aria-label={!isExpanded ? ariaLabel : ''}
+            onClickCapture={e => {
+              handleExpand(e);
+            }}
+            onKeyDown={e => {
+              handleExpand(e);
+            }}
+          >
+            <MessageThreadMeta
+              expanded={isExpanded}
+              message={message}
+              isRead={isRead}
+              hasAttachments={hasAttachments}
+            />
+            <MessageThreadBody expanded={isExpanded} text={message.body} />
             {isExpanded &&
               message.attachments?.length > 0 && (
                 <MessageThreadAttachments

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadMeta.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadMeta.jsx
@@ -3,17 +3,51 @@ import PropTypes from 'prop-types';
 import { dateFormat } from '../../util/helpers';
 
 const MessageThreadMeta = props => {
-  const { message, isRead } = props;
+  const { message, isRead, expanded, hasAttachments } = props;
+
+  const expandButton = () => {
+    return (
+      <div className="vads-u-flex--auto">
+        <div role="button" className="vads-u-font-weight--bold" tabIndex={-1}>
+          {expanded ? (
+            <>
+              <span>close</span>
+              <i
+                className="fas fa-angle-up vads-u-margin--0p5"
+                aria-hidden="true"
+              />
+            </>
+          ) : (
+            <>
+              <span>expand</span>
+              <i
+                className="fas fa-angle-down vads-u-margin--0p5"
+                aria-hidden="true"
+              />
+            </>
+          )}
+        </div>
+      </div>
+    );
+  };
   return (
     <div className="message-thread-meta vads-u-padding-bottom--1">
-      <p data-testid="from" style={{ fontWeight: !isRead ? 'bold' : '' }}>
-        <strong>From: </strong>
-        {message.senderName}
-        {/* TODO no triage group name in response */}
-        {props.expanded && message.triageGroupName
-          ? ` (${message.triageGroupName})`
-          : ''}
-      </p>
+      <div className="vads-u-display--flex">
+        <p
+          className="vads-u-flex--1 vads-u-padding-right--2"
+          data-testid="from"
+          style={{ fontWeight: !isRead ? 'bold' : '' }}
+        >
+          <strong>From: </strong>
+          {message.senderName}
+          {/* TODO no triage group name in response */}
+          {props.expanded && message.triageGroupName
+            ? ` (${message.triageGroupName})`
+            : ''}
+        </p>
+        {expandButton()}
+      </div>
+
       {props.expanded && (
         <>
           <p data-testid="to">
@@ -27,9 +61,7 @@ const MessageThreadMeta = props => {
         </>
       )}
       <p className="message-date" data-testid="message-date">
-        {(message.attachment ||
-          message.hasAttachments ||
-          message.attachments?.length) && (
+        {hasAttachments && (
           <i
             className="fas fa-paperclip vads-u-padding-right--0p5"
             label="paperclip"
@@ -46,6 +78,7 @@ const MessageThreadMeta = props => {
 
 MessageThreadMeta.propTypes = {
   expanded: PropTypes.bool,
+  hasAttachments: PropTypes.bool,
   isRead: PropTypes.bool,
   message: PropTypes.object,
 };

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadMeta.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadMeta.jsx
@@ -8,7 +8,7 @@ const MessageThreadMeta = props => {
   const expandButton = () => {
     return (
       <div className="vads-u-flex--auto">
-        <div role="button" className="vads-u-font-weight--bold" tabIndex={-1}>
+        <div className="vads-u-font-weight--bold" tabIndex={-1}>
           {expanded ? (
             <>
               <span>close</span>

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadMeta.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadMeta.jsx
@@ -8,7 +8,7 @@ const MessageThreadMeta = props => {
   const expandButton = () => {
     return (
       <div className="vads-u-flex--auto">
-        <div className="vads-u-font-weight--bold" tabIndex={-1}>
+        <div className="vads-u-font-weight--bold" role="button">
           {expanded ? (
             <>
               <span>close</span>

--- a/src/applications/mhv/secure-messaging/components/PrintMessageThread.jsx
+++ b/src/applications/mhv/secure-messaging/components/PrintMessageThread.jsx
@@ -24,7 +24,7 @@ const PrintMessageThread = props => {
     return (
       <>
         {messageThread?.length > 0 && (
-          <div className="message-thread-list">
+          <div data-testid="print-thread" className="message-thread-list">
             {messageThread.map((m, i) => {
               return (
                 <div key={i}>

--- a/src/applications/mhv/secure-messaging/sass/message-thread.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-thread.scss
@@ -2,6 +2,10 @@
 
 .older-messages {
   width: inherit;
+
+  h2 {
+    font-size: 20px;
+  }
   a:visited {
     color: $color-link-default;
     text-decoration: underline;

--- a/src/applications/mhv/secure-messaging/tests/components/MessageThreadComponents/message-thread-item.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageThreadComponents/message-thread-item.unit.spec.jsx
@@ -24,7 +24,13 @@ describe('Meesage thread item', () => {
       },
     );
 
-    waitFor(fireEvent.click(screen.getByTestId('expand-message-button')));
+    waitFor(
+      fireEvent.click(
+        screen.getByTestId(
+          `expand-message-button-${messageResponse.messageId}`,
+        ),
+      ),
+    );
     expect(
       screen.getByTestId('message-body-attachments-label').textContent,
     ).to.equal('Attachments');

--- a/src/applications/mhv/secure-messaging/tests/containers/Compose.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/Compose.unit.spec.jsx
@@ -241,7 +241,7 @@ describe('Compose container', () => {
       expect(
         screen.getByText('Messages in this conversation', {
           exact: true,
-          selector: 'h3',
+          selector: 'h2',
         }),
       ).to.exist;
 

--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/message-specialCharacter-response.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/message-specialCharacter-response.json
@@ -1,28 +1,28 @@
 {
-    "data": {
-        "id": "7179975",
-        "type": "messages",
-        "attributes": {
-            "messageId": 7179975,
-            "category": "MEDICATIONS",
-            "subject": "Special Characters Message",
-            "body": "Test with Special Characters %$#^&",
-            "attachment": false,
-            "sentDate": "2022-09-12T15:10:13.000Z",
-            "senderId": 20029,
-            "senderName": "ISLAM, MOHAMMAD  RAFIQ",
-            "recipientId": 6820911,
-            "recipientName": "ECSTEN, THOMAS ",
-            "readReceipt": "READ",
-            "triageGroupName": "The best Ones"
-        },
-        "relationships": {
-            "attachments": {
-                "data": []
-            }
-        },
-        "links": {
-            "self": "http://127.0.0.1:3000/my_health/v1/messaging/messages/7179975"
-        }
+  "data": {
+    "id": "7179975",
+    "type": "messages",
+    "attributes": {
+      "messageId": 7179975,
+      "category": "MEDICATIONS",
+      "subject": "Special Characters Message",
+      "body": "Test with Special Characters %$#^&",
+      "attachment": false,
+      "sentDate": "2022-09-12T15:10:13.000Z",
+      "senderId": 20029,
+      "senderName": "ISLAM, MOHAMMAD RAFIQ",
+      "recipientId": 6820911,
+      "recipientName": "ECSTEN, THOMAS ",
+      "readReceipt": "READ",
+      "triageGroupName": "The best Ones"
+    },
+    "relationships": {
+      "attachments": {
+        "data": []
+      }
+    },
+    "links": {
+      "self": "http://127.0.0.1:3000/my_health/v1/messaging/messages/7179975"
     }
+  }
 }

--- a/src/applications/mhv/secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -183,7 +183,12 @@ class PatientMessageDetailsPage {
       }`,
       threadMessageDetails,
     ).as('messageDetails');
-    cy.get('[aria-label="Expand message"]')
+    cy.get('.older-messages')
+      .find(
+        `[data-testid="expand-message-button-${
+          threadMessageDetails.data.attributes.messageId
+        }"]`,
+      )
       .eq(index - 1)
       .click();
   };

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-basic-search.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-basic-search.cypress.spec.js
@@ -14,7 +14,7 @@ describe('Secure Messaging Basic Search Tests', () => {
     const landingPage = new PatientInboxPage();
     const site = new SecureMessagingSite();
     site.login();
-    landingPage.loadPage();
+    landingPage.loadInboxMessages();
   });
   it('Basic Search Axe Check', () => {
     cy.intercept(


### PR DESCRIPTION
## Summary

- This is in response to [Midpoint Review - Accessibility Feedback - VFS MHV Secure Messaging, MHV Secure Messaging, Secure Messaging #51913](https://github.com/department-of-veterans-affairs/va.gov-team/issues/51913) for some of the following items:
- As a sighted mouse user, I would move my mouse to the message preview and click (either on the chevron itself or on the whole message preview as a click target). Straightforward interaction.
- As a sighted keyboard user, I would press [Tab] until I see that focus is on the message that I want to open, and press [Enter] or [Spacebar]. Straightforward interaction.
- As a sighted voice command user, my expectation is to say a command like "Click [something]" and have that action happen. But it's not clear what the [something] is to say. How much of the message preview do I need to say out loud? Even if I say all of the preview text out loud, will that be mapped to the right action? And similarly for closing an opened message, what do I say? The interaction isn't clear. 
- > Buttons will have a label of Expand/Collapse depending on the state. User will say "Click Expand" or "Click Collapse". Those buttons will get a number associated with each one for correlation. Then a user will say "One" or "Two" etc to pick the right message to expand

- As a non-sighted screen reader user, when I [Tab] to an interactive element (link, button, etc) my expectation is that a unique label for the element is announced by my screen reader. What gets announced by the screen reader when I [Tab] to a collapsed message? Is it the entire message preview, or something else? And when I want to close a message and [Tab] back to it, what gets announced then?
- >  The label that is read by the screen reader contains the following message `{New} from {SENDER_NAME} , {SENT_TIMESTAMP_FORMATTED}. Click to Expand message,`

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/51913
- [SM to VA.gov: MUST - Update expand of messages to be accessible via screen reader, voice command, etc](https://vajira.max.gov/browse/MHV-42347)


## Testing done

- Testing performed with VoiceOver screen reader and macOS voice control
- Manual SQA testing pending

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| Desktop | <img src="https://user-images.githubusercontent.com/87077843/224812968-37e2fc4f-5aa0-4c6d-839d-57d0cca598cc.png" width=150px /> | 
<img src="https://user-images.githubusercontent.com/87077843/224813883-22a8941e-d9f0-4f9b-bcba-026187812dcd.png" width=150px /> | 
<img src="https://user-images.githubusercontent.com/87077843/224814290-48cbb610-0f1b-46bf-996b-1e9958ca4c38.png" width=150px /> | 

## What areas of the site does it impact?
My Health - Secure Messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

