### PR TITLE
rm 526EZ Introduction page a tag style that broke icon

### DIFF
--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -221,15 +221,6 @@ div.review {
   }
 }
 
-/* Introduction page */
-article[data-location="introduction"]
-{
-  a.vads-c-action-link--green {
-    display: block;
-    line-height: 1em;
-  }
-}
-
 /* Confirmation page */
 article[data-location="confirmation"] {
   h1[tabindex="-1"] {


### PR DESCRIPTION
## Summary
Remove a couple of CSS rules to fix some broken styling on an icon.

## Related issue(s)
[55306](https://app.zenhub.com/workspaces/disability-experience-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/55306)

## Testing done
Visual, see screenshots.


## Screenshots
_Before (spotted in staging, reproduced on local dev):_
<img width="710" alt="Screenshot 2023-03-16 at 3 23 29 PM" src="https://user-images.githubusercontent.com/123964597/225757429-8a5f223b-573a-4d57-9c73-a1c8df9f06aa.png">

_And after the fix:_
<img width="748" alt="Screenshot 2023-03-16 at 4 23 28 PM" src="https://user-images.githubusercontent.com/123964597/225757451-acb4c45c-0f68-4175-b547-b61e9fa6c9cf.png">

_Mobile looks good, too now:_
<img width="386" alt="Screenshot 2023-03-16 at 4 34 44 PM" src="https://user-images.githubusercontent.com/123964597/225757779-9cb9760d-c717-495a-8cc8-26fedca0ff82.png">
