### PR TITLE
Add TeamSites information to acceptance criteria

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,52 +1,67 @@
 **Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.
 
-
 ## Summary
 
-- *(Summarize the changes that have been made to the platform)*
-- *(If bug, how to reproduce)*
-- *(What is the solution, why is this the solution)*
-- *(Which team do you work for, does your team own the maintenance of this component?)*
-- *(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)*
+- _(Summarize the changes that have been made to the platform)_
+- _(If bug, how to reproduce)_
+- _(What is the solution, why is this the solution)_
+- _(Which team do you work for, does your team own the maintenance of this component?)_
+- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
 
 ## Related issue(s)
-- department-of-veterans-affairs/va.gov-team#0000
-- *Link to ticket created in va.gov-team repo*
-- *Link to previous change of the code/bug (if applicable)*
-- *Link to epic if not included in ticket*
 
+- _Link to ticket created in va.gov-team repo_
+department-of-veterans-affairs/va.gov-team#0000
+- _Link to previous change of the code/bug (if applicable)_
+department-of-veterans-affairs/vets-website#0000
+- _Link to epic if not included in ticket_
+department-of-veterans-affairs/va.gov-team#0000
 
 ## Testing done
 
-- *Describe what the old behavior was prior to the change*
-- *Describe the steps required to verify your changes are working as expected*
-- *Describe the tests completed and the results*
-- *Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)*
-
+- _Describe what the old behavior was prior to the change_
+- _Describe the steps required to verify your changes are working as expected_
+- _Describe the tests completed and the results_
+- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_
 
 ## Screenshots
-_Note: This field is mandatory for component work and UI changes (non-component work should NOT have screenshots)._
 
-| | Before | After |
-| --- | --- | --- |
-| Mobile | | |
-| Desktop | | |
+_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
+
+|         | Before | After |
+| ------- | ------ | ----- |
+| Mobile  |        |       |
+| Desktop |        |       |
 
 ## What areas of the site does it impact?
+
 *(Describe what parts of the site are impacted and*if*code touched other areas)*
 
 ## Acceptance criteria
 
-- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
-- [ ]  No error nor warning in the console.
-- [ ]  Events are being sent to the appropriate logging solution
-- [ ]  Documentation has been updated (link to documentation)
-- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
-- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
-- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
-- [ ]  I added a screenshot of the developed feature
-- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
+### Quality Assurance & Testing
 
+- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
+- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
+- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
+- [ ] Screenshot of the developed feature is added
+- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
+
+### Error Handling
+
+- [ ] Browser console contains no warnings or errors.
+- [ ] Events are being sent to the appropriate logging solution
+- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
+
+### Authentication
+
+- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
+
+### Team Sites (only applies to modifications to the VA.go header)
+
+- [ ] The vets-website header does not contain any web-components
+- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
+- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
 
 ## Requested Feedback
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,7 +57,7 @@ _Note: This field is mandatory for UI changes (non-component work should NOT hav
 
 - [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
 
-### Team Sites (only applies to modifications made to the VA.go header)
+### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:
 
 - [ ] The vets-website header does not contain any web-components
 - [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,7 +57,7 @@ _Note: This field is mandatory for UI changes (non-component work should NOT hav
 
 - [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
 
-### Team Sites (only applies to modifications to the VA.go header)
+### Team Sites (only applies to modifications made to the VA.go header)
 
 - [ ] The vets-website header does not contain any web-components
 - [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

This PR updates the Pull Request template for vets-website. More specifically it cleans up the formatting of **Related issue(s)** portion and further breaks down the **Acceptance criteria** into bite-sized chunks for easier parsing and checking.  Additionally, it creates an additional Team Sites section that falls inline with [Jill Adams recommendations](https://dsva.slack.com/archives/CE4304QPK/p1682009034147109) in the `vfs-all-teams` Slack channel about modifications made to the VA.gov injected header.

This issue stemmed from the injected header on Team Sites breaking styles due to web components being incompatible with Team Sites (likely due to CORS issues). See ([Post Mortem issue 913](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/pull/913))

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#57289
- department-of-veterans-affairs/va.gov-team-sensitive/pull/913
- [Post Mortem injected header broken](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/2f6d5cc067f4a565497be366f309d283ddac22e8/Postmortems/2022/2022-10-07-web-component-breaks-teamsites.md)

## Testing done

No testing required


## Screenshots
No screenshots required

## What areas of the site does it impact?
Only impacts Pull Request template. No code is affected

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [ ]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

:warn

## Requested Feedback

I want to check with Jill Adams and the VSA Public Websites FE team to see if the Acceptance Criteria content makes sense
