### PR TITLE
MBMS-39017 fixed Grammar issues on preneed introduction page

### DIFF
--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -49,7 +49,6 @@ class IntroductionPage extends React.Component {
                   <a href={getAppUrl('facilities')}>
                     Find a VA national cemetery
                   </a>
-                  .
                 </li>
                 <li>
                   Service history or the service history of the service member
@@ -57,7 +56,7 @@ class IntroductionPage extends React.Component {
                   your or your sponsor’s:
                   <ul>
                     <li>
-                      Social Security number (and Military Service Number if
+                      Social Security number (and Military Service number if
                       it’s different than the Social Security number)
                     </li>
                     <li>VA claim number (if you know it)</li>

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -47,7 +47,9 @@ class IntroductionPage extends React.Component {
                   buried.
                   <br />
                   <a href={getAppUrl('facilities')}>
-                    Find a VA national cemetery
+                    {environment.isProduction()
+                      ? 'Find a VA national cemetery.'
+                      : 'Find a VA national cemetery'}
                   </a>
                 </li>
                 <li>
@@ -56,8 +58,9 @@ class IntroductionPage extends React.Component {
                   your or your sponsor’s:
                   <ul>
                     <li>
-                      Social Security number (and Military Service number if
-                      it’s different than the Social Security number)
+                      {environment.isProduction()
+                        ? 'Social Security number (and Military Service Number if it’s different than the Social Security number)'
+                        : 'Social Security number (and Military Service number if it’s different than the Social Security number)'}
                     </li>
                     <li>VA claim number (if you know it)</li>
                     <li>Date and place of birth</li>


### PR DESCRIPTION
# [MBMS-39017](https://vajira.max.gov/browse/MBMS-39017)
#### (Click Link Above to see Jira Bug)

## Summary

- Issue: Incorrect grammar on introduction page
- Feature Flag Status: Does not impact 
- Steps to reproduce: Navigate to the form's introduction and scroll to Step 1 for prepare and you will see the incorrect grammar noted above.
- Expected results: Remove period at the end of link and change to "Military Service number" (located under the 'Prepare' step of the subway pattern.)
- Actual Results: "Find a VA national cemetery" has a period after the word "cemetery" and "Military Service Number" is capitalized


## Testing done

- Local Testing

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

#### Before:
![image](https://user-images.githubusercontent.com/122034971/225709509-2b4cd3bc-a51e-4644-a152-edaea28f96db.png)

#### After:
![image](https://user-images.githubusercontent.com/122034971/225710462-29262891-8ffc-44d7-8fa3-f28e15f5c4ac.png)

## Acceptance criteria

- [x]  Grammar issues have been corrected.