### PR TITLE
MHV-43440 SM to VA.gov: Add link to landing page which navigates to MHV SM

### DIFF
--- a/src/applications/mhv/secure-messaging/components/Dashboard/WelcomeMessage.jsx
+++ b/src/applications/mhv/secure-messaging/components/Dashboard/WelcomeMessage.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
+import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import FeedbackEmail from '../shared/FeedbackEmail';
 
 const WelcomeMessage = () => {
+  const fullState = useSelector(state => state);
   return (
     <div className="welcome-message">
       <h2>What to know as you try out this tool</h2>
@@ -17,7 +20,11 @@ const WelcomeMessage = () => {
       <p>
         <strong>Note:</strong> You still have access to the previous version of
         secure messaging. You can go back to that version at any time.{' '}
-        <a target="blank" href={mhvUrl(true, 'home')}>
+        <a
+          href={mhvUrl(isAuthenticatedWithSSOe(fullState), 'secure-messaging')}
+          target="_blank"
+          rel="noreferrer"
+        >
           Go back to the previous version of secure messaging
         </a>
       </p>

--- a/src/applications/mhv/secure-messaging/components/Dashboard/WelcomeMessage.jsx
+++ b/src/applications/mhv/secure-messaging/components/Dashboard/WelcomeMessage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 import FeedbackEmail from '../shared/FeedbackEmail';
 
 const WelcomeMessage = () => {
@@ -7,16 +8,18 @@ const WelcomeMessage = () => {
       <h2>What to know as you try out this tool</h2>
       <p>
         We’re giving the trusted My HealtheVet secure messaging tool a new home
-        here on VA.gov. You can use this tool to communicate securely with your
-        care team online-just like you can today on the My HealtheVet website.
+        on VA.gov. And we need your feedback to help us keep making this tool
+        better for you and all Veterans.
       </p>
       <p>
-        We need your feedback to help us keep making this tool better for you
-        and all Veterans.
+        Email your feedback and questions to us at <FeedbackEmail />.
       </p>
       <p>
-        Email us at <FeedbackEmail /> to tell us what you think. We can also
-        answer questions about how to use the tool.
+        <strong>Note:</strong> You still have access to the previous version of
+        secure messaging. You can go back to that version at any time.{' '}
+        <a target="blank" href={mhvUrl(true, 'home')}>
+          Go back to the previous version of secure messaging
+        </a>
       </p>
     </div>
   );

--- a/src/applications/mhv/secure-messaging/tests/containers/LandingPageAuth.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/LandingPageAuth.unit.spec.jsx
@@ -53,32 +53,19 @@ describe('Landing dashboard', () => {
     expect(screen.getByText(`What to know as you try out this tool`)).to.exist;
   });
 
-  /* it('displays a search component', () => {
-    expect(
-      screen.getByText(`Search for messages`, {
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText(`Search messages`, {
-        exact: true,
-      }),
-    ).to.exist;
-  }); */
-
-  /* it('displays a Folders List component', () => {
-    expect(
-      screen.getByText(`Folders`, {
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText(`TESTAGAIN`, {
-        exact: true,
+  it('displays a MHV URL Link', () => {
+    const link = screen.getByText(
+      `Go back to the previous version of secure messaging`,
+      {
         selector: 'a',
-      }),
-    ).to.exist;
-  }); */
+      },
+    );
+    expect(link).to.have.attribute(
+      'href',
+      'https://int.eauth.va.gov/mhv-portal-web/eauth',
+    );
+    expect(link).to.have.attribute('target', 'blank');
+  });
 
   it('displays a FAQ component', () => {
     expect(screen.getByText(`Questions about using messages`)).to.exist;

--- a/src/applications/mhv/secure-messaging/tests/containers/LandingPageAuth.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/LandingPageAuth.unit.spec.jsx
@@ -2,15 +2,24 @@ import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
+import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 import LandingPageAuth from '../../containers/LandingPageAuth';
 import reducer from '../../reducers';
 import folderList from '../fixtures/folder-response.json';
 import { unreadCountInbox } from '../../util/helpers';
+import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 
 describe('Landing dashboard', () => {
   const initialState = {
     sm: {
       folders: { folderList },
+    },
+    user: {
+      profile: {
+        session: {
+          ssoe: true,
+        },
+      },
     },
   };
 
@@ -62,9 +71,9 @@ describe('Landing dashboard', () => {
     );
     expect(link).to.have.attribute(
       'href',
-      'https://int.eauth.va.gov/mhv-portal-web/eauth',
+      mhvUrl(isAuthenticatedWithSSOe(initialState), 'secure-messaging'),
     );
-    expect(link).to.have.attribute('target', 'blank');
+    expect(link).to.have.attribute('target', '_blank');
   });
 
   it('displays a FAQ component', () => {


### PR DESCRIPTION
## Summary

SM to VA.gov: Add link to landing page that goes back to MHV SM

**User Story:**
As a SM user, I want to be able to navigate back to MHV SM so that

**Acceptance Criteria:**
AC1 Link back to MHV SM has been implemented
AC2 Replace current content in the "What to know as you try out this tool" section with this content:

> _What to know as you try out this tool
> We’re giving the trusted My HealtheVet secure messaging tool a new home on VA.gov. And we need your feedback to help us keep making this tool better for you and all Veterans._
> 
> _Email your feedback and questions to us at [VAmhvfeedback@va.gov](mailto:VAmhvfeedback@va.gov)._
> 
> _Note: You still have access to the previous version of secure messaging. You can go back to that version at any time. [deep link to secure messaging on MHV website] Go back to the previous version of secure messaging_

**Links to UCD:**
Sketch Link [Desktop](https://www.sketch.com/s/77fd8aec-67b1-446d-b64a-8b942865be82/v/JmarVz/a/uuid/FE4395D0-4384-4530-9B95-4008B585BEDE) | [Mobile](https://www.sketch.com/s/77fd8aec-67b1-446d-b64a-8b942865be82/v/JmarVz/a/uuid/3904F65C-F602-4BEB-A802-DDA4514FE4C9)
Other Design Notes

## Related issue(s)
- [Jira SM to VA.gov: Add link to landing page which navigates to MHV SM](https://vajira.max.gov/browse/MHV-43440)

## Testing done

- SQA + unit testing


## Screenshots

| | Before | After |
| --- | --- | --- |
| Mobile | <img width="100" alt="image" src="https://user-images.githubusercontent.com/87077843/230957044-18d3163e-481e-4f95-9bb7-132523e05a59.png"> | <img width="100" alt="image" src="https://user-images.githubusercontent.com/87077843/230956999-2d8cabc0-5b62-41bc-b7fc-e15e708a5b24.png"> |
| Desktop | <img width="200" alt="image" src="https://user-images.githubusercontent.com/87077843/230956910-9634efad-7487-46c3-ae37-19946d5aad16.png"> | <img width="200" alt="image" src="https://user-images.githubusercontent.com/87077843/230956708-a31bd6f6-08b1-4264-ae15-e8921007446f.png"> |

## What areas of the site does it impact?
My Health - Secure Messaging / Authenticated landing page

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

