### PR TITLE
[eFSR] Updated goForward path for utility bills summary page

### DIFF
--- a/src/applications/financial-status-report/components/utilityBills/UtilityBillSummary.jsx
+++ b/src/applications/financial-status-report/components/utilityBills/UtilityBillSummary.jsx
@@ -28,7 +28,7 @@ const UtilityBillSummary = ({
   };
 
   const goForward = () => {
-    goToPath('/repayments');
+    goToPath('/credit-card-bills');
   };
 
   const cardBody = text => (


### PR DESCRIPTION
## Summary
Updated UtilityBIllsSummary `goToPath` to point at new credit card bills page instead of repayments to avoid loop caused by trying to access a page that has `depends` currently false

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#0000
- *Link to ticket created in va.gov-team repo*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*


## Testing done
Manual testing locally and in review instance

## What areas of the site does it impact?
FSR Utility bills page(s), hidden behind enhanced feature flag. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
