### PR TITLE
Vet and spouse employment navigation

### DIFF
--- a/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
+++ b/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import PropTypes from 'prop-types';
-import { MiniSummaryCard } from './shared/MiniSummaryCard';
+import {
+  EmptyMiniSummaryCard,
+  MiniSummaryCard,
+} from './shared/MiniSummaryCard';
 import { setJobIndex } from '../utils/session';
 import { dateFormatter } from '../utils/helpers';
 
@@ -117,13 +120,17 @@ const EmploymentHistorySummaryCard = ({
   };
 
   return (
-    <MiniSummaryCard
-      editDestination={handleClick(index)}
-      heading={employmentCardHeading}
-      body={cardBody}
-      onDelete={() => onDelete(index)}
-      showDelete
-    />
+    (!job && (
+      <EmptyMiniSummaryCard content="No employment history provided" />
+    )) || (
+      <MiniSummaryCard
+        editDestination={handleClick(index)}
+        heading={employmentCardHeading}
+        body={cardBody}
+        onDelete={() => onDelete(index)}
+        showDelete
+      />
+    )
   );
 };
 

--- a/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
+++ b/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
@@ -1,42 +1,140 @@
 import React from 'react';
-import { browserHistory } from 'react-router';
+import { connect, useDispatch } from 'react-redux';
+import { setData } from 'platform/forms-system/src/js/actions';
+import PropTypes from 'prop-types';
+import { MiniSummaryCard } from './shared/MiniSummaryCard';
 import { setJobIndex } from '../utils/session';
+import { dateFormatter } from '../utils/helpers';
 
-const EmploymentHistorySummaryCard = ({ job, index, isSpouse }) => {
-  const employmentCardHeading = `${job.employerName}`;
-  const employmentCardSubheading = `From ${job.from} to ${
-    job.isCurrent ? 'Now' : job.to
-  }`;
+const EmploymentHistorySummaryCard = ({
+  job,
+  index,
+  isSpouse,
+  formData,
+  setFormData,
+}) => {
+  const {
+    employerName,
+    from,
+    to,
+    type,
+    grossMonthlyIncome,
+    deductions,
+    isCurrent,
+  } = job ?? {};
 
-  const handleClick = () => {
-    setJobIndex(index);
-    if (isSpouse) {
-      browserHistory.push(`/enhanced-spouse-employment-records`);
-    } else {
-      browserHistory.push(`/enhanced-employment-records`);
-    }
+  const dispatch = useDispatch();
+
+  const handleClick = jobIndex => () => {
+    setJobIndex(jobIndex);
+    return isSpouse
+      ? {
+          pathname: `/enhanced-spouse-employment-records`,
+        }
+      : {
+          pathname: `/enhanced-employment-records`,
+        };
   };
 
-  return (
-    <article
-      className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-bottom--2"
-      data-testid="employment-history-item"
-    >
-      <h3 className="vads-u-margin--0">{employmentCardHeading}</h3>
+  const onDelete = deleteIndex => {
+    const updatedEmploymentHistory = {
+      ...formData.personalData.employmentHistory,
+      [isSpouse ? 'spouse' : 'veteran']: {
+        ...formData.personalData.employmentHistory[
+          isSpouse ? 'spouse' : 'veteran'
+        ],
+        employmentRecords: formData.personalData.employmentHistory[
+          isSpouse ? 'spouse' : 'veteran'
+        ].employmentRecords.filter((_, i) => i !== deleteIndex),
+      },
+    };
+
+    dispatch(
+      setFormData({
+        ...formData,
+        personalData: {
+          ...formData.personalData,
+          employmentHistory: updatedEmploymentHistory,
+        },
+      }),
+    );
+  };
+
+  const employmentCardHeading = `${type} employment at ${employerName}`;
+
+  const cardBody = (
+    <div>
       <p className="vads-u-margin-y--2 vads-u-font-weight--normal">
-        {employmentCardSubheading}
+        Dates:
+        <span className="vads-u-margin-x--1">
+          <strong>
+            {dateFormatter(from)} - {isCurrent ? 'Present' : dateFormatter(to)}
+          </strong>
+        </span>
       </p>
-      <a
-        onClick={() => {
-          handleClick();
-        }}
-        href="#/edit"
-        aria-label={`Edit Employment History for ${employmentCardHeading}`}
-      >
-        Edit
-      </a>
-    </article>
+      {grossMonthlyIncome && (
+        <p>
+          Gross Monthly Income: <strong> ${grossMonthlyIncome}</strong>
+        </p>
+      )}
+      {deductions && (
+        <div>
+          {deductions.map((deduction, i) => (
+            <p key={i}>
+              {deduction.name}: <strong>${deduction.amount}</strong>
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <MiniSummaryCard
+      editDestination={handleClick(index)}
+      heading={employmentCardHeading}
+      body={cardBody}
+      onDelete={() => onDelete(index)}
+      showDelete
+    />
   );
 };
 
-export default EmploymentHistorySummaryCard;
+EmploymentHistorySummaryCard.propTypes = {
+  formData: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  isSpouse: PropTypes.bool.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  job: PropTypes.shape({
+    employerName: PropTypes.string,
+    from: PropTypes.string,
+    to: PropTypes.string,
+    type: PropTypes.string,
+    grossMonthlyIncome: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    deductions: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      }),
+    ),
+    isCurrent: PropTypes.bool,
+  }),
+};
+
+const mapStateToProps = ({ form }) => {
+  return {
+    formData: form.data,
+  };
+};
+
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EmploymentHistorySummaryCard);

--- a/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
+++ b/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
@@ -118,11 +118,10 @@ const EmploymentHistorySummaryCard = ({
       PropTypes.number,
     ]),
   };
+  const emptyPrompt = `Select the ‘add additional job link to add another job. Select the continue button to move on to the next question.`;
 
   return (
-    (!job && (
-      <EmptyMiniSummaryCard content="No employment history provided" />
-    )) || (
+    (!job && <EmptyMiniSummaryCard content={emptyPrompt} />) || (
       <MiniSummaryCard
         editDestination={handleClick(index)}
         heading={employmentCardHeading}

--- a/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
+++ b/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
@@ -62,32 +62,59 @@ const EmploymentHistorySummaryCard = ({
 
   const employmentCardHeading = `${type} employment at ${employerName}`;
 
+  const StyledParagraph = ({ children }) => (
+    <p className="vads-u-margin-y--0">{children}</p>
+  );
+
+  StyledParagraph.propTypes = {
+    children: PropTypes.node, // PropType for the children prop (can be any renderable content)
+  };
+
+  // Reusable functional component to render expense information
+  const EmploymentCardBody = ({ label, value }) => (
+    <StyledParagraph>
+      {label}: <strong>{value}</strong>
+    </StyledParagraph>
+  );
+
   const cardBody = (
-    <div>
-      <p className="vads-u-margin-y--2 vads-u-font-weight--normal">
-        Dates:
-        <span className="vads-u-margin-x--1">
-          <strong>
-            {dateFormatter(from)} - {isCurrent ? 'Present' : dateFormatter(to)}
-          </strong>
-        </span>
-      </p>
+    <div className="vads-u-margin-y--1">
+      {/* Render date information */}
+      <EmploymentCardBody
+        label="Dates"
+        value={`${dateFormatter(from)} - ${
+          isCurrent ? 'Present' : dateFormatter(to)
+        }`}
+      />
+
+      {/* Conditionally render gross monthly income information */}
       {grossMonthlyIncome && (
-        <p>
-          Gross Monthly Income: <strong> ${grossMonthlyIncome}</strong>
-        </p>
+        <EmploymentCardBody
+          label="Gross Monthly Income"
+          value={`$${grossMonthlyIncome}`}
+        />
       )}
-      {deductions && (
-        <div>
-          {deductions.map((deduction, i) => (
-            <p key={i}>
-              {deduction.name}: <strong>${deduction.amount}</strong>
-            </p>
-          ))}
-        </div>
-      )}
+
+      {/* Render deductions information */}
+      {deductions &&
+        deductions.map((deduction, i) => (
+          <EmploymentCardBody
+            key={i}
+            label={deduction.name}
+            value={`$${deduction.amount}`}
+          />
+        ))}
     </div>
   );
+
+  EmploymentCardBody.propTypes = {
+    label: PropTypes.string, // PropType for the label prop (string)
+    value: PropTypes.oneOfType([
+      // PropType for the value prop (can be string or number)
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+  };
 
   return (
     <MiniSummaryCard

--- a/src/applications/financial-status-report/components/EmploymentQuestion.jsx
+++ b/src/applications/financial-status-report/components/EmploymentQuestion.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import { clearJobIndex } from '../utils/session';
+
+const EmploymentQuestion = props => {
+  const {
+    data,
+    goBack,
+    goToPath,
+    setFormData,
+    contentBeforeButtons,
+    contentAfterButtons,
+  } = props;
+
+  const [hasJobToAdd, setHasJobToAdd] = useState(
+    data.questions?.vetIsEmployed ?? false,
+  );
+
+  const hasJobs =
+    data.personalData?.employmentHistory?.veteran?.employmentRecords;
+
+  useEffect(() => {
+    clearJobIndex();
+  }, []);
+
+  useEffect(
+    () => {
+      setFormData({
+        ...data,
+        questions: {
+          ...data?.questions,
+          vetIsEmployed: hasJobToAdd,
+        },
+      });
+    },
+    [hasJobToAdd],
+  );
+
+  const goForward = () => {
+    if (hasJobToAdd) {
+      const path = hasJobs
+        ? '/employment-history'
+        : '/enhanced-employment-records';
+      goToPath(path);
+    } else {
+      goToPath('/your-benefits');
+    }
+  };
+
+  const onSelection = event => {
+    const { value } = event?.detail || {};
+    if (value === undefined) return;
+    setHasJobToAdd(value === 'true');
+  };
+
+  return (
+    <form>
+      <VaRadio
+        class="vads-u-margin-y--2"
+        label="Have you had another job in the last 2 years?"
+        onVaValueChange={onSelection}
+        required
+      >
+        <va-radio-option
+          id="has-job"
+          label="Yes"
+          value="true"
+          checked={hasJobToAdd}
+        />
+        <va-radio-option
+          id="has-no-job"
+          label="No"
+          value="false"
+          name="primary"
+          checked={!hasJobToAdd}
+        />
+      </VaRadio>
+      {contentBeforeButtons}
+      <FormNavButtons goBack={goBack} goForward={goForward} submitToContinue />
+      {contentAfterButtons}
+    </form>
+  );
+};
+
+EmploymentQuestion.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+};
+
+export default EmploymentQuestion;

--- a/src/applications/financial-status-report/components/EnhancedEmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedEmploymentRecord.jsx
@@ -183,8 +183,8 @@ const EmploymentRecord = props => {
     <form onSubmit={updateFormData}>
       <legend className="schemaform-block-title">Add a job</legend>
       <p className="vads-u-padding-top--1">
-        Tell us about a job you’ve had in the past 2 years that you received pay
-        stubs for. You’ll need to provide your income information if it’s a
+        Tell us about any jobs you’ve had in the past 2 years that you received
+        pay stubs for. You’ll need to provide your income information if it’s a
         current job.
       </p>
       <div className="input-size-5">

--- a/src/applications/financial-status-report/components/EnhancedEmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedEmploymentRecord.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import { setData } from 'platform/forms-system/src/js/actions';
 import {
   VaSelect,
@@ -52,8 +53,9 @@ const EmploymentRecord = props => {
 
   const handleEmployerNameChange = event => {
     handleChange('employerName', event.target.value);
+    setEmployerNameError(false);
   };
-
+  const [toDateError, setToDateError] = useState();
   const [fromDateError, setFromDateError] = useState();
 
   const userType = 'veteran';
@@ -80,9 +82,9 @@ const EmploymentRecord = props => {
     }
 
     if (
-      !employmentRecord.type &&
-      !employmentRecord.employerName &&
-      employmentRecord.employerName !== ''
+      !employmentRecord.type ||
+      employmentRecord.type === '' ||
+      (!employmentRecord.employerName && employmentRecord.employerName !== '')
     ) {
       return;
     }
@@ -229,11 +231,15 @@ const EmploymentRecord = props => {
           label="Date you stopped work at this job?"
           name="to"
           onDateChange={e => handlers.handleDateChange('to', e.target.value)}
-          // onDateBlur={e =>
-          //   validateYear(e.target.value || '', setToDateError, endError)
-          // }
+          onDateBlur={e =>
+            validateYear(
+              e.target.value || '',
+              setToDateError,
+              'Please enter your employment end date.',
+            )
+          }
           required
-          // error={toDateError}
+          error={toDateError}
         />
       </div>
       <Checkbox
@@ -257,6 +263,14 @@ const EmploymentRecord = props => {
       {onReviewPage ? updateButton : navButtons}
     </form>
   );
+};
+
+EmploymentRecord.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  onReviewPage: PropTypes.bool,
 };
 
 const mapStateToProps = ({ form }) => {

--- a/src/applications/financial-status-report/components/EnhancedEmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedEmploymentRecord.jsx
@@ -181,6 +181,12 @@ const EmploymentRecord = props => {
 
   return (
     <form onSubmit={updateFormData}>
+      <legend className="schemaform-block-title">Add a job</legend>
+      <p className="vads-u-padding-top--1">
+        Tell us about a job you’ve had in the past 2 years that you received pay
+        stubs for. You’ll need to provide your income information if it’s a
+        current job.
+      </p>
       <div className="input-size-5">
         <VaSelect
           id="type"

--- a/src/applications/financial-status-report/components/EnhancedSpouseEmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedSpouseEmploymentRecord.jsx
@@ -180,7 +180,7 @@ const EmploymentRecord = props => {
     <form onSubmit={updateFormData}>
       <legend className="schemaform-block-title">Add a job</legend>
       <p className="vads-u-padding-top--1">
-        Tell us about any job your spouse had in the past 2 years that they
+        Tell us about any jobs your spouse had in the past 2 years that they
         received pay stubs for. You’ll need to provide their income information
         if it’s a current job.
       </p>

--- a/src/applications/financial-status-report/components/EnhancedSpouseEmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedSpouseEmploymentRecord.jsx
@@ -178,6 +178,12 @@ const EmploymentRecord = props => {
 
   return (
     <form onSubmit={updateFormData}>
+      <legend className="schemaform-block-title">Add a job</legend>
+      <p className="vads-u-padding-top--1">
+        Tell us about any job your spouse had in the past 2 years that they
+        received pay stubs for. You’ll need to provide their income information
+        if it’s a current job.
+      </p>
       <div className="input-size-5">
         <VaSelect
           id="type"
@@ -187,6 +193,7 @@ const EmploymentRecord = props => {
           value={employmentRecord.type}
           onVaSelect={handlers.onChange}
           error={typeError}
+          class="advanced-search-field"
         >
           <option value=""> </option>
           <option value="Full time">Full time</option>
@@ -205,6 +212,7 @@ const EmploymentRecord = props => {
           onDateBlur={e =>
             validateYear(e.target.value || '', setFromDateError, startError)
           }
+          className="vads-u-margin-top--0"
           required
           error={fromDateError}
         />

--- a/src/applications/financial-status-report/components/EnhancedSpouseEmploymentRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedSpouseEmploymentRecord.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import { setData } from 'platform/forms-system/src/js/actions';
 import {
   VaSelect,
@@ -259,6 +260,14 @@ const EmploymentRecord = props => {
       {onReviewPage ? updateButton : navButtons}
     </form>
   );
+};
+
+EmploymentRecord.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  onReviewPage: PropTypes.bool,
 };
 
 const mapStateToProps = ({ form }) => {

--- a/src/applications/financial-status-report/components/PayrollDeductionChecklist.jsx
+++ b/src/applications/financial-status-report/components/PayrollDeductionChecklist.jsx
@@ -94,7 +94,11 @@ const PayrollDeductionChecklist = props => {
         },
       });
     }
-    goToPath(`/deduction-values`);
+    if (selectedDeductions.length > 0) {
+      goToPath(`/deduction-values`);
+    } else {
+      goToPath(`/employment-history`);
+    }
   };
 
   const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;

--- a/src/applications/financial-status-report/components/SpouseEmploymentQuestion.jsx
+++ b/src/applications/financial-status-report/components/SpouseEmploymentQuestion.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import { clearJobIndex } from '../utils/session';
+
+const SpouseEmploymentQuestion = props => {
+  const {
+    data,
+    goBack,
+    goToPath,
+    setFormData,
+    contentBeforeButtons,
+    contentAfterButtons,
+  } = props;
+
+  const [hasJobToAdd, setHasJobToAdd] = useState(
+    data.questions?.spouseIsEmployed ?? false,
+  );
+
+  const hasJobs =
+    data.personalData?.employmentHistory?.spouse?.employmentRecords;
+
+  useEffect(() => {
+    clearJobIndex();
+  }, []);
+
+  useEffect(
+    () => {
+      setFormData({
+        ...data,
+        questions: {
+          ...data?.questions,
+          spouseIsEmployed: hasJobToAdd,
+        },
+      });
+    },
+    [hasJobToAdd],
+  );
+
+  const handlers = {
+    nextPage: () => {
+      if (hasJobToAdd) {
+        const path = hasJobs
+          ? '/spouse-employment-history'
+          : '/enhanced-spouse-employment-records';
+        goToPath(path);
+      } else {
+        goToPath('/spouse-benefits');
+      }
+    },
+  };
+
+  const onSelection = event => {
+    const { value } = event?.detail || {};
+    if (value === undefined) return;
+    setHasJobToAdd(value === 'true');
+  };
+
+  return (
+    <form onSubmit={handlers.nextPage}>
+      <legend className="schemaform-block-title">
+        Your spouse’s work history
+      </legend>
+      <VaRadio
+        class="vads-u-margin-y--2"
+        label="Has your spouse had any jobs in the last 2 years? "
+        onVaValueChange={onSelection}
+        required
+      >
+        <va-radio-option
+          id="has-job"
+          label="Yes"
+          value="true"
+          checked={hasJobToAdd}
+        />
+        <va-radio-option
+          id="has-no-job"
+          label="No"
+          value="false"
+          name="primary"
+          checked={!hasJobToAdd}
+        />
+      </VaRadio>
+      {contentBeforeButtons}
+      <FormNavButtons goBack={goBack} submitToContinue />
+      {contentAfterButtons}
+    </form>
+  );
+};
+
+SpouseEmploymentQuestion.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+};
+
+export default SpouseEmploymentQuestion;

--- a/src/applications/financial-status-report/components/SpousePayrollDeductionChecklist.jsx
+++ b/src/applications/financial-status-report/components/SpousePayrollDeductionChecklist.jsx
@@ -94,7 +94,11 @@ const SpousePayrollDeductionChecklist = props => {
         },
       });
     }
-    goToPath(`/spouse-deduction-values`);
+    if (selectedDeductions.length > 0) {
+      goToPath(`/spouse-deduction-values`);
+    } else {
+      goToPath(`/spouse-employment-history`);
+    }
   };
 
   const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;

--- a/src/applications/financial-status-report/components/shared/MiniSummaryCard.jsx
+++ b/src/applications/financial-status-report/components/shared/MiniSummaryCard.jsx
@@ -61,14 +61,17 @@ export const MiniSummaryCard = ({
     </div>
   );
 };
-
 MiniSummaryCard.propTypes = {
-  editDestination: Proptypes.shape({
-    pathname: Proptypes.string.isRequired,
-    search: Proptypes.string.isRequired,
-  }).isRequired,
+  editDestination: Proptypes.oneOfType([
+    Proptypes.shape({
+      pathname: Proptypes.string.isRequired,
+      search: Proptypes.string.isRequired,
+    }),
+    Proptypes.func,
+  ]).isRequired,
   heading: Proptypes.string.isRequired,
   body: Proptypes.object,
+  index: Proptypes.number,
   showDelete: Proptypes.bool,
   onDelete: Proptypes.func,
 };

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -32,8 +32,6 @@ import UtilityBillSummary from '../components/utilityBills/UtilityBillSummary';
 import UtilityBillSummaryReview from '../components/utilityBills/UtilityBillSummaryReview';
 import submitForm from './submitForm';
 import SpouseEmploymentHistoryWidget from '../pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget';
-import InstallmentContract from '../components/InstallmentContract';
-import InstallmentContractSummary from '../pages/expenses/repayments/InstallmentContractSummary';
 import EmploymentQuestion from '../components/EmploymentQuestion';
 import InstallmentContract from '../components/InstallmentContract';
 import InstallmentContractSummary from '../pages/expenses/repayments/InstallmentContractSummary';

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -505,18 +505,6 @@ const formConfig = {
             !formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
         },
-
-        // spouseEmploymentQuestion: {
-        //   path: 'enhanced-spouse-employment-question',
-        //   title: 'Employment',
-        //   uiSchema: pages.spouseEmploymentQuestion.uiSchema,
-        //   schema: pages.spouseEmploymentQuestion.schema,
-        //   depends: formData =>
-        //     formData.questions.isMarried &&
-        //     formData['view:enhancedFinancialStatusReport'],
-        //   editModeOnReviewPage: false,
-        // },
-
         spouseAdditionalIncomeCheckList: {
           path: 'spouse-additional-income-checklist',
           title: 'Additional income options',

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -34,6 +34,7 @@ import submitForm from './submitForm';
 import SpouseEmploymentHistoryWidget from '../pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget';
 import InstallmentContract from '../components/InstallmentContract';
 import InstallmentContractSummary from '../pages/expenses/repayments/InstallmentContractSummary';
+import EmploymentQuestion from '../components/EmploymentQuestion';
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -158,6 +159,7 @@ const formConfig = {
           title: 'Employment',
           uiSchema: pages.employment.uiSchema,
           schema: pages.employment.schema,
+          depends: formData => !formData['view:enhancedFinancialStatusReport'],
         },
         // loop begins
         employmentRecords: {
@@ -169,6 +171,15 @@ const formConfig = {
             formData.questions.vetIsEmployed &&
             !formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
+        },
+        employmentQuestion: {
+          path: 'employment-question',
+          title: 'Employment',
+          CustomPage: EmploymentQuestion,
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          depends: formData => formData['view:enhancedFinancialStatusReport'],
         },
         enhancedEmploymentRecords: {
           path: 'enhanced-employment-records',

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -32,6 +32,7 @@ import UtilityBillSummary from '../components/utilityBills/UtilityBillSummary';
 import UtilityBillSummaryReview from '../components/utilityBills/UtilityBillSummaryReview';
 import submitForm from './submitForm';
 import SpouseEmploymentHistoryWidget from '../pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget';
+import SpouseEmploymentQuestion from '../components/SpouseEmploymentQuestion';
 import EmploymentQuestion from '../components/EmploymentQuestion';
 import InstallmentContract from '../components/InstallmentContract';
 import InstallmentContractSummary from '../pages/expenses/repayments/InstallmentContractSummary';
@@ -328,6 +329,91 @@ const formConfig = {
           uiSchema: pages.spouseInformation.uiSchema,
           schema: pages.spouseInformation.schema,
         },
+        spouseName: {
+          path: 'spouse-name',
+          title: 'Spouse name',
+          uiSchema: pages.spouseName.uiSchema,
+          schema: pages.spouseName.schema,
+          depends: formData =>
+            formData.questions.isMarried &&
+            formData['view:enhancedFinancialStatusReport'],
+        },
+        spouseEmploymentQuestion: {
+          path: 'enhanced-spouse-employment-question',
+          title: 'Spouse employment',
+          CustomPage: SpouseEmploymentQuestion,
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          depends: formData =>
+            formData.questions.isMarried &&
+            formData['view:enhancedFinancialStatusReport'],
+          editModeOnReviewPage: false,
+        },
+        enhancedSpouseEmploymentRecords: {
+          path: 'enhanced-spouse-employment-records',
+          title: 'Employment',
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          depends: formData =>
+            formData.questions.isMarried &&
+            formData.questions.spouseIsEmployed &&
+            formData['view:enhancedFinancialStatusReport'],
+          editModeOnReviewPage: true,
+          CustomPage: EnhancedSpouseEmploymentRecord,
+          CustomPageReview: null,
+        },
+        enhancedSpouseGrossMonthlyIncome: {
+          path: 'spouse-gross-monthly-income',
+          title: 'Gross monthly income',
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          depends: formData =>
+            formData.questions.isMarried &&
+            formData.questions.spouseIsEmployed &&
+            formData['view:enhancedFinancialStatusReport'],
+          editModeOnReviewPage: true,
+          CustomPage: SpouseGrossMonthlyIncomeInput,
+          CustomPageReview: null,
+        },
+        spousePayrollDeductionChecklist: {
+          path: 'spouse-deduction-checklist',
+          title: 'Payroll deductions',
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          depends: formData =>
+            formData.questions.isMarried &&
+            formData.questions.spouseIsEmployed &&
+            formData['view:enhancedFinancialStatusReport'],
+          editModeOnReviewPage: true,
+          CustomPage: SpousePayrollDeductionChecklist,
+          CustomPageReview: null,
+        },
+        spousePayrollDeductionInputList: {
+          title: 'Spouse deduction amounts',
+          path: 'spouse-deduction-values',
+          // listOfIssues defined in next section
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          // needed to bypass bug on review & submit page
+          depends: formData =>
+            formData.questions.isMarried &&
+            formData.questions.spouseIsEmployed &&
+            formData['view:enhancedFinancialStatusReport'],
+          CustomPage: SpousePayrollDeductionInputList,
+          CustomPageReview: null,
+        },
+        spouseEmploymentHistory: {
+          path: 'spouse-employment-history',
+          title: 'Employment',
+          uiSchema: pages.spouseEmploymentHistory.uiSchema,
+          schema: pages.spouseEmploymentHistory.schema,
+          depends: formData =>
+            formData.questions.spouseIsEmployed &&
+            formData['view:enhancedFinancialStatusReport'],
+          editModeOnReviewPage: true,
+          CustomPage: SpouseEmploymentHistoryWidget,
+        },
         spouseEmployment: {
           path: 'spouse-employment',
           title: 'Spouse employment',
@@ -366,9 +452,7 @@ const formConfig = {
           title: 'Spouse benefits',
           uiSchema: pages.spouseBenefits.uiSchema,
           schema: pages.spouseBenefits.schema,
-          depends: formData =>
-            formData.questions.isMarried &&
-            !formData['view:enhancedFinancialStatusReport'],
+          depends: formData => formData.questions.isMarried,
         },
         spouseBenefitRecords: {
           path: 'spouse-benefit-records',
@@ -377,8 +461,7 @@ const formConfig = {
           schema: pages.spouseBenefitRecords.schema,
           depends: formData =>
             formData.questions.isMarried &&
-            formData.questions.spouseHasBenefits &&
-            !formData['view:enhancedFinancialStatusReport'],
+            formData.questions.spouseHasBenefits,
         },
         spouseSocialSecurity: {
           path: 'spouse-social-security',
@@ -419,74 +502,18 @@ const formConfig = {
             !formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
         },
-        spouseEmploymentQuestion: {
-          path: 'enhanced-spouse-employment-question',
-          title: 'Employment',
-          uiSchema: pages.spouseEmploymentQuestion.uiSchema,
-          schema: pages.spouseEmploymentQuestion.schema,
-          depends: formData =>
-            formData.questions.isMarried &&
-            formData['view:enhancedFinancialStatusReport'],
-          editModeOnReviewPage: false,
-        },
-        enhancedSpouseEmploymentRecords: {
-          path: 'enhanced-spouse-employment-records',
-          title: 'Employment',
-          uiSchema: {},
-          schema: { type: 'object', properties: {} },
-          depends: formData =>
-            formData.questions.isMarried &&
-            formData.questions.spouseIsEmployed &&
-            formData['view:enhancedFinancialStatusReport'],
-          editModeOnReviewPage: true,
-          CustomPage: EnhancedSpouseEmploymentRecord,
-          CustomPageReview: null,
-        },
-        enhancedSpouseGrossMonthlyIncome: {
-          path: 'spouse-gross-monthly-income',
-          title: 'Gross monthly income',
-          uiSchema: pages.spouseGrossMonthlyIncome.uiSchema,
-          schema: pages.spouseGrossMonthlyIncome.schema,
-          depends: formData =>
-            formData.questions.spouseIsEmployed &&
-            formData['view:enhancedFinancialStatusReport'],
-          editModeOnReviewPage: true,
-          CustomPage: SpouseGrossMonthlyIncomeInput,
-        },
-        spousePayrollDeductionChecklist: {
-          path: 'spouse-deduction-checklist',
-          title: 'Payroll deductions',
-          uiSchema: pages.spousePayrollDeductionChecklist.uiSchema,
-          schema: pages.spousePayrollDeductionChecklist.schema,
-          depends: formData =>
-            formData.questions.spouseIsEmployed &&
-            formData['view:enhancedFinancialStatusReport'],
-          editModeOnReviewPage: true,
-          CustomPage: SpousePayrollDeductionChecklist,
-        },
-        spousePayrollDeductionInputList: {
-          title: 'Spouse deduction amounts',
-          path: 'spouse-deduction-values',
-          // listOfIssues defined in next section
-          uiSchema: pages.spousePayrollDeductionInputList.uiSchema,
-          schema: pages.spousePayrollDeductionInputList.schema,
-          // needed to bypass bug on review & submit page
-          depends: formData =>
-            formData.questions.spouseIsEmployed &&
-            formData['view:enhancedFinancialStatusReport'],
-          CustomPage: SpousePayrollDeductionInputList,
-        },
-        spouseEmploymentHistory: {
-          path: 'spouse-employment-history',
-          title: 'Employment',
-          uiSchema: pages.spouseEmploymentHistory.uiSchema,
-          schema: pages.spouseEmploymentHistory.schema,
-          depends: formData =>
-            formData.questions.spouseIsEmployed &&
-            formData['view:enhancedFinancialStatusReport'],
-          editModeOnReviewPage: true,
-          CustomPage: SpouseEmploymentHistoryWidget,
-        },
+
+        // spouseEmploymentQuestion: {
+        //   path: 'enhanced-spouse-employment-question',
+        //   title: 'Employment',
+        //   uiSchema: pages.spouseEmploymentQuestion.uiSchema,
+        //   schema: pages.spouseEmploymentQuestion.schema,
+        //   depends: formData =>
+        //     formData.questions.isMarried &&
+        //     formData['view:enhancedFinancialStatusReport'],
+        //   editModeOnReviewPage: false,
+        // },
+
         spouseAdditionalIncomeCheckList: {
           path: 'spouse-additional-income-checklist',
           title: 'Additional income options',

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -185,13 +185,14 @@ const formConfig = {
         enhancedEmploymentRecords: {
           path: 'enhanced-employment-records',
           title: 'Employment',
-          uiSchema: pages.enhancedEmploymentRecords.uiSchema,
-          schema: pages.enhancedEmploymentRecords.schema,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
           depends: formData =>
             formData.questions.vetIsEmployed &&
             formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
           CustomPage: EnhancedEmploymentRecord,
+          CustomPageReview: null,
         },
         grossMonthlyIncome: {
           path: 'gross-monthly-income',
@@ -234,13 +235,14 @@ const formConfig = {
         employmentHistorySummary: {
           path: 'employment-history',
           title: 'Employment',
-          uiSchema: pages.employmentHistory.uiSchema,
-          schema: pages.employmentHistory.schema,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
           depends: formData =>
             formData.questions.vetIsEmployed &&
             formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
           CustomPage: EmploymentHistoryWidget,
+          CustomPageReview: null,
         },
         income: {
           title: 'Income',
@@ -409,13 +411,14 @@ const formConfig = {
         spouseEmploymentHistory: {
           path: 'spouse-employment-history',
           title: 'Employment',
-          uiSchema: pages.spouseEmploymentHistory.uiSchema,
-          schema: pages.spouseEmploymentHistory.schema,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
           depends: formData =>
             formData.questions.spouseIsEmployed &&
             formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
           CustomPage: SpouseEmploymentHistoryWidget,
+          CustomPageReview: null,
         },
         spouseEmployment: {
           path: 'spouse-employment',

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -35,6 +35,8 @@ import SpouseEmploymentHistoryWidget from '../pages/income/employmentEnhanced/Sp
 import InstallmentContract from '../components/InstallmentContract';
 import InstallmentContractSummary from '../pages/expenses/repayments/InstallmentContractSummary';
 import EmploymentQuestion from '../components/EmploymentQuestion';
+import InstallmentContract from '../components/InstallmentContract';
+import InstallmentContractSummary from '../pages/expenses/repayments/InstallmentContractSummary';
 
 const formConfig = {
   rootUrl: manifest.rootUrl,

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -196,36 +196,39 @@ const formConfig = {
         grossMonthlyIncome: {
           path: 'gross-monthly-income',
           title: 'Gross monthly income',
-          uiSchema: pages.grossMonthlyIncome.uiSchema,
-          schema: pages.grossMonthlyIncome.schema,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
           depends: formData =>
             formData.questions.vetIsEmployed &&
             formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
           CustomPage: GrossMonthlyIncomeInput,
+          CustomPageReview: null,
         },
         payrollDeductionChecklist: {
           path: 'deduction-checklist',
           title: 'Payroll deductions',
-          uiSchema: pages.payrollDeductionChecklist.uiSchema,
-          schema: pages.payrollDeductionChecklist.schema,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
           depends: formData =>
             formData.questions.vetIsEmployed &&
             formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
           CustomPage: PayrollDeductionChecklist,
+          CustomPageReview: null,
         },
         payrollDeductionInputList: {
           title: 'Deduction amounts',
           path: 'deduction-values',
           // listOfIssues defined in next section
-          uiSchema: pages.payrollDeductionInputList.uiSchema,
-          schema: pages.payrollDeductionInputList.schema,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
           // needed to bypass bug on review & submit page
           depends: formData =>
             formData.questions.vetIsEmployed &&
             formData['view:enhancedFinancialStatusReport'],
           CustomPage: PayrollDeductionInputList,
+          CustomPageReview: null,
         },
         // loop ends with option to re enter here
         employmentHistorySummary: {

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/EmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/EmploymentHistoryWidget.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { useSelector, connect } from 'react-redux';
 import EmploymentHistorySummaryCard from '../../../components/EmploymentHistorySummaryCard';
+import { EmptyMiniSummaryCard } from '../../../components/shared/MiniSummaryCard';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { clearJobIndex } from '../../../utils/session';
 
@@ -37,14 +38,18 @@ const EmploymentHistoryWidget = props => {
     <form onSubmit={handlers.onSubmit}>
       <legend className="schemaform-block-title">Your work history</legend>
       <div className="vads-u-margin-top--3" data-testid="debt-list">
-        {employmentHistory.map((job, index) => (
-          <EmploymentHistorySummaryCard
-            key={`${index}-${job.employername}`}
-            job={job}
-            index={index}
-            isSpouse={false}
-          />
-        ))}
+        {employmentHistory.length === 0 ? (
+          <EmptyMiniSummaryCard content="No employment history provided" />
+        ) : (
+          employmentHistory.map((job, index) => (
+            <EmploymentHistorySummaryCard
+              key={`${index}-${job.employername}`}
+              job={job}
+              index={index}
+              isSpouse={false}
+            />
+          ))
+        )}
       </div>
       <Link
         className="vads-c-action-link--green"

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/EmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/EmploymentHistoryWidget.jsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
 import { useSelector, connect } from 'react-redux';
-import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import EmploymentHistorySummaryCard from '../../../components/EmploymentHistorySummaryCard';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { clearJobIndex } from '../../../utils/session';
 
 const EmploymentHistoryWidget = props => {
   const { goToPath, goBack, onReviewPage } = props;
-  const [hasAdditionalJobToAdd, setHasAdditionalJobToAdd] = useState('false');
 
   const formData = useSelector(state => state.form.data);
   const employmentHistory =
@@ -21,18 +21,10 @@ const EmploymentHistoryWidget = props => {
     onSubmit: event => {
       event.preventDefault();
       let path = '/benefits';
-      if (hasAdditionalJobToAdd === 'true') {
-        path = '/enhanced-employment-records';
-      } else if (efsrFeatureFlag) {
+      if (efsrFeatureFlag) {
         path = '/your-benefits';
       }
       goToPath(path);
-    },
-    onSelection: event => {
-      const { value } = event?.detail || {};
-      if (value) {
-        setHasAdditionalJobToAdd(value);
-      }
     },
   };
 
@@ -41,6 +33,7 @@ const EmploymentHistoryWidget = props => {
 
   return (
     <form onSubmit={handlers.onSubmit}>
+      <legend className="schemaform-block-title">Your work history</legend>
       <div className="vads-u-margin-top--3" data-testid="debt-list">
         {employmentHistory.map((job, index) => (
           <EmploymentHistorySummaryCard
@@ -51,31 +44,21 @@ const EmploymentHistoryWidget = props => {
           />
         ))}
       </div>
-      <VaRadio
-        class="vads-u-margin-y--2"
-        label="Have you had another job in the last 2 years?"
-        onVaValueChange={handlers.onSelection}
-        required
+      <Link
+        className="vads-c-action-link--green"
+        to="/enhanced-employment-records"
       >
-        <va-radio-option
-          id="home-phone"
-          label="Yes"
-          value="true"
-          checked={hasAdditionalJobToAdd === 'true'}
-        />
-        <va-radio-option
-          id="mobile-phone"
-          label="No"
-          value="false"
-          name="primary"
-          checked={hasAdditionalJobToAdd === 'false'}
-        />
-      </VaRadio>
+        Add another job from the last 2 years
+      </Link>
       {onReviewPage ? updateButton : navButtons}
     </form>
   );
 };
-
+EmploymentHistoryWidget.propTypes = {
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  onReviewPage: PropTypes.bool,
+};
 const mapStateToProps = ({ form }) => {
   return {
     formData: form.data,

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/EmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/EmploymentHistoryWidget.jsx
@@ -7,28 +7,30 @@ import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavBut
 import { clearJobIndex } from '../../../utils/session';
 
 const EmploymentHistoryWidget = props => {
-  const { goToPath, goBack, onReviewPage } = props;
+  const { goToPath, goForward, onReviewPage } = props;
 
   const formData = useSelector(state => state.form.data);
   const employmentHistory =
     formData.personalData.employmentHistory.veteran.employmentRecords || [];
-  const efsrFeatureFlag = formData['view:enhancedFinancialStatusReport'];
+
   useEffect(() => {
     clearJobIndex();
   }, []);
 
   const handlers = {
-    onSubmit: event => {
+    onBackClick: event => {
       event.preventDefault();
-      let path = '/benefits';
-      if (efsrFeatureFlag) {
-        path = '/your-benefits';
-      }
-      goToPath(path);
+      goToPath('/employment-question');
     },
   };
 
-  const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+  const navButtons = (
+    <FormNavButtons
+      goBack={handlers.onBackClick}
+      goForward={goForward}
+      submitToContinue
+    />
+  );
   const updateButton = <button type="submit">Review update button</button>;
 
   return (
@@ -55,7 +57,7 @@ const EmploymentHistoryWidget = props => {
   );
 };
 EmploymentHistoryWidget.propTypes = {
-  goBack: PropTypes.func.isRequired,
+  goForward: PropTypes.func.isRequired,
   goToPath: PropTypes.func.isRequired,
   onReviewPage: PropTypes.bool,
 };

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
@@ -3,6 +3,7 @@ import { useSelector, connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import EmploymentHistorySummaryCard from '../../../components/EmploymentHistorySummaryCard';
+import { EmptyMiniSummaryCard } from '../../../components/shared/MiniSummaryCard';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { clearJobIndex } from '../../../utils/session';
 
@@ -39,14 +40,18 @@ const SpouseEmploymentHistoryWidget = props => {
         Your spouse’s work history
       </legend>
       <div className="vads-u-margin-top--3" data-testid="debt-list">
-        {employmentHistory.map((job, index) => (
-          <EmploymentHistorySummaryCard
-            key={`${index}-${job.employername}`}
-            job={job}
-            index={index}
-            isSpouse
-          />
-        ))}
+        {employmentHistory.length === 0 ? (
+          <EmptyMiniSummaryCard content="No employment history provided" />
+        ) : (
+          employmentHistory.map((job, index) => (
+            <EmploymentHistorySummaryCard
+              key={`${index}-${job.employername}`}
+              job={job}
+              index={index}
+              isSpouse
+            />
+          ))
+        )}
       </div>
       <Link
         className="vads-c-action-link--green"

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
@@ -7,7 +7,7 @@ import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavBut
 import { clearJobIndex } from '../../../utils/session';
 
 const SpouseEmploymentHistoryWidget = props => {
-  const { goToPath, goBack, onReviewPage } = props;
+  const { goToPath, goForward, onReviewPage } = props;
 
   const formData = useSelector(state => state.form.data);
   const employmentHistory =
@@ -18,18 +18,23 @@ const SpouseEmploymentHistoryWidget = props => {
   }, []);
 
   const handlers = {
-    onSubmit: event => {
+    onBackClick: event => {
       event.preventDefault();
-      const path = efsrFeatureFlag ? '/dependents-count' : '/dependents';
-      goToPath(path);
+      goToPath('/enhanced-spouse-employment-question');
     },
   };
 
-  const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+  const navButtons = (
+    <FormNavButtons
+      goBack={handlers.onBackClick}
+      goForward={goForward}
+      submitToContinue
+    />
+  );
   const updateButton = <button type="submit">Review update button</button>;
 
   return (
-    <form onSubmit={handlers.onSubmit}>
+    <form>
       <legend className="schemaform-block-title">
         Your spouse’s work history
       </legend>
@@ -61,6 +66,7 @@ const SpouseEmploymentHistoryWidget = props => {
 
 SpouseEmploymentHistoryWidget.propTypes = {
   goBack: PropTypes.func.isRequired,
+  goForward: PropTypes.func.isRequired,
   goToPath: PropTypes.func.isRequired,
   onReviewPage: PropTypes.bool,
 };

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
@@ -33,6 +33,7 @@ const SpouseEmploymentHistoryWidget = props => {
     />
   );
   const updateButton = <button type="submit">Review update button</button>;
+  const emptyPrompt = `Select the ‘add additional job link to add another job. Select the continue button to move on to the next question.`;
 
   return (
     <form>
@@ -41,7 +42,7 @@ const SpouseEmploymentHistoryWidget = props => {
       </legend>
       <div className="vads-u-margin-top--3" data-testid="debt-list">
         {employmentHistory.length === 0 ? (
-          <EmptyMiniSummaryCard content="No employment history provided" />
+          <EmptyMiniSummaryCard content={emptyPrompt} />
         ) : (
           employmentHistory.map((job, index) => (
             <EmploymentHistorySummaryCard

--- a/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
+++ b/src/applications/financial-status-report/pages/income/employmentEnhanced/SpouseEmploymentHistoryWidget.jsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, connect } from 'react-redux';
-import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
 import EmploymentHistorySummaryCard from '../../../components/EmploymentHistorySummaryCard';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { clearJobIndex } from '../../../utils/session';
 
 const SpouseEmploymentHistoryWidget = props => {
   const { goToPath, goBack, onReviewPage } = props;
-  const [hasAdditionalJobToAdd, setHasAdditionalJobToAdd] = useState(false);
 
   const formData = useSelector(state => state.form.data);
   const employmentHistory =
@@ -18,22 +18,9 @@ const SpouseEmploymentHistoryWidget = props => {
   }, []);
 
   const handlers = {
-    onSelection: event => {
-      const value = event?.detail?.value;
-      if (value) {
-        setHasAdditionalJobToAdd(true);
-      }
-    },
     onSubmit: event => {
       event.preventDefault();
-      let path = '/dependents';
-      if (efsrFeatureFlag && hasAdditionalJobToAdd) {
-        path = '/enhanced-spouse-employment-records';
-      } else if (hasAdditionalJobToAdd) {
-        path = '/spouse-employment-records';
-      } else if (efsrFeatureFlag && !hasAdditionalJobToAdd) {
-        path = '/dependents-count';
-      }
+      const path = efsrFeatureFlag ? '/dependents-count' : '/dependents';
       goToPath(path);
     },
   };
@@ -43,6 +30,9 @@ const SpouseEmploymentHistoryWidget = props => {
 
   return (
     <form onSubmit={handlers.onSubmit}>
+      <legend className="schemaform-block-title">
+        Your spouse’s work history
+      </legend>
       <div className="vads-u-margin-top--3" data-testid="debt-list">
         {employmentHistory.map((job, index) => (
           <EmploymentHistorySummaryCard
@@ -53,28 +43,26 @@ const SpouseEmploymentHistoryWidget = props => {
           />
         ))}
       </div>
-      <VaRadio
-        class="vads-u-margin-y--2"
-        label="Has your spouse had another job in the last 2 years?"
-        onVaValueChange={handlers.onSelection}
-        required
+      <Link
+        className="vads-c-action-link--green"
+        to={
+          efsrFeatureFlag
+            ? '/enhanced-spouse-employment-records'
+            : '/spouse-employment-records'
+        }
       >
-        <va-radio-option
-          id="has-additional-job"
-          label="Yes"
-          value
-          checked={hasAdditionalJobToAdd}
-        />
-        <va-radio-option
-          id="has-no-additional-job"
-          label="No"
-          value={false}
-          checked={!hasAdditionalJobToAdd}
-        />
-      </VaRadio>
+        Add another job from the last 2 years
+      </Link>
+
       {onReviewPage ? updateButton : navButtons}
     </form>
   );
+};
+
+SpouseEmploymentHistoryWidget.propTypes = {
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  onReviewPage: PropTypes.bool,
 };
 
 const mapStateToProps = ({ form }) => {

--- a/src/applications/financial-status-report/pages/income/spouse/spouseName.js
+++ b/src/applications/financial-status-report/pages/income/spouse/spouseName.js
@@ -1,0 +1,45 @@
+export const uiSchema = {
+  'ui:title': 'Your spouse information',
+  personalData: {
+    spouseFullName: {
+      first: {
+        'ui:title': 'What’s your spouse’s first name?',
+        'ui:options': {
+          widgetClassNames: 'input-size-3',
+        },
+        'ui:required': () => true,
+        'ui:errorMessages': {
+          required: "Please enter your spouse's first name.",
+        },
+      },
+      last: {
+        'ui:title': 'What’s your spouse’s last name?',
+        'ui:options': {
+          widgetClassNames: 'input-size-3',
+        },
+      },
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    personalData: {
+      type: 'object',
+      properties: {
+        spouseFullName: {
+          type: 'object',
+          properties: {
+            first: {
+              type: 'string',
+            },
+            last: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/financial-status-report/pages/index.js
+++ b/src/applications/financial-status-report/pages/index.js
@@ -13,6 +13,7 @@ import * as additionalIncome from './income/additionalIncome';
 import * as additionalIncomeChecklist from './income/additionalIncome/additionalIncomeChecklist';
 import * as additionalIncomeValues from './income/additionalIncome/additionalIncomeValues';
 import * as spouseInformation from './income/spouse/spouseInfo';
+import * as spouseName from './income/spouse/spouseName';
 import * as spouseSocialSecurity from './income/spouse/socialSecurity';
 import * as spouseSocialSecurityRecords from './income/spouse/socialSecurity/records';
 import * as spouseAdditionalIncome from './income/spouse/additionalIncome';
@@ -85,6 +86,7 @@ export {
   socialSecurity,
   socialSecurityRecords,
   additionalIncome,
+  spouseName,
   additionalIncomeRecords,
   additionalIncomeChecklist,
   additionalIncomeValues,


### PR DESCRIPTION
## Summary

Back navigation in the midst of updating employment history has some unexpected results like kicking the user back to the summary page with an incomplete record and adding an additional blank record. Another note is the payroll deductions checkbox to input box selection pages, if no checkbox is selected, the input list page is empty and it should be skipped.

Steps to recreate issue:

- Answer yes to"have you had a job in the last 2 years", click continue.
- Enter employer information, click continue.
- Select back on gross monthly income page.
- This returns user to summary page with incomplete data.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#55200


## Testing done

- Cypress testing
- Manual testing
- Navigate to `/manage-va-debt/request-debt-help-form-5655/employment-history` after filling out the employment form to test



## Screenshots



### Before

<table>
  <tr>
    <th>Original</th>
  </tr>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/231890971-4daeb605-294f-4d17-aa55-8e5d98dfba3b.png" alt="Original" width="300" />
    </td>

  </tr>
</table>


### After - Employment history (Veteran)

<table>
  <tr>
    <th>Veteran Screenshot 1</th>
    <th>Veteran Screenshot 2</th>
  </tr>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/232908878-b93ac2cb-8c92-4ec9-8035-2fe6b051f6d0.png" alt="Screenshot 1" width="300" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/232908944-1e0aa187-1a4b-41d9-b515-68f49ec2e84d.png" alt="Screenshot 2" width="300" />
    </td>
  </tr>
</table>


### After - Employment history (Spouse)

<table>
  <tr>
    <th>Spouse Screenshot 1</th>
    <th>Spouse Screenshot 2</th>
  </tr>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/232909245-7b6334ac-4714-4b57-a23d-9c82a9d18e26.png" alt="Screenshot 1" width="300" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/232909289-0f7faa33-faf7-435e-abc2-eee4bea2ece5.png" alt="Screenshot 2" width="300" />
    </td>
  </tr>
</table>

## What areas of the site does it impact?
Financial status report employment history form

## Acceptance criteria
- [x]  Veteran employment history matches new design
- [x]  Spouse employment history matches new design
- [x]  Unit and e2e test are updated and passing

