### PR TITLE
cypress screenshot update

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -104,7 +104,11 @@ Current features day-of only: `yarn cy:run --env with_screenshots=true --spec sr
 
 Phone appointments PCI: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-phone.pci.cypress.spec.js`
 
-Travel Pay PCI: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js`
+Travel Pay day-of: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js`
+
+Errors only day-of: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-errors.day-of.cypress.spec.js`
+
+Errors only PCI: `yarn cy:run --env with_screenshots=true --spec src/applications/check-in/tests/e2e/screenshots/screenshots-errors.pci.cypress.spec.js`
 
 ### Adding additional screenshots
 There is a cypress command that gets imported in our local commands named `createScreenshots`. It is best used after an axe check on the page you wish to capture. Add cy.createScreenshots([filename]) and also make sure that the test is imported in one of the screenshot scripts listed above. Filename syntax should be `application--page-name` example: `Pre-check-in--Validate-with-DOB`. The command will automatically get screenshots for translated versions of the page.

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -142,7 +142,11 @@ const Error = () => {
           ),
         },
         {
-          type: form.data['travel-question'] === 'no' ? 'info' : 'warning',
+          type:
+            form.data['travel-question'] === 'no' ||
+            !isTravelReimbursementEnabled
+              ? 'info'
+              : 'warning',
           message: getTravelMessage(),
         },
       ];

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useTranslation, Trans } from 'react-i18next';
 
 import { makeSelectError, makeSelectForm } from '../../selectors';
+import { makeSelectFeatureToggles } from '../../utils/selectors/feature-toggles';
 import Wrapper from '../../components/layout/Wrapper';
 import { phoneNumbers } from '../../utils/appConstants';
 import ExternalLink from '../../components/ExternalLink';
@@ -15,11 +16,18 @@ const Error = () => {
   const selectForm = useMemo(makeSelectForm, []);
   const form = useSelector(selectForm);
 
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const featureToggles = useSelector(selectFeatureToggles);
+  const { isTravelReimbursementEnabled } = featureToggles;
+
   let alerts = [];
   let header = '';
 
   const getTravelMessage = () => {
-    if (form.data['travel-question'] === 'no') {
+    if (
+      form.data['travel-question'] === 'no' ||
+      !isTravelReimbursementEnabled
+    ) {
       return (
         <>
           <p className="vads-u-margin-top--0">

--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
@@ -58,6 +58,7 @@ describe('Check In Experience', () => {
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateCheckedInMessage();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Day-of-check-in--Appointment-detail-checked-in');
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -63,6 +63,9 @@ describe('Check In Experience', () => {
       AppointmentDetails.validatePhone();
       AppointmentDetails.validateCheckInButton();
       AppointmentDetails.validateReturnToAppointmentsPageButton();
+      cy.createScreenshots(
+        'Day-of-check-in--Appointment-detail-with-check-in-button',
+      );
       cy.injectAxeThenAxeCheck();
     });
     it('Can check-in from details page for eligible appointment', () => {
@@ -90,6 +93,9 @@ describe('Check In Experience', () => {
       AppointmentDetails.validateAppointmentMessage();
       AppointmentDetails.validateNoCheckInButton();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Day-of-check-in--Appointment-detail-ineligible-apppointment',
+      );
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Check In Experience -- ', () => {
   });
   it('C5722 - Check in failed with a 200 and error message in the body', () => {
     Appointments.attemptCheckIn(1);
-    Error.validatePageLoaded();
+    Error.validatePageLoaded('check-in-failed-find-out');
     cy.injectAxe();
     cy.axeCheck();
     cy.createScreenshots('Day-of-check-in--Error-on-check-in-no-travel-claim');

--- a/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/check-in-failed.cypress.spec.js
@@ -44,6 +44,6 @@ describe('Check In Experience -- ', () => {
     Error.validatePageLoaded();
     cy.injectAxe();
     cy.axeCheck();
-    cy.createScreenshots('Day-of-check-in--Error');
+    cy.createScreenshots('Day-of-check-in--Error-on-check-in-no-travel-claim');
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/errors/max.validation.failed.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/max.validation.failed.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Check In Experience -- ', () => {
       ValidateVeteran.attemptToGoToNextPage();
 
       Error.validatePageLoaded('max-validation');
-      cy.createScreenshots('Day-of-check-in--validation-error');
+      cy.createScreenshots('Day-of-check-in--Error-validation-error');
     });
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.404.on.validate.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.404.on.validate.cypress.spec.js
@@ -23,5 +23,6 @@ describe('Check In Experience', () => {
     Error.validateURL();
     Error.validatePageLoaded('uuid-not-found');
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Day-of-check-in--Error-expired');
   });
 });

--- a/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.validate.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/errors/server.500.on.validate.cypress.spec.js
@@ -23,5 +23,6 @@ describe('Check In Experience -- ', () => {
     Error.validateURL();
     Error.validatePageLoaded();
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Day-of-check-in--Error-generic');
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -55,6 +55,7 @@ describe('Pre-Check In Experience', () => {
       AppointmentDetails.validateWhere();
       AppointmentDetails.validatePhone();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Pre-check-in--Appointment-detail--in-person');
     });
   });
 
@@ -105,6 +106,9 @@ describe('Pre-Check In Experience', () => {
       AppointmentDetails.validateWhere('phone');
       AppointmentDetails.validatePhone();
       cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Pre-check-in--Phone-appointment--Appointment-detail',
+      );
     });
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
@@ -37,7 +37,8 @@ describe('Pre-Check In Experience ', () => {
     Error.validateExpiredPageLoaded();
     Error.validateAccordionBlocks();
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Pre-check-in--expired-error--default-accordions');
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--expired-error');
+    cy.createScreenshots('Pre-check-in--expired-error--expanded-accordions');
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Pre-Check In Experience ', () => {
       window.sessionStorage.clear();
     });
   });
-  it('Expird appointment Error', () => {
+  it('Expired appointment Error', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
     ValidateVeteran.validatePage.preCheckIn();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Pre-Check In Experience ', () => {
       window.sessionStorage.clear();
     });
   });
-  it('Render Error is caught', () => {
+  it('Expird appointment Error', () => {
     cy.visitPreCheckInWithUUID();
     // page: Validate
     ValidateVeteran.validatePage.preCheckIn();

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec.js
@@ -37,8 +37,13 @@ describe('Pre-Check In Experience ', () => {
     // UUID with canceled appointments should navigate to the error page.
     Error.validateCanceledPageLoaded();
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots(
+      'Pre-check-in--canceled-appointment--default-accordions',
+    );
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--canceled-appointment');
+    cy.createScreenshots(
+      'Pre-check-in--canceled-appointment--expanded-accordions',
+    );
   });
   it('Not every appointment is cancelled should result in a generic Error Page', () => {
     apiData.payload.appointments[1].status = '';

--- a/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec.js
@@ -37,7 +37,8 @@ describe('Pre-Check In Experience ', () => {
     Error.validatePast15MinutesPageLoaded();
     Error.validateAccordionBlocks();
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Pre-check-in--past-15-min--default-accordions');
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--past-15-min');
+    cy.createScreenshots('Pre-check-in--past-15-min--expanded-accordions');
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
@@ -88,7 +88,12 @@ describe('Pre-Check In Experience ', () => {
       .should('equal', 200);
 
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots(
+      'Pre-check-in--Confirmation-answer-yes-to-all--default-accordions',
+    );
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--Confirmation-answer-yes-to-all');
+    cy.createScreenshots(
+      'Pre-check-in--Confirmation-answer-yes-to-all--expanded-accordions',
+    );
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/phone-appointments/phone.appointment.canceled.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/phone-appointments/phone.appointment.canceled.cypress.spec.js
@@ -44,7 +44,12 @@ describe('Pre-Check In Experience ', () => {
     Error.validateCanceledPageLoaded();
     Error.validateAccordionBlocks();
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots(
+      'Pre-check-in--Phone-appointment--canceled-error--default-accordions',
+    );
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--Phone-appointment--canceled-error');
+    cy.createScreenshots(
+      'Pre-check-in--Phone-appointment--canceled-error--expanded-accordions',
+    );
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/phone-appointments/phone.appointment.expired.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/phone-appointments/phone.appointment.expired.cypress.spec.js
@@ -44,7 +44,12 @@ describe('Pre-Check In Experience ', () => {
     Error.validateExpiredPageLoaded('phone');
     Error.validateAccordionBlocks();
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots(
+      'Pre-check-in--Phone-appointment--expired-error--default-accordions',
+    );
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--Phone-appointment--expired-error');
+    cy.createScreenshots(
+      'Pre-check-in--Phone-appointment--expired-error--expanded-accordions',
+    );
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/phone-appointments/phone.appointment.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/phone-appointments/phone.appointment.path.cypress.spec.js
@@ -66,9 +66,12 @@ describe('Pre-Check In Experience ', () => {
     Confirmation.validatePageLoaded();
     Confirmation.validateAppointmentType('phone');
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots(
+      'Pre-check-in--Phone-appointment--Confirmation-answer-yes-to-all--default-accordions',
+    );
     Confirmation.expandAllAccordions();
     cy.createScreenshots(
-      'Pre-check-in--Phone-appointment--Confirmation-answer-yes-to-all',
+      'Pre-check-in--Phone-appointment--Confirmation-answer-yes-to-all--expanded-accordions',
     );
   });
   it('Happy Path no to demographics', () => {
@@ -99,9 +102,12 @@ describe('Pre-Check In Experience ', () => {
     Confirmation.validatePageLoaded();
 
     cy.injectAxeThenAxeCheck();
+    cy.createScreenshots(
+      'Pre-check-in--Phone-appointment--Confirmation-answer-no-to-all--default-accordions',
+    );
     Confirmation.expandAllAccordions();
     cy.createScreenshots(
-      'Pre-check-in--Phone-appointment--Confirmation-answer-no-to-all',
+      'Pre-check-in--Phone-appointment--Confirmation-answer-no-to-all--expanded-accordions',
     );
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec.js
@@ -77,8 +77,13 @@ describe('Pre-Check In Experience ', () => {
 
     // page: Confirmation
     Confirmation.validatePageLoaded();
+    cy.createScreenshots(
+      'Pre-check-in--confirmation-answer-no-to-all--default-accordions',
+    );
     Confirmation.expandAllAccordions();
-    cy.createScreenshots('Pre-check-in--confirmation-answer-no-to-all');
+    cy.createScreenshots(
+      'Pre-check-in--confirmation-answer-no-to-all--expanded-accordions',
+    );
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec.js
@@ -79,7 +79,6 @@ describe('Pre-Check In Experience ', () => {
 
     // page: Confirmation
     Confirmation.validatePageLoaded();
-    Confirmation.expandAllAccordions();
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec.js
@@ -80,9 +80,6 @@ describe('Pre-Check In Experience ', () => {
     // page: Confirmation
     Confirmation.validatePageLoaded();
     Confirmation.expandAllAccordions();
-    cy.createScreenshots(
-      'Pre-check-in--phone-appt-confirmation-answer-no-to-all',
-    );
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/check-in/tests/e2e/commands/index.js
+++ b/src/applications/check-in/tests/e2e/commands/index.js
@@ -40,18 +40,18 @@ Cypress.Commands.add('createScreenshots', filename => {
     // Hide local only BackToHome link
     cy.get('.local-start-again').invoke('attr', 'style', 'display: none;');
     // Create screenshot
-    cy.screenshot(filename);
+    cy.screenshot(`english/${filename}`);
     // Wait while screenshot is created
     cy.wait(1000);
     // Capture Spanish
     cy.get('[data-testid="translate-button-es"]').click();
     cy.wait(1000);
-    cy.screenshot(`${filename}-spanish`);
+    cy.screenshot(`spanish/${filename}-spanish`);
     cy.wait(1000);
     // Capture Tagalog
     cy.get('[data-testid="translate-button-tl"]').click();
     cy.wait(1000);
-    cy.screenshot(`${filename}-tagalog`);
+    cy.screenshot(`tagalog/${filename}-tagalog`);
     cy.wait(1000);
     // Back to english
     cy.get('[data-testid="translate-button-en"]').click();

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-current.all.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-current.all.cypress.spec.js
@@ -1,15 +1,7 @@
 (async () => {
   if (Cypress.env('with_screenshots')) {
-    await import('../../../pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/get-session/500.status.code.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec');
-    await import('../../../day-of/tests/e2e/happy-path/current.happy.path.cypress.spec');
-    await import('../../../day-of/tests/e2e/errors/check-in-failed.cypress.spec');
-    await import('../../../day-of/tests/e2e/extra-validation/validation.failed.cypress.spec');
+    await import('./screenshots-current.day-of.cypress.spec');
+    await import('./screenshots-current.pci.cypress.spec');
   }
 })();
 describe('Screenshots all', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-current.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-current.day-of.cypress.spec.js
@@ -1,8 +1,10 @@
 (async () => {
   if (Cypress.env('with_screenshots')) {
     await import('../../../day-of/tests/e2e/happy-path/current.happy.path.cypress.spec');
-    await import('../../../day-of/tests/e2e/errors/check-in-failed.cypress.spec');
     await import('../../../day-of/tests/e2e/extra-validation/validation.failed.cypress.spec');
+    await import('../../../day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js');
+    await import('../../../day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js');
+    await import('./screenshots-errors.day-of.cypress.spec');
   }
 })();
 describe('Screenshots day-of', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-current.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-current.day-of.cypress.spec.js
@@ -2,8 +2,8 @@
   if (Cypress.env('with_screenshots')) {
     await import('../../../day-of/tests/e2e/happy-path/current.happy.path.cypress.spec');
     await import('../../../day-of/tests/e2e/extra-validation/validation.failed.cypress.spec');
-    await import('../../../day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js');
-    await import('../../../day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js');
+    await import('../../../day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec');
+    await import('../../../day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec');
     await import('./screenshots-errors.day-of.cypress.spec');
   }
 })();

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-current.pci.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-current.pci.cypress.spec.js
@@ -1,15 +1,11 @@
 (async () => {
   if (Cypress.env('with_screenshots')) {
     await import('../../../pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/get-session/500.status.code.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js');
     await import('./screenshots-phone.pci.cypress.spec');
+    await import('./screenshots-errors.pci.cypress.spec');
   }
 })();
 describe('Screenshots PCI', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-current.pci.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-current.pci.cypress.spec.js
@@ -3,7 +3,7 @@
     await import('../../../pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js');
+    await import('../../../pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec');
     await import('./screenshots-phone.pci.cypress.spec');
     await import('./screenshots-errors.pci.cypress.spec');
   }

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.day-of.cypress.spec.js
@@ -1,9 +1,9 @@
 (async () => {
   if (Cypress.env('with_screenshots')) {
     await import('../../../day-of/tests/e2e/errors/check-in-failed.cypress.spec');
-    await import('../../../day-of/tests/e2e/errors/server.404.on.validate.cypress.spec.js');
-    await import('../../../day-of/tests/e2e/errors/server.500.on.validate.cypress.spec.js');
-    await import('../../../day-of/tests/e2e/errors/max.validation.failed.cypress.spec.js');
+    await import('../../../day-of/tests/e2e/errors/server.404.on.validate.cypress.spec');
+    await import('../../../day-of/tests/e2e/errors/server.500.on.validate.cypress.spec');
+    await import('../../../day-of/tests/e2e/errors/max.validation.failed.cypress.spec');
   }
 })();
 describe('Screenshots PCI', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.day-of.cypress.spec.js
@@ -1,0 +1,13 @@
+(async () => {
+  if (Cypress.env('with_screenshots')) {
+    await import('../../../day-of/tests/e2e/errors/check-in-failed.cypress.spec');
+    await import('../../../day-of/tests/e2e/errors/server.404.on.validate.cypress.spec.js');
+    await import('../../../day-of/tests/e2e/errors/server.500.on.validate.cypress.spec.js');
+    await import('../../../day-of/tests/e2e/errors/max.validation.failed.cypress.spec.js');
+  }
+})();
+describe('Screenshots PCI', () => {
+  it('is true', () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.pci.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.pci.cypress.spec.js
@@ -1,12 +1,12 @@
 (async () => {
   if (Cypress.env('with_screenshots')) {
     await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec.js');
+    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/errors/get-session/500.status.code.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/errors/max.validation.failed.cypress.spec.js');
-    await import('../../../pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec.js');
+    await import('../../../pre-check-in/tests/e2e/errors/max.validation.failed.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec');
   }
 })();
 describe('Screenshots PCI', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.pci.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-errors.pci.cypress.spec.js
@@ -1,0 +1,16 @@
+(async () => {
+  if (Cypress.env('with_screenshots')) {
+    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-expired/error.expired.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-past-15-min/error.past15min.cypress.spec.js');
+    await import('../../../pre-check-in/tests/e2e/errors/get-pre-check-in/error.in.body.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/errors/get-session/500.status.code.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/errors/pre-check-in-for-canceled-appt/error.canceled.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/errors/max.validation.failed.cypress.spec.js');
+    await import('../../../pre-check-in/tests/e2e/errors/post-pre-check-in/error.in.body.cypress.spec.js');
+  }
+})();
+describe('Screenshots PCI', () => {
+  it('is true', () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-phone.pci.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-phone.pci.cypress.spec.js
@@ -3,7 +3,6 @@
     await import('../../../pre-check-in/tests/e2e/phone-appointments/phone.appointment.path.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/phone-appointments/phone.appointment.canceled.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/phone-appointments/phone.appointment.expired.cypress.spec');
-    await import('../../../pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec');
   }
 })();
 describe('Screenshots PCI phone appointments', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-phone.pci.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-phone.pci.cypress.spec.js
@@ -3,6 +3,7 @@
     await import('../../../pre-check-in/tests/e2e/phone-appointments/phone.appointment.path.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/phone-appointments/phone.appointment.canceled.cypress.spec');
     await import('../../../pre-check-in/tests/e2e/phone-appointments/phone.appointment.expired.cypress.spec');
+    await import('../../../pre-check-in/tests/e2e/posting-answers/answered.no.to.three.questions.with.phone.appt.cypress.spec');
   }
 })();
 describe('Screenshots PCI phone appointments', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js
@@ -2,7 +2,7 @@
   if (Cypress.env('with_screenshots')) {
     await import('../../../day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec');
     await import('../../../day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec');
-    await import('../../../day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec.js');
+    await import('../../../day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec');
   }
 })();
 describe('Screenshots day-of travel pay', () => {

--- a/src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/screenshots/screenshots-travel-pay.day-of.cypress.spec.js
@@ -2,6 +2,7 @@
   if (Cypress.env('with_screenshots')) {
     await import('../../../day-of/tests/e2e/travel-path/travel.pay.path.cypress.spec');
     await import('../../../day-of/tests/e2e/travel-path/travel.pay.unhappy.path.cypress.spec');
+    await import('../../../day-of/tests/e2e/travel-path/travel.pay.errors.cypress.spec.js');
   }
 })();
 describe('Screenshots day-of travel pay', () => {


### PR DESCRIPTION
## Summary

Updates our screenshot generation. Some instances of cy.createScreenshots were not being imported into the screenshot files. We were missing a few error scenarios. Also added the appointment details screens. 

I also found a bug where we were displaying a travel message as if the user was making a claim on the error page when the feature flag was off. this was also fixed in this PR.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#56279

## What areas of the site does it impact?
Cypress generated screenshots

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
