### PR TITLE
updated modality icon color & border color

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentCard.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentCard.jsx
@@ -25,7 +25,10 @@ function VideoAppointmentDescription({ appointment }) {
   }
   return (
     <>
-      <i aria-hidden="true" className="fas fa-video vads-u-margin-right--1" />
+      <i
+        aria-hidden="true"
+        className="fas fa-video vads-u-margin-right--1 vads-u-color--gray"
+      />
       VA Video Connect {desc}
     </>
   );
@@ -130,7 +133,7 @@ export default function AppointmentCard({
             <>
               <i
                 aria-hidden="true"
-                className="fas fa-phone vads-u-margin-right--1"
+                className="fas fa-phone vads-u-margin-right--1 vads-u-color--gray"
               />
               Phone call
             </>

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentColumnLayout.jsx
@@ -69,7 +69,7 @@ export default function AppointmentColumnLayout({
       <AppointmentColumn
         className={classNames(
           'vaos-appts__column--2',
-          'vads-u-border-color--gray-lighter',
+          'vads-u-border-color--gray-medium',
           'vads-u-margin-left--2',
           'vads-u-padding-y--2',
           'small-screen:vads-u-margin-left--4',
@@ -115,6 +115,7 @@ export default function AppointmentColumnLayout({
                     className={classNames(
                       'fas',
                       'vads-u-margin-right--1',
+                      'vads-u-color--gray',
                       modalityIcon,
                     )}
                   />

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItemGroup.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItemGroup.jsx
@@ -196,7 +196,7 @@ export default function AppointmentListItemGroup({ data }) {
           <div
             className={classNames('vads-l-col--4', 'vads-u-padding-y--2', {
               'vads-u-border-bottom--1px': isBorderBottom,
-              'vads-u-border-color--gray-lighter': isBorderBottom,
+              'vads-u-border-color--gray-medium': isBorderBottom,
             })}
           >
             <div
@@ -211,7 +211,7 @@ export default function AppointmentListItemGroup({ data }) {
           <div
             className={classNames('vads-l-col--4', 'vads-u-padding-y--2', {
               'vads-u-border-bottom--1px': isBorderBottom,
-              'vads-u-border-color--gray-lighter': isBorderBottom,
+              'vads-u-border-color--gray-medium': isBorderBottom,
             })}
           >
             <div style={styles.canceled}>
@@ -237,7 +237,7 @@ export default function AppointmentListItemGroup({ data }) {
               'vads-u-text-align--right',
               {
                 'vads-u-border-bottom--1px': isBorderBottom,
-                'vads-u-border-color--gray-lighter': isBorderBottom,
+                'vads-u-border-color--gray-medium': isBorderBottom,
               },
             )}
           >

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestAppointmentLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestAppointmentLayout.jsx
@@ -38,7 +38,7 @@ export default function RequestAppointmentLayout({ appointment }) {
         <AppointmentColumn
           className={classNames(
             'vaos-appts__column--2',
-            'vads-u-border-color--gray-lighter',
+            'vads-u-border-color--gray-medium',
             'vads-u-padding-y--2',
             {
               'vads-u-border-top--1px': grouped && !first,
@@ -61,6 +61,7 @@ export default function RequestAppointmentLayout({ appointment }) {
                       className={classNames(
                         'fas',
                         'vads-u-margin-right--1',
+                        'vads-u-color--gray',
                         modalityIcon,
                       )}
                     />

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -148,7 +148,7 @@ export default function UpcomingAppointmentsList() {
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',
                 {
-                  'vads-u-border-bottom--1px': featureAppointmentList,
+                  'vads-u-border-bottom--1px vads-u-border-color--gray-medium': featureAppointmentList,
                 },
               )}
               data-cy="upcoming-appointment-list"


### PR DESCRIPTION
This PR:
- Changes divider line color to #757575
- Changes modality icon colors #5B616B


<img width="1152" alt="Screenshot 2023-03-15 at 8 11 40 PM" src="https://user-images.githubusercontent.com/47654119/225475686-47ffe9b0-7c23-42e6-8d8e-8599f652950c.png">
<img width="1234" alt="Screenshot 2023-03-15 at 8 14 11 PM" src="https://user-images.githubusercontent.com/47654119/225476199-209ee84d-e47f-4eb2-a162-580260d233ad.png">
<img width="1229" alt="Screenshot 2023-03-15 at 8 14 47 PM" src="https://user-images.githubusercontent.com/47654119/225476268-869b4202-a4de-469f-8caf-7f6ac9d86471.png">
