### PR TITLE
Fixing 26-4555 titles on review page

### DIFF
--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -77,7 +77,7 @@ const formConfig = {
         },
         personalInformation2: {
           path: 'personal-information-2',
-          title: "Personal Information (cont'd)",
+          title: "Identification Information",
           uiSchema: personalInformation2.uiSchema,
           schema: personalInformation2.schema,
         },
@@ -88,13 +88,13 @@ const formConfig = {
       pages: {
         contactInformation1: {
           path: 'contact-information-1',
-          title: 'Contact Information',
+          title: 'Mailing Address',
           uiSchema: contactInformation1.uiSchema,
           schema: contactInformation1.schema,
         },
         contactInformation2: {
           path: 'contact-information-2',
-          title: 'Additional contact information',
+          title: 'Phone number and email address',
           uiSchema: contactInformation2.uiSchema,
           schema: contactInformation2.schema,
         },
@@ -106,14 +106,14 @@ const formConfig = {
         previousSahApplication1: {
           path: 'previous-sah-application-1',
           title:
-            'Have you previously applied for a specially adapted housing (SAH) grant?',
+            'Specially adapted housing grant applications',
           uiSchema: previousSahApplication1.uiSchema,
           schema: previousSahApplication1.schema,
         },
         previousSahApplication2: {
           path: 'previous-sah-application-2',
           title:
-            'Details about your past application for a specially adapted housing grant',
+            'Past SAH grant application details',
           depends: formData =>
             formData[previousSahApplicationFields.parentObject][
               previousSahApplicationFields.hasPreviousSahApplication
@@ -123,14 +123,14 @@ const formConfig = {
         },
         previousShaApplication1: {
           path: 'previous-sha-application-1',
-          title: 'Have you applied for a special home adaptation (SHA) grant?',
+          title: 'Special home adaptation grant applications',
           uiSchema: previousHiApplication1.uiSchema,
           schema: previousHiApplication1.schema,
         },
         previousShaApplication2: {
           path: 'previous-sha-application-2',
           title:
-            'Details about your past application for a special home adaptation grant',
+            'Past SHA grant applications details',
           depends: formData =>
             formData[previousHiApplicationFields.parentObject][
               previousHiApplicationFields.hasPreviousHiApplication
@@ -146,13 +146,13 @@ const formConfig = {
         livingSituation1: {
           path: 'living-situation-1',
           title:
-            'Are you currently living in a nursing home or medical care facility?',
+            'Current arrangement',
           uiSchema: livingSituation1.uiSchema,
           schema: livingSituation1.schema,
         },
         livingSituation2: {
           path: 'living-situation-2',
-          title: 'Details about your current living situation',
+          title: 'Facility details',
           depends: formData =>
             formData[livingSituationFields.parentObject][
               livingSituationFields.isInCareFacility
@@ -167,7 +167,7 @@ const formConfig = {
       pages: {
         remarks: {
           path: 'additional-information',
-          title: 'Additional information',
+          title: 'Service-connected conditions',
           uiSchema: remarks.uiSchema,
           schema: remarks.schema,
         },

--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -71,13 +71,13 @@ const formConfig = {
       pages: {
         personalInformation1: {
           path: 'personal-information-1',
-          title: 'Personal Information',
+          title: 'Personal information',
           uiSchema: personalInformation1.uiSchema,
           schema: personalInformation1.schema,
         },
         personalInformation2: {
           path: 'personal-information-2',
-          title: "Identification Information",
+          title: "Identification information",
           uiSchema: personalInformation2.uiSchema,
           schema: personalInformation2.schema,
         },
@@ -88,7 +88,7 @@ const formConfig = {
       pages: {
         contactInformation1: {
           path: 'contact-information-1',
-          title: 'Mailing Address',
+          title: 'Mailing address',
           uiSchema: contactInformation1.uiSchema,
           schema: contactInformation1.schema,
         },


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/146 Made text edits to match other form edits

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *(Summarize the changes that have been made to the platform)*
- Made text edits to be consistent with rest of form

- *(Which team do you work for, does your team own the maintenance of this component?)*
Veteran Facing forms

## Related issue(s)
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/146


## Testing done

- *Describe what the old behavior was prior to the change*
Language on the review page did not match previous edits


## What areas of the site does it impact?
Only the [Adaptive Housing Form](https://staging.va.gov/housing-assistance/disability-housing-grants/adapted-housing/)

