### PR TITLE
#VFEP-416 #comment removed repeating 'compare'

### DIFF
--- a/src/applications/gi/components/CompareCheckbox.jsx
+++ b/src/applications/gi/components/CompareCheckbox.jsx
@@ -7,7 +7,7 @@ export default function CompareCheckbox({
   handleCompareUpdate,
   cityState,
 }) {
-  const name = `Compare ${institution} ${cityState}`;
+  const name = `${institution} ${cityState}`;
   return (
     <div className="vads-u-padding--0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5">
       <Checkbox


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- *(Summarize the changes that have been made to the platform)*
- --The compare checkbox in the comparison tool would repeat the word 'compare' twice when using a screen reader. The cause was  created by having the word 'compare' as part of the aria label. The screen reader would read the text label of 'Compare' followed but the aria label which also starts with the word 'Compare'. To solve this issue I removed the word 'compare' from the aria label.
- *(If bug, how to reproduce)*NA
- *(What is the solution, why is this the solution)*
- --The solution was to remove the word 'Compare' from the aria label. By doing so it eliminates the word 'Compare' from being read twice.
- *(Which team do you work for, does your team own the maintenance of this component?)*
- --I work for GovCIO, we are the code owners of this change.
- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
- --No flipper in use, this code will go into production after staging.

## Related issue(s)
- *Link to ticket created in va.gov-team repo*
- --Jira Link https://vajira.max.gov/browse/VFEP-416
- *Link to previous change of the code/bug (if applicable)* NA
- *Link to epic if not included in ticket*
- -- https://vajira.max.gov/browse/VFEP-100

## Testing done

- *Describe what the old behavior was prior to the change*
- -- Prior to the removal of the word 'compare' in the aria label, a screen reader would read 'Compare' twice; once from the checkbox label and then from the aria label
- *Describe the steps required to verify your changes are working as expected*
- --Use a screen reader when in the comparison tool and tab to the 'Compare' checkbox. If the screen reader outputs 'Compare' only once, then it is working as intended.
- *Describe the tests completed and the results*
- --Testing done on local machine with screen reader. Testing passed. Additional testing will be done with QA in staging before prod release.
- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)* NA


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

Code snipits of before and after change

BEFORE:
![image](https://user-images.githubusercontent.com/88905347/233171815-2324b7b4-dd36-4401-93e9-a6ac92ed613a.png)

AFTER:
![image](https://user-images.githubusercontent.com/88905347/233171912-7c58074d-d4b9-4684-ac3b-797adee215e6.png)


## What areas of the site does it impact?
- -- This impacts the comparison tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_NA
