### PR TITLE
VACMS-12697 logo alt text fix for homepage modal

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -57,7 +57,11 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
               dismiss();
             }}
           >
-            <img src="/img/design/logo/va-logo.png" alt="VA logo" width="300" />
+            <img
+              src="/img/design/logo/va-logo.png"
+              alt="VA logo and Seal, U.S. Department of Veterans Affairs"
+              width="300"
+            />
             <h1
               id="homepage-modal-label-title"
               className="vads-u-font-size--lg vads-u-margin-top--2p5"


### PR DESCRIPTION
## Summary

Original PR: https://github.com/department-of-veterans-affairs/content-build/pull/1515

Fixing one add'l location of alt text in the homepage modal

## Related issue(s)
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12697

## QA steps

_What needs to be checked to prove this works?_
Load VA.gov, inspect logo in the homepage modal, verify updated alt text reads "VA logo and Seal, U.S. Department of Veterans Affairs"

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
