### PR TITLE
Staging: Duplicate Appointments Display

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -80,9 +80,9 @@ function hasPartialResults(response) {
   );
 }
 
-function hasBackendSystemFailure(response) {
-  return response.backendSystemFailures?.length > 0;
-}
+// function hasBackendSystemFailure(response) {
+//   return response.backendSystemFailures?.length > 0;
+// }
 // Sort the requested appointments, latest appointments appear at the top of the list.
 function apptRequestSort(a, b) {
   return new Date(b.created).getTime() - new Date(a.created).getTime();
@@ -125,13 +125,15 @@ export async function fetchAppointments({
         }
         return !appt.requestedPeriods;
       });
-
       appointments.push(...transformVAOSAppointments(filteredAppointments));
-      if (hasBackendSystemFailure(allAppointments)) {
-        appointments.push(...transformVAOSAppointments(filteredAppointments), {
-          meta: allAppointments.backendSystemFailures,
-        });
-      }
+
+      // Removing this check because it's causing a bug in staging. See: #55677.
+      // Note: Re write check for new generic alert messages.
+      // if (hasBackendSystemFailure(allAppointments)) {
+      //   appointments.push(...transformVAOSAppointments(filteredAppointments), {
+      //     meta: allAppointments.backendSystemFailures,
+      //   });
+      // }
 
       if (useV2VA && useV2CC) {
         return appointments;

--- a/src/applications/vaos/tests/appointment-list/components/VistaSchedulingServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/VistaSchedulingServiceAlert.unit.spec.jsx
@@ -31,7 +31,8 @@ describe('VAOS <AppointmentsPage>', () => {
     MockDate.reset();
   });
 
-  describe('when vaOnlineSchedulingVAOSV2Next flag is on', () => {
+  // Skipping BE Alert tests. Related to: #55677
+  describe.skip('when vaOnlineSchedulingVAOSV2Next flag is on', () => {
     it('should display VistaSchedulingServiceAlert if there is a failure returned', async () => {
       const appointmentTime = moment().add(1, 'days');
       const start = moment()
@@ -162,7 +163,8 @@ describe('VAOS <AppointmentsPage>', () => {
     });
   });
 
-  describe('when vaOnlineSchedulingVAOSV2Next flag is off', () => {
+  // Skipping BE Alert tests. Related to: #55677
+  describe.skip('when vaOnlineSchedulingVAOSV2Next flag is off', () => {
     it('should not display VistaSchedulingServiceAlert if there is an error returned', async () => {
       const appointmentTime = moment().add(1, 'days');
       const start = moment()


### PR DESCRIPTION
This PR:
- Removes check for BE failures that's causing duplicate appointments to display.