### PR TITLE
Google Analytics events for Organic Adoption Modal

### DIFF
--- a/src/platform/user/authentication/components/OrganicAdoptionExperimentModal.jsx
+++ b/src/platform/user/authentication/components/OrganicAdoptionExperimentModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
@@ -8,17 +8,6 @@ import { isAuthenticatedWithOAuth } from '../selectors';
 
 const OrganicAdoptionExperimentModal = ({ visible = false, onClose }) => {
   const useOAuth = useSelector(isAuthenticatedWithOAuth);
-
-  useEffect(
-    () => {
-      recordEvent({
-        event: `organic-adoption-experiment-modal-${
-          visible ? 'opened' : 'closed'
-        }`,
-      });
-    },
-    [visible],
-  );
 
   const setDismissalCookie = () => {
     const date = new Date();

--- a/src/platform/user/authentication/components/OrganicAdoptionExperimentModal.jsx
+++ b/src/platform/user/authentication/components/OrganicAdoptionExperimentModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
@@ -8,6 +8,17 @@ import { isAuthenticatedWithOAuth } from '../selectors';
 
 const OrganicAdoptionExperimentModal = ({ visible = false, onClose }) => {
   const useOAuth = useSelector(isAuthenticatedWithOAuth);
+
+  useEffect(
+    () => {
+      recordEvent({
+        event: `organic-adoption-experiment-modal-${
+          visible ? 'opened' : 'closed'
+        }`,
+      });
+    },
+    [visible],
+  );
 
   const setDismissalCookie = () => {
     const date = new Date();
@@ -79,11 +90,15 @@ const OrganicAdoptionExperimentModal = ({ visible = false, onClose }) => {
           <li>A phone number where you can be reached</li>
         </ul>
         <div className="alert-actions">
-          <button type="button" onClick={onPrimaryButtonClick}>
+          <button
+            className="va-button usa-button"
+            type="button"
+            onClick={onPrimaryButtonClick}
+          >
             Get Login.gov now
           </button>
           <button
-            className="button-secondary"
+            className="va-button usa-button-secondary"
             onClick={onSecondaryButtonClick}
             type="button"
           >


### PR DESCRIPTION
## Summary
Add classes to buttons for automated GA reporting
Add a lifecycle event for tracking modal close/open

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/55329

## Testing done
Using GA inspector chrome extension, see the analytics events fire as expected.

## Screenshots
 No visual changes

## What areas of the site does it impact?
Organic Adoption Modal

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
- [x]  [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
