### PR TITLE
Modify aria label

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
@@ -23,7 +23,7 @@ const AppointmentListItemVaos = props => {
 
   const typeOfCare = appointment.clinicStopCodeName
     ? appointment.clinicStopCodeName
-    : t('VA-appointment');
+    : '';
 
   const infoBlockMessage = () => {
     if (appointment?.kind === 'phone') {
@@ -95,7 +95,7 @@ const AppointmentListItemVaos = props => {
                 type: typeOfCare,
               })}
             >
-              Details
+              {t('details')}
             </a>
           </div>
         )}

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
@@ -23,7 +23,7 @@ const AppointmentListItemVaos = props => {
 
   const typeOfCare = appointment.clinicStopCodeName
     ? appointment.clinicStopCodeName
-    : '';
+    : t('VA-appointment');
 
   const infoBlockMessage = () => {
     if (appointment?.kind === 'phone') {
@@ -92,7 +92,7 @@ const AppointmentListItemVaos = props => {
               onClick={e => goToDetails(e, appointment)}
               aria-label={t('details-for-appointment', {
                 time: appointmentDateTime,
-                type: typeOfCare,
+                type: appointment.clinicStopCodeName ? typeOfCare : 'VA',
               })}
             >
               {t('details')}

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItemVaos.jsx
@@ -21,10 +21,6 @@ const AppointmentListItemVaos = props => {
   const pagesToShowDetails = ['details', 'complete', 'confirmation'];
   const showDetailsLink = pagesToShowDetails.includes(page) && goToDetails;
 
-  const typeOfCare = appointment.clinicStopCodeName
-    ? appointment.clinicStopCodeName
-    : t('VA-appointment');
-
   const infoBlockMessage = () => {
     if (appointment?.kind === 'phone') {
       return (
@@ -56,7 +52,9 @@ const AppointmentListItemVaos = props => {
           data-testid="appointment-type-and-provider"
           className="vads-u-font-weight--bold"
         >
-          {typeOfCare}
+          {appointment.clinicStopCodeName
+            ? appointment.clinicStopCodeName
+            : t('VA-appointment')}
           {appointment.doctorName
             ? ` ${t('with')} ${appointment.doctorName}`
             : ''}
@@ -92,7 +90,9 @@ const AppointmentListItemVaos = props => {
               onClick={e => goToDetails(e, appointment)}
               aria-label={t('details-for-appointment', {
                 time: appointmentDateTime,
-                type: appointment.clinicStopCodeName ? typeOfCare : 'VA',
+                type: appointment.clinicStopCodeName
+                  ? appointment.clinicStopCodeName
+                  : 'VA',
               })}
             >
               {t('details')}

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -218,6 +218,7 @@
   "reason-for-visit": "Reason for visit",
   "appointment-day": "{{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
   "back-to-appointments": "Back to appointments",
+  "details": "Details",
   "details-for-appointment": "Details for {{ type }} appointment at {{ time, time }}",
   "directions-to-location": "Directions to {{ location }}",
   "directions": "Directions",


### PR DESCRIPTION
## Summary

- Updates aria label to avoid redundant appointment word

ex:

With appointment type:
"Details for Mental health appointment at 4:28 p.m."

Without appointment type:
"Details for appointment at 4:28 p.m."

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#55226](https://github.com/department-of-veterans-affairs/va.gov-team/issues/55226)


## Testing done

- Visual

