### PR TITLE
Supplemental Claims | Design & a11y fixes

### DIFF
--- a/src/applications/appeals/995/components/AddIssue.jsx
+++ b/src/applications/appeals/995/components/AddIssue.jsx
@@ -1,14 +1,10 @@
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   VaMemorableDate,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-// updatePage isn't available for CustomPage on non-review pages, see
-// https://github.com/department-of-veterans-affairs/va.gov-team/issues/33797
-import { setData } from 'platform/forms-system/src/js/actions';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { getSelected, calculateIndexOffset } from '../utils/helpers';
@@ -32,10 +28,8 @@ import { content } from '../content/addIssue';
 const ISSUES_PAGE = `/${CONTESTABLE_ISSUES_PATH}`;
 const REVIEW_AND_SUBMIT = '/review-and-submit';
 
-const AddIssue = props => {
-  const { data, goToPath, setFormData, testingIndex } = props;
+const AddIssue = ({ data, goToPath, setFormData, testingIndex }) => {
   const { contestedIssues = [], additionalIssues = [] } = data || {};
-
   const allIssues = contestedIssues.concat(additionalIssues);
 
   // get index from url '/add-issue?index={index}' or testingIndex
@@ -213,13 +207,4 @@ AddIssue.propTypes = {
   testingIndex: PropTypes.number,
 };
 
-const mapDispatchToProps = {
-  setFormData: setData,
-};
-
-export default connect(
-  null,
-  mapDispatchToProps,
-)(AddIssue);
-
-export { AddIssue };
+export default AddIssue;

--- a/src/applications/appeals/995/components/AddIssue.jsx
+++ b/src/applications/appeals/995/components/AddIssue.jsx
@@ -164,7 +164,9 @@ const AddIssue = ({ data, goToPath, setFormData, testingIndex }) => {
         >
           {content.name.hint}
         </VaTextInput>
-        <br />
+
+        <br role="presentation" />
+
         <VaMemorableDate
           name="decision-date"
           label={content.date.label}

--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -515,7 +515,8 @@ const EvidencePrivateRecords = ({
           autocomplete="section-provider postal-code"
         />
 
-        <br />
+        <br role="presentation" />
+
         <VaCheckboxGroup
           label={content.issuesLabel}
           name="issues"

--- a/src/applications/appeals/995/components/EvidenceSummary.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummary.jsx
@@ -106,7 +106,12 @@ const EvidenceSummary = ({
             tabbable when hidden
           - Only render the alert content since the screenreader can still
             target the headers inside */}
-        <va-alert id="no-evidence" status="warning" visible={visibleError}>
+        <va-alert
+          id="no-evidence"
+          status="warning"
+          visible={visibleError}
+          class="vads-u-margin-top--4"
+        >
           {visibleError && (
             <>
               <H slot="headline">{content.missingEvidenceHeader}</H>

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -369,7 +369,9 @@ const EvidenceVaRecords = ({
           error={showError('name') || errors.unique || null}
           autocomplete="section-facility name"
         />
-        <br />
+
+        <br role="presentation" />
+
         <VaCheckboxGroup
           label={content.conditions}
           name="issues"

--- a/src/applications/appeals/995/components/VeteranInformation.jsx
+++ b/src/applications/appeals/995/components/VeteranInformation.jsx
@@ -54,7 +54,9 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
           Gender: <span className="gender">{genderLabels?.[gender] || ''}</span>
         </p>
       </div>
-      <br />
+
+      <br role="presentation" />
+
       <p>
         <strong>Note:</strong> If you need to update your personal information,
         you can call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />.

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -86,12 +86,9 @@ export const errorMessages = {
   // endDateInPast: 'The end date must be in the future',
   endDateBeforeStart: 'The end date must be after the start date',
 
-  invalidDateRange: (min, max) =>
-    `You must enter a year between ${min} and ${max}`,
   decisions: {
     missingDate: 'You must enter a decision date',
-    pastDate:
-      'You must add an issue with a decision date that’s less than 100 years old',
+    pastDate: 'You must add a decision date that’s in the past',
     newerDate: 'You must add a more recent decision date',
   },
   evidence: {

--- a/src/applications/appeals/995/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/containers/ConfirmationPage.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { selectProfile } from 'platform/user/selectors';
 import scrollTo from 'platform/utilities/ui/scrollTo';
 import { focusElement } from 'platform/utilities/ui';
+import { resetStoredSubTask } from 'platform/forms/sub-task';
 
 import { FORMAT_READABLE } from '../constants';
 import { getSelected, getIssueName } from '../utils/helpers';
@@ -27,6 +28,7 @@ export class ConfirmationPage extends React.Component {
     ));
     const fullName = `${name.first} ${name.middle || ''} ${name.last}`;
     const submitDate = moment(submission?.timestamp);
+    resetStoredSubTask();
 
     return (
       <div>

--- a/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import sinon from 'sinon';
 
-import { AddIssue } from '../../components/AddIssue';
+import AddIssue from '../../components/AddIssue';
 import {
   errorMessages,
   MAX_LENGTH,

--- a/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
@@ -102,10 +102,7 @@ describe('<AddIssue>', () => {
     $('button#submit', container).click();
 
     const date = $('va-memorable-date', container);
-    expect(date.error).to.contain(
-      // partial match
-      errorMessages.invalidDateRange('xxxx', '').split('xxxx')[0],
-    );
+    expect(date.error).to.eq(errorMessages.decisions.pastDate);
   });
   it('should show an error when the issue date is > 1 year in the future', () => {
     const decisionDate = getDate({ offset: { months: +13 } });

--- a/src/applications/appeals/995/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/date.unit.spec.js
@@ -35,7 +35,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a range error for dates too old', () => {
     validateDate(errors, '1899-01-01');
-    expect(errorMessage).to.contain('enter a year between');
+    expect(errorMessage).to.eq(errorMessages.decisions.newerDate);
     expect(isValidDate('1899')).to.be.false;
   });
   it('should throw an error for dates in the future', () => {

--- a/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
@@ -129,7 +129,7 @@ describe('VA evidence', () => {
       validateVaToDate(errors, {
         evidenceDates: { to: getDate({ offset: { years: 101 } }) },
       });
-      expect(errors.addError.args[0][0]).contains('must enter a year between');
+      expect(errors.addError.args[0][0]).eq(errorMessages.evidence.pastDate);
     });
   });
 
@@ -385,7 +385,7 @@ describe('Private evidence', () => {
       validatePrivateToDate(errors, {
         treatmentDateRange: { to: getDate({ offset: { years: 101 } }) },
       });
-      expect(errors.addError.args[0][0]).contains('must enter a year between');
+      expect(errors.addError.args[0][0]).eq(errorMessages.evidence.pastDate);
     });
   });
 

--- a/src/applications/appeals/995/validations/date.js
+++ b/src/applications/appeals/995/validations/date.js
@@ -1,7 +1,6 @@
 import moment from 'moment';
 
 import { parseISODate } from 'platform/forms-system/src/js/helpers';
-import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
 
 import { fixDateFormat } from '../utils/replace';
 import { errorMessages, FORMAT_YMD, MAX_YEARS_PAST } from '../constants';
@@ -32,10 +31,6 @@ export const validateDate = (errors, rawString = '', fullData) => {
     errors.addError(errorMessages[dateType].missingDate);
   } else if (!date.isValid()) {
     errors.addError(errorMessages.invalidDate);
-  } else if (year?.length >= 4 && !isValidYear(year)) {
-    errors.addError(
-      errorMessages.invalidDateRange(minDate.year(), maxDate.year()),
-    );
   } else if (date.isSameOrAfter(maxDate)) {
     // Lighthouse won't accept same day (as submission) decision date
     errors.addError(errorMessages[dateType].pastDate);


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Various fixes:
  > - Update date error messaging; there was a logic error that was fixed, and another [problem with the `va-memorable-date` web component](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1593) to be fixed by the Design system team
  > - Add margin above no evidence summary page alert
  > - Fix save-in-progress not being called after adding or editing a contestable issue
  > - Clear subtask values on confirmation page; this makes the subtask (`/start` page) show when returning to the intro page
  > - Add `role="presentation"` to all `<br />` (so screen readers don't read it out)
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#55277](https://github.com/department-of-veterans-affairs/va.gov-team/issues/55277)

## Testing done

- *Describe what the old behavior was prior to the change*
  > All tests passing. Only minor changes to the date error messaging was required. Other changes are visual or background changes
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

Appropriate date error message showing for a date in the future
<img width="583" alt="A date of May 22, 2024 (a future date) is entered into the va-memorable-date component with an error message above it stating You must add a decision date that's in the past" src="https://user-images.githubusercontent.com/136959/225744608-dc3f67b9-67b6-4ac6-96cd-14b89104bace.png">

Margin added between header and alert
<img width="589" alt="Top margin matching the bottom margin around an alert message of We noticed you didn't add new evidence; previously the alert was immediately below the header with text confirm or edit your evidence" src="https://user-images.githubusercontent.com/136959/225744610-406daf37-4ba5-4672-a16b-71b03b11217c.png">

Save-in-progress success alert shown after editing the last entry
<img width="566" alt="green save in progress success message shown under the back and continue button after returning to the contestable issues page" src="https://user-images.githubusercontent.com/136959/225744607-196ebb63-0308-4998-8927-06ddc0849c65.png">

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
