### PR TITLE
DHP-589 Fix bug where connection unavailable alert renders for a split second

### DIFF
--- a/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
+++ b/src/applications/dhp-connected-devices/components/ConnectedDevicesContainer.jsx
@@ -11,6 +11,7 @@ import {
 } from '../constants/alerts';
 
 export const ConnectedDevicesContainer = () => {
+  const [hasLoaded, setHasLoaded] = useState(false);
   const [connectionAvailable, setConnectionAvailable] = useState(false);
   const [connectedDevices, setConnectedDevices] = useState([]);
   const [successAlert, setSuccessAlert] = useState(false);
@@ -43,6 +44,8 @@ export const ConnectedDevicesContainer = () => {
         }
       } catch (err) {
         // console.error('getConnectedDevices error:', err);
+      } finally {
+        setHasLoaded(true);
       }
     };
     getConnectedDevices();
@@ -83,6 +86,7 @@ export const ConnectedDevicesContainer = () => {
         <DevicesToConnectSection
           connectedDevices={connectedDevices}
           connectionAvailable={connectionAvailable}
+          hasLoaded={hasLoaded}
         />
       </div>
     </>

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -6,6 +6,7 @@ import { DeviceConnectionAlert } from './DeviceConnectionAlerts';
 export const DevicesToConnectSection = ({
   connectedDevices,
   connectionAvailable,
+  hasLoaded,
 }) => {
   const areAllDevicesConnected = () => {
     try {
@@ -59,9 +60,18 @@ export const DevicesToConnectSection = ({
     );
   };
 
-  return connectionAvailable ? devicesToConnect() : error();
+  const devicesAvailableToConnect = connectionAvailable
+    ? devicesToConnect()
+    : error();
+  return !hasLoaded ? (
+    <va-loading-indicator set-focus />
+  ) : (
+    devicesAvailableToConnect
+  );
 };
 
 DevicesToConnectSection.propTypes = {
   connectedDevices: PropTypes.array.isRequired,
+  connectionAvailable: PropTypes.bool.isRequired,
+  hasLoaded: PropTypes.bool.isRequired,
 };

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -64,7 +64,7 @@ export const DevicesToConnectSection = ({
     ? devicesToConnect()
     : error();
   return !hasLoaded ? (
-    <va-loading-indicator set-focus />
+    <va-loading-indicator data-testid="va-loading-indicator" set-focus />
   ) : (
     devicesAvailableToConnect
   );

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -76,6 +76,10 @@ const connectionUnavailableResponse = {
   connectionAvailable: false,
 };
 
+const errorResponse = {
+  status: 401,
+};
+
 describe('Connect Devices Container When Connections Available', () => {
   it('should render DeviceConnectionSection and DeviceConnectionCards when devices are not connected', async () => {
     mockApiRequest(noDevicesConnectedResponse);
@@ -168,8 +172,22 @@ describe('Connect Devices Container When Connections Available', () => {
 });
 
 describe('Connect Devices Container When Connections Unavailable', () => {
-  it('should render DeviceConnectionSection and DeviceConnectionCards when devices are not connected', async () => {
+  it('should render connection unavailable alert when device connection is unavailable', async () => {
     mockApiRequest(connectionUnavailableResponse);
+
+    const connectionUnavailableContainer = renderInReduxProvider(
+      <ConnectedDevicesContainer />,
+    );
+
+    expect(
+      await connectionUnavailableContainer.findByTestId(
+        'connection-unavailable-alert',
+      ),
+    ).to.exist;
+  });
+
+  it('should render connection unavailable alert when error response is returned', async () => {
+    mockApiRequest(errorResponse);
 
     const connectionUnavailableContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,

--- a/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/ConnectedDevicesContainer.spec.js
@@ -76,10 +76,6 @@ const connectionUnavailableResponse = {
   connectionAvailable: false,
 };
 
-const errorResponse = {
-  status: 401,
-};
-
 describe('Connect Devices Container When Connections Available', () => {
   it('should render DeviceConnectionSection and DeviceConnectionCards when devices are not connected', async () => {
     mockApiRequest(noDevicesConnectedResponse);
@@ -187,7 +183,17 @@ describe('Connect Devices Container When Connections Unavailable', () => {
   });
 
   it('should render connection unavailable alert when error response is returned', async () => {
-    mockApiRequest(errorResponse);
+    const err = {
+      errors: [
+        {
+          title: 'Not authorized',
+          detail: 'Not authorized',
+          code: '401',
+          status: '401',
+        },
+      ],
+    };
+    mockApiRequest(err, false);
 
     const connectionUnavailableContainer = renderInReduxProvider(
       <ConnectedDevicesContainer />,

--- a/src/applications/dhp-connected-devices/tests/components/DevicesToConnectSection.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/DevicesToConnectSection.spec.js
@@ -26,6 +26,7 @@ describe('Devices to Connect Section', () => {
       <DevicesToConnectSection
         connectedDevices={devices}
         connectionAvailable
+        hasLoaded
       />,
     );
 
@@ -40,9 +41,23 @@ describe('Devices to Connect Section', () => {
       <DevicesToConnectSection
         connectedDevices={devices}
         connectionAvailable={false}
+        hasLoaded
       />,
     );
 
     expect(section.getByTestId('connection-unavailable-alert')).to.exist;
+  });
+
+  it('renders loading indicator when hasLoaded is false', async () => {
+    const section = render(
+      <DevicesToConnectSection
+        connectedDevices={[]}
+        connectionAvailable
+        hasLoaded={false}
+      />,
+    );
+
+    expect(section.getByTestId('va-loading-indicator')).to.exist;
+    expect(section.queryByTestId('connection-unavailable-alert')).to.not.exist;
   });
 });


### PR DESCRIPTION
## Summary
This app/module is owned by the Digital Health Platform team. 

Bug description - When an authenticated, identity-proofed user accesses the device registration page, the "Unable to connect" UI component is visible when the page loads, and then disappears after a tenth of a second.  The component should be rendered if and only if an authenticated user without an ICN accesses the page.

Bug fix - Render a VA Loading Indicator before the API request resolves.

## Related issue(s)
https://vajira.max.gov/browse/DHP-589


## Testing done
- Tested that before api request is resolved, a va-loading-indicator is rendered
- Tested that when the api request resolves to an error, an alert notifying the Veteran is rendered
- Tested that when the api request resolves and the veteran does not have an ICN, an alert notifying the Veteran is rendered
- Tested that when the api request resolves and the veteran has an ICN, they are able to connect a health device

## Screenshots
#### Before
![Screenshot 2023-03-21 at 12 12 24 PM](https://user-images.githubusercontent.com/1357047/226703327-41c0876c-dbf1-4fb7-b08c-c49ff357a7fc.png)
Mobile
![Screenshot 2023-03-21 at 12 16 03 PM](https://user-images.githubusercontent.com/1357047/226704020-c9259022-6e3f-40fa-b39c-a2f363b977a5.png)

#### After 
![Screenshot 2023-03-21 at 12 13 02 PM](https://user-images.githubusercontent.com/1357047/226703599-0a578c13-1f9a-4766-aa19-2776b637c88e.png)
Mobile
![Screenshot 2023-03-21 at 12 15 34 PM](https://user-images.githubusercontent.com/1357047/226704059-6eef1ffb-0206-46ce-885b-cb55e5c7405f.png)

## What areas of the site does it impact?
va.gov/health-care/connected-devices/ page

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback
General feedback is welcome, especially about the approach