### PR TITLE
VACMS-11814: Removes target="_blank" from Facility Locator directions link

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
@@ -20,7 +20,6 @@ function LocationDirectionsLink({ location, from }) {
           location.searchString
         }&daddr=${address}`}
         rel="noopener noreferrer"
-        target="_blank"
       >
         {from === 'FacilityDetail' && <i className="fa fa-road" />}
         Get directions on Google Maps

--- a/src/applications/facility-locator/tests/components/search-results/LocationDirectionsLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationDirectionsLink.unit.spec.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import _ from 'lodash';
 import { shallow } from 'enzyme';
-import LocationDirectionsLink from '../../../components/search-results-items/common/LocationDirectionsLink';
 import { expect } from 'chai';
+import LocationDirectionsLink from '../../../components/search-results-items/common/LocationDirectionsLink';
 import testDataFacilities from '../../../constants/mock-facility-v1.json';
 import testDataProviders from '../../../constants/mock-facility-data-v1.json';
 
@@ -13,7 +13,7 @@ const verifyLink = data => {
         ...data,
         ...{ searchString: 'my house' },
       }}
-      from={'SearchResult'}
+      from="SearchResult"
     />,
   );
 
@@ -24,7 +24,6 @@ const verifyLink = data => {
     href:
       'https://maps.google.com?saddr=my house&daddr=7901 Metropolis Drive, Austin, TX 78744-3111',
     rel: 'noopener noreferrer',
-    target: '_blank',
   });
   expect(wrapper.find('a').text()).to.equal(
     'Get directions on Google Mapsto Austin VA Clinic',


### PR DESCRIPTION
## Summary
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11814

Clicking "Get directions on Google Maps" previously resulted in Google Maps opening in a new tab. This behavior was not good for accessibility. This PR changes that behavior to open in the existing tab.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11814

## Testing done
1. Visit `/find-locations`.
2. Complete fields:
    - City, state or postal code: "New York"
    - Facility type: "VA health"
    - Service type: "All VA health services"
3. Click "Search"
4. Find top result: "Margaret Cochran Corbin VA Campus"
5. Within that result, click "Get directions on Google Maps".
6. Confirm that Google Maps opens in the _existing tab_.
7. Click the "back" button.
8. Confirm that you're taken back to the previous search results.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/228873920-bb5d4a09-7816-40cd-ab44-256d4860e869.png)

## What areas of the site does it impact?
The change impacts _only_ this one link in the Facility Locator.

## Acceptance criteria
- [ ]  ~I fixed|updated|added unit tests and integration tests for each feature (if applicable).~
- [x]  No error nor warning in the console.
- [ ]  ~Events are being sent to the appropriate logging solution~
- [ ]  ~Documentation has been updated (link to documentation)~
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  ~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~
- [ ]  ~If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected~
- [x]  I added a screenshot of the developed feature
- [ ]  ~[Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed~


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
