### PR TITLE
Updates the event tag on the healthcare 'Review your messages' link

### DIFF
--- a/src/applications/personalization/dashboard/components/health-care-v2/HealthCareContentV2.jsx
+++ b/src/applications/personalization/dashboard/components/health-care-v2/HealthCareContentV2.jsx
@@ -177,7 +177,7 @@ const HealthCareContentV2 = ({
                   onClick={() =>
                     recordEvent({
                       event: 'nav-linkslist',
-                      'links-list-header': 'Review your messages',
+                      'links-list-header': 'View your messages',
                       'links-list-section-header': 'Health care',
                     })
                   }


### PR DESCRIPTION
## Summary

As part of the 2022 My VA Audit, we're making many UX improvements. After QA, under the My VA Health Care section, we discovered that GA event tag for the "Review your messages" link is incorrect - it is appearing as `Navigation - Link List - Health care - Review your messages`.

This PR updates the GA event tag to be `Navigation - Link List - Health care - View your messages`

## Related issue(s)
- Ticket: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/54792](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54792)
- Epic: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934)


## Testing done

- By using the Google Analytics developer tools, I confirmed the right tag is being fired when the link is clicked.

## What areas of the site does it impact?
My VA -> Health Care -> Review your messages link

## Acceptance criteria

- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
