### PR TITLE
Add vertical margin around submit buttons

### DIFF
--- a/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
@@ -1,17 +1,17 @@
 import React, { useEffect } from 'react';
 import { focusElement, getScrollOptions } from 'platform/utilities/ui';
 import Scroll from 'react-scroll';
-import Back from './Back';
-import ProgressButton from '../../components/ProgressButton';
 import PropTypes from 'prop-types';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
 import scrollTo from 'platform/utilities/ui/scrollTo';
+import ProgressButton from '../../components/ProgressButton';
+import Back from './Back';
 
 export default function ClientError(props) {
   const { buttonText, formConfig, onBack, onSubmit, testId } = props;
-  const Element = Scroll.Element;
+  const { Element } = Scroll;
   const scrollToError = () => {
     scrollTo('errorScrollElement', getScrollOptions());
   };
@@ -42,7 +42,7 @@ export default function ClientError(props) {
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons">
+      <Row classNames="form-progress-buttons vads-u-margin-y--2">
         <Column classNames="small-6 medium-5">
           <Back onButtonClick={onBack} />
         </Column>

--- a/src/platform/forms-system/src/js/review/submit-states/Default.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Default.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Back from './Back';
-import ProgressButton from '../../components/ProgressButton';
 import PropTypes from 'prop-types';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import ProgressButton from '../../components/ProgressButton';
+import Back from './Back';
 
 export default function Default(props) {
   const { buttonText, formConfig, onBack, onSubmit } = props;
@@ -19,11 +19,11 @@ export default function Default(props) {
   return (
     <>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons vads-u-display--flex">
-        <Column classNames={`vads-u-flex--1`}>
+      <Row classNames="form-progress-buttons vads-u-display--flex vads-u-margin-y--2">
+        <Column classNames="vads-u-flex--1">
           <Back onButtonClick={onBack} />
         </Column>
-        <Column classNames={`vads-u-flex--1`}>
+        <Column classNames="vads-u-flex--1">
           <ProgressButton
             ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}

--- a/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
@@ -7,7 +7,7 @@ import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
 import FormSaveErrorMessage from 'platform/forms/components/review/FormSaveErrorMessage';
 import { Column, Row } from 'platform/forms/components/common/grid';
-// const FormSaveErrorMessage = props => props?.children;
+
 export default function GenericError(props) {
   const { appType, formConfig, onSubmit, testId } = props;
   let submitButton;
@@ -33,7 +33,13 @@ export default function GenericError(props) {
   if (process.env.NODE_ENV !== 'production') {
     submitButton = (
       <Column classNames="small-6 usa-width-one-half medium-6">
-        <a onClick={onSubmit}>Submit again</a>
+        <button
+          type="button"
+          className="usa-button-secondary"
+          onClick={onSubmit}
+        >
+          Submit again
+        </button>
       </Column>
     );
   }
@@ -46,10 +52,10 @@ export default function GenericError(props) {
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons schemaform-back-buttons">
+      <Row classNames="form-progress-buttons schemaform-back-buttons vads-u-margin-y--2">
         <Column classNames="small-6 usa-width-one-half medium-6">
-          <a href="/">
-            <button className="usa-button-primary">Go Back to VA.gov</button>
+          <a href="/" className="usa-button-primary">
+            Go Back to VA.gov
           </a>
         </Column>
         {submitButton}
@@ -61,5 +67,6 @@ export default function GenericError(props) {
 GenericError.propTypes = {
   appType: PropTypes.string,
   formConfig: PropTypes.object,
+  testId: PropTypes.string,
   onSubmit: PropTypes.func,
 };

--- a/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Back from './Back';
-import ProgressButton from '../../components/ProgressButton';
 import PropTypes from 'prop-types';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import ProgressButton from '../../components/ProgressButton';
+import Back from './Back';
 
 export default function Pending(props) {
   const { formConfig, onBack, onSubmit } = props;
@@ -19,7 +19,7 @@ export default function Pending(props) {
   return (
     <>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons">
+      <Row classNames="form-progress-buttons vads-u-margin-y--2">
         <Column classNames="small-6 medium-5">
           <Back onButtonClick={onBack} />
         </Column>

--- a/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Back from './Back';
-import ProgressButton from '../../components/ProgressButton';
 import PropTypes from 'prop-types';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import ProgressButton from '../../components/ProgressButton';
+import Back from './Back';
 
 export default function Submitted(props) {
   const { formConfig, onBack, onSubmit } = props;
@@ -19,7 +19,7 @@ export default function Submitted(props) {
   return (
     <>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons">
+      <Row classNames="form-progress-buttons vads-u-margin-y--2">
         <Column classNames="small-6 medium-5">
           <Back onButtonClick={onBack} />
         </Column>

--- a/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import moment from 'moment';
-import { timeFromNow } from '../../utilities/date';
 
-import Back from './Back';
-import ProgressButton from '../../components/ProgressButton';
 import PropTypes from 'prop-types';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import ProgressButton from '../../components/ProgressButton';
+import Back from './Back';
+import { timeFromNow } from '../../utilities/date';
 
 export default function ThrottledError(props) {
   const { buttonText, when, formConfig, onBack, onSubmit, testId } = props;
@@ -35,7 +35,7 @@ export default function ThrottledError(props) {
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons">
+      <Row classNames="form-progress-buttons vads-u-margin-y--2">
         <Column classNames="small-6 medium-5">
           <Back onButtonClick={onBack} />
         </Column>

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Back from './Back';
-import ProgressButton from '../../components/ProgressButton';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import ProgressButton from '../../components/ProgressButton';
+import Back from './Back';
 import ErrorLinks from './ErrorLinks';
 
 function ValidationError(props) {
@@ -41,7 +41,7 @@ function ValidationError(props) {
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons">
+      <Row classNames="form-progress-buttons vads-u-margin-y--2">
         <Column classNames="small-6 medium-5">
           <Back onButtonClick={onBack} />
         </Column>


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > The original work in #23709 didn't include the margin around the back and submit application buttons.
  >
  > In the generic error component, ESLint errors prevented committing changes, so these changes were made:
  > - Button nested inside the go to VA.gov link was removed; This should be a link for material honesty, but left as a button style.
  > - The "submit again" link was changed into a button; note, this button is _only_ visible in non-production environments 
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Add vertical margin to _all_ submit state components (alongside of the `form-progress-buttons` class)
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#55481](https://github.com/department-of-veterans-affairs/va.gov-team/issues/55481)

## Testing done

- *Describe what the old behavior was prior to the change*
  > No vertical margin around back & submit application buttons
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Visual testing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Pre-submit | <img width="636" alt="Screenshot 2023-03-28 at 1 50 05 PM" src="https://user-images.githubusercontent.com/136959/228339368-d3cc5f0d-93b3-47ac-9fa5-887ac22923f4.png"> | <img width="704" alt="Screenshot 2023-03-28 at 1 16 19 PM" src="https://user-images.githubusercontent.com/136959/228339378-623048d1-2fd7-41b9-8950-824ac8c90dc8.png"> |
| Generic error (non-production) | <img width="654" alt="Screenshot 2023-03-28 at 1 46 55 PM" src="https://user-images.githubusercontent.com/136959/228339372-aa88501a-14fe-4920-9f96-d6c3808383a3.png"> | <img width="645" alt="Screenshot 2023-03-28 at 1 44 47 PM" src="https://user-images.githubusercontent.com/136959/228339376-6bbd74bf-4af9-451c-bfa4-afae0f3f8759.png"> |

## What areas of the site does it impact?

_All_ review & submit page back and submit buttons

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
