### PR TITLE
VFEP-457 #comment Conditionally render the Cumulative post 9/11 dropd…

### DIFF
--- a/src/applications/gi/components/SearchBenefits.jsx
+++ b/src/applications/gi/components/SearchBenefits.jsx
@@ -24,6 +24,12 @@ const SearchBenefits = ({
 }) => {
   const [isDisabled, setIsDisabled] = useState(true);
   const chapter33Check = giBillChapter === '33a' || giBillChapter === '33b';
+  /*
+    ***toggleCumulativeDropDown***
+    Hide Cumulative Post 9/11 active-duty service drop down if applicant selects 'Fry Scholarship'
+    as their GI Bill Benefit
+  */
+  const toggleCumulativeDropDown = () => giBillChapter !== '33b';
   const handleChange = e => {
     const field = e.target.name;
     const { value } = e.target;
@@ -171,10 +177,6 @@ const SearchBenefits = ({
           { optionValue: '0.6', optionLabel: '6 months: 60%' },
           { optionValue: '0.5', optionLabel: '90 days: 50%' },
           {
-            optionValue: '1.00',
-            optionLabel: 'GYSGT Fry Scholarship: 100%',
-          }, // notice not 1.0
-          {
             optionValue: 'service discharge',
             optionLabel: 'Service-Connected Discharge: 100%',
           },
@@ -185,7 +187,7 @@ const SearchBenefits = ({
         ]}
         value={cumulativeService}
         alt="Cumulative Post-9/11 active-duty service"
-        visible={chapter33Check}
+        visible={chapter33Check && toggleCumulativeDropDown()}
         onChange={e => {
           recordEvent({
             event: 'gibct-form-change',

--- a/src/applications/gi/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi/components/profile/BenefitsForm.jsx
@@ -29,7 +29,6 @@ const BenefitsForm = ({
     { optionValue: '0.7', optionLabel: '18 months: 70%' },
     { optionValue: '0.6', optionLabel: '6 months: 60%' },
     { optionValue: '0.5', optionLabel: '90 days: 50%' },
-    // { optionValue: '1.00', optionLabel: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
     {
       optionValue: 'service discharge',
       optionLabel: 'Service-Connected Discharge: 100%',

--- a/src/applications/gi/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi/components/profile/BenefitsForm.jsx
@@ -29,7 +29,7 @@ const BenefitsForm = ({
     { optionValue: '0.7', optionLabel: '18 months: 70%' },
     { optionValue: '0.6', optionLabel: '6 months: 60%' },
     { optionValue: '0.5', optionLabel: '90 days: 50%' },
-    { optionValue: '1.00', optionLabel: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
+    // { optionValue: '1.00', optionLabel: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
     {
       optionValue: 'service discharge',
       optionLabel: 'Service-Connected Discharge: 100%',
@@ -57,6 +57,12 @@ const BenefitsForm = ({
 
   const renderYourMilitaryDetails = () => {
     const chapter33Check = giBillChapter === '33a' || giBillChapter === '33b';
+    /*
+      ***toggleCumulativeDropDown***
+      Hide Cumulative Post 9/11 active-duty service drop down if applicant selects 'Fry Scholarship'
+      as their GI Bill Benefit
+    */
+    const toggleCumulativeDropDown = () => giBillChapter !== '33b';
     return (
       <div>
         <ExpandingGroup open={militaryStatus === 'spouse'}>
@@ -172,7 +178,8 @@ const BenefitsForm = ({
               options={cumulativeServiceOptions()}
               value={cumulativeService}
               alt="Cumulative Post-9/11 active-duty service"
-              visible={chapter33Check}
+              // visible={false}
+              visible={chapter33Check && toggleCumulativeDropDown()}
               onChange={eligibilityChange}
               onFocus={handleInputFocus}
             />


### PR DESCRIPTION
…own when selecting Gi Bill benefit

## Summary

- *(Summarize the changes that have been made to the platform)*
- -- In the Calculate your benefits section of the comparison tool, we removed the option of the Fry Scholarship from the cumulative post 9/11 active-duty service dropdown field. The Cumulative Post 9/11 active-duty service dropdown field has also been conditionally configured to not show if the user selects the 'Fry Scholarship' as their GI Benefit.
- --Additionally there is a similar filter when using the search that has the same function listed above. Changes will be made in both locations.
- *(If bug, how to reproduce)*NA
- *(What is the solution, why is this the solution)*
- --These changes came from EDU to make the comparison tool easier to use and understand.
- *(Which team do you work for, does your team own the maintenance of this component?)*
- --I work for GovCIO and we are the code owners for this change
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
- --No Flipper, code will be released to prod after staging

## Related issue(s)
- *Link to ticket created in va.gov-team repo*
- --Jira ticket -> https://vajira.max.gov/browse/VFEP-415
- *Link to previous change of the code/bug (if applicable)*NA
- *Link to epic if not included in ticket*
---https://vajira.max.gov/browse/VFEP-400

## Testing done

- *Describe what the old behavior was prior to the change*
- --The 'Fry Scholar' was a selection in the Cumulative Post 9/11 active-duty service drop down, and the dropdown did not disappear if the user selected the 'Fry scholarship' as their GI Benefit. Same with the fields in the search results section.
- *Describe the steps required to verify your changes are working as expected*
- --Verify that in the Cumulative post 9/11 active-duty service drop-down that the selection of "GYSGT Fry Scholarship: 100%" is no longer there. Also, when the applicant selects the 'Fry Scholarship' as their GI Benefit, the Cumulative Post 9/11 active-duty service drop down should no longer be visible. Do the same with the filters in the search results section.
- *Describe the tests completed and the results*
- -- Testing preform on local machine, and will be tested further with QA once in staging.
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*NA


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

Before:
![image](https://user-images.githubusercontent.com/88905347/232867166-1e44b4ce-65d3-41fa-8e3c-1d2b0e8da4e7.png)
![image](https://user-images.githubusercontent.com/88905347/232867213-94ed8454-5ebf-43df-8f40-b7ccfc482d80.png)
![image](https://user-images.githubusercontent.com/88905347/232866291-30829a2b-6ac1-4a0b-8107-133bdacf8391.png)
![image](https://user-images.githubusercontent.com/88905347/232866354-f72b4094-0cc8-4229-b9f2-e55e54d62ddf.png)



After:
![image](https://user-images.githubusercontent.com/88905347/232867355-b1e9040a-eccd-4697-b94c-dda2fcc88fae.png)
![image](https://user-images.githubusercontent.com/88905347/232867402-6d0806d0-939a-498e-9bac-98ccca6ffcf5.png)
![image](https://user-images.githubusercontent.com/88905347/232866026-2c9592d8-7dd5-4d17-b845-4a35fe18a77f.png)
![image](https://user-images.githubusercontent.com/88905347/232866157-8a2ef30b-6ecf-42da-93eb-c5753c0da3bb.png)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
---This impacts the institution profile view within the Comparison tool, and the search by location in the comparison tool.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_NA
