### PR TITLE
updated divider color

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItemGroup.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItemGroup.jsx
@@ -179,7 +179,7 @@ export default function AppointmentListItemGroup({ data }) {
               'vads-u-padding-right--1',
               {
                 'vads-u-border-bottom--1px': isBorderBottom,
-                'vads-u-border-color--gray-lighter': isBorderBottom,
+                'vads-u-border-color--gray-medium': isBorderBottom,
               },
             )}
           >

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/ListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/ListItem.jsx
@@ -22,6 +22,7 @@ export default function ListItem({
         {
           'vads-u-border-top--1px': borderTop,
           'vads-u-border-bottom--1px': borderBottom,
+          'vads-u-border-color--gray-medium': borderBottom,
         },
       )}
       data-cy="appointment-list-item" // TODO: Update e2e tests to look for appointment-list-item

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/UpcomingAppointmentLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/UpcomingAppointmentLayout.jsx
@@ -27,6 +27,7 @@ export default function UpcomingAppointmentLayout({
             'vaos-appts__listItem',
             {
               'vads-u-border-bottom--1px': !isLastInMonth,
+              'vads-u-border-color--gray-medium': !isLastInMonth,
             },
           )}
         >
@@ -81,6 +82,7 @@ export default function UpcomingAppointmentLayout({
             'vaos-appts__listItem--clickable',
             {
               'vads-u-border-bottom--1px': !isLastInMonth,
+              'vads-u-border-color--gray-medium': !isLastInMonth,
             },
           )}
         >

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/index.jsx
@@ -270,7 +270,10 @@ export default function PastAppointmentsListNew() {
               className={classNames(
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',
-                { 'vads-u-border-bottom--1px': featureAppointmentList },
+                {
+                  'vads-u-border-bottom--1px': featureAppointmentList,
+                  'vads-u-border-color--gray-medium': featureAppointmentList,
+                },
               )}
               data-cy="past-appointment-list"
               role="list"

--- a/src/applications/vaos/appointment-list/sass/styles.scss
+++ b/src/applications/vaos/appointment-list/sass/styles.scss
@@ -150,6 +150,7 @@ li.vaos-appts__listItem--clickable[data-status="upcoming"]:last-child
 
 li.vaos-appts__listItem--clickable[data-status="pending"]:last-child {
   border-bottom: 1px solid !important;
+  border-color: $color-gray-medium !important;
 }
 
 .vaos-appts__column--1 {


### PR DESCRIPTION
Peter [left a comment](https://app.zenhub.com/workspaces/vaos-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/54101) that some of the divider lines were not updated so this PR:
- updates divider line color to: #757575.

<img width="1298" alt="Screenshot 2023-03-16 at 3 24 55 PM" src="https://user-images.githubusercontent.com/47654119/225731519-803d5afa-f927-4144-8f54-834e666592cb.png">
<img width="1233" alt="Screenshot 2023-03-16 at 3 25 15 PM" src="https://user-images.githubusercontent.com/47654119/225731599-8be7da71-6928-445e-8ad7-a31cfa69299b.png">
