### PR TITLE
Update environment helper function docs to explain e2e behavior

### DIFF
--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -66,7 +66,12 @@ export default Object.freeze({
     return VSP_ENVIRONMENTS[environment.BUILDTYPE];
   },
 
-  /** Determines whether the current environment is a production environment. */
+  /**
+   * Determines whether the current environment is a production environment.
+   *
+   * NB: this returns true in e2e (Cypress) tests, as they are run on
+   *     a production build.
+   */
   isProduction() {
     return environment.BUILDTYPE === ENVIRONMENTS.VAGOVPROD;
   },
@@ -81,7 +86,12 @@ export default Object.freeze({
     return environment.BUILDTYPE === ENVIRONMENTS.VAGOVDEV;
   },
 
-  /** Determines whether the current environment is a local environment. */
+  /**
+   * Determines whether the current environment is a local environment.
+   *
+   * NB: this returns false in e2e (Cypress) tests, as they are run on
+   *     a production build.
+   */
   isLocalhost() {
     return environment.BUILDTYPE === ENVIRONMENTS.LOCALHOST;
   },


### PR DESCRIPTION
## Summary

Updates docblocks for `environment.isProduction()` and `environment.isLocalhost()` to explain behavior on e2e tests. See https://dsva.slack.com/archives/CBU0KDSB1/p1681415612449429 for more background
