### PR TITLE
Check in/23671/btsss refactor 2

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -722,12 +722,12 @@ class ApiInitializer {
   initializeBtsssPost = {
     withSuccess: () => {
       cy.intercept('POST', `/check_in/v0/travel_claims/`, req => {
-        req.reply(btsss.post.createMockSuccessResponse());
+        req.reply(202, btsss.post.createMockSuccessResponse());
       });
     },
     withFailure: () => {
       cy.intercept('POST', `/check_in/v0/travel_claims/`, req => {
-        req.reply(btsss.post.createMockFailedResponse());
+        req.reply(500, btsss.post.createMockFailedResponse());
       });
     },
   };

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -725,9 +725,9 @@ class ApiInitializer {
         req.reply(btsss.post.createMockSuccessResponse());
       });
     },
-    withFailure: (errorCode = 400, errorType) => {
+    withFailure: () => {
       cy.intercept('POST', `/check_in/v0/travel_claims/`, req => {
-        req.reply(errorCode, btsss.post.createMockFailedResponse(errorType));
+        req.reply(btsss.post.createMockFailedResponse());
       });
     },
   };

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -93,7 +93,7 @@ const responses = {
     if (!uuid || !appointmentDate) {
       return res.status(500).json(btsss.post.createMockFailedResponse());
     }
-    return res.json(btsss.post.createMockSuccessResponse({}));
+    return res.status(202).json(btsss.post.createMockSuccessResponse({}));
   },
 };
 

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/btsss/post.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/btsss/post.js
@@ -1,26 +1,18 @@
 const createMockSuccessResponse = _data => {
   return {
     data: {
-      value: {
-        claimNumber: 'TC202207000011666',
-      },
-      formatters: [],
-      contentTypes: [],
-      declaredType: null,
-      statusCode: 200,
+      statusCode: 202,
     },
-    status: 200,
+    status: 202,
   };
 };
 
-const createMockFailedResponse = errorType => {
+const createMockFailedResponse = () => {
   return {
     data: {
       error: true,
-      code: errorType,
-      message: '10/16/2020 : Error message',
     },
-    status: 400,
+    status: 500,
   };
 };
 

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -46,8 +46,6 @@ const CheckInConfirmation = props => {
   const {
     travelPayEligible,
     travelPayClaimError,
-    travelPayClaimErrorCode,
-    travelPayClaimData,
     travelPayClaimRequested,
     travelPayClaimSent,
   } = useSendTravelPayClaim(appointment);
@@ -150,9 +148,7 @@ const CheckInConfirmation = props => {
         {doTravelPay && (
           <TravelPayAlert
             travelPayEligible={travelPayEligible}
-            travelPayClaimData={travelPayClaimData}
             travelPayClaimError={travelPayClaimError}
-            travelPayClaimErrorCode={travelPayClaimErrorCode}
           />
         )}
 

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -98,6 +98,12 @@ const CheckInConfirmation = props => {
     [checkInDataError, updateError],
   );
 
+  let pageTitle = t('youre-checked-in');
+
+  if (doTravelPay && (!travelPayEligible || travelPayClaimError)) {
+    pageTitle += ` ${t('we-couldnt-file-reimbursement')}`;
+  }
+
   const renderLoadingMessage = () => {
     return (
       <div>
@@ -112,7 +118,7 @@ const CheckInConfirmation = props => {
   const renderConfirmationMessage = () => {
     return (
       <Wrapper
-        pageTitle={t('youre-checked-in')}
+        pageTitle={pageTitle}
         testID="multiple-appointments-confirm"
       >
         <p className="vads-u-font-family--serif">{t('your-appointment')}</p>

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -117,10 +117,7 @@ const CheckInConfirmation = props => {
 
   const renderConfirmationMessage = () => {
     return (
-      <Wrapper
-        pageTitle={pageTitle}
-        testID="multiple-appointments-confirm"
-      >
+      <Wrapper pageTitle={pageTitle} testID="multiple-appointments-confirm">
         <p className="vads-u-font-family--serif">{t('your-appointment')}</p>
         <ol
           className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list"

--- a/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
@@ -30,13 +30,13 @@ const TravelPayAlert = props => {
               />
             </p>
             <ExternalLink
-                href="/health-care/get-reimbursed-for-travel-pay/"
-                hrefLang="en"
-                eventId="request-travel-pay-reimbursement-from-confirmation-with-btsss-error--link-clicked"
-                eventPrefix="nav"
-              >
-                {t('find-out-how-to-file--link')}
-              </ExternalLink>
+              href="/health-care/get-reimbursed-for-travel-pay/"
+              hrefLang="en"
+              eventId="request-travel-pay-reimbursement-from-confirmation-with-btsss-error--link-clicked"
+              eventPrefix="nav"
+            >
+              {t('find-out-how-to-file--link')}
+            </ExternalLink>
           </div>
         </va-alert>
       ) : (

--- a/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
@@ -4,123 +4,95 @@ import { useTranslation, Trans } from 'react-i18next';
 import ExternalLink from '../../../components/ExternalLink';
 
 const TravelPayAlert = props => {
-  const {
-    travelPayEligible,
-    travelPayClaimData,
-    travelPayClaimError,
-    travelPayClaimErrorCode,
-  } = props;
+  const { travelPayEligible, travelPayClaimError } = props;
 
   const { t } = useTranslation();
 
-  let errorMsg = '';
-  let errorStatus = '';
-  let errorLinkEventId = 'clicked-how-to-file-link-from-api-error';
-  if (
-    travelPayClaimError &&
-    travelPayClaimErrorCode === 'CLM_002_CLAIM_EXISTS'
-  ) {
-    errorMsg = t('check-travel-claim-status');
-    errorStatus = 'info';
-    errorLinkEventId = 'clicked-how-to-file-link-from-claim-exists-error';
-  } else {
-    errorMsg = (
-      <Trans
-        i18nKey="sorry-something-went-wrong-on-our-end-with-filing-your-travel-claim"
-        components={[<span key="bold" className="vads-u-font-weight--bold" />]}
-      />
-    );
-    errorStatus = 'warning';
-  }
-
   return (
     <>
-      {travelPayEligible &&
-        travelPayClaimData && (
-          <va-alert
-            background-only
-            show-icon
-            data-testid="travel-pay-message"
-            status="success"
-          >
-            <div>
+      {travelPayClaimError ? (
+        <va-alert
+          background-only
+          show-icon
+          data-testid="travel-pay-message"
+          status="info"
+        >
+          <div>
+            <p
+              className="vads-u-margin-top--0"
+              data-testid="travel-pay-error-message"
+            >
+              <Trans
+                i18nKey="sorry-something-went-wrong-on-our-end-with-filing-your-travel-claim"
+                components={[
+                  <span key="bold" className="vads-u-font-weight--bold" />,
+                ]}
+              />
+            </p>
+          </div>
+        </va-alert>
+      ) : (
+        <>
+          {travelPayEligible && (
+            <va-alert
+              background-only
+              show-icon
+              data-testid="travel-pay-message"
+              status="success"
+            >
+              <div>
+                <p
+                  className="vads-u-margin-top--0"
+                  data-testid="travel-pay-eligible-success-message"
+                >
+                  <Trans
+                    i18nKey="processing-travel-claim"
+                    components={[
+                      <span key="bold" className="vads-u-font-weight--bold" />,
+                    ]}
+                  />
+                </p>
+              </div>
+            </va-alert>
+          )}
+
+          {!travelPayEligible && (
+            <va-alert
+              background-only
+              show-icon
+              data-testid="travel-pay-message"
+              status="warning"
+            >
               <p
                 className="vads-u-margin-top--0"
-                data-testid="travel-pay-eligible-success-message"
+                data-testid="travel-pay-not-eligible-message"
               >
                 <Trans
-                  i18nKey="processing-travel-claim"
+                  i18nKey="travel-pay-cant-file-message"
                   components={[
                     <span key="bold" className="vads-u-font-weight--bold" />,
                   ]}
                 />
               </p>
-            </div>
-          </va-alert>
-        )}
-
-      {!travelPayEligible && (
-        <va-alert
-          background-only
-          show-icon
-          data-testid="travel-pay-message"
-          status="warning"
-        >
-          <p
-            className="vads-u-margin-top--0"
-            data-testid="travel-pay-not-eligible-message"
-          >
-            <Trans
-              i18nKey="travel-pay-cant-file-message"
-              components={[
-                <span key="bold" className="vads-u-font-weight--bold" />,
-              ]}
-            />
-          </p>
-          <ExternalLink
-            href="/resources/how-to-file-a-va-travel-reimbursement-claim-online/"
-            hrefLang="en"
-            eventId="clicked-how-to-file-link-from-ineligible"
-            eventPrefix="nav"
-          >
-            {t('find-out-how-to-file--link')}
-          </ExternalLink>
-        </va-alert>
+              <ExternalLink
+                href="/resources/how-to-file-a-va-travel-reimbursement-claim-online/"
+                hrefLang="en"
+                eventId="clicked-how-to-file-link-from-ineligible"
+                eventPrefix="nav"
+              >
+                {t('find-out-how-to-file--link')}
+              </ExternalLink>
+            </va-alert>
+          )}
+        </>
       )}
-
-      {travelPayEligible &&
-        travelPayClaimError && (
-          <va-alert
-            background-only
-            show-icon
-            data-testid="travel-pay-message"
-            status={errorStatus}
-          >
-            <p
-              className="vads-u-margin-top--0"
-              data-testid="travel-pay-claim-error-message"
-            >
-              {errorMsg}
-            </p>
-            <ExternalLink
-              href="/resources/how-to-file-a-va-travel-reimbursement-claim-online/"
-              hrefLang="en"
-              eventId={errorLinkEventId}
-              eventPrefix="nav"
-            >
-              {t('find-out-how-to-file--link')}
-            </ExternalLink>
-          </va-alert>
-        )}
     </>
   );
 };
 
 TravelPayAlert.propTypes = {
-  travelPayClaimError: PropTypes.bool.isRequired,
-  travelPayEligible: PropTypes.bool.isRequired,
-  travelPayClaimData: PropTypes.object,
-  travelPayClaimErrorCode: PropTypes.string,
+  travelPayEligible: PropTypes.bool,
+  travelPayClaimError: PropTypes.bool,
 };
 
 export default TravelPayAlert;

--- a/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
@@ -15,7 +15,7 @@ const TravelPayAlert = props => {
           background-only
           show-icon
           data-testid="travel-pay-message"
-          status="info"
+          status="warning"
         >
           <div>
             <p
@@ -29,6 +29,14 @@ const TravelPayAlert = props => {
                 ]}
               />
             </p>
+            <ExternalLink
+                href="/health-care/get-reimbursed-for-travel-pay/"
+                hrefLang="en"
+                eventId="request-travel-pay-reimbursement-from-confirmation-with-btsss-error--link-clicked"
+                eventPrefix="nav"
+              >
+                {t('find-out-how-to-file--link')}
+              </ExternalLink>
           </div>
         </va-alert>
       ) : (

--- a/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
@@ -42,11 +42,7 @@ describe('check in', () => {
     it('renders a generic api error message', () => {
       const component = render(
         <I18nextProvider i18n={i18n}>
-          <TravelPayAlert
-            travelPayEligible
-            travelPayClaimError
-            travelPayClaimErrorCode="CLM_011_LOL_DUNNO"
-          />
+          <TravelPayAlert travelPayEligible travelPayClaimError />
         </I18nextProvider>,
       );
       expect(component.getByTestId('travel-pay-claim-error-message')).to.exist;
@@ -54,23 +50,6 @@ describe('check in', () => {
         component.getByTestId('travel-pay-claim-error-message'),
       ).to.have.text(
         "We’re sorry, something went wrong on our end. We can't file a travel reimbursement claim for you now. But you can still file within 30 days of the appointment.",
-      );
-    });
-    it('renders a already exists api error message', () => {
-      const component = render(
-        <I18nextProvider i18n={i18n}>
-          <TravelPayAlert
-            travelPayEligible
-            travelPayClaimError
-            travelPayClaimErrorCode="CLM_002_CLAIM_EXISTS"
-          />
-        </I18nextProvider>,
-      );
-      expect(component.getByTestId('travel-pay-claim-error-message')).to.exist;
-      expect(
-        component.getByTestId('travel-pay-claim-error-message'),
-      ).to.have.text(
-        'You can check the status of your travel reimbursement claim online 24/7 on the Beneficiary Travel Self Service System (BTSSS). You can access BTSSS through the AccessVA travel claim portal.',
       );
     });
   });

--- a/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
@@ -45,10 +45,8 @@ describe('check in', () => {
           <TravelPayAlert travelPayEligible travelPayClaimError />
         </I18nextProvider>,
       );
-      expect(component.getByTestId('travel-pay-claim-error-message')).to.exist;
-      expect(
-        component.getByTestId('travel-pay-claim-error-message'),
-      ).to.have.text(
+      expect(component.getByTestId('travel-pay-error-message')).to.exist;
+      expect(component.getByTestId('travel-pay-error-message')).to.have.text(
         "We’re sorry, something went wrong on our end. We can't file a travel reimbursement claim for you now. But you can still file within 30 days of the appointment.",
       );
     });

--- a/src/applications/check-in/day-of/pages/Landing.jsx
+++ b/src/applications/check-in/day-of/pages/Landing.jsx
@@ -33,7 +33,6 @@ const Landing = props => {
     setShouldSendDemographicsFlags,
     setShouldSendTravelPayClaim,
     setCurrentToken,
-    setTravelClaimData,
   } = useSessionStorage(false);
   const dispatch = useDispatch();
 
@@ -74,7 +73,6 @@ const Landing = props => {
               // if session with read.full exists, go to check in page
               setShouldSendDemographicsFlags(window, true);
               setShouldSendTravelPayClaim(window, true);
-              setTravelClaimData(window, null);
               setCurrentToken(window, token);
               const pages = createForm();
               const firstPage = pages[0];
@@ -109,7 +107,6 @@ const Landing = props => {
       setSession,
       setShouldSendDemographicsFlags,
       setShouldSendTravelPayClaim,
-      setTravelClaimData,
     ],
   );
   return (

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -7,6 +7,12 @@ class Confirmation {
       .and('include.text', 'checked in');
   };
 
+  validateBtsssIssue = () => {
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('include.text', 'But we couldn\'t file your travel claim.');
+  };
+
   validatePageLoadedWithNoBtsssClaim = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -10,7 +10,7 @@ class Confirmation {
   validateBtsssIssue = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
-      .and('include.text', 'But we couldn\'t file your travel claim.');
+      .and('include.text', "But we couldn't file your travel claim.");
   };
 
   validatePageLoadedWithNoBtsssClaim = () => {

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec.js
@@ -116,6 +116,7 @@ describe('Check In Experience', () => {
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       Appointments.attemptCheckIn(1);
+      Confirmation.validateBtsssIssue();
       Confirmation.validatePageLoadedWithBtsssIneligible();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots(

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
@@ -18,7 +18,6 @@ describe('Check In Experience', () => {
         initializeSessionGet,
         initializeSessionPost,
         initializeCheckInDataGet,
-        initializeCheckInDataPost,
         initializeDemographicsPatch,
       } = ApiInitializer;
       initializeFeatureToggle.withTravelPay();
@@ -28,7 +27,6 @@ describe('Check In Experience', () => {
       initializeCheckInDataGet.withSuccess({
         appointments,
       });
-      initializeCheckInDataPost.withSuccess();
       cy.visitWithUUID();
       ValidateVeteran.validatePage.dayOf();
       ValidateVeteran.validateVeteran();
@@ -48,7 +46,8 @@ describe('Check In Experience', () => {
       });
     });
     it('shows the correct error message for generic api error.', () => {
-      ApiInitializer.initializeBtsssPost.withFailure(400, 'CLM_011_LOL_DUNNO');
+      ApiInitializer.initializeCheckInDataPost.withSuccess();
+      ApiInitializer.initializeBtsssPost.withFailure();
       TravelPages.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       TravelPages.attemptToGoToNextPage();
@@ -66,32 +65,8 @@ describe('Check In Experience', () => {
       Appointments.attemptCheckIn(1);
       Confirmation.validatePageLoadedWithBtsssGenericFailure();
       cy.injectAxeThenAxeCheck();
-      cy.createScreenshots('Day-of-check-in--travel-pay--btsss-generic-error');
-    });
-    it('shows the correct error message for travel claim exists api error.', () => {
-      ApiInitializer.initializeBtsssPost.withFailure(
-        400,
-        'CLM_002_CLAIM_EXISTS',
-      );
-      TravelPages.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
-      TravelPages.attemptToGoToNextPage();
-      TravelPages.validatePageLoaded('vehicle');
-      cy.injectAxeThenAxeCheck();
-      TravelPages.attemptToGoToNextPage();
-      TravelPages.validatePageLoaded('address');
-      cy.injectAxeThenAxeCheck();
-      TravelPages.attemptToGoToNextPage();
-      TravelPages.validatePageLoaded('mileage');
-      cy.injectAxeThenAxeCheck();
-      TravelPages.attemptToGoToNextPage();
-      Appointments.validatePageLoaded();
-      cy.injectAxeThenAxeCheck();
-      Appointments.attemptCheckIn(1);
-      Confirmation.validatePageLoadedWithBtsssTravelClaimExistsFailure();
-      cy.injectAxeThenAxeCheck();
       cy.createScreenshots(
-        'Day-of-check-in--travel-pay--btsss-travel-claim-exists',
+        'Day-of-check-in--travel-pay--btsss-generic-api-error',
       );
     });
   });

--- a/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec.js
@@ -63,6 +63,7 @@ describe('Check In Experience', () => {
       Appointments.validatePageLoaded();
       cy.injectAxeThenAxeCheck();
       Appointments.attemptCheckIn(1);
+      Confirmation.validateBtsssIssue();
       Confirmation.validatePageLoadedWithBtsssGenericFailure();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots(

--- a/src/applications/check-in/hooks/useSendTravelPayClaim.jsx
+++ b/src/applications/check-in/hooks/useSendTravelPayClaim.jsx
@@ -8,18 +8,12 @@ import { useTravelPayFlags } from './useTravelPayFlags';
 const useSendTravelPayClaim = appointment => {
   const [isLoading, setIsLoading] = useState(false);
   const [travelPayClaimError, setTravelPayClaimError] = useState(false);
-  const [travelPayClaimErrorCode, setTravelPayClaimErrorCode] = useState('');
   const [travelPayClaimRequested, setTravelPayClaimRequested] = useState();
 
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
   const featureToggles = useSelector(selectFeatureToggles);
   const { isTravelReimbursementEnabled } = featureToggles;
-  const {
-    getShouldSendTravelPayClaim,
-    setTravelClaimData,
-    getTravelClaimData,
-  } = useSessionStorage(false);
-  const travelPayClaimData = getTravelClaimData(window);
+  const { getShouldSendTravelPayClaim } = useSessionStorage(false);
   const {
     travelPayData,
     travelPayClaimSent,
@@ -47,12 +41,8 @@ const useSendTravelPayClaim = appointment => {
       setIsLoading(true);
       api.v2
         .postDayOfTravelPayClaim(travelPayData)
-        .then(json => {
-          setTravelClaimData(window, json.data);
-        })
-        .catch(e => {
+        .catch(() => {
           setTravelPayClaimError(true);
-          setTravelPayClaimErrorCode(e.data.code);
         })
         .finally(() => {
           setTravelPayClaimSent(true);
@@ -62,7 +52,6 @@ const useSendTravelPayClaim = appointment => {
     [
       getShouldSendTravelPayClaim,
       isTravelReimbursementEnabled,
-      setTravelClaimData,
       setTravelPayClaimSent,
       travelPayData,
       travelPayEligible,
@@ -73,10 +62,8 @@ const useSendTravelPayClaim = appointment => {
 
   return {
     travelPayClaimError,
-    travelPayClaimErrorCode,
     travelPayEligible,
     isLoading,
-    travelPayClaimData,
     travelPayClaimRequested,
     travelPayClaimSent,
   };

--- a/src/applications/check-in/hooks/useSessionStorage.jsx
+++ b/src/applications/check-in/hooks/useSessionStorage.jsx
@@ -134,20 +134,6 @@ const useSessionStorage = (isPreCheckIn = true) => {
     [SESSION_STORAGE_KEYS],
   );
 
-  const setTravelClaimData = useCallback(
-    (window, value) => {
-      setSessionKey(window, SESSION_STORAGE_KEYS.TRAVEL_CLAIM_DATA, value);
-    },
-    [SESSION_STORAGE_KEYS],
-  );
-
-  const getTravelClaimData = useCallback(
-    window => {
-      return getSessionKey(window, SESSION_STORAGE_KEYS.TRAVEL_CLAIM_DATA);
-    },
-    [SESSION_STORAGE_KEYS],
-  );
-
   return {
     clearCurrentSession,
     setCurrentToken,
@@ -162,8 +148,6 @@ const useSessionStorage = (isPreCheckIn = true) => {
     getProgressState,
     setPermissions,
     getPermissions,
-    setTravelClaimData,
-    getTravelClaimData,
   };
 };
 


### PR DESCRIPTION
## Summary
This is a second attempt at this PR. It leaves the calls to vets-api for BTSSS intact, but mocks the 202 accepted response as the happy response and catches any error. The only error we expect is a server 500 error since vets-api is not sending any response for another endpoint. Adds an edge case scenario where a user successfully checks in but then vets-api dies before the BTSSS request is sent. In that case the user sees a checked-in page but with our old error message for BTSSS.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#23671
- *Link to ticket created in va.gov-team repo*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*


## Testing done
Updates unit and e2e tests


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


