### PR TITLE
[MHV-40737] Updated Save Draft Button to use inline errors instead of modal

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -220,12 +220,13 @@ const ComposeForm = props => {
     return messageValid;
   };
 
-  const saveDraftHandler = type => {
+  const saveDraftHandler = async type => {
     if (type === 'manual') {
       setUserSaved(true);
-      if (!checkMessageValidity()) {
-        setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE);
-        return;
+
+      await setMessageInvalid(false);
+      if (checkMessageValidity()) {
+        setNavigationError(null);
       }
       if (attachments.length) {
         setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE_DRAFT_ATTACHMENT);

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -196,12 +196,13 @@ const ReplyForm = props => {
     }
   };
 
-  const saveDraftHandler = type => {
+  const saveDraftHandler = async type => {
     if (type === 'manual') {
       setUserSaved(true);
-      if (!checkMessageValidity()) {
-        setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE);
-        return;
+
+      await setMessageInvalid(false);
+      if (checkMessageValidity()) {
+        setNavigationError(null);
       }
       if (attachments.length) {
         setSaveError(ErrorMessages.ComposeForm.UNABLE_TO_SAVE_DRAFT_ATTACHMENT);


### PR DESCRIPTION
## Summary

- If there is an error on the reply or compose draft when a user clicks on Save Draft button, the user focus on the inline error, not modal.

- A modal will still be displayed/used if the user tries to save a draft with an attachment.

- To reproduce: Navigate to Compose a message to save it was a draft, or Reply to a message then save it was a draft.

- *Solution: Removed modal to focus on inline errors instead
- *MHV - Secure Messaging*

## Related issue(s)
- department-of-veterans-affairs/vets-website
- *[Link to ticket created in va.gov-team repo](https://vajira.max.gov/browse/MHV-40737)*

## Testing done

- *Describe the old behavior was prior to the change: When a user selects 'Save Draft' on a Reply or Compose message, a generic modal would appear*


## Screenshots


| | Mobile Before | <img width="342" alt="Screenshot 2023-04-18 at 11 30 21 AM" src="https://user-images.githubusercontent.com/59583325/232844075-f12d3ca1-93bf-45fc-a314-9b686b4e930c.png"> | 

| | Mobile After | 
![image](https://user-images.githubusercontent.com/59583325/232845315-9ac2d789-f61a-4d01-9d30-e99f460f4280.png) |

| Desktop Before |  | <img width="722" alt="Screenshot 2023-04-18 at 11 22 20 AM" src="https://user-images.githubusercontent.com/59583325/232843868-21c9201e-875b-4e8e-9adc-198b18dc9a33.png"> |

| Desktop After |  | <img width="749" alt="Screenshot 2023-04-18 at 11 00 06 AM" src="https://user-images.githubusercontent.com/59583325/232844279-71d89ad1-e498-4882-9be7-eec3c73d5b66.png"> |


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
