### PR TITLE
Remove sendRequestMessage for v0

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -28,7 +28,6 @@ import {
 import {
   submitRequest,
   submitAppointment,
-  sendRequestMessage,
   getCommunityCare,
 } from '../../services/var';
 import {
@@ -893,27 +892,6 @@ export function submitAppointmentOrRequest(history) {
         } else {
           requestBody = transformFormToVARequest(getState());
           requestData = await submitRequest('va', requestBody);
-        }
-
-        if (!featureVAOSServiceRequests) {
-          try {
-            const requestMessage = data.reasonAdditionalInfo;
-            if (requestMessage) {
-              await sendRequestMessage(requestData.id, requestMessage);
-            }
-          } catch (error) {
-            // These are ancillary updates, the request went through if the first submit
-            // succeeded
-            captureError(error, false, 'Request message failure', {
-              messageLength: newAppointment?.data?.reasonAdditionalInfo?.length,
-              hasLineBreak: newAppointment?.data?.reasonAdditionalInfo?.includes(
-                '\r\n',
-              ),
-              hasNewLine: newAppointment?.data?.reasonAdditionalInfo?.includes(
-                '\n',
-              ),
-            });
-          }
         }
 
         dispatch({

--- a/src/applications/vaos/services/var/index.js
+++ b/src/applications/vaos/services/var/index.js
@@ -239,14 +239,6 @@ export function submitAppointment(appointment) {
   });
 }
 
-export function sendRequestMessage(id, messageText) {
-  return apiRequestWithUrl(`/vaos/v0/appointment_requests/${id}/messages`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messageText }),
-  }).then(parseApiObject);
-}
-
 export function getRequestEligibilityCriteria(sites) {
   return apiRequestWithUrl(
     `/vaos/v0/request_eligibility_criteria?${sites

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -107,12 +107,6 @@ describe('VAOS VA request flow', () => {
       expect(body).to.have.property('phoneNumber', '5035551234');
     });
 
-    // Check messages requestBody is as expected
-    cy.wait('@v0:create:messages').should(xhr => {
-      const { body } = xhr.request;
-      expect(body).to.have.property('messageText', 'cough');
-    });
-
     // Confirmation page
     cy.url().should('include', '/requests/testing');
     // cy.findByText('VA appointment');

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -415,9 +415,6 @@ describe('VAOS <ReviewPage> CC request with provider selection', () => {
       state: 'DC',
       zipCode: '20005-3477',
     });
-
-    const messageData = JSON.parse(global.fetch.getCall(1).args[1].body);
-    expect(messageData.messageText).to.equal('I need an appt');
   });
 
   it('should show error message on failure', async () => {


### PR DESCRIPTION

## Summary
We have a list of v0 calls we want to get rid of. This ticket focuses on getting rid of any usage of `sendRequestMessage`.


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#53108



## Testing done

unit test and e2e test


## Screenshots
n/a

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
v0 function in VAOS

## Acceptance criteria

- [ ]  No reference to sendRequestMessage anywhere in vets-website.
- [ ]  Remove all mocks associated with this api function (If any).
- [ ]  Remove unit test for this function (If any).
- [ ]  Remove e2e tests for this function (If any).


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
