### PR TITLE
Add nested app functionality to cross app test.

### DIFF
--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -15,7 +15,19 @@ const changedAppsConfig = require('../../config/changed-apps-build.json');
 const getManifests = filePath => {
   const root = path.join(__dirname, '../..');
   const rootAppFolderName = filePath.split('/')[2];
+
+  // const rootAppFolderNameArr = filePath.split('/');
+  // const sliceOffset =
+  //   rootAppFolderNameArr.length -
+  //   (rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') < 0
+  //     ? 0
+  //     : 1);
+  // const rootAppFolderName = rootAppFolderNameArr
+  //   .slice(2, sliceOffset)
+  //   .join('/');
+
   const fullAppPath = path.join(root, './src/applications', rootAppFolderName);
+  // console.log(fullAppPath);
 
   if (!fs.existsSync(fullAppPath)) return [];
 
@@ -38,13 +50,22 @@ const getAllowedApps = (filePath, allowedApps) => {
   if (!filePath.startsWith(appsDirectory)) return [];
 
   const manifests = getManifests(filePath);
-  const rootAppFolderNameArr = filePath.split('/');
-  console.log(rootAppFolderNameArr, 'rootAppFolderArr');
-  const appIndex =
-    rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') === -1
-      ? rootAppFolderNameArr.length - 1
-      : rootAppFolderNameArr.length - 2;
-  const rootAppFolderName = rootAppFolderNameArr[appIndex];
+  console.log(manifests);
+  const rootAppFolderName = filePath.split('/')[2];
+  // const rootAppFolderNameArr = filePath.split('/');
+  // const rootAppFolderNameArrIndex =
+  //   rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') < 0
+  //     ? rootAppFolderNameArr.length - 1
+  //     : rootAppFolderNameArr.length - 2;
+  // const rootAppFolderName = rootAppFolderNameArr[rootAppFolderNameArrIndex];
+
+  //   rootAppFolderNameArr[2] +
+  //   (rootAppFolderNameArr[3] !== undefined &&
+  //   rootAppFolderNameArr[3].indexOf('.') < 0
+  //     ? `/${rootAppFolderNameArr[3]}`
+  //     : '');
+
+  // console.log(rootAppFolderName);
   const allowedApp = allowedApps.find(
     app => app.rootFolder === rootAppFolderName,
   );

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -6,6 +6,19 @@ const commandLineArgs = require('command-line-args');
 
 const changedAppsConfig = require('../../config/changed-apps-build.json');
 
+const deriveRootAppFolderName = (filePath, isUngrouped = false) => {
+  if (!isUngrouped) {
+    return filePath.split('/')[2];
+  }
+  const rootAppFolderNameArr = filePath.split('/');
+  const sliceOffset =
+    rootAppFolderNameArr.length -
+    (rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') < 0
+      ? 0
+      : 1);
+  return rootAppFolderNameArr.slice(2, sliceOffset).join('/');
+};
+
 /**
  * Gets the manifest of all apps in the root app folder that a file belongs to.
  *
@@ -14,20 +27,8 @@ const changedAppsConfig = require('../../config/changed-apps-build.json');
  */
 const getManifests = filePath => {
   const root = path.join(__dirname, '../..');
-  const rootAppFolderName = filePath.split('/')[2];
-
-  // const rootAppFolderNameArr = filePath.split('/');
-  // const sliceOffset =
-  //   rootAppFolderNameArr.length -
-  //   (rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') < 0
-  //     ? 0
-  //     : 1);
-  // const rootAppFolderName = rootAppFolderNameArr
-  //   .slice(2, sliceOffset)
-  //   .join('/');
-
+  const rootAppFolderName = deriveRootAppFolderName(filePath, false);
   const fullAppPath = path.join(root, './src/applications', rootAppFolderName);
-  // console.log(fullAppPath);
 
   if (!fs.existsSync(fullAppPath)) return [];
 
@@ -50,31 +51,18 @@ const getAllowedApps = (filePath, allowedApps) => {
   if (!filePath.startsWith(appsDirectory)) return [];
 
   const manifests = getManifests(filePath);
-  console.log(manifests);
-  const rootAppFolderName = filePath.split('/')[2];
-  // const rootAppFolderNameArr = filePath.split('/');
-  // const rootAppFolderNameArrIndex =
-  //   rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') < 0
-  //     ? rootAppFolderNameArr.length - 1
-  //     : rootAppFolderNameArr.length - 2;
-  // const rootAppFolderName = rootAppFolderNameArr[rootAppFolderNameArrIndex];
-
-  //   rootAppFolderNameArr[2] +
-  //   (rootAppFolderNameArr[3] !== undefined &&
-  //   rootAppFolderNameArr[3].indexOf('.') < 0
-  //     ? `/${rootAppFolderNameArr[3]}`
-  //     : '');
-
-  // console.log(rootAppFolderName);
+  const rawAppFolderName = deriveRootAppFolderName(filePath);
   const allowedApp = allowedApps.find(
-    app => app.rootFolder === rootAppFolderName,
+    app => app.rootFolder === rawAppFolderName,
   );
 
   if (allowedApp) {
-    const { slackGroup, continuousDeployment } = allowedApp;
+    const { slackGroup, continuousDeployment, ungroup = false } = allowedApp;
+    const rootAppFolderName = deriveRootAppFolderName(filePath, ungroup);
     return manifests.map(({ entryName, rootUrl }) => ({
       entryName,
       rootUrl,
+      ungroup,
       rootPath: path.join(appsDirectory, rootAppFolderName),
       slackGroup,
       continuousDeployment,

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -39,6 +39,7 @@ const getAllowedApps = (filePath, allowedApps) => {
 
   const manifests = getManifests(filePath);
   const rootAppFolderName = filePath.split('/')[2];
+  console.log(rootAppFolderName, 'rootAppFolderName');
   const allowedApp = allowedApps.find(
     app => app.rootFolder === rootAppFolderName,
   );

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -38,8 +38,13 @@ const getAllowedApps = (filePath, allowedApps) => {
   if (!filePath.startsWith(appsDirectory)) return [];
 
   const manifests = getManifests(filePath);
-  const rootAppFolderName = filePath.split('/')[2];
-  console.log(rootAppFolderName, 'rootAppFolderName');
+  const rootAppFolderNameArr = filePath.split('/');
+  console.log(rootAppFolderNameArr, 'rootAppFolderArr');
+  const appIndex =
+    rootAppFolderNameArr[rootAppFolderNameArr.length - 1].indexOf('.') === -1
+      ? rootAppFolderNameArr.length - 1
+      : rootAppFolderNameArr.length - 2;
+  const rootAppFolderName = rootAppFolderNameArr[appIndex];
   const allowedApp = allowedApps.find(
     app => app.rootFolder === rootAppFolderName,
   );

--- a/script/github-actions/get-changed-apps.unit.spec.js
+++ b/script/github-actions/get-changed-apps.unit.spec.js
@@ -6,10 +6,11 @@ import {
   isContinuousDeploymentEnabled,
 } from './get-changed-apps';
 
-const createManifest = name => {
+const createManifest = (name, ungroup = false) => {
   return JSON.stringify({
     appName: name.toUpperCase(),
     entryFile: `./${name}-entry.jsx`,
+    ungroup,
     entryName: name,
     rootUrl: `/${name}`,
   });


### PR DESCRIPTION
Altering the logic on `get-changed-apps.js` to account for nested apps when testing for cross dependencies. 