### PR TITLE
add workflow to generate main image

### DIFF
--- a/.github/workflows/preview-environment-update-main.yml
+++ b/.github/workflows/preview-environment-update-main.yml
@@ -1,4 +1,4 @@
-name: Preview Environment Deployment
+name: Preview Environment - Update main image
 
 on:
   push:
@@ -6,7 +6,8 @@ on:
       - 'main'
 
 jobs:
-  deploy-preview-environment:
+  update-preview-environment-main-image:
+    name: Update preview environment main image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,6 +53,6 @@ jobs:
       #     push: false
       #     # Update tags and ECR Repository
       #     tags: |
-      #       ${{ steps.login-ecr.outputs.registry }}/dsva/preview-environment/vets-website:main
+      #       ${{ steps.login-ecr.outputs.registry }}/dsva/preview-environment/vets-website:latest
       #     # cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
       #     # cache-to: type=inline

--- a/.github/workflows/preview-environment-update-main.yml
+++ b/.github/workflows/preview-environment-update-main.yml
@@ -1,11 +1,9 @@
 name: Preview Environment Deployment
 
 on:
-  repository_dispatch:
-    types: [deploy_review_instance]
   push:
     branches:
-      - '**'
+      - 'main'
 
 jobs:
   deploy-preview-environment:
@@ -39,15 +37,6 @@ jobs:
           path: |
             .cache/yarn
             node_modules
-
-      - name: Get Source Repo and Source Ref
-        run: node ./script/github-actions/pe-deploy-source.js
-        env:
-          SOURCE_EVENT: ${{ github.event_name }}
-          SOURCE_BRANCH: ${{ github.event.client_payload.source_ref }}
-          SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
-          WORKFLOW_BRANCH: ${{ github.ref_name }}
-
       # - name: Login to ECR # Update ECR credentials if necessary
       #   id: login-ecr
       #   uses: aws-actions/amazon-ecr-login@v1
@@ -63,15 +52,6 @@ jobs:
       #     push: false
       #     # Update tags and ECR Repository
       #     tags: |
-      #       ${{ steps.login-ecr.outputs.registry }}/dsva/preview-environment/${{ env.SOURCE_REPO }}:${{ env.SOURCE_REF_SANITIZED }}
+      #       ${{ steps.login-ecr.outputs.registry }}/dsva/preview-environment/vets-website:main
       #     # cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
       #     # cache-to: type=inline
-
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
-          event-type: deploy_review_instance
-          repository: department-of-veterans-affairs/devops
-          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}", "source_ref_sanitized": "${{ env.SOURCE_REF_SANITIZED }}" }'
-          # Once docker image is built, add the name of the image to this object as a new property.

--- a/script/github-actions/pe-cleanup.js
+++ b/script/github-actions/pe-cleanup.js
@@ -56,7 +56,7 @@ const deleteFiles = valuesFiles => {
 
 if (process.env.TRIGGERING_EVENT === 'delete') {
   const valuesFiles = fs
-    .readdirSync('./manifests/apps/preview-environment/dev/environment-values/')
+    .readdirSync('./manifests/apps/preview-environment/dev/pe-envs/')
     .filter(file =>
       file.includes(
         `${process.env.CURRENT_REPOSITORY}-${process.env.DELETED_BRANCH}`,


### PR DESCRIPTION
## Summary

- Preview environments that start from an outside repository, but require this repository's code to be part of the build will need an updated version of the main branch to include in the build. This will push a new image of the main branch to ECR every time it is updated and will tag it as the latest.

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#54990](https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/54990)

## What areas of the site does it impact?
Preview Environments MVP

## Acceptance criteria

- [ ] Workflow runs every time main is updated.
- [ ] Workflow generates and stores a new version of main image in ECR
