### PR TITLE
 #56997: Display C&P Appointments on the Appointments List (Upcoming and Past)

### DIFF
--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -7,6 +7,7 @@ import {
   APPOINTMENT_STATUS,
   APPOINTMENT_TYPES,
   VIDEO_TYPES,
+  SERVICE_CATEGORY,
 } from '../../utils/constants';
 import {
   getVAAppointmentLocationId,
@@ -348,6 +349,11 @@ export function selectIsVideo(appointment) {
 export function selectTypeOfCareName(appointment) {
   const { name } =
     getTypeOfCareById(appointment.vaos.apiData?.serviceType) || {};
+  const serviceCategoryName =
+    appointment.vaos.apiData?.serviceCategory?.[0].text || {};
+  if (serviceCategoryName === SERVICE_CATEGORY.compensationAndPension) {
+    return serviceCategoryName;
+  }
   return name;
 }
 

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -7,7 +7,7 @@ import {
   APPOINTMENT_STATUS,
   APPOINTMENT_TYPES,
   VIDEO_TYPES,
-  SERVICE_CATEGORY,
+  COMP_AND_PEN,
 } from '../../utils/constants';
 import {
   getVAAppointmentLocationId,
@@ -351,8 +351,9 @@ export function selectTypeOfCareName(appointment) {
     getTypeOfCareById(appointment.vaos.apiData?.serviceType) || {};
   const serviceCategoryName =
     appointment.vaos.apiData?.serviceCategory?.[0].text || {};
-  if (serviceCategoryName === SERVICE_CATEGORY.compensationAndPension) {
-    return serviceCategoryName;
+  if (serviceCategoryName === COMP_AND_PEN) {
+    const { displayName } = getTypeOfCareById(serviceCategoryName);
+    return displayName;
   }
   return name;
 }

--- a/src/applications/vaos/appointment-list/redux/tests/selectors.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/redux/tests/selectors.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('appointment-list / redux / selectors', () => {
       },
     };
     const typeOfCareName = selectTypeOfCareName(appointment);
-    expect(typeOfCareName).to.equal('COMPENSATION & PENSION');
+    expect(typeOfCareName).to.equal('Compensation and pension exam');
   });
   it('should return Audiology and speech as type of care', () => {
     const appointment = {

--- a/src/applications/vaos/appointment-list/redux/tests/selectors.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/redux/tests/selectors.unit.spec.jsx
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+
+import { selectTypeOfCareName } from '../selectors';
+
+describe('appointment-list / redux / selectors', () => {
+  it('should return COMPENSATION & PENSION as type of care', () => {
+    const appointment = {
+      vaos: {
+        apiData: {
+          serviceType: 'audiology',
+          serviceCategory: [
+            {
+              coding: [
+                {
+                  system:
+                    'http://www.va.gov/Terminology/VistADefinedTerms/409_1',
+                  code: 'COMPENSATION & PENSION',
+                  display: 'COMPENSATION & PENSION',
+                },
+              ],
+              text: 'COMPENSATION & PENSION',
+            },
+          ],
+        },
+      },
+    };
+    const typeOfCareName = selectTypeOfCareName(appointment);
+    expect(typeOfCareName).to.equal('COMPENSATION & PENSION');
+  });
+  it('should return Audiology and speech as type of care', () => {
+    const appointment = {
+      vaos: {
+        apiData: {
+          serviceType: 'audiology',
+          serviceCategory: [
+            {
+              coding: [
+                {
+                  system:
+                    'http://www.va.gov/Terminology/VistADefinedTerms/409_1',
+                  code: 'REGULAR',
+                  display: 'REGULAR',
+                },
+              ],
+              text: 'REGULAR',
+            },
+          ],
+        },
+      },
+    };
+    const typeOfCareName = selectTypeOfCareName(appointment);
+    expect(typeOfCareName).to.equal('Audiology and speech');
+  });
+});

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1252,6 +1252,98 @@
       }
     },
     {
+      "id": "167311",
+      "type": "appointments",
+      "attributes": {
+        "id": "167311",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383339353233"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "audiology",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "audiology"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "COMPENSATION & PENSION",
+                "display": "COMPENSATION & PENSION"
+              }
+            ],
+            "text": "COMPENSATION & PENSION"
+          }
+        ],
+        "patientIcn": "1013120826V646496",
+        "locationId": "983GC",
+        "clinic": "945",
+        "start": "2023-03-22T13:00:00Z",
+        "end": "2023-03-22T14:00:00Z",
+        "created": "2023-03-17T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ]
+        },
+        "serviceName": "FTC C&P AUDIO BEV",
+        "physicalLocation": "FORT COLLINS AUDIO",
+        "friendlyName": "C&P BEV AUDIO FTC",
+        "location": {
+          "id": "983GC",
+          "type": "appointments",
+          "attributes": {
+            "id": "983GC",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Fort Collins VA Clinic",
+            "classification": "Multi-Specialty CBOC",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 40.553875,
+            "long": -105.08795,
+            "website": "https://www.cheyenne.va.gov/locations/Fort_Collins_VA_CBOC.asp",
+            "phone": {
+              "main": "970-224-1550"
+            },
+            "physicalAddress": {
+              "line": [
+                "2509 Research Boulevard"
+              ],
+              "city": "Fort Collins",
+              "state": "CO",
+              "postalCode": "80526-8108"
+            },
+            "healthService": [
+              "Audiology",
+              "EmergencyCare",
+              "MentalHealthCare",
+              "PrimaryCare",
+              "SpecialtyCare"
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "147685",
       "type": "appointments",
       "attributes": {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1290,8 +1290,8 @@
         "patientIcn": "1013120826V646496",
         "locationId": "983GC",
         "clinic": "945",
-        "start": "2023-03-22T13:00:00Z",
-        "end": "2023-03-22T14:00:00Z",
+        "start": "2023-06-22T13:00:00Z",
+        "end": "2023-06-22T14:00:00Z",
         "created": "2023-03-17T00:00:00Z",
         "cancellable": true,
         "extension": {

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -10,6 +10,7 @@ import {
   TYPES_OF_SLEEP_CARE,
   AUDIOLOGY_TYPES_OF_CARE,
   TYPES_OF_CARE,
+  SERVICE_CATEGORY,
 } from './constants';
 
 export const CANCELLED_APPOINTMENT_SET = new Set([
@@ -75,6 +76,7 @@ export function getTypeOfCareById(inputId) {
     ...TYPES_OF_SLEEP_CARE,
     ...AUDIOLOGY_TYPES_OF_CARE,
     ...TYPES_OF_CARE,
+    ...SERVICE_CATEGORY,
   ];
 
   return allTypesOfCare.find(

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -94,6 +94,7 @@ export const PURPOSE_TEXT_V2 = [
 
 export const PODIATRY_ID = 'tbd-podiatry';
 export const COVID_VACCINE_ID = 'covid';
+export const COMP_AND_PEN = 'COMPENSATION & PENSION';
 
 /**
  * @typedef TypeOfCare
@@ -457,7 +458,10 @@ export const ERROR_CODES = [
     detail: 'Failure to fetch Requests',
   },
 ];
-export const SERVICE_CATEGORY = {
-  compensationAndPension: 'COMPENSATION & PENSION',
-  regular: 'REGULAR',
-};
+export const SERVICE_CATEGORY = [
+  {
+    id: COMP_AND_PEN,
+    idV2: COMP_AND_PEN,
+    displayName: 'Compensation and pension exam',
+  },
+];

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -461,7 +461,6 @@ export const ERROR_CODES = [
 export const SERVICE_CATEGORY = [
   {
     id: COMP_AND_PEN,
-    idV2: COMP_AND_PEN,
     displayName: 'Compensation and pension exam',
   },
 ];

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -457,3 +457,7 @@ export const ERROR_CODES = [
     detail: 'Failure to fetch Requests',
   },
 ];
+export const SERVICE_CATEGORY = {
+  compensationAndPension: 'COMPENSATION & PENSION',
+  regular: 'REGULAR',
+};


### PR DESCRIPTION
- Updated Type of Care selector to accommodate C&P appointments.
- Added new unit tests. I wrote these unit tests differently from how we currently write them. I'm interested in your feedback on this.

**Past Appt list**:
<img width="1285" alt="Screenshot 2023-04-25 at 12 47 15 PM" src="https://user-images.githubusercontent.com/47654119/234346706-f4edbe72-658c-426e-bb11-ab16789edca1.png">
<img width="439" alt="Screenshot 2023-04-25 at 12 48 42 PM" src="https://user-images.githubusercontent.com/47654119/234347027-dbd11b4a-ea93-470c-9ba8-c955bf364272.png">

**Upcoming Appt list**: 
<img width="1273" alt="Screenshot 2023-04-25 at 12 50 13 PM" src="https://user-images.githubusercontent.com/47654119/234347413-2707bae1-f9b0-4519-8e14-ff3d738c9ae9.png">
<img width="838" alt="Screenshot 2023-04-25 at 12 51 06 PM" src="https://user-images.githubusercontent.com/47654119/234347625-96b196c8-7ad2-4da9-b643-eabd4531e852.png">

