### PR TITLE
(feature) added restrictions about no facilities

### DIFF
--- a/src/applications/mhv/landing-page/containers/tests/App.unit.spec.js
+++ b/src/applications/mhv/landing-page/containers/tests/App.unit.spec.js
@@ -17,7 +17,11 @@ const generateInitState = ({
   profileLoading = false,
   currentlyLoggedIn = true,
   isCernerPatient = false,
+  hasFacilities = true,
 }) => {
+  const facilities = hasFacilities
+    ? [{ facilityId: '123', isCerner: false }]
+    : [];
   return {
     featureToggles: {
       loading,
@@ -49,7 +53,7 @@ const generateInitState = ({
         },
         facilities: isCernerPatient
           ? [{ facilityId: '757', isCerner: true }]
-          : [],
+          : facilities,
       },
     },
   };
@@ -187,6 +191,25 @@ describe('MHV landing page', () => {
         mhvLandingPageEnabled: true,
         serviceName: CSP_IDS.MHV,
         isCerner: true,
+      });
+      const store = mockStore(initState);
+      const replace = sinon.spy();
+      global.window.location = { ...global.window.location, replace };
+      const { container } = render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+      expect(container.querySelector('h1')).to.not.exist;
+      expect(replace.called).to.be.true;
+    });
+    it('user is authenticated with feature enabled but has no facilities -- should not show the landing page', () => {
+      const middleware = [];
+      const mockStore = configureStore(middleware);
+      const initState = generateInitState({
+        loading: false,
+        mhvLandingPageEnabled: true,
+        hasFacilities: false,
       });
       const store = mockStore(initState);
       const replace = sinon.spy();

--- a/src/applications/mhv/landing-page/mocks/api/index.js
+++ b/src/applications/mhv/landing-page/mocks/api/index.js
@@ -8,7 +8,7 @@ const user = require('./user/index');
 
 const responses = {
   ...commonResponses,
-  'GET /v0/user': user.noFacilityUser,
+  'GET /v0/user': user.defaultUser,
   'GET /v0/feature_toggles': featureToggles.generateFeatureToggles({}),
 };
 

--- a/src/applications/mhv/landing-page/mocks/api/index.js
+++ b/src/applications/mhv/landing-page/mocks/api/index.js
@@ -8,7 +8,7 @@ const user = require('./user/index');
 
 const responses = {
   ...commonResponses,
-  'GET /v0/user': user.defaultUser,
+  'GET /v0/user': user.noFacilityUser,
   'GET /v0/feature_toggles': featureToggles.generateFeatureToggles({}),
 };
 

--- a/src/applications/mhv/landing-page/mocks/api/user/index.js
+++ b/src/applications/mhv/landing-page/mocks/api/user/index.js
@@ -125,6 +125,61 @@ const cernerUser = {
   meta: { errors: null },
 };
 
+const noFacilityUser = {
+  data: {
+    attributes: {
+      profile: {
+        sign_in: {
+          service_name: 'idme',
+          auth_broker: 'iam',
+          ssoe: true,
+        },
+        email: 'fake@fake.com',
+        loa: { current: 3 },
+        first_name: 'Harry',
+        middle_name: '',
+        last_name: 'Doe',
+        gender: 'F',
+        birth_date: '1985-01-01',
+        verified: true,
+      },
+      session: {
+        auth_broker: 'iam',
+        ssoe: true,
+        transactionid: 'sf8mUOpuAoxkx8uWxI6yrBAS/t0yrsjDKqktFz255P0=',
+      },
+      veteran_status: {
+        status: 'OK',
+        is_veteran: true,
+        served_in_military: true,
+      },
+      in_progress_forms: [],
+      prefills_available: ['21-526EZ'],
+      services: [
+        'facilities',
+        'hca',
+        'edu-benefits',
+        'evss-claims',
+        'form526',
+        'user-profile',
+        'health-records',
+        'rx',
+        'messaging',
+      ],
+      va_profile: {
+        status: 'OK',
+        birth_date: '19511118',
+        family_name: 'Hunter',
+        gender: 'M',
+        given_names: ['Julio', 'E'],
+        active_status: 'active',
+        facilities: [],
+      },
+    },
+  },
+  meta: { errors: null },
+};
+
 const generateUserWithServiceProvider = ({ serviceProvider = 'idme' }) => {
   return {
     ...defaultUser,
@@ -146,5 +201,6 @@ const generateUserWithServiceProvider = ({ serviceProvider = 'idme' }) => {
 module.exports = {
   defaultUser,
   cernerUser,
+  noFacilityUser,
   generateUserWithServiceProvider,
 };

--- a/src/applications/mhv/landing-page/mocks/api/user/index.js
+++ b/src/applications/mhv/landing-page/mocks/api/user/index.js
@@ -63,7 +63,6 @@ const defaultUser = {
   meta: { errors: null },
 };
 
-/* eslint-disable camelcase */
 const cernerUser = {
   data: {
     attributes: {
@@ -125,59 +124,21 @@ const cernerUser = {
   meta: { errors: null },
 };
 
-const noFacilityUser = {
-  data: {
-    attributes: {
-      profile: {
-        sign_in: {
-          service_name: 'idme',
-          auth_broker: 'iam',
-          ssoe: true,
+const generateUserWithFacilities = ({ facilities = [], name = 'Harry' }) => {
+  return {
+    ...defaultUser,
+    data: {
+      ...defaultUser.data,
+      attributes: {
+        ...defaultUser.data.attributes,
+        profile: {
+          ...defaultUser.data.attributes.profile,
+          facilities,
+          first_name: name,
         },
-        email: 'fake@fake.com',
-        loa: { current: 3 },
-        first_name: 'Harry',
-        middle_name: '',
-        last_name: 'Doe',
-        gender: 'F',
-        birth_date: '1985-01-01',
-        verified: true,
-      },
-      session: {
-        auth_broker: 'iam',
-        ssoe: true,
-        transactionid: 'sf8mUOpuAoxkx8uWxI6yrBAS/t0yrsjDKqktFz255P0=',
-      },
-      veteran_status: {
-        status: 'OK',
-        is_veteran: true,
-        served_in_military: true,
-      },
-      in_progress_forms: [],
-      prefills_available: ['21-526EZ'],
-      services: [
-        'facilities',
-        'hca',
-        'edu-benefits',
-        'evss-claims',
-        'form526',
-        'user-profile',
-        'health-records',
-        'rx',
-        'messaging',
-      ],
-      va_profile: {
-        status: 'OK',
-        birth_date: '19511118',
-        family_name: 'Hunter',
-        gender: 'M',
-        given_names: ['Julio', 'E'],
-        active_status: 'active',
-        facilities: [],
       },
     },
-  },
-  meta: { errors: null },
+  };
 };
 
 const generateUserWithServiceProvider = ({ serviceProvider = 'idme' }) => {
@@ -198,9 +159,12 @@ const generateUserWithServiceProvider = ({ serviceProvider = 'idme' }) => {
   };
 };
 
+const noFacilityUser = generateUserWithFacilities({ facilities: [] });
+
 module.exports = {
   defaultUser,
   cernerUser,
   noFacilityUser,
   generateUserWithServiceProvider,
+  generateUserWithFacilities,
 };

--- a/src/applications/mhv/landing-page/tests/restrict-by-facilities-list/facilities.access.cypress.spec.js
+++ b/src/applications/mhv/landing-page/tests/restrict-by-facilities-list/facilities.access.cypress.spec.js
@@ -1,0 +1,28 @@
+import manifest from '../../manifest.json';
+
+import ApiInitializer from '../utilities/ApiInitializer';
+import LandingPage from '../pages/LandingPage';
+
+describe(manifest.appName, () => {
+  describe('restrict access based on patient facilities', () => {
+    beforeEach(() => {
+      ApiInitializer.initializeFeatureToggle.withCurrentFeatures();
+    });
+    // eslint-disable-next-line @department-of-veterans-affairs/axe-check-required
+    it('landing page is disabled for patients with no facilities', () => {
+      ApiInitializer.initializeUserData.withFacilities({ facilities: [] });
+      LandingPage.visitPageAsCernerPatient();
+      LandingPage.validateRedirectHappened();
+    });
+    it('landing page is disabled for patients with facilities', () => {
+      ApiInitializer.initializeUserData.withFacilities({
+        facilities: [{ facilityId: '123', isCerner: false }],
+      });
+
+      LandingPage.visitPage();
+      LandingPage.validatePageLoaded();
+      LandingPage.validateURL();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});

--- a/src/applications/mhv/landing-page/tests/utilities/ApiInitializer.js
+++ b/src/applications/mhv/landing-page/tests/utilities/ApiInitializer.js
@@ -39,6 +39,13 @@ class ApiInitializer {
     withCernerPatient: () => {
       cy.intercept('GET', '/v0/user*', userData.cernerPatient);
     },
+    withFacilities: ({ facilities = [] }) => {
+      cy.intercept(
+        'GET',
+        '/v0/user*',
+        userData.generateUserWithFacilities({ facilities }),
+      );
+    },
   };
 }
 

--- a/src/applications/mhv/landing-page/utilities/feature-toggles/feature-toggles.unit.spec.js
+++ b/src/applications/mhv/landing-page/utilities/feature-toggles/feature-toggles.unit.spec.js
@@ -34,7 +34,7 @@ describe(manifest.appName, () => {
       const result = isLandingPageEnabledForUser(state);
       expect(result).to.be.false;
     });
-    it('app is disabled if the feature is enabled; the user is logged in as idme', () => {
+    it('app is enabled if the feature is enabled; the user is logged in as idme', () => {
       const state = {
         featureToggles: {
           mhv_landing_page_enabled: true,
@@ -44,6 +44,12 @@ describe(manifest.appName, () => {
             signIn: {
               serviceName: CSP_IDS.ID_ME,
             },
+            facilities: [
+              {
+                facilityId: '668',
+                isCerner: false,
+              },
+            ],
           },
           login: {
             currentlyLoggedIn: true,
@@ -63,6 +69,12 @@ describe(manifest.appName, () => {
             signIn: {
               serviceName: CSP_IDS.LOGIN_GOV,
             },
+            facilities: [
+              {
+                facilityId: '668',
+                isCerner: false,
+              },
+            ],
           },
           login: {
             currentlyLoggedIn: true,
@@ -164,6 +176,26 @@ describe(manifest.appName, () => {
       };
       const result = isLandingPageEnabledForUser(state);
       expect(result).to.be.true;
+    });
+    it('app is disabled if the feature is enabled AND the user is logged AND has no facilities', () => {
+      const state = {
+        featureToggles: {
+          mhv_landing_page_enabled: true,
+        },
+        user: {
+          profile: {
+            facilities: [],
+            signIn: {
+              serviceName: CSP_IDS.ID_ME,
+            },
+          },
+          login: {
+            currentlyLoggedIn: true,
+          },
+        },
+      };
+      const result = isLandingPageEnabledForUser(state);
+      expect(result).to.be.false;
     });
   });
 });

--- a/src/applications/mhv/landing-page/utilities/feature-toggles/index.js
+++ b/src/applications/mhv/landing-page/utilities/feature-toggles/index.js
@@ -18,6 +18,11 @@ const isLandingPageEnabledForUser = (state = {}) => {
   }
   const { serviceName } = user?.profile?.signIn;
   const isCernerPatient = selectIsCernerPatient(state);
-  return ENABLED_LOGIN_PROVIDERS.includes(serviceName) && !isCernerPatient;
+  const hasFacilities = user.profile.facilities?.length > 0;
+  return (
+    ENABLED_LOGIN_PROVIDERS.includes(serviceName) &&
+    !isCernerPatient &&
+    hasFacilities
+  );
 };
 export { isLandingPageEnabledForUser };


### PR DESCRIPTION
## Summary

If a user does not have any values in user/va_profile/facilities, do not allow them to navigate to va.gov/my-health and see the new authenticated landing page. Instead, they will continue to be directed to the MHV portal.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/54958


## Testing done

- unit
- cypres
