### PR TITLE
Fix FormNav component to support chapter-title function-callback prop

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -61,7 +61,7 @@ export default function FormNav(props) {
         ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
         : formConfig.chapters[page.chapterKey].title;
     if (typeof chapterName === 'function') {
-      chapterName = chapterName();
+      chapterName = chapterName({ formData, formConfig });
     }
   }
 

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -80,6 +80,31 @@ describe('Schemaform FormNav', () => {
     expect(tree.getByTestId('navFormHeader')).to.be.empty;
   });
 
+  it('should render dynamic chapter-title stepText', () => {
+    const currentPath = 'testing1';
+    const formConfigDefaultData = { ...getDefaultData() };
+
+    // use a function for chapter-title instead of a string
+    formConfigDefaultData.chapters.chapter1.title = ({
+      formData,
+      formConfig,
+    }) => {
+      if (!!formData && !!formConfig) {
+        return 'Title [from function]';
+      }
+
+      return '[no params provided to function]';
+    };
+
+    const tree = render(
+      <FormNav formConfig={formConfigDefaultData} currentPath={currentPath} />,
+    );
+
+    expect(tree.getByTestId('navFormHeader').textContent).to.contain(
+      'Step 1 of 3: Title [from function]',
+    );
+  });
+
   it('should display correct chapter number & total in stepText after previous progress-hidden chapter', () => {
     const currentPath = 'testing2';
     const formConfigDefaultData = { ...getDefaultData() };


### PR DESCRIPTION
## Summary

- Fix Forms-Library's FormNav.jsx component to finally support a function in form-configuration's chapter title property.\*
- Add `{ formData, formConfig}` as a parameter to FormNav's chapterName function-callback.
- Team: VA.gov Platform Product Forms
- Not using feature-flag; this is a bugfix.

\*This was a feature mentioned in Forms Library docs, but never worked because FormNav's chapterName callback never had any params provided.  So, this change should be innocuous to existing forms.

## Related issue(s)
- Encountered need to dynamicize chapter title in new form 21-10210: Veteran-info pages' chapter-titles need to say "Your ... information" for one flow and "Veteran's ... information" in other flows.


## Testing done

- Temporarily used a function for `_mock-form`'s chapter-title prop.  Worked as expected.
- Added dynamic chapter-title test-case and ran locally.  Passed.
- Now waiting for auto-checks here to complete before making PR Ready-for-review.  Just to make doubly sure we have no regressions.

## What areas of the site does it impact?
All other form-apps [all PR unit- and e2e-test checks should pass].

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).

