### PR TITLE
[MHV 42338] consume unread vs read receipt from api.

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -12,9 +12,7 @@ const MessageThreadItem = props => {
   const dispatch = useDispatch();
   const [isExpanded, setIsExpanded] = useState(false);
   const { message } = props;
-  // TODO currently setting isRead to true due to a bug in the backend. This will need to be reverted once the backend is fixed.
-  const isRead = true;
-  // const isRead = message.readReceipt === 'READ';
+  const isRead = message.readReceipt === 'READ';
 
   useEffect(
     () => {

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -38,7 +38,7 @@ const MessageThreadItem = props => {
         setIsExpanded(!isExpanded);
       }
 
-      if (!isRead && !isExpanded) {
+      if (!isExpanded) {
         dispatch(markMessageAsReadInThread(message.messageId));
       }
     }

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -12,7 +12,7 @@ const MessageThreadItem = props => {
   const dispatch = useDispatch();
   const [isExpanded, setIsExpanded] = useState(false);
   const { message } = props;
-  const isRead = message.readReceipt === 'READ';
+  const isRead = message.readReceipt === 'READ' || message.readReceipt === null;
 
   useEffect(
     () => {

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -12,7 +12,7 @@ const MessageThreadItem = props => {
   const dispatch = useDispatch();
   const [isExpanded, setIsExpanded] = useState(false);
   const { message } = props;
-  const isRead = message.readReceipt === 'READ' || message.readReceipt === null;
+  const isRead = message.readReceipt === 'READ';
 
   useEffect(
     () => {

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadItem.jsx
@@ -38,9 +38,7 @@ const MessageThreadItem = props => {
         setIsExpanded(!isExpanded);
       }
 
-      if (!isExpanded) {
-        // TODO replace line above with a line below once readReceipt is fixed in the backend
-        // if (!isRead && !isExpanded) {
+      if (!isRead && !isExpanded) {
         dispatch(markMessageAsReadInThread(message.messageId));
       }
     }


### PR DESCRIPTION
This PR only handles reverting the read variable in the messageThreadItem component to instead assign it from props.

## Summary
Read receipt is now fixed, and the messages inside of the message thread will now have a circle icon next to them if they are unread.

## Related issue(s)
- [Consume read receipt API change (update front end) from MHV SM team](https://vajira.max.gov/browse/MHV-42338)


## Testing done

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | | |
| --- | --- | --- |
| |<img width="702" alt="image" src="https://user-images.githubusercontent.com/107279507/228592317-4ee5525a-25f0-4f79-9ce4-ad760aec4cd9.png">| |

## What areas of the site does it impact?
Secure Messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
