### PR TITLE
DHP 567 Terms and Conditions

### DIFF
--- a/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceConnectionCard.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import environment from 'platform/utilities/environment';
+import { TermsAndConditions } from './TermsAndConditions';
 
 export const DeviceConnectionCard = ({ device }) => {
   return (
     <div className="connect-device">
-      <h3 className="vads-u-margin-y--0">{device.name}</h3>
+      <h3
+        className="vads-u-margin-y--0"
+        data-testid={`${device.key}-name-header`}
+      >
+        {device.name}
+      </h3>
+      <TermsAndConditions device={device} />
       <p className="vads-u-margin-y--0">
         <va-link
           active

--- a/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
+++ b/src/applications/dhp-connected-devices/components/DeviceDisconnectionCard.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import environment from 'platform/utilities/environment';
 import { DisconnectModal } from './DisconnectModal';
+import { TermsAndConditions } from './TermsAndConditions';
 
 export const DeviceDisconnectionCard = ({ device }) => {
   const [modalVisible, setModalVisible] = useState(false);
@@ -31,6 +32,7 @@ export const DeviceDisconnectionCard = ({ device }) => {
           {device.name}{' '}
           <span className="connected-header-text"> - Connected</span>{' '}
         </h3>
+        <TermsAndConditions device={device} />
         <p className="vads-u-margin-y--0">
           <button
             type="button"

--- a/src/applications/dhp-connected-devices/components/FAQSections.jsx
+++ b/src/applications/dhp-connected-devices/components/FAQSections.jsx
@@ -15,43 +15,51 @@ export const FirstFAQSection = () => {
         }}
       >
         <va-accordion-item
-          header="Why are we doing this pilot with Fitbit?"
+          header="Why are we doing this pilot?"
           id="dhp-faq-first-section-first-question"
           aria-controls="dhp-faq-first-section-first-question"
           data-testid="faq-first-section-first-question"
         >
-          The goal of the Digital Health Platform Fitbit pilot (the “Pilot”) is
-          to help the VA understand the best ways for Veterans to connect and
-          share their connected device data (i.e., data from a Fitbit) with
-          their VA care team. By volunteering to connect your device, you will
-          be helping the VA and other Veterans by supporting an early-stage
-          evaluation of a new offering from VA. We expect this pilot to take
-          about 6 to 12 months, and your ability to connect your device with the
-          VA to share data through the Digital Health Platform may be
-          discontinued after the pilot is over. There may still be other ways
-          for you to keep sharing the data with your care team at that time, and
-          we will let you know about any available options after the Pilot is
-          over. The Pilot is not meant to replace normal care activities between
-          you and your VA care team.
+          The VA Digital Health Platform Fitbit Pilot (i.e., the Pilot) is an
+          effort designed to evaluate how VA can provide you with an opportunity
+          to share your patient-generated data (PGD) with your VA care team.
+          This pilot is not meant to replace normal care activities between you
+          and your VA care team. The estimated duration of this pilot is 6-12
+          months, after which your ability to connect and share data through the
+          Digital Health Platform may be discontinued.
         </va-accordion-item>
         <va-accordion-item
-          header="Do I have to participate in this pilot?"
+          header="What can I expect if I participate in this pilot?"
           id="dhp-faq-first-section-second-question"
           aria-controls="dhp-faq-first-section-second-question"
           data-testid="faq-first-section-second-question"
         >
-          It is your decision to be part of this Pilot program. It is completely
-          voluntary. Your participation is voluntary, and you have the right to
-          refuse to participate. You do not have to take part in this Pilot to
-          receive treatment at the VA. Your choice will not affect in any way
-          your current or future medical care or any other benefits from the VA
-          to which you are otherwise entitled.
+          By participating in the pilot, the data you choose to share with the
+          VA may be accessed by your VA care team and discussed with you. At any
+          time, you can choose to opt out of the pilot and disconnect your
+          device in the Connected Devices section. If you choose to opt out of
+          the pilot, any data will be retained for a minimum timeframe of 6-12
+          months (duration of the pilot). At the end of the pilot, data will be
+          retained for a minimum timeframe of 6 to 12 months.
         </va-accordion-item>
         <va-accordion-item
-          header="What is a connected device and why might I use one?"
+          header="Do I have to participate in this pilot?"
           id="dhp-faq-first-section-third-question"
           aria-controls="dhp-faq-first-section-third-question"
           data-testid="faq-first-section-third-question"
+        >
+          It is your decision to be part of this pilot program. Your
+          participation is voluntary and have the right to refuse to
+          participate. You do not have to take part in this pilot to receive
+          treatment at the VA. Your choice will not affect in any way your
+          current or future medical care or any other benefits from VA to which
+          you are otherwise entitled.
+        </va-accordion-item>
+        <va-accordion-item
+          header="What is a connected device and why might I use one?"
+          id="dhp-faq-first-section-fourth-question"
+          aria-controls="dhp-faq-first-section-fourth-question"
+          data-testid="faq-first-section-fourth-question"
         >
           A connected device is any device that can connect to the internet so
           that it can communicate with other devices or computers. Examples of
@@ -96,7 +104,11 @@ export const SecondFAQSection = () => {
               HealtheVet, or ID.me account
               <ol type="a">
                 <li>
-                  <a href="https://www.va.gov/resources/signing-in-to-vagov/">
+                  <a
+                    href="https://www.va.gov/resources/signing-in-to-vagov/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     Signing in to VA.gov guide
                   </a>
                 </li>
@@ -115,6 +127,8 @@ export const SecondFAQSection = () => {
           <a
             href="https://www.youtube.com/watch?v=37aRcEZ3vyo"
             aria-label="This video will help Veterans connect their Fitbit device to va.gov"
+            target="_blank"
+            rel="noreferrer"
           >
             video
           </a>{' '}
@@ -138,7 +152,11 @@ export const SecondFAQSection = () => {
               HealtheVet, or ID.me account
               <ol type="a">
                 <li>
-                  <a href="https://www.va.gov/resources/signing-in-to-vagov/">
+                  <a
+                    href="https://www.va.gov/resources/signing-in-to-vagov/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     Signing in to VA.gov guide
                   </a>
                 </li>
@@ -158,6 +176,8 @@ export const SecondFAQSection = () => {
           <a
             href="https://www.youtube.com/watch?v=37aRcEZ3vyo"
             aria-label="This video will help Veterans disconnect their Fitbit device to va.gov"
+            target="_blank"
+            rel="noreferrer"
           >
             video
           </a>{' '}
@@ -197,24 +217,24 @@ export const SecondFAQSection = () => {
           aria-controls="dhp-faq-second-section-fifth-question"
           data-testid="faq-second-section-fifth-question"
         >
-          VA will keep information about you, including any connected device
+          We will keep information about you, including any patient-generated
           data that you share, strictly confidential to the extent required by
           law. The VA will not sell, rent, or otherwise provide your personal
           information to outside marketers. Information collected via VA.gov,
-          including data shared with VA as a part of this Pilot, may be shared
+          include data shared with VA as a part of this pilot, may be shared
           with employees, contractors, and other service providers as necessary
           to respond to a request, provide a service, or as otherwise authorized
           by law.
         </va-accordion-item>
         <va-accordion-item
-          header="Does VA keep my data after I disconnect a device?"
+          header="What will happen if I decide to disconnect my device?"
           id="dhp-faq-second-section-sixth-question"
           aria-controls="dhp-faq-second-section-sixth-question"
           data-testid="faq-second-section-sixth-question"
         >
-          VA will no longer receive new data from your device after it is
-          disconnected. Data shared while your device was connected will not be
-          deleted.
+          The VA will no longer receive new data from your device after it is
+          disconnected. The data shared while your device was connected will not
+          be deleted.
         </va-accordion-item>
       </va-accordion>
     </>
@@ -242,7 +262,11 @@ export const ThirdFAQSection = () => {
           data-testid="faq-third-section-first-question"
         >
           Please visit the{' '}
-          <a href="https://myhelp.fitbit.com/s/support?language=en_US">
+          <a
+            href="https://myhelp.fitbit.com/s/support?language=en_US"
+            target="_blank"
+            rel="noreferrer"
+          >
             Fitbit support website
           </a>{' '}
           or call <va-telephone contact="8776234997" international /> for Fitbit
@@ -261,7 +285,11 @@ export const ThirdFAQSection = () => {
           aria-controls="dhp-faq-third-section-second-question"
           data-testid="faq-third-section-second-question"
         >
-          <a href="https://www.va.gov/resources/signing-in-to-vagov/">
+          <a
+            href="https://www.va.gov/resources/signing-in-to-vagov/"
+            target="_blank"
+            rel="noreferrer"
+          >
             Signing in to VA.gov guide.
           </a>{' '}
           Please contact the VA help desk that applies to you from the list
@@ -287,13 +315,21 @@ export const ThirdFAQSection = () => {
             </li>
             <ul>
               <li>
-                <a href="https://www.myhealth.va.gov/forgot-user-id?action=new">
+                <a
+                  href="https://www.myhealth.va.gov/forgot-user-id?action=new"
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   Forgot Your My HealtheVet User ID
                 </a>{' '}
                 (Continue to My HealtheVet Only)
               </li>
               <li>
-                <a href="https://www.myhealth.va.gov/forgot-password?action=new">
+                <a
+                  href="https://www.myhealth.va.gov/forgot-password?action=new"
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   Forgot Your My HealtheVet Password
                 </a>{' '}
                 (Continue to My HealtheVet Only)
@@ -326,7 +362,10 @@ export const FourthFAQSection = () => {
           aria-controls="dhp-faq-fourth-section-first-question"
           data-testid="faq-fourth-section-first-question"
         >
-          Contact <a href="mailto:VA-DHP-Pilot@va.gov">VA-DHP-Pilot@va.gov</a>
+          Contact{' '}
+          <a href="mailto:VA-DHP-Pilot@va.gov" target="_blank" rel="noreferrer">
+            VA-DHP-Pilot@va.gov
+          </a>
         </va-accordion-item>
       </va-accordion>
     </>

--- a/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
+++ b/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
@@ -34,7 +34,7 @@ const TermsAndConditionsContentMap = {
 
 export const TermsAndConditions = ({ device }) => {
   return (
-    <p>
+    <p data-testid={`${device.key}-terms-and-conditions`}>
       By connecting your {device.name} to VA.gov, you consent to the{' '}
       <a
         href="https://www.va.gov/privacy-policy/"
@@ -44,7 +44,10 @@ export const TermsAndConditions = ({ device }) => {
         va.gov privacy policy
       </a>{' '}
       in addition to the following:
-      <va-additional-info trigger="View Terms">
+      <va-additional-info
+        trigger="View Terms"
+        data-testid={`${device.key}-terms-and-conditions-content`}
+      >
         {TermsAndConditionsContentMap[device.key]}
       </va-additional-info>
     </p>

--- a/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
+++ b/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+function FitbitTermsAndConditions() {
+  return (
+    <div>
+      <ul>
+        <li>
+          Sign into Fitbit and share your Fitbit data with VA. Fitbit data
+          includes, but is not limited to heart rate, exercise, sleep, activity,
+          and diet (caloric) data (i.e., your patient-generated data).
+        </li>
+        <li>
+          Your data (including, but not limited to, heart rate, exercise habits,
+          sleep, activity, and diet data) will be automatically retrieved from
+          Fitbit via an automated process and stored within the VA in a secure
+          environment.
+        </li>
+        <li>
+          Your Fitbit data will be displayed in a dashboard that can be viewed
+          by VA clinicians and health coaches.
+        </li>
+        <li>
+          Your VA care teams may discuss data from this dashboard with you.
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const TermsAndConditionsContentMap = {
+  fitbit: <FitbitTermsAndConditions />,
+};
+
+export const TermsAndConditions = ({ device }) => {
+  return (
+    <p>
+      By connecting your {device.name} to VA.gov, you consent to the{' '}
+      <a
+        href="https://www.va.gov/privacy-policy/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        va.gov privacy policy
+      </a>{' '}
+      in addition to the following:
+      <va-additional-info trigger="View Terms">
+        {TermsAndConditionsContentMap[device.key]}
+      </va-additional-info>
+    </p>
+  );
+};
+
+TermsAndConditions.propTypes = {
+  device: PropTypes.object.isRequired,
+};

--- a/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
+++ b/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
@@ -45,7 +45,7 @@ export const TermsAndConditions = ({ device }) => {
           >
             va.gov privacy policy
           </a>{' '}
-          in addition to the following:
+          in addition to the following terms.
           <va-additional-info
             trigger="View Terms"
             data-testid={`${device.key}-terms-and-conditions-content`}

--- a/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
+++ b/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
@@ -33,25 +33,30 @@ const TermsAndConditionsContentMap = {
 };
 
 export const TermsAndConditions = ({ device }) => {
-  return (
-    <p data-testid={`${device.key}-terms-and-conditions`}>
-      By connecting your {device.name} to VA.gov, you consent to the{' '}
-      <a
-        href="https://www.va.gov/privacy-policy/"
-        target="_blank"
-        rel="noreferrer"
-      >
-        va.gov privacy policy
-      </a>{' '}
-      in addition to the following:
-      <va-additional-info
-        trigger="View Terms"
-        data-testid={`${device.key}-terms-and-conditions-content`}
-      >
-        {TermsAndConditionsContentMap[device.key]}
-      </va-additional-info>
-    </p>
-  );
+  if (device.key in TermsAndConditionsContentMap) {
+    return (
+      <>
+        <p data-testid={`${device.key}-terms-and-conditions`}>
+          By connecting your {device.name} to VA.gov, you consent to the{' '}
+          <a
+            href="https://www.va.gov/privacy-policy/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            va.gov privacy policy
+          </a>{' '}
+          in addition to the following:
+          <va-additional-info
+            trigger="View Terms"
+            data-testid={`${device.key}-terms-and-conditions-content`}
+          >
+            {TermsAndConditionsContentMap[device.key]}
+          </va-additional-info>
+        </p>
+      </>
+    );
+  }
+  return <></>;
 };
 
 TermsAndConditions.propTypes = {

--- a/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
+++ b/src/applications/dhp-connected-devices/components/TermsAndConditions.jsx
@@ -43,7 +43,7 @@ export const TermsAndConditions = ({ device }) => {
             target="_blank"
             rel="noreferrer"
           >
-            va.gov privacy policy
+            VA.gov privacy policy
           </a>{' '}
           in addition to the following terms.
           <va-additional-info

--- a/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
@@ -8,12 +8,14 @@ describe('Device connection card', () => {
   it('Renders vendors name', () => {
     const card = renderInReduxProvider(
       <DeviceConnectionCard
-        device={{ name: 'Test Vendor' }}
+        device={{ name: 'Test Vendor', key: 'test-vendor' }}
         authUrl="www.google.com"
       />,
     );
-
-    expect(card.getByText(/Test Vendor/)).to.exist;
+    expect(card.getByTestId('test-vendor-name-header')).to.exist;
+    expect(card.getByTestId('test-vendor-terms-and-conditions')).to.exist;
+    expect(card.getByTestId('test-vendor-terms-and-conditions-content')).to
+      .exist;
   });
   it('Has aria label for screen reader users', () => {
     const card = mount(

--- a/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
@@ -8,32 +8,29 @@ describe('Device connection card', () => {
   it('Renders vendors name', () => {
     const card = renderInReduxProvider(
       <DeviceConnectionCard
-        device={{ name: 'Test Vendor', key: 'test-vendor' }}
+        device={{ name: 'Fitbit', key: 'fitbit' }}
         authUrl="www.google.com"
       />,
     );
-    expect(card.getByTestId('test-vendor-name-header')).to.exist;
+    expect(card.getByTestId('fitbit-name-header')).to.exist;
   });
   it('Renders vendor terms and conditions', () => {
     const card = renderInReduxProvider(
       <DeviceConnectionCard
-        device={{ name: 'Test Vendor', key: 'test-vendor' }}
+        device={{ name: 'Fitbit', key: 'fitbit' }}
         authUrl="www.google.com"
       />,
     );
-    expect(card.getByTestId('test-vendor-terms-and-conditions')).to.exist;
-    expect(card.getByTestId('test-vendor-terms-and-conditions-content')).to
-      .exist;
+    expect(card.getByTestId('fitbit-terms-and-conditions')).to.exist;
+    expect(card.getByTestId('fitbit-terms-and-conditions-content')).to.exist;
   });
   it('Has aria label for screen reader users', () => {
     const card = mount(
-      <DeviceConnectionCard
-        device={{ key: 'test-vendor', name: 'Test Vendor' }}
-      />,
+      <DeviceConnectionCard device={{ key: 'fitbit', name: 'Fitbit' }} />,
     );
     expect(
-      card.find('[data-testid="test-vendor-connect-link"]').prop('aria-label'),
-    ).to.equal('Connect Test Vendor');
+      card.find('[data-testid="fitbit-connect-link"]').prop('aria-label'),
+    ).to.equal('Connect Fitbit');
     card.unmount();
   });
 });

--- a/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceConnectionCard.spec.js
@@ -13,6 +13,14 @@ describe('Device connection card', () => {
       />,
     );
     expect(card.getByTestId('test-vendor-name-header')).to.exist;
+  });
+  it('Renders vendor terms and conditions', () => {
+    const card = renderInReduxProvider(
+      <DeviceConnectionCard
+        device={{ name: 'Test Vendor', key: 'test-vendor' }}
+        authUrl="www.google.com"
+      />,
+    );
     expect(card.getByTestId('test-vendor-terms-and-conditions')).to.exist;
     expect(card.getByTestId('test-vendor-terms-and-conditions-content')).to
       .exist;

--- a/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/DeviceDisconnectionCard.spec.jsx
@@ -19,6 +19,7 @@ describe('Device disconnection card', () => {
     screen = render(<DeviceDisconnectionCard device={device} />);
     disconnectBtn = screen.getByRole('button', {
       name: 'Disconnect Test Vendor',
+      key: 'test-vendor',
     });
   });
 
@@ -38,6 +39,11 @@ describe('Device disconnection card', () => {
       disconnectBtn.focus();
       fireEvent.keyDown(disconnectBtn, { keyCode: tabKeyCode });
       expect(getDisconnectModal(screen)).to.not.exist;
+    });
+    it('Renders vendor terms and conditions', () => {
+      expect(screen.getByTestId('test-vendor-terms-and-conditions')).to.exist;
+      expect(screen.getByTestId('test-vendor-terms-and-conditions-content')).to
+        .exist;
     });
   });
 

--- a/src/applications/dhp-connected-devices/tests/components/FAQSections.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/FAQSections.spec.js
@@ -112,7 +112,7 @@ describe('FAQSections component', () => {
     it('renders the second item', () => {
       const faq = screen.getByTestId('faq-third-section-second-question');
       expect(faq.getAttribute('header')).to.eq(
-        'I can’t login or need help with my VA account',
+        'I can’t log in or need help with my VA account',
       );
     });
   });

--- a/src/applications/dhp-connected-devices/tests/components/FAQSections.spec.js
+++ b/src/applications/dhp-connected-devices/tests/components/FAQSections.spec.js
@@ -22,20 +22,24 @@ describe('FAQSections component', () => {
 
     it('renders the first item', () => {
       const faq = screen.getByTestId('faq-first-section-first-question');
-      expect(faq.getAttribute('header')).to.eq(
-        'Why are we doing this pilot with Fitbit?',
-      );
+      expect(faq.getAttribute('header')).to.eq('Why are we doing this pilot?');
     });
 
     it('renders the second item', () => {
       const faq = screen.getByTestId('faq-first-section-second-question');
       expect(faq.getAttribute('header')).to.eq(
-        'Do I have to participate in this pilot?',
+        'What can I expect if I participate in this pilot?',
       );
     });
 
     it('renders the third item', () => {
       const faq = screen.getByTestId('faq-first-section-third-question');
+      expect(faq.getAttribute('header')).to.eq(
+        'Do I have to participate in this pilot?',
+      );
+    });
+    it('renders the fourth item', () => {
+      const faq = screen.getByTestId('faq-first-section-fourth-question');
       expect(faq.getAttribute('header')).to.eq(
         'What is a connected device and why might I use one?',
       );
@@ -88,7 +92,7 @@ describe('FAQSections component', () => {
     it('renders the sixth item', () => {
       const faq = screen.getByTestId('faq-second-section-sixth-question');
       expect(faq.getAttribute('header')).to.eq(
-        'Does VA keep my data after I disconnect a device?',
+        'What will happen if I decide to disconnect my device?',
       );
     });
   });

--- a/src/applications/dhp-connected-devices/tests/components/TermsAndConditions.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/components/TermsAndConditions.spec.jsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { expect } from 'chai';
+import { TermsAndConditions } from '../../components/TermsAndConditions';
+
+describe('Terms and Conditions', () => {
+  const deviceNoTsAndCs = {
+    name: 'Test Vendor',
+    key: 'test-vendor',
+  };
+
+  const fitbitDevice = {
+    name: 'Fitbit',
+    key: 'fitbit',
+  };
+
+  it('Renders vendor terms and conditions', () => {
+    const screen = render(<TermsAndConditions device={fitbitDevice} />);
+    expect(screen.getByTestId('fitbit-terms-and-conditions')).to.exist;
+    expect(screen.getByTestId('fitbit-terms-and-conditions-content')).to.exist;
+    expect(
+      screen.getByText('Sign into Fitbit and share your Fitbit data with VA'),
+    ).to.exist;
+    expect(screen.getByText('View Terms')).to.exist;
+  });
+  it('Only renders Ts and Cs for device in TermsAndConditionsContentMap', () => {
+    const screen = render(<TermsAndConditions device={deviceNoTsAndCs} />);
+    expect(screen.getByTestId('test-vendor-terms-and-conditions')).to.not.exist;
+    expect(screen.getByTestId('test-vendor-terms-and-conditions-content')).to
+      .not.exist;
+  });
+});


### PR DESCRIPTION
## Summary
- Adds terms and conditions disclaimer to device connection page
- Updates some working in DHP FAQs

## Testing done

- Unit testing
- Manual testing

## Screenshots
![Screenshot 2023-03-24 at 3 54 26 PM](https://user-images.githubusercontent.com/54145406/228047908-9786d909-dec8-4a7f-8570-
![Screenshot 2023-03-24 at 3 58 44 PM](https://user-images.githubusercontent.com/54145406/228047940-ab6f454d-f07b-440a-b6ff-e20c0878a34a.png)
f8a5ce19c2a7.png)


## What areas of the site does it impact?
/health-care/connected-devices page only

## Acceptance criteria

- [x]  Given a Veteran has not connected their Fitbit

When they are on the connected devices page

Then they will see the T&Cs collapsed by default and above the connect button

- [x] Given a Veteran has connected their Fitbit

When they are on the connected devices page

Then the T&Cs will be shown collapsed by default and above the disconnect button

- [x] Given a Veteran has not connected their Fitbit

When they click on "view terms"

Then it will expand/collapse
- [x] Given a Veteran is on the connected devices page

When they click on a link in the FAQs

Then the link will open in a new browser tab and focus on that tab

