### PR TITLE
26-4555 Change "remarks" page to use checkboxes and a textarea

### DIFF
--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -3,7 +3,7 @@ import fullSchema from 'vets-json-schema/dist/26-4555-schema.json';
 
 import footerContent from 'platform/forms/components/FormFooter';
 import preSubmitInfo from '../containers/PreSubmitSignature';
-import transformForSubmit from '../../shared/config/submit-transformer';
+import transformForSubmit from './submit-transformer';
 import prefillTransformer from './prefill-transformer';
 import getHelp from '../containers/GetFormHelp';
 

--- a/src/applications/simple-forms/26-4555/config/submit-transformer.js
+++ b/src/applications/simple-forms/26-4555/config/submit-transformer.js
@@ -1,0 +1,37 @@
+import sharedTransformForSubmit from '../../shared/config/submit-transformer';
+
+export default function transformForSubmit(formConfig, form) {
+  const remarksFormData = form.data.remarks;
+  const remarksUiSchema =
+    formConfig.chapters.additionalInformationChapter.pages.remarks.uiSchema
+      .remarks;
+
+  let remarkString = '';
+
+  Object.keys(remarksFormData).forEach(remarkKey => {
+    // filters by 'truthy' values, so non-empty strings and 'true' checkboxes
+    if (remarksFormData[remarkKey]) {
+      // 'true' checkboxes add their ui:title
+      // non-empty strings add their string content
+      remarkString +=
+        remarksFormData[remarkKey] === true
+          ? `${remarksUiSchema[remarkKey]['ui:title']}, `
+          : `${remarksFormData[remarkKey]}, `;
+    }
+  });
+
+  // removes final ', ' and trims whitespace
+  remarkString = remarkString.slice(0, remarkString.length - 2).trim();
+
+  const transformedData = JSON.parse(
+    sharedTransformForSubmit(formConfig, form),
+  );
+
+  if (remarkString === '') {
+    delete transformedData.remarks;
+
+    return JSON.stringify(transformedData);
+  }
+
+  return JSON.stringify({ ...transformedData, remarks: remarkString });
+}

--- a/src/applications/simple-forms/26-4555/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/IntroductionPage.jsx
@@ -31,7 +31,8 @@ class IntroductionPage extends React.Component {
           prefillEnabled={formConfig.prefillEnabled}
           messages={formConfig.savedFormMessages}
           pageList={pageList}
-          startText="Start the Application"
+          startText="Start the housing grant application"
+          testActionLink
         >
           Please complete the 26-4555 form to apply for adapted housing.
         </SaveInProgressIntro>

--- a/src/applications/simple-forms/26-4555/pages/remarks.js
+++ b/src/applications/simple-forms/26-4555/pages/remarks.js
@@ -4,36 +4,96 @@ export default {
   uiSchema: {
     remarks: {
       'ui:title': (
-        <p>
-          Please describe any service-connected conditions you may have due to
-          your military service. If you have a VA Decision Rating, please
-          include that as well.
-        </p>
-      ),
-      'ui:description': (
         <>
-          <va-additional-info trigger="Why do I need to provide this information?">
-            <p>
-              A service-connected condition is a disability related to an injury
-              or disease that developed during or was aggravated while on active
-              duty or active duty for training. VA also pays disability
-              compensation for disabilities resulting from injury, heart attack,
-              or stroke that occurred during inactive duty training. This
-              information helps establish your basic eligibility for a Specially
-              Adapted Housing Grant.
-            </p>
-          </va-additional-info>
+          <h3 className="vads-u-font-size--h2 vads-u-color--gray-dark vads-u-margin-y--0">
+            Service-connected conditions
+          </h3>
         </>
       ),
-      'ui:widget': 'textarea',
+      'ui:description': (
+        <p>
+          Do you have any of these conditions that were caused&mdash;or made
+          worse&mdash;by your service?
+        </p>
+      ),
+      respiratoryIllness: {
+        'ui:title': 'A severe respiratory (breathing-related) illness',
+      },
+      blindness: {
+        'ui:title':
+          'Blindness in both eyes (with 20/200 visual acuity or less)',
+      },
+      lossOfHands: {
+        'ui:title': 'Loss or loss of use of both hands',
+      },
+      lossOfLimbs: {
+        'ui:title': 'Loss or loss of use of more than one limb',
+      },
+      lossOfLegs: {
+        'ui:title':
+          'Loss or loss of use of a lower leg along with the residuals (lasting effects) of an organic (natural) disease or injury',
+      },
+      lossOfExtremity: {
+        'ui:title':
+          'The loss, or loss of use, of one lower extremity (foot or leg) after September 11, 2001, which makes it so you can’t balance or walk without the help of braces, crutches, canes, or a wheelchair',
+      },
+      burns: {
+        'ui:title': 'Severe burns',
+      },
+      otherConditions: {
+        'ui:title':
+          'If your conditions aren’t listed, you can write them here:',
+        'ui:widget': 'textarea',
+      },
+    },
+    'view:additionalInformation': {
+      'ui:description': (
+        <va-additional-info trigger="Why we ask for this information?">
+          <p>
+            We use the information you provide to help decide if you&rsquo;re
+            eligible for a grant. To be eligible, you must have a qualifying
+            service-connected condition. There are also other factors that
+            affect your eligibility.
+          </p>
+        </va-additional-info>
+      ),
     },
   },
   schema: {
     type: 'object',
-    required: [],
     properties: {
       remarks: {
-        type: 'string',
+        type: 'object',
+        properties: {
+          respiratoryIllness: {
+            type: 'boolean',
+          },
+          blindness: {
+            type: 'boolean',
+          },
+          lossOfHands: {
+            type: 'boolean',
+          },
+          lossOfLimbs: {
+            type: 'boolean',
+          },
+          lossOfLegs: {
+            type: 'boolean',
+          },
+          lossOfExtremity: {
+            type: 'boolean',
+          },
+          burns: {
+            type: 'boolean',
+          },
+          otherConditions: {
+            type: 'string',
+          },
+        },
+      },
+      'view:additionalInformation': {
+        type: 'object',
+        properties: {},
       },
     },
   },

--- a/src/applications/simple-forms/26-4555/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/simple-forms/26-4555/tests/e2e/fixtures/data/maximal-test.json
@@ -1,6 +1,15 @@
 {
   "data": {
-    "remarks": "total blindess",
+    "remarks": {
+      "respiratoryIllness": true,
+      "blindness": true,
+      "lossOfHands": true,
+      "lossOfLimbs": true,
+      "lossOfLegs": true,
+      "lossOfExtremity": true,
+      "burns": true,
+      "otherConditions": "This really weird fungus thing"
+    },
     "livingSituation": {
       "careFacilityName": "One Stone Facility Care",
       "careFacilityAddress": {

--- a/src/applications/simple-forms/26-4555/tests/pages/remarks.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/remarks.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('remarks page', () => {
 
     expect(
       container.querySelectorAll('input, select, textarea'),
-    ).to.have.lengthOf(1);
+    ).to.have.lengthOf(8);
   });
 
   it('should show the correct number of errors on submit', () => {


### PR DESCRIPTION
## Summary
This pull request updates the remarks page, which was previously a single textarea, to a multi-select checkbox + textarea combo. With this change also comes the addition of a custom submit transformer, which still uses the custom shared submit transformer, that maps all the data from the checked checkboxes and textarea to the `remarks` string. This is done for two reasons. One, to keep the original JSON schema structure the same. And two, the PDF only has a single text field input for this information, so the data _needs_ to be mapped to a single field. With the front end doing the lifting, the back end can continue to simply map the supplied string to the field in the PDF.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#139

## Screenshots
<img width="404" alt="image" src="https://user-images.githubusercontent.com/53942725/225773666-800698a9-1924-4d07-8657-5caf27028f5a.png">
