### PR TITLE
Skip FormNav.jsx unit-test case

### DIFF
--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -120,7 +120,8 @@ describe('Schemaform FormNav', () => {
     );
   });
 
-  it('should display/return correct chapter title when title-function uses onReviewPage parameter', () => {
+  // skipping due to flakiness in CI
+  it.skip('should display/return correct chapter title when title-function uses onReviewPage parameter', () => {
     const formConfigDefaultData = { ...getDefaultData() };
     const formPageChapterTitle = 'Testing';
     const reviewPageChapterTitle = 'Testing [on review page]';

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -106,7 +106,7 @@ describe('Schemaform FormNav', () => {
     );
   });
 
-  it('should display correct chapter number & total in stepText after previous progress-hidden chapter', () => {
+  it('should display correct chapter number & total in stepText after previous progress-hidden chapter', function() {
     if (!environment.isLocalhost()) {
       this.skip();
     }

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, waitFor } from '@testing-library/react';
 
+import environment from 'platform/utilities/environment';
 import FormNav from '../../../src/js/components/FormNav';
 
 describe('Schemaform FormNav', () => {
@@ -106,6 +107,10 @@ describe('Schemaform FormNav', () => {
   });
 
   it('should display correct chapter number & total in stepText after previous progress-hidden chapter', () => {
+    if (!environment.isLocalhost()) {
+      this.skip();
+    }
+
     const currentPath = 'testing2';
     const formConfigDefaultData = { ...getDefaultData() };
 
@@ -120,8 +125,7 @@ describe('Schemaform FormNav', () => {
     );
   });
 
-  // skipping due to flakiness in CI
-  it.skip('should display/return correct chapter title when title-function uses onReviewPage parameter', () => {
+  it('should display/return correct chapter title when title-function uses onReviewPage parameter', () => {
     const formConfigDefaultData = { ...getDefaultData() };
     const formPageChapterTitle = 'Testing';
     const reviewPageChapterTitle = 'Testing [on review page]';


### PR DESCRIPTION
## Summary

- Skip forms-library's FormNav-component unit-test case that's flaking in CI

