### PR TITLE
Hotfix for HCA review page disclosure behavior

### DIFF
--- a/src/applications/hca/components/PreSubmitNotice/index.jsx
+++ b/src/applications/hca/components/PreSubmitNotice/index.jsx
@@ -1,27 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const PreSubmitNotice = props => {
-  const { preSubmitInfo, showError, onSectionComplete } = props;
+  const { formData, preSubmitInfo, showError, onSectionComplete } = props;
   const { field, required } = preSubmitInfo;
-  const [accepted, setAccepted] = useState(false);
-
-  /**
-   * set section completed value and unset if user navigates away from the page
-   * before submitting the form.
-   */
-  useEffect(
-    () => {
-      onSectionComplete(accepted);
-
-      return () => {
-        onSectionComplete(false);
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [accepted],
-  );
 
   return (
     <>
@@ -94,13 +77,13 @@ const PreSubmitNotice = props => {
       <VaCheckbox
         required={required}
         name={field}
-        checked={accepted}
+        checked={formData[field]}
         error={
-          showError && !accepted
+          showError && !formData[field]
             ? 'You must accept the agreement before continuing.'
             : undefined
         }
-        onVaChange={event => setAccepted(event.target.checked)}
+        onVaChange={event => onSectionComplete(event.target.checked)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
       />
     </>

--- a/src/applications/hca/components/PreSubmitNotice/index.jsx
+++ b/src/applications/hca/components/PreSubmitNotice/index.jsx
@@ -1,10 +1,19 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const PreSubmitNotice = props => {
-  const { formData, preSubmitInfo, showError, onSectionComplete } = props;
+  const { preSubmitInfo, showError, onSectionComplete } = props;
   const { field, required } = preSubmitInfo;
+  const [accepted, setAccepted] = useState(false);
+
+  useEffect(
+    () => {
+      onSectionComplete(accepted);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [accepted],
+  );
 
   return (
     <>
@@ -77,13 +86,13 @@ const PreSubmitNotice = props => {
       <VaCheckbox
         required={required}
         name={field}
-        checked={formData[field]}
+        checked={accepted}
         error={
-          showError && !formData[field]
+          showError && !accepted
             ? 'You must accept the agreement before continuing.'
             : undefined
         }
-        onVaChange={event => onSectionComplete(event.target.checked)}
+        onVaChange={event => setAccepted(event.target.checked)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
       />
     </>


### PR DESCRIPTION
## Description
This PR fixes a small bug in the unmount function of the onSectionComplete call to the privacy acceptance agreement portion of the HCA review page. With the unmount functionality in place, the checkbox would clear and briefly display an error message when moving from review to completion page. This could be confusing to users and does more harm than good.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#56847

## Acceptance criteria

- [ ]  No error messages display on successful submission of the form