### PR TITLE
VACMS-12160 increase from 25 to 50% for new homepage modal

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -21,7 +21,7 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
     hasRedirectParam = searchParams.has('next');
   }
   const isAllowed = useStaggeredFeatureRelease(
-    25,
+    50,
     'show-homepage-soft-launch-modal',
   );
 


### PR DESCRIPTION
## Summary

For homepage modal promoting the new homepage, increasing to show to 50% of users.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12160

## What areas of the site does it impact?
Homepage modal

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
