### PR TITLE
Forms Library: Replace deprecated LoadingIndicator with web component

### DIFF
--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -9,7 +9,6 @@ import {
   formDescriptions,
   formBenefits,
 } from 'applications/personalization/dashboard/helpers';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { VaButtonPair } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import {
@@ -101,7 +100,7 @@ export class ApplicationStatus extends React.Component {
 
       return (
         <div className="sip-application-status vads-u-margin-bottom--2 vads-u-margin-top--0">
-          <LoadingIndicator message={message} />
+          <va-loading-indicator label="Loading" message={message} />
         </div>
       );
     }

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -6,6 +6,10 @@ import { connect } from 'react-redux';
 import FormApp from 'platform/forms-system/src/js/containers/FormApp';
 import { getNextPagePath } from 'platform/forms-system/src/js/routing';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import environment from 'platform/utilities/environment';
+import { getScrollOptions } from 'platform/utilities/ui';
+import { restartShouldRedirect } from 'platform/site-wide/wizard';
 import {
   LOAD_STATUSES,
   PREFILL_STATUSES,
@@ -13,17 +17,12 @@ import {
   setFetchFormStatus,
   fetchInProgressForm,
 } from './actions';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { isInProgressPath } from '../helpers';
 import { getSaveInProgressState } from './selectors';
-import environment from 'platform/utilities/environment';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
-import { getScrollOptions } from 'platform/utilities/ui';
-import { restartShouldRedirect } from 'platform/site-wide/wizard';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 /*
  * Primary component for a schema generated form app.
@@ -33,6 +32,7 @@ class RoutedSavableApp extends React.Component {
     super(props);
     this.location = props.location || window.location;
   }
+
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     window.addEventListener('beforeunload', this.onbeforeunload);
@@ -71,6 +71,7 @@ class RoutedSavableApp extends React.Component {
       this.redirectOrLoad(this.props);
     }
   }
+
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillReceiveProps(newProps) {
     // When a user is logged in, the profile finishes loading after the component
@@ -248,17 +249,28 @@ class RoutedSavableApp extends React.Component {
       (!formConfig.disableSave && this.shouldRedirectOrLoad)
     ) {
       content = (
-        <LoadingIndicator message="Retrieving your profile information..." />
+        <va-loading-indicator
+          label="Loading"
+          message="Retrieving your profile information..."
+        />
       );
     } else if (!formConfig.disableSave && loadingForm) {
       content = (
-        <LoadingIndicator message={`Retrieving your saved ${appType}...`} />
+        <va-loading-indicator
+          label="Loading"
+          message={`Retrieving your saved ${appType}...`}
+        />
       );
     } else if (
       !formConfig.disableSave &&
       this.props.savedStatus === SAVE_STATUSES.pending
     ) {
-      content = <LoadingIndicator message={`Saving your ${appType}...`} />;
+      content = (
+        <va-loading-indicator
+          label="Loading"
+          message={`Saving your ${appType}...`}
+        />
+      );
     } else {
       content = (
         <FormApp formConfig={formConfig} currentLocation={currentLocation}>

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('schemaform <ApplicationStatus>', () => {
       />,
     );
 
-    expect(tree.subTree('LoadingIndicator')).to.not.be.false;
+    expect(tree.subTree('va-loading-indicator')).to.not.be.false;
   });
   it('should render apply button', () => {
     const tree = SkinDeep.shallowRender(

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableApp.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableApp.unit.spec.jsx
@@ -84,7 +84,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       </RoutedSavableApp>,
     );
 
-    expect(tree.everySubTree('LoadingIndicator')).not.to.be.empty;
+    expect(tree.everySubTree('va-loading-indicator')).not.to.be.empty;
   });
   it('should route when prefill unfilled', () => {
     const formConfig = {


### PR DESCRIPTION

## Summary

This will replace the deprecated `LoadingIndicator` React component with its corresponding web component `va-loading-indicator`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1532

## Testing done

Observed locally and E2E + Unit tests passing

## Screenshots

### Before

<img width="888" alt="before" src="https://user-images.githubusercontent.com/872479/234999780-363cc9a2-a4af-4b6b-9360-9ccc97a5efbb.png">


### After

<img width="944" alt="after" src="https://user-images.githubusercontent.com/872479/234999789-15936165-3ad5-4f40-8ae5-5c4bd4ce29cf.png">


## What areas of the site does it impact?

Any app using the save in progress `ApplicationStatus` or `RouteSavableApp` from the forms library.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
