### PR TITLE
Update HCA short form flow conditionals

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -332,6 +332,7 @@ const formConfig = {
           title: 'Spouse\u2019s information',
           initialData: {},
           depends: formData =>
+            !isShortFormEligible(formData) &&
             formData.discloseFinancialInformation &&
             (formData.maritalStatus?.toLowerCase() === 'married' ||
               formData.maritalStatus?.toLowerCase() === 'separated'),
@@ -341,7 +342,9 @@ const formConfig = {
         dependentInformation: {
           path: 'household-information/dependent-information',
           title: 'Dependent information',
-          depends: formData => formData.discloseFinancialInformation,
+          depends: formData =>
+            !isShortFormEligible(formData) &&
+            formData.discloseFinancialInformation,
           uiSchema: dependentInformation.uiSchema,
           schema: dependentInformation.schema,
         },
@@ -349,14 +352,18 @@ const formConfig = {
           path: 'household-information/annual-income',
           title: 'Annual income',
           initialData: {},
-          depends: formData => formData.discloseFinancialInformation,
+          depends: formData =>
+            !isShortFormEligible(formData) &&
+            formData.discloseFinancialInformation,
           uiSchema: annualIncome.uiSchema,
           schema: annualIncome.schema,
         },
         deductibleExpenses: {
           path: 'household-information/deductible-expenses',
           title: 'Deductible expenses',
-          depends: formData => formData.discloseFinancialInformation,
+          depends: formData =>
+            !isShortFormEligible(formData) &&
+            formData.discloseFinancialInformation,
           uiSchema: deductibleExpenses.uiSchema,
           schema: deductibleExpenses.schema,
         },


### PR DESCRIPTION
## Description
In testing the Heath Care Application flows, a scenario was found to not follow the expected Short Form flow behavior. IF a Veteran changes their answer on the review page for the Compensation question, the form should skip all parts of the household section, however, in this case, the conditionals on household pages only rely on the conditional for the financial disclosure page. The PR updates the form page conditionals to check both the financial disclosure and short form eligibility conditionals.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#56024

## Acceptance criteria
- [ ]  When a Veteran changes their answer for the Compensation question, the 10-10EZ form will update to follow the appropriate flow, depending on the answer (short form or long form)
