### PR TITLE
57739 VAOS fixes reason code transformer

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -96,7 +96,7 @@ export function getAppointmentInfoFromComments(comments, key) {
   if (key === 'reasonCode') {
     const reasonCode = appointmentInfo
       ? appointmentInfo
-          .filter(item => item.includes('preferred dates:'))[0]
+          .filter(item => item.includes('reason code:'))[0]
           ?.split(':')[1]
       : null;
     const transformedReasonCode = { code: reasonCode };


### PR DESCRIPTION
## Summary

When the user selects the `reason code` and enters their comments in the Choose a reason for appointment page, the app should display what the user selected and display the free text comment on the Review details, Appointment Details and Request details page. 

This is not currently happening because there is a bug in the transformer for this data.

- Changed transformer to look for `reason code:` in the comments field
- Instructions for reproduction are here: https://github.com/department-of-veterans-affairs/va.gov-team/issues/57739


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/57739

## Testing done
- Local testing
- Unit testing
- e2e testing

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

