### PR TITLE
build vets-website to run on localhost

### DIFF
--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -13,10 +13,11 @@ tar -xf vagovdev.tar.bz2 -C content-build/build/localhost/
 echo "set yarn to allow self-signed cert for install"
 yarn config set "strict-ssl" false
 
-# Watch vets-website
-echo "Install and watch vets-website"
+# Build and watch vets-website
+echo "Install, build, and watch vets-website"
 cd vets-website
 yarn install
+yarn build:webpack:local
 yarn watch &
 
 # Serve the content-build


### PR DESCRIPTION
The `yarn watch` command starts the Webpack development server in the development environment, which builds the application in-memory and serves the assets. 

Currently we're running `yarn watch` without specifying a build environment, so it uses the default environment defined in the `webpack.config.js` file which is probably `dev`.

This PR explicitly builds the app to run on `localhost`.