### PR TITLE
VIC updates to remove the word 'printed'

### DIFF
--- a/src/applications/veteran-id-card/containers/EmailCapture.jsx
+++ b/src/applications/veteran-id-card/containers/EmailCapture.jsx
@@ -26,7 +26,7 @@ class EmailCapture extends React.Component {
     if (this.props.success) {
       view = (
         <div>
-          <h1>Printed Veteran ID Card</h1>
+          <h1>Veteran ID Card</h1>
           <AlertBox
             headline="Thank you for your email address. We will follow up with instructions on how to proceed with the application."
             content={''}
@@ -38,7 +38,7 @@ class EmailCapture extends React.Component {
     } else {
       view = (
         <div>
-          <h1>Printed Veteran ID Card</h1>
+          <h1>Veteran ID Card</h1>
           <p>
             You've reached the new Veteran ID Card application. We're excited to
             bring this important recognition to Veterans. We've experienced a

--- a/src/applications/veteran-id-card/containers/Main.jsx
+++ b/src/applications/veteran-id-card/containers/Main.jsx
@@ -110,14 +110,14 @@ class Main extends React.Component {
     const view = (
       <div className="row">
         <div className="usa-width-two-thirds medium-8 vet-id-card">
-          <h1>Printed Veteran ID Card</h1>
+          <h1>Veteran ID Card</h1>
           <p>
-            You can use your printed Veteran ID Card (VIC) instead of your DD214
+            You can use your Veteran ID Card (VIC) instead of your DD214
             to get discounts on goods and services offered to Veterans. You can
             also use other identification cards for this purpose. Find out if
             you need a VIC or if you already have what you need.
           </p>
-          <h3>Should I request a printed Veteran ID card?</h3>
+          <h3>Should I request a Veteran ID card?</h3>
           <p>
             You <b>do not</b> need to request this card if you have one of
             these:


### PR DESCRIPTION
## Summary

- Removed several instances of the word "printed" from the authenticated content. This is a request from VEO because the VIC is no longer printed and they're sending out promotions around the digital card tomorrow 4/18.
- I've made this change from sitewide content/IA/accessibility team with a request to Public Websites to review (per conversation with Dave Conlon).

## Related issue(s)

[56953](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/gh/department-of-veterans-affairs/va.gov-team/56953)

## Testing done

- Reviewed previews of files after commits to ensure removal of instances of the word "printed"


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

