### PR TITLE
12980 manage create account block

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -100,7 +100,6 @@ class SearchHelpSignIn extends Component {
           this.props.isHeaderV2 ? '' : ' vads-u-padding-top--1'
         }`}
       >
-        {/* {this.renderCreateAccountBlock()} */}
         {/* Search */}
         {!this.props.isHeaderV2 && (
           <SearchMenu

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -26,7 +26,7 @@ class SearchHelpSignIn extends Component {
   };
 
   componentDidMount() {
-    this.checkHomepageCreateAccountBlock();
+    this.showHomepageCreateAccountBlock();
   }
 
   componentDidUpdate(prevProps) {
@@ -36,7 +36,7 @@ class SearchHelpSignIn extends Component {
     ) {
       return;
     }
-    this.checkHomepageCreateAccountBlock();
+    this.showHomepageCreateAccountBlock();
   }
 
   handleSignInSignUp = e => {
@@ -55,9 +55,9 @@ class SearchHelpSignIn extends Component {
 
   handleAccountMenuClick = this.handleMenuClick('account');
 
-  checkHomepageCreateAccountBlock = () => {
+  showHomepageCreateAccountBlock = () => {
     if (
-      this.shouldRenderSignedInContent() &&
+      !this.shouldRenderSignedInContent() &&
       (window.location.pathname === '/' ||
         window.location.pathname === '/new-home-page/')
     ) {

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -25,6 +25,20 @@ class SearchHelpSignIn extends Component {
     ]),
   };
 
+  componentDidMount() {
+    this.checkHomepageCreateAccountBlock();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.isLoggedIn === this.props.isLoggedIn &&
+      prevProps.isProfileLoading === this.props.isProfileLoading
+    ) {
+      return;
+    }
+    this.checkHomepageCreateAccountBlock();
+  }
+
   handleSignInSignUp = e => {
     e.preventDefault();
     this.props.onSignInSignUp();
@@ -41,37 +55,44 @@ class SearchHelpSignIn extends Component {
 
   handleAccountMenuClick = this.handleMenuClick('account');
 
-  renderSignInContent = () => {
-    const isLoading = this.props.isProfileLoading;
-    const shouldRenderSignedInContent =
-      (!isLoading && this.props.isLoggedIn) || (isLoading && hasSession());
-
-    const isSubdomain = isVATeamSiteSubdomain();
-
-    // Render if (1) profile has loaded and the user is confirmed logged in or
-    // (2) loading is in progress and the session is still considered active.
-    if (shouldRenderSignedInContent) {
-      return (
-        <SignInProfileMenu
-          disabled={isLoading}
-          clickHandler={this.handleAccountMenuClick}
-          greeting={this.props.userGreeting}
-          isOpen={this.props.isMenuOpen.account}
-          isLOA3={this.props.isLOA3}
-        />
-      );
-    }
-    // This handles logic to reveal the create account block on the homepage if the user is not logged in
+  checkHomepageCreateAccountBlock = () => {
     if (
-      window.location.pathname === '/' ||
-      window.location.pathname === '/new-home-page/'
+      this.shouldRenderSignedInContent() &&
+      (window.location.pathname === '/' ||
+        window.location.pathname === '/new-home-page/')
     ) {
+      // This handles logic to reveal the create account block on the homepage if the user is not logged in
       const createAccountBlock = document.getElementsByClassName(
         'homepage-hero__create-account',
       )[0];
       if (createAccountBlock) {
         createAccountBlock.classList.remove('vads-u-display--none');
       }
+    }
+  };
+
+  shouldRenderSignedInContent = () => {
+    return (
+      (!this.props.isProfileLoading && this.props.isLoggedIn) ||
+      (this.props.isProfileLoading && hasSession())
+    );
+  };
+
+  renderSignInContent = () => {
+    const isSubdomain = isVATeamSiteSubdomain();
+
+    // Render if (1) profile has loaded and the user is confirmed logged in or
+    // (2) loading is in progress and the session is still considered active.
+    if (this.shouldRenderSignedInContent()) {
+      return (
+        <SignInProfileMenu
+          disabled={this.props.isProfileLoading}
+          clickHandler={this.handleAccountMenuClick}
+          greeting={this.props.userGreeting}
+          isOpen={this.props.isMenuOpen.account}
+          isLOA3={this.props.isLOA3}
+        />
+      );
     }
     return (
       <div className="sign-in-links">

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -61,7 +61,18 @@ class SearchHelpSignIn extends Component {
         />
       );
     }
-
+    // This handles logic to reveal the create account block on the homepage if the user is not logged in
+    if (
+      window.location.pathname === '/' ||
+      window.location.pathname === '/new-home-page/'
+    ) {
+      const createAccountBlock = document.getElementsByClassName(
+        'homepage-hero__create-account',
+      )[0];
+      if (createAccountBlock) {
+        createAccountBlock.classList.remove('vads-u-display--none');
+      }
+    }
     return (
       <div className="sign-in-links">
         {!isSubdomain && (
@@ -89,6 +100,7 @@ class SearchHelpSignIn extends Component {
           this.props.isHeaderV2 ? '' : ' vads-u-padding-top--1'
         }`}
       >
+        {/* {this.renderCreateAccountBlock()} */}
         {/* Search */}
         {!this.props.isHeaderV2 && (
           <SearchMenu


### PR DESCRIPTION
## Summary

- Adds logic to manage display of the create account block on the new homepage
- A separate content-build PR will add a 'display none' class to the create account block, this adds JavaScript that will manage whether the block is hidden based on login state
- Because this requires a separate content-build PR, this won't be testable in a review instance. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12980


## Testing done

- Local testing


## Screenshots
_Note: 
<img width="1512" alt="Screen Shot 2023-04-06 at 1 23 01 PM" src="https://user-images.githubusercontent.com/61624970/230453901-c5ec455c-16be-46aa-8fe2-46131ad4bbb8.png">
<img width="1512" alt="Screen Shot 2023-04-06 at 1 21 10 PM" src="https://user-images.githubusercontent.com/61624970/230453904-81a0f935-d058-4595-bd4c-2611c5869224.png">
This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
homepage

## Acceptance criteria

- [ ] Create account renders for logged out users
- [ ] Create account block is hidden for logged in users


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
