### PR TITLE
Check in/54909/travel complete page

### DIFF
--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -71,7 +71,7 @@ const Footer = ({ router, isPreCheckIn }) => {
           <va-telephone contact="988" /> {t('and-select-1')}
         </p>
       )}
-      {currentPage === 'complete' &&
+      {currentPage.includes('complete') &&
         !isPreCheckIn && (
           <div data-testid="day-of-travel-extra-message">
             <p>

--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -71,7 +71,8 @@ const Footer = ({ router, isPreCheckIn }) => {
           <va-telephone contact="988" /> {t('and-select-1')}
         </p>
       )}
-      {currentPage.includes('complete') &&
+      {currentPage &&
+        currentPage.includes('complete') &&
         !isPreCheckIn && (
           <div data-testid="day-of-travel-extra-message">
             <p>

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -46,10 +46,8 @@ const CheckInConfirmation = props => {
   const { t } = useTranslation();
   const { jumpToPage } = useFormRouting(router);
   const appointment = selectedAppointment;
-  const appointmentDateTime = new Date(appointment.startTime);
 
   const {
-    isLoading,
     travelPayEligible,
     travelPayClaimError,
     travelPayClaimErrorCode,
@@ -78,25 +76,8 @@ const CheckInConfirmation = props => {
     [travelPayClaimSent, setShouldSendTravelPayClaim],
   );
 
-  let pageTitle = t('youre-checked-in', {
-    date: appointmentDateTime,
-  });
   const doTravelPay = isTravelReimbursementEnabled && travelPayClaimRequested;
 
-  if (doTravelPay && !isLoading) {
-    pageTitle += ' ';
-
-    if (travelPayClaimData && !travelPayClaimError && travelPayEligible) {
-      pageTitle += t('received-reimbursement-claim');
-    } else if (
-      travelPayClaimError &&
-      travelPayClaimErrorCode === 'CLM_002_CLAIM_EXISTS'
-    ) {
-      pageTitle += t('you-created-a-travel-claim-already');
-    } else {
-      pageTitle += t('we-couldnt-file-reimbursement');
-    }
-  }
   const handleDetailClick = e => {
     e.preventDefault();
     recordEvent({
@@ -136,7 +117,10 @@ const CheckInConfirmation = props => {
 
   const renderConfirmationMessage = () => {
     return (
-      <Wrapper pageTitle={pageTitle} testID="multiple-appointments-confirm">
+      <Wrapper
+        pageTitle={t('youre-checked-in')}
+        testID="multiple-appointments-confirm"
+      >
         <p className="vads-u-font-family--serif">{t('your-appointment')}</p>
         <ol
           className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list"

--- a/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
@@ -37,22 +37,24 @@ const TravelPayAlert = props => {
     <>
       {travelPayEligible &&
         travelPayClaimData && (
-          <va-alert background-only show-icon data-testid="travel-pay-message">
+          <va-alert
+            background-only
+            show-icon
+            data-testid="travel-pay-message"
+            status="success"
+          >
             <div>
               <p
                 className="vads-u-margin-top--0"
                 data-testid="travel-pay-eligible-success-message"
               >
-                {t('check-travel-claim-status')}
+                <Trans
+                  i18nKey="processing-travel-claim"
+                  components={[
+                    <span key="bold" className="vads-u-font-weight--bold" />,
+                  ]}
+                />
               </p>
-              <ExternalLink
-                href="/accessva-travel-claim/"
-                hrefLang="en"
-                eventId="clicked-go-to-accessva-from-success"
-                eventPrefix="nav"
-              >
-                {t('go-to-the-accessva-travel-claim-portal-now')}
-              </ExternalLink>
             </div>
           </va-alert>
         )}

--- a/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('check in', () => {
       expect(
         component.getByTestId('travel-pay-eligible-success-message'),
       ).to.have.text(
-        'You can check the status of your travel reimbursement claim online 24/7 on the Beneficiary Travel Self Service System (BTSSS). You can access BTSSS through the AccessVA travel claim portal.',
+        'We’re processing your travel reimbursement claim request. We’ll send you a text message with the submission status of your travel reimbursement claim.',
       );
     });
     it('renders a not eligible message', () => {

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -22,21 +22,17 @@ class Confirmation {
   };
 
   validatePageLoadedWithBtsssSubmission = () => {
-    cy.get('h1', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('include.text', 'And we received your travel claim');
+    cy.get('h1', { timeout: Timeouts.slow }).should('be.visible');
     cy.get('[data-testid="travel-pay-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .and(
         'include.text',
-        'You can check the status of your travel reimbursement claim online',
+        'We’re processing your travel reimbursement claim request.',
       );
   };
 
   validatePageLoadedWithBtsssIneligible = () => {
-    cy.get('h1', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('include.text', "couldn't file your travel claim");
+    cy.get('h1', { timeout: Timeouts.slow }).should('be.visible');
     cy.get('[data-testid="travel-pay-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .and(
@@ -46,9 +42,7 @@ class Confirmation {
   };
 
   validatePageLoadedWithBtsssGenericFailure = () => {
-    cy.get('h1', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('include.text', "couldn't file your travel claim");
+    cy.get('h1', { timeout: Timeouts.slow }).should('be.visible');
     cy.get('[data-testid="travel-pay-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .and(
@@ -58,9 +52,7 @@ class Confirmation {
   };
 
   validatePageLoadedWithBtsssTravelClaimExistsFailure = () => {
-    cy.get('h1', { timeout: Timeouts.slow })
-      .should('be.visible')
-      .and('include.text', "You've created a travel claim already.");
+    cy.get('h1', { timeout: Timeouts.slow }).should('be.visible');
     cy.get('[data-testid="travel-pay-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
       .and(
@@ -100,6 +92,12 @@ class Confirmation {
         'contain',
         '/resources/how-to-file-a-va-travel-reimbursement-claim-online/',
       );
+  };
+
+  validateExtraFooterMessage = () => {
+    cy.get('div[data-testid="day-of-travel-extra-message"]').should(
+      'be.visible',
+    );
   };
 
   attemptGoBackToAppointments = () => {

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
@@ -71,6 +71,7 @@ describe('Check In Experience', () => {
       cy.createScreenshots('Day-of-check-in--travel-pay--appointments');
       Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssSubmission();
+      Confirmation.validateExtraFooterMessage();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--travel-pay--confirmation-success');
     });

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -223,5 +223,6 @@
   "directions": "Directions",
   "were-sorry-this-link-has-expired": "We’re sorry. This link has expired.",
   "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>.",
-  "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment."
+  "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment.",
+  "processing-travel-claim": "<0>We’re processing your travel reimbursement claim request.</0> We’ll send you a text message with the submission status of your travel reimbursement claim."
 }


### PR DESCRIPTION
## Summary
This PR begins to remove some of the old BTSS functionality. The page title manipulation is removed and the success message has been updated. There is [another ticket](https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/gh/department-of-veterans-affairs/va.gov-team/54281) to remove the btsss hook and the error handling.

This ticket also repairs the existing functionality to show additional travel information in the footer. This got broke by the work to add the active appointment to the url.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#54909

## Testing done
Updates tests and adds e2e test for the footer block.

## Screenshots
![localhost_3001_health-care_appointment-check-in_complete_0001-0001 (7)](https://user-images.githubusercontent.com/13967174/225164106-e74348e9-a26b-4fdc-af66-81dcf5ba266e.png)


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

