### PR TITLE
Form 21-4142 – fix depends logic for preparer address 2 page

### DIFF
--- a/src/applications/simple-forms/21-4142/config/form.js
+++ b/src/applications/simple-forms/21-4142/config/form.js
@@ -210,15 +210,15 @@ const formConfig = {
           depends: formData =>
             (!formData[preparerIdentificationFields.parentObject][
               [preparerIdentificationFields.preparerHasSameAddressAsVeteran]
-            ] &&
-              formData[preparerIdentificationFields.parentObject][
-                [preparerIdentificationFields.relationshipToVeteran]
-              ] !== veteranIsSelfText) ||
-            !veteranDirectRelative.includes(
-              formData[preparerIdentificationFields.parentObject][
-                [preparerIdentificationFields.relationshipToVeteran]
-              ],
-            ),
+            ] ||
+              !veteranDirectRelative.includes(
+                formData[preparerIdentificationFields.parentObject][
+                  [preparerIdentificationFields.relationshipToVeteran]
+                ],
+              )) &&
+            formData[preparerIdentificationFields.parentObject][
+              [preparerIdentificationFields.relationshipToVeteran]
+            ] !== veteranIsSelfText,
           uiSchema: preparerAddress2.uiSchema,
           schema: preparerAddress2.schema,
         },


### PR DESCRIPTION
Noticed a bug where in the case the preparer was the veteran it was still asking for preparer address. Now it cannot ask for preparer address if the preparer is the veteran. If the preparer is not the veteran, it will ask if either they have selected any non-relative title, or if they said they have a different address when prompted (only visible to relatives)

## Summary

- Update depends logic

## Testing done

- Tested flow locally
- Logic works as described above in form flow and on review page

## What areas of the site does it impact?

Form 21-4142 (not yet prod)