### PR TITLE
Custom expanded group replacement

### DIFF
--- a/src/applications/financial-status-report/components/ResolutionDebtCards.jsx
+++ b/src/applications/financial-status-report/components/ResolutionDebtCards.jsx
@@ -6,7 +6,6 @@ import {
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 import { setData } from 'platform/forms-system/src/js/actions';
 import Telephone, {
@@ -15,6 +14,7 @@ import Telephone, {
 } from '@department-of-veterans-affairs/component-library/Telephone';
 import { deductionCodes } from '../constants/deduction-codes';
 import { currency } from '../utils/helpers';
+import ExpandedGroup from './shared/ExpandedGroup';
 
 const ExpandedContent = ({
   index,
@@ -172,7 +172,7 @@ const ResolutionDebtCards = ({
               <strong>Amount owed: </strong>
               {subTitle}
             </p>
-            <ExpandingGroup
+            <ExpandedGroup
               open={type && !compPenWaiver}
               additionalClass="form-expanding-group-active-radio"
             >
@@ -204,7 +204,7 @@ const ResolutionDebtCards = ({
                 submitted={submitted}
                 errorSchema={errorSchema}
               />
-            </ExpandingGroup>
+            </ExpandedGroup>
           </div>
         );
       })}

--- a/src/applications/financial-status-report/components/ResolutionOptions.jsx
+++ b/src/applications/financial-status-report/components/ResolutionOptions.jsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { setData } from 'platform/forms-system/src/js/actions';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import { RESOLUTION_OPTION_TYPES } from '../constants';
+import ExpandedGroup from './shared/ExpandedGroup';
 
 const ResolutionOptions = ({ formContext }) => {
   const dispatch = useDispatch();
@@ -136,7 +136,7 @@ const ResolutionOptions = ({ formContext }) => {
       )}
       {!isEditing && <>{renderResolutionSelectionText()}</>}
       {isEditing && (
-        <ExpandingGroup
+        <ExpandedGroup
           open={currentDebt.resolutionOption === RESOLUTION_OPTION_TYPES.WAIVER}
         >
           <div>
@@ -219,7 +219,7 @@ const ResolutionOptions = ({ formContext }) => {
               </div>
             </label>
           </div>
-        </ExpandingGroup>
+        </ExpandedGroup>
       )}
     </div>
   );

--- a/src/applications/financial-status-report/components/shared/ExpandedGroup.jsx
+++ b/src/applications/financial-status-report/components/shared/ExpandedGroup.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { CSSTransition } from 'react-transition-group';
+
+const ExpandedGroup = ({
+  open,
+  showPlus,
+  children,
+  additionalClass,
+  expandedContentId,
+}) => {
+  const [visibleChild, hiddenChild] = React.Children.toArray(children);
+
+  return (
+    <div>
+      {visibleChild}
+      {showPlus && <span>{open ? '-' : '+'}</span>}
+      <CSSTransition
+        in={open}
+        timeout={300}
+        classNames="expanded-group"
+        unmountOnExit
+        id={expandedContentId}
+      >
+        <div className={classNames(additionalClass)}>{hiddenChild}</div>
+      </CSSTransition>
+    </div>
+  );
+};
+
+ExpandedGroup.propTypes = {
+  children: PropTypes.node.isRequired,
+  open: PropTypes.bool.isRequired,
+  additionalClass: PropTypes.string,
+  expandedContentId: PropTypes.string,
+  showPlus: PropTypes.bool,
+};
+
+ExpandedGroup.defaultProps = {
+  showPlus: false,
+  additionalClass: '',
+  expandedContentId: '',
+};
+
+export default ExpandedGroup;


### PR DESCRIPTION
Deadline: On Friday, March 31st
Remove soon-to-be deprecated Expanding Group React component from debt applications.

FSR ExpandingGroup Locations:
src/applications/financial-status-report/components/ResolutionDebtCards.jsx
src/applications/financial-status-report/components/ResolutionOptions.jsx

Helpful links:
[DSVA Announcement](https://dsva.slack.com/archives/C03R5SBELQM/p1676910531869329)
[Deprecated component documentation](https://design.va.gov/storybook/?path=/docs/components-expandinggroup--closed)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/54354


## Summary

- Replace soon to be deprecated expanding group with custom implementation


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#53953


## Testing done

todo


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

todo


## Requested Feedback

todo
