### PR TITLE
Update examples of payment put errors

### DIFF
--- a/src/applications/personalization/profile/mocks/endpoints/payment-history/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/payment-history/index.js
@@ -286,7 +286,7 @@ module.exports = {
       },
     },
     errors: {
-      fraud: {
+      generic: {
         errors: [
           {
             title: 'Unprocessable Entity',

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -50,10 +50,13 @@ const responses = {
 
     // This is a 'normal' payment history / control case data
     // payments.paymentHistory.simplePaymentHistory
-
     return res.status(200).json(payments.paymentHistory.simplePaymentHistory);
   },
   'PUT /v0/ppiu/payment_information': (_req, res) => {
+    // example payment error that can only be returned from PUT method
+    // see payment-history endpoint folder for further examples
+    // payments.paymentInformation.errors.generic;
+
     return res
       .status(200)
       .json(


### PR DESCRIPTION
## Summary

- Some basic updates to document some of the PUT errors that are present in the mock server
- Updates the generic error not to be called 'fraud'
- The format of these may change a bit once the lighthouse BE integration is ready for testing, but these use cases and their error codes should be copyable into a new endpoint folder for mocking that new endpoint.
- Each error can be tested locally by changing the data that is returned for the `PUT /v0/ppiu/payment_information` mock endpoint, and some examples of how that is done have been added and commented out.
- No real functionality changes were made to the way the frontend is functioning, but this PR is just for updating the use case responses and prep that endpoint to be used with the new lighthouse BE integration.

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54879)


## Testing done

-  Locally tested the various error code responses to PUT updates to CNP direct deposit form.


## What areas of the site does it impact?
Mock server of Profile

## Acceptance criteria

- [x]  Mock server updated with error examples and generic error name updated.
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs