### PR TITLE
Add penalty statement to review page

### DIFF
--- a/src/applications/simple-forms/26-4555/containers/PreSubmitSignature.jsx
+++ b/src/applications/simple-forms/26-4555/containers/PreSubmitSignature.jsx
@@ -95,6 +95,12 @@ const PreSubmitSignature = ({
 
   return (
     <>
+      <p className="vads-u-padding-x--3">
+        <strong>Note:</strong> According to federal law, there are criminal
+        penalties, including a fine and/or imprisonment for up to 5 years, for
+        withholding information or for providing incorrect information (See 18
+        U.S.C. 1001).
+      </p>
       <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--3 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--3">
         <h3>Statement of truth</h3>
         <p>


### PR DESCRIPTION
## Summary
This adds the penalty notice to the review page of the 26-4555 form. On the design system site, there is a documented component for this (see https://design.va.gov/components/form/penalty-notice), but I can't find an actual matching usable component, so I'm confused by the documentation.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#152

## Screenshots
<img width="502" alt="image" src="https://user-images.githubusercontent.com/53942725/227285643-23886152-3607-432d-9c15-76b4ca5ac2db.png">
