### PR TITLE
Appointment List Redesign - Remove truncation from mobile view

### DIFF
--- a/src/applications/vaos/appointment-list/sass/styles.scss
+++ b/src/applications/vaos/appointment-list/sass/styles.scss
@@ -183,10 +183,8 @@ div[id^="vaos-appts__detail-"] {
 
 .vaos-appts__text--truncate {
   @include media($xsmall-screen) {
-    white-space: nowrap;
     overflow: hidden !important;
     text-overflow: ellipsis !important;
-    max-width: 170px;
   }
   @include media($medium-screen) {
     max-width: 222px;


### PR DESCRIPTION
This Pr:
- Removes truncation of appointment type of care on mobile.

![localhost_3001_health-care_schedule-view-va-appointments_appointments_(iPhone SE)](https://user-images.githubusercontent.com/47654119/226742315-e13934cc-11d3-4d05-85fc-50c95bb3e3a1.png)
