### PR TITLE
fix to display atlas address

### DIFF
--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -457,7 +457,11 @@ export function selectModalityText(appointment) {
   //
   // TODO: What default should be displayed if the data is corrupt an there is
   // no facility name?
-  if (facilityName && isVideoAtlas) return `At ${facilityName}`;
+  if (facilityName) return `At ${facilityName}`;
+  if (isVideoAtlas) {
+    const { line, city, state } = appointment.videoData.atlasLocation.address;
+    return `At ${line} ${city}, ${state}`;
+  }
 
   if (isInPerson || isVideoClinic) {
     return facilityName ? `At ${facilityName}` : 'At VA facility';


### PR DESCRIPTION
## Summary
This PR displays the facility address for ATLAS appointments.


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#54559


## Testing done
Unit


## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_appointments_ (5)](https://user-images.githubusercontent.com/3587066/225396525-2f335400-ee11-4214-8aef-7c717e368b7e.png)


## What areas of the site does it impact?
VAOS


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
