### PR TITLE
Review & submit | Update accordion error style

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -359,7 +359,7 @@ class ReviewCollapsibleChapter extends React.Component {
     }
 
     const classes = classNames('usa-accordion-bordered', 'form-review-panel', {
-      'schemaform-review-chapter-warning': this.props.hasUnviewedPages,
+      'schemaform-review-chapter-error': this.props.hasUnviewedPages,
     });
 
     const headerClasses = classNames(
@@ -394,20 +394,19 @@ class ReviewCollapsibleChapter extends React.Component {
               {this.props.hasUnviewedPages && (
                 <span
                   aria-describedby={`collapsibleButton${this.id}`}
-                  className="schemaform-review-chapter-warning-icon"
+                  className="schemaform-review-chapter-error-icon"
                 />
               )}
             </h3>
             {this.props.hasUnviewedPages && (
-              <span
-                className="vads-u-color--secondary vads-u-border-left--10px vads-u-border-color--secondary vads-u-display--flex vads-u-padding-left--1p5 vads-u-align-items--center vads-u-font-weight--bold"
-                role="alert"
-                style={{ minHeight: '50px' }}
+              <va-alert
+                status="error"
+                background-only
                 aria-describedby={`collapsibleButton${this.id}`}
               >
                 <span className="sr-only">Error</span>
                 {chapterTitle} needs to be updated
-              </span>
+              </va-alert>
             )}
             <div id={`collapsible-${this.id}`}>{pageContent}</div>
           </li>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -400,6 +400,7 @@ class ReviewCollapsibleChapter extends React.Component {
             </h3>
             {this.props.hasUnviewedPages && (
               <va-alert
+                role="alert"
                 status="error"
                 background-only
                 aria-describedby={`collapsibleButton${this.id}`}

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -381,6 +381,12 @@ class ReviewCollapsibleChapter extends React.Component {
         <ul className="usa-unstyled-list" role="list">
           <li>
             <h3 className={headerClasses}>
+              {this.props.hasUnviewedPages && (
+                <span
+                  aria-describedby={`collapsibleButton${this.id}`}
+                  className="schemaform-review-chapter-error-icon"
+                />
+              )}
               <button
                 className="usa-button-unstyled"
                 aria-expanded={this.props.open ? 'true' : 'false'}
@@ -391,12 +397,6 @@ class ReviewCollapsibleChapter extends React.Component {
               >
                 {chapterTitle || ''}
               </button>
-              {this.props.hasUnviewedPages && (
-                <span
-                  aria-describedby={`collapsibleButton${this.id}`}
-                  className="schemaform-review-chapter-error-icon"
-                />
-              )}
             </h3>
             {this.props.hasUnviewedPages && (
               <va-alert

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -411,9 +411,7 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('.schemaform-review-chapter-warning').length).to.equal(
-      1,
-    );
+    expect(wrapper.find('.schemaform-review-chapter-error').length).to.equal(1);
     expect(wrapper.find('.schemaform-review-page-warning').length).to.equal(1);
     wrapper.unmount();
   });

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -491,19 +491,24 @@ legend.schemaform-label.schemaform-file-label {
   }
 }
 
+.form-review-panel .accordion-header > button.usa-button-unstyled {
+  padding: 2.5rem 4.5rem 2.5rem 2.5rem;
+  line-height: 2.2rem;
+}
+
 .schemaform-review-chapter-error {
   .schemaform-chapter-accordion-header {
     position: relative;
     margin-bottom: 0;
     border-bottom: 0.5rem solid var(--color-secondary-lightest);
-    > .usa-button-unstyled {
+    > button.usa-button-unstyled {
+      padding-left: 5rem;
       background-color: $color-secondary-lightest;
-      padding-left: 2rem;
     }
     .schemaform-review-chapter-error-icon {
       position: absolute;
       top: calc(50% - 0.6em);
-      right: 2rem;
+      left: 1.5rem;
       display: block;
       background-image: url("~uswds/dist/img/alerts/error.png");
       background-image: url("~uswds/dist/img/alerts/error.svg");

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -498,6 +498,7 @@ legend.schemaform-label.schemaform-file-label {
     border-bottom: 0.5rem solid var(--color-secondary-lightest);
     > .usa-button-unstyled {
       background-color: $color-secondary-lightest;
+      padding-left: 2rem;
     }
     .schemaform-review-chapter-error-icon {
       position: absolute;

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -491,19 +491,21 @@ legend.schemaform-label.schemaform-file-label {
   }
 }
 
-.schemaform-review-chapter-warning {
+.schemaform-review-chapter-error {
   .schemaform-chapter-accordion-header {
     position: relative;
+    margin-bottom: 0;
+    border-bottom: 0.5rem solid var(--color-secondary-lightest);
     > .usa-button-unstyled {
-      background-color: $color-gold-lightest;
+      background-color: $color-secondary-lightest;
     }
-    .schemaform-review-chapter-warning-icon {
+    .schemaform-review-chapter-error-icon {
       position: absolute;
-      top: 2.8rem;
-      right: 4rem;
+      top: calc(50% - 0.6em);
+      right: 2rem;
       display: block;
-      background-image: url("~uswds/dist/img/alerts/warning.png");
-      background-image: url("~uswds/dist/img/alerts/warning.svg");
+      background-image: url("~uswds/dist/img/alerts/error.png");
+      background-image: url("~uswds/dist/img/alerts/error.svg");
       width: 2em;
       height: 1.2em;
       background-size: 1.8em;
@@ -511,9 +513,9 @@ legend.schemaform-label.schemaform-file-label {
     }
   }
   .schemaform-chapter-accordion-content {
-    border-right-color: $color-gold-lightest;
-    border-left-color: $color-gold-lightest;
-    border-bottom-color: $color-gold-lightest;
+    border-right-color: $color-secondary-lightest;
+    border-left-color: $color-secondary-lightest;
+    border-bottom-color: $color-secondary-lightest;
   }
 }
 
@@ -639,15 +641,6 @@ legend.schemaform-label.schemaform-file-label {
 .schemaform-confirmation-claim-header {
   font-size: $h4-font-size;
   margin-top: 1em;
-}
-
-.usa-accordion,
-.usa-accordion-bordered {
-  > ul {
-    button {
-      border-radius: $button-border-radius;
-    }
-  }
 }
 
 .schemaform-title-underline {


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Upon submitting a form with validation errors, the accordion on the review & submit page changes to a yellow warning background color and displays a warning icon. A warning message is shown below the header. This PR changes the styling so that the accordion is showing a red error background color and icon. Summary of changes were made:
  > - Accordion styled with an error color and icon
  > - Alert span replaced by an error `va-alert`
  > - Aligned accordion error icon with accordion state icon for multi-line headers on small screens
  > - Left-aligned accordion header text with alert text 
  > - Moved the error icon to the left of the header text
  > - Removed accordion button border radius
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > This global change is more in line with a form submission error, not the warning that was previously shown
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

- [Slack conversation](https://dsva.slack.com/archives/C01DBGX4P45/p1681140060365449?thread_ts=1681138571.443339&cid=C01DBGX4P45)
- [#56608](https://github.com/department-of-veterans-affairs/va.gov-team/issues/56608)
- [DESIGN](https://www.sketch.com/s/d2416db4-9a4f-4919-abe4-20ba4bdcfd89/a/MmyE0Kz)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Accordion warning color with warning icon shown when form errors occurred
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Updated unit tests; all passing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | <img width="297" alt="accordion-warning-mobile" src="https://user-images.githubusercontent.com/136959/231281101-e957b006-a180-4e19-9a4d-cac4528be8e0.png"> | <img width="314" alt="accordion-error-mobile" src="https://user-images.githubusercontent.com/136959/231287091-9ceae6a2-7575-4c81-88b3-e788b8a4a59c.png"> |
| Desktop | ![accordion-warning-desktop](https://user-images.githubusercontent.com/136959/231281103-25314c38-4d4e-439e-b69a-4ea8a5d5bd33.png) | <img width="645" alt="accordion-error-desktop" src="https://user-images.githubusercontent.com/136959/231287090-35bb5253-09b3-4b2e-95ac-a5f454336c6d.png"> |

## What areas of the site does it impact?
 
All form review & submit pages

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
