### PR TITLE
VACMS-12697 logo alt text

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -82,7 +82,7 @@ export default `
           )}" class="va-header-logo">
           <img src="${replaceWithStagingDomain(
             'https://www.va.gov/img/header-logo.png',
-          )}" alt="VA logo and seal"/>
+          )}" alt="VA logo and Seal, U.S. Department of Veterans Affairs"/>
           </a>
         </div>
         <div id="va-nav-controls"></div>

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -120,7 +120,7 @@
         <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
           <div class="va-header-logo-wrapper">
             <a href="/" class="va-header-logo">
-              <img src="/img/header-logo.png" alt="VA logo and seal"/>
+              <img src="/img/header-logo.png" alt="VA logo and Seal, U.S. Department of Veterans Affairs"/>
             </a>
           </div>
           <div id="va-nav-controls"></div>

--- a/src/platform/site-wide/va-footer/components/Footer.jsx
+++ b/src/platform/site-wide/va-footer/components/Footer.jsx
@@ -70,7 +70,7 @@ class Footer extends Component {
                 src={replaceWithStagingDomain(
                   'https://www.va.gov/img/homepage/va-logo-white.png',
                 )}
-                alt="VA logo and seal"
+                alt="VA logo and Seal, U.S. Department of Veterans Affairs"
                 width="200"
                 className="vads-u-height--auto"
               />


### PR DESCRIPTION
## Summary

508 office has requested new alt text for the VA logo. 

Code changes are identical to a prior copy change for alt text: 
https://github.com/department-of-veterans-affairs/content-build/pull/1336
https://github.com/department-of-veterans-affairs/vets-website/pull/22486

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12697

Related PR: https://github.com/department-of-veterans-affairs/content-build/pull/1515


## Screenshots

![Screenshot 2023-03-22 at 10 51 21 AM](https://user-images.githubusercontent.com/85581471/226993985-124219f6-9e1c-4bdb-b95b-132151bd8322.png)


## What areas of the site does it impact?
Header & Footer, including injected

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
