### PR TITLE
Better handle error message display for HCA benefits disclosure

### DIFF
--- a/src/applications/hca/components/PreSubmitNotice/index.jsx
+++ b/src/applications/hca/components/PreSubmitNotice/index.jsx
@@ -1,18 +1,39 @@
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const PreSubmitNotice = props => {
-  const { preSubmitInfo, showError, onSectionComplete } = props;
+  const { preSubmitInfo, showError, onSectionComplete, submission } = props;
   const { field, required } = preSubmitInfo;
-  const [accepted, setAccepted] = useState(false);
 
+  const [accepted, setAccepted] = useState(false);
+  const [error, setError] = useState(undefined);
+  const formSubmitted = !!submission.status;
+
+  // set section complete value--unset if user navigates away from the page before submitting the form.
   useEffect(
     () => {
       onSectionComplete(accepted);
+
+      return () => {
+        onSectionComplete(false);
+      };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [accepted],
+  );
+
+  // set error message status
+  useEffect(
+    () => {
+      const hasError = accepted === true || formSubmitted ? false : showError;
+      const message = hasError
+        ? 'You must accept the agreement before continuing.'
+        : undefined;
+      setError(message);
+    },
+    [accepted, showError, formSubmitted],
   );
 
   return (
@@ -86,12 +107,7 @@ const PreSubmitNotice = props => {
       <VaCheckbox
         required={required}
         name={field}
-        checked={accepted}
-        error={
-          showError && !accepted
-            ? 'You must accept the agreement before continuing.'
-            : undefined
-        }
+        error={error}
         onVaChange={event => setAccepted(event.target.checked)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
       />
@@ -103,7 +119,14 @@ PreSubmitNotice.propTypes = {
   formData: PropTypes.object,
   preSubmitInfo: PropTypes.object,
   showError: PropTypes.bool,
+  submission: PropTypes.object,
   onSectionComplete: PropTypes.func,
 };
 
-export default PreSubmitNotice;
+const mapStateToProps = state => {
+  return {
+    submission: state.form.submission,
+  };
+};
+
+export default connect(mapStateToProps)(PreSubmitNotice);

--- a/src/applications/hca/tests/components/PreSubmitNotice/PreSubmitNotice.unit.spec.js
+++ b/src/applications/hca/tests/components/PreSubmitNotice/PreSubmitNotice.unit.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -6,6 +7,16 @@ import sinon from 'sinon';
 import PreSubmitNotice from '../../../components/PreSubmitNotice';
 
 describe('hca <PreSubmitNotice>', () => {
+  const defaultStore = {
+    getState: () => ({
+      form: {
+        submission: {},
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  };
+
   const defaultProps = {
     formData: {},
     preSubmitInfo: {
@@ -20,7 +31,11 @@ describe('hca <PreSubmitNotice>', () => {
   };
 
   it('should render', () => {
-    const { container } = render(<PreSubmitNotice {...defaultProps} />);
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <PreSubmitNotice {...defaultProps} />
+      </Provider>,
+    );
     const checkbox = container.querySelector(
       `[name="${defaultProps.preSubmitInfo.field}"]`,
     );
@@ -41,12 +56,15 @@ describe('hca <PreSubmitNotice>', () => {
       'required',
       `${defaultProps.preSubmitInfo.required}`,
     );
-    expect(checkbox).to.have.attribute('checked', 'false');
   });
 
-  it('should render error message if data is false and `showError` is set to true', () => {
+  it('should render error message if form data value is false and `showError` is set to true', () => {
     const props = { ...defaultProps, showError: true };
-    const { container } = render(<PreSubmitNotice {...props} />);
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <PreSubmitNotice {...props} />
+      </Provider>,
+    );
     const checkbox = container.querySelector(
       `[name="${defaultProps.preSubmitInfo.field}"]`,
     );
@@ -57,12 +75,47 @@ describe('hca <PreSubmitNotice>', () => {
     );
   });
 
-  it('should not render error message if data is true', () => {
+  it('should not render error message if form data value is true', () => {
     const props = {
       ...defaultProps,
       formData: { privacyAgreementAccepted: true },
     };
-    const { container } = render(<PreSubmitNotice {...props} />);
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <PreSubmitNotice {...props} />
+      </Provider>,
+    );
+    const checkbox = container.querySelector(
+      `[name="${defaultProps.preSubmitInfo.field}"]`,
+    );
+
+    expect(checkbox).to.not.have.attribute(
+      'error',
+      defaultProps.preSubmitInfo.error,
+    );
+  });
+
+  it('should not render error message if form has been submitted', () => {
+    const store = {
+      getState: () => ({
+        form: {
+          submission: {
+            status: 'submitPending',
+          },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const props = {
+      ...defaultProps,
+      formData: { privacyAgreementAccepted: true },
+    };
+    const { container } = render(
+      <Provider store={store}>
+        <PreSubmitNotice {...props} />
+      </Provider>,
+    );
     const checkbox = container.querySelector(
       `[name="${defaultProps.preSubmitInfo.field}"]`,
     );
@@ -74,7 +127,11 @@ describe('hca <PreSubmitNotice>', () => {
   });
 
   it('should fire `onSectionComplete` when the checkbox is clicked', () => {
-    const { container } = render(<PreSubmitNotice {...defaultProps} />);
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <PreSubmitNotice {...defaultProps} />
+      </Provider>,
+    );
     const checkbox = container.querySelector(
       `[name="${defaultProps.preSubmitInfo.field}"]`,
     );


### PR DESCRIPTION
## Description
When submitting a form with a custom component for the PreSubmitInfo form section, the agreement acceptance checkbox clears while submission is in progress and incorrectly indicates that the form has an error. This PR checks the submission status of the form and only renders the error message if submission is not pending.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#56847

## Testing done
- [x] Unit testing
- [x] Cypress testing

## Acceptance criteria
- [ ] No error messages display while form is pending submission