### PR TITLE
(feature) added call to drupal data on mega-menu

### DIFF
--- a/src/platform/site-wide/mega-menu/index.js
+++ b/src/platform/site-wide/mega-menu/index.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
+import { connectDrupalSourceOfTruthCerner } from 'platform/utilities/cerner/dsot';
 import startReactApp from '../../startup/react';
 import Main from './containers/Main';
 
@@ -17,6 +18,8 @@ import Main from './containers/Main';
  * @param {Redux.Store} store The common store used on the site
  */
 export default function startMegaMenuWidget(data, store) {
+  connectDrupalSourceOfTruthCerner(store.dispatch);
+
   startReactApp(
     <Provider store={store}>
       <Main megaMenuData={data} />


### PR DESCRIPTION
## Summary

- In order to use isCerner  logic, we need to call cerner data on loading of the mega menu
- [Slack Thread](https://dsva.slack.com/archives/C52CL1PKQ/p1680793891321189)
## What areas of the site does it impact?

- Header/Mega Menu. There is now an extra *.json call 
