### PR TITLE
Supplemental Claims | Ignore "empty" memorable dates with 2 dashes

### DIFF
--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -210,8 +210,10 @@ const EvidencePrivateRecords = ({
     onChange: event => {
       const { target = {} } = event;
       const fieldName = target.name;
-      // detail.value from va-select & target.value from va-text-input
-      const value = event.detail?.value || target.value;
+      // detail.value from va-select &
+      // target.value from va-text-input & va-memorable-date
+      const value = event.detail?.value || target.value || '';
+      // empty va-memorable-date may return '--'
       updateCurrentFacility({ [fieldName]: value });
     },
 

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -171,8 +171,8 @@ const EvidenceVaRecords = ({
     onChange: event => {
       const { target = {} } = event;
       const fieldName = target.name;
-      // detail.value from va-select & target.value from va-text-input
-      const value = event.detail?.value || target.value;
+      // target.value from va-text-input & va-memorable-date
+      const value = target.value || '';
       updateCurrentLocation({ [fieldName]: value });
     },
 

--- a/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
@@ -142,6 +142,8 @@ describe('VA evidence', () => {
       expect(isEmptyVaEntry({ issues: [] })).to.be.true;
       expect(isEmptyVaEntry({ evidenceDates: null })).to.be.true;
       expect(isEmptyVaEntry({ evidenceDates: {} })).to.be.true;
+      expect(isEmptyVaEntry({ evidenceDates: { from: '--', to: '--' } })).to.be
+        .true;
       expect(
         isEmptyVaEntry({
           locationAndName: '',
@@ -426,6 +428,9 @@ describe('Private evidence', () => {
       expect(isEmptyPrivateEntry({ issues: [] })).to.be.true;
       expect(isEmptyPrivateEntry({ treatmentDateRange: null })).to.be.true;
       expect(isEmptyPrivateEntry({ treatmentDateRange: {} })).to.be.true;
+      expect(
+        isEmptyPrivateEntry({ treatmentDateRange: { from: '--', to: '--' } }),
+      ).to.be.true;
       expect(
         isEmptyPrivateEntry({
           providerFacilityName: '',

--- a/src/applications/appeals/995/validations/evidence.js
+++ b/src/applications/appeals/995/validations/evidence.js
@@ -5,6 +5,8 @@ import { isValidUSZipCode } from 'platform/forms/address';
 import { errorMessages, MAX_LENGTH } from '../constants';
 import { validateDate } from './date';
 
+const REGEX_EMPTY_DATE = /--/;
+
 /* *** VA *** */
 export const validateVaLocation = (errors, data) => {
   const { locationAndName } = data || {};
@@ -40,11 +42,13 @@ export const validateVaToDate = (errors, data) => {
 };
 
 // Check if VA evidence object is empty
+// an empty va-memorable-date value may equal '--'
 export const isEmptyVaEntry = (checkData = {}) =>
   [
     checkData.locationAndName || '',
     ...(checkData.issues || []),
-    ...Object.values(checkData.evidenceDates || {}),
+    (checkData.evidenceDates?.from || '').replace(REGEX_EMPTY_DATE, ''),
+    (checkData.evidenceDates?.to || '').replace(REGEX_EMPTY_DATE, ''),
   ].join('') === '';
 
 export const validateVaUnique = (errors, _data, fullData) => {
@@ -131,12 +135,15 @@ export const validatePrivateToDate = (errors, data) => {
   }
 };
 
+// Check if private evidence object is empty
+// an empty va-memorable-date value may equal '--'
 export const isEmptyPrivateEntry = (checkData = {}) => {
   const result = [
     checkData.providerFacilityName || '',
     ...Object.values(checkData.providerFacilityAddress || {}),
     ...(checkData.issues || []),
-    ...Object.values(checkData.treatmentDateRange || {}),
+    (checkData.treatmentDateRange?.from || '').replace(REGEX_EMPTY_DATE, ''),
+    (checkData.treatmentDateRange?.to || '').replace(REGEX_EMPTY_DATE, ''),
   ].join('');
   // country defaults to 'USA' when adding a new entry
   return result === '' || result === 'USA';


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > A11y review noted that the remove entry modal would appear after adding and removing a date within the `va-memorable-date` web component. This is an issue with the [web component returning `--` as a value instead of an empty string](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1665). Work-around has been added
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#54721](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54721)

## Testing done

- *Describe what the old behavior was prior to the change*
  > empty entry checker did not account for an "empty" date of `'--'`
- *Describe the steps required to verify your changes are working as expected*
  > - Start with a new entry (VA or private)
  > - Enter a partial or full treatment date
  > - Remove the date completely
  > - Navigate back - this should not show a modal and remove the entry automatically 
- *Describe the tests completed and the results*
  > Added unit test
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

N/A

## What areas of the site does it impact?

Supplemental Claims (1% in production)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
