### PR TITLE
Change event names

### DIFF
--- a/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Introduction/IntroductionDisplay.jsx
@@ -45,12 +45,6 @@ const IntroductionDisplay = props => {
     },
     [isPreCheckInActionLinkTopPlacementEnabled],
   );
-  useEffect(() => {
-    const slug = `pre-check-in-viewed-introduction-VAOS-design`;
-    recordEvent({
-      event: createAnalyticsSlug(slug, 'nav'),
-    });
-  }, []);
   const accordionContent = [
     {
       header: t('will-va-protect-my-personal-health-information'),
@@ -90,11 +84,14 @@ const IntroductionDisplay = props => {
       if (e?.key && e.key !== ' ') {
         return;
       }
-      let slug = `pre-check-in-started-${
-        isPhone ? 'phone' : 'in-person'
-      }-VAOS-design`;
-      // Save this for when we go back to testing action link.
-      if (isPreCheckInActionLinkTopPlacementEnabled) slug += '-top-position';
+      let slug = `pre-check-in-started-${isPhone ? 'phone' : 'in-person'}`;
+
+      const position = isPreCheckInActionLinkTopPlacementEnabled
+        ? 'top'
+        : 'bottom';
+
+      slug += `-${position}-position`;
+
       recordEvent({
         event: createAnalyticsSlug(slug, 'nav'),
       });


### PR DESCRIPTION
## Summary

Rename events on the pre-check-in introduction for both views and action link clicks.

Events should be:

    pre-check-in-viewed-introduction-top-position
    pre-check-in-viewed-introduction-bottom-position
    pre-check-in-started-phone-top-position
    pre-check-in-started-in-person-top-position
    pre-check-in-started-phone-bottom-position
    pre-check-in-started-in-person-bottom-position

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#57463](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57463)

## Testing done

- Data layer console

## What areas of the site does it impact?

Check-in pre-check-in introduction

## Acceptance criteria

Event names match what's outline in this [thread](https://dsva.slack.com/archives/C03KQAUFVT6/p1682524615844559?thread_ts=1682432711.209789&cid=C03KQAUFVT6)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

