### PR TITLE
Revert "Adds URLs for disability pages and updates render logic for h…

### DIFF
--- a/src/applications/static-pages/i18Select/I18Select.js
+++ b/src/applications/static-pages/i18Select/I18Select.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import { connect } from 'react-redux';
 import { setOnThisPageText } from './utilities/helpers';
+import { connect } from 'react-redux';
 import { ALL_LANGUAGES } from './utilities/constants';
 
 const I18Select = ({ baseUrls, languageCode }) => {
@@ -39,7 +39,7 @@ const I18Select = ({ baseUrls, languageCode }) => {
               >
                 {languageConfig.label}{' '}
               </a>
-              {i !== Object.keys(baseUrls).length - 1 && (
+              {i !== ALL_LANGUAGES.length - 1 && (
                 <span
                   className=" vads-u-margin-left--0p5 vads-u-margin-right--0p5 vads-u-color--gray
                     vads-u-height--20"

--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(18);
+    expect(result.length).to.equal(12);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(18);
+    expect(result.length).to.equal(12);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {
@@ -29,6 +29,6 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(tag)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(24);
+    expect(result.length).to.equal(12);
   });
 });

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -34,28 +34,4 @@ export default {
     es: '/resources/the-pact-act-and-your-va-benefits-esp',
     tl: '/resources/the-pact-act-and-your-va-benefits-tag',
   },
-  disability: {
-    en: '/disability/eligibility/',
-    es: '/disability/eligibility-esp/',
-  },
-  fileDisability: {
-    en: '/disability/how-to-file-claim/',
-    es: '/disability/how-to-file-claim-esp/',
-  },
-  afterFileDisability: {
-    en: '/disability/after-you-file-claim/',
-    es: '/disability/after-you-file-claim-esp/',
-  },
-  healthCareEligibility: {
-    en: '/health-care/eligibility/',
-    es: '/health-care/eligibility-esp/',
-  },
-  healthCareHowToApply: {
-    en: '/health-care/how-to-apply/',
-    es: '/health-care/how-to-apply-esp/',
-  },
-  healthCareAfterAppy: {
-    en: '/health-care/after-you-apply/',
-    es: '/health-care/after-you-apply-esp/',
-  },
 };


### PR DESCRIPTION
…andling 2 languages (#23549)"

This reverts commit 7db1783d3e6704d877c02af25b4bf62ac18679c3.

## Related issues
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12694
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12931

## Description
I merged this PR prematurely: https://github.com/department-of-veterans-affairs/vets-website/pull/23549

Probably: It needs to be reverted until we get approval from content-team, then re-staged. (UGH.) 
Slack thread to triple check with Randi that this could go ahead and we don't need to revert, tbd: https://dsva.slack.com/archives/C01K37HRUAH/p1678747326719939.  If we haven't heard from Randi by the time daily deploy rolls around on Tues 3/14, should merge this revert.