### PR TITLE
VACMS-13506: Replaces <LoadingIndicator> with <va-loading-indicator>

### DIFF
--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -1,16 +1,15 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { object, func } from 'prop-types';
-import { fetchProviderDetail } from '../actions';
 import { focusElement } from 'platform/utilities/ui';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import scrollTo from 'platform/utilities/ui/scrollTo';
+import { fetchProviderDetail } from '../actions';
 import LocationMap from '../components/LocationMap';
 import LocationAddress from '../components/search-results-items/common/LocationAddress';
 import LocationPhoneLink from '../components/search-results-items/common/LocationPhoneLink';
 import LocationDirectionsLink from '../components/search-results-items/common/LocationDirectionsLink';
 import AppointmentInfo from '../components/AppointmentInfo';
 import ProviderDetailBlock from '../components/ProviderDetailBlock';
-import scrollTo from 'platform/utilities/ui/scrollTo';
 
 /**
  * Container component for the CC Provider Detail page
@@ -114,7 +113,7 @@ class ProviderDetail extends Component {
     if (currentQuery.inProgress) {
       return (
         <div>
-          <LoadingIndicator message="Loading information..." />
+          <va-loading-indicator message="Loading information..." />
         </div>
       );
     }

--- a/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { apiRequest } from 'platform/utilities/api';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import FacilityTitle from './FacilityTitle';
 import FacilityAddress from './FacilityAddress';
 import FacilityPhone from './FacilityPhone';
@@ -38,7 +37,7 @@ export default class BasicFacilityListWidget extends React.Component {
 
   render() {
     if (this.state.loading) {
-      return <LoadingIndicator message="Loading facilities..." />;
+      return <va-loading-indicator message="Loading facilities..." />;
     }
 
     if (this.state.error) {

--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { formatDateLong } from 'platform/utilities/date';
 import { connect } from 'react-redux';
 import _ from 'lodash';
@@ -28,7 +27,7 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
   render() {
     if (this.props.loading || !Object.keys(this.props.facility).length) {
       return (
-        <LoadingIndicator
+        <va-loading-indicator
           message={`Loading facility's ${
             this.props.service
           } appointment wait times...`}

--- a/src/applications/static-pages/facilities/FacilityDetailWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityDetailWidget.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import { connect } from 'react-redux';
 import { buildHours } from '../../facility-locator/utils/facilityHours';
 import FacilityAddress from './FacilityAddress';
 import FacilityPhone from './FacilityPhone';
 import FacilityApiAlert from './FacilityApiAlert';
-import { connect } from 'react-redux';
 
 export function FacilityDetailWidget({ loading, error, facility }) {
   if (loading || !Object.keys(facility).length) {
-    return <LoadingIndicator message="Loading facility..." />;
+    return <va-loading-indicator message="Loading facility..." />;
   }
 
   if (error) {
@@ -18,7 +17,7 @@ export function FacilityDetailWidget({ loading, error, facility }) {
   const CLINICAL_HOURS_COLUMN_MODIFIER = 5;
 
   // Sort and compile facility hours into a list
-  const hours = facility.attributes.hours;
+  const { hours } = facility.attributes;
   const builtHours = buildHours(hours, true);
   const clinicalHours = builtHours.map((day, index) => {
     const [abbrvDay, times] = day.split(': ');

--- a/src/applications/static-pages/facilities/FacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityListWidget.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { apiRequest } from 'platform/utilities/api';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import FacilityApiAlert from './FacilityApiAlert';
 import { sortFacilitiesByName } from './facilityUtilities';
 import FacilityTitle from './FacilityTitle';
@@ -38,7 +37,7 @@ export default class FacilityListWidget extends React.Component {
 
   render() {
     if (this.state.loading) {
-      return <LoadingIndicator message="Loading facilities..." />;
+      return <va-loading-indicator message="Loading facilities..." />;
     }
 
     if (this.state.error) {

--- a/src/applications/static-pages/facilities/FacilityMapSatelliteMainWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityMapSatelliteMainWidget.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { fetchMainSatelliteLocationFacility } from './actions';
@@ -73,7 +72,7 @@ export class FacilityMapSatelliteMainWidget extends React.Component {
 
   render() {
     if (this.props.loading) {
-      return <LoadingIndicator message="Loading facility..." />;
+      return <va-loading-indicator message="Loading facility..." />;
     }
 
     if (this.props.error) {

--- a/src/applications/static-pages/facilities/FacilityMapWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityMapWidget.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { connect } from 'react-redux';
 import { mapboxToken } from '../../facility-locator/utils/mapboxToken';
 import { buildAddressArray } from '../../facility-locator/utils/facilityAddress';
@@ -40,7 +39,7 @@ export class FacilityMapWidget extends React.Component {
 
   render() {
     if (this.props.loading) {
-      return <LoadingIndicator message="Loading facility..." />;
+      return <va-loading-indicator message="Loading facility..." />;
     }
 
     if (this.props.error) {

--- a/src/applications/static-pages/facilities/FacilityMapWidgetDynamic.jsx
+++ b/src/applications/static-pages/facilities/FacilityMapWidgetDynamic.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { fetchMultiFacility } from './actions';
@@ -83,7 +82,7 @@ export class FacilityMapWidgetDynamic extends React.Component {
     const error = multiError ? multiError[facilityID] : false;
 
     if (loading) {
-      return <LoadingIndicator message="Loading facility..." />;
+      return <va-loading-indicator message="Loading facility..." />;
     }
 
     if (error) {

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { formatDateLong } from 'platform/utilities/date';
 import { displayPercent } from 'platform/utilities/ui';
 import { connect } from 'react-redux';
@@ -9,7 +8,7 @@ import FacilityDataLink from './FacilityDataLink';
 export function FacilityPatientSatisfactionScoresWidget(props) {
   if (props.loading || !Object.keys(props.facility).length) {
     return (
-      <LoadingIndicator message="Loading facility patient satisfaction scores..." />
+      <va-loading-indicator message="Loading facility patient satisfaction scores..." />
     );
   }
 

--- a/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { apiRequest } from 'platform/utilities/api';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import FacilityApiAlert from './FacilityApiAlert';
 import { cleanPhoneNumber, sortFacilitiesByName } from './facilityUtilities';
 import FacilityAddress from './FacilityAddress';
@@ -37,7 +36,7 @@ export default class OtherFacilityListWidget extends React.Component {
 
   render() {
     if (this.state.loading) {
-      return <LoadingIndicator message="Loading facilities..." />;
+      return <va-loading-indicator message="Loading facilities..." />;
     }
 
     if (this.state.error) {
@@ -61,13 +60,9 @@ export default class OtherFacilityListWidget extends React.Component {
               {facility.attributes.phone.main && (
                 <div className="main-phone vads-u-margin-bottom--1">
                   <strong>Main phone: </strong>
-                  <a
-                    href={`tel:${cleanPhoneNumber(
-                      facility.attributes.phone.main,
-                    )}`}
-                  >
-                    {cleanPhoneNumber(facility.attributes.phone.main)}
-                  </a>
+                  <va-telephone
+                    contact={cleanPhoneNumber(facility.attributes.phone.main)}
+                  />
                 </div>
               )}
               {facility.attributes.classification && (

--- a/src/applications/static-pages/facilities/tests/BasicFacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/BasicFacilityListWidget.unit.spec.jsx
@@ -18,7 +18,7 @@ describe('facilities <FacilityListWidget>', () => {
       },
     );
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
     tree.unmount();
   });
 
@@ -30,7 +30,7 @@ describe('facilities <FacilityListWidget>', () => {
     );
     tree.instance().request.then(() => {
       tree.update();
-      expect(tree.find('LoadingIndicator').exists()).to.be.false;
+      expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
       const facilityNameComponent = tree.find('FacilityTitle').dive();
       const facilityName = facilityNameComponent.find('h3');

--- a/src/applications/static-pages/facilities/tests/FacilityAppointmentWaitTimesWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/FacilityAppointmentWaitTimesWidget.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('facilities <FacilityAppointmentWaitTimesWidget>', () => {
   it('should render loading', () => {
     const tree = shallow(<FacilityAppointmentWaitTimesWidget loading />);
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
     tree.unmount();
   });
 
@@ -21,7 +21,7 @@ describe('facilities <FacilityAppointmentWaitTimesWidget>', () => {
       />,
     );
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.false;
+    expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
     const appointmentWaitTimesHeader = tree.find('h3');
     expect(appointmentWaitTimesHeader.text()).to.contain(

--- a/src/applications/static-pages/facilities/tests/FacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/FacilityListWidget.unit.spec.jsx
@@ -18,7 +18,7 @@ describe('facilities <FacilityListWidget>', () => {
       },
     );
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
     tree.unmount();
   });
 
@@ -30,7 +30,7 @@ describe('facilities <FacilityListWidget>', () => {
     );
     tree.instance().request.then(() => {
       tree.update();
-      expect(tree.find('LoadingIndicator').exists()).to.be.false;
+      expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
       const facilityNameComponent = tree.find('FacilityTitle').dive();
       const facilityName = facilityNameComponent.find('h3');

--- a/src/applications/static-pages/facilities/tests/FacilityMapWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/FacilityMapWidget.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('facilities <FacilityMapWidget>', () => {
   it('should render loading', () => {
     const tree = shallow(<FacilityMapWidget loading />);
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
     tree.unmount();
   });
 

--- a/src/applications/static-pages/facilities/tests/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
   it('should render loading', () => {
     const tree = shallow(<FacilityPatientSatisfactionScoresWidget loading />);
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
     tree.unmount();
   });
 
@@ -23,7 +23,7 @@ describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
       />,
     );
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.false;
+    expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
     const facilityPatientSatisfactionScoresEffectiveDate = tree.find(
       '#facility-patient-satisfaction-scores-effective-date',
@@ -63,7 +63,7 @@ describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
       />,
     );
     expect(tree).to.be.empty;
-    expect(tree.find('LoadingIndicator').exists()).to.be.false;
+    expect(tree.find('va-loading-indicator').exists()).to.be.false;
     expect(tree.find('h2#our-patient-satisfaction-scores').exists()).to.be
       .false;
 

--- a/src/applications/static-pages/facilities/tests/NearbyVetCenters.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/NearbyVetCenters.unit.spec.jsx
@@ -4,8 +4,8 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { mockApiRequest } from 'platform/testing/unit/helpers.js';
-import NearbyVetCenters from '../vet-center/NearByVetCenters';
 import * as mapboxUtils from 'applications/facility-locator/utils/mapbox';
+import NearbyVetCenters from '../vet-center/NearByVetCenters';
 
 const createFakeStore = state => {
   return {
@@ -90,7 +90,7 @@ describe('NearbyVetCenters', () => {
         <NearbyVetCenters />
       </Provider>,
     );
-    expect(wrapper.find('LoadingIndicator').exists()).to.be.true;
+    expect(wrapper.find('va-loading-indicator').exists()).to.be.true;
     wrapper.unmount();
   });
 
@@ -104,7 +104,7 @@ describe('NearbyVetCenters', () => {
         <NearbyVetCenters />
       </Provider>,
     );
-    expect(wrapper.find('LoadingIndicator').exists()).to.be.false;
+    expect(wrapper.find('va-loading-indicator').exists()).to.be.false;
     wrapper.unmount();
   });
 
@@ -144,8 +144,8 @@ describe('NearbyVetCenters', () => {
         <Provider store={fakeStore}>
           <NearbyVetCenters
             mainVetCenterAddress={mainVetCenterAddress}
-            mainVetCenterId={'vc_0434V'}
-            mainVetCenterPhone={'906-233-0244'}
+            mainVetCenterId="vc_0434V"
+            mainVetCenterPhone="906-233-0244"
           />
         </Provider>,
       );

--- a/src/applications/static-pages/facilities/tests/OtherFacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/OtherFacilityListWidget.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('facilities <OtherFacilityListWidget>', () => {
       },
     );
 
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
     tree.unmount();
   });
 
@@ -27,7 +27,7 @@ describe('facilities <OtherFacilityListWidget>', () => {
     );
     tree.instance().request.then(() => {
       tree.update();
-      expect(tree.find('LoadingIndicator').exists()).to.be.false;
+      expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
       const facilityName = tree.find('h3');
       expect(facilityName.text()).to.contain(

--- a/src/applications/static-pages/facilities/tests/OtherFacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/OtherFacilityListWidget.unit.spec.jsx
@@ -41,7 +41,10 @@ describe('facilities <OtherFacilityListWidget>', () => {
       );
 
       const mainPhone = tree.find('.main-phone');
-      expect(mainPhone.text()).to.contain('Main phone: 866-482-7488');
+      expect(mainPhone.exists()).to.be.true;
+      const vaTelephone = mainPhone.find('va-telephone');
+      expect(vaTelephone.exists()).to.be.true;
+      expect(vaTelephone.prop('contact')).to.equal('866-482-7488');
 
       const facilityType = tree.find('.facility-type');
       expect(facilityType.text()).to.contain('VA Medical Center (VAMC)');

--- a/src/applications/static-pages/facilities/vet-center/NearByVetCenters.jsx
+++ b/src/applications/static-pages/facilities/vet-center/NearByVetCenters.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { apiRequest } from 'platform/utilities/api';
 import { connect, useDispatch } from 'react-redux';
 import VetCenterInfoSection from './components/VetCenterInfoSection';
@@ -128,7 +127,7 @@ const NearByVetCenters = props => {
   );
 
   if (props.facilitiesLoading) {
-    return <LoadingIndicator message="Loading facilities..." />;
+    return <va-loading-indicator message="Loading facilities..." />;
   }
 
   // TODO: consider moving to a separate component


### PR DESCRIPTION
## Summary
In Facilities-owned files:
- Replaces instances of <LoadingIndicator> React component with <va-loading-indicator> Web Component.
- Replaces one instance of a telephone number in an <a> tag with <va-telephone> because file couldn't be saved without modifaction.

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13506

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13506

## Testing done

All changes were the same. Namely, replaced `<LoadingIndicator message={message} />` with `<va-loading-indicator message={message} />`. I spot checked as many of these as I could.  One good way to see this in action is to run the application without a real API endpoint, which will have the effect of keeping loading indicators showing (because API requests never complete).

- `yarn watch --env entry=static-pages`
- Visit http://localhost:3002/minneapolis-health-care/locations/minneapolis-va-medical-center/
- Expand "Cardiology" accordion
- Confirm that the loading indicator shows with message "Loading facility's cardiology appointment wait times..."
- (See screenshot below)

## Screenshots

![image](https://user-images.githubusercontent.com/6863534/235702403-89d7404d-3287-4400-89b2-46f8fe6bcaba.png)

## Acceptance criteria
See original issue.

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- ~[ ] Documentation has been updated ([link to documentation](#) \*if necessary)~
- [x] Screenshot of the developed feature is added
- ~[ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed~
