### PR TITLE
Currency Input Style

### DIFF
--- a/src/applications/financial-status-report/components/monetary/MonetaryInputList.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryInputList.jsx
@@ -47,6 +47,7 @@ const MonetaryInputList = props => {
       prompt={prompt}
       submitted={submitted}
       onChange={event => onChange(event)}
+      currency
     />
   );
 };

--- a/src/applications/financial-status-report/components/shared/CurrencyInput.jsx
+++ b/src/applications/financial-status-report/components/shared/CurrencyInput.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const CurrencyInputWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const CurrencySymbol = styled.span`
+  position: absolute;
+  left: 0.2em;
+  top: 4.7em;
+  pointer-events: none; /* Make sure the input remains clickable */
+`;
+
+const StyledVaNumberInput = Component => {
+  const WrappedComponent = ({ currency, ...props }) => {
+    if (!currency) {
+      return <Component {...props} />;
+    }
+
+    return (
+      <CurrencyInputWrapper>
+        <CurrencySymbol>$</CurrencySymbol>
+        <Component {...props} />
+      </CurrencyInputWrapper>
+    );
+  };
+
+  WrappedComponent.displayName = `withCurrency(${Component.displayName ||
+    Component.name})`;
+
+  // define prop types
+  WrappedComponent.propTypes = {
+    currency: PropTypes.bool,
+  };
+
+  return WrappedComponent;
+};
+
+export default StyledVaNumberInput;

--- a/src/applications/financial-status-report/components/shared/InputList.jsx
+++ b/src/applications/financial-status-report/components/shared/InputList.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { VaNumberInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import withCurrency from './CurrencyInput';
+
+const CurrencyInputList = withCurrency(VaNumberInput);
 
 const InputList = ({
   errorList,
@@ -8,6 +12,7 @@ const InputList = ({
   submitted,
   title = '',
   onChange,
+  currency = false,
 }) => {
   return (
     <div>
@@ -15,7 +20,7 @@ const InputList = ({
       <p>{prompt}</p>
       {inputs?.map((input, key) => (
         <div key={input.name + key} className="vads-u-margin-y--2">
-          <va-number-input
+          <CurrencyInputList
             className="no-wrap input-size-3"
             error={
               submitted && errorList.includes(input.name)
@@ -29,6 +34,7 @@ const InputList = ({
             onInput={onChange}
             required
             value={input.amount}
+            currency={currency}
           />
         </div>
       ))}
@@ -37,6 +43,7 @@ const InputList = ({
 };
 
 InputList.propTypes = {
+  currency: PropTypes.bool,
   errorList: PropTypes.arrayOf(PropTypes.string),
   inputs: PropTypes.arrayOf(
     PropTypes.shape({


### PR DESCRIPTION
WIP

## Summary

`va-number-input` doesn't currently support including a $ to represent currency input, so we will need a temporary styling update to apply until it has been added. There is currently a currency-input class defined in the FSR that can probably be modified to target the shadow root input component of the` va-number-input`.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#55213

## Testing done

- *Manual
-  Cypress


## Screenshots

### Example 1 (Old) Not using `VaNumberInput` - existed before starting this task
![Screenshot 2023-03-21 at 3 04 47 PM](https://user-images.githubusercontent.com/3916436/226752191-141685fc-3b08-48e3-b606-3eede07f7c82.png)

### Example 2 (New) Note the inconsistencies with spacing 
![Screenshot 2023-03-21 at 3 05 07 PM](https://user-images.githubusercontent.com/3916436/226752202-063ebafe-0f02-4ab0-a336-01e01eaa4c61.png)

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  Currency inputs on the FSR that use va-number-input show a $


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
