### PR TITLE
Separating rendering of EVSS and Lighthouse claims for DetailsPage

### DIFF
--- a/src/applications/claims-status/components/evss/DetailsPageContent.jsx
+++ b/src/applications/claims-status/components/evss/DetailsPageContent.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+export default function DefaultPageContent({ claim }) {
+  const {
+    claimType,
+    contentionList,
+    dateFiled,
+    vaRepresentative,
+  } = claim.attributes;
+
+  return (
+    <>
+      <h3 className="vads-u-visibility--screen-reader">Claim details</h3>
+      <dl className="claim-details">
+        <dt className="claim-detail-label">
+          <h4>Claim type</h4>
+        </dt>
+        <dd>{claimType || 'Not Available'}</dd>
+        <dt className="claim-detail-label">
+          <h4>What you’ve claimed</h4>
+        </dt>
+        <dd>
+          {contentionList && contentionList.length ? (
+            <ul className="claim-detail-list">
+              {contentionList.map((contention, index) => (
+                <li key={index} className="claim-detail-list-item">
+                  {contention}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            'Not Available'
+          )}
+        </dd>
+        <dt className="claim-detail-label">
+          <h4>Date received</h4>
+        </dt>
+        <dd>{moment(dateFiled).format('MMM D, YYYY')}</dd>
+        <dt className="claim-detail-label">
+          <h4>Your representative for VA claims</h4>
+        </dt>
+        <dd>{vaRepresentative || 'Not Available'}</dd>
+      </dl>
+    </>
+  );
+}
+
+DefaultPageContent.propTypes = {
+  claim: PropTypes.object,
+};

--- a/src/applications/claims-status/components/evss/DetailsPageContent.jsx
+++ b/src/applications/claims-status/components/evss/DetailsPageContent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 
-export default function DefaultPageContent({ claim }) {
+export default function DetailsPageContent({ claim }) {
   const {
     claimType,
     contentionList,
@@ -47,6 +47,6 @@ export default function DefaultPageContent({ claim }) {
   );
 }
 
-DefaultPageContent.propTypes = {
+DetailsPageContent.propTypes = {
   claim: PropTypes.object,
 };

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -50,12 +50,16 @@ class DetailsPage extends React.Component {
 
   getPageContent() {
     const { claim, useLighthouse } = this.props;
-
     if (!useLighthouse) {
       return <DetailsPageContent claim={claim} />;
     }
 
-    const { claimDate, claimType, contentions } = claim.attributes;
+    const {
+      claimType,
+      contentionList,
+      dateFiled,
+      vaRepresentative,
+    } = claim.attributes;
 
     return (
       <>
@@ -69,11 +73,11 @@ class DetailsPage extends React.Component {
             <h4>What you’ve claimed</h4>
           </dt>
           <dd>
-            {contentions && contentions.length ? (
+            {contentionList && contentionList.length ? (
               <ul className="claim-detail-list">
-                {contentions.map((contention, index) => (
+                {contentionList.map((contention, index) => (
                   <li key={index} className="claim-detail-list-item">
-                    {contention.name}
+                    {contention}
                   </li>
                 ))}
               </ul>
@@ -84,7 +88,11 @@ class DetailsPage extends React.Component {
           <dt className="claim-detail-label">
             <h4>Date received</h4>
           </dt>
-          <dd>{moment(claimDate).format('MMM D, YYYY')}</dd>
+          <dd>{moment(dateFiled).format('MMM D, YYYY')}</dd>
+          <dt className="claim-detail-label">
+            <h4>Your representative for VA claims</h4>
+          </dt>
+          <dd>{vaRepresentative || 'Not Available'}</dd>
         </dl>
       </>
     );

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -5,7 +5,13 @@ import PropTypes from 'prop-types';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
+// START lighthouse_migration
+import DetailsPageContent from '../components/evss/DetailsPageContent';
+// END lighthouse_migration
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
+// START lighthouse_migration
+import { cstUseLighthouse } from '../selectors';
+// END lighthouse_migration
 import { getClaimType } from '../utils/helpers';
 import { setUpPage, isTab, setFocus } from '../utils/page';
 
@@ -42,53 +48,54 @@ class DetailsPage extends React.Component {
       : `Details - Your ${getClaimType(this.props.claim)} Claim`;
   }
 
+  getPageContent() {
+    const { claim, useLighthouse } = this.props;
+
+    if (!useLighthouse) {
+      return <DetailsPageContent claim={claim} />;
+    }
+
+    const { claimDate, claimType, contentions } = claim.attributes;
+
+    return (
+      <>
+        <h3 className="vads-u-visibility--screen-reader">Claim details</h3>
+        <dl className="claim-details">
+          <dt className="claim-detail-label">
+            <h4>Claim type</h4>
+          </dt>
+          <dd>{claimType || 'Not Available'}</dd>
+          <dt className="claim-detail-label">
+            <h4>What you’ve claimed</h4>
+          </dt>
+          <dd>
+            {contentions && contentions.length ? (
+              <ul className="claim-detail-list">
+                {contentions.map((contention, index) => (
+                  <li key={index} className="claim-detail-list-item">
+                    {contention.name}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              'Not Available'
+            )}
+          </dd>
+          <dt className="claim-detail-label">
+            <h4>Date received</h4>
+          </dt>
+          <dd>{moment(claimDate).format('MMM D, YYYY')}</dd>
+        </dl>
+      </>
+    );
+  }
+
   render() {
     const { claim, loading, synced } = this.props;
 
     let content = null;
     if (!loading) {
-      const {
-        claimType,
-        contentionList,
-        dateFiled,
-        vaRepresentative,
-      } = claim.attributes;
-
-      content = (
-        <>
-          <h3 className="vads-u-visibility--screen-reader">Claim details</h3>
-          <dl className="claim-details">
-            <dt className="claim-detail-label">
-              <h4>Claim type</h4>
-            </dt>
-            <dd>{claimType || 'Not Available'}</dd>
-            <dt className="claim-detail-label">
-              <h4>What you’ve claimed</h4>
-            </dt>
-            <dd>
-              {contentionList && contentionList.length ? (
-                <ul className="claim-detail-list">
-                  {contentionList.map((contention, index) => (
-                    <li key={index} className="claim-detail-list-item">
-                      {contention}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                'Not Available'
-              )}
-            </dd>
-            <dt className="claim-detail-label">
-              <h4>Date received</h4>
-            </dt>
-            <dd>{moment(dateFiled).format('MMM D, YYYY')}</dd>
-            <dt className="claim-detail-label">
-              <h4>Your representative for VA claims</h4>
-            </dt>
-            <dd>{vaRepresentative || 'Not Available'}</dd>
-          </dl>
-        </>
-      );
+      content = this.getPageContent();
     }
 
     return (
@@ -111,6 +118,7 @@ function mapStateToProps(state) {
     claim: claimsState.claimDetail.detail,
     lastPage: claimsState.routing.lastPage,
     synced: claimsState.claimSync.synced,
+    useLighthouse: cstUseLighthouse(state),
   };
 }
 
@@ -119,6 +127,7 @@ DetailsPage.propTypes = {
   lastPage: PropTypes.string,
   loading: PropTypes.bool,
   synced: PropTypes.bool,
+  useLighthouse: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(DetailsPage);

--- a/src/applications/claims-status/tests/components/DetailsPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DetailsPage.unit.spec.jsx
@@ -13,7 +13,9 @@ describe('<DetailsPage>', () => {
     };
 
     const tree = SkinDeep.shallowRender(<DetailsPage claim={claim} />);
-    expect(tree.subTree('.claim-detail-list').text()).to.contain(
+    const content = tree.dive(['DetailsPageContent']);
+
+    expect(content.subTree('.claim-detail-list').text()).to.contain(
       'Condition 1Condition 2',
     );
   });
@@ -26,6 +28,10 @@ describe('<DetailsPage>', () => {
     };
 
     const tree = SkinDeep.shallowRender(<DetailsPage claim={claim} />);
-    expect(tree.subTree('.claim-details').text()).to.contain('Not Available');
+    const content = tree.dive(['DetailsPageContent']);
+
+    expect(content.subTree('.claim-details').text()).to.contain(
+      'Not Available',
+    );
   });
 });


### PR DESCRIPTION
## Summary
There was a previous PR to separate the rendering of EVSS and Lighthouse version of claims for the Status tab and the Files tab; This PR does the same thing for the Details tab. Originally the data schemas were similar enough for the parts of the claim that the details page uses, but recently there were changes to the Lighthouse data schema and it seemed to make sense to separate the rendering of the Details Page content as well

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#50036

## Testing done
Existings tests continue to pass

## What areas of the site does it impact?

*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
