### PR TITLE
MHV-42407: left nav subpath toggle and printing fixed

### DIFF
--- a/src/applications/mhv/medical-records/components/Navigation.jsx
+++ b/src/applications/mhv/medical-records/components/Navigation.jsx
@@ -50,7 +50,7 @@ const Navigation = () => {
       path: '/health-history',
       label: 'Health history',
       datatestid: 'health-history-sidebar',
-      subPaths: healthHistoryPaths,
+      subpaths: healthHistoryPaths,
     },
     {
       path: '/share-your-medical-record',
@@ -99,21 +99,25 @@ const Navigation = () => {
 
   const handleActiveLinksStyle = path => {
     if (path === '/' && location.pathname === '/') return 'is-active';
-    if (path !== '/' && location.pathname === path) return 'is-active';
+    if (location.pathname === path) return 'is-active';
     return '';
   };
 
-  const subMenu = subPaths => {
+  const handleSubpathsOpen = path => {
+    return location.pathname !== '/' && location.pathname.includes(path);
+  };
+
+  const subMenu = subpaths => {
     return (
       <div className="sidebar-navigation-mr-list-menu">
         <ul className="usa-sidenav-list sub-list">
-          {subPaths.map((subPath, j) => (
-            <li key={j} data-testid={subPath.datatestid}>
+          {subpaths.map((subpath, j) => (
+            <li key={j} data-testid={subpath.datatestid}>
               <Link
-                className={handleActiveLinksStyle(subPath.path)}
-                to={subPath.path}
+                className={handleActiveLinksStyle(subpath.path)}
+                to={subpath.path}
               >
-                <span>{subPath.label}</span>
+                <span>{subpath.label}</span>
               </Link>
             </li>
           ))}
@@ -123,7 +127,7 @@ const Navigation = () => {
   };
 
   return (
-    <div className="medical-records-navigation vads-u-flex--auto vads-u-padding-bottom--7 medium-screen:vads-u-padding-bottom--0">
+    <div className="medical-records-navigation vads-u-flex--auto vads-u-padding-bottom--7 medium-screen:vads-u-padding-bottom--0 no-print">
       {openNavigationBurgerButton()}
       {(isNavigationOpen && isMobile) || isMobile === false ? (
         <div className="sidebar-navigation">
@@ -152,7 +156,9 @@ const Navigation = () => {
                     </Link>
                   </div>
 
-                  {path.subPaths && subMenu(path.subPaths)}
+                  {path.subpaths &&
+                    handleSubpathsOpen(path.path) &&
+                    subMenu(path.subpaths)}
                 </li>
               ))}
             </ul>

--- a/src/applications/mhv/medical-records/containers/HealthHistory.jsx
+++ b/src/applications/mhv/medical-records/containers/HealthHistory.jsx
@@ -33,7 +33,7 @@ const HealthHistory = () => {
           <va-link
             className="section-link"
             active
-            href="/my-health/medical-records/allergies"
+            href="/my-health/medical-records/health-history/allergies"
             text="Review your allergies"
             data-testid="section-link"
           />
@@ -47,7 +47,7 @@ const HealthHistory = () => {
           <va-link
             className="section-link"
             active
-            href="/my-health/medical-records/notes"
+            href="/my-health/medical-records/health-history/notes"
             text="Review your care summaries and notes"
             data-testid="section-link"
           />
@@ -65,7 +65,7 @@ const HealthHistory = () => {
           <va-link
             className="section-link"
             active
-            href="/my-health/medical-records/health-conditions"
+            href="/my-health/medical-records/health-history/health-conditions"
             text="Review your health conditions"
             data-testid="section-link"
           />
@@ -79,7 +79,7 @@ const HealthHistory = () => {
           <va-link
             className="section-link"
             active
-            href="/my-health/medical-records/vaccines"
+            href="/my-health/medical-records/health-history/vaccines"
             text="Review your vaccines"
             data-testid="section-link"
           />
@@ -97,7 +97,7 @@ const HealthHistory = () => {
           <va-link
             className="section-link"
             active
-            href="/my-health/medical-records/vitals"
+            href="/my-health/medical-records/health-history/vitals"
             text="Review your vitals"
             data-testid="section-link"
           />

--- a/src/applications/mhv/medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/VitalDetails.jsx
@@ -7,16 +7,11 @@ import { VaPagination } from '@department-of-veterans-affairs/component-library/
 import { dateFormat } from '../util/helpers';
 import { setBreadcrumbs } from '../actions/breadcrumbs';
 import { getVitalDetails } from '../actions/vitals';
+import PrintHeader from '../components/shared/PrintHeader';
 
 const MAX_PAGE_LIST_LENGTH = 5;
 const VitalDetails = () => {
   const filteredVitals = useSelector(state => state.mr.vitals.vitalDetails);
-  const user = useSelector(state => state.user.profile);
-  const { first, last, middle, suffix } = user.userFullName;
-  const name = user.first
-    ? `${last}, ${first} ${middle}, ${suffix}`
-    : 'Doe, John R., Jr.';
-  const { dob } = user;
   const { vitalType } = useParams();
   const dispatch = useDispatch();
 
@@ -191,12 +186,7 @@ const VitalDetails = () => {
 
   return (
     <>
-      <div className="print-only print-header">
-        <span>
-          {name} - {dob}
-        </span>
-        <h4>CONFIDENTIAL</h4>
-      </div>
+      <PrintHeader />
 
       {content()}
     </>


### PR DESCRIPTION
## Summary
The medical records left nav has been fixed to toggle subpaths properly so they are shown when the parent is open and closed when not. They have also been fixed to not show on print views. 

## Related issue(s)
https://vajira.max.gov/browse/MHV-42407

## Testing done
No new tests needed

## Screenshots
<img width="278" alt="Screenshot 2023-04-03 at 5 50 41 PM" src="https://user-images.githubusercontent.com/107576133/229651383-6eef9dc7-a6bc-4bed-8479-02e1113469de.png">
<img width="319" alt="Screenshot 2023-04-03 at 5 51 18 PM" src="https://user-images.githubusercontent.com/107576133/229651388-498c5c65-9e0f-4a10-86f1-cc7028831e0a.png">
<img width="569" alt="Screenshot 2023-04-03 at 5 51 39 PM" src="https://user-images.githubusercontent.com/107576133/229651400-ede3f7cf-3956-49fb-8fd5-de42b7bdc620.png">

## What areas of the site does it impact?
MHV medical records rebuild app

## Acceptance criteria
- [ ]  The left navigation for Health History has been complete and follows the latest design in Sketch
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
