### PR TITLE
Supplemental Claims | Show evidence modal on newly added pages

### DIFF
--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -271,7 +271,7 @@ const EvidencePrivateRecords = ({
       // a new empty entry
       if (isEmptyPrivateEntry(currentData)) {
         updateCurrentFacility({ remove: true });
-      } else if (hasErrors() && addOrEdit === 'edit') {
+      } else if (hasErrors()) {
         // focus on first error
         updateState({
           submitted: true,

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -231,7 +231,7 @@ const EvidenceVaRecords = ({
       // a new empty entry
       if (isEmptyVaEntry(currentData)) {
         updateCurrentLocation({ remove: true });
-      } else if (hasErrors() && addOrEdit === 'edit') {
+      } else if (hasErrors()) {
         updateState({
           submitted: true,
           modal: { show: true, direction: NAV_PATHS.back },


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > When partially filling out a new evidence page, the modal would not appear when navigating back because it was only doing this for previous ('editing' instead of 'newly added') entries 
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Now shows the modal while navigating back for _all_ partially valid entries
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#54721](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54721)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Modal would not appear, and navigate to previous page, after adding a new location, and modifying one field
- *Describe the steps required to verify your changes are working as expected*
  > Add a new location, modify one field, then navigate back - the modal will now appear
- *Describe the tests completed and the results*
  > All tests passing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

N/A

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
