### PR TITLE
Show an error message when GET /v0/user fails

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -176,6 +176,7 @@ const Dashboard = ({
     <RequiredLoginView
       serviceRequired={[backendServices.USER_PROFILE]}
       user={props.user}
+      showProfileErrorMessage={shouldShowV2Dashboard}
     >
       <DowntimeNotification
         appTitle="user dashboard"

--- a/src/platform/user/authorization/components/RequiredLoginView.jsx
+++ b/src/platform/user/authorization/components/RequiredLoginView.jsx
@@ -27,6 +27,15 @@ const RequiredLoginLoader = () => {
   );
 };
 
+const ProfileErrorMessage = () => {
+  return (
+    <div className="vads-u-text-align--center">
+      <h2>We’re sorry. Something went wrong on our end.</h2>
+      <p>Please refresh this page or try again later.</p>
+    </div>
+  );
+};
+
 export const RequiredLoginView = props => {
   const { user, verify, useSiS } = props;
 
@@ -134,6 +143,10 @@ export const RequiredLoginView = props => {
     });
   };
   const renderWrappedContent = () => {
+    if (user.profile.errors) {
+      return <ProfileErrorMessage />;
+    }
+
     if (user.profile.loading) {
       return <RequiredLoginLoader />;
     }

--- a/src/platform/user/authorization/components/RequiredLoginView.jsx
+++ b/src/platform/user/authorization/components/RequiredLoginView.jsx
@@ -37,7 +37,7 @@ const ProfileErrorMessage = () => {
 };
 
 export const RequiredLoginView = props => {
-  const { user, verify, useSiS } = props;
+  const { user, verify, useSiS, showProfileErrorMessage = false } = props;
 
   const shouldSignIn = useCallback(() => !user.login.currentlyLoggedIn, [
     user.login.currentlyLoggedIn,
@@ -143,7 +143,7 @@ export const RequiredLoginView = props => {
     });
   };
   const renderWrappedContent = () => {
-    if (user.profile.errors) {
+    if (showProfileErrorMessage && user.profile.errors) {
       return <ProfileErrorMessage />;
     }
 
@@ -177,6 +177,7 @@ RequiredLoginView.propTypes = {
     PropTypes.arrayOf(validService),
   ]).isRequired,
   user: PropTypes.object.isRequired,
+  showProfileErrorMessage: PropTypes.bool,
   useSiS: PropTypes.bool,
   verify: PropTypes.bool,
 };

--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -12,6 +12,7 @@ export const PROFILE_LOADING_FINISHED = 'PROFILE_LOADING_FINISHED';
 export const REMOVING_SAVED_FORM = 'REMOVING_SAVED_FORM';
 export const REMOVING_SAVED_FORM_SUCCESS = 'REMOVING_SAVED_FORM_SUCCESS';
 export const REMOVING_SAVED_FORM_FAILURE = 'REMOVING_SAVED_FORM_FAILURE';
+export const PROFILE_ERROR = 'PROFILE_ERROR';
 
 export * from './mhv';
 
@@ -27,6 +28,12 @@ export function updateProfileFields(payload) {
 export function profileLoadingFinished() {
   return {
     type: PROFILE_LOADING_FINISHED,
+  };
+}
+
+export function profileError() {
+  return {
+    type: PROFILE_ERROR,
   };
 }
 
@@ -81,6 +88,8 @@ export function initializeProfile() {
       ) {
         dispatch(updateLoggedInStatus(false));
         teardownProfileSession();
+      } else {
+        dispatch(profileError());
       }
     }
   };

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -10,6 +10,7 @@ import {
   FETCH_MHV_ACCOUNT_FAILURE,
   FETCH_MHV_ACCOUNT_SUCCESS,
   REMOVING_SAVED_FORM_SUCCESS,
+  PROFILE_ERROR,
 } from '../actions';
 
 const initialState = {
@@ -44,6 +45,7 @@ const initialState = {
   services: [],
   session: {},
   mhvTransitionEligible: false,
+  errors: false,
 };
 
 const updateMhvAccountState = (state, mhvAccount) =>
@@ -91,6 +93,9 @@ function profileInformation(state = initialState, action) {
       const forms = state.savedForms.filter(el => el.form !== action.formId);
       return set('savedForms', forms, state);
     }
+
+    case PROFILE_ERROR:
+      return set('errors', true, state);
 
     default:
       return state;

--- a/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
+++ b/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
@@ -131,6 +131,22 @@ describe('<RequiredLoginView>', () => {
     wrapper.unmount();
   });
 
+  it('should render an error message on API error', () => {
+    props = generateProps({
+      user: { ...loa1User, profile: { errors: true } },
+    });
+    const wrapper = mount(
+      <RequiredLoginView {...props}>
+        <TestChildComponent name="one" />
+      </RequiredLoginView>,
+    );
+
+    const loader = wrapper.find('ProfileErrorMessage');
+    expect(loader.length).to.equal(1);
+
+    wrapper.unmount();
+  });
+
   it('should display children when service is available', () => {
     props = generateProps({
       user: loa3User,

--- a/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
+++ b/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
@@ -65,12 +65,14 @@ const generateProps = ({
   user = loa1User,
   loginUrl = 'http://fake-login-url',
   verifyUrl = 'http://fake-verify-url',
+  showProfileErrorMessage = false,
 }) => ({
   verify,
   serviceRequired,
   user,
   loginUrl,
   verifyUrl,
+  showProfileErrorMessage,
 });
 
 function TestChildComponent({ name }) {
@@ -128,12 +130,14 @@ describe('<RequiredLoginView>', () => {
     );
 
     expect(wrapper.text()).to.contain('Loading your information...');
+    expect(wrapper.find('ProfileErrorMessage').length).to.equal(0);
     wrapper.unmount();
   });
 
-  it('should render an error message on API error', () => {
+  it('should render ProfileErrorMessage when showProfileErrorMessage is set', () => {
     props = generateProps({
       user: { ...loa1User, profile: { errors: true } },
+      showProfileErrorMessage: true,
     });
     const wrapper = mount(
       <RequiredLoginView {...props}>
@@ -143,7 +147,6 @@ describe('<RequiredLoginView>', () => {
 
     const loader = wrapper.find('ProfileErrorMessage');
     expect(loader.length).to.equal(1);
-
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Summary

As part of the 2022 My VA Audit, we're making many UX improvements. After QA, under the My VA Health Care section, we discovered that if we cannot connect to MPI (i.e. the GET/user/ call fails) the entire My VA page will fail to load (showing an infinitely spinning loading indicator).  

This PR presents an error message to the user whenever calls to `GET /v0/user` fails.

## Related issue(s)
- Ticket: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/49094](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49094)
- Epic: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934)


## Testing done

- Blocked calls to `GET /v0/user` using Chrome developer tools
- Verified the error message is shown on the Dashboard when this happens
- Upated Platform unit spec for the `RequiredLoginView` component


## Screenshots

| Before | After |
| --- | --- |
| ![user-error-before](https://user-images.githubusercontent.com/534756/228074233-687f4f4a-dcef-422c-983f-f7c9a8e549f6.png)| ![user-error-after](https://user-images.githubusercontent.com/534756/228073150-d6293ce6-dfa3-4ad8-acf2-09fd7c15d4e3.png) |


## What areas of the site does it impact?

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
