### PR TITLE
My VA - update URL for "Check your Post-9/11 GI Bill benefits" link

### DIFF
--- a/src/applications/personalization/dashboard/components/education-and-training/EducationAndTraining.jsx
+++ b/src/applications/personalization/dashboard/components/education-and-training/EducationAndTraining.jsx
@@ -47,7 +47,7 @@ const EducationAndTraining = () => {
           <IconCTALink
             text="Check your Post-9/11 GI Bill benefits"
             icon="dollar-sign"
-            href="/education/gi-bill/post-9-11/ch-33-benefit/"
+            href="/education/gi-bill/post-9-11/ch-33-benefit/status"
             testId="check-gi-bill-benefits-from-cta"
             onClick={() =>
               recordEvent({

--- a/src/applications/personalization/dashboard/tests/e2e/loa1.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/loa1.cypress.spec.js
@@ -14,6 +14,8 @@ import manifest from '~/applications/personalization/dashboard/manifest.json';
 function loa1DashboardTest(mobile, stubs) {
   cy.visit(manifest.rootUrl);
 
+  // TODO: update cy.viewport to Cypress.env().vaTopMobileViewports
+  // https://depo-platform-documentation.scrollhelp.site/developer-docs/viewport-testing-helper-functions
   if (mobile) {
     cy.viewport('iphone-4');
   }
@@ -21,6 +23,9 @@ function loa1DashboardTest(mobile, stubs) {
   // make sure that the "Verify" alert is shown
   cy.findByText(/Verify your identity to access/i).should('exist');
   cy.findByText(/we need to make sure you’re you/i).should('exist');
+  cy.findByRole('link', { name: 'Verify your identity' })
+    .should('have.attr', 'href', '/verify')
+    .click();
 
   // focus should be on the h1
   cy.focused()
@@ -107,16 +112,5 @@ describe('The My VA Dashboard', () => {
 
   it('should handle LOA1 users at mobile phone size', () => {
     loa1DashboardTest(true, stubs);
-  });
-});
-
-describe('When clicking on the verify your identity link', () => {
-  it('should focus on the h1 element', () => {
-    cy.login(loa1User);
-    cy.visit(manifest.rootUrl);
-    cy.findByRole('link', { name: 'Verify your identity' })
-      .should('have.attr', 'href', '/verify')
-      .click();
-    cy.get('h1').should('be.focused');
   });
 });


### PR DESCRIPTION
## Summary
In UAT for My VA UX improvements, we found that the "Check your Post-9/11 GI Bill benefits" links to the content page for Post-9/11 GI bill benefits and we need it to deep link directly into the tool. This PR updates the URL on that link in the Education and Training section. Confirmed that GA tracking remains the same.

This PR also updates the `loa1.cypress.spec.js` e2e test, to make it more isolated to My VA. This also removes a terminal error that was haunting us for a while 👻 

## Related issue(s)
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/56336
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/41934

## Testing done
- visually locally
- all unit and e2e test pass

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| Before | After |
| --- | --- |
| ![post-9-11-gi-bill_href-before](https://user-images.githubusercontent.com/8542413/230679324-9f41ed4c-289d-4a11-a1e7-9b02b68a8a27.png) | ![post-9-11-gi-bill_href-after](https://user-images.githubusercontent.com/8542413/230679360-62ce5490-3a8a-42cf-8599-f05ebfabdc05.png) |

## What areas of the site does it impact?
My VA

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Documentation has been updated ([link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/my-va/2022-audit/documentation/education-and-training-FE-documentation.md))
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

