### PR TITLE
Feature flippers: add static page flipper for 26-4555

### DIFF
--- a/src/applications/static-pages/simple-forms/26-4555/App.js
+++ b/src/applications/static-pages/simple-forms/26-4555/App.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+const App = ({ formEnabled }) => {
+  if (formEnabled === undefined) {
+    return <va-loading-indicator set-focus message="Loading..." />;
+  }
+
+  if (formEnabled) {
+    return (
+      <>
+        <p>You can apply online right now.</p>
+        <a
+          className="vads-c-action-link--green"
+          href="/housing-assistance/disability-housing-grants/apply-for-grant-form-26-4555"
+        >
+          Apply for an adapted housing grant
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p>You can apply online right now on eBenefits.</p>
+      <p>
+        When you go to the eBenefits website, you may need to sign in with your
+        <strong>DS Logon</strong> account to access the application. If you
+        don’t have a <strong>DS Logon</strong> account, you can register for one
+        there.
+      </p>
+      <a
+        className="vads-c-action-link--green"
+        href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant"
+      >
+        Apply now on eBenefits
+      </a>
+    </>
+  );
+};
+
+App.propTypes = {
+  formEnabled: PropTypes.bool,
+};
+
+const mapStateToProps = store => ({
+  formEnabled: toggleValues(store)[FEATURE_FLAG_NAMES.form264555],
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/static-pages/simple-forms/26-4555/entry.js
+++ b/src/applications/static-pages/simple-forms/26-4555/entry.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Provider } from 'react-redux';
+
+export default function create264555Access(store, widgetType) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "form-26-4555" */ './App.js').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+}

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -79,6 +79,7 @@ import create1095BDownloadCTA from './download-1095b';
 
 import createEnrollmentVerificationLoginWidget from './view-enrollment-verification-login/createEnrollmentVerificationLoginWidget';
 import createEducationLettersLoginWidget from './view-education-letters-login/createEducationLettersLoginWidget';
+import create264555Access from './simple-forms/26-4555/entry';
 
 // Set the app name header when using the apiRequest helper
 window.appName = 'static-pages';
@@ -211,6 +212,7 @@ createEducationLettersLoginWidget(
   store,
   widgetTypes.VIEW_EDUCATION_LETTERS_LOGIN,
 );
+create264555Access(store, widgetTypes.FORM_264555_CTA);
 
 // Create the My VA Login widget only on the homepage.
 if (window.location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -30,6 +30,7 @@ export default {
   FIND_VA_FORMS_INVALID_PDF_ALERT: 'find-va-forms-pdf-download-helper',
   FORM_10182_CTA: 'form-10182-cta',
   FORM_686_CTA: 'form-686-CTA',
+  FORM_264555_CTA: 'form264555',
   GET_MEDICAL_RECORDS_PAGE: 'get-medical-records-page',
   HEALTH_CARE_APP_STATUS: 'health-care-app-status',
   HIGHER_LEVEL_REVIEW_APP_STATUS: 'higher-level-review-status',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -66,6 +66,7 @@ export default Object.freeze({
   findFormsShowPdfModal: 'find_forms_show_pdf_modal',
   fileUploadShortWorkflowEnabled: 'file_upload_short_workflow_enabled',
   form10182Nod: 'form10182_nod',
+  form264555: 'form264555',
   fsrConfirmationEmail: 'fsr_confirmation_email',
   gibctEybBottomSheet: 'gibct_eyb_bottom_sheet',
   gibctSchoolRatings: 'gibct_school_ratings',


### PR DESCRIPTION
Add static pages and flipper for form 26-4555

[vets-api pr](https://github.com/department-of-veterans-affairs/vets-api/pull/12248)


## Summary

- add static pages that show either the new digital form, or link to the old eBenefits form

## Related issue(s)
- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/94


## Testing done

- tested flipper locally to confirm it changed arbitrary site content (not static pages, as those go to Drupal)


## What areas of the site does it impact?
Form 26-4555, Drupal static pages

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

