### PR TITLE
Add GitHub deployment logic to PE deployment workflow

### DIFF
--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -48,7 +48,7 @@ jobs:
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           WORKFLOW_BRANCH: ${{ github.ref_name }}
 
-      - name: start deployment
+      - name: Start Deployment
         uses: bobheadxi/deployments@v1
         id: deployment
         with:
@@ -56,9 +56,6 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           env: production
           ref: ${{ env.SOURCE_REF }}
-
-      - name: Log deployment ID
-        run: echo ${{ steps.deployment.outputs.deployment_id }}
 
       # - name: Login to ECR # Update ECR credentials if necessary
       #   id: login-ecr
@@ -85,5 +82,5 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           event-type: deploy_review_instance
           repository: department-of-veterans-affairs/devops
-          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}", "source_ref_sanitized": "${{ env.SOURCE_REF_SANITIZED }}" }'
+          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}", "source_ref_sanitized": "${{ env.SOURCE_REF_SANITIZED }}", "deployment_id": "${{ steps.deployment.outputs.deployment_id }}" }'
           # Once docker image is built, add the name of the image to this object as a new property.

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -40,6 +40,16 @@ jobs:
             .cache/yarn
             node_modules
 
+      - name: Start Deployment
+        if: ${{ env.SOURCE_REPO }} == 'vets-website'
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          env: master/${{ env.SOURCE_REF_SANITIZED }}/main
+          ref: ${{ github.ref_name }}
+
       - name: Get Source Repo and Source Ref
         run: node ./script/github-actions/pe-deploy-source.js
         env:
@@ -47,15 +57,8 @@ jobs:
           SOURCE_BRANCH: ${{ github.event.client_payload.source_ref }}
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           WORKFLOW_BRANCH: ${{ github.ref_name }}
-
-      - name: Start Deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          step: start
-          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
-          env: production
-          ref: ${{ env.SOURCE_REF }}
+          SOURCE_DEPLOYMENT: ${{ github.event.client_payload.deployment_id }}
+          WORKFLOW_DEPLOYMENT: ${{ steps.deployment.outputs.deployment_id }}
 
       # - name: Login to ECR # Update ECR credentials if necessary
       #   id: login-ecr
@@ -82,5 +85,5 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           event-type: deploy_review_instance
           repository: department-of-veterans-affairs/devops
-          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}", "source_ref_sanitized": "${{ env.SOURCE_REF_SANITIZED }}", "deployment_id": "${{ steps.deployment.outputs.deployment_id }}" }'
+          client-payload: '{"source_repo": "${{ env.SOURCE_REPO }}", "source_ref": "${{ env.SOURCE_REF }}", "source_ref_sanitized": "${{ env.SOURCE_REF_SANITIZED }}", "deployment_id": "${{ env.DEPLOYMENT_ID }}" }'
           # Once docker image is built, add the name of the image to this object as a new property.

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -48,9 +48,6 @@ jobs:
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           WORKFLOW_BRANCH: ${{ github.ref_name }}
 
-      - name: Log Deployment
-        run: echo "hello world"
-
       # - name: Login to ECR # Update ECR credentials if necessary
       #   id: login-ecr
       #   uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -48,6 +48,9 @@ jobs:
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           WORKFLOW_BRANCH: ${{ github.ref_name }}
 
+      - name: Log Deployment
+        run: echo "hello world"
+
       # - name: Login to ECR # Update ECR credentials if necessary
       #   id: login-ecr
       #   uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -48,9 +48,20 @@ jobs:
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           WORKFLOW_BRANCH: ${{ github.ref_name }}
 
-      - name: Login to ECR # Update ECR credentials if necessary
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          env: production
+
+      - name: Log deployment ID
+        run: echo ${{ steps.deployment.outputs.deployment_id }}
+
+      # - name: Login to ECR # Update ECR credentials if necessary
+      #   id: login-ecr
+      #   uses: aws-actions/amazon-ecr-login@v1
 
       # - name: Build Docker Image #use "file" input to designate alternate dockerfile path. Defaults to "Dockerfile": https://github.com/docker/build-push-action
       #   uses: docker/build-push-action@v2

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -48,9 +48,9 @@ jobs:
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           WORKFLOW_BRANCH: ${{ github.ref_name }}
 
-      # - name: Login to ECR # Update ECR credentials if necessary
-      #   id: login-ecr
-      #   uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to ECR # Update ECR credentials if necessary
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
       # - name: Build Docker Image #use "file" input to designate alternate dockerfile path. Defaults to "Dockerfile": https://github.com/docker/build-push-action
       #   uses: docker/build-push-action@v2

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -55,6 +55,7 @@ jobs:
           step: start
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           env: production
+          ref: ${{ env.SOURCE_REF }}
 
       - name: Log deployment ID
         run: echo ${{ steps.deployment.outputs.deployment_id }}

--- a/script/github-actions/pe-deploy-source.js
+++ b/script/github-actions/pe-deploy-source.js
@@ -4,9 +4,8 @@ const sourceEvent = process.env.SOURCE_EVENT;
 const sourceRepo = process.env.SOURCE_REPO;
 const sourceRef = process.env.SOURCE_BRANCH;
 const workflowRef = process.env.WORKFLOW_BRANCH;
-const deployment = process.env.DEPLOYMENT_ID;
-
-core.exportVariable('DEPLOYMENT_ID', deployment);
+const sourceDeployment = process.env.SOURCE_DEPLOYMENT;
+const workflowDeployment = process.env.WORKFLOW_DEPLOYMENT;
 
 if (
   sourceEvent === 'repository_dispatch' ||
@@ -18,6 +17,7 @@ if (
     'SOURCE_REF_SANITIZED',
     sourceRef.replace(/[^a-zA-Z0-9-_]/g, ''),
   );
+  core.exportVariable('DEPLOYMENT_ID', sourceDeployment);
 } else {
   core.exportVariable('SOURCE_REPO', 'vets-website');
   core.exportVariable('SOURCE_REF', workflowRef);
@@ -25,4 +25,5 @@ if (
     'SOURCE_REF_SANITIZED',
     workflowRef.replace(/[^a-zA-Z0-9-_]/g, '-'),
   );
+  core.exportVariable('DEPLOYMENT_ID', workflowDeployment);
 }

--- a/script/github-actions/pe-deploy-source.js
+++ b/script/github-actions/pe-deploy-source.js
@@ -4,6 +4,9 @@ const sourceEvent = process.env.SOURCE_EVENT;
 const sourceRepo = process.env.SOURCE_REPO;
 const sourceRef = process.env.SOURCE_BRANCH;
 const workflowRef = process.env.WORKFLOW_BRANCH;
+const deployment = process.env.DEPLOYMENT_ID;
+
+core.exportVariable('DEPLOYMENT_ID', deployment);
 
 if (
   sourceEvent === 'repository_dispatch' ||


### PR DESCRIPTION
## Summary

- This adds GItHub deployment logic that will be passed to our devops workflow to enable the updating of deployments once a PE has been launched.

## Related issue(s)
https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/54978

## Testing done

Testing requires merging so the repository dispatch trigger can run appropriately.

## What areas of the site does it impact?
Preview environments MVP

## Acceptance criteria

- [ ]  A proper deployment ID is either generated or passed along as appropriate.

