### PR TITLE
[MHV-39025] Updated Delete Thread to use new ThreadAPI call

### DIFF
--- a/src/applications/mhv/secure-messaging/actions/messages.js
+++ b/src/applications/mhv/secure-messaging/actions/messages.js
@@ -3,7 +3,7 @@ import {
   getMessageList,
   getMessage,
   getMessageHistory,
-  deleteMessage as deleteMessageCall,
+  deleteMessageThread as deleteMessageCall,
   moveMessageThread as moveThreadCall,
   createMessage,
   createReplyToMessage,
@@ -223,12 +223,13 @@ export const retrieveMessageThread = (
 };
 
 /**
- * @param {Long} messageId
+ * @param {Long} threadId
+ *  * @param {Long} folderId
  * @returns
  */
-export const deleteMessage = messageId => async dispatch => {
+export const deleteMessage = (threadId, folderId) => async dispatch => {
   try {
-    await deleteMessageCall(messageId);
+    await deleteMessageCall(threadId, folderId);
     dispatch(
       addAlert(
         Constants.ALERT_TYPE_SUCCESS,

--- a/src/applications/mhv/secure-messaging/actions/messages.js
+++ b/src/applications/mhv/secure-messaging/actions/messages.js
@@ -227,9 +227,9 @@ export const retrieveMessageThread = (
  *  * @param {Long} folderId
  * @returns
  */
-export const deleteMessage = (threadId, folderId) => async dispatch => {
+export const deleteMessage = threadId => async dispatch => {
   try {
-    await deleteMessageCall(threadId, folderId);
+    await deleteMessageCall(threadId);
     dispatch(
       addAlert(
         Constants.ALERT_TYPE_SUCCESS,

--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -1,5 +1,6 @@
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
+import { DefaultFolders } from '../util/constants';
 
 const apiBasePath = `${environment.API_URL}/my_health/v1`;
 
@@ -358,7 +359,9 @@ export const moveMessageThread = (threadId, toFolderId) => {
  */
 export const deleteMessageThread = threadId => {
   return apiRequest(
-    `${apiBasePath}/messaging/threads/${threadId}/move?folder_id=-3
+    `${apiBasePath}/messaging/threads/${threadId}/move?folder_id=${
+      DefaultFolders.DELETED.id
+    }
   `,
     {
       method: 'PATCH',

--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -351,6 +351,24 @@ export const moveMessageThread = (threadId, toFolderId) => {
     },
   );
 };
+/**
+ * Delete message thread (i.g. move to Trash folder).
+ * @param {Long} threadId
+ * @param {Long} toFolderId
+ * @returns
+ */
+export const deleteMessageThread = (threadId, toFolderId) => {
+  return apiRequest(
+    `${apiBasePath}/messaging/threads/${threadId}/move?folder_id=${toFolderId}
+  `,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+};
 
 /**
  * Get a list of triage teams.

--- a/src/applications/mhv/secure-messaging/api/SmApi.js
+++ b/src/applications/mhv/secure-messaging/api/SmApi.js
@@ -354,12 +354,11 @@ export const moveMessageThread = (threadId, toFolderId) => {
 /**
  * Delete message thread (i.g. move to Trash folder).
  * @param {Long} threadId
- * @param {Long} toFolderId
  * @returns
  */
-export const deleteMessageThread = (threadId, toFolderId) => {
+export const deleteMessageThread = threadId => {
   return apiRequest(
-    `${apiBasePath}/messaging/threads/${threadId}/move?folder_id=${toFolderId}
+    `${apiBasePath}/messaging/threads/${threadId}/move?folder_id=-3
   `,
     {
       method: 'PATCH',

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/TrashButton.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/TrashButton.jsx
@@ -1,21 +1,28 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-// import { useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import DeleteMessageModal from '../Modals/DeleteMessageModal';
 import { deleteMessage } from '../../actions/messages';
-// import { navigateToFolderByFolderId } from '../../util/helpers';
-// import * as Constants from '../../util/constants';
+import { navigateToFolderByFolderId } from '../../util/helpers';
+import * as Constants from '../../util/constants';
 
 const TrashButton = props => {
   const { activeFolder, messageId, threadId, visible } = props;
   const dispatch = useDispatch();
-  // const history = useHistory();
+  const history = useHistory();
   const [isDeleteVisible, setIsDeleteVisible] = useState(false);
 
   const handleDeleteMessageConfirm = () => {
     setIsDeleteVisible(false);
-    dispatch(deleteMessage(threadId, activeFolder.folderId));
+    dispatch(deleteMessage(threadId)).then(() => {
+      navigateToFolderByFolderId(
+        activeFolder
+          ? activeFolder.folderId
+          : Constants.DefaultFolders.DELETED.id,
+        history,
+      );
+    });
   };
 
   const deleteMessageModal = () => {

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/TrashButton.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/TrashButton.jsx
@@ -1,28 +1,21 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+// import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import DeleteMessageModal from '../Modals/DeleteMessageModal';
 import { deleteMessage } from '../../actions/messages';
-import { navigateToFolderByFolderId } from '../../util/helpers';
-import * as Constants from '../../util/constants';
+// import { navigateToFolderByFolderId } from '../../util/helpers';
+// import * as Constants from '../../util/constants';
 
 const TrashButton = props => {
   const { activeFolder, messageId, threadId, visible } = props;
   const dispatch = useDispatch();
-  const history = useHistory();
+  // const history = useHistory();
   const [isDeleteVisible, setIsDeleteVisible] = useState(false);
 
   const handleDeleteMessageConfirm = () => {
     setIsDeleteVisible(false);
-    dispatch(deleteMessage(messageId)).then(() => {
-      navigateToFolderByFolderId(
-        activeFolder
-          ? activeFolder.folderId
-          : Constants.DefaultFolders.DELETED.id,
-        history,
-      );
-    });
+    dispatch(deleteMessage(threadId, activeFolder.folderId));
   };
 
   const deleteMessageModal = () => {

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-delete-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-delete-message-with-attachment.cypress.spec.js
@@ -19,8 +19,10 @@ describe('Secure Messaging - Delete Message with Attachment', () => {
     landingPage.loadInboxMessages(mockMessages, mockMessagewithAttachment);
 
     cy.intercept(
-      'DELETE',
-      '/my_health/v1/messaging/messages/7192838',
+      'PATCH',
+      `/my_health/v1/messaging/threads/${
+        mockThreadwithAttachment.data.at(0).attributes.threadId
+      }/move?folder_id=-3`,
       mockMessagewithAttachment,
     ).as('deleteMessagewithAttachment');
 

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-delete-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-delete-message-with-attachment.cypress.spec.js
@@ -17,7 +17,11 @@ describe('Secure Messaging - Delete Message with Attachment', () => {
     mockMessagewithAttachment.data.attributes.attachment = true;
     mockMessagewithAttachment.data.attributes.body = 'attachment';
     landingPage.loadInboxMessages(mockMessages, mockMessagewithAttachment);
-
+    cy.intercept(
+      'GET',
+      '/my_health/v1/messaging/folders/0/messages?per_page=-1&useCache=false',
+      mockMessages,
+    ).as('messagesFolder');
     cy.intercept(
       'PATCH',
       `/my_health/v1/messaging/threads/${

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -30,7 +30,7 @@ export const Alerts = {
     GET_MESSAGE_ERROR: 'We’re sorry. Something went wrong on our end.',
     DELETE_MESSAGE_SUCCESS: 'Message thread was successfully moved to Trash.',
     DELETE_MESSAGE_ERROR:
-      'Message thread could not be deleted. Try again later. If this problem persists, contact the help desk.',
+      'Message could not be deleted. Try again later. If this problem persists, contact the help desk.',
     DRAFT_CANNOT_REPLY_INFO_HEADER:
       'This conversation is too old for new replies',
     DRAFT_CANNOT_REPLY_INFO_BODY: `The last message in this conversation is more than 45 days old. If you want to continue this conversation, you'll need to start a new message.`,

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -28,9 +28,9 @@ export const Alerts = {
       "The last message in this conversation is more than 45 days old. If you want to continue this conversation, you'll need to start a new message.",
     CANNOT_REPLY_INFO_HEADER: 'This conversation is too old for new replies',
     GET_MESSAGE_ERROR: 'We’re sorry. Something went wrong on our end.',
-    DELETE_MESSAGE_SUCCESS: 'Message was successfully moved to Trash.',
+    DELETE_MESSAGE_SUCCESS: 'Message thread was successfully moved to Trash.',
     DELETE_MESSAGE_ERROR:
-      'Message could not be deleted. Try again later. If this problem persists, contact the help desk.',
+      'Message thread could not be deleted. Try again later. If this problem persists, contact the help desk.',
     DRAFT_CANNOT_REPLY_INFO_HEADER:
       'This conversation is too old for new replies',
     DRAFT_CANNOT_REPLY_INFO_BODY: `The last message in this conversation is more than 45 days old. If you want to continue this conversation, you'll need to start a new message.`,


### PR DESCRIPTION
## Summary

- *Updated Delete thread API Call to move MessageThreads to the Trash Folder*

## Related issue(s)
- department-of-veterans-affairs/vets-website
https://vajira.max.gov/browse/MHV-39025


## Testing done

## Screenshots
**If call is successful, then the screen will be redirected to the active Folder**

(What screen looks like if api call fails)
<img width="709" alt="Screenshot 2023-03-29 at 10 38 12 AM" src="https://user-images.githubusercontent.com/59583325/228609996-d74ade85-4bfd-4f61-b7ac-ea03f722b17c.png">


## What areas of the site does it impact?
Va.gov - Secure Messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
