### PR TITLE
Display generic error message for various appointment list page

### DIFF
--- a/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.jsx
+++ b/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.jsx
@@ -9,11 +9,28 @@ function displayType(errorCodes, location) {
   const isPast = location.pathname.endsWith('/past');
   const isUpcoming = location.pathname.endsWith('/');
 
-  if (errorCodes.some(code => code === 10000 || code === 10006) && isPending) {
+  if (
+    errorCodes.some(
+      code =>
+        code === 10000 ||
+        code === 10006 ||
+        code === 9002 ||
+        code === 9003 ||
+        code === 9008,
+    ) &&
+    isPending
+  ) {
     return 'requests';
   }
   if (
-    errorCodes.some(code => code === 10000 || code === 10005) &&
+    errorCodes.some(
+      code =>
+        code === 10000 ||
+        code === 10005 ||
+        code === 9006 ||
+        code === 9007 ||
+        code === 9008,
+    ) &&
     (isPast || isUpcoming)
   ) {
     return 'appointments';

--- a/src/applications/vaos/services/mocks/v2/meta_failures.json
+++ b/src/applications/vaos/services/mocks/v2/meta_failures.json
@@ -14,6 +14,41 @@
             "detail": "siteId=983, patientDfn=7216690, patientIcn=1012845943V900681, startDate=2022-10-24T00:00Z, endDate=2023-12-23T00: 00Z"
         },
         {
+            "system": "HSRM",
+            "status": "500",
+            "code": 9002,
+            "message": "Could not get CC request from HSRM Service. The request was invalid",
+            "detail": "siteId=983, patientDfn=7216690, patientIcn=1012845943V900681, startDate=2022-10-24T00:00Z, endDate=2023-12-23T00: 00Z"
+        },
+        {
+            "system": "HSRM",
+            "status": "500",
+            "code": 9003,
+            "message": "Could not get CC request from HSRM Service",
+            "detail": "siteId=983, patientDfn=7216690, patientIcn=1012845943V900681, startDate=2022-10-24T00:00Z, endDate=2023-12-23T00: 00Z"
+        },
+        {
+            "system": "HSRM",
+            "status": "500",
+            "code": 9006,
+            "message": "Could not get CC Appointments from HSRM Service. The request was invalid",
+            "detail": "siteId=983, patientDfn=7216690, patientIcn=1012845943V900681, startDate=2022-10-24T00:00Z, endDate=2023-12-23T00: 00Z"
+        },
+        {
+            "system": "HSRM",
+            "status": "500",
+            "code": 9007,
+            "message": "Could not get CC Appointments from HSRM Service.",
+            "detail": "siteId=983, patientDfn=7216690, patientIcn=1012845943V900681, startDate=2022-10-24T00:00Z, endDate=2023-12-23T00: 00Z"
+        },
+        {
+            "system": "HSRM",
+            "status": "500",
+            "code": 9008,
+            "message": "Could not get any CC appointment/request information from HSRM Service.",
+            "detail": "siteId=983, patientDfn=7216690, patientIcn=1012845943V900681, startDate=2022-10-24T00:00Z, endDate=2023-12-23T00: 00Z"
+        },
+        {
             "system": "VSP",
             "status": "500",
             "code": 10000,

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -425,6 +425,26 @@ export const SPACE_BAR = 32;
 
 export const ERROR_CODES = [
   {
+    code: 9002,
+    detail: 'Failure to fetch CC requests from HSRM',
+  },
+  {
+    code: 9003,
+    detail: 'Failure to fetch CC requests from HSRM',
+  },
+  {
+    code: 9006,
+    detail: 'Failure to fetch CC Appointments from HSRM',
+  },
+  {
+    code: 9007,
+    detail: 'Failure to fetch CC Appointments from HSRM',
+  },
+  {
+    code: 9008,
+    detail: 'Failure to fetch CC from HSRM - Generic Error',
+  },
+  {
     code: 10000,
     detail: 'Failure to fetch - Generic Error',
   },


### PR DESCRIPTION
## Summary
When any of the systems are unavailable, the frontend will display a generic message to the user that their upcoming/pending/past appointment lists may be unavailable to view. We recently received error codes from HSRM service. 
![HSRM_error_codes](https://user-images.githubusercontent.com/54327023/232919347-e08d8127-a453-40b3-94db-3fa42d7ffb68.png)

We want to account for these HSRM codes as well:
- 9002: Could not fetch cc Appt requests form HSRM (Requests)
- 9003: Could not fetch cc Appt requests form HSRM (Requests)
- 9006: Could not fetch cc Appt from HSRM (Booked appts)
- 9007: Could not fetch cc Appt form HSRM (Booked appts)
- 9008: Could not fetch cc Appt form HSRM (General)

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#55279

## Testing done

To test locally.
Setup: In src/applications/vaos/services/mocks/index.js, uncomment line 38 and comment out line 41. 

  1.  To test for generic alert message to display in the **pending** list, go to the `meta_failures.json` delete all the objects that are not related to code 9002. This scenario tests for failure to fetch CC request from HSRM Service. It will display "We can't display all your requests." in the pending list page. Repeat the same for code 9003

| Code | Upcoming | Pending |
| --- | --- | --- |
| 9002, 9003 |<img width="322" alt="Screenshot 2023-04-18 at 4 19 52 PM" src="https://user-images.githubusercontent.com/54327023/232925936-0ab9e7e5-ccbd-490a-a1c8-5e92ac2bdea7.png"> | <img width="320" alt="Screenshot 2023-04-17 at 2 06 59 PM" src="https://user-images.githubusercontent.com/54327023/232613350-d2ae5e34-b7b2-457e-a004-58217a48b6e3.png">|

2.  To test for generic alert message to display in the **upcoming** and **past** appointment list, go to the `meta_failures.json` delete all the objects that are not related to code 9006. This scenario tests for failure to fetch CC booked appointments from HSRM Service. It will display "We can't display all your appointments." in the upcoming list page and past appointment list page. No error message alert will display in the pending list page. Repeat the same for code 9007.


| Code | Upcoming | Pending |
| --- | --- | --- |
| 9006, 9007 |<img width="318" alt="Screenshot 2023-04-18 at 4 21 36 PM" src="https://user-images.githubusercontent.com/54327023/232925768-0e138a35-f7e0-461b-9cb6-e112e1ed87f2.png"> | <img width="321" alt="Screenshot 2023-04-17 at 2 27 32 PM" src="https://user-images.githubusercontent.com/54327023/232614746-3f17a9c7-ae9a-44e2-a062-fcf2c47f2524.png"> |

3. To test for generic alert message to display in the **upcoming**, **pending** and **past** appointment list, go to the `meta_failures.json` delete all the objects that are not related to code 9008. This scenario tests for failure to fetch CC generic information from HSRM Service. It will display "We can't display all your appointments." in the upcoming list page and past appointment list page. It will display "We can't display all your requests." in the pending list page. 

| Code | Upcoming | Pending |
| --- | --- | --- |
| 9008 |<img width="318" alt="Screenshot 2023-04-18 at 4 21 36 PM" src="https://user-images.githubusercontent.com/54327023/232925768-0e138a35-f7e0-461b-9cb6-e112e1ed87f2.png"> | <img width="320" alt="Screenshot 2023-04-17 at 2 06 59 PM" src="https://user-images.githubusercontent.com/54327023/232613350-d2ae5e34-b7b2-457e-a004-58217a48b6e3.png">|

## Screenshots
See above


## What areas of the site does it impact?
*VAOS appointment list

## Acceptance criteria

- [x]  Failure to fetch CC request from HSRM will display "We can't display all your requests." in the pending list page. No alert message in upcoming or past appointment list
- [x]  Failure to fetch CC Appointments from HSRM will display "We can't display all your appointments." in the upcoming and past appointment list page. No alert message in pending appointment list
- [x]  failure to fetch CC generic information from HSRM Service will display "We can't display all your appointments." in the upcoming/past appointment list page and "We can't display all your requests." in the pending list page
- [x]  When list page refreshes the alert message remains



## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
