### PR TITLE
Add facility address to details view

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -28,6 +28,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - pacificTimezoneUUID: `6c72b801-74ac-47fe-82af-cfe59744b45f`
   - allAppointmentTypesUUID: `bb48c558-7b35-44ec-8ab7-32b7d49364fc`
   - missingUUID: `a5895713-ca42-4244-9f38-f8b5db020d04`
+  - noFacilityAddressUUID: `5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3`
 
 ### Pre-check-in
   - defaultUUID: `46bebc0a-b99c-464f-a5c5-560bc9eae287`
@@ -38,6 +39,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - expiredUUID: `354d5b3a-b7b7-4e5c-99e4-8d563f15c521`
   - expiredPhoneUUID: `08ba56a7-68b7-4b9f-b779-53ba609140ef`
   - missingUUID: `a5895713-ca42-4244-9f38-f8b5db020d04`
+  - noFacilityAddressUUID: `5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3`
   - allDemographicsCurrentUUID: `e544c217-6fe8-44c5-915f-6c3d9908a678`
   - onlyDemographicsCurrentUUID: `7397abc0-fb4d-4238-a3e2-32b0e47a1527` (NoK and Emergency Contact not current)
 

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/pre-check-in-data/get.js
@@ -19,6 +19,8 @@ const expiredPhoneUUID = '08ba56a7-68b7-4b9f-b779-53ba609140ef';
 const allDemographicsCurrentUUID = 'e544c217-6fe8-44c5-915f-6c3d9908a678';
 const onlyDemographicsCurrentUUID = '7397abc0-fb4d-4238-a3e2-32b0e47a1527';
 
+const noFacilityAddressUUID = '5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3';
+
 const isoDateWithoutTimezoneFormat = "yyyy-LL-dd'T'HH:mm:ss";
 
 const createMockSuccessResponse = (
@@ -46,6 +48,14 @@ const createMockSuccessResponse = (
   let location = null;
   let checkInSteps = [];
   let status = '';
+  let facilityAddress = {
+    zip: '92357-1000',
+    street1: '11201 Benton Street',
+    state: 'CA',
+    street2: null,
+    street3: null,
+    city: 'Loma Linda',
+  };
 
   let demographicsNeedsUpdateValue = demographicsNeedsUpdate;
   let demographicsConfirmedAtValue = demographicsConfirmedAt;
@@ -105,6 +115,9 @@ const createMockSuccessResponse = (
     apptKind = 'phone';
     location = '';
   }
+  if (token === noFacilityAddressUUID) {
+    facilityAddress = {};
+  }
   return {
     id: token || defaultUUID,
     payload: {
@@ -118,6 +131,7 @@ const createMockSuccessResponse = (
           checkInSteps,
           preCheckInValid: true,
           appointmentIen: 1111,
+          facilityAddress,
         }),
         createAppointment({
           clinicLocation: location ?? 'SECOND FLOOR ROOM 2',
@@ -126,6 +140,7 @@ const createMockSuccessResponse = (
           startTime: mockTime,
           checkInSteps,
           preCheckInValid: true,
+          facilityAddress,
         }),
       ],
       patientDemographicsStatus: {

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -106,6 +106,14 @@ const createAppointment = ({
   clinicStopCodeName = 'Mental health',
   doctorName = 'Dr. Jones',
   clinicIen = '0001',
+  facilityAddress = {
+    zip: '92357-1000',
+    street1: '11201 Benton Street',
+    state: 'CA',
+    street2: null,
+    street3: null,
+    city: 'Loma Linda',
+  },
 } = {}) => {
   const formattedStartTime = dateFns.format(
     startTime,
@@ -169,6 +177,7 @@ const createAppointment = ({
     clinicStopCodeName,
     doctorName,
     clinicIen,
+    facilityAddress,
   };
 };
 

--- a/src/applications/check-in/components/AddressBlock.jsx
+++ b/src/applications/check-in/components/AddressBlock.jsx
@@ -40,7 +40,7 @@ const AddressBlock = ({ address, showDirections = false, placeName }) => {
   };
 
   return (
-    <>
+    <div data-testid="address-block">
       <span data-testid="address-line-street1">{address.street1}</span>
       {lineTwo}
       {lineThree}
@@ -68,7 +68,7 @@ const AddressBlock = ({ address, showDirections = false, placeName }) => {
             </a>
           </div>
         )}
-    </>
+    </div>
   );
 };
 AddressBlock.propTypes = {

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -36,6 +36,8 @@ const AppointmentDetails = props => {
   const appointmentDay = new Date(appointment?.startTime);
   const isPhoneAppointment = appointment?.kind === 'phone';
   const { appointmentId } = router.params;
+  const isPreCheckIn = app === 'preCheckIn';
+
   useLayoutEffect(
     () => {
       if (appointmentId) {
@@ -134,17 +136,18 @@ const AppointmentDetails = props => {
                   {isPhoneAppointment ? t('clinic') : t('where-to-attend')}
                 </h2>
                 {!isPhoneAppointment && (
-                  <div
-                    className="vads-u-margin-bottom--2"
-                    data-testid="appointment-details--facility-value"
-                  >
+                  <div data-testid="appointment-details--facility-value">
                     {appointment.facility}
                     <br />
-                    <AddressBlock
-                      address={appointment.facilityAddress}
-                      placeName={appointment.facility}
-                      showDirections
-                    />
+                    {appointment.facilityAddress?.street1 && (
+                      <div className="vads-u-margin-bottom--2">
+                        <AddressBlock
+                          address={appointment.facilityAddress}
+                          placeName={appointment.facility}
+                          showDirections={isPreCheckIn}
+                        />
+                      </div>
+                    )}
                   </div>
                 )}
                 <div data-testid="appointment-details--clinic-value">

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -21,6 +21,7 @@ import Wrapper from '../../layout/Wrapper';
 import BackButton from '../../BackButton';
 import AppointmentAction from '../../AppointmentDisplay/AppointmentAction';
 import AppointmentMessage from '../../AppointmentDisplay/AppointmentMessage';
+import AddressBlock from '../../AddressBlock';
 
 const AppointmentDetails = props => {
   const { router } = props;
@@ -133,8 +134,17 @@ const AppointmentDetails = props => {
                   {isPhoneAppointment ? t('clinic') : t('where-to-attend')}
                 </h2>
                 {!isPhoneAppointment && (
-                  <div data-testid="appointment-details--facility-value">
+                  <div
+                    className="vads-u-margin-bottom--2"
+                    data-testid="appointment-details--facility-value"
+                  >
                     {appointment.facility}
+                    <br />
+                    <AddressBlock
+                      address={appointment.facilityAddress}
+                      placeName={appointment.facility}
+                      showDirections
+                    />
                   </div>
                 )}
                 <div data-testid="appointment-details--clinic-value">

--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -60,6 +60,8 @@ describe('Check In Experience', () => {
       AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere();
+      AppointmentDetails.validateFacilityAddress(true);
+      AppointmentDetails.validateDirectionsLink(false);
       AppointmentDetails.validatePhone();
       AppointmentDetails.validateCheckInButton();
       AppointmentDetails.validateReturnToAppointmentsPageButton();

--- a/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -45,17 +45,66 @@ describe('Pre-Check In Experience', () => {
         window.sessionStorage.clear();
       });
     });
-    it('Appointment details page content loads for in person appointment', () => {
+    it('Appointment details page content loads for in person appointment with address', () => {
       Confirmation.clickDetails();
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateSubtitleInPerson();
       AppointmentDetails.validateWhen();
       AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
-      AppointmentDetails.validateWhere();
+      AppointmentDetails.validateWhere('in-person');
+      AppointmentDetails.validateFacilityAddress(true);
+      AppointmentDetails.validateDirectionsLink(true);
       AppointmentDetails.validatePhone();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Pre-check-in--Appointment-detail--in-person');
+    });
+  });
+
+  describe('Appointment details in person no facility address', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializePreCheckInDataGet,
+        initializePreCheckInDataPost,
+      } = ApiInitializer;
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
+
+      initializeSessionPost.withSuccess();
+      initializePreCheckInDataGet.withSuccess({
+        uuid: '5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3',
+      });
+
+      initializePreCheckInDataPost.withSuccess();
+
+      cy.visitPreCheckInWithUUID();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Introduction.validatePageLoaded();
+      Introduction.attemptToGoToNextPage();
+      Demographics.validatePageLoaded();
+      Demographics.attemptToGoToNextPage();
+      EmergencyContact.validatePageLoaded();
+      EmergencyContact.attemptToGoToNextPage();
+      NextOfKin.validatePageLoaded();
+      NextOfKin.attemptToGoToNextPage();
+      Confirmation.validatePageContent();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('Appointment details displays without address when no address is present', () => {
+      Confirmation.clickDetails();
+      AppointmentDetails.validateFacilityAddress(false);
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Pre-check-in--Appointment-detail--in-person--no-facility-address',
+      );
     });
   });
 

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -54,8 +54,20 @@ class AppointmentDetails {
       'be.visible',
     );
     if (type === 'in-person') {
+      cy.get('div[data-testid="appointment-details--facility-value"]').should(
+        'be.visible',
+      );
+      cy.get('div[data-testid="address-block"]').should('be.visible');
       cy.get('div[data-testid="appointment-details--location-value"]').should(
         'be.visible',
+      );
+    } else {
+      cy.get('div[data-testid="appointment-details--facility-value"]').should(
+        'not.exist',
+      );
+      cy.get('div[data-testid="address-block"]').should('not.exist');
+      cy.get('div[data-testid="appointment-details--location-value"]').should(
+        'not.exist',
       );
     }
   };

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -46,6 +46,22 @@ class AppointmentDetails {
     );
   };
 
+  validateDirectionsLink = visible => {
+    if (visible) {
+      cy.get('div[data-testid="directions-link"]').should('be.visible');
+    } else {
+      cy.get('div[data-testid="directions-link"]').should('not.exist');
+    }
+  };
+
+  validateFacilityAddress = visible => {
+    if (visible) {
+      cy.get('div[data-testid="address-block"]').should('be.visible');
+    } else {
+      cy.get('div[data-testid="address-block"]').should('not.exist');
+    }
+  };
+
   validateWhere = (type = 'in-person') => {
     cy.get('div[data-testid="appointment-details--where"]').should(
       'be.visible',
@@ -57,7 +73,7 @@ class AppointmentDetails {
       cy.get('div[data-testid="appointment-details--facility-value"]').should(
         'be.visible',
       );
-      cy.get('div[data-testid="address-block"]').should('be.visible');
+
       cy.get('div[data-testid="appointment-details--location-value"]').should(
         'be.visible',
       );
@@ -65,7 +81,6 @@ class AppointmentDetails {
       cy.get('div[data-testid="appointment-details--facility-value"]').should(
         'not.exist',
       );
-      cy.get('div[data-testid="address-block"]').should('not.exist');
       cy.get('div[data-testid="appointment-details--location-value"]').should(
         'not.exist',
       );

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -48,9 +48,9 @@ class AppointmentDetails {
 
   validateDirectionsLink = visible => {
     if (visible) {
-      cy.get('div[data-testid="directions-link"]').should('be.visible');
+      cy.get('a[data-testid="directions-link"]').should('be.visible');
     } else {
-      cy.get('div[data-testid="directions-link"]').should('not.exist');
+      cy.get('a[data-testid="directions-link"]').should('not.exist');
     }
   };
 

--- a/src/applications/check-in/tests/unit/mocks/mock-appointments.js
+++ b/src/applications/check-in/tests/unit/mocks/mock-appointments.js
@@ -12,6 +12,14 @@ const singleAppointment = [
     checkInWindowStart: '2022-01-03T14:56:04.788Z',
     checkInWindowEnd: '2022-01-03T14:56:04.788Z',
     checkedInTime: '',
+    facilityAddress: {
+      zip: '92357-1000',
+      street1: '11201 Benton Street',
+      state: 'CA',
+      street2: null,
+      street3: null,
+      city: 'Loma Linda',
+    },
   },
 ];
 
@@ -29,6 +37,14 @@ const multipleAppointments = [
     checkInWindowStart: '2021-11-30T17:12:10.694Z',
     checkInWindowEnd: '2021-11-30T17:12:10.694Z',
     checkedInTime: '',
+    facilityAddress: {
+      zip: '92357-1000',
+      street1: '11201 Benton Street',
+      state: 'CA',
+      street2: null,
+      street3: null,
+      city: 'Loma Linda',
+    },
   },
   {
     facility: 'LOMA LINDA VA CLINIC',
@@ -43,6 +59,14 @@ const multipleAppointments = [
     checkInWindowStart: '2021-11-30T17:12:10.694Z',
     checkInWindowEnd: '2021-11-30T17:12:10.694Z',
     checkedInTime: '',
+    facilityAddress: {
+      zip: '92357-1000',
+      street1: '11201 Benton Street',
+      state: 'CA',
+      street2: null,
+      street3: null,
+      city: 'Loma Linda',
+    },
   },
   {
     facility: 'LOMA LINDA VA CLINIC',
@@ -57,6 +81,14 @@ const multipleAppointments = [
     checkInWindowStart: '2021-11-30T17:12:10.694Z',
     checkInWindowEnd: '2021-11-30T17:12:10.694Z',
     checkedInTime: '',
+    facilityAddress: {
+      zip: '92357-1000',
+      street1: '11201 Benton Street',
+      state: 'CA',
+      street2: null,
+      street3: null,
+      city: 'Loma Linda',
+    },
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds facility address to details view

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#52132](https://github.com/department-of-veterans-affairs/va.gov-team/issues/52132)

## Testing done

- Cypress
- Visual

## Screenshots
![Screen Shot 2023-04-26 at 3 30 06 PM](https://user-images.githubusercontent.com/2982977/234692835-1cb2580d-890e-4c7d-be4a-0a650f071d34.png)

## What areas of the site does it impact?

CIE day-of and pre-check-in

## Acceptance criteria

The facility address shows up for in person appointments but not for phone.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
