### PR TITLE
Add USDS Signature pattern to the Review Page of 26-4555

### DIFF
--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -1,8 +1,8 @@
 import environment from 'platform/utilities/environment';
 import fullSchema from 'vets-json-schema/dist/26-4555-schema.json';
 
-import preSubmitInfo from 'platform/forms/preSubmitInfo';
 import footerContent from 'platform/forms/components/FormFooter';
+import preSubmitInfo from '../containers/PreSubmitSignature';
 import transformForSubmit from '../../shared/config/submit-transformer';
 import prefillTransformer from './prefill-transformer';
 import getHelp from '../containers/GetFormHelp';

--- a/src/applications/simple-forms/26-4555/containers/PreSubmitSignature.jsx
+++ b/src/applications/simple-forms/26-4555/containers/PreSubmitSignature.jsx
@@ -1,0 +1,171 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
+
+const PreSubmitSignature = ({
+  formData,
+  showError,
+  onSectionComplete,
+  formSubmission,
+}) => {
+  const isSubmitPending = formSubmission.status === 'submitPending';
+  const hasSubmit = !!formSubmission.status;
+  const { first, middle, last } = formData.veteran.fullName;
+  const [certifyChecked, setCertifyChecked] = useState(false);
+  const [certifyCheckboxError, setCertifyCheckboxError] = useState(false);
+  const [signatureError, setSignatureError] = useState(false);
+  const [signature, setSignature] = useState({
+    value: '',
+    dirty: false,
+  });
+  const isDirty = signature.dirty;
+  const setNewSignature = event => {
+    setSignature({ value: event.target.value, dirty: true });
+  };
+
+  const normalize = string => {
+    if (!string) {
+      return '';
+    }
+
+    return string
+      .split(' ')
+      .join('')
+      .toLowerCase();
+  };
+
+  // validate input name with name on file
+  // signature matching logic is done with spaces removed
+  const nameOnFile = normalize(first) + normalize(middle) + normalize(last);
+  const inputValue = normalize(signature.value);
+  const signatureMatches = !!nameOnFile && nameOnFile === inputValue;
+
+  useEffect(
+    () => {
+      // show error if user has touched input and signature does not match
+      // show error if there is a form error and has not been submitted
+      if ((isDirty && !signatureMatches) || (showError && !hasSubmit)) {
+        setSignatureError(true);
+      }
+
+      // if input has been touched and signature matches allow submission
+      // if input is dirty and representative is signing skip validation
+      // make sure signature is not undefined
+      if (isDirty && signatureMatches) {
+        setSignatureError(false);
+      }
+    },
+    [showError, hasSubmit, isDirty, signature.dirty, signatureMatches],
+  );
+
+  useEffect(
+    () => {
+      if (showError && !hasSubmit) {
+        setCertifyCheckboxError(!certifyChecked);
+        setSignatureError(!signatureMatches);
+      }
+    },
+    [showError, hasSubmit, certifyChecked, signatureMatches],
+  );
+
+  useEffect(
+    () => {
+      if (certifyChecked && isDirty && signatureMatches) {
+        onSectionComplete(true);
+      }
+      return () => {
+        onSectionComplete(false);
+        setSignatureError(false);
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isDirty, certifyChecked, signatureMatches, setSignatureError],
+  );
+
+  if (isSubmitPending) {
+    return (
+      <div className="vads-u-margin-bottom--3">
+        <va-loading-indicator
+          label="Loading"
+          message="We’re processing your application."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--3 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--3">
+        <h3>Statement of truth</h3>
+        <p>
+          I certify that I am applying for assistance in acquiring specially
+          adapted housing or special home adaptation grant because of the nature
+          of my service-connected disability. I understand that there are
+          medical and economic features yet to be considered before I am
+          eligible for this benefit, and that I will be notified of the action
+          taken on this application as soon as possible.
+        </p>
+        <p>
+          I have read and accept the{' '}
+          <a
+            aria-label="Privacy policy, will open in new tab"
+            target="_blank"
+            href="/privacy-policy/"
+          >
+            privacy policy
+          </a>
+          .
+        </p>
+
+        <va-text-input
+          label="Your full name"
+          class="signature-input"
+          id="veteran-signature"
+          name="veteran-signature"
+          onInput={setNewSignature}
+          type="text"
+          required
+          error={
+            signatureError
+              ? `Please enter your name exactly as it appears on your application: ${first} ${middle ||
+                  ''} ${last}`
+              : ''
+          }
+        />
+
+        <Checkbox
+          name="veteran-certify"
+          checked={certifyChecked}
+          onValueChange={value => setCertifyChecked(value)}
+          label="I certify the information above is correct and true to the best of my knowledge and belief."
+          errorMessage={
+            certifyCheckboxError && 'You must certify by checking the box.'
+          }
+          required
+        />
+      </article>
+    </>
+  );
+};
+
+PreSubmitSignature.propTypes = {
+  formData: PropTypes.object,
+  formSubmission: PropTypes.object,
+  showError: PropTypes.bool,
+  onSectionComplete: PropTypes.func,
+};
+
+const mapStateToProps = ({ form }) => {
+  return {
+    formSubmission: form.submission,
+  };
+};
+
+export default {
+  required: true,
+  CustomComponent: connect(
+    mapStateToProps,
+    null,
+  )(PreSubmitSignature),
+};


### PR DESCRIPTION
## Summary
This adds the design system [signature pattern](https://design.va.gov/patterns/ask-users-for/signature) to the review page of the 26-4555 form. I copied the majority of this code from [this file](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/financial-status-report/components/PreSubmitSignature.jsx) that was utilizing a similar pattern. 

There are a few things with my implementation that I would like to improve in the future. 

The main one is re-usability. This contains a hardcoded paragraph with text that is specifically for the 26-4555 form. Ideally, this paragraph would be customizable by accepting some sort of string parameter, then the pattern could live in our "shared" directory and be re-used more easily. 

The other issue is the use of the component library `Checkbox` component. Ideally, this should be `va-checkbox`, but I encountered a number of UI issues trying to implement it in addition to fighting against the logic that I copied from the previously linked file. Due to time constraints, I left it how it was.

Lastly, there is an `AGREED` property that's being added to the POSTed data. I don't know exactly where it comes from, and it's not really a problem because that value is irrelevant to our submission, but it would be nice to track it down and figure it out/remove that addition. It also means that we aren't using the `privacyAgreementAccepted` property in our schema anymore, so this should be removed at some point.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#133


## Screenshots
<img width="457" alt="image" src="https://user-images.githubusercontent.com/53942725/225360506-8ef613aa-6f43-4bad-8b90-e93d04ba107f.png">
