### PR TITLE
Too early message update

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentMessage.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentMessage.unit.spec.jsx
@@ -108,7 +108,7 @@ describe('check-in', () => {
 
       expect(action.getByTestId('too-early-message')).to.exist;
       expect(action.getByTestId('too-early-message')).to.have.text(
-        'You can check in starting at this time: 2:00 p.m.',
+        'You can check in starting at: 2:00 p.m.',
       );
     });
     it('should render the bad status message for appointments with INELIGIBLE_ALREADY_CHECKED_IN status', () => {

--- a/src/applications/check-in/day-of/tests/e2e/pages/Appointments.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Appointments.js
@@ -41,7 +41,7 @@ class Appointments {
       {
         timeout: Timeouts.slow,
       },
-    ).should('contain', 'You can check in starting at this time: 11:00 a.m.');
+    ).should('contain', 'You can check in starting at: 11:00 a.m.');
   };
 
   validateEarlyStatusWithoutTime = (appointmentNumber = 2) => {

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -157,7 +157,7 @@
   "work-phone": "Work phone",
   "yes": "Yes",
   "you-are-already-checked-in": "You are already checked in.",
-  "you-can-check-in-starting-at-this-time": "You can check in starting at this time: {{date, time}}",
+  "you-can-check-in-starting-at-this-time": "You can check in starting at: {{date, time}}",
   "you-can-pre-check-in-online-until-date": "You can pre-check in online until {{date, mdY}}.",
   "you-can-still-check-in-once-you-arrive": "You can still check-in with your phone once you arrive at your appointment.",
   "you-can-sign-in-to-your-va-gov-profile": "You can <0>{{link}}</0> to your VA.gov profile to update your contact information online.",


### PR DESCRIPTION
## Summary
Update the string value for the key: `you-can-check-in-starting-at-this-time` this is an exception to our rule to make a new key for text updates. I made the exception because it was a minor change and I didn't want to loose the Spanish and Tagalog translations. We should flag this for a new translation in both though.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#54511

## Testing done
Updates unit and e2e tests with new string.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

