### PR TITLE
Supplemental Claims | Update evidence navigation behavior

### DIFF
--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -99,7 +99,8 @@ const EvidencePrivateRecords = ({
 
   const availableIssues = getSelected(data).map(getIssueName);
 
-  const addOrEdit = isEmptyPrivateEntry(currentData) ? 'add' : 'edit';
+  const getPageType = entry => (isEmptyPrivateEntry(entry) ? 'add' : 'edit');
+  const [addOrEdit, setAddorEdit] = useState(getPageType(currentData));
 
   // *** validations ***
   const errors = {
@@ -124,7 +125,9 @@ const EvidencePrivateRecords = ({
 
   useEffect(
     () => {
-      setCurrentData(providerFacility?.[currentIndex] || defaultData);
+      const entry = providerFacility?.[currentIndex] || defaultData;
+      setCurrentData(entry);
+      setAddorEdit(getPageType(entry));
       setCurrentState(defaultState);
       focusEvidence();
       setForceReload(false);

--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -11,14 +11,13 @@ import {
 
 import environment from 'platform/utilities/environment';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
-import { focusElement } from 'platform/utilities/ui';
-import scrollTo from 'platform/utilities/ui/scrollTo';
 import { countries, states } from 'platform/forms/address';
 
 import { EVIDENCE_PRIVATE_PATH, NO_ISSUES_SELECTED } from '../constants';
 
 import { content } from '../content/evidencePrivateRecords';
 import { getSelected, getIssueName } from '../utils/helpers';
+import { getIndex } from '../utils/evidence';
 
 import { checkValidations } from '../validations';
 import {
@@ -34,6 +33,7 @@ import {
   validatePrivateUnique,
   isEmptyPrivateEntry,
 } from '../validations/evidence';
+import { focusEvidence } from '../utils/focus';
 
 const PRIVATE_PATH = `/${EVIDENCE_PRIVATE_PATH}`;
 // const REVIEW_AND_SUBMIT = '/review-and-submit';
@@ -83,18 +83,12 @@ const EvidencePrivateRecords = ({
   contentAfterButtons,
 }) => {
   const { providerFacility = [] } = data || {};
-  const getIndex = () => {
-    // get index from url '/va-medical-records?index={index}' or testingIndex
-    const searchIndex = new URLSearchParams(window.location.search);
-    let index = parseInt(searchIndex.get('index') || testingIndex || '0', 10);
-    if (Number.isNaN(index) || index > providerFacility.length) {
-      index = providerFacility.length;
-    }
-    return index;
-  };
 
   // *** state ***
-  const [currentIndex, setCurrentIndex] = useState(getIndex());
+  // currentIndex is zero-based
+  const [currentIndex, setCurrentIndex] = useState(
+    getIndex(providerFacility, testingIndex),
+  );
   const [currentData, setCurrentData] = useState(
     providerFacility?.[currentIndex] || defaultData,
   );
@@ -128,18 +122,11 @@ const EvidencePrivateRecords = ({
 
   const hasErrors = () => Object.values(errors).filter(Boolean).length;
 
-  const focusErrors = () => {
-    if (hasErrors()) {
-      focusElement('[error]');
-    }
-  };
-
   useEffect(
     () => {
       setCurrentData(providerFacility?.[currentIndex] || defaultData);
       setCurrentState(defaultState);
-      focusElement(hasErrors() ? '[error]' : 'h3');
-      scrollTo('topPageElement');
+      focusEvidence();
       setForceReload(false);
     },
     // don't include providerFacility or we clear state & move focus every time
@@ -206,7 +193,7 @@ const EvidencePrivateRecords = ({
     const newProviderFacility = [...providerFacility];
     if (!isEmptyPrivateEntry(providerFacility[index])) {
       // only insert a new entry if the existing entry isn't empty
-      newProviderFacility.splice(index, 0, {});
+      newProviderFacility.splice(index, 0, defaultData);
     }
     setFormData({ ...data, providerFacility: newProviderFacility });
     goToPageIndex(index);
@@ -247,11 +234,9 @@ const EvidencePrivateRecords = ({
     onAddAnother: event => {
       event.preventDefault();
       if (hasErrors()) {
-        updateState({
-          submitted: true,
-          modal: { show: currentIndex !== 0, direction: NAV_PATHS.add },
-        });
-        focusElement('[error]');
+        // don't show modal
+        updateState({ submitted: true });
+        focusEvidence();
         return;
       }
       // clear state and insert a new entry after the current index (previously
@@ -263,15 +248,13 @@ const EvidencePrivateRecords = ({
 
     onGoForward: event => {
       event.preventDefault();
+      updateState({ submitted: true });
+      // non-empty entry, focus on error
       if (hasErrors()) {
-        updateState({
-          submitted: true,
-          modal: { show: currentIndex !== 0, direction: NAV_PATHS.forward },
-        });
-        focusElement('[error]');
+        focusEvidence();
         return;
       }
-      updateState({ submitted: true });
+
       const nextIndex = currentIndex + 1;
       if (currentIndex < providerFacility.length - 1) {
         goToPageIndex(nextIndex);
@@ -281,7 +264,11 @@ const EvidencePrivateRecords = ({
       }
     },
     onGoBack: () => {
-      if (hasErrors() && currentIndex !== 0) {
+      // show modal if there are errors; don't show _immediately after_ adding
+      // a new empty entry
+      if (isEmptyPrivateEntry(currentData)) {
+        updateCurrentFacility({ remove: true });
+      } else if (hasErrors() && addOrEdit === 'edit') {
         // focus on first error
         updateState({
           submitted: true,
@@ -302,7 +289,7 @@ const EvidencePrivateRecords = ({
       // For unit testing only
       event.stopPropagation();
       updateState({ submitted: true, modal: { show: false, direction: '' } });
-      focusErrors();
+      focusEvidence();
     },
     onModalYes: () => {
       // Yes, keep providerFacility; do nothing for forward & add
@@ -317,16 +304,14 @@ const EvidencePrivateRecords = ({
           goToPageIndex(prevIndex);
         }
       }
-      focusErrors();
+      focusEvidence();
     },
     onModalNo: () => {
       // No, clear current data and navigate
       const { direction } = currentState.modal;
       setCurrentData(defaultData);
-      // Using returned providerFacility value to block going forward if the
-      // providerFacilities array has a zero length - the `providerFacility`
-      // value is not updated in time
-      const updatedFacility = updateCurrentFacility({ remove: true });
+      updateCurrentFacility({ remove: true });
+
       updateState({ submitted: true, modal: { show: false, direction: '' } });
       if (direction === NAV_PATHS.back) {
         const prevIndex = currentIndex - 1;
@@ -335,17 +320,6 @@ const EvidencePrivateRecords = ({
         } else {
           // index only passed here for testing purposes
           goBack(prevIndex);
-        }
-      } else if (direction === NAV_PATHS.forward) {
-        if (updatedFacility.length > 0) {
-          if (currentIndex < updatedFacility.length) {
-            goToPageIndex(currentIndex);
-          } else {
-            setForceReload(true);
-            goForward(data, currentIndex);
-          }
-        } else {
-          goToPageIndex(currentIndex);
         }
       } else {
         // restart this current page with empty fields (they chose No)
@@ -394,7 +368,7 @@ const EvidencePrivateRecords = ({
         <VaModal
           clickToClose
           status="info"
-          modalTitle={content.modal.title}
+          modalTitle={content.modal.title(currentData)}
           primaryButtonText={content.modal.yes}
           secondaryButtonText={content.modal.no}
           onCloseEvent={handlers.onModalClose}

--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -15,7 +15,7 @@ import { focusElement } from 'platform/utilities/ui';
 import scrollTo from 'platform/utilities/ui/scrollTo';
 import { countries, states } from 'platform/forms/address';
 
-import { EVIDENCE_PRIVATE_PATH } from '../constants';
+import { EVIDENCE_PRIVATE_PATH, NO_ISSUES_SELECTED } from '../constants';
 
 import { content } from '../content/evidencePrivateRecords';
 import { getSelected, getIssueName } from '../utils/helpers';
@@ -525,15 +525,19 @@ const EvidencePrivateRecords = ({
           error={showError('issues')}
           required
         >
-          {availableIssues.map(issue => (
-            <va-checkbox
-              key={issue}
-              name="issues"
-              label={issue}
-              value={issue}
-              checked={(currentData?.issues || []).includes(issue)}
-            />
-          ))}
+          {availableIssues.length ? (
+            availableIssues.map((issue, index) => (
+              <va-checkbox
+                key={index}
+                name="issues"
+                label={issue}
+                value={issue}
+                checked={(currentData?.issues || []).includes(issue)}
+              />
+            ))
+          ) : (
+            <strong>{NO_ISSUES_SELECTED}</strong>
+          )}
         </VaCheckboxGroup>
 
         <VaMemorableDate

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -13,7 +13,7 @@ import ProgressButton from 'platform/forms-system/src/js/components/ProgressButt
 import { focusElement } from 'platform/utilities/ui';
 import scrollTo from 'platform/utilities/ui/scrollTo';
 
-import { EVIDENCE_VA_PATH } from '../constants';
+import { EVIDENCE_VA_PATH, NO_ISSUES_SELECTED } from '../constants';
 
 import { content } from '../content/evidenceVaRecords';
 import { getSelected, getIssueName } from '../utils/helpers';
@@ -380,8 +380,8 @@ const EvidenceVaRecords = ({
           error={showError('issues')}
           required
         >
-          {availableIssues.map((issue, index) => {
-            return (
+          {availableIssues.length ? (
+            availableIssues.map((issue, index) => (
               <va-checkbox
                 key={index}
                 name="issues"
@@ -389,8 +389,10 @@ const EvidenceVaRecords = ({
                 value={issue}
                 checked={(currentData?.issues || []).includes(issue)}
               />
-            );
-          })}
+            ))
+          ) : (
+            <strong>{NO_ISSUES_SELECTED}</strong>
+          )}
         </VaCheckboxGroup>
 
         <VaMemorableDate

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -10,13 +10,12 @@ import {
 
 import environment from 'platform/utilities/environment';
 import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
-import { focusElement } from 'platform/utilities/ui';
-import scrollTo from 'platform/utilities/ui/scrollTo';
 
 import { EVIDENCE_VA_PATH, NO_ISSUES_SELECTED } from '../constants';
 
 import { content } from '../content/evidenceVaRecords';
 import { getSelected, getIssueName } from '../utils/helpers';
+import { getIndex } from '../utils/evidence';
 
 import { checkValidations } from '../validations';
 import {
@@ -27,6 +26,7 @@ import {
   validateVaUnique,
   isEmptyVaEntry,
 } from '../validations/evidence';
+import { focusEvidence } from '../utils/focus';
 
 const VA_PATH = `/${EVIDENCE_VA_PATH}`;
 // const REVIEW_AND_SUBMIT = '/review-and-submit';
@@ -63,18 +63,12 @@ const EvidenceVaRecords = ({
   contentAfterButtons,
 }) => {
   const { locations = [] } = data || {};
-  const getIndex = () => {
-    // get index from url '/va-medical-records?index={index}' or testingIndex
-    const searchIndex = new URLSearchParams(window.location.search);
-    let index = parseInt(searchIndex.get('index') || testingIndex || '0', 10);
-    if (Number.isNaN(index) || index > locations.length) {
-      index = locations.length;
-    }
-    return index;
-  };
 
   // *** state ***
-  const [currentIndex, setCurrentIndex] = useState(getIndex()); // zero-based
+  // currentIndex is zero-based
+  const [currentIndex, setCurrentIndex] = useState(
+    getIndex(locations, testingIndex),
+  );
   const [currentData, setCurrentData] = useState(
     locations?.[currentIndex] || defaultData,
   );
@@ -103,18 +97,11 @@ const EvidenceVaRecords = ({
 
   const hasErrors = () => Object.values(errors).filter(Boolean).length;
 
-  const focusErrors = () => {
-    if (hasErrors()) {
-      focusElement('[error]');
-    }
-  };
-
   useEffect(
     () => {
       setCurrentData(locations?.[currentIndex] || defaultData);
       setCurrentState(defaultState);
-      focusElement(hasErrors() ? '[error]' : 'h3');
-      scrollTo('topPageElement');
+      focusEvidence();
       setForceReload(false);
     },
     // don't include locations or we clear state & move focus every time
@@ -167,7 +154,7 @@ const EvidenceVaRecords = ({
     const newLocations = [...locations];
     if (!isEmptyVaEntry(locations[index])) {
       // only insert a new entry if the existing entry isn't empty
-      newLocations.splice(index, 0, {});
+      newLocations.splice(index, 0, defaultData);
     }
     setFormData({ ...data, locations: newLocations });
     goToPageIndex(index);
@@ -208,11 +195,9 @@ const EvidenceVaRecords = ({
     onAddAnother: event => {
       event.preventDefault();
       if (hasErrors()) {
-        updateState({
-          submitted: true,
-          modal: { show: currentIndex !== 0, direction: NAV_PATHS.add },
-        });
-        focusElement('[error]');
+        // don't show modal
+        updateState({ submitted: true });
+        focusEvidence();
         return;
       }
       // clear state and insert a new entry after the current index (previously
@@ -223,15 +208,13 @@ const EvidenceVaRecords = ({
     },
     onGoForward: event => {
       event.preventDefault();
+      updateState({ submitted: true });
+      // non-empty entry, focus on error
       if (hasErrors()) {
-        updateState({
-          submitted: true,
-          modal: { show: currentIndex !== 0, direction: NAV_PATHS.forward },
-        });
-        focusElement('[error]');
+        focusEvidence();
         return;
       }
-      updateState({ submitted: true });
+
       const nextIndex = currentIndex + 1;
       if (currentIndex < locations.length - 1) {
         goToPageIndex(nextIndex);
@@ -241,7 +224,11 @@ const EvidenceVaRecords = ({
       }
     },
     onGoBack: () => {
-      if (hasErrors() && currentIndex !== 0) {
+      // show modal if there are errors; don't show _immediately after_ adding
+      // a new empty entry
+      if (isEmptyVaEntry(currentData)) {
+        updateCurrentLocation({ remove: true });
+      } else if (hasErrors() && addOrEdit === 'edit') {
         updateState({
           submitted: true,
           modal: { show: true, direction: NAV_PATHS.back },
@@ -261,7 +248,7 @@ const EvidenceVaRecords = ({
       // For unit testing only
       event.stopPropagation();
       updateState({ submitted: true, modal: { show: false, direction: '' } });
-      focusErrors();
+      focusEvidence();
     },
     onModalYes: () => {
       // Yes, keep location; do nothing for forward & add
@@ -276,15 +263,14 @@ const EvidenceVaRecords = ({
           goToPageIndex(prevIndex);
         }
       }
-      focusErrors();
+      focusEvidence();
     },
     onModalNo: () => {
       // No, clear current data and navigate
       const { direction } = currentState.modal;
       setCurrentData(defaultData);
-      // Using returned locations value to block going forward if the locations
-      // array has a zero length - the `locations` value is not updated in time
-      const updatedLocations = updateCurrentLocation({ remove: true });
+      updateCurrentLocation({ remove: true });
+
       updateState({ submitted: true, modal: { show: false, direction: '' } });
       if (direction === NAV_PATHS.back) {
         const prevIndex = currentIndex - 1;
@@ -293,17 +279,6 @@ const EvidenceVaRecords = ({
         } else {
           // index only passed here for testing purposes
           goBack(prevIndex);
-        }
-      } else if (direction === NAV_PATHS.forward) {
-        if (updatedLocations.length > 0) {
-          if (currentIndex < updatedLocations.length) {
-            goToPageIndex(currentIndex);
-          } else {
-            setForceReload(true);
-            goForward(data, currentIndex);
-          }
-        } else {
-          goToPageIndex(currentIndex);
         }
       } else {
         // restart this current page with empty fields (they chose No)
@@ -346,7 +321,7 @@ const EvidenceVaRecords = ({
         <VaModal
           clickToClose
           status="info"
-          modalTitle={content.modalTitle}
+          modalTitle={content.modalTitle(currentData)}
           primaryButtonText={content.modalYes}
           secondaryButtonText={content.modalNo}
           onCloseEvent={handlers.onModalClose}

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -77,9 +77,10 @@ const EvidenceVaRecords = ({
 
   const [currentState, setCurrentState] = useState(defaultState);
 
-  const availableIssues = getSelected(data).map(getIssueName);
+  const getPageType = entry => (isEmptyVaEntry(entry) ? 'add' : 'edit');
+  const [addOrEdit, setAddOrEdit] = useState(getPageType(currentData));
 
-  const addOrEdit = isEmptyVaEntry(currentData) ? 'add' : 'edit';
+  const availableIssues = getSelected(data).map(getIssueName);
 
   // *** validations ***
   const errors = {
@@ -99,7 +100,9 @@ const EvidenceVaRecords = ({
 
   useEffect(
     () => {
-      setCurrentData(locations?.[currentIndex] || defaultData);
+      const entry = locations?.[currentIndex] || defaultData;
+      setCurrentData(entry);
+      setAddOrEdit(getPageType(entry));
       setCurrentState(defaultState);
       focusEvidence();
       setForceReload(false);

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -78,6 +78,7 @@ import {
   focusRadioH3,
   focusAlertH3,
   focusIssue,
+  focusEvidence,
   focusUploads,
 } from '../utils/focus';
 
@@ -178,7 +179,6 @@ const formConfig = {
           CustomPageReview: PrimaryPhoneReview,
           uiSchema: primaryPhone.uiSchema,
           schema: primaryPhone.schema,
-          // needs useCustomScrollAndFocus: true to work
           scrollAndFocusTarget: focusRadioH3,
         },
       },
@@ -230,7 +230,6 @@ const formConfig = {
           CustomPageReview: null, // reviewField renders this!
           uiSchema: notice5103.uiSchema,
           schema: notice5103.schema,
-          // needs useCustomScrollAndFocus: true to work
           scrollAndFocusTarget: focusAlertH3,
           initialData: {
             form5103Acknowledged: false,
@@ -251,6 +250,7 @@ const formConfig = {
           uiSchema: blankUiSchema,
           schema: blankSchema,
           hideHeaderRow: true,
+          scrollAndFocusTarget: focusEvidence,
         },
         evidencePrivateRecordsRequest: {
           title: 'Request private medical records',
@@ -259,7 +259,6 @@ const formConfig = {
           CustomPageReview: null,
           uiSchema: evidencePrivateRequest.uiSchema,
           schema: evidencePrivateRequest.schema,
-          // needs useCustomScrollAndFocus: true to work
           scrollAndFocusTarget: focusRadioH3,
         },
         evidencePrivateRecordsAuthorization: {
@@ -279,6 +278,7 @@ const formConfig = {
           CustomPageReview: null,
           uiSchema: blankUiSchema,
           schema: blankSchema,
+          scrollAndFocusTarget: focusEvidence,
         },
         evidencePrivateLimitation: {
           title: 'Private medical record limitations',

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -123,6 +123,7 @@ export const errorMessages = {
 };
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';
+export const NO_ISSUES_SELECTED = 'No issues were selected';
 
 // contested issue dates
 export const FORMAT_YMD = 'YYYY-MM-DD';

--- a/src/applications/appeals/995/content/IssueSummary.jsx
+++ b/src/applications/appeals/995/content/IssueSummary.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { getSelected } from '../utils/helpers';
 import { getDate } from '../utils/dates';
-import { SELECTED, FORMAT_READABLE } from '../constants';
+import { SELECTED, FORMAT_READABLE, NO_ISSUES_SELECTED } from '../constants';
 
 const legendClassNames = [
   'vads-u-margin-top--0',
@@ -29,23 +29,29 @@ const IssueSummary = ({ formData }) => {
         </h3>
       </legend>
       <ul className="issues-summary vads-u-margin-bottom--0">
-        {issues.map((issue, index) => (
-          <li key={index} className={listClassNames}>
-            <h4 className="capitalize vads-u-margin-top--0 vads-u-padding-right--2">
-              {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
-            </h4>
-            <div>
-              Decision date:{' '}
-              {getDate({
-                date:
-                  issue.attributes?.approxDecisionDate ||
-                  issue.decisionDate ||
-                  '',
-                pattern: FORMAT_READABLE,
-              })}
-            </div>
+        {issues.length ? (
+          issues.map((issue, index) => (
+            <li key={index} className={listClassNames}>
+              <h4 className="capitalize vads-u-margin-top--0 vads-u-padding-right--2">
+                {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
+              </h4>
+              <div>
+                Decision date:{' '}
+                {getDate({
+                  date:
+                    issue.attributes?.approxDecisionDate ||
+                    issue.decisionDate ||
+                    '',
+                  pattern: FORMAT_READABLE,
+                })}
+              </div>
+            </li>
+          ))
+        ) : (
+          <li>
+            <strong>{NO_ISSUES_SELECTED}</strong>
           </li>
-        ))}
+        )}
       </ul>
     </fieldset>
   );

--- a/src/applications/appeals/995/content/evidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/content/evidencePrivateRecords.jsx
@@ -21,7 +21,8 @@ export const content = {
   fromLabel: 'First treatment date (you can estimate)',
   toLabel: 'Last treatment date (you can estimate)',
   modal: {
-    title: 'Do you want to keep this location?',
+    title: ({ providerFacilityName }) =>
+      `Do you want to keep ${providerFacilityName || 'this location'}?`,
     description: 'We’ve saved your current information',
     yes: 'Yes',
     no: 'No, remove this location',

--- a/src/applications/appeals/995/content/evidenceVaRecords.jsx
+++ b/src/applications/appeals/995/content/evidenceVaRecords.jsx
@@ -15,7 +15,8 @@ export const content = {
   dateStart: 'First treatment date (you can estimate)',
   dateEnd: 'Last treatment date (you can estimate)',
   addAnother: 'Add another location',
-  modalTitle: 'Do you want to keep this location?',
+  modalTitle: ({ locationAndName }) =>
+    `Do you want to keep ${locationAndName || 'this location'}?`,
   modalDescription: 'We’ve saved your current information.',
   modalYes: 'Yes',
   modalNo: 'No, remove this location',

--- a/src/applications/appeals/995/sass/995-supplemental-claim.scss
+++ b/src/applications/appeals/995/sass/995-supplemental-claim.scss
@@ -172,8 +172,9 @@ article[data-location="supporting-evidence/private-medical-records"] {
   /* Add margin for error messages, otherwise the label + error + input take up
    * the same space
    */
+  va-select[error],
   va-text-input[error] {
-    margin-top: 2.5rem;
+    margin-top: 3rem;
   }
 }
 

--- a/src/applications/appeals/995/tests/components/EvidencePrivateRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidencePrivateRecords.unit.spec.jsx
@@ -12,6 +12,13 @@ import {
 import { getDate } from '../../utils/dates';
 import { $, $$ } from '../../utils/ui';
 
+/*
+| Data     | Forward     | Back               | Add another      |
+|----------|-------------|--------------------|------------------|
+| Complete | Next page   | Prev page          | New page (empty) |
+| Empty    | Focus error | Prev page & remove | Focus error      |
+| Partial  | Focus error | Modal & Prev page  | Focus error      |
+ */
 describe('<EvidencePrivateRecords>', () => {
   const validDate = getDate({ offset: { months: -2 } });
   const mockData = {
@@ -74,20 +81,6 @@ describe('<EvidencePrivateRecords>', () => {
     </div>
   );
 
-  const testAndCloseModal = async container => {
-    // modal visible
-    await waitFor(() =>
-      expect($('va-modal', container).getAttribute('visible')).to.eq('true'),
-    );
-
-    // close modal by clicking method-assigned hidden button
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() =>
-      expect($('va-modal', container).getAttribute('visible')).to.eq('false'),
-    );
-  };
-
   const getErrorElements = container =>
     $$(
       [
@@ -98,26 +91,6 @@ describe('<EvidencePrivateRecords>', () => {
       ].join(','),
       container,
     );
-
-  const getAndTestAllErrors = (container, options = {}) => {
-    const errors = errorMessages.evidence;
-    const errorEls = getErrorElements(container);
-    [
-      errors.facilityMissing,
-      options.ignoreCountry ? null : errors.country, // default set to USA
-      errors.street,
-      errors.city,
-      errors.state,
-      errors.postal,
-      errors.issuesMissing,
-      errors.missingDate,
-      errors.missingDate,
-    ]
-      .filter(Boolean)
-      .forEach((error, index) => {
-        expect(errorEls[index].error).to.eq(error);
-      });
-  };
 
   it('should render', () => {
     const { container } = render(setup());
@@ -130,464 +103,461 @@ describe('<EvidencePrivateRecords>', () => {
     expect($('.vads-c-action-link--green', container)).to.exist;
   });
 
-  // *** CLOSE MODAL ***
-  it('should show error messages after closing modal after submitting empty page', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, {}, mockFacility2],
+  // *** VALID DATA ***
+  describe('valid data navigation', () => {
+    it('should navigate forward to limitation page with valid data', async () => {
+      const goSpy = sinon.spy();
+      const data = { ...mockData, providerFacility: [mockFacility] };
+      const page = setup({
+        index: 0,
+        goForward: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
+      await waitFor(() => expect(goSpy.calledWith(data)).to.be.true);
+    });
+    it('should navigate back to private records request page with valid data', async () => {
+      const goSpy = sinon.spy();
+      const data = { ...mockData, providerFacility: [mockFacility] };
+      const index = 0;
+      const page = setup({
+        index,
+        goBack: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+      // passing a negative index is okay, we're leaving the indexed pages
+      await waitFor(() => expect(goSpy.calledWith(index - 1)).to.be.true);
+    });
+    it('should navigate from zero index to a new empty facility page, of index 1, with valid data', async () => {
+      const goSpy = sinon.spy();
+      const data = {
+        ...mockData,
+        providerFacility: [mockFacility, {}, mockFacility2],
+      };
+      const index = 0;
+      const page = setup({
+        index,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index + 1}`))
+          .to.be.true;
+      });
+    });
+    it('should navigate from zero index, with valid data, to next index when inserting another entry', async () => {
+      const goSpy = sinon.spy();
+      const providerFacility = [mockFacility, mockFacility2, {}];
+      const data = { ...mockData, providerFacility };
+      const index = 0;
+      const page = setup({
+        index,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index + 1}`))
+          .to.be.true;
+      });
+    });
+  });
+
+  // *** EMPTY PAGE ***
+  describe('empty page navigation', () => {
+    const getAndTestAllErrors = (container, options = {}) => {
+      const errors = errorMessages.evidence;
+      const errorEls = getErrorElements(container);
+      [
+        errors.facilityMissing,
+        options.ignoreCountry ? null : errors.country, // default set to USA
+        errors.street,
+        errors.city,
+        errors.state,
+        errors.postal,
+        errors.issuesMissing,
+        errors.missingDate,
+        errors.missingDate,
+      ]
+        .filter(Boolean)
+        .forEach((error, index) => {
+          expect(errorEls[index].error).to.eq(error);
+        });
     };
-    const page = setup({
-      index,
-      method: 'onModalClose',
-      goForward: goSpy,
-      goToPath: goSpy,
-      data,
+
+    it('should show & focus error messages after going forward on an empty first page', async () => {
+      const goSpy = sinon.spy();
+      const index = 0;
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+      });
+      const { container } = render(page);
+
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.false;
+        getAndTestAllErrors(container, { ignoreCountry: true });
+      });
     });
-    const { container } = render(page);
+    it('should show & focus error messages after going forward on an empty second page', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        providerFacility: [mockFacility, {}, mockFacility2],
+      };
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
 
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
 
-    expect(goSpy.called).to.be.false;
-    await waitFor(() => getAndTestAllErrors(container));
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.false;
+        getAndTestAllErrors(container);
+      });
+    });
+    it('should go back on an empty page on first entry', async () => {
+      const goSpy = sinon.spy();
+      const index = 0;
+      const page = setup({ index, goBack: goSpy, goToPath: goSpy });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.true;
+        expect(goSpy.calledWith(index - 1)).to.be.true;
+      });
+    });
+
+    it('should go back and remove empty page', async () => {
+      const goSpy = sinon.spy();
+      const setDataSpy = sinon.spy();
+      const data = { ...mockData, providerFacility: [mockFacility, {}] };
+      const page = setup({
+        index: 1,
+        goToPath: goSpy,
+        setFormData: setDataSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.true;
+        expect(setDataSpy.called).to.be.true;
+        expect(setDataSpy.lastCall.args[0].providerFacility.length).to.eq(1);
+      });
+    });
+    it('should show & focus on error messages after adding new location on an empty second page', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        providerFacility: [mockFacility, {}, mockFacility2],
+      };
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.false;
+        getAndTestAllErrors(container);
+      });
+    });
   });
 
-  // *** FORWARD ***
-  it('should navigate forward to limitation page with valid data', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, providerFacility: [mockFacility] };
-    const page = setup({
-      index: 0,
-      goForward: goSpy,
-      data,
-    });
-    const { container } = render(page);
+  describe('partial/invalid data navigation', () => {
+    const testAndCloseModal = async (container, total) => {
+      expect(getErrorElements(container).length).to.eq(total);
+      // modal visible
+      await waitFor(() =>
+        expect($('va-modal', container).getAttribute('visible')).to.eq('true'),
+      );
 
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await waitFor(() => expect(goSpy.calledWith(data)).to.be.true);
-  });
-
-  it('should show modal when submitting an empty page', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, providerFacility: [mockFacility, {}] };
-    const page = setup({
-      index: 1,
-      goForward: goSpy,
-      data,
-    });
-    const { container } = render(page);
-    fireEvent.submit($('form', container));
-
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('true');
-      expect(goSpy.called).to.be.false;
-    });
-  });
-
-  it('should not show modal (reveal errors) when going forward on an empty page on first entry only', async () => {
-    const goSpy = sinon.spy();
-    const index = 0;
-    const page = setup({ index, goForward: goSpy });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-primary', container));
-
-    await waitFor(() => {
-      expect(goSpy.called).to.be.false;
-      getAndTestAllErrors(container, { ignoreCountry: true });
-    });
-  });
-
-  it('should not navigate, but will show errors when choosing "Yes" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, {}, mockFacility2],
+      // close modal by clicking method-assigned hidden button
+      fireEvent.click($('#test-method', container));
+      await waitFor(() =>
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false'),
+      );
     };
-    const page = setup({
-      index,
-      method: 'onModalYes',
-      goForward: goSpy,
-      goToPath: goSpy,
-      data,
+
+    it('should not navigate, but will show errors after continuing', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        providerFacility: [
+          mockFacility,
+          { providerFacilityName: 'foo' },
+          mockFacility2,
+        ],
+      };
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
+
+      await waitFor(() => {
+        expect(goSpy.called).to.be.false;
+        expect(getErrorElements(container).length).to.eq(8);
+        expect(document.activeElement).to.eq($('[error]', container));
+      });
     });
-    const { container } = render(page);
 
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
+    // *** BACK ***
+    it('should show modal, select "No, remove this location", then navigate back to previous index', async () => {
+      const goSpy = sinon.spy();
+      const setDataSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        providerFacility: [
+          mockFacility,
+          { providerFacilityName: 'foo' },
+          mockFacility2,
+        ],
+      };
+      const page = setup({
+        index,
+        method: 'onModalNo', // remove partial entry
+        goBack: goSpy,
+        goToPath: goSpy,
+        setFormData: setDataSpy,
+        data,
+      });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      expect(goSpy.called).to.be.false;
-      getAndTestAllErrors(container);
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+      await testAndCloseModal(container, 8);
+
+      await waitFor(() => {
+        expect(setDataSpy.called).to.be.true;
+        expect(setDataSpy.lastCall.args[0].providerFacility.length).to.eq(2);
+        expect(goSpy.called).to.be.true;
+        expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index - 1}`))
+          .to.be.true;
+      });
     });
-  });
 
-  it('should navigate forward to next index when choosing "No" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const index = 2;
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, mockFacility2],
-    };
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goForward: goSpy,
-      data,
+    it('should show modal, select "Yes", then navigate back to previous index', async () => {
+      const goSpy = sinon.spy();
+      const setDataSpy = sinon.spy();
+      const index = 2;
+      const page = setup({
+        index,
+        method: 'onModalYes', // keep partial entry
+        goToPath: goSpy,
+        setFormData: setDataSpy,
+        data: {
+          ...mockData,
+          providerFacility: [
+            mockFacility,
+            mockFacility2,
+            { providerFacilityName: 'foo' },
+          ],
+        },
+      });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+      await testAndCloseModal(container, 8);
+
+      await waitFor(() => {
+        expect(setDataSpy.called).to.be.false; // no data change
+        expect(goSpy.called).to.be.true;
+        expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index - 1}`))
+          .to.be.true;
+      });
     });
-    const { container } = render(page);
 
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
+    // *** ADD ANOTHER ***
+    it('should not navigate, but show errors after adding another and choosing "Yes" on an empty page', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const page = setup({
+        index,
+        goToPath: goSpy,
+        data: {
+          ...mockData,
+          providerFacility: [mockFacility, { lproviderFacilityName: 'foo' }],
+        },
+      });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      expect(getErrorElements(container).length).to.eq(0);
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
 
-      // going forward requires passing the form data
-      expect(goSpy.calledWith(data)).to.be.true;
-      // index still at 2, because we've moved beyond the indexed pages
-      expect(goSpy.firstCall.args[1]).to.eq(index);
-    });
-  });
-
-  it('should navigate forward to private limitation page when choosing "No" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const data = {
-      ...mockData,
-      providerFacility: [
-        mockFacility,
-        mockFacility2,
-        { providerFacilityName: 'Location 3' },
-      ],
-    };
-    const page = setup({
-      index: 2,
-      method: 'onModalNo',
-      goForward: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-
-    await testAndCloseModal(container);
-    await waitFor(() => expect(goSpy.calledWith(data)).to.be.true);
-  });
-
-  // *** BACK ***
-  it('should navigate back to private records request page with valid data', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, providerFacility: [mockFacility] };
-    const index = 0;
-    const page = setup({
-      index,
-      goBack: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-secondary', container));
-    // passing a negative index is okay, we're leaving the indexed pages
-    await waitFor(() => expect(goSpy.calledWith(index - 1)).to.be.true);
-  });
-
-  it('should not show modal when going back on an empty page on first entry only', async () => {
-    const goSpy = sinon.spy();
-    const index = 0;
-    const page = setup({ index, goBack: goSpy, goToPath: goSpy });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-secondary', container));
-
-    await waitFor(() => {
-      expect(goSpy.called).to.be.true;
-      expect(goSpy.calledWith(index - 1)).to.be.true;
-    });
-  });
-
-  it('should navigate back to previous index page, after choosing "Yes" in modal', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, {}, mockFacility2],
-    };
-    const page = setup({
-      index,
-      method: 'onModalYes',
-      goBack: goSpy,
-      goToPath: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.usa-button-secondary', container));
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index - 1}`))
-        .to.be.true;
+      await waitFor(() => {
+        expect(goSpy.called).to.be.false;
+        expect(getErrorElements(container).length).to.eq(9);
+        expect(document.activeElement).to.eq($('[error]', container));
+      });
     });
   });
 
-  it('should navigate back one index when choosing "No" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goToPath: goSpy,
-      data: { ...mockData, providerFacility: [mockFacility, {}] },
+  describe('other errors', () => {
+    it('should show error when start treatment date is in the future', async () => {
+      const from = getDate({ offset: { years: +1 } });
+      const data = {
+        ...mockData,
+        providerFacility: [{ treatmentDateRange: { from } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:from' });
+      const { container } = render(page);
+
+      const dateFrom = $('va-memorable-date', container);
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateFrom);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        expect(dateFrom.error).to.contain(errorMessages.evidence.pastDate);
+      });
     });
-    const { container } = render(page);
 
-    // back
-    fireEvent.click($('.usa-button-secondary', container));
-    await testAndCloseModal(container);
+    it('should show error when last treatment date is in the future', async () => {
+      const to = getDate({ offset: { years: +1 } });
+      const data = {
+        ...mockData,
+        providerFacility: [{ treatmentDateRange: { to } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:to' });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      expect(goSpy.called).to.be.true;
-      expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index - 1}`))
-        .to.be.true;
+      const dateTo = $$('va-memorable-date', container)[1];
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateFrom);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        expect(dateTo.error).to.contain(errorMessages.evidence.pastDate);
+      });
     });
-  });
 
-  // *** ADD ANOTHER ***
-  it('should navigate from zero index to a new empty facility page, of index 1, with valid data', async () => {
-    const goSpy = sinon.spy();
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, {}, mockFacility2],
-    };
-    const index = 0;
-    const page = setup({
-      index,
-      goToPath: goSpy,
-      data,
+    it('should show an error when the start treatment date is too far in the past', async () => {
+      const from = getDate({ offset: { years: -101 } });
+      const data = {
+        ...mockData,
+        providerFacility: [{ treatmentDateRange: { from } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:from' });
+      const { container } = render(page);
+
+      const dateFrom = $('va-memorable-date', container);
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateFrom);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        expect(dateFrom.error).to.contain(errorMessages.evidence.newerDate);
+      });
     });
-    const { container } = render(page);
 
-    // add
-    fireEvent.click($('.vads-c-action-link--green', container));
+    it('should show an error when the last treatment date is too far in the past', async () => {
+      const to = getDate({ offset: { years: -101 } });
+      const data = {
+        ...mockData,
+        providerFacility: [{ treatmentDateRange: { to } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:to' });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('false');
-      expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index + 1}`))
-        .to.be.true;
+      const dateTo = $$('va-memorable-date', container)[1];
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateTo);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        expect(dateTo.error).to.contain(errorMessages.evidence.newerDate);
+      });
     });
-  });
 
-  it('should navigate from zero index, with valid data, to next index when inserting another entry', async () => {
-    const goSpy = sinon.spy();
-    const providerFacility = [mockFacility, mockFacility2, {}];
-    const data = { ...mockData, providerFacility };
-    const index = 0;
-    const page = setup({
-      index,
-      goToPath: goSpy,
-      data,
+    it('should show an error when the last treatment date is before the start', async () => {
+      const from = getDate({ offset: { years: -5 } });
+      const to = getDate({ offset: { years: -10 } });
+      const data = {
+        ...mockData,
+        providerFacility: [{ treatmentDateRange: { from, to } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:to' });
+      const { container } = render(page);
+
+      const dateTo = $$('va-memorable-date', container)[1];
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateTo);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        expect(dateTo.error).to.contain(errorMessages.endDateBeforeStart);
+      });
     });
-    const { container } = render(page);
 
-    // add
-    fireEvent.click($('.vads-c-action-link--green', container));
+    it('should show an error when the issue is not unique', async () => {
+      const data = {
+        ...mockData,
+        providerFacility: [mockFacility, mockFacility],
+      };
+      const page = setup({ index: 1, data });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('false');
-      expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index + 1}`))
-        .to.be.true;
-    });
-  });
+      const input = $('va-text-input', container);
+      fireEvent.blur(input);
 
-  it('should show modal when adding another on an empty page', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goToPath: goSpy,
-      data: { ...mockData, providerFacility: [mockFacility, {}] },
-    });
-    const { container } = render(page);
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('true');
-      expect(goSpy.called).to.be.false;
-    });
-  });
-
-  it('should not navigate, but show errors after adding another and choosing "Yes" on an empty page', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalYes',
-      goToPath: goSpy,
-      data: { ...mockData, providerFacility: [mockFacility, {}] },
-    });
-    const { container } = render(page);
-
-    // add
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      getAndTestAllErrors(container);
-      expect(goSpy.called).to.be.false;
-    });
-  });
-
-  it('should not navigate, but clear all data after adding another and choosing "No" on an empty page', async () => {
-    const goSpy = sinon.spy();
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, { providerFacilityName: 'test' }, {}],
-    };
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goToPath: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      // stay on the same index, but clear all fields
-      expect(goSpy.calledWith(`/${EVIDENCE_PRIVATE_PATH}?index=${index}`)).to.be
-        .true;
-      expect(getErrorElements(container).length).to.eq(0);
-    });
-  });
-
-  it('should show error when start treatment date is in the future', async () => {
-    const from = getDate({ offset: { years: +1 } });
-    const data = {
-      ...mockData,
-      providerFacility: [{ treatmentDateRange: { from } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:from' });
-    const { container } = render(page);
-
-    const dateFrom = $('va-memorable-date', container);
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateFrom);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect(dateFrom.error).to.contain(errorMessages.evidence.pastDate);
-    });
-  });
-
-  it('should show error when last treatment date is in the future', async () => {
-    const to = getDate({ offset: { years: +1 } });
-    const data = {
-      ...mockData,
-      providerFacility: [{ treatmentDateRange: { to } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:to' });
-    const { container } = render(page);
-
-    const dateTo = $$('va-memorable-date', container)[1];
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateFrom);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect(dateTo.error).to.contain(errorMessages.evidence.pastDate);
-    });
-  });
-
-  it('should show an error when the start treament date is too far in the past', async () => {
-    const from = getDate({ offset: { years: -101 } });
-    const data = {
-      ...mockData,
-      providerFacility: [{ treatmentDateRange: { from } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:from' });
-    const { container } = render(page);
-
-    const dateFrom = $('va-memorable-date', container);
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateFrom);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect(dateFrom.error).to.contain(errorMessages.evidence.newerDate);
-    });
-  });
-
-  it('should show an error when the last treatment date is too far in the past', async () => {
-    const to = getDate({ offset: { years: -101 } });
-    const data = {
-      ...mockData,
-      providerFacility: [{ treatmentDateRange: { to } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:to' });
-    const { container } = render(page);
-
-    const dateTo = $$('va-memorable-date', container)[1];
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateTo);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect(dateTo.error).to.contain(errorMessages.evidence.newerDate);
-    });
-  });
-
-  it('should show an error when the last treatment date is before the start', async () => {
-    const from = getDate({ offset: { years: -5 } });
-    const to = getDate({ offset: { years: -10 } });
-    const data = {
-      ...mockData,
-      providerFacility: [{ treatmentDateRange: { from, to } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:to' });
-    const { container } = render(page);
-
-    const dateTo = $$('va-memorable-date', container)[1];
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateTo);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect(dateTo.error).to.contain(errorMessages.endDateBeforeStart);
-    });
-  });
-
-  it('should show an error when the issue is not unique', async () => {
-    const data = {
-      ...mockData,
-      providerFacility: [mockFacility, mockFacility],
-    };
-    const page = setup({ index: 1, data });
-    const { container } = render(page);
-
-    const input = $('va-text-input', container);
-    fireEvent.blur(input);
-
-    await waitFor(() => {
-      expect(input.error).to.contain(errorMessages.evidence.unique);
+      await waitFor(() => {
+        expect(input.error).to.contain(errorMessages.evidence.unique);
+      });
     });
   });
 });

--- a/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
@@ -13,6 +13,13 @@ import {
 import { getDate } from '../../utils/dates';
 import { $, $$ } from '../../utils/ui';
 
+/*
+| Data     | Forward     | Back               | Add another      |
+|----------|-------------|--------------------|------------------|
+| Complete | Next page   | Prev page          | New page (empty) |
+| Empty    | Focus error | Prev page & remove | Focus error      |
+| Partial  | Focus error | Modal & Prev page  | Focus error      |
+ */
 describe('<EvidenceVaRecords>', () => {
   const validDate = getDate({ offset: { months: -2 } });
   const mockData = {
@@ -65,34 +72,11 @@ describe('<EvidenceVaRecords>', () => {
     </div>
   );
 
-  const testAndCloseModal = async container => {
-    // modal visible
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('true');
-    });
-
-    // close modal by clicking method-assigned hidden button
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('false');
-    });
-  };
-
   const getErrorElements = container =>
     $$(
       'va-text-input[error], va-checkbox-group[error], va-memorable-date[error]',
       container,
     );
-
-  const getAndTestAllErrors = container => {
-    const errors = errorMessages.evidence;
-    const errorEls = getErrorElements(container);
-    expect(errorEls[0].error).to.eq(errors.locationMissing);
-    expect(errorEls[1].error).to.eq(errors.issuesMissing);
-    expect(errorEls[2].error).to.eq(errorMessages.evidence.missingDate);
-    expect(errorEls[3].error).to.eq(errorMessages.evidence.missingDate);
-  };
 
   it('should render', () => {
     const { container } = render(setup());
@@ -105,456 +89,457 @@ describe('<EvidenceVaRecords>', () => {
     expect($('.vads-c-action-link--green', container)).to.exist;
   });
 
-  // *** CLOSE MODAL ***
-  it('should show error messages after closing modal after submitting empty page', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const data = { ...mockData, locations: [mockLocation, {}, mockLocation2] };
-    const page = setup({
-      index,
-      method: 'onModalClose',
-      goForward: goSpy,
-      goToPath: goSpy,
-      data,
+  // *** VALID DATA ***
+  describe('valid data navigation', () => {
+    it('should navigate forward to VA private request page with valid data', async () => {
+      const goSpy = sinon.spy();
+      const data = { ...mockData, locations: [mockLocation] };
+      const page = setup({
+        index: 0,
+        goForward: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.calledWith(data)).to.be.true;
+      });
     });
-    const { container } = render(page);
+    it('should navigate back to VA records request page with valid data', async () => {
+      const goSpy = sinon.spy();
+      const data = { ...mockData, locations: [mockLocation] };
+      const index = 0;
+      const page = setup({
+        index,
+        goBack: goSpy,
+        data,
+      });
+      const { container } = render(page);
 
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
 
-    await waitFor(() => {
-      expect(goSpy.called).to.be.false;
-      getAndTestAllErrors(container);
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        // passing a negative index is okay, we're leaving the indexed pages
+        expect(goSpy.calledWith(index - 1)).to.be.true;
+      });
     });
-  });
+    it('should navigate from zero index to a new empty location page, of index 1, with valid data', async () => {
+      const goSpy = sinon.spy();
+      const data = {
+        ...mockData,
+        locations: [mockLocation, {}, mockLocation2],
+      };
+      const index = 0;
+      const page = setup({
+        index,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
 
-  // *** FORWARD ***
-  it('should navigate forward to VA private request page with valid data', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, locations: [mockLocation] };
-    const page = setup({
-      index: 0,
-      goForward: goSpy,
-      data,
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index + 1}`)).to
+          .be.true;
+      });
     });
-    const { container } = render(page);
 
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await waitFor(() => expect(goSpy.calledWith(data)).to.be.true);
-  });
+    it('should navigate from zero index, with valid data, to next index when inserting another entry', async () => {
+      const goSpy = sinon.spy();
+      const locations = [mockLocation, mockLocation2, {}];
+      const data = { ...mockData, locations };
+      const index = 0;
+      const page = setup({
+        index,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
 
-  it('should show modal when submitting an empty page', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, locations: [mockLocation, {}] };
-    const page = setup({
-      index: 1,
-      goForward: goSpy,
-      data,
-    });
-    const { container } = render(page);
-    fireEvent.submit($('form', container));
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
 
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('true');
-      expect(goSpy.called).to.be.false;
-    });
-  });
-
-  it('should not show modal (reveal errors) when going forward on an empty page on first entry only', async () => {
-    const goSpy = sinon.spy();
-    const index = 0;
-    const page = setup({ index, goForward: goSpy });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-primary', container));
-
-    await waitFor(() => {
-      expect(goSpy.called).to.be.false;
-      getAndTestAllErrors(container);
-    });
-  });
-
-  it('should not navigate, but will show errors when choosing "Yes" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const data = { ...mockData, locations: [mockLocation, {}, mockLocation2] };
-    const page = setup({
-      index,
-      method: 'onModalYes',
-      goForward: goSpy,
-      goToPath: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      expect(goSpy.called).to.be.false;
-      getAndTestAllErrors(container);
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index + 1}`)).to
+          .be.true;
+      });
     });
   });
 
-  it('should navigate forward to next index when choosing "No" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const index = 2;
-    const data = { ...mockData, locations: [mockLocation, mockLocation2] };
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goForward: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      expect(getErrorElements(container).length).to.eq(0);
-
-      // going forward requires passing the form data
-      expect(goSpy.calledWith(data)).to.be.true;
-      // index still at 2, because we've moved beyond the indexed pages
-      expect(goSpy.firstCall.args[1]).to.eq(index);
-    });
-  });
-
-  it('should navigate forward to VA private request page when choosing "No" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, locations: [mockLocation, mockLocation2] };
-    const page = setup({
-      index: 2,
-      method: 'onModalNo',
-      goForward: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.usa-button-primary', container));
-    await testAndCloseModal(container);
-    await waitFor(() => expect(goSpy.calledWith(data)).to.be.true);
-  });
-
-  // *** BACK ***
-  it('should navigate back to VA records request page with valid data', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, locations: [mockLocation] };
-    const index = 0;
-    const page = setup({
-      index,
-      goBack: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-secondary', container));
-
-    await waitFor(() => {
-      // passing a negative index is okay, we're leaving the indexed pages
-      expect(goSpy.calledWith(index - 1)).to.be.true;
-    });
-  });
-
-  it('should not show modal when going back on an empty page on first entry only', async () => {
-    const goSpy = sinon.spy();
-    const index = 0;
-    const page = setup({ index, goBack: goSpy });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-secondary', container));
-
-    await waitFor(() => {
-      expect(goSpy.called).to.be.true;
-      expect(goSpy.calledWith(index - 1)).to.be.true;
-    });
-  });
-
-  it('should navigate back to previous index page, after choosing "Yes" in modal', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const data = { ...mockData, locations: [mockLocation, {}, mockLocation2] };
-    const page = setup({
-      index,
-      method: 'onModalYes',
-      goBack: goSpy,
-      goToPath: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // continue
-    fireEvent.click($('.usa-button-secondary', container));
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index - 1}`)).to.be
-        .true;
-    });
-  });
-
-  it('should navigate back one index when choosing "No" after continuing', async () => {
-    const goSpy = sinon.spy();
-    const index = 2;
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goToPath: goSpy,
-      data: { ...mockData, locations: [mockLocation, mockLocation2] },
-    });
-    const { container } = render(page);
-
-    // back
-    fireEvent.click($('.usa-button-secondary', container));
-    await testAndCloseModal(container);
-
-    await waitFor(() => {
-      expect(goSpy.called).to.be.true;
-      expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index - 1}`)).to.be
-        .true;
-    });
-  });
-
-  // *** ADD ANOTHER ***
-  it('should navigate from zero index to a new empty location page, of index 1, with valid data', async () => {
-    const goSpy = sinon.spy();
-    const data = { ...mockData, locations: [mockLocation, {}, mockLocation2] };
-    const index = 0;
-    const page = setup({
-      index,
-      goToPath: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // add
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('false');
-      expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index + 1}`)).to.be
-        .true;
-    });
-  });
-
-  it('should navigate from zero index, with valid data, to next index when inserting another entry', async () => {
-    const goSpy = sinon.spy();
-    const locations = [mockLocation, mockLocation2, {}];
-    const data = { ...mockData, locations };
-    const index = 0;
-    const page = setup({
-      index,
-      goToPath: goSpy,
-      data,
-    });
-    const { container } = render(page);
-
-    // add
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('false');
-      expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index + 1}`)).to.be
-        .true;
-    });
-  });
-
-  it('should show modal when adding another on an empty page', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goToPath: goSpy,
-      data: { ...mockData, locations: [mockLocation, {}] },
-    });
-    const { container } = render(page);
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await waitFor(() => {
-      expect($('va-modal', container).getAttribute('visible')).to.eq('true');
-      expect(goSpy.called).to.be.false;
-    });
-  });
-
-  it('should not navigate, but show errors after adding another and choosing "Yes" on an empty page', async () => {
-    const goSpy = sinon.spy();
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalYes',
-      goToPath: goSpy,
-      data: { ...mockData, locations: [mockLocation, {}] },
-    });
-    const { container } = render(page);
-
-    // add
-    fireEvent.click($('.vads-c-action-link--green', container));
-
-    await testAndCloseModal(container);
-    await waitFor(() => {
-      getAndTestAllErrors(container);
-      expect(goSpy.called).to.be.false;
-    });
-  });
-
-  it('should not navigate, but clear all data after adding another and choosing "No" on an empty page', async () => {
-    const goSpy = sinon.spy();
-    const data = {
-      ...mockData,
-      locations: [mockLocation, { locationAndName: 'test' }],
+  // *** EMPTY PAGE ***
+  describe('empty page navigation', () => {
+    const getAndTestAllErrors = container => {
+      expect(document.activeElement).to.eq($('[error]', container));
+      const errors = errorMessages.evidence;
+      const errorEls = getErrorElements(container);
+      expect(errorEls[0].error).to.eq(errors.locationMissing);
+      expect(errorEls[1].error).to.eq(errors.issuesMissing);
+      expect(errorEls[2].error).to.eq(errorMessages.evidence.missingDate);
+      expect(errorEls[3].error).to.eq(errorMessages.evidence.missingDate);
     };
-    const index = 1;
-    const page = setup({
-      index,
-      method: 'onModalNo',
-      goToPath: goSpy,
-      data,
+
+    it('should show & focus on error messages after going forward on an empty first page', async () => {
+      const goSpy = sinon.spy();
+      const index = 0;
+      const page = setup({ index, goForward: goSpy });
+      const { container } = render(page);
+
+      // forward
+      fireEvent.click($('.usa-button-primary', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.false;
+        getAndTestAllErrors(container);
+      });
     });
-    const { container } = render(page);
+    it('should show & focus on error messages after going forward on an empty second page', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        locations: [mockLocation, {}, mockLocation2],
+      };
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
 
-    // continue
-    fireEvent.click($('.vads-c-action-link--green', container));
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
 
-    await testAndCloseModal(container);
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.false;
+        getAndTestAllErrors(container);
+      });
+    });
+    it('should go back on an empty page on first entry', async () => {
+      const goSpy = sinon.spy();
+      const index = 0;
+      const page = setup({ index, goBack: goSpy });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      // stay on the same index, but clear all fields
-      expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index}`)).to.be
-        .true;
-      expect(getErrorElements(container).length).to.eq(0);
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.true;
+        expect(goSpy.calledWith(index - 1)).to.be.true;
+      });
+    });
+
+    it('should go back and remove empty page', async () => {
+      const goSpy = sinon.spy();
+      const setDataSpy = sinon.spy();
+      const data = { ...mockData, locations: [mockLocation, {}] };
+      const page = setup({
+        index: 1,
+        goToPath: goSpy,
+        setFormData: setDataSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.true;
+        expect(setDataSpy.called).to.be.true;
+        expect(setDataSpy.lastCall.args[0].locations.length).to.eq(1);
+      });
+    });
+    it('should show & focus on error messages after adding new location on an empty second page', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        locations: [mockLocation, {}, mockLocation2],
+      };
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
+
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+        expect(goSpy.called).to.be.false;
+        getAndTestAllErrors(container);
+      });
     });
   });
 
-  it('should show error when location name is too long', async () => {
-    const name = 'abcdef '.repeat(MAX_LENGTH.EVIDENCE_LOCATION_AND_NAME / 6);
-    const data = { ...mockData, locations: [{ locationAndName: name }] };
-    const page = setup({ index: 0, data });
-    const { container } = render(page);
+  describe('partial/invalid data navigation', () => {
+    const testAndCloseModal = async (container, total) => {
+      expect(getErrorElements(container).length).to.eq(total);
+      // modal visible
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('true');
+      });
 
-    const input = $('va-text-input', container);
-    fireEvent.blur(input);
-
-    await waitFor(() => {
-      expect(input.error).to.contain(errorMessages.evidence.locationMaxLength);
-    });
-  });
-
-  it('should show error when start treatment date is in the future', async () => {
-    const from = getDate({ offset: { years: +1 } });
-    const data = {
-      ...mockData,
-      locations: [{ evidenceDates: { from } }],
+      // close modal by clicking method-assigned hidden button
+      fireEvent.click($('#test-method', container));
+      await waitFor(() => {
+        expect($('va-modal', container).getAttribute('visible')).to.eq('false');
+      });
     };
-    const page = setup({ index: 0, data, method: 'onBlur:from' });
-    const { container } = render(page);
 
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateFrom);
-    fireEvent.click($('#test-method', container));
+    it('should not navigate, but will show errors after continuing', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        locations: [mockLocation, { locationAndName: 'foo' }, mockLocation2],
+      };
+      const page = setup({
+        index,
+        goForward: goSpy,
+        goToPath: goSpy,
+        data,
+      });
+      const { container } = render(page);
 
-    await waitFor(() => {
-      const dateFrom = $('va-memorable-date', container);
-      expect(dateFrom.error).to.contain(errorMessages.evidence.pastDate);
+      // continue
+      fireEvent.click($('.usa-button-primary', container));
+
+      await waitFor(() => {
+        expect(goSpy.called).to.be.false;
+        expect(getErrorElements(container).length).to.eq(3);
+        expect(document.activeElement).to.eq($('[error]', container));
+      });
+    });
+
+    // *** BACK ***
+    it('should show modal, select "No, remove this location", then navigate back to previous index', async () => {
+      const goSpy = sinon.spy();
+      const setDataSpy = sinon.spy();
+      const index = 1;
+      const data = {
+        ...mockData,
+        locations: [mockLocation, { locationAndName: 'foo' }, mockLocation2],
+      };
+      const page = setup({
+        index,
+        method: 'onModalNo', // remove partial entry
+        goBack: goSpy,
+        goToPath: goSpy,
+        setFormData: setDataSpy,
+        data,
+      });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+      await testAndCloseModal(container, 3);
+
+      await waitFor(() => {
+        expect(setDataSpy.called).to.be.true;
+        expect(setDataSpy.lastCall.args[0].locations.length).to.eq(2);
+        expect(goSpy.called).to.be.true;
+        expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index - 1}`)).to
+          .be.true;
+      });
+    });
+
+    it('should show modal, select "Yes", then navigate back to previous index', async () => {
+      const goSpy = sinon.spy();
+      const setDataSpy = sinon.spy();
+      const index = 2;
+      const page = setup({
+        index,
+        method: 'onModalYes', // keep partial entry
+        goToPath: goSpy,
+        setFormData: setDataSpy,
+        data: {
+          ...mockData,
+          locations: [mockLocation, mockLocation2, { locationAndName: 'foo' }],
+        },
+      });
+      const { container } = render(page);
+
+      // back
+      fireEvent.click($('.usa-button-secondary', container));
+      await testAndCloseModal(container, 3);
+
+      await waitFor(() => {
+        expect(setDataSpy.called).to.be.false; // no data change
+        expect(goSpy.called).to.be.true;
+        expect(goSpy.calledWith(`/${EVIDENCE_VA_PATH}?index=${index - 1}`)).to
+          .be.true;
+      });
+    });
+
+    // *** ADD ANOTHER ***
+    it('should not navigate, but show errors after adding another and choosing "Yes" on an empty page', async () => {
+      const goSpy = sinon.spy();
+      const index = 1;
+      const page = setup({
+        index,
+        goToPath: goSpy,
+        data: {
+          ...mockData,
+          locations: [mockLocation, { locationAndName: 'foo' }],
+        },
+      });
+      const { container } = render(page);
+
+      // add
+      fireEvent.click($('.vads-c-action-link--green', container));
+
+      await waitFor(() => {
+        expect(goSpy.called).to.be.false;
+        expect(getErrorElements(container).length).to.eq(3);
+        expect(document.activeElement).to.eq($('[error]', container));
+      });
     });
   });
 
-  it('should show error when last treatment date is in the future', async () => {
-    const to = getDate({ offset: { years: +1 } });
-    const data = {
-      ...mockData,
-      locations: [{ evidenceDates: { to } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:to' });
-    const { container } = render(page);
+  describe('other errors', () => {
+    // *** OTHER ERRORS ***
+    it('should show error when location name is too long', async () => {
+      const name = 'abcdef '.repeat(MAX_LENGTH.EVIDENCE_LOCATION_AND_NAME / 6);
+      const data = { ...mockData, locations: [{ locationAndName: name }] };
+      const page = setup({ index: 0, data });
+      const { container } = render(page);
 
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateFrom);
-    fireEvent.click($('#test-method', container));
+      const input = $('va-text-input', container);
+      fireEvent.blur(input);
 
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(input.error).to.contain(
+          errorMessages.evidence.locationMaxLength,
+        );
+      });
+    });
+
+    it('should show error when start treatment date is in the future', async () => {
+      const from = getDate({ offset: { years: +1 } });
+      const data = {
+        ...mockData,
+        locations: [{ evidenceDates: { from } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:from' });
+      const { container } = render(page);
+
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateFrom);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        const dateFrom = $('va-memorable-date', container);
+        expect(dateFrom.error).to.contain(errorMessages.evidence.pastDate);
+      });
+    });
+
+    it('should show error when last treatment date is in the future', async () => {
+      const to = getDate({ offset: { years: +1 } });
+      const data = {
+        ...mockData,
+        locations: [{ evidenceDates: { to } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:to' });
+      const { container } = render(page);
+
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateFrom);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        const dateTo = $$('va-memorable-date', container)[1];
+        expect(dateTo.error).to.contain(errorMessages.evidence.pastDate);
+      });
+    });
+
+    it('should show an error when the start treament date is too far in the past', async () => {
+      const from = getDate({ offset: { years: -101 } });
+      const data = {
+        ...mockData,
+        locations: [{ evidenceDates: { from } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:from' });
+      const { container } = render(page);
+
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateFrom);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        const dateFrom = $('va-memorable-date', container);
+        expect(dateFrom.error).to.contain(errorMessages.evidence.newerDate);
+      });
+    });
+
+    it('should show an error when the last treatment date is too far in the past', async () => {
+      const to = getDate({ offset: { years: -101 } });
+      const data = {
+        ...mockData,
+        locations: [{ evidenceDates: { to } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:to' });
+      const { container } = render(page);
+
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateTo);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        const dateTo = $$('va-memorable-date', container)[1];
+        expect(dateTo.error).to.contain(errorMessages.evidence.newerDate);
+      });
+    });
+
+    it('should show an error when the last treatment date is before the start', async () => {
+      const from = getDate({ offset: { years: -5 } });
+      const to = getDate({ offset: { years: -10 } });
+      const data = {
+        ...mockData,
+        locations: [{ evidenceDates: { from, to } }],
+      };
+      const page = setup({ index: 0, data, method: 'onBlur:to' });
+      const { container } = render(page);
+
       const dateTo = $$('va-memorable-date', container)[1];
-      expect(dateTo.error).to.contain(errorMessages.evidence.pastDate);
+      // blur date inputs - va-text-input blur works, but not the va-memorable-date?
+      // fireEvent.blur(dateTo);
+      fireEvent.click($('#test-method', container));
+
+      await waitFor(() => {
+        expect(dateTo.error).to.contain(errorMessages.endDateBeforeStart);
+      });
     });
-  });
 
-  it('should show an error when the start treament date is too far in the past', async () => {
-    const from = getDate({ offset: { years: -101 } });
-    const data = {
-      ...mockData,
-      locations: [{ evidenceDates: { from } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:from' });
-    const { container } = render(page);
+    it('should show an error when the issue is not unique', async () => {
+      const data = { ...mockData, locations: [mockLocation, mockLocation] };
+      const page = setup({ index: 1, data });
+      const { container } = render(page);
 
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateFrom);
-    fireEvent.click($('#test-method', container));
+      const input = $('va-text-input', container);
+      fireEvent.blur(input);
 
-    await waitFor(() => {
-      const dateFrom = $('va-memorable-date', container);
-      expect(dateFrom.error).to.contain(errorMessages.evidence.newerDate);
-    });
-  });
-
-  it('should show an error when the last treatment date is too far in the past', async () => {
-    const to = getDate({ offset: { years: -101 } });
-    const data = {
-      ...mockData,
-      locations: [{ evidenceDates: { to } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:to' });
-    const { container } = render(page);
-
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateTo);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      const dateTo = $$('va-memorable-date', container)[1];
-      expect(dateTo.error).to.contain(errorMessages.evidence.newerDate);
-    });
-  });
-
-  it('should show an error when the last treatment date is before the start', async () => {
-    const from = getDate({ offset: { years: -5 } });
-    const to = getDate({ offset: { years: -10 } });
-    const data = {
-      ...mockData,
-      locations: [{ evidenceDates: { from, to } }],
-    };
-    const page = setup({ index: 0, data, method: 'onBlur:to' });
-    const { container } = render(page);
-
-    const dateTo = $$('va-memorable-date', container)[1];
-    // blur date inputs - va-text-input blur works, but not the va-memorable-date?
-    // fireEvent.blur(dateTo);
-    fireEvent.click($('#test-method', container));
-
-    await waitFor(() => {
-      expect(dateTo.error).to.contain(errorMessages.endDateBeforeStart);
-    });
-  });
-
-  it('should show an error when the issue is not unique', async () => {
-    const data = { ...mockData, locations: [mockLocation, mockLocation] };
-    const page = setup({ index: 1, data });
-    const { container } = render(page);
-
-    const input = $('va-text-input', container);
-    fireEvent.blur(input);
-
-    await waitFor(() => {
-      expect(input.error).to.contain(errorMessages.evidence.unique);
+      await waitFor(() => {
+        expect(input.error).to.contain(errorMessages.evidence.unique);
+      });
     });
   });
 });

--- a/src/applications/appeals/995/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/ITFWrapper.unit.spec.jsx
@@ -324,7 +324,7 @@ describe('ITFWrapper', () => {
         </ITFWrapper>
       </Provider>,
     );
-    // Fetch succeded and expired ITF was returned
+    // Fetch succeeded and expired ITF was returned
     // This is used to catch cases where the status field is out of date
     await waitFor(() => {
       expect(mockDispatch.called).to.be.true;

--- a/src/applications/appeals/995/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/focus.unit.spec.js
@@ -8,6 +8,7 @@ import {
   // focusRadioH3,
   focusAlertH3,
   focusIssue,
+  focusEvidence,
   focusUploads,
 } from '../../utils/focus';
 import { LAST_SC_ITEM } from '../../constants';
@@ -107,6 +108,35 @@ describe('focusIssue', () => {
     await focusIssue(0, container);
     await waitFor(() => {
       const target = $('#issue-1 .edit-issue-link', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusEvidence', () => {
+  const renderPage = hasError =>
+    render(
+      <div id="main">
+        <h3>Title</h3>
+        {hasError ? <div error="true" /> : <div />}
+      </div>,
+    );
+
+  it('should focus on header', async () => {
+    const { container } = await renderPage();
+
+    await focusEvidence(null, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on error', async () => {
+    const { container } = await renderPage(true);
+
+    await focusEvidence(null, container);
+    await waitFor(() => {
+      const target = $('[error]', container);
       expect(document.activeElement).to.eq(target);
     });
   });

--- a/src/applications/appeals/995/utils/evidence.js
+++ b/src/applications/appeals/995/utils/evidence.js
@@ -1,0 +1,9 @@
+export const getIndex = (data, testingIndex) => {
+  // get index from url '/{path}?index={index}' or testingIndex
+  const searchIndex = new URLSearchParams(window.location.search);
+  let index = parseInt(searchIndex.get('index') || testingIndex || '0', 10);
+  if (Number.isNaN(index) || index > data.length) {
+    index = data.length;
+  }
+  return index;
+};

--- a/src/applications/appeals/995/utils/focus.js
+++ b/src/applications/appeals/995/utils/focus.js
@@ -2,6 +2,7 @@ import {
   focusElement,
   scrollTo,
   scrollToTop,
+  scrollToFirstError,
   defaultFocusSelector,
   waitForRenderThenFocus,
 } from 'platform/utilities/ui';
@@ -46,6 +47,19 @@ export const focusAlertH3 = () => {
   // va-alert header is not in the shadow DOM, but still the content doesn't
   // immediately render
   waitForRenderThenFocus('h3');
+};
+
+export const focusEvidence = (_index, root) => {
+  setTimeout(() => {
+    const error = $('[error]', root);
+    if (error) {
+      scrollToFirstError();
+      focusElement(error);
+    } else {
+      scrollTo('topPageElement');
+      focusElement('#main h3', null, root);
+    }
+  });
 };
 
 export const focusUploads = (_index, root) => {

--- a/src/applications/appeals/995/utils/focus.js
+++ b/src/applications/appeals/995/utils/focus.js
@@ -36,7 +36,7 @@ export const focusRadioH3 = () => {
   const radio = $('va-radio');
   if (radio) {
     // va-radio content doesn't immediately render
-    waitForRenderThenFocus('#main h3', radio.shadowRoot);
+    waitForRenderThenFocus('h3', radio.shadowRoot);
   } else {
     focusElement(defaultFocusSelector);
   }


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > -  Update evidence page navigation behavior; the modal will now only show when navigating back on a page with errors
  >    | Data      | Forward     | Back               | Add another      |
  >    |-----------|-------------|--------------------|------------------|
  >    | All valid | Next page   | Prev page          | New page (empty) |
  >    | Empty     | Focus error | Prev page & remove | Focus error      |
  >    | Partial   | Focus error | Modal & Prev page  | Focus error      |
  > - Updated the modal title
  > - Update page title so that "add" and "edit" will not update while typing
  > - Show message if no issues were selected on the review & submit page
  > - Fix focus selector
  > - Code clean up
  > - Updated unit tests
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Behavior changes recommended by a11y and design
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
  > March 30, 2023 soft release

## Related issue(s)

[#54721](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54721)

## Testing done

- *Describe what the old behavior was prior to the change*
  > A modal would show up if the evidence page had _any_ errors
- *Describe the steps required to verify your changes are working as expected*
  > Log in to SC locally or in the review instance, and test the behavior using the table above
- *Describe the tests completed and the results*
  > Updated unit tests to match new behavior; all passing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

Modal with named entry
<img width="717" alt="VA facility named 'Some hometown' visible behind the modal, and a modal with the title 'Do you want to keep some hometown?'" src="https://user-images.githubusercontent.com/136959/228312716-5e46ab30-caac-454f-a3fc-7e97b2f171ce.png">

Modal with missing name
<img width="687" alt="VA facility is not included in the input behind the modal, so the modal title shows 'Do you want to keep this location?'" src="https://user-images.githubusercontent.com/136959/228312711-3887401b-ccbd-4c3a-96f3-7a549cd413c3.png">

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
