### PR TITLE
Update error message for vaFileNumber to match schema

### DIFF
--- a/src/applications/simple-forms/26-4555/pages/personalInformation2.js
+++ b/src/applications/simple-forms/26-4555/pages/personalInformation2.js
@@ -22,8 +22,7 @@ export default {
       [veteranFields.vaFileNumber]: {
         'ui:title': 'VA file number (if you have one)',
         'ui:errorMessages': {
-          pattern:
-            'Please input a valid VA file number: 7 to 9 numeric digits, & may start with a letter "C" or "c".',
+          pattern: 'Your VA file number must be 8 or 9 digits',
         },
       },
     },


### PR DESCRIPTION
## Summary
This PR updates the error message for `vaFileNumber` to match the vets-json-schema update here: department-of-veterans-affairs/vets-json-schema#759

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#149