### PR TITLE
Add aria-describedby to legal text on review page of 26-4555

### DIFF
--- a/src/applications/simple-forms/26-4555/containers/PreSubmitSignature.jsx
+++ b/src/applications/simple-forms/26-4555/containers/PreSubmitSignature.jsx
@@ -103,7 +103,7 @@ const PreSubmitSignature = ({
       </p>
       <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--3 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--3">
         <h3>Statement of truth</h3>
-        <p>
+        <p id="certify-text">
           I certify that I am applying for assistance in acquiring specially
           adapted housing or special home adaptation grant because of the nature
           of my service-connected disability. I understand that there are
@@ -137,6 +137,7 @@ const PreSubmitSignature = ({
                   ''} ${last}`
               : ''
           }
+          ariaDescribedby="certify-text"
         />
 
         <Checkbox


### PR DESCRIPTION
## Summary
This pull request adds the `aria-describedby` field to the text input used in the signature review section of the review page of 26-4555.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#55699