### PR TITLE
VFEP-411 fix 22-5495 e2e test

### DIFF
--- a/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
+++ b/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
@@ -14,7 +14,7 @@ const form = createTestConfig(
     dataSets: ['minimal'],
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),
-      mocks: path.join(__dirname, 'fixtures', 'mocks'),
+      // mocks: path.join(__dirname, 'fixtures', 'mocks'),
     },
     setupPerTest: () => {
       cy.login(mockUser);
@@ -33,17 +33,8 @@ const form = createTestConfig(
     },
     pageHooks: {
       introduction: ({ afterHook }) => {
-        cy.findByText(/Find the right application form/i, {
-          selector: 'button',
-        })
-          .first()
-          .click();
-        cy.get('#NewBenefit-1').check();
-        cy.get('#TransferredBenefits-2').check();
-        cy.get('#apply-now-link').click();
-
         afterHook(() => {
-          cy.findAllByText(/Start the education application/i, {
+          cy.contains(/continue/i, {
             selector: 'button',
           })
             .first()
@@ -51,10 +42,12 @@ const form = createTestConfig(
         });
       },
     },
-    skip: true, // skip allowed while removing the secondary wizard. will turn to false after secondary wizard has been removed
+    skip: false,
   },
   manifest,
   formConfig,
 );
 
-testForm(form);
+for (let i = 0; i < 10; i++) {
+  testForm(form);
+}

--- a/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
+++ b/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
@@ -14,7 +14,7 @@ const form = createTestConfig(
     dataSets: ['minimal'],
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),
-      // mocks: path.join(__dirname, 'fixtures', 'mocks'),
+      mocks: path.join(__dirname, 'fixtures', 'mocks'),
     },
     setupPerTest: () => {
       cy.login(mockUser);
@@ -48,6 +48,4 @@ const form = createTestConfig(
   formConfig,
 );
 
-for (let i = 0; i < 10; i++) {
-  testForm(form);
-}
+testForm(form);

--- a/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
+++ b/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
@@ -47,6 +47,4 @@ const form = createTestConfig(
   manifest,
   formConfig,
 );
-for (let i = 0; i < 20; i++) {
-  testForm(form);
-}
+testForm(form);

--- a/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
+++ b/src/applications/edu-benefits/5495/tests/e2e/edu-5495.cypress.spec.js
@@ -47,5 +47,6 @@ const form = createTestConfig(
   manifest,
   formConfig,
 );
-
-testForm(form);
+for (let i = 0; i < 20; i++) {
+  testForm(form);
+}


### PR DESCRIPTION
## Summary
--Test was flag as being "Flaky" and needing reworked

- *(Summarize the changes that have been made to the platform)*
- --After reviewing this e2e test, there was test code referencing code from Form 22-5495 that had been deleted. Removed this code. Additionally, the test was written to find the text inside the element and not the text that can be seen on screen for the entry button to get into the form.  Changed cy.findAllByText(/Start the education application/i to cy.contains(/continue/i. The text "Start the education application" can be found in the element but the text the screen sees is "continue". After making these changes I wrapped the test in a for loop and ran the test 30 times. Each test result passed.
- *(If bug, how to reproduce)* NA
- *(What is the solution, why is this the solution)*
- --Solution is mentioned above.
- *(Which team do you work for, does your team own the maintenance of this component?)*
- --I work for GovCIO and we are the code owners for this e2e test
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)* NA

## Related issue(s)
- *Link to ticket created in va.gov-team repo*
- --https://vajira.max.gov/browse/VFEP-411
- *Link to previous change of the code/bug (if applicable)* NA
- *Link to epic if not included in ticket* NA


## Testing done

- *Describe what the old behavior was prior to the change*
- --e2e test would fail prior to changes
- *Describe the steps required to verify your changes are working as expected*
- -- running e2e test locally with the following command yarn cy:run --spec location/to/local/file
- *Describe the tests completed and the results*
- -- Testing of e2e done on local machine
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)* NA


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._
Screenshot of updated test passing 10 times
![image](https://user-images.githubusercontent.com/88905347/232107294-7ae01541-fcab-4623-8eb3-4cad7ae31f24.png)


## What areas of the site does it impact?
This impacts the e2e test for Form 22-5495 which will run anytime new code is pushed

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_NA
