### PR TITLE
VACMS-13117 Remove BTSSS feature toggle logic

### DIFF
--- a/src/applications/static-pages/BTSSS-login/App/index.jsx
+++ b/src/applications/static-pages/BTSSS-login/App/index.jsx
@@ -5,19 +5,14 @@ import PropTypes from 'prop-types';
 import { isLoggedIn } from 'platform/user/selectors';
 import AuthContext from '../AuthContext';
 import UnauthContext from '../UnauthContext';
-import { selectFeatureToggle } from '../selectors';
 
-export const App = ({ currentlyLoggedIn, showBtsssLoginWidget }) => {
-  if (showBtsssLoginWidget) {
-    return currentlyLoggedIn ? <AuthContext /> : <UnauthContext />;
-  }
-  return <></>;
+export const App = ({ currentlyLoggedIn }) => {
+  return currentlyLoggedIn ? <AuthContext /> : <UnauthContext />;
 };
 
 const mapStateToProps = state => {
   return {
     currentlyLoggedIn: isLoggedIn(state),
-    showBtsssLoginWidget: selectFeatureToggle(state),
   };
 };
 
@@ -27,6 +22,5 @@ export default connect(
 )(App);
 
 App.propTypes = {
-  showBtsssLoginWidget: PropTypes.bool,
   currentlyLoggedIn: PropTypes.bool,
 };

--- a/src/applications/static-pages/BTSSS-login/App/index.unit.spec.js
+++ b/src/applications/static-pages/BTSSS-login/App/index.unit.spec.js
@@ -10,27 +10,16 @@ import UnauthContext from '../UnauthContext';
 
 describe('BTSSS Widget', () => {
   it('renders what we expect when unauthenticated', () => {
-    const wrapper = shallow(
-      <App currentlyLoggedIn={false} showBtsssLoginWidget />,
-    );
+    const wrapper = shallow(<App currentlyLoggedIn={false} />);
     expect(wrapper.find(UnauthContext)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContext)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders what we expect when authenticated', () => {
-    const wrapper = shallow(<App currentlyLoggedIn showBtsssLoginWidget />);
+    const wrapper = shallow(<App currentlyLoggedIn />);
     expect(wrapper.find(UnauthContext)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContext)).to.have.lengthOf(1);
-    wrapper.unmount();
-  });
-
-  it('Should not render either when feature flag is falsey', () => {
-    const wrapper = shallow(
-      <App currentlyLoggedIn showBtsssLoginWidget={false} />,
-    );
-    expect(wrapper.find(UnauthContext)).to.have.lengthOf(0);
-    expect(wrapper.find(AuthContext)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/BTSSS-login/selectors.js
+++ b/src/applications/static-pages/BTSSS-login/selectors.js
@@ -1,8 +1,0 @@
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
-const selectFeatureToggle = state => {
-  return toggleValues(state)[FEATURE_FLAG_NAMES.btsssLoginWidget];
-};
-
-export { selectFeatureToggle };

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,7 +1,6 @@
 // prettier-ignore
 
 export default Object.freeze({
-  btsssLoginWidget: 'btsss_login_widget',
   caregiverSigiEnabled: 'caregiver_sigi_enabled',
   caregiverUseFacilitiesApi: 'caregiver_use_facilities_API',
   cernerOverride463: 'cerner_override_463',


### PR DESCRIPTION
## Summary
Previously the BTSSS login widget was created with a feature flag. This removes the feature flag so the widget will appear in the unauthenticated and authenticated states.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13117

## Testing done
Tested unauthenticated and authenticated state locally in desktop and mobile views and BTSSS widget appears.

## Screenshots
Mobile - Before & After
(not logged in)
<img width="383" alt="Screenshot 2023-04-24 at 9 22 40 AM" src="https://user-images.githubusercontent.com/19175324/234027005-02dfa1d8-21d5-4819-afcc-c9d24450ed35.png">

(logged in)
<img width="402" alt="Screenshot 2023-04-24 at 9 43 11 AM" src="https://user-images.githubusercontent.com/19175324/234031556-426d381e-6c27-4b86-b85d-353e277ec896.png">

Desktop - Before & After
(not logged in)
<img width="952" alt="Screenshot 2023-04-21 at 4 30 04 PM" src="https://user-images.githubusercontent.com/19175324/234024979-144802b1-8e42-4d54-8b16-742ca72391df.png">

(logged in)
<img width="757" alt="Screenshot 2023-04-24 at 9 43 03 AM" src="https://user-images.githubusercontent.com/19175324/234031485-ba610bb0-763d-493b-993f-3e35204723c2.png">

## What areas of the site does it impact?
BTSSS widget only.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature