### PR TITLE
Update spacing for the Upcoming Pending and Past links

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
@@ -13,10 +13,16 @@ export default function AppointmentListNavigation({ count, callback }) {
   );
 
   if (featureStatusImprovement) {
+    const isPending = !!location.pathname.endsWith('/pending');
+    const isPast = !!location.pathname.endsWith('/past');
+    const isUpcoming = !!location.pathname.endsWith('/');
+
     return (
       <nav
         aria-label="Appointment list navigation"
-        className="vaos-appts__breadcrumb"
+        className={`vaos-appts__breadcrumb xsmall-screen:${
+          isPast ? 'vads-u-margin-bottom--2' : 'vads-u-margin-bottom--3'
+        } small-screen:vads-u-margin-bottom--4`}
       >
         <ul>
           <li>
@@ -25,7 +31,7 @@ export default function AppointmentListNavigation({ count, callback }) {
               to="/"
               onClick={() => callback(true)}
               // eslint-disable-next-line jsx-a11y/aria-proptypes
-              aria-current={`${!!location.pathname.endsWith('/')}`}
+              aria-current={isUpcoming}
             >
               Upcoming
             </NavLink>
@@ -41,7 +47,7 @@ export default function AppointmentListNavigation({ count, callback }) {
                 });
               }}
               // eslint-disable-next-line jsx-a11y/aria-proptypes
-              aria-current={`${!!location.pathname.endsWith('pending')}`}
+              aria-current={isPending}
             >
               {`Pending (${count})`}
             </NavLink>
@@ -57,7 +63,7 @@ export default function AppointmentListNavigation({ count, callback }) {
                 });
               }}
               // eslint-disable-next-line jsx-a11y/aria-proptypes
-              aria-current={`${!!location.pathname.endsWith('past')}`}
+              aria-current={isPast}
             >
               Past
             </NavLink>

--- a/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
@@ -13,9 +13,9 @@ export default function AppointmentListNavigation({ count, callback }) {
   );
 
   if (featureStatusImprovement) {
-    const isPending = !!location.pathname.endsWith('/pending');
-    const isPast = !!location.pathname.endsWith('/past');
-    const isUpcoming = !!location.pathname.endsWith('/');
+    const isPending = location.pathname.endsWith('/pending');
+    const isPast = location.pathname.endsWith('/past');
+    const isUpcoming = location.pathname.endsWith('/');
 
     return (
       <nav

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Switch, Route, useHistory, useLocation } from 'react-router-dom';
+import classNames from 'classnames';
 import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
@@ -115,8 +116,8 @@ export default function AppointmentsPageV2() {
   } = getDropdownValueFromLocation(location.pathname);
 
   let prefix = 'Your';
-  const isPending = !!location.pathname.endsWith('/pending');
-  const isPast = !!location.pathname.endsWith('/past');
+  const isPending = location.pathname.endsWith('/pending');
+  const isPast = location.pathname.endsWith('/past');
 
   if (featureStatusImprovement) {
     if (isPending) {
@@ -199,11 +200,13 @@ export default function AppointmentsPageV2() {
   return (
     <PageLayout showBreadcrumbs showNeedHelp>
       <h1
-        className={`xsmall-screen:${
-          isPending ? 'vads-u-margin-bottom--1' : 'vads-u-margin-bottom--2'
-        } vads-u-flex--1 vaos-hide-for-print small-screen:${
-          isPending ? 'vads-u-margin-bottom--2' : 'vads-u-margin-bottom--4'
-        }`}
+        className={classNames(
+          `xsmall-screen:${
+            isPending ? 'vads-u-margin-bottom--1' : 'vads-u-margin-bottom--2'
+          } vads-u-flex--1 vaos-hide-for-print small-screen:${
+            isPending ? 'vads-u-margin-bottom--2' : 'vads-u-margin-bottom--4'
+          }`,
+        )}
       >
         {pageTitle}
       </h1>

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -5,7 +5,10 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import PropTypes from 'prop-types';
-import { selectFeatureStatusImprovement } from '../../../redux/selectors';
+import {
+  selectFeatureStatusImprovement,
+  selectFeatureAppointmentList,
+} from '../../../redux/selectors';
 import RequestedAppointmentsList from '../RequestedAppointmentsList';
 import UpcomingAppointmentsList from '../UpcomingAppointmentsList';
 import PastAppointmentsListV2 from '../PastAppointmentsListV2';
@@ -95,6 +98,9 @@ export default function AppointmentsPageV2() {
   const [hasTypeChanged, setHasTypeChanged] = useState(false);
   let [pageTitle] = useState('VA online scheduling');
 
+  const featureAppointmentList = useSelector(state =>
+    selectFeatureAppointmentList(state),
+  );
   const featureStatusImprovement = useSelector(state =>
     selectFeatureStatusImprovement(state),
   );
@@ -109,11 +115,14 @@ export default function AppointmentsPageV2() {
   } = getDropdownValueFromLocation(location.pathname);
 
   let prefix = 'Your';
+  const isPending = !!location.pathname.endsWith('/pending');
+  const isPast = !!location.pathname.endsWith('/past');
+
   if (featureStatusImprovement) {
-    if (location.pathname.endsWith('pending')) {
+    if (isPending) {
       prefix = 'Pending';
       pageTitle = `${prefix} appointments`;
-    } else if (location.pathname.endsWith('past')) {
+    } else if (isPast) {
       prefix = 'Past';
       pageTitle = `${prefix} appointments`;
     } else {
@@ -179,11 +188,31 @@ export default function AppointmentsPageV2() {
 
   const history = useHistory();
 
+  let paragraphText =
+    'Below is your list of appointment requests that haven’t been scheduled yet.';
+  if (featureAppointmentList) {
+    paragraphText = 'These appointment requests haven’t been scheduled yet.';
+  } else if (featureStatusImprovement) {
+    paragraphText =
+      'Your appointment requests that haven’t been scheduled yet.';
+  }
   return (
     <PageLayout showBreadcrumbs showNeedHelp>
-      <h1 className="vads-u-flex--1 vads-u-margin-bottom--1p5 vaos-hide-for-print">
+      <h1
+        className={`xsmall-screen:${
+          isPending ? 'vads-u-margin-bottom--1' : 'vads-u-margin-bottom--2'
+        } vads-u-flex--1 vaos-hide-for-print small-screen:${
+          isPending ? 'vads-u-margin-bottom--2' : 'vads-u-margin-bottom--4'
+        }`}
+      >
         {pageTitle}
       </h1>
+      {/* change the order where message shows in pending list before nav menu */}
+      {pageTitle === 'Pending appointments' && (
+        <p className="xsmall-screen:vads-u-margin-top--0 vads-u-margin-bottom--2 vaos-hide-for-print small-screen:vads-u-margin-bottom--4">
+          {paragraphText}
+        </p>
+      )}
       <DowntimeNotification
         appTitle="VA online scheduling tool"
         isReady

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/PastAppointmentsDateDropdown.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/PastAppointmentsDateDropdown.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import classNames from 'classnames';
 import Select from '../../../components/Select';
 import { selectFeatureStatusImprovement } from '../../../redux/selectors';
 
@@ -51,6 +52,9 @@ export default function PastAppointmentsDateDropdown({
         id="date-dropdown"
         value={dateRangeIndex.toString()}
         label="Select a date range"
+        className={classNames(
+          'xsmall-screen:vads-u-margin-bottom--3 small-screen:vads-u-margin-bottom--4 ',
+        )}
       />
       {!featureStatusImprovement && (
         <button

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/index.jsx
@@ -260,6 +260,7 @@ export default function PastAppointmentsListNew() {
             <h3
               id={`appointment_list_${monthDate.format('YYYY-MM')}`}
               data-cy="past-appointment-list-header"
+              className="vads-u-margin-top--0"
             >
               <span className="sr-only">Appointments in </span>
               {monthDate.format('MMMM YYYY')}

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentsListGroup.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentsListGroup.jsx
@@ -18,10 +18,7 @@ import RequestListItem from './AppointmentsPageV2/RequestListItem';
 import NoAppointments from './NoAppointments';
 import InfoAlert from '../../components/InfoAlert';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
-import {
-  selectFeatureAppointmentList,
-  selectFeatureStatusImprovement,
-} from '../../redux/selectors';
+import { selectFeatureAppointmentList } from '../../redux/selectors';
 import RequestAppointmentLayout from './AppointmentsPageV2/RequestAppointmentLayout';
 import BackendAppointmentServiceAlert from './BackendAppointmentServiceAlert';
 
@@ -37,9 +34,6 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
   );
   const featureAppointmentList = useSelector(state =>
     selectFeatureAppointmentList(state),
-  );
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
   );
 
   const dispatch = useDispatch();
@@ -107,15 +101,6 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
     return 0;
   });
 
-  let paragraphText =
-    'Below is your list of appointment requests that haven’t been scheduled yet.';
-  if (featureAppointmentList) {
-    paragraphText = 'These appointment requests haven’t been scheduled yet.';
-  } else if (featureStatusImprovement) {
-    paragraphText =
-      'Your appointment requests that haven’t been scheduled yet.';
-  }
-
   return (
     <>
       <div aria-live="polite" className="sr-only">
@@ -123,7 +108,6 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
       </div>
       <>
         <BackendAppointmentServiceAlert />
-        <p className="vaos-hide-for-print">{paragraphText}</p>
 
         {!appointmentsByStatus.flat().includes(APPOINTMENT_STATUS.proposed) && (
           <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-y--3">

--- a/src/applications/vaos/appointment-list/components/ScheduleNewAppointment.jsx
+++ b/src/applications/vaos/appointment-list/components/ScheduleNewAppointment.jsx
@@ -26,7 +26,7 @@ function ScheduleNewAppointmentButton() {
   return (
     <button
       type="button"
-      className="vaos-hide-for-print"
+      className="xsmall-screen:vads-u-margin-bottom--2 vaos-hide-for-print vads-u-margin--0 small-screen:vads-u-margin-bottom--4"
       aria-label="Start scheduling an appointment"
       id="schedule-button"
       onClick={handleClick(history, dispatch)}

--- a/src/applications/vaos/appointment-list/sass/styles.scss
+++ b/src/applications/vaos/appointment-list/sass/styles.scss
@@ -126,7 +126,6 @@
 }
 
 .vaos-appts__breadcrumb {
-  padding: 2em 0;
 
   ul {
     margin: 0;

--- a/src/applications/vaos/components/Select.jsx
+++ b/src/applications/vaos/components/Select.jsx
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-function Select({ onChange, options, id, label, value }) {
+function Select({
+  onChange,
+  options,
+  id,
+  label,
+  value,
+  className = 'vads-u-margin-bottom--1p5',
+}) {
   const selectOptions = options.map((o, index) => {
     return (
       <option
@@ -21,7 +28,7 @@ function Select({ onChange, options, id, label, value }) {
       id={id}
       label={label ?? 'Select'}
       onVaSelect={onChange}
-      className="usa-select vads-u-margin-bottom--1p5"
+      className={className}
       value={value}
       data-testid="vaosSelect"
     >
@@ -36,6 +43,7 @@ Select.propTypes = {
   id: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  className: PropTypes.string,
   label: PropTypes.string,
 };
 


### PR DESCRIPTION
## Summary
Since adding the navigation links to each status page (Upcoming, Pending and Past), we need to make adjustments to the  at breakpoints based on the [design spec](https://www.figma.com/file/XmvY7ijIOTPgfQ3cTXodJD/Subnavigation?node-id=13-33&t=XeM0C0NOMhHE4sjH-0)


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#56790



## Testing done

- visual test using chrome dev tool

## Screenshots
**Styling Limitation on Past appointment list for Mobile breakpoint**
The breadcrumb has a margin bottom of 16px. However due to the label, "Select a date range" that's part of a form construction, it is assigned with a top margin of 30px. I am not able to target the label selector to give it a top margin of 0px. I mentioned the style limitation during standup.


<img width="1446" alt="Screenshot 2023-04-20 at 5 45 54 PM" src="https://user-images.githubusercontent.com/54327023/233516105-66286bc6-2dad-4803-a1fa-edc918a777b2.png">

**Past Tablet**
<img width="774" alt="Screenshot 2023-04-20 at 6 12 51 PM" src="https://user-images.githubusercontent.com/54327023/233517851-9f0a1bda-0e81-4b6d-b8ef-14ea812c41cf.png">

**Past Desktop**
<img width="1011" alt="Screenshot 2023-04-20 at 6 16 20 PM" src="https://user-images.githubusercontent.com/54327023/233518133-20fb871d-9c7c-49da-a93b-de84705d4e0f.png">


**Upcoming Desktop**
All other status list page meet design spec for breakpoints. 
<img width="1010" alt="Screenshot 2023-04-20 at 5 22 46 PM" src="https://user-images.githubusercontent.com/54327023/233512894-5a2c6889-46ef-4aa4-acb4-65f143f530b8.png">

**Upcoming Tablet**
<img width="783" alt="Screenshot 2023-04-20 at 5 22 19 PM" src="https://user-images.githubusercontent.com/54327023/233512953-56a4bab5-d720-4faf-a924-a50921f007a3.png">

**Upcoming Mobile**
<img width="394" alt="Screenshot 2023-04-20 at 5 20 46 PM" src="https://user-images.githubusercontent.com/54327023/233512974-82cf69de-6666-4654-980d-bedcbcce809a.png">


## Screenshots
_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._

| | Before | After |
| --- | --- | --- |
| Mobile | | |
| Desktop | | |

## What areas of the site does it impact?
*breakpoints*

## Acceptance criteria

- [ ]  Match spacing based on design spec for Upcoming appointment list for Desktop/Tablet/Mobile breakpoints
- [ ]  Match spacing based on design spec for Past appointment for list Desktop/Tablet/Mobile breakpoints
- [ ]  Match spacing based on design spec for Pending appointment for list Desktop/Tablet/Mobile breakpoints
- [ ]  Move the text "These appointment requests haven’t been scheduled yet." above the breadcrumb menu to the match [design spec](https://www.figma.com/file/XmvY7ijIOTPgfQ3cTXodJD/Subnavigation?node-id=1102-12896&t=XeM0C0NOMhHE4sjH-0) on the Pending appointment list page



## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
