### PR TITLE
HCA acceptance checkbox data type mismatch hotfix

### DIFF
--- a/src/applications/hca/components/PreSubmitNotice/index.jsx
+++ b/src/applications/hca/components/PreSubmitNotice/index.jsx
@@ -1,10 +1,28 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const PreSubmitNotice = props => {
-  const { formData, preSubmitInfo, showError, onSectionComplete } = props;
+  const { preSubmitInfo, showError, onSectionComplete } = props;
   const { field, required } = preSubmitInfo;
+  const [accepted, setAccepted] = useState(false);
+
+  /**
+   * set section completed value and unset if user navigates away from the page
+   * before submitting the form.
+   */
+  useEffect(
+    () => {
+      onSectionComplete(accepted);
+
+      return () => {
+        onSectionComplete(false);
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [accepted],
+  );
+
   return (
     <>
       <h3>Agreement</h3>
@@ -76,13 +94,13 @@ const PreSubmitNotice = props => {
       <VaCheckbox
         required={required}
         name={field}
-        checked={formData[field] || false}
+        checked={accepted}
         error={
-          showError && !formData[field]
+          showError && !accepted
             ? 'You must accept the agreement before continuing.'
             : undefined
         }
-        onVaChange={onSectionComplete}
+        onVaChange={event => setAccepted(event.target.checked)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
       />
     </>

--- a/src/applications/hca/tests/components/PreSubmitNotice/PreSubmitNotice.unit.spec.js
+++ b/src/applications/hca/tests/components/PreSubmitNotice/PreSubmitNotice.unit.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -73,12 +73,12 @@ describe('hca <PreSubmitNotice>', () => {
     );
   });
 
-  it('should fire `onSectionComplete` when the onChange event is triggered from the checkbox', () => {
+  it('should fire `onSectionComplete` when the checkbox is clicked', () => {
     const { container } = render(<PreSubmitNotice {...defaultProps} />);
     const checkbox = container.querySelector(
       `[name="${defaultProps.preSubmitInfo.field}"]`,
     );
-    checkbox.__events.vaChange();
+    fireEvent.click(checkbox);
     expect(defaultProps.onSectionComplete.called).to.be.true;
   });
 });


### PR DESCRIPTION
## Description
This PR updates the `PreSubmitNotice` to fix the data type for the accepted checkbox value. Additionally, it unchecks the acceptance checkbox if the user navigates away before submitting.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#56847

## Testing done
- [x] Unit tests

## Acceptance criteria

- [ ]  No errors on form submission
