### PR TITLE
VACMS-12162: Removes use of useStaggeredFeatureRelease in new home page modal

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -6,7 +6,6 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
-import { useStaggeredFeatureRelease } from 'platform/utilities/react-hooks';
 
 function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
   const noscriptElements = document.getElementsByTagName('noscript');
@@ -20,16 +19,11 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
     const searchParams = new URLSearchParams(window.location.search);
     hasRedirectParam = searchParams.has('next');
   }
-  const isAllowed = useStaggeredFeatureRelease(
-    75,
-    'show-homepage-soft-launch-modal',
-  );
 
   return (
     <>
       {vaHomePreviewModal &&
-        !hasRedirectParam &&
-        isAllowed && (
+        !hasRedirectParam && (
           <VaModal
             role="dialog"
             cssClass="va-modal announcement-brand-consolidation"


### PR DESCRIPTION
## Summary
Ensures that the new homepage modal is displayed once per session for all users by removing the useStaggeredFeatureRelease hook from the HomepageRedesignModal.

## Related issue(s)
- [department-of-veterans-affairs/va.gov-cms#12162](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12162)

## Testing done
- *Describe what the old behavior was prior to the change*

The useStaggeredFeatureRelease hook is meant to be used in non-authenticated parts of the site for staggered release of new features. In this case, we have been staggering the release of the new homepage modal, which presents to the user the option of navigating to the new home page, or staying on the current home page. Previously, the modal was rolled out to 75% of users.

- *Describe what the old behavior was prior to the change*

After this change is applied, the new home page modal will be shown to 100% of users, once per session.

- *Describe the steps required to verify your changes are working as expected*

Using a new session, visit the home page of the target environment. You should see a modal asking to visit the new home page (see below).

A subsequent refresh of the home page should not display the modal.

## Screenshots
<img width="572" alt="Screenshot 2023-04-20 at 1 39 41 PM" src="https://user-images.githubusercontent.com/221539/233482727-59e9fbfb-f614-404f-828b-f182de812dfb.png">

## What areas of the site does it impact?
The home page

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature
