### PR TITLE
MHV-43155 Secure Messaging: Set proper error focus on Compose and Reply forms

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/CategoryInput.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/CategoryInput.jsx
@@ -26,9 +26,9 @@ const CategoryInput = props => {
     [dispatch],
   );
 
-  const categoryChangeHandler = ({ target }) => {
-    setCategory(target.value);
-    setCategoryError(null);
+  const categoryChangeHandler = e => {
+    setCategory(e.detail.value || e.target.value);
+    if (e.detail.value || e.target.value) setCategoryError(null);
     setUnsavedNavigationError();
   };
 
@@ -44,7 +44,7 @@ const CategoryInput = props => {
           label="Category"
           className=" fieldset-input message-category"
           error={categoryError}
-          onRadioOptionSelected={categoryChangeHandler}
+          onVaValueChange={categoryChangeHandler}
         >
           {categories?.map((item, i) => (
             <VaRadioOption

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -6,6 +6,7 @@ import {
   VaModal,
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FileInput from './FileInput';
 import CategoryInput from './CategoryInput';
 import AttachmentsList from '../AttachmentsList';
@@ -46,6 +47,7 @@ const ComposeForm = props => {
   const [formPopulated, setFormPopulated] = useState(false);
   const [fieldsString, setFieldsString] = useState('');
   const [sendMessageFlag, setSendMessageFlag] = useState(false);
+  const [messageInvalid, setMessageInvalid] = useState(false);
   const [userSaved, setUserSaved] = useState(false);
   const [navigationError, setNavigationError] = useState(null);
   const [saveError, setSaveError] = useState(null);
@@ -68,6 +70,16 @@ const ComposeForm = props => {
     TEST_RESULTS,
     EDUCATION,
   } = Categories;
+
+  const focusOnErrorField = () => {
+    focusElement(
+      document
+        .querySelectorAll('[error]:not([error=""]')[0]
+        .shadowRoot.querySelector(
+          '[aria-describedby="error-message"], #error-message',
+        ),
+    );
+  };
 
   useEffect(
     () => {
@@ -119,6 +131,15 @@ const ComposeForm = props => {
       }
     },
     [sendMessageFlag, isSaving],
+  );
+
+  useEffect(
+    () => {
+      if (messageInvalid) {
+        focusOnErrorField();
+      }
+    },
+    [messageInvalid],
   );
 
   const recipientExists = recipientId => {
@@ -182,6 +203,7 @@ const ComposeForm = props => {
   };
 
   const checkMessageValidity = () => {
+    // setMessageInvalid(false);
     let messageValid = true;
     if (!selectedRecipient || selectedRecipient === '') {
       setRecipientError('Please select a recipient.');
@@ -199,6 +221,7 @@ const ComposeForm = props => {
       setCategoryError('Please select a category.');
       messageValid = false;
     }
+    setMessageInvalid(!messageValid);
     return messageValid;
   };
 
@@ -250,8 +273,9 @@ const ComposeForm = props => {
     if (!attachments.length) setNavigationError(null);
   };
 
-  const sendMessageHandler = () => {
+  const sendMessageHandler = async () => {
     // TODO add GA event
+    await setMessageInvalid(false);
     if (checkMessageValidity()) {
       setSendMessageFlag(true);
       setNavigationError(null);

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -194,7 +194,11 @@ const ComposeForm = props => {
 
   const checkMessageValidity = () => {
     let messageValid = true;
-    if (!selectedRecipient || selectedRecipient === '') {
+    if (
+      selectedRecipient === '0' ||
+      selectedRecipient === '' ||
+      !selectedRecipient
+    ) {
       setRecipientError('Please select a recipient.');
       messageValid = false;
     }
@@ -305,8 +309,10 @@ const ComposeForm = props => {
 
   const recipientHandler = e => {
     setSelectedRecipient(e.detail.value);
-    if (e.detail.value) setRecipientError('');
-    setUnsavedNavigationError();
+    if (e.detail.value !== '0') {
+      if (e.detail.value) setRecipientError('');
+      setUnsavedNavigationError();
+    }
   };
 
   const subjectHandler = e => {

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -6,7 +6,6 @@ import {
   VaModal,
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FileInput from './FileInput';
 import CategoryInput from './CategoryInput';
 import AttachmentsList from '../AttachmentsList';
@@ -16,6 +15,7 @@ import useDebounce from '../../hooks/use-debounce';
 import DeleteDraft from '../Draft/DeleteDraft';
 import { sortRecipients } from '../../util/helpers';
 import { sendMessage } from '../../actions/messages';
+import { focusOnErrorField } from '../../util/formHelpers';
 import RouteLeavingGuard from '../shared/RouteLeavingGuard';
 import HowToAttachFiles from '../HowToAttachFiles';
 import {
@@ -70,16 +70,6 @@ const ComposeForm = props => {
     TEST_RESULTS,
     EDUCATION,
   } = Categories;
-
-  const focusOnErrorField = () => {
-    focusElement(
-      document
-        .querySelectorAll('[error]:not([error=""]')[0]
-        .shadowRoot.querySelector(
-          '[aria-describedby="error-message"], #error-message',
-        ),
-    );
-  };
 
   useEffect(
     () => {
@@ -203,7 +193,6 @@ const ComposeForm = props => {
   };
 
   const checkMessageValidity = () => {
-    // setMessageInvalid(false);
     let messageValid = true;
     if (!selectedRecipient || selectedRecipient === '') {
       setRecipientError('Please select a recipient.');

--- a/src/applications/mhv/secure-messaging/util/formHelpers.js
+++ b/src/applications/mhv/secure-messaging/util/formHelpers.js
@@ -1,0 +1,11 @@
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+
+export const focusOnErrorField = () => {
+  focusElement(
+    document
+      .querySelectorAll('[error]:not([error=""]')[0]
+      .shadowRoot.querySelector(
+        '[aria-describedby="error-message"], #error-message, #input-error-message',
+      ),
+  );
+};

--- a/src/applications/mhv/secure-messaging/util/formHelpers.js
+++ b/src/applications/mhv/secure-messaging/util/formHelpers.js
@@ -1,11 +1,13 @@
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 export const focusOnErrorField = () => {
-  focusElement(
-    document
-      .querySelectorAll('[error]:not([error=""]')[0]
-      .shadowRoot.querySelector(
-        '[aria-describedby="error-message"], #error-message, #input-error-message',
-      ),
-  );
+  const errors = document.querySelectorAll('[error]:not([error=""]');
+  const firstError =
+    errors.length > 0 &&
+    errors[0]?.shadowRoot?.querySelector(
+      '[aria-describedby="error-message"], #error-message, #input-error-message',
+    );
+  if (firstError) {
+    focusElement(firstError);
+  }
 };


### PR DESCRIPTION
## Summary

Given a form with multiple required fields, upon hitting the send/submit button -keyboard focus moves to the highest error in the form.

**User Story:** As a Secure Messaging User, I want to be able to understand where my errors are on the compose message screen if I am using a screen reader so that I can fix the mistakes and send my message.

**Acceptance Criteria:**
AC1 Keyboard focus moves to the highest error in the form. (Multiple errors)

## Related issue(s)
- [MHV-43155 SM to VA.gov: MUST Accessibility Feedback - Multiple error response in form](https://vajira.max.gov/browse/MHV-43155)

## Testing done

- unit testing
- cypress testing
- SQA validation


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

<img width=250 src="https://user-images.githubusercontent.com/87077843/229651162-830bd4de-10e9-40e7-b854-c15f5131c78c.png"/>

## What areas of the site does it impact?
My Health - Secure Messaging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

