### PR TITLE
Higher-Level Review | Change "senior reviewer" to "higher-level reviewer"

### DIFF
--- a/src/applications/appeals/996/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/996/containers/IntroductionPage.jsx
@@ -118,7 +118,7 @@ export class IntroductionPage extends React.Component {
         <p>
           If you or your representative disagree with VA’s decision on your
           claim, you can request a Higher-Level Review. With a Higher-Level
-          Review, a senior reviewer will take a new look at your case and the
+          Review, a higher-level reviewer will take a new look at your case and
           evidence you already provided. The reviewer will decide whether the
           decision can be changed based on a difference of opinion or an error.
         </p>
@@ -126,7 +126,7 @@ export class IntroductionPage extends React.Component {
           You can’t submit new evidence with a Higher-Level Review
         </h2>
         <p>
-          The senior reviewer will only review the evidence you already
+          The higher-level reviewer will only review the evidence you already
           provided. If you have new and relevant evidence, you can{' '}
           <a href={SUPPLEMENTAL_CLAIM_URL}>file a Supplemental Claim</a>.
         </p>

--- a/src/applications/appeals/996/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/996/containers/IntroductionPage.jsx
@@ -119,8 +119,9 @@ export class IntroductionPage extends React.Component {
           If you or your representative disagree with VA’s decision on your
           claim, you can request a Higher-Level Review. With a Higher-Level
           Review, a higher-level reviewer will take a new look at your case and
-          evidence you already provided. The reviewer will decide whether the
-          decision can be changed based on a difference of opinion or an error.
+          the evidence you already provided. The reviewer will decide whether
+          the decision can be changed based on a difference of opinion or an
+          error.
         </p>
         <h2 className="vads-u-font-size--h3">
           You can’t submit new evidence with a Higher-Level Review

--- a/src/applications/appeals/996/wizard/WizardContainer.jsx
+++ b/src/applications/appeals/996/wizard/WizardContainer.jsx
@@ -39,7 +39,7 @@ export const WizardContainer = ({ setWizardStatus }) => {
         <h2>Is this the form I need?</h2>
         <p>
           Use this form if you disagree with our decision on your claim and want
-          a senior reviewer to review your case again. You can’t submit any new
+          a higher-level reviewer to review your case again. You can’t submit
           evidence with a Higher-Level Review.
         </p>
         <p>Answer a question to get started.</p>

--- a/src/applications/appeals/996/wizard/WizardContainer.jsx
+++ b/src/applications/appeals/996/wizard/WizardContainer.jsx
@@ -40,7 +40,7 @@ export const WizardContainer = ({ setWizardStatus }) => {
         <p>
           Use this form if you disagree with our decision on your claim and want
           a higher-level reviewer to review your case again. You can’t submit
-          evidence with a Higher-Level Review.
+          any new evidence with a Higher-Level Review.
         </p>
         <p>Answer a question to get started.</p>
         <Wizard

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -751,10 +751,10 @@ export function getStatusContents(appeal, name = {}) {
       contents.description = (
         <div>
           <p>
-            By requesting a Higher-Level Review, you asked for a higher-level at
-            at the {aojDescription} to look at your case and determine whether
+            By requesting a Higher-Level Review, you asked for a higher-level
+            reviewer at the {aojDescription} to look at your case and determine
             whether they can change the decision based on a difference of
-            because VA made an error.
+            opinion or because VA made an error.
           </p>
           {details.informalConference && (
             <p>

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -746,13 +746,14 @@ export function getStatusContents(appeal, name = {}) {
       );
       break;
     case STATUS_TYPES.hlrReceived:
-      contents.title = 'A senior reviewer is taking a new look at your case';
+      contents.title =
+        'A higher-level reviewer is taking a new look at your case';
       contents.description = (
         <div>
           <p>
-            By requesting a Higher-Level Review, you asked for a senior reviewer
+            By requesting a Higher-Level Review, you asked for a higher-level at
             at the {aojDescription} to look at your case and determine whether
-            they can change the decision based on a difference of opinion or
+            whether they can change the decision based on a difference of
             because VA made an error.
           </p>
           {details.informalConference && (
@@ -799,9 +800,10 @@ export function getStatusContents(appeal, name = {}) {
       contents.title = `The ${aojDescription} is correcting an error`;
       contents.description = (
         <p>
-          During their review, the senior reviewer identified an error that must
-          be corrected before deciding your case. If needed, VA may contact you
-          to ask for more evidence or to schedule a new medical exam.
+          During their review, the higher-level reviewer identified an error
+          that must be corrected before deciding your case. If needed, VA may
+          contact you to ask for more evidence or to schedule a new medical
+          exam.
         </p>
       );
       break;
@@ -1670,7 +1672,7 @@ export function getNextEvents(appeal) {
         header: '', // intentionally empty
         events: [
           {
-            title: 'The senior reviewer will make a new decision',
+            title: 'The higher-level reviewer will make a new decision',
             description: (
               <p>
                 The {getAojDescription(appeal.attributes.aoj)} will send you a
@@ -2004,9 +2006,9 @@ export function getAlertContent(alert, appealIsActive) {
                 DECISION_REVIEW_OPTIONS.higherLevelReview,
               ) && (
                 <li className="next-event">
-                  <h3>Ask for a new look from a senior reviewer</h3>
+                  <h3>Ask for a new look from a higher-level reviewer</h3>
                   <p>
-                    A senior reviewer will look at your case and determine
+                    A higher-level reviewer will look at your case and determine
                     whether the decision can be changed based on a difference of
                     opinion or because VA made an error. This option is called a
                     <a href="/decision-reviews/higher-level-review">
@@ -2054,7 +2056,7 @@ export function getAlertContent(alert, appealIsActive) {
                 DECISION_REVIEW_OPTIONS.higherLevelReview,
               ) && (
                 <li>
-                  Ask for a new look from a senior reviewer (Higher-Level
+                  Ask for a new look from a higher-level reviewer (Higher-Level
                   Review)
                 </li>
               )}

--- a/src/applications/personalization/dashboard/utils/appeals-v2-helpers.jsx
+++ b/src/applications/personalization/dashboard/utils/appeals-v2-helpers.jsx
@@ -913,7 +913,7 @@ export function getNextEvents(appeal) {
         header: '', // intentionally empty
         events: [
           {
-            title: 'The senior reviewer will make a new decision',
+            title: 'The higher-level reviewer will make a new decision',
             description: (
               <p>
                 The {getAojDescription(appeal.attributes.aoj)} will send you a
@@ -1247,9 +1247,9 @@ export function getAlertContent(alert, appealIsActive) {
                 DECISION_REVIEW_OPTIONS.higherLevelReview,
               ) && (
                 <li className="next-event">
-                  <h3>Ask for a new look from a senior reviewer</h3>
+                  <h3>Ask for a new look from a higher-level reviewer</h3>
                   <p>
-                    A senior reviewer will look at your case and determine
+                    A higher-level reviewer will look at your case and determine
                     whether the decision can be changed based on a difference of
                     opinion or because VA made an error. This option is called a
                     <a href="/decision-reviews/higher-level-review">
@@ -1297,7 +1297,7 @@ export function getAlertContent(alert, appealIsActive) {
                 DECISION_REVIEW_OPTIONS.higherLevelReview,
               ) && (
                 <li>
-                  Ask for a new look from a senior reviewer (Higher-Level
+                  Ask for a new look from a higher-level reviewer (Higher-Level
                   Review)
                 </li>
               )}

--- a/src/applications/personalization/dashboard/utils/getStatusContents.jsx
+++ b/src/applications/personalization/dashboard/utils/getStatusContents.jsx
@@ -503,10 +503,10 @@ export function getStatusContents(appeal, name = {}) {
       contents.description = (
         <div>
           <p>
-            By requesting a Higher-Level Review, you asked for a higher-level
+            By requesting a Higher-Level Review, you asked for a higher-level at
             the {aojDescription} to look at your case and determine whether they
-            they can change the decision based on a difference of opinion or
-            because VA made an error.
+            can change the decision based on a difference of opinion or because
+            VA made an error.
           </p>
           {details.informalConference && (
             <p>

--- a/src/applications/personalization/dashboard/utils/getStatusContents.jsx
+++ b/src/applications/personalization/dashboard/utils/getStatusContents.jsx
@@ -498,12 +498,13 @@ export function getStatusContents(appeal, name = {}) {
       );
       break;
     case STATUS_TYPES.hlrReceived:
-      contents.title = 'A senior reviewer is taking a new look at your case';
+      contents.title =
+        'A higher-level reviewer is taking a new look at your case';
       contents.description = (
         <div>
           <p>
-            By requesting a Higher-Level Review, you asked for a senior reviewer
-            at the {aojDescription} to look at your case and determine whether
+            By requesting a Higher-Level Review, you asked for a higher-level
+            the {aojDescription} to look at your case and determine whether they
             they can change the decision based on a difference of opinion or
             because VA made an error.
           </p>
@@ -551,9 +552,10 @@ export function getStatusContents(appeal, name = {}) {
       contents.title = `The ${aojDescription} is correcting an error`;
       contents.description = (
         <p>
-          During their review, the senior reviewer identified an error that must
-          be corrected before deciding your case. If needed, VA may contact you
-          to ask for more evidence or to schedule a new medical exam.
+          During their review, the higher-level reviewer identified an error
+          that must be corrected before deciding your case. If needed, VA may
+          contact you to ask for more evidence or to schedule a new medical
+          exam.
         </p>
       );
       break;


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Content updates to replace `senior reviewer` with `higher-level reviewer`

- *(If bug, how to reproduce)*
  > N/A
- *(What is the solution, why is this the solution)*
  > Find and replace.
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Decision Reviews Team
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)* 
  > Application is now live

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#55419

## Testing done

- *Describe what the old behavior was prior to the change*
  > verbiage was `senior reviewer`
- *Describe the steps required to verify your changes are working as expected*
  > Visually check where the reviewer type is mentioned to make sure it says `higher-level reviewer` instead of `senior reviewer`
- *Describe the tests completed and the results*
  > confirmed unit tests are all passing

## Screenshots

**Introduction Page**:
  > /decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/
     - <img width="697" alt="IntroductionPage" src="https://user-images.githubusercontent.com/37054305/228342682-dbc8fb07-eebb-482c-8af4-ab034b67ee4d.png">

## What areas of the site does it impact?
Higher Level Reviews (VA Form 20-0996 ) application

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
