### PR TITLE
Add copay, communication & benefits disclosure to HCA review page

### DIFF
--- a/src/applications/hca/components/PreSubmitNotice/index.jsx
+++ b/src/applications/hca/components/PreSubmitNotice/index.jsx
@@ -24,15 +24,15 @@ const PreSubmitNotice = props => {
           nonservice-connected VA medical care or services.
         </li>
         <li>
-          You’ve read and accept our privacy policy.
-          <br />
-          <a
-            aria-label="Read our privacy policy, will open in new tab"
-            target="_blank"
-            href="/privacy-policy/"
-          >
-            Read our privacy policy
-          </a>
+          You’ve read and accept our privacy policy.{' '}
+          <span className="vads-u-display--block">
+            <a target="_blank" href="/privacy-policy/">
+              Read our privacy policy
+              <span className="vads-u-visibility--screen-reader">
+                , will open in new tab
+              </span>
+            </a>
+          </span>
         </li>
       </ul>
       <va-additional-info

--- a/src/applications/hca/components/PreSubmitNotice/index.jsx
+++ b/src/applications/hca/components/PreSubmitNotice/index.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const PreSubmitNotice = props => {
+  const { formData, preSubmitInfo, showError, onSectionComplete } = props;
+  const { field, required } = preSubmitInfo;
+  return (
+    <>
+      <h3>Agreement</h3>
+      <p>By submitting this application, you agree to these statements:</p>
+      <ul data-testid="hca-agreement-statements">
+        <li>
+          You’ll pay any VA copays for care or services (including urgent care)
+          that may apply, based on your priority group and other factors.
+        </li>
+        <li>
+          You agree that we can contact you at the email, home phone number, and
+          mobile phone number you gave us in the application.
+        </li>
+        <li>
+          You agree to the assignment of benefits so we can bill your other
+          health insurance or other responsible party for charges of
+          nonservice-connected VA medical care or services.
+        </li>
+        <li>
+          You’ve read and accept our privacy policy.
+          <br />
+          <a
+            aria-label="Read our privacy policy, will open in new tab"
+            target="_blank"
+            href="/privacy-policy/"
+          >
+            Read our privacy policy
+          </a>
+        </li>
+      </ul>
+      <va-additional-info
+        trigger="Read more about the assignment of benefits"
+        class="vads-u-margin-y--2"
+      >
+        <p>
+          I understand that pursuant to 38 U.S.C. Section 1729 and 42 U.S.C.
+          2651, the Department of Veterans Affairs (VA) is authorized to recover
+          or collect from my health plan (HP) or any other legally responsible
+          third party for the reasonable charges of nonservice-connected VA
+          medical care or services furnished or provided to me. I hereby
+          authorize payment directly to VA from any HP under which I am covered
+          (including coverage provided under my spouse’s HP) that is responsible
+          for payment of the charges for my medical care, including benefits
+          otherwise payable to me or my spouse. Furthermore, I hereby assign to
+          the VA any claim I may have against any person or entity who is or may
+          be legally responsible for the payment of the cost of medical services
+          provided to me by the VA. I understand that this assignment shall not
+          limit or prejudice my right to recover for my own benefit any amount
+          in excess of the cost of medical services provided to me by the VA or
+          any other amount to which I may be entitled. I hereby appoint the
+          Attorney General of the United States and the Secretary of Veterans'
+          Affairs and their designees as my Attorneys-in-fact to take all
+          necessary and appropriate actions in order to recover and receive all
+          or part of the amount herein assigned. I hereby authorize the VA to
+          disclose, to my attorney and to any third party or administrative
+          agency who may be responsible for payment of the cost of medical
+          services provided to me, information from my medical records as
+          necessary to verify my claim. Further, I hereby authorize any such
+          third party or administrative agency to disclose to the VA any
+          information regarding my claim.
+        </p>
+      </va-additional-info>
+      <p>
+        <strong>Note:</strong> According to federal law, there are criminal
+        penalties, including a fine and/or imprisonment for up to 5 years, for
+        withholding information or for providing incorrect information. (See 18
+        U.S.C. 1001)
+      </p>
+      <VaCheckbox
+        required={required}
+        name={field}
+        checked={formData[field] || false}
+        error={
+          showError && !formData[field]
+            ? 'You must accept the agreement before continuing.'
+            : undefined
+        }
+        onVaChange={onSectionComplete}
+        label="I certify the information above is correct and true to the best of my knowledge and belief."
+      />
+    </>
+  );
+};
+
+PreSubmitNotice.propTypes = {
+  formData: PropTypes.object,
+  preSubmitInfo: PropTypes.object,
+  showError: PropTypes.bool,
+  onSectionComplete: PropTypes.func,
+};
+
+export default PreSubmitNotice;

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -1,6 +1,5 @@
 // platform imports
 import environment from 'platform/utilities/environment';
-import preSubmitInfo from 'platform/forms/preSubmitInfo';
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
@@ -13,6 +12,7 @@ import FormFooter from '../components/FormFooter';
 import GetHelp from '../components/GetHelp';
 import SubmissionErrorAlert from '../components/FormAlerts/SubmissionErrorAlert';
 import { DowntimeWarning } from '../components/FormAlerts';
+import PreSubmitNotice from '../components/PreSubmitNotice';
 import IntroductionPage from '../containers/IntroductionPage';
 import {
   prefillTransformer,
@@ -121,7 +121,11 @@ const formConfig = {
   submissionError: SubmissionErrorAlert,
   title: 'Apply for VA health care',
   subTitle: 'Form 10-10EZ',
-  preSubmitInfo,
+  preSubmitInfo: {
+    required: true,
+    field: 'privacyAgreementAccepted',
+    CustomComponent: PreSubmitNotice,
+  },
   footerContent: FormFooter,
   getHelp: GetHelp,
   defaultDefinitions: {

--- a/src/applications/hca/tests/components/PreSubmitNotice/PreSubmitNotice.unit.spec.js
+++ b/src/applications/hca/tests/components/PreSubmitNotice/PreSubmitNotice.unit.spec.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import PreSubmitNotice from '../../../components/PreSubmitNotice';
+
+describe('hca <PreSubmitNotice>', () => {
+  const defaultProps = {
+    formData: {},
+    preSubmitInfo: {
+      required: true,
+      field: 'privacyAgreementAccepted',
+      error: 'You must accept the agreement before continuing.',
+      label:
+        'I certify the information above is correct and true to the best of my knowledge and belief.',
+    },
+    showError: false,
+    onSectionComplete: sinon.spy(),
+  };
+
+  it('should render', () => {
+    const { container } = render(<PreSubmitNotice {...defaultProps} />);
+    const checkbox = container.querySelector(
+      `[name="${defaultProps.preSubmitInfo.field}"]`,
+    );
+
+    expect(
+      container.querySelectorAll(
+        'li',
+        '[data-testid="hca-agreement-statements"]',
+      ),
+    ).to.have.lengthOf(4);
+    expect(container.querySelector('va-additional-info')).to.exist;
+    expect(checkbox).to.exist;
+    expect(checkbox).to.have.attribute(
+      'label',
+      defaultProps.preSubmitInfo.label,
+    );
+    expect(checkbox).to.have.attribute(
+      'required',
+      `${defaultProps.preSubmitInfo.required}`,
+    );
+    expect(checkbox).to.have.attribute('checked', 'false');
+  });
+
+  it('should render error message if data is false and `showError` is set to true', () => {
+    const props = { ...defaultProps, showError: true };
+    const { container } = render(<PreSubmitNotice {...props} />);
+    const checkbox = container.querySelector(
+      `[name="${defaultProps.preSubmitInfo.field}"]`,
+    );
+
+    expect(checkbox).to.have.attribute(
+      'error',
+      defaultProps.preSubmitInfo.error,
+    );
+  });
+
+  it('should not render error message if data is true', () => {
+    const props = {
+      ...defaultProps,
+      formData: { privacyAgreementAccepted: true },
+    };
+    const { container } = render(<PreSubmitNotice {...props} />);
+    const checkbox = container.querySelector(
+      `[name="${defaultProps.preSubmitInfo.field}"]`,
+    );
+
+    expect(checkbox).to.not.have.attribute(
+      'error',
+      defaultProps.preSubmitInfo.error,
+    );
+  });
+
+  it('should fire `onSectionComplete` when the onChange event is triggered from the checkbox', () => {
+    const { container } = render(<PreSubmitNotice {...defaultProps} />);
+    const checkbox = container.querySelector(
+      `[name="${defaultProps.preSubmitInfo.field}"]`,
+    );
+    checkbox.__events.vaChange();
+    expect(defaultProps.onSectionComplete.called).to.be.true;
+  });
+});

--- a/src/applications/hca/tests/e2e/hca-aiq.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-aiq.cypress.spec.js
@@ -79,6 +79,8 @@ describe('HCA-AIQ', () => {
       .should('have.text', 'Yes');
     cy.get('[name="privacyAgreementAccepted"]')
       .scrollIntoView()
+      .shadow()
+      .find('[type="checkbox"]')
       .check();
     cy.findByText(/submit/i, { selector: 'button' }).click();
     cy.wait('@mockSubmit').then(interception => {
@@ -117,6 +119,8 @@ describe('HCA-AIQ', () => {
       .should('have.text', 'No');
     cy.get('[name="privacyAgreementAccepted"]')
       .scrollIntoView()
+      .shadow()
+      .find('[type="checkbox"]')
       .check();
     cy.findByText(/submit/i, { selector: 'button' }).click();
     cy.wait('@mockSubmit').then(interception => {

--- a/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
@@ -6,7 +6,7 @@ import mockFacilities from './fixtures/mocks/mockFacilities.json';
 import prefillAiq from './fixtures/mocks/mockPrefillAiq.json';
 import mockUserAiq from './fixtures/mocks/mockUserAiq';
 import minTestData from './fixtures/data/minimal-test.json';
-import * as aiqHelpers from './helpers';
+import * as shortformHelpers from './helpers';
 
 const testData = minTestData.data;
 
@@ -97,25 +97,29 @@ describe('HCA-Shortform-Authenticated-High-Disability', () => {
     cy.injectAxe();
     cy.axeCheck();
 
-    aiqHelpers.goToNextPage('/veteran-information/maiden-name-information');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage(
+      '/veteran-information/maiden-name-information',
+    );
+    shortformHelpers.shortFormAdditionalHelpAssertion();
 
-    aiqHelpers.goToNextPage('/veteran-information/birth-sex');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/veteran-information/birth-sex');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
 
-    aiqHelpers.goToNextPage('/veteran-information/demographic-information');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage(
+      '/veteran-information/demographic-information',
+    );
+    shortformHelpers.shortFormAdditionalHelpAssertion();
 
-    // aiqHelpers.goToNextPage('/veteran-information/american-indian');
-    // aiqHelpers.shortFormAdditionalHelpAssertion();
+    // shortformHelpers.goToNextPage('/veteran-information/american-indian');
+    // shortformHelpers.shortFormAdditionalHelpAssertion();
     // cy.get('#root_sigiIsAmericanIndianNo[type="radio"]').check();
 
-    aiqHelpers.goToNextPage('/veteran-information/veteran-address');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/veteran-information/veteran-address');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
     cy.get('[type=radio]').check('N');
 
-    aiqHelpers.goToNextPage('/veteran-information/veteran-home-address');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/veteran-information/veteran-home-address');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
     cy.get('#root_veteranHomeAddress_street').type(
       testData.veteranAddress.street,
     );
@@ -127,30 +131,30 @@ describe('HCA-Shortform-Authenticated-High-Disability', () => {
       testData.veteranAddress.postalCode,
     );
 
-    aiqHelpers.goToNextPage('/veteran-information/contact-information');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/veteran-information/contact-information');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
 
     cy.wait('@mockSip');
 
     // medicaid
-    aiqHelpers.goToNextPage('/insurance-information/medicaid');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/insurance-information/medicaid');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
     cy.get('[type=radio]#root_isMedicaidEligibleNo')
       .first()
       .scrollIntoView()
       .check('N');
 
     // general insurance
-    aiqHelpers.goToNextPage('/insurance-information/general');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/insurance-information/general');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
 
     cy.get('[type=radio]#root_isCoveredByHealthInsuranceNo')
       .first()
       .scrollIntoView()
       .check('N');
 
-    aiqHelpers.goToNextPage('/insurance-information/va-facility');
-    aiqHelpers.shortFormAdditionalHelpAssertion();
+    shortformHelpers.goToNextPage('/insurance-information/va-facility');
+    shortformHelpers.shortFormAdditionalHelpAssertion();
     cy.get('[name="root_view:preferredFacility_view:facilityState"]').select(
       testData['view:preferredFacility']['view:facilityState'],
     );
@@ -160,14 +164,13 @@ describe('HCA-Shortform-Authenticated-High-Disability', () => {
       .find('select')
       .select(testData['view:preferredFacility'].vaMedicalFacility);
 
-    aiqHelpers.goToNextPage('review-and-submit');
+    shortformHelpers.goToNextPage('review-and-submit');
 
     cy.get('[name="privacyAgreementAccepted"]')
-      .find('[type="checkbox"]')
       .scrollIntoView()
-      .check({
-        force: true,
-      });
+      .shadow()
+      .find('[type="checkbox"]')
+      .check();
     cy.findByText(/submit/i, { selector: 'button' }).click();
     cy.wait('@mockSubmit');
     cy.location('pathname').should('include', '/confirmation');
@@ -236,27 +239,31 @@ describe('HCA-Shortform-Authenticated-Low-Disability', () => {
       '/veteran-information/personal-information',
     );
 
-    aiqHelpers.goToNextPage('/veteran-information/birth-information');
-    aiqHelpers.goToNextPage('/veteran-information/maiden-name-information');
-    aiqHelpers.goToNextPage('/veteran-information/birth-sex');
-    aiqHelpers.goToNextPage('/veteran-information/demographic-information');
+    shortformHelpers.goToNextPage('/veteran-information/birth-information');
+    shortformHelpers.goToNextPage(
+      '/veteran-information/maiden-name-information',
+    );
+    shortformHelpers.goToNextPage('/veteran-information/birth-sex');
+    shortformHelpers.goToNextPage(
+      '/veteran-information/demographic-information',
+    );
 
-    // aiqHelpers.goToNextPage('/veteran-information/american-indian');
+    // shortformHelpers.goToNextPage('/veteran-information/american-indian');
     // cy.get('#root_sigiIsAmericanIndianNo[type="radio"]').check();
 
-    aiqHelpers.goToNextPage('/veteran-information/veteran-address');
+    shortformHelpers.goToNextPage('/veteran-information/veteran-address');
     cy.get('[type=radio]')
       .first()
       .scrollIntoView()
       .check('Y');
 
-    aiqHelpers.goToNextPage('/veteran-information/contact-information');
+    shortformHelpers.goToNextPage('/veteran-information/contact-information');
     cy.wait('@mockSip');
 
     cy.injectAxe();
     cy.axeCheck();
 
-    aiqHelpers.shortFormSelfDisclosureToSubmit();
+    shortformHelpers.shortFormSelfDisclosureToSubmit();
   });
 });
 
@@ -301,21 +308,29 @@ describe('HCA-Shortform-UnAuthenticated', () => {
     cy.findByLabelText(/social security/i).type(
       testData.veteranSocialSecurityNumber,
     );
-    aiqHelpers.goToNextPage('veteran-information/profile-information');
-    aiqHelpers.goToNextPage('veteran-information/profile-information-ssn');
-    aiqHelpers.goToNextPage('veteran-information/profile-information-dob');
+    shortformHelpers.goToNextPage('veteran-information/profile-information');
+    shortformHelpers.goToNextPage(
+      'veteran-information/profile-information-ssn',
+    );
+    shortformHelpers.goToNextPage(
+      'veteran-information/profile-information-dob',
+    );
 
-    aiqHelpers.goToNextPage('/veteran-information/birth-information');
-    aiqHelpers.goToNextPage('/veteran-information/maiden-name-information');
-    aiqHelpers.goToNextPage('/veteran-information/birth-sex');
+    shortformHelpers.goToNextPage('/veteran-information/birth-information');
+    shortformHelpers.goToNextPage(
+      '/veteran-information/maiden-name-information',
+    );
+    shortformHelpers.goToNextPage('/veteran-information/birth-sex');
     cy.get('[type=radio]').check('M');
 
-    aiqHelpers.goToNextPage('/veteran-information/demographic-information');
+    shortformHelpers.goToNextPage(
+      '/veteran-information/demographic-information',
+    );
 
-    // aiqHelpers.goToNextPage('/veteran-information/american-indian');
+    // shortformHelpers.goToNextPage('/veteran-information/american-indian');
     // cy.get('#root_sigiIsAmericanIndianNo[type="radio"]').check();
 
-    aiqHelpers.goToNextPage('/veteran-information/veteran-address');
+    shortformHelpers.goToNextPage('/veteran-information/veteran-address');
     cy.get('#root_veteranAddress_street').type(testData.veteranAddress.street);
     cy.get('#root_veteranAddress_city').type(testData.veteranAddress.city);
     cy.get('#root_veteranAddress_state').select(testData.veteranAddress.state);
@@ -328,11 +343,11 @@ describe('HCA-Shortform-UnAuthenticated', () => {
       .scrollIntoView()
       .check('Y');
 
-    aiqHelpers.goToNextPage('/veteran-information/contact-information');
+    shortformHelpers.goToNextPage('/veteran-information/contact-information');
 
     cy.injectAxe();
     cy.axeCheck();
 
-    aiqHelpers.shortFormSelfDisclosureToSubmit();
+    shortformHelpers.shortFormSelfDisclosureToSubmit();
   });
 });

--- a/src/applications/hca/tests/e2e/hca.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca.cypress.spec.js
@@ -51,6 +51,16 @@ const testConfig = createTestConfig(
           cy.get('.usa-button-primary').click();
         });
       },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('[name="privacyAgreementAccepted"]')
+            .scrollIntoView()
+            .shadow()
+            .find('[type="checkbox"]')
+            .check();
+          cy.findByText(/submit/i, { selector: 'button' }).click();
+        });
+      },
     },
 
     setupPerTest: () => {

--- a/src/applications/hca/tests/e2e/helpers.js
+++ b/src/applications/hca/tests/e2e/helpers.js
@@ -12,14 +12,11 @@ export const goToNextPage = pagePath => {
     cy.location('pathname').should('include', pagePath);
   }
 };
+
 export const advanceToAiqPage = () => {
-  // cy.findAllByText(/start.+application/i, { selector: 'button' })
-  //   .first()
-  //   .click();
-
-  // changed above to the following because of flaky test due to cy.findAllByText(/start.+application/i, { selector: 'button' })
-  cy.get('#1-continueButton').click();
-
+  cy.get('[href="#start"]')
+    .first()
+    .click();
   cy.wait('@mockSip');
   cy.location('pathname').should(
     'include',
@@ -31,6 +28,7 @@ export const advanceToAiqPage = () => {
   goToNextPage('/veteran-information/demographic-information');
   goToNextPage('/veteran-information/american-indian');
 };
+
 export const advanceFromAiqToReviewPage = () => {
   goToNextPage('/veteran-information/veteran-address');
   cy.get('[type=radio]')
@@ -68,13 +66,9 @@ export const advanceFromAiqToReviewPage = () => {
 };
 
 export const advanceToServiceInfoPage = () => {
-  // cy.findAllByText(/start.+application/i, { selector: 'button' })
-  //   .first()
-  //   .click();
-
-  // changed above to the following because of flaky test due to cy.findAllByText(/start.+application/i, { selector: 'button' })
-  cy.get('#1-continueButton').click();
-
+  cy.get('[href="#start"]')
+    .first()
+    .click();
   cy.wait('@mockSip');
   cy.location('pathname').should(
     'include',
@@ -181,11 +175,10 @@ export const shortFormSelfDisclosureToSubmit = () => {
     .should('have.text', 'Yes (50% or higher rating)');
 
   cy.get('[name="privacyAgreementAccepted"]')
-    .find('[type="checkbox"]')
     .scrollIntoView()
-    .check({
-      force: true,
-    });
+    .shadow()
+    .find('[type="checkbox"]')
+    .check();
   cy.findByText(/submit/i, { selector: 'button' }).click();
   cy.wait('@mockSubmit').then(interception => {
     // check submitted vaCompensationType value.


### PR DESCRIPTION
## Description
The stakeholders for the HCA (10-10EZ) have requested that the formal disclosure regarding Copays, Communications and Assignment of Benefits be added to the online 10-10EZ form. This PR adds the disclosure to the review page by way of a custom component added to the `preSubmitInfo` section in the form config.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#56847

## Testing done
- [x] Unit tests
- [x] Cypress testing

## Screenshots
![Screenshot 2023-04-24 at 12 48 34 PM](https://user-images.githubusercontent.com/6738544/234063588-b5ad5f87-7133-4a24-90f8-88ffef762465.png)
![Screenshot 2023-04-24 at 12 48 52 PM](https://user-images.githubusercontent.com/6738544/234063610-ae520eed-37c8-41c3-a807-5858d833d064.png)
![Screenshot 2023-04-24 at 12 49 02 PM](https://user-images.githubusercontent.com/6738544/234063621-c37c092a-d53d-4b6e-aca4-12203716b14b.png)

## Acceptance criteria
- [ ]  No errors are rendered on the page or in the console on initial render
- [ ]  Form cannot be submitted without checking the disclosure acceptance checkbox
- [ ]  Form can be submitted with disclosure acceptance checkbox clicked