### PR TITLE
Supplemental Claims | Fix submission bug

### DIFF
--- a/src/applications/appeals/995/config/submit-transformer.js
+++ b/src/applications/appeals/995/config/submit-transformer.js
@@ -9,7 +9,7 @@ import {
   getForm4142,
 } from '../utils/submit';
 
-import { EVIDENCE_OTHER } from '../constants';
+import { EVIDENCE_OTHER, SUPPORTED_BENEFIT_TYPES_LIST } from '../constants';
 
 export function transform(formConfig, form) {
   // https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current
@@ -18,7 +18,11 @@ export function transform(formConfig, form) {
     const { benefitType, additionalDocuments } = formData;
 
     const attributes = {
-      benefitType,
+      // fall back to compensation; this will fix a few existing submission
+      // with "other" benefit type set that are being rejected
+      benefitType: SUPPORTED_BENEFIT_TYPES_LIST.includes(benefitType)
+        ? benefitType
+        : 'compensation',
       ...getClaimantData(formData),
 
       veteran: {

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -141,7 +141,7 @@ export const REVIEW_ISSUES = 'onReviewPageIssues';
 
 // Values from benefitTypes in Lighthouse 0995 schema
 // schema.definitions.scCreate.properties.data.properties.attributes.properties.benefitType.emum;
-const supportedBenefitTypes = [
+export const SUPPORTED_BENEFIT_TYPES_LIST = [
   'compensation', // Phase 1
   // 'pensionSurvivorsBenefits',
   // 'fiduciary',
@@ -158,7 +158,7 @@ export const AMA_DATE = '2019-02-19'; // Appeals Modernization Act in effect
 
 export const SUPPORTED_BENEFIT_TYPES = constants.benefitTypes.map(type => ({
   ...type,
-  isSupported: supportedBenefitTypes.includes(type.value),
+  isSupported: SUPPORTED_BENEFIT_TYPES_LIST.includes(type.value),
 }));
 
 // Once we include the 'pensionSurvivorsBenefits' type, we will need to know

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -28,6 +28,7 @@ import {
 
 import ITFWrapper from './ITFWrapper';
 import { WIP } from '../components/WIP';
+import { SUPPORTED_BENEFIT_TYPES_LIST } from '../constants';
 
 export const App = ({
   loggedIn,
@@ -79,10 +80,13 @@ export const App = ({
 
   useEffect(
     () => {
-      if (show995) {
+      if (
+        show995 &&
+        SUPPORTED_BENEFIT_TYPES_LIST.includes(subTaskBenefitType)
+      ) {
         // form data is reset after logging in and from the save-in-progress data,
         // so get it from the session storage
-        if (!formData.benefitType && subTaskBenefitType) {
+        if (!formData.benefitType) {
           setFormData({
             ...formData,
             benefitType: subTaskBenefitType,
@@ -172,7 +176,7 @@ export const App = ({
     return <WIP />;
   }
 
-  if (!subTaskBenefitType) {
+  if (!SUPPORTED_BENEFIT_TYPES_LIST.includes(subTaskBenefitType)) {
     router.push('/start');
     content = wrapInH1(
       <va-loading-indicator message="Please wait while we restart the application for you." />,

--- a/src/applications/appeals/995/tests/config/submit-transformer.unit.spec.js
+++ b/src/applications/appeals/995/tests/config/submit-transformer.unit.spec.js
@@ -26,4 +26,18 @@ describe('transform', () => {
 
     expect(transformedResult).to.deep.equal(transformedNoEvidence);
   });
+
+  it('should set the benefitType to "compensation" for non-supported entries', () => {
+    const data = {
+      data: {
+        ...maximalData.data,
+        benefitType: 'other',
+      },
+    };
+    const transformedResult = JSON.parse(transform(formConfig, data));
+    // copy over variables that change based on date & location
+    transformedResult.data.attributes.veteran.timezone = 'America/Los_Angeles';
+
+    expect(transformedResult).to.deep.equal(transformedMaximalData);
+  });
 });

--- a/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
@@ -216,4 +216,19 @@ describe('App', () => {
     expect(alert.getAttribute('message')).to.contain('restart the app');
     expect(push.calledWith('/start')).to.be.true;
   });
+
+  it('should redirect to start for unsupported benefit types', () => {
+    const push = sinon.spy();
+    const { props, data } = getData({ push, data: { benefitType: 'other' } });
+    const { container } = render(
+      <Provider store={mockStore(data)}>
+        <App {...props} />
+      </Provider>,
+    );
+
+    const alert = $('va-loading-indicator', container);
+    expect(alert).to.exist;
+    expect(alert.getAttribute('message')).to.contain('restart the app');
+    expect(push.calledWith('/start')).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
  > Sentry reported 4 submissions with a `benefitType` set to `"other"`. This shouldn't happen, but to fix it:
  > - The form now redirects back to the `/start` page for non-supported benefit types
  > - Once the `/start` page selection is made with a supported benefit type, if the form data already contains a non-supported type, it will be reverted to "compensation" prior to submission (we only support "compensation" types at this time)
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution)*
  > Prevent submitting anything other than "compensation" (for now)
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits decision reviews
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*

## Related issue(s)

[#56851](https://github.com/department-of-veterans-affairs/va.gov-team/issues/56851)

## Testing done

- *Describe what the old behavior was prior to the change*
  > Somehow "other" `benefitType` were being submitted to Lighthouse
- *Describe the steps required to verify your changes are working as expected*
- *Describe the tests completed and the results*
  > Added unit tests; all passing
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*

## Screenshots

N/A

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
