### PR TITLE
Removing instances of the word Printed

### DIFF
--- a/src/applications/veteran-id-card/containers/EmailCapture.jsx
+++ b/src/applications/veteran-id-card/containers/EmailCapture.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { submitEmail, setEmail } from '../actions';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import TextInput from '@department-of-veterans-affairs/component-library/TextInput';
+import { submitEmail, setEmail } from '../actions';
 
 class EmailCapture extends React.Component {
   constructor(props) {
@@ -26,10 +26,10 @@ class EmailCapture extends React.Component {
     if (this.props.success) {
       view = (
         <div>
-          <h1>Printed Veteran ID Card</h1>
+          <h1>Veteran ID Card</h1>
           <AlertBox
             headline="Thank you for your email address. We will follow up with instructions on how to proceed with the application."
-            content={''}
+            content=""
             isVisible
             status="success"
           />
@@ -38,7 +38,7 @@ class EmailCapture extends React.Component {
     } else {
       view = (
         <div>
-          <h1>Printed Veteran ID Card</h1>
+          <h1>Veteran ID Card</h1>
           <p>
             You've reached the new Veteran ID Card application. We're excited to
             bring this important recognition to Veterans. We've experienced a

--- a/src/applications/veteran-id-card/containers/Main.jsx
+++ b/src/applications/veteran-id-card/containers/Main.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { has, head } from 'lodash';
-import { initiateIdRequest, timeoutRedirect } from '../actions';
-import config from '../config';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import EmailVICHelp from 'platform/static-data/EmailVICHelp';
+import { initiateIdRequest, timeoutRedirect } from '../actions';
+import config from '../config';
 
 class Main extends React.Component {
   constructor(props) {
@@ -65,7 +65,7 @@ class Main extends React.Component {
   renderVicError() {
     const headline = (
       <h4 className="usa-alert-heading">
-        We're sorry. Something went wrong when loading the page.
+        We’re sorry. Something went wrong when loading the page.
       </h4>
     );
     const content = (
@@ -87,13 +87,13 @@ class Main extends React.Component {
 
   renderErrors() {
     const { errors } = this.props;
-    const code = head(errors).code;
+    const { code } = head(errors);
     const detail = has(config.messages, code)
       ? config.messages[code]
       : config.messages.default;
     const content = (
       <div>
-        <h4 className="usa-alert-heading">We can't process your request</h4>
+        <h4 className="usa-alert-heading">We can’t process your request</h4>
         {detail}
       </div>
     );
@@ -110,14 +110,14 @@ class Main extends React.Component {
     const view = (
       <div className="row">
         <div className="usa-width-two-thirds medium-8 vet-id-card">
-          <h1>Printed Veteran ID Card</h1>
+          <h1>Veteran ID Card</h1>
           <p>
-            You can use your printed Veteran ID Card (VIC) instead of your DD214
-            to get discounts on goods and services offered to Veterans. You can
-            also use other identification cards for this purpose. Find out if
-            you need a VIC or if you already have what you need.
+            You can use your Veteran ID Card (VIC) instead of your DD214 to get
+            discounts on goods and services offered to Veterans. You can also
+            use other identification cards for this purpose. Find out if you
+            need a VIC or if you already have what you need.
           </p>
-          <h3>Should I request a printed Veteran ID card?</h3>
+          <h3>Should I request a Veteran ID card?</h3>
           <p>
             You <b>do not</b> need to request this card if you have one of
             these:
@@ -151,8 +151,8 @@ class Main extends React.Component {
             request.{' '}
           </p>
           <p>
-            <strong>Note:</strong> To continue, you'll need a government-issued
-            ID (like your driver's license) and a photo of yourself from the
+            <strong>Note:</strong> To continue, you’ll need a government-issued
+            ID (like your driver’s license) and a photo of yourself from the
             shoulders up. Make sure you have what you need for this next step.
           </p>
           <div>


### PR DESCRIPTION
Dupe of https://github.com/department-of-veterans-affairs/vets-website/pull/23957, to see if branch naming is affecting test runs.

## Summary

- Removed several instances of the word "printed" from the authenticated content. This is a request from VEO because the VIC is no longer printed and they're sending out promotions around the digital card tomorrow 4/18.
- I've made this change from sitewide content/IA/accessibility team with a request to Public Websites to review (per conversation with Dave Conlon).

## Related issue(s)

[56953](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/gh/department-of-veterans-affairs/va.gov-team/56953)

## Testing done

- Reviewed previews of files after commits to ensure removal of instances of the word "printed"


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

