### PR TITLE
MHV-41592, 41163 Secure messaging: Success alert on sending drafts

### DIFF
--- a/src/applications/mhv/secure-messaging/actions/messages.js
+++ b/src/applications/mhv/secure-messaging/actions/messages.js
@@ -152,10 +152,8 @@ export const retrieveMessageThread = (
   if (!refresh) {
     dispatch(clearMessage());
   }
-  const response = await getMessageThread(messageId);
-  if (response.errors) {
-    // TODO Add error handling
-  } else {
+  try {
+    const response = await getMessageThread(messageId);
     const msgResponse = await getMessage(response.data[0].attributes.messageId);
     if (!msgResponse.errors) {
       // finding last sent message in a thread to check if it is not too old for replies
@@ -198,6 +196,13 @@ export const retrieveMessageThread = (
         response: { data: response.data.slice(1, response.data.length) },
       });
     }
+  } catch (e) {
+    const errorMessage =
+      e.errors[0].status === '404'
+        ? Constants.Alerts.Thread.THREAD_NOT_FOUND_ERROR
+        : e.errors[0]?.detail;
+    dispatch(addAlert(Constants.ALERT_TYPE_ERROR, '', errorMessage));
+    throw e;
   }
 };
 

--- a/src/applications/mhv/secure-messaging/components/shared/AlertBackgroundBox.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/AlertBackgroundBox.jsx
@@ -1,3 +1,10 @@
+/** TODO
+ * This component requires a further decision on how to habdle the alertList.
+ * Currently, we are displaying the most recent alert marked as active.
+ * We may want to display all active alerts, or only the most recent alert.
+ * Multiple alerts are not currently supported.
+ * They can be displayed as a list in one alert box, or as multiple alert boxes.
+ */
 import React, { useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -7,7 +14,6 @@ import { closeAlert, focusOutAlert } from '../../actions/alerts';
 
 const AlertBackgroundBox = props => {
   const dispatch = useDispatch();
-  const alertVisible = useSelector(state => state.sm.alerts?.alertVisible);
   const alertList = useSelector(state => state.sm.alerts?.alertList);
   const [activeAlert, setActiveAlert] = useState(null);
   const alertRef = useRef();
@@ -16,15 +22,13 @@ const AlertBackgroundBox = props => {
     () => {
       if (alertList?.length) {
         const filteredSortedAlerts = alertList
-          .filter(alert => alert.isActive)
+          .filter(alert => alert?.isActive)
           .sort((a, b) => {
             // Sort chronologically descending.
             return b.datestamp - a.datestamp;
           });
-        if (filteredSortedAlerts.length > 0) {
-          // The activeAlert is the most recent alert marked as active.
-          setActiveAlert(filteredSortedAlerts[0]);
-        }
+        // The activeAlert is the most recent alert marked as active.
+        setActiveAlert(filteredSortedAlerts[0] || null);
       }
     },
     [alertList],
@@ -41,7 +45,7 @@ const AlertBackgroundBox = props => {
     dispatch(focusOutAlert());
   };
 
-  return alertVisible && activeAlert ? (
+  return activeAlert ? (
     <VaAlert
       ref={alertRef}
       background-only

--- a/src/applications/mhv/secure-messaging/containers/ThreadDetails.jsx
+++ b/src/applications/mhv/secure-messaging/containers/ThreadDetails.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui/index';
 import PropTypes from 'prop-types';
 import MessageThread from '../components/MessageThread/MessageThread';
@@ -16,12 +16,14 @@ import InterstitialPage from './InterstitialPage';
 import { PrintMessageOptions } from '../util/constants';
 import { closeAlert } from '../actions/alerts';
 import CannotReplyAlert from '../components/shared/CannotReplyAlert';
+import { navigateToFolderByFolderId } from '../util/helpers';
 
 const ThreadDetails = props => {
   const { threadId } = useParams();
   const { testing } = props;
   const dispatch = useDispatch();
   const location = useLocation();
+  const history = useHistory();
   const { triageTeams } = useSelector(state => state.sm.triageTeams);
   const {
     message,
@@ -33,6 +35,7 @@ const ThreadDetails = props => {
   const { draftMessage, draftMessageHistory } = useSelector(
     state => state.sm.draftDetails,
   );
+  const { folder } = useSelector(state => state.sm.folders);
 
   const [isMessage, setIsMessage] = useState(false);
   const [isDraft, setIsDraft] = useState(false);
@@ -45,9 +48,13 @@ const ThreadDetails = props => {
     () => {
       if (threadId) {
         dispatch(getTriageTeams());
-        dispatch(retrieveMessageThread(threadId)).then(() => {
-          setIsLoaded(true);
-        });
+        dispatch(retrieveMessageThread(threadId))
+          .then(() => {
+            setIsLoaded(true);
+          })
+          .catch(() => {
+            navigateToFolderByFolderId(folder?.folderId || 0, history);
+          });
       }
       return () => {
         dispatch(clearDraft());

--- a/src/applications/mhv/secure-messaging/reducers/alerts.js
+++ b/src/applications/mhv/secure-messaging/reducers/alerts.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { Actions } from '../util/actionTypes';
 
 const initialState = {
@@ -21,7 +22,9 @@ export const alertsReducer = (state = initialState, action) => {
         alertList: state.alertList.map(alert => {
           return {
             ...alert,
-            isActive: false,
+            isActive: moment(alert.datestamp)
+              .add(2, 'seconds')
+              .isAfter(moment(new Date())),
           };
         }),
       };

--- a/src/applications/mhv/secure-messaging/reducers/alerts.js
+++ b/src/applications/mhv/secure-messaging/reducers/alerts.js
@@ -22,6 +22,8 @@ export const alertsReducer = (state = initialState, action) => {
         alertList: state.alertList.map(alert => {
           return {
             ...alert,
+            // to prevent setting isActive to false prematurely
+            // value of 2 seconds is arbitrary
             isActive: moment(alert.datestamp)
               .add(2, 'seconds')
               .isAfter(moment(new Date())),

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -129,6 +129,7 @@ export const Alerts = {
   },
   Thread: {
     GET_THREAD_ERROR: 'We’re sorry. Something went wrong on our end.',
+    THREAD_NOT_FOUND_ERROR: 'This conversation was not found.',
   },
 };
 


### PR DESCRIPTION

## Summary

SM to VA.gov: Defect - Reply success message
Compose message has success message when message is sent but not when user is replying.
Also, for Reply flow the user remains on the same message. In legacy user is navigated to the folder where the message they replied to resides.


Draft message flow:
Compose a message
Save it as draft
Navigate to the draft folder and open the message
Send the message

Finding: No success message is displayed on the UI as it does for sending new message or replying to a message.

## Related issue(s)

- [SM to VA.gov: No success message when draft message is sent](https://vajira.max.gov/browse/MHV-41592)
- [SM to VA.gov: Defect - Reply success message](https://vajira.max.gov/browse/MHV-41163)

## Testing done

- SQA Testing

## Screenshots

No visual changes

## What areas of the site does it impact?

My Health - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

