### PR TITLE
Replace AlertBox React component with 

### DIFF
--- a/src/platform/forms/save-in-progress/DowntimeMessage.jsx
+++ b/src/platform/forms/save-in-progress/DowntimeMessage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
 
@@ -34,6 +33,3 @@ export default function DowntimeMessage({
     </va-alert>
   );
 }
-DowntimeMessage.propTypes = {
-  downtime: PropTypes.string.isRequired,
-};

--- a/src/platform/forms/save-in-progress/DowntimeMessage.jsx
+++ b/src/platform/forms/save-in-progress/DowntimeMessage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
 
@@ -8,17 +8,17 @@ export default function DowntimeMessage({
   isAfterSteps,
   formConfig,
 }) {
-  const endTime = downtime.endTime;
+  const { endTime } = downtime;
   const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
   return (
-    <AlertBox
+    <va-alert
       className={classNames({
         'schemaform-downtime-after-steps': isAfterSteps,
       })}
-      headline={`This ${appType} is down for maintenance.`}
       isVisible
       status="warning"
     >
+      <h3 slot="headline">{`This ${appType} is down for maintenance.`}</h3>
       {endTime ? (
         <p>
           We’re making some updates to this {appType}. We’re sorry it’s not
@@ -31,6 +31,9 @@ export default function DowntimeMessage({
           working right now. Please check back soon.
         </p>
       )}
-    </AlertBox>
+    </va-alert>
   );
 }
+DowntimeMessage.propTypes = {
+  downtime: PropTypes.string.isRequired,
+};

--- a/src/platform/forms/tests/save-in-progress/DowntimeMessage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/DowntimeMessage.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import moment from 'moment';
 
@@ -7,31 +7,20 @@ import DowntimeMessage from '../../save-in-progress/DowntimeMessage';
 
 describe('<DowntimeMessage>', () => {
   it('should render with generic message', () => {
-    const tree = shallow(<DowntimeMessage downtime={{}} />);
-
-    expect(
-      tree
-        .find('AlertBox')
-        .dive()
-        .text(),
-    ).to.contain('We’re sorry it’s not working right now.');
-    tree.unmount();
+    const { container } = render(<DowntimeMessage downtime={{}} />);
+    expect(container.querySelector('va-alert p')).to.contain.text(
+      'We’re sorry it’s not working right now.',
+    );
   });
 
   it('should render with window message', () => {
     const endTime = moment().add(2, 'days');
-    const tree = shallow(<DowntimeMessage downtime={{ endTime }} />);
+    const { container } = render(<DowntimeMessage downtime={{ endTime }} />);
 
-    expect(
-      tree
-        .find('AlertBox')
-        .dive()
-        .text(),
-    ).to.contain(
+    expect(container.querySelector('va-alert p')).to.contain.text(
       `We’re sorry it’s not working right now, and we hope to be finished by ${endTime.format(
         'MMMM Do, LT',
       )}`,
     );
-    tree.unmount();
   });
 });

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
@@ -224,7 +224,7 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
       );
 
       expect(submit.find('.not-down').exists()).to.be.false;
-      expect(submit.find('AlertBox').exists()).to.be.true;
+      expect(submit.find('va-alert').exists()).to.be.true;
       submit.unmount();
     });
   });


### PR DESCRIPTION
## Summary

The PR replaces the `AlertBox` React component in the forms library with its corresponding web component and updates any affected tests.

`va-alert (VaAlert)`

https://design.va.gov/storybook/?path=/docs/components-va-alert--default

## Related issue(s)
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1535

## Testing done

- Viewed locally to confirm UI is correct
- Updated Unit tests

## Screenshots
Before
![Screenshot 2023-04-11 at 10 07 55 AM](https://user-images.githubusercontent.com/1413938/231189599-c59fad7c-ba59-4fcb-9f35-070c01205cc9.png)

After
![230979373-4bbc4196-7666-4c89-9e52-39da1ddb0836](https://user-images.githubusercontent.com/1413938/231189645-3dc30956-f4c6-42d1-b0f3-4ae6cdfb79c6.png)

## What areas of the site does it impact?
Any apps using the save in progress `DowntimeMessage`

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


