### PR TITLE
Profile/aw/55590/account security mhv call deprecation

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -43,7 +43,6 @@ import {
   isLoggedIn,
 } from '~/platform/user/selectors';
 import { signInServiceName as signInServiceNameSelector } from '~/platform/user/authentication/selectors';
-import { fetchMHVAccount as fetchMHVAccountAction } from '~/platform/user/profile/actions';
 import { connectDrupalSourceOfTruthCerner as dispatchConnectDrupalSourceOfTruthCerner } from '~/platform/utilities/cerner/dsot';
 
 import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from '~/applications/personalization/rated-disabilities/actions';
@@ -60,7 +59,6 @@ class Profile extends Component {
       fetchCNPPaymentInformation,
       fetchEDUPaymentInformation,
       fetchFullName,
-      fetchMHVAccount,
       fetchMilitaryInformation,
       fetchPersonalInformation,
       fetchTotalDisabilityRating,
@@ -71,7 +69,6 @@ class Profile extends Component {
       shouldFetchEDUDirectDepositInformation,
       connectDrupalSourceOfTruthCerner,
     } = this.props;
-    fetchMHVAccount();
     connectDrupalSourceOfTruthCerner();
     if (isLOA3 && isInMVI) {
       fetchFullName();
@@ -260,7 +257,6 @@ Profile.propTypes = {
   fetchCNPPaymentInformation: PropTypes.func.isRequired,
   fetchEDUPaymentInformation: PropTypes.func.isRequired,
   fetchFullName: PropTypes.func.isRequired,
-  fetchMHVAccount: PropTypes.func.isRequired,
   fetchMilitaryInformation: PropTypes.func.isRequired,
   fetchPersonalInformation: PropTypes.func.isRequired,
   fetchTotalDisabilityRating: PropTypes.func.isRequired,
@@ -364,7 +360,6 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = {
   fetchFullName: fetchHeroAction,
-  fetchMHVAccount: fetchMHVAccountAction,
   fetchMilitaryInformation: fetchMilitaryInformationAction,
   fetchPersonalInformation: fetchPersonalInformationAction,
   fetchCNPPaymentInformation: fetchCNPPaymentInformationAction,

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -36,7 +36,6 @@ import backendServices from '~/platform/user/profile/constants/backendServices';
 import {
   createIsServiceAvailableSelector,
   isMultifactorEnabled,
-  selectProfile,
   isLOA1 as isLOA1Selector,
   isLOA3 as isLOA3Selector,
   isInMPI as isInMVISelector,
@@ -303,13 +302,6 @@ const mapStateToProps = state => {
   const hasLoadedMilitaryInformation =
     isLOA1 || !isInMVI || state.vaProfile?.militaryInformation;
 
-  // when the call to load MHV fails, `errors` will be set to a non-null value
-  // when the call succeeds, the `accountState` will be set to a non-null value
-  const hasLoadedMHVInformation =
-    !isInMVI ||
-    selectProfile(state)?.mhvAccount?.errors ||
-    selectProfile(state)?.mhvAccount?.accountState;
-
   // this piece of state will be set if the call to load personal info succeeds
   // or fails:
   const hasLoadedPersonalInformation =
@@ -330,7 +322,6 @@ const mapStateToProps = state => {
   const hasLoadedAllData =
     !isInMVI ||
     (hasLoadedFullName &&
-      hasLoadedMHVInformation &&
       hasLoadedPersonalInformation &&
       hasLoadedMilitaryInformation &&
       (shouldFetchTotalDisabilityRating

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
@@ -7,7 +7,6 @@ import {
   isInMPI as isInMPISelector,
   hasMPIConnectionError as hasMPIConnectionErrorSelector,
   isMultifactorEnabled as isMultifactorEnabledSelector,
-  selectProfile,
 } from '~/platform/user/selectors';
 import { signInServiceName as signInServiceNameSelector } from '~/platform/user/authentication/selectors';
 
@@ -22,8 +21,6 @@ import { recordCustomProfileEvent } from '../../util';
 export const AccountSecurityContent = ({
   isIdentityVerified,
   isMultifactorEnabled,
-  mhvAccount,
-  showMHVTermsAndConditions,
   showMPIConnectionError,
   showNotInMPIError,
   signInServiceName,
@@ -48,8 +45,6 @@ export const AccountSecurityContent = ({
         signInServiceName={signInServiceName}
         isIdentityVerified={isIdentityVerified}
         isMultifactorEnabled={isMultifactorEnabled}
-        showMHVTermsAndConditions={showMHVTermsAndConditions}
-        mhvAccount={mhvAccount}
       />
     </>
   );
@@ -59,28 +54,13 @@ AccountSecurityContent.propTypes = {
   isBlocked: PropTypes.bool.isRequired,
   isIdentityVerified: PropTypes.bool.isRequired,
   isMultifactorEnabled: PropTypes.bool.isRequired,
-  showMHVTermsAndConditions: PropTypes.bool.isRequired,
   showMPIConnectionError: PropTypes.bool.isRequired,
   showNotInMPIError: PropTypes.bool.isRequired,
   showWeHaveVerifiedYourID: PropTypes.bool.isRequired,
   signInServiceName: PropTypes.string.isRequired,
-  isInMPI: PropTypes.bool,
-  mhvAccount: PropTypes.shape({
-    accountLevel: PropTypes.string,
-    accountState: PropTypes.string,
-    errors: PropTypes.array,
-    loading: PropTypes.bool,
-    termsAndConditionsAccepted: PropTypes.bool.isRequired,
-  }),
 };
 
 export const mapStateToProps = state => {
-  const profile = selectProfile(state);
-  const { verified, mhvAccount } = profile;
-  const showMHVTermsAndConditions =
-    verified &&
-    (mhvAccount.termsAndConditionsAccepted ||
-      mhvAccount.accountState === 'needs_terms_acceptance');
   const isInMPI = isInMPISelector(state);
   const isIdentityVerified = isLOA3Selector(state);
   const hasMPIConnectionError = hasMPIConnectionErrorSelector(state);
@@ -91,15 +71,13 @@ export const mapStateToProps = state => {
   const isBlocked = selectIsBlocked(state);
 
   return {
+    isBlocked,
     isIdentityVerified,
     isMultifactorEnabled: isMultifactorEnabledSelector(state),
-    mhvAccount,
-    showWeHaveVerifiedYourID,
     showMPIConnectionError,
     showNotInMPIError,
-    showMHVTermsAndConditions,
+    showWeHaveVerifiedYourID,
     signInServiceName: signInServiceNameSelector(state),
-    isBlocked,
   };
 };
 

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityTables.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityTables.jsx
@@ -14,15 +14,10 @@ const mfaHandler = () => {
   mfa();
 };
 
-const termsAndConditionsUrl =
-  '/health-care/medical-information-terms-conditions';
-
 const AccountSetupTable = ({
   title,
   isIdentityVerified,
   isMultifactorEnabled,
-  showMHVTermsAndConditions,
-  mhvAccount,
 }) => {
   return (
     <section className="profile-info-table vads-u-margin-bottom--2 vads-u-border--1px vads-u-border-color--gray-lighter">
@@ -73,61 +68,6 @@ const AccountSetupTable = ({
             someone gets your password.
           </List.ContentIncomplete>
         </List.Item>
-
-        <List.Item
-          complete={mhvAccount.termsAndConditionsAccepted}
-          shouldShow={showMHVTermsAndConditions}
-        >
-          <List.HeadingComplete>
-            Review terms and conditions
-          </List.HeadingComplete>
-
-          <List.ContentComplete>
-            <p className="vads-u-margin-y--0">
-              You’ve accepted the terms and conditions for using VA.gov health
-              tools
-            </p>
-            <a
-              href={termsAndConditionsUrl}
-              onClick={() =>
-                recordEvent({
-                  event: 'profile-navigation',
-                  'profile-action': 'view-link',
-                  'profile-section': 'terms',
-                })
-              }
-            >
-              View terms and conditions for medical information
-            </a>
-          </List.ContentComplete>
-
-          {mhvAccount.accountState === 'needs_terms_acceptance' && (
-            <>
-              <List.HeadingIncomplete>
-                <a
-                  href={termsAndConditionsUrl}
-                  onClick={() =>
-                    recordEvent({
-                      event: 'profile-navigation',
-                      'profile-action': 'view-link',
-                      'profile-section': 'terms',
-                    })
-                  }
-                >
-                  Review terms and conditions
-                </a>
-              </List.HeadingIncomplete>
-
-              <List.ContentIncomplete>
-                Before using our health tools, you’ll need to read and agree to
-                the terms and conditions for medical information. This will give
-                us permission to share your VA medical information with you.
-                Once you do this, you can use the tools to refill your VA
-                prescriptions or download your VA health records.
-              </List.ContentIncomplete>
-            </>
-          )}
-        </List.Item>
       </List>
     </section>
   );
@@ -136,11 +76,6 @@ const AccountSetupTable = ({
 AccountSetupTable.propTypes = {
   isIdentityVerified: PropTypes.bool.isRequired,
   isMultifactorEnabled: PropTypes.bool.isRequired,
-  mhvAccount: PropTypes.shape({
-    termsAndConditionsAccepted: PropTypes.bool.isRequired,
-    accountState: PropTypes.string.isRequired,
-  }).isRequired,
-  showMHVTermsAndConditions: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
 };
 
@@ -148,8 +83,6 @@ export const AccountSecurityTables = ({
   signInServiceName,
   isIdentityVerified,
   isMultifactorEnabled,
-  showMHVTermsAndConditions,
-  mhvAccount,
 }) => {
   return (
     <>
@@ -171,8 +104,6 @@ export const AccountSecurityTables = ({
         title="Account setup"
         isIdentityVerified={isIdentityVerified}
         isMultifactorEnabled={isMultifactorEnabled}
-        showMHVTermsAndConditions={showMHVTermsAndConditions}
-        mhvAccount={mhvAccount}
       />
     </>
   );

--- a/src/applications/personalization/profile/components/account-security/ConditionalProcessList.jsx
+++ b/src/applications/personalization/profile/components/account-security/ConditionalProcessList.jsx
@@ -27,16 +27,6 @@ ConditionalProcessList.propTypes = {
 const CompleteContext = createContext();
 CompleteContext.displayName = 'CompleteContext';
 
-const useComplete = () => {
-  const context = useContext(CompleteContext);
-
-  if (typeof context !== 'boolean') {
-    throw new Error('useComplete must be used within a ListItem component');
-  }
-
-  return context;
-};
-
 // The ListItem component is a wrapper for the list item content, and
 // conditionally renders the content based on the `complete` prop
 
@@ -68,7 +58,7 @@ const headingClasses =
   'vads-u-margin-y--0 vads-u-padding-top--0p5 item-heading vads-u-font-size--h4';
 
 const HeadingComplete = ({ children, headingLevel = 3 }) => {
-  const complete = useComplete();
+  const complete = useContext(CompleteContext);
   const Heading = `h${headingLevel}`;
   return complete ? (
     <Heading className={headingClasses}>{children}</Heading>
@@ -81,7 +71,7 @@ HeadingComplete.propTypes = {
 };
 
 const HeadingIncomplete = ({ children, headingLevel = 3 }) => {
-  const complete = useComplete();
+  const complete = useContext(CompleteContext);
   const Heading = `h${headingLevel}`;
   return !complete ? (
     <Heading className={headingClasses}>{children}</Heading>
@@ -94,7 +84,7 @@ HeadingIncomplete.propTypes = {
 };
 
 const ContentComplete = ({ children }) => {
-  const complete = useComplete();
+  const complete = useContext(CompleteContext);
   return complete ? (
     <div className="vads-u-margin-y--0 vads-u-padding-top--1">{children}</div>
   ) : null;
@@ -103,7 +93,7 @@ const ContentComplete = ({ children }) => {
 ContentComplete.propTypes = { children: PropTypes.node.isRequired };
 
 const ContentIncomplete = ({ children }) => {
-  const complete = useComplete();
+  const complete = useContext(CompleteContext);
   return !complete ? (
     <div className="vads-u-margin-y--0 vads-u-padding-top--1">{children}</div>
   ) : null;

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -370,17 +370,6 @@ describe('mapStateToProps', () => {
         const props = mapStateToProps(state);
         expect(props.showLoader).to.be.true;
       });
-
-      it('is `true` when the call to fetch MHV info has not resolved but all others have', () => {
-        const state = makeDefaultState();
-        state.user.profile.mhvAccount = {
-          accountState: null,
-          errors: null,
-          loading: false,
-        };
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
     });
 
     describe('when direct deposit info should not be fetched because the user has not set up 2FA', () => {
@@ -421,16 +410,6 @@ describe('mapStateToProps', () => {
 
       it('is `true` when the call to fetch the full name has not resolved', () => {
         delete state.vaProfile.hero;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch MHV info has not resolved', () => {
-        state.user.profile.mhvAccount = {
-          accountState: null,
-          errors: null,
-          loading: false,
-        };
         const props = mapStateToProps(state);
         expect(props.showLoader).to.be.true;
       });

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -16,7 +16,6 @@ describe('Profile', () => {
   let defaultProps;
   let fetchFullNameSpy;
   let fetchMilitaryInfoSpy;
-  let fetchMHVAccountSpy;
   let fetchCNPPaymentInfoSpy;
   let fetchPersonalInfoSpy;
   let fetchTotalDisabilityRatingSpy;
@@ -25,7 +24,6 @@ describe('Profile', () => {
   beforeEach(() => {
     fetchFullNameSpy = sinon.spy();
     fetchMilitaryInfoSpy = sinon.spy();
-    fetchMHVAccountSpy = sinon.spy();
     fetchCNPPaymentInfoSpy = sinon.spy();
     fetchPersonalInfoSpy = sinon.spy();
     fetchTotalDisabilityRatingSpy = sinon.spy();
@@ -34,7 +32,6 @@ describe('Profile', () => {
     defaultProps = {
       connectDrupalSourceOfTruthCerner: connectDrupalSourceOfTruthCernerSpy,
       fetchFullName: fetchFullNameSpy,
-      fetchMHVAccount: fetchMHVAccountSpy,
       fetchMilitaryInformation: fetchMilitaryInfoSpy,
       fetchCNPPaymentInformation: fetchCNPPaymentInfoSpy,
       fetchPersonalInformation: fetchPersonalInfoSpy,
@@ -116,12 +113,6 @@ describe('Profile', () => {
         expect(fetchPersonalInfoSpy.called).to.be.false;
         wrapper.unmount();
       });
-    });
-
-    it('should fetch the My HealtheVet data', () => {
-      const wrapper = shallow(<Profile {...defaultProps} />);
-      expect(fetchMHVAccountSpy.called).to.be.true;
-      wrapper.unmount();
     });
 
     describe('when `shouldFetchCNPDirectDepositInformation` is `true`', () => {

--- a/src/applications/personalization/profile/tests/e2e/account-security/conditional-process-list.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/account-security/conditional-process-list.cypress.spec.js
@@ -7,22 +7,11 @@ import fullName from '../../fixtures/full-name-success.json';
 import personalInformation from '../../fixtures/personal-information-success-enhanced.json';
 import serviceHistory from '../../fixtures/service-history-success.json';
 
-context('when user is LOA3, verified, TOA accepted, but Non 2Fa', () => {
+context('when user is LOA3 but Non 2Fa', () => {
   beforeEach(() => {
     cy.intercept('v0/profile/full_name', fullName);
     cy.intercept('v0/profile/personal_information', personalInformation);
     cy.intercept('v0/profile/service_history', () => serviceHistory);
-    cy.intercept('v0/mhv_account', {
-      data: {
-        id: '',
-        type: 'mhv_accounts',
-        attributes: {
-          accountLevel: null,
-          accountState: 'no_account',
-          termsAndConditionsAccepted: true,
-        },
-      },
-    });
 
     cy.login(userNon2Fa);
   });
@@ -38,9 +27,6 @@ context('when user is LOA3, verified, TOA accepted, but Non 2Fa', () => {
     // check content within the process list
     cy.findByText('We’ve verified your identity.');
     cy.findByRole('button', { name: 'Add 2-factor authentication' });
-    cy.findByText(
-      'You’ve accepted the terms and conditions for using VA.gov health tools',
-    );
 
     cy.injectAxeThenAxeCheck();
   });


### PR DESCRIPTION
## Summary

- Removes call to `/mhv_account` on profile
- Updates conditional process list to not throw error
- Updates Account Security List to not include the MHV terms and conditions content

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/55590


## Testing done

- Updated and removed tests for Profile from removed api call
- To verify, load profile locally and check that the `/mhv_account` endpoint is not called

## What areas of the site does it impact?
Profile

## Acceptance criteria

- [x] Removed call to `mhv_account`
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
