### PR TITLE
Change button text for top action link

### DIFF
--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -7,6 +7,7 @@
   "answer-a-few-questions-to-find-out-if-you-can-file-your-claim-now": "Answer a few questions to find out if you can file your claim now.",
   "answer-pre-check-in-questions": "Answer pre-check-in questions",
   "answer-questions": "Answer questions",
+  "complete-pre-check-in": "Complete pre-check-in",
   "answer-yes-if-you-traveled-from-the-address": "Answer “Yes” if you traveled from the address listed here and you certify that it’s not a Post Office box.",
   "are-you-claiming-only-mileage-and-no-other": "Are you claiming only mileage and no other expenses today?",
   "ask-a-staff-member": "Ask a staff member.",

--- a/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
@@ -33,18 +33,18 @@ const IntroductionDisplay = props => {
 
   const [privacyActModalOpen, setPrivacyActModalOpen] = useState(false);
   // Save this useEffect for when we go back to testing action link.
-  // useEffect(
-  //   () => {
-  //     const position = isPreCheckInActionLinkTopPlacementEnabled
-  //       ? 'top'
-  //       : 'bottom';
-  //     const slug = `pre-check-in-viewed-introduction-${position}-position`;
-  //     recordEvent({
-  //       event: createAnalyticsSlug(slug, 'nav'),
-  //     });
-  //   },
-  //   [isPreCheckInActionLinkTopPlacementEnabled],
-  // );
+  useEffect(
+    () => {
+      const position = isPreCheckInActionLinkTopPlacementEnabled
+        ? 'top'
+        : 'bottom';
+      const slug = `pre-check-in-viewed-introduction-${position}-position`;
+      recordEvent({
+        event: createAnalyticsSlug(slug, 'nav'),
+      });
+    },
+    [isPreCheckInActionLinkTopPlacementEnabled],
+  );
   useEffect(() => {
     const slug = `pre-check-in-viewed-introduction-VAOS-design`;
     recordEvent({
@@ -90,18 +90,18 @@ const IntroductionDisplay = props => {
       if (e?.key && e.key !== ' ') {
         return;
       }
-      const slug = `pre-check-in-started-${
+      let slug = `pre-check-in-started-${
         isPhone ? 'phone' : 'in-person'
       }-VAOS-design`;
       // Save this for when we go back to testing action link.
-      // if (isPreCheckInActionLinkTopPlacementEnabled) slug += '-top-position';
+      if (isPreCheckInActionLinkTopPlacementEnabled) slug += '-top-position';
       recordEvent({
         event: createAnalyticsSlug(slug, 'nav'),
       });
       e.preventDefault();
       goToNextPage();
     },
-    [isPhone, goToNextPage],
+    [isPhone, goToNextPage, isPreCheckInActionLinkTopPlacementEnabled],
   );
 
   const StartButton = () => (
@@ -115,7 +115,9 @@ const IntroductionDisplay = props => {
         onKeyDown={handleStart}
         onClick={handleStart}
       >
-        {t('answer-questions')}
+        {isPreCheckInActionLinkTopPlacementEnabled
+          ? t('complete-pre-check-in')
+          : t('answer-questions')}
       </a>
     </div>
   );

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
@@ -48,7 +48,7 @@ class Introduction {
 
   validateStartButtonTopPlacement = () => {
     cy.get('div[data-testid="start-button"]')
-      .contains('Answer questions')
+      .contains('Complete pre-check-in')
       .parent()
       .prev()
       .contains('Your answers will');


### PR DESCRIPTION
## Summary

- Changes the text  on the top positioned action link for pre-check-in
- Re enables the feature flag switching for A/B testing the top and bottom position of the button

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#54250](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54250)


## Testing done

- Visual

## Screenshots

![Screen Shot 2023-04-20 at 12 17 39 PM](https://user-images.githubusercontent.com/2982977/233430017-858682dc-63af-4e2a-84e2-8183b08364e3.png)
![Screen Shot 2023-04-20 at 12 17 34 PM](https://user-images.githubusercontent.com/2982977/233430022-fe6fdf39-4f70-4c71-8ac5-bf7a9139ede5.png)


## What areas of the site does it impact?
CIE Pre-check-in

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

