### PR TITLE
SM to VA.gov: moving all error messages to constants

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -22,6 +22,7 @@ import {
   draftAutoSaveTimeout,
   Categories,
   Prompts,
+  ErrorMessages,
 } from '../../util/constants';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
@@ -199,19 +200,19 @@ const ComposeForm = props => {
       selectedRecipient === '' ||
       !selectedRecipient
     ) {
-      setRecipientError('Please select a recipient.');
+      setRecipientError(ErrorMessages.ComposeForm.RECIPIENT_REQUIRED);
       messageValid = false;
     }
     if (!subject || subject === '') {
-      setSubjectError('Subject cannot be blank.');
+      setSubjectError(ErrorMessages.ComposeForm.SUBJECT_REQUIRED);
       messageValid = false;
     }
     if (messageBody === '' || messageBody.match(/^[\s]+$/)) {
-      setBodyError('Message body cannot be blank.');
+      setBodyError(ErrorMessages.ComposeForm.BODY_REQUIRED);
       messageValid = false;
     }
     if (!category || category === '') {
-      setCategoryError('Please select a category.');
+      setCategoryError(ErrorMessages.ComposeForm.CATEGORY_REQUIRED);
       messageValid = false;
     }
     setMessageInvalid(!messageValid);
@@ -222,21 +223,11 @@ const ComposeForm = props => {
     if (type === 'manual') {
       setUserSaved(true);
       if (!checkMessageValidity()) {
-        setSaveError({
-          title: "We can't save this message yet",
-          p1:
-            'We need more information from you before we can save this draft.',
-          p2:
-            "You can continue editing your draft and then save it. Or you can delete it. If you delete a draft, you can't get it back.",
-        });
+        setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE);
         return;
       }
       if (attachments.length) {
-        setSaveError({
-          title: "We can't save attachments in a draft message",
-          p1:
-            "If you save this message as a draft, you'll need to attach your files again when you're ready to send the message.",
-        });
+        setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE_DRAFT_ATTACHMENT);
         setNavigationError(null);
       }
     }
@@ -298,10 +289,7 @@ const ComposeForm = props => {
 
   const setUnsavedNavigationError = () => {
     setNavigationError({
-      title: "We can't save this message yet",
-      p1: 'We need more information from you before we can save this draft.',
-      p2:
-        "You can continue editing your draft and then save it. Or you can delete it. If you delete a draft, you can't get it back.",
+      ...ErrorMessages.ComposeForm.UNABLE_TO_SAVE,
       confirmButtonText: 'Continue editing',
       cancelButtonText: 'Delete draft',
     });

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/DraftSavedInfo.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/DraftSavedInfo.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { dateFormat } from '../../util/helpers';
+import { ErrorMessages } from '../../util/constants';
 
 const DraftSavedInfo = props => {
   const { userSaved } = props;
@@ -32,7 +33,7 @@ const DraftSavedInfo = props => {
         visible="true"
       >
         <p className="vads-u-margin-y--0">
-          Something went wrong... Failed to save message.
+          {ErrorMessages.ComposeForm.UNABLE_TO_SAVE_OTHER}
         </p>
       </va-alert>
     );

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/FileInput.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/FileInput.jsx
@@ -1,6 +1,10 @@
 import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { acceptedFileTypes, Attachments } from '../../util/constants';
+import {
+  acceptedFileTypes,
+  Attachments,
+  ErrorMessages,
+} from '../../util/constants';
 
 const FileInput = ({ attachments, setAttachments }) => {
   const [error, setError] = useState();
@@ -28,7 +32,7 @@ const FileInput = ({ attachments, setAttachments }) => {
 
     if (selectedFile.size === 0) {
       setError({
-        message: 'Your file is empty. Try attaching a different file.',
+        message: ErrorMessages.ComposeForm.ATTACHMENTS.FILE_EMPTY,
       });
       fileInputRef.current.value = null;
       return;
@@ -36,7 +40,7 @@ const FileInput = ({ attachments, setAttachments }) => {
 
     if (!fileExtension || !acceptedFileTypes[fileExtension.toLowerCase()]) {
       setError({
-        message: `We can't attach this file type. Try attaching a DOC, JPG, PDF, PNG, RTF, TXT, or XLS.`,
+        message: ErrorMessages.ComposeForm.ATTACHMENTS.INVALID_FILE_TYPE,
       });
       fileInputRef.current.value = null;
       return;
@@ -48,7 +52,7 @@ const FileInput = ({ attachments, setAttachments }) => {
       ).length > 0
     ) {
       setError({
-        message: 'You have already attached this file.',
+        message: ErrorMessages.ComposeForm.ATTACHMENTS.FILE_DUPLICATE,
       });
       fileInputRef.current.value = null;
       return;
@@ -65,8 +69,7 @@ const FileInput = ({ attachments, setAttachments }) => {
 
     if (selectedFile.size > Attachments.MAX_FILE_SIZE) {
       setError({
-        message:
-          'Your file is too large. Try attaching a file smaller than 6MB.',
+        message: ErrorMessages.ComposeForm.ATTACHMENTS.FILE_TOO_LARGE,
       });
       fileInputRef.current.value = null;
       return;
@@ -78,7 +81,7 @@ const FileInput = ({ attachments, setAttachments }) => {
     ) {
       setError({
         message:
-          'Your files are too large. The total size of all files must be smaller than 10MB.',
+          ErrorMessages.ComposeForm.ATTACHMENTS.TOTAL_MAX_FILE_SIZE_EXCEEDED,
       });
       fileInputRef.current.value = null;
       return;

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -16,7 +16,7 @@ import EmergencyNote from '../EmergencyNote';
 import HowToAttachFiles from '../HowToAttachFiles';
 import { dateFormat, navigateToFolderByFolderId } from '../../util/helpers';
 import RouteLeavingGuard from '../shared/RouteLeavingGuard';
-import { draftAutoSaveTimeout } from '../../util/constants';
+import { ErrorMessages, draftAutoSaveTimeout } from '../../util/constants';
 import MessageThreadBody from '../MessageThread/MessageThreadBody';
 
 const ReplyForm = props => {
@@ -181,7 +181,7 @@ const ReplyForm = props => {
   const checkMessageValidity = () => {
     let messageValid = true;
     if (messageBody === '' || messageBody.match(/^[\s]+$/)) {
-      setBodyError('Message body cannot be blank.');
+      setBodyError(ErrorMessages.ComposeForm.BODY_REQUIRED);
       messageValid = false;
     }
     setMessageInvalid(!messageValid);
@@ -200,21 +200,11 @@ const ReplyForm = props => {
     if (type === 'manual') {
       setUserSaved(true);
       if (!checkMessageValidity()) {
-        setSaveError({
-          title: "We can't save this message yet",
-          p1:
-            'We need more information from you before we can save this draft.',
-          p2:
-            "You can continue editing your draft and then save it. Or you can delete it. If you delete a draft, you can't get it back.",
-        });
+        setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE);
         return;
       }
       if (attachments.length) {
-        setSaveError({
-          title: "We can't save attachments in a draft message",
-          p1:
-            "If you save this message as a draft, you'll need to attach your files again when you're ready to send the message.",
-        });
+        setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE_DRAFT_ATTACHMENT);
         setNavigationError(null);
       }
     }
@@ -280,9 +270,7 @@ const ReplyForm = props => {
 
   if (!sendMessageFlag && !navigationError && attachments.length) {
     setNavigationError({
-      title: "We can't save attachments in a draft message",
-      p1:
-        "If you save this message as a draft, you'll need to attach your files again when you're ready to send the message.",
+      ...ErrorMessages.ComposeForm.UNABLE_TO_SAVE_DRAFT_ATTACHMENT,
       confirmButtonText: 'Continue editing',
       cancelButtonText: 'OK',
     });

--- a/src/applications/mhv/secure-messaging/components/Dashboard/DashboardSearch.jsx
+++ b/src/applications/mhv/secure-messaging/components/Dashboard/DashboardSearch.jsx
@@ -8,7 +8,7 @@ import {
 import AdvancedSearchExpander from '../Search/AdvancedSearchExpander';
 import { foldersList as folders } from '../../selectors';
 import { runBasicSearch } from '../../actions/search';
-import { DefaultFolders as Folders } from '../../util/constants';
+import { ErrorMessages, DefaultFolders as Folders } from '../../util/constants';
 
 const DashboardSearch = () => {
   const dispatch = useDispatch();
@@ -23,12 +23,12 @@ const DashboardSearch = () => {
 
   const handleSearchSubmit = () => {
     if (!searchFolder) {
-      setSearchFolderError('Please select a folder');
+      setSearchFolderError(ErrorMessages.SearchForm.FOLDER_REQUIRED);
     } else {
       setSearchFolderError(null);
     }
     if (!keyword) {
-      setKeywordError('Please enter a keyword');
+      setKeywordError(ErrorMessages.SearchForm.KEYWORD_REQUIRED);
     } else {
       setKeywordError(null);
     }
@@ -57,7 +57,9 @@ const DashboardSearch = () => {
                 onVaSelect={e => {
                   setSearchFolder(e.target.value);
                   setSearchFolderError(
-                    e.target.value ? null : 'Please select a folder',
+                    e.target.value
+                      ? null
+                      : ErrorMessages.SearchForm.FOLDER_REQUIRED,
                   );
                 }}
                 error={searchFolderError}
@@ -79,7 +81,9 @@ const DashboardSearch = () => {
                   onInput={e => {
                     setKeyword(e.target.value);
                     setKeywordError(
-                      e.target.value ? null : 'Please enter a keyword',
+                      e.target.value
+                        ? null
+                        : ErrorMessages.SearchForm.KEYWORD_REQUIRED,
                     );
                   }}
                   value={keyword}

--- a/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
+++ b/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
@@ -13,7 +13,7 @@ import {
   retrieveFolder,
 } from '../actions/folders';
 import { closeAlert } from '../actions/alerts';
-import { Alerts } from '../util/constants';
+import { Alerts, ErrorMessages } from '../util/constants';
 
 const ManageFolderButtons = () => {
   const dispatch = useDispatch();
@@ -76,9 +76,9 @@ const ManageFolderButtons = () => {
     folderMatch = null;
     folderMatch = folders.filter(testFolder => testFolder.name === folderName);
     if (folderName === '' || folderName.match(/^[\s]+$/)) {
-      setNameWarning('Folder name cannot be blank');
+      setNameWarning(ErrorMessages.ManageFolders.FOLDER_NAME_REQUIRED);
     } else if (folderMatch.length > 0) {
-      setNameWarning('Folder name already in use. Please use another name.');
+      setNameWarning(ErrorMessages.ManageFolders.FOLDER_NAME_EXISTS);
     } else if (folderName.match(/^[0-9a-zA-Z\s]+$/)) {
       closeRenameModal();
       dispatch(renameFolder(folderId, folderName)).then(() => {
@@ -89,7 +89,7 @@ const ManageFolderButtons = () => {
       });
     } else {
       setNameWarning(
-        'Folder name can only contain letters, numbers, and spaces.',
+        ErrorMessages.ManageFolders.FOLDER_NAME_INVALID_CHARACTERS,
       );
     }
   };

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
@@ -49,7 +49,9 @@ const MoveMessageToFolderBtn = props => {
 
   const handleConfirmMoveFolderTo = () => {
     if (selectedFolder === null) {
-      setFolderInputError('Please select a folder to move the message to.');
+      setFolderInputError(
+        Constants.ErrorMessages.MoveConversation.FOLDER_REQUIRED,
+      );
     } else {
       if (selectedFolder === 'newFolder') {
         setIsNewModalVisible(true);

--- a/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/AdvancedSearchForm.jsx
@@ -15,7 +15,7 @@ import {
 } from '../../util/inputContants';
 import { runAdvancedSearch } from '../../actions/search';
 import { dateFormat } from '../../util/helpers';
-import { DefaultFolders as Folders } from '../../util/constants';
+import { ErrorMessages, DefaultFolders as Folders } from '../../util/constants';
 
 const AdvancedSearchForm = props => {
   const {
@@ -61,11 +61,11 @@ const AdvancedSearchForm = props => {
     if (dateRange === 'custom' || testingDateRange) {
       if (!fromDate && !testingFromDate) {
         formInvalid = true;
-        setFromDateError('Please enter a start date');
+        setFromDateError(ErrorMessages.SearchForm.START_DATE_REQUIRED);
       }
       if (!toDate && !testingToDate) {
         formInvalid = true;
-        setToDateError('Please enter an end date');
+        setToDateError(ErrorMessages.SearchForm.END_DATE_REQUIRED);
       }
       if (
         (fromDate || testingFromDate) &&
@@ -73,8 +73,8 @@ const AdvancedSearchForm = props => {
         moment(toDate || testingToDate).isBefore(fromDate || testingFromDate)
       ) {
         formInvalid = true;
-        setFromDateError('Start date must be on or before end date');
-        setToDateError('End date must be on or after start date');
+        setFromDateError(ErrorMessages.SearchForm.START_DATE_AFTER_END_DATE);
+        setToDateError(ErrorMessages.SearchForm.END_DATE_BEFORE_START_DATE);
       }
     } else if (
       dateRange === 'any' &&
@@ -139,10 +139,7 @@ const AdvancedSearchForm = props => {
           status="error"
           visible
         >
-          <p>
-            Please use at least one of the following search fields or choose a
-            date range other than 'any'.
-          </p>
+          <p>{ErrorMessages.SearchForm.NO_FIELDS_SELECTED_MODAL_HEADER}</p>
           <ul>
             <li>Message ID</li>
             <li>From</li>

--- a/src/applications/mhv/secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/Search/SearchForm.jsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { VaSearchInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { runBasicSearch } from '../../actions/search';
 import AdvancedSearchExpander from './AdvancedSearchExpander';
+import { ErrorMessages } from '../../util/constants';
 
 const SearchForm = props => {
   const { folder, keyword, resultsCount, query } = props;
@@ -28,7 +29,7 @@ const SearchForm = props => {
     setSearchTermError(null);
 
     if (!searchTerm) {
-      setSearchTermError('Please enter a search term');
+      setSearchTermError(ErrorMessages.SearchForm.SEARCH_TERM_REQUIRED);
       return;
     }
     dispatch(runBasicSearch(folder.folderId, e.target.value.toLowerCase()));

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -20,6 +20,56 @@ export const DefaultFolders = {
   },
 };
 
+export const ErrorMessages = {
+  ComposeForm: {
+    RECIPIENT_REQUIRED: 'Please select a recipient.',
+    CATEGORY_REQUIRED: 'Please select a category.',
+    SUBJECT_REQUIRED: 'Subject cannot be blank.',
+    BODY_REQUIRED: 'Message body cannot be blank.',
+    UNABLE_TO_SAVE: {
+      title: "We can't save this message yet",
+      p1: 'We need more information from you before we can save this draft.',
+      p2:
+        "You can continue editing your draft and then save it. Or you can delete it. If you delete a draft, you can't get it back.",
+    },
+    UNABLE_TO_SAVE_DRAFT_ATTACHMENT: {
+      title: "We can't save attachments in a draft message",
+      p1:
+        "If you save this message as a draft, you'll need to attach your files again when you're ready to send the message.",
+    },
+    UNABLE_TO_SAVE_OTHER: 'Something went wrong... Failed to save message.',
+    ATTACHMENTS: {
+      FILE_EMPTY: 'Your file is empty. Try attaching a different file.',
+      INVALID_FILE_TYPE: `We can't attach this file type. Try attaching a DOC, JPG, PDF, PNG, RTF, TXT, or XLS.`,
+      FILE_DUPLICATE: 'You have already attached this file.',
+      FILE_TOO_LARGE:
+        'Your file is too large. Try attaching a file smaller than 6MB.',
+      TOTAL_MAX_FILE_SIZE_EXCEEDED:
+        'Your files are too large. The total size of all files must be smaller than 10MB.',
+    },
+  },
+  SearchForm: {
+    FOLDER_REQUIRED: 'Please select a folder',
+    KEYWORD_REQUIRED: 'Please enter a keyword',
+    START_DATE_REQUIRED: 'Please enter a start date',
+    END_DATE_REQUIRED: 'Please enter an end date',
+    START_DATE_AFTER_END_DATE: 'Start date must be on or before end date',
+    END_DATE_BEFORE_START_DATE: 'End date must be on or after start date',
+    NO_FIELDS_SELECTED_MODAL_HEADER:
+      "Please use at least one of the following search fields or choose a date range other than 'any'.",
+    SEARCH_TERM_REQUIRED: 'Please enter a search term',
+  },
+  MoveConversation: {
+    FOLDER_REQUIRED: 'Please select a folder to move the message to.',
+  },
+  ManageFolders: {
+    FOLDER_NAME_REQUIRED: 'Folder name cannot be blank',
+    FOLDER_NAME_EXISTS: 'Folder name already in use. Please use another name.',
+    FOLDER_NAME_INVALID_CHARACTERS:
+      'Folder name can only contain letters, numbers, and spaces.',
+  },
+};
+
 export const Alerts = {
   Message: {
     BLOCKED_MESSAGE_ERROR:


### PR DESCRIPTION
## Summary

- reconsolidating all error messages to appear in one constants file


## Testing done

- unit and e2e testing 


## Screenshots
no front end changes

## What areas of the site does it impact?
My Health - Secure Messaging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
