### PR TITLE
Allow for form without vets-json-schema

### DIFF
--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -49,7 +49,7 @@ const formConfigKeys = [
   'transformForSubmit',
   'confirmation',
   'preSubmitInfo',
-  'hasVetsJsonSchema',
+  'skipVetsJsonSchemaCheck',
   'footerContent',
   'getHelp',
   'errorText',
@@ -162,7 +162,7 @@ const validFormConfigKeys = formConfig => {
 };
 
 const validVetsJsonSchema = formConfig => {
-  if (formConfig.hasVetsJsonSchema === false) {
+  if (formConfig.skipVetsJsonSchemaCheck === true) {
     return;
   }
   let { formId } = formConfig;
@@ -178,7 +178,7 @@ const validVetsJsonSchema = formConfig => {
   } else {
     expect(schemaFormIds).to.include(
       formId,
-      `the formId "${formId}" does not match an entry in vets-json-schema/dist/schemas. a) Add the ID to missingFromVetsJsonSchema, b) add the corresponding schema to the vets-json-schema repo, or c) set hasVetsJsonSchema to false in the formConfig if it should not have a corresponding vets-json-schema.`,
+      `the formId "${formId}" does not match an entry in vets-json-schema/dist/schemas. a) Add the ID to missingFromVetsJsonSchema, b) add the corresponding schema to the vets-json-schema repo, or c) set skipVetsJsonSchemaCheck to true if the vets-json-schema should not be verified.`,
     );
   }
 };

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -49,6 +49,7 @@ const formConfigKeys = [
   'transformForSubmit',
   'confirmation',
   'preSubmitInfo',
+  'hasVetsJsonSchema',
   'footerContent',
   'getHelp',
   'errorText',
@@ -160,13 +161,14 @@ const validFormConfigKeys = formConfig => {
   });
 };
 
-const validFormId = formConfig => {
+const validVetsJsonSchema = formConfig => {
+  if (formConfig.hasVetsJsonSchema === false) {
+    return;
+  }
   let { formId } = formConfig;
   if (Object.keys(remapFormId).includes(formId)) {
     formId = remapFormId[formId];
   }
-
-  validStringProperty(formConfig, 'formId');
   const schemaFormIds = Object.keys(schemas);
   if (missingFromVetsJsonSchema.includes(formId)) {
     expect(schemaFormIds).to.not.include(
@@ -176,7 +178,7 @@ const validFormId = formConfig => {
   } else {
     expect(schemaFormIds).to.include(
       formId,
-      `the formId "${formId}" does not match an entry in vets-json-schema/dist/schemas. Add the ID to missingFromVetsJsonSchema or add the corresponding schema to the vets-json-schema repo.`,
+      `the formId "${formId}" does not match an entry in vets-json-schema/dist/schemas. a) Add the ID to missingFromVetsJsonSchema, b) add the corresponding schema to the vets-json-schema repo, or c) set hasVetsJsonSchema to false in the formConfig if it should not have a corresponding vets-json-schema.`,
     );
   }
 };
@@ -291,7 +293,8 @@ describe('form:', () => {
         import(configFilePath).then(({ default: formConfig }) => {
           validStringProperty(formConfig, 'ariaDescribedBySubmit', false);
           validFormConfigKeys(formConfig);
-          validFormId(formConfig);
+          validStringProperty(formConfig, 'formId');
+          validVetsJsonSchema(formConfig);
           validStringProperty(formConfig, 'rootUrl', true);
           validNumberProperty(formConfig, 'version');
           validMigrations(formConfig);


### PR DESCRIPTION
## Summary

Add the ability to add `skipVetsJsonSchemaCheck: true` to your `formConfig` in your `config/form.js` to opt-out of verifying a vets-json-schema.

This is intended to:
- Allow for a more seamless process for new forms where `vets-website` can get a head start without the `vets-json-schema` in place yet.  Currently if you want to do `vets-website` first, you have to modify platform file `forms.unit.spec.js` every time, by including `missingFromVetsJsonSchema`, and then removing it afterwards. This involves platform approval on two different steps (removal and addition).
- `missingFromVetsJsonSchema` would still be be checked by default if you do not include `skipVetsJsonSchemaCheck`
- This will not affect any existing forms. `vets-json-schema` will still be checked.
- Some future forms may not want to use `vets-json-schema` at all
- Tested this solution on a new form, and it works properly

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#166

## Testing done

- All unit tests pass


## Screenshots
No change.

## What areas of the site does it impact?
Future forms having ability to opt out of vets-json-schema

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Documentation has been updated (link to documentation)
