### PR TITLE
Remove new line character that's breaking linting

### DIFF
--- a/src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx
+++ b/src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx
@@ -9,7 +9,6 @@ import {
   MiniSummaryCard,
 } from '../../../components/shared/MiniSummaryCard';
 
-
 import { currency as currencyFormatter } from '../../../utils/helpers';
 
 const EmploymentHistoryWidget = props => {


### PR DESCRIPTION
Getting the following linting error:

Error: src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx:12:1:Delete `⏎`

This PR removes the new line character