### PR TITLE
Bugfix: Remove newline characters from remarksString

### DIFF
--- a/src/applications/simple-forms/26-4555/config/submit-transformer.js
+++ b/src/applications/simple-forms/26-4555/config/submit-transformer.js
@@ -15,12 +15,12 @@ export default function transformForSubmit(formConfig, form) {
       // non-empty strings add their string content
       remarkString +=
         remarksFormData[remarkKey] === true
-          ? `${remarksUiSchema[remarkKey]['ui:title']}, `
-          : `${remarksFormData[remarkKey]}, `;
+          ? `${remarksUiSchema[remarkKey]['ui:title']}; `
+          : `${remarksFormData[remarkKey].replaceAll('\n', '; ')}; `;
     }
   });
 
-  // removes final ', ' and trims whitespace
+  // removes final '; ' and trims whitespace
   remarkString = remarkString.slice(0, remarkString.length - 2).trim();
 
   const transformedData = JSON.parse(


### PR DESCRIPTION
## Summary
We were getting JSON parsing errors on the back end when submitting new line characters in the remarks string. This PR removes the new line characters before submitting the form data to vets-api.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team-forms#173