### PR TITLE
Simple forms - 26_4555 - parse confirmation number from response

### DIFF
--- a/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
@@ -19,7 +19,7 @@ export class ConfirmationPage extends React.Component {
     const { submission, formId, data } = form;
     const { fullName } = data.veteran;
     const submitDate = submission.timestamp;
-    const confirmationNumber = '---';
+    const confirmationNumber = submission.response?.confirmationNumber;
 
     return (
       <div>


### PR DESCRIPTION
Parse confirmation number from response and display on the confirmation page


## Summary

- Parses confirmation number from response, allowing for null

## Testing done

- Tested locally for both scenarios: displays when present, does not display when empty

## What areas of the site does it impact?
Forms

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

