### PR TITLE
Refactor forms-systems ReviewCollapsibleChapter title-function support

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -190,7 +190,9 @@ const formConfig = {
   chapters: {
     veteranDetails: {
       title: ({ formContext }) =>
-        `${formContext.onReviewPage ? 'Review ' : ''}Veteran Details`,
+        `${
+          !!formContext && formContext.onReviewPage ? 'Review ' : ''
+        }Veteran Details`,
       pages: {
         veteranInformation: {
           title: 'Veteran information',

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -191,7 +191,6 @@ const formConfig = {
     veteranDetails: {
       title: ({ formContext }) =>
         `${formContext.onReviewPage ? 'Review ' : ''}Veteran Details`,
-      // title: isReviewPage => `${isReviewPage ? 'Review ' : ''}Veteran Details`,
       pages: {
         veteranInformation: {
           title: 'Veteran information',

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -189,7 +189,9 @@ const formConfig = {
   preSubmitInfo,
   chapters: {
     veteranDetails: {
-      title: isReviewPage => `${isReviewPage ? 'Review ' : ''}Veteran Details`,
+      title: ({ formContext }) =>
+        `${formContext.onReviewPage ? 'Review ' : ''}Veteran Details`,
+      // title: isReviewPage => `${isReviewPage ? 'Review ' : ''}Veteran Details`,
       pages: {
         veteranInformation: {
           title: 'Veteran information',

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -189,10 +189,8 @@ const formConfig = {
   preSubmitInfo,
   chapters: {
     veteranDetails: {
-      title: ({ formContext }) =>
-        `${
-          !!formContext && formContext.onReviewPage ? 'Review ' : ''
-        }Veteran Details`,
+      title: ({ onReviewPage }) =>
+        `${onReviewPage ? 'Review ' : ''}Veteran Details`,
       pages: {
         veteranInformation: {
           title: 'Veteran information',

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -56,8 +56,9 @@ export default function FormNav(props) {
 
   if (page) {
     const onReviewPage = page.chapterKey === 'review';
-
     current = chapters.indexOf(page.chapterKey) + 1;
+
+    // The review page is always part of our forms, but isn’t listed in chapter list
     chapterName = onReviewPage
       ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
       : formConfig.chapters[page.chapterKey].title;

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -53,15 +53,17 @@ export default function FormNav(props) {
   let current;
   let chapterName;
   let inProgressMessage = null;
+
   if (page) {
+    const onReviewPage = page.chapterKey === 'review';
+
     current = chapters.indexOf(page.chapterKey) + 1;
-    // The review page is always part of our forms, but isn’t listed in chapter list
-    chapterName =
-      page.chapterKey === 'review'
-        ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
-        : formConfig.chapters[page.chapterKey].title;
-    if (typeof chapterName === 'function') {
-      const onReviewPage = page.chapterKey === 'review';
+    chapterName = onReviewPage
+      ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
+      : formConfig.chapters[page.chapterKey].title;
+    if (typeof chapterName === 'function' && !onReviewPage) {
+      // for FormNav, we only call chapter-config title-function if
+      // not on review-page.
       chapterName = chapterName({ formData, formConfig, onReviewPage });
     }
   }

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -61,7 +61,8 @@ export default function FormNav(props) {
         ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
         : formConfig.chapters[page.chapterKey].title;
     if (typeof chapterName === 'function') {
-      chapterName = chapterName({ formData, formConfig });
+      const onReviewPage = page.chapterKey === 'review';
+      chapterName = chapterName({ formData, formConfig, onReviewPage });
     }
   }
 

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -81,11 +81,16 @@ class ReviewCollapsibleChapter extends React.Component {
     const { form } = this.props;
     const formData = form.data;
     const formConfig = form;
+    const { formContext } = this.props;
 
     let chapterTitle = chapterFormConfig.title;
 
     if (typeof chapterFormConfig.title === 'function') {
-      chapterTitle = chapterFormConfig.title({ formData, formConfig });
+      chapterTitle = chapterFormConfig.title({
+        formData,
+        formConfig,
+        formContext,
+      });
     }
     if (chapterFormConfig.reviewTitle) {
       chapterTitle = chapterFormConfig.reviewTitle;

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -25,8 +25,8 @@ const scrollOffset = -40;
  * Displays all the pages in a chapter on the review page
  */
 class ReviewCollapsibleChapter extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.handleEdit = this.handleEdit.bind(this);
   }
 
@@ -78,9 +78,14 @@ class ReviewCollapsibleChapter extends React.Component {
   };
 
   getChapterTitle = chapterFormConfig => {
+    const { form } = this.props;
+    const formData = form.data;
+    const formConfig = form;
+
     let chapterTitle = chapterFormConfig.title;
+
     if (typeof chapterFormConfig.title === 'function') {
-      chapterTitle = chapterFormConfig.title(true);
+      chapterTitle = chapterFormConfig.title({ formData, formConfig });
     }
     if (chapterFormConfig.reviewTitle) {
       chapterTitle = chapterFormConfig.reviewTitle;

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -81,7 +81,7 @@ class ReviewCollapsibleChapter extends React.Component {
     const { form } = this.props;
     const formData = form.data;
     const formConfig = form;
-    const { formContext } = this.props;
+    const onReviewPage = true;
 
     let chapterTitle = chapterFormConfig.title;
 
@@ -89,7 +89,7 @@ class ReviewCollapsibleChapter extends React.Component {
       chapterTitle = chapterFormConfig.title({
         formData,
         formConfig,
-        formContext,
+        onReviewPage,
       });
     }
     if (chapterFormConfig.reviewTitle) {

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -120,6 +120,35 @@ describe('Schemaform FormNav', () => {
     );
   });
 
+  it('should display/return correct chapter title when title-function uses onReviewPage parameter', () => {
+    const formConfigDefaultData = { ...getDefaultData() };
+    const formPageChapterTitle = 'Testing';
+    const reviewPageChapterTitle = 'Testing [on review page]';
+
+    formConfigDefaultData.chapters.chapter1.title = ({ onReviewPage }) => {
+      if (onReviewPage) {
+        return reviewPageChapterTitle;
+      }
+
+      return formPageChapterTitle;
+    };
+
+    const tree = render(
+      <FormNav formConfig={formConfigDefaultData} currentPath="testing1" />,
+    );
+
+    // assert actual chapter title on form-page
+    expect(tree.getByTestId('navFormHeader').textContent).to.contain(
+      `Step 1 of 3: ${formPageChapterTitle}`,
+    );
+
+    // actual chapter accordions are outside FormNav, so we assert on
+    // what's returned from calling the title-function directly
+    expect(
+      formConfigDefaultData.chapters.chapter1.title({ onReviewPage: true }),
+    ).to.eq(reviewPageChapterTitle);
+  });
+
   it('should display a custom review page title', () => {
     const formConfigReviewData = getReviewData();
     const currentPath = 'review-and-submit';

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -594,8 +594,8 @@ describe('<ReviewCollapsibleChapter>', () => {
     ];
     const chapterKey = 'test';
     const chapter = {
-      title: ({ formData, formConfig }) => {
-        if (formData && formConfig) {
+      title: ({ formData, formConfig, onReviewPage }) => {
+        if (formData && formConfig && onReviewPage) {
           return testChapterTitleFromFunction;
         }
 

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -580,6 +580,66 @@ describe('<ReviewCollapsibleChapter>', () => {
     wrapper.unmount();
   });
 
+  it('should show dynamic chapter title', () => {
+    const testChapterTitle = 'test chapter title';
+    const testChapterTitleFromFunction = `${testChapterTitle} [from function]`;
+
+    const onEdit = sinon.spy();
+    const pages = [
+      {
+        pageKey: 'test',
+        title: testChapterTitleFromFunction,
+        updateFormData: (oldData, newData) => ({ ...newData, bar: 'baz' }),
+      },
+    ];
+    const chapterKey = 'test';
+    const chapter = {
+      title: ({ formData, formConfig }) => {
+        if (formData && formConfig) {
+          return testChapterTitleFromFunction;
+        }
+
+        return testChapterTitle;
+      },
+    };
+    const form = {
+      pages: {
+        test: {
+          title: testChapterTitleFromFunction,
+          schema: {
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+            },
+          },
+          uiSchema: {},
+          editMode: false,
+        },
+      },
+      data: {},
+    };
+    const setPagesViewed = sinon.spy();
+
+    const wrapper = mount(
+      <ReviewCollapsibleChapter
+        setPagesViewed={setPagesViewed}
+        viewedPages={new Set()}
+        onEdit={onEdit}
+        open
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    expect(wrapper.find('h3.accordion-header').text()).to.equal(
+      testChapterTitleFromFunction,
+    );
+
+    wrapper.unmount();
+  });
+
   it('does not display page if all fields are hidden on review', () => {
     const pages = [
       {


### PR DESCRIPTION
## Summary

- Refactor chapter-title function-callback in Forms Library's `ReviewCollapsibleChapter.jsx` component to provide more parameters for dynamic chapter-title functions:
  - Problem: This component currently only provides a `true` parameter to the `getChapterName` call if the chapter-title property's a function, to indicate whether we're on the review-page.  For our new Form 21-10210, we actually need to change Veteran-info chapter-titles based on previous pages' form-data.
  - Solution: 
    - Replace existing unnamed `true` param [which only supported checking whether current page is review-page] with `{ formData, formConfig, onReviewPage }`, so as to support title-functions that need to check more things in their conditional-logic.
    - Also, to prevent regressions, refactor `FormNav.jsx` to also provide onReviewPage as a 3rd callback parameter.
- Team: Platform VA Product Forms
- Not using a feature-flag for this.

## Related issue(s)
- Encountered need to dynamicize chapter-title for new Form 21-10210, but ReviewCollapsibleChapter only provide a boolean `true` to indicate we're on the review-page.  21-10210 needs to dynamicize a chapter-title based on previous pages' field-values [from formData].

## Testing done

- Local:
  - Added new test-case for chapter-title function support.  Passed.
  - Temporarily used a function for one of _mock-form's chapter-titles.  Worked as expected.
- Also, will wait 'til all test-related Checks here Pass before making the PR Ready-for-review.


## What areas of the site does it impact?
All existing forms, but since the function-support _never_ worked properly; this fix should be innocuous. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).

