### PR TITLE
[VA-13504] Deprecated Component Migration (Telephone)

### DIFF
--- a/src/applications/facility-locator/components/VABenefitsCall.jsx
+++ b/src/applications/facility-locator/components/VABenefitsCall.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
 export default function VABenefitsCall() {
   return (
@@ -13,10 +10,9 @@ export default function VABenefitsCall() {
       </p>
       <p className="p1">
         <strong>To get help with benefits</strong>, call{' '}
-        <Telephone contact={CONTACTS.VA_BENEFITS} /> toll-free. We’re here
+        <va-telephone contact={CONTACTS.VA_BENEFITS} /> toll-free. We’re here
         Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have hearing{' '}
-        loss, call TTY:{' '}
-        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
+        loss, call TTY: <va-telephone contact="711" />.
       </p>
     </div>
   );

--- a/src/applications/facility-locator/components/search-results-items/common/Covid19PhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/Covid19PhoneLink.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import { parsePhoneNumber } from '../../../utils/phoneNumbers';
 
 const Covid19PhoneLink = ({
@@ -31,11 +30,11 @@ const Covid19PhoneLink = ({
         {labelText}
         :&nbsp;
       </strong>
-      <Telephone
+      <va-telephone
         className="vads-u-margin-left--0p25"
         contact={contact}
         extension={extension || parsedExtension}
-        ariaDescribedById={labelId}
+        aria-describedby={labelId}
       />
     </div>
   );

--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import { LocationType } from '../../../constants';
 import { parsePhoneNumber } from '../../../utils/phoneNumbers';
 import CCProviderPhoneLink from './CCProviderPhoneLink';
@@ -33,16 +32,16 @@ export const renderPhoneNumber = (
       )}
       {title && <strong id={phoneNumberId}>{title}: </strong>}
       {subTitle}
-      <Telephone
+      <va-telephone
         className={
           subTitle ? 'vads-u-margin-left--0p5' : 'vads-u-margin-left--0p25'
         }
         contact={contact}
         extension={extension}
-        ariaDescribedById={phoneNumberId}
+        aria-describedby={phoneNumberId}
       >
         {formattedPhoneNumber}
-      </Telephone>
+      </va-telephone>
     </div>
   );
 };

--- a/src/applications/facility-locator/tests/components/VABenefitsCall.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/VABenefitsCall.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('<VABenefitsCall>', () => {
     expect(wrapper.find('div').length).to.equal(1);
     expect(wrapper.find('p').length).to.equal(2);
     expect(wrapper.find('a').length).to.equal(1);
-    expect(wrapper.find('Telephone').length).to.equal(2);
+    expect(wrapper.find('va-telephone').length).to.equal(2);
     wrapper.unmount();
   });
 });

--- a/src/applications/facility-locator/tests/components/search-results/LocationPhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationPhoneLink.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('LocationPhoneLink', () => {
     const wrapper = shallow(
       <LocationPhoneLink location={locationWithGoodPhone} />,
     );
-    expect(wrapper.find('Telephone').length).to.equal(1);
+    expect(wrapper.find('va-telephone').length).to.equal(1);
     expect(wrapper.find('strong').text()).to.equal('Main number: ');
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/components/search-results/common/Covid19PhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/common/Covid19PhoneLink.unit.spec.jsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import Covid19PhoneLink from '../../../../components/search-results-items/common/Covid19PhoneLink';
 
 describe('Covid19PhoneLink', () => {
-  it('Should render with number', () => {
+  it('Should render web component with number', () => {
     const phone = {
       number: '999-456-7890',
     };
@@ -15,13 +15,13 @@ describe('Covid19PhoneLink', () => {
         .text()
         .trim(),
     ).to.equal('Call to schedule:');
-    expect(wrapper.find('Telephone').html()).to.equal(
-      '<a class="no-wrap vads-u-margin-left--0p25" href="tel:+19994567890" aria-label="9 9 9. 4 5 6. 7 8 9 0.">999-456-7890</a>',
+    expect(wrapper.find('va-telephone').html()).to.equal(
+      '<va-telephone className="vads-u-margin-left--0p25" contact="9994567890" extension=""></va-telephone>',
     );
     wrapper.unmount();
   });
 
-  it('Should render with number and extension', () => {
+  it('Should render web component with number and extension', () => {
     const phone = {
       number: '999-456-7890',
       extension: '421',
@@ -33,13 +33,13 @@ describe('Covid19PhoneLink', () => {
         .text()
         .trim(),
     ).to.equal('Call to schedule:');
-    expect(wrapper.find('Telephone').html()).to.equal(
-      '<a class="no-wrap vads-u-margin-left--0p25" href="tel:+19994567890,421" aria-label="9 9 9. 4 5 6. 7 8 9 0. extension 4 2 1.">999-456-7890, ext. 421</a>',
+    expect(wrapper.find('va-telephone').html()).to.equal(
+      '<va-telephone className="vads-u-margin-left--0p25" contact="9994567890" extension="421"></va-telephone>',
     );
     wrapper.unmount();
   });
 
-  it('Should render with number with parsed extension', () => {
+  it('Should render web component with number with parsed extension', () => {
     const phone = {
       number: '999-456-7890 x421',
     };
@@ -50,8 +50,8 @@ describe('Covid19PhoneLink', () => {
         .text()
         .trim(),
     ).to.equal('Call to schedule:');
-    expect(wrapper.find('Telephone').html()).to.equal(
-      '<a class="no-wrap vads-u-margin-left--0p25" href="tel:+19994567890,421" aria-label="9 9 9. 4 5 6. 7 8 9 0. extension 4 2 1.">999-456-7890, ext. 421</a>',
+    expect(wrapper.find('va-telephone').html()).to.equal(
+      '<va-telephone className="vads-u-margin-left--0p25" contact="9994567890" extension="421"></va-telephone>',
     );
     wrapper.unmount();
   });


### PR DESCRIPTION
## Summary

This replaces the React `Telephone` components with the [`va-telephone` web components.](https://design.va.gov/storybook/?path=/docs/components-va-telephone--default) The properties transitioned the same except for `ariaDescribedById`, which was replaced with `aria-describedby` for the same effect.

## Related issue(s)

Closes [13504](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13504)
Relates to [13179](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13179)

## Testing done

Visual, confirmed the components rendered the same on [the facilities search page](http://localhost:3001/find-locations/?address=Keswick%2C%20Virginia%2022947%2C%20United%20States&bounds%5B%5D%5B%5D=-79.759175&bounds%5B%5D%5B%5D=36.622639&bounds%5B%5D%5B%5D=-76.95917499999999&bounds%5B%5D%5B%5D=39.422639&bounds%5B%5D%5B%5D%5B%5D=-79.759175&bounds%5B%5D%5B%5D%5B%5D=36.622639&bounds%5B%5D%5B%5D%5B%5D=-76.95917499999999&bounds%5B%5D%5B%5D%5B%5D=39.422639&bounds%5B%5D%5B%5D%5B%5D%5B%5D=-79.759175&bounds%5B%5D%5B%5D%5B%5D%5B%5D=36.622639&bounds%5B%5D%5B%5D%5B%5D%5B%5D=-76.95917499999999&bounds%5B%5D%5B%5D%5B%5D%5B%5D=39.422639&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-79.17065032993372&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=37.3146547912056&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-77.53303226616534&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=38.77495779890711&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-80.0190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=36.2775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-77.2190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.0775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-80.0190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=36.2775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-77.2190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.0775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-80.0190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=36.2775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-77.2190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.0775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-80.0190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=36.2775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-77.2190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.0775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-80.0190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=36.2775920440554&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-77.2190526172645&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.0775920440554&context=Keswick%2C%20Virginia%2022947%2C%20United%20States&facilityType=benefits&latitude=38.022639&longitude=-78.359175&page=1&radius=13&searchString=Keswick%2C%20Virginia%2022947%2C%20United%20States&serviceType&bounds%5B%5D=-79.759175&bounds%5B%5D=36.622639&bounds%5B%5D=-76.95917499999999&bounds%5B%5D=39.422639) and [a facility details page.](http://localhost:3001/find-locations/facility/vba_314i)

<img width="1002" alt="Screen Shot 2023-05-01 at 2 24 35 PM" src="https://user-images.githubusercontent.com/10790736/235505955-4577a282-e1e4-4b20-89f5-6b6a6f47c5e2.png">

<img width="1014" alt="Screen Shot 2023-05-01 at 2 24 44 PM" src="https://user-images.githubusercontent.com/10790736/235505973-a05a4559-46ba-4ce8-ad30-74b38206bd84.png">

## What areas of the site does it impact?

Facility search and facility details.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
