### PR TITLE
#VFEP-433 Update jump link to the right ID for ratings system in the comparison tool 

### DIFF
--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -146,7 +146,7 @@ export default function InstitutionProfile({
       {displayStars &&
         isProduction && (
           <ProfileSection label="Veteran ratings" id="veteran-ratings">
-            <div id="profile-school-ratings">
+            <div>
               <SchoolRatings
                 ratingAverage={institution.institutionRating.overallAvg}
                 ratingCount={

--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -332,7 +332,7 @@ const ProfilePageHeader = ({
               </span>{' '}
               (
               <a
-                href="#profile-school-ratings"
+                href="#veteran-ratings"
                 onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
               >
                 See {ratingCount} ratings by Veterans

--- a/src/applications/gi/tests/components/profile/InstitutionProfile.unit.spec.jsx
+++ b/src/applications/gi/tests/components/profile/InstitutionProfile.unit.spec.jsx
@@ -16,7 +16,7 @@ describe('<InstitutionProfile>', () => {
         }}
       />,
     );
-    expect(tree.find('#profile-school-ratings').length).to.eq(1);
+    expect(tree.find('#veteran-ratings').length).to.eq(1);
     tree.unmount();
   });
   it('should not render ratings if rating count < minimum', () => {
@@ -30,7 +30,7 @@ describe('<InstitutionProfile>', () => {
         }}
       />,
     );
-    expect(tree.find('#profile-school-ratings').length).to.eq(0);
+    expect(tree.find('#veteran-ratings').length).to.eq(0);
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Summary

- *(Summarize the changes that have been made to the platform)*
- -- With the new ratings system in the comparison tool, the jumplink associated with the (See X ratings by Veterans) was not pointed to the right div id.
- *(If bug, how to reproduce)*NA
- *(What is the solution, why is this the solution)*
- --The solution was to delete the current Div id that was on line 149 of the InstitutionProfile.jsx and point the href in line 335 of the ProfilePageHeader.jsx file to the veteran-ratings ID on line 148 of the InstitutionProfile.jsx file. Now when the user clicks on the link (See X ratings by Veterans) they are taken tot he top of the Div of the ratings section and not just below. (See screem shots below for visual)
- *(Which team do you work for, does your team own the maintenance of this component?)*
- --I work for GovCIO and we are the code owners of this
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
- --Update is made to code that is already hidden behind environmental variables.

## Related issue(s)
- *Link to ticket created in va.gov-team repo*
- --https://vajira.max.gov/browse/VFEP-433
- *Link to previous change of the code/bug (if applicable)*NA
- *Link to epic if not included in ticket*
- --- --https://vajira.max.gov/browse/VFEP-5


## Testing done

- *Describe what the old behavior was prior to the change*
- --Prior to update, jump link would take the user just below the title of the Veterans rating section
- *Describe the steps required to verify your changes are working as expected*
- --When a user clicks on the (See X ratings by veterans) link in the top of the institution profile page, the user should jump down to the Veterans ratings section and see the title of this section (See screenshots below for visual)
- *Describe the tests completed and the results*
- --Testing was done on local machine. further QA will be conducted in staging
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*NA


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

BEFORE: jumplink took the user right after the title of the section
![image](https://user-images.githubusercontent.com/88905347/232113623-2484e37b-08cc-4381-af68-f8a8f156681d.png)

AFTER: jumplink now takes the user to the top of the title of the section
![image](https://user-images.githubusercontent.com/88905347/232113549-85602964-ad71-48ec-84c8-91615704ebe3.png)


## What areas of the site does it impact?
---This impacts the Comparison tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_NA
