### PR TITLE
make session timeout modal render above all other content

### DIFF
--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -15,7 +15,7 @@ import startMegaMenuWidget from './mega-menu';
 import startMobileMenuButton from './mobile-menu-button';
 import startSideNav from './side-nav';
 import startUserNavWidget from './user-nav';
-import startLogoutModal from './user-nav/startLogoutModal.js';
+import startLogoutModal from './user-nav/startLogoutModal';
 import startVAFooter from './va-footer';
 import { addOverlayTriggers } from './legacy/menu';
 

--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -15,6 +15,7 @@ import startMegaMenuWidget from './mega-menu';
 import startMobileMenuButton from './mobile-menu-button';
 import startSideNav from './side-nav';
 import startUserNavWidget from './user-nav';
+import startLogoutModal from './user-nav/startLogoutModal.js';
 import startVAFooter from './va-footer';
 import { addOverlayTriggers } from './legacy/menu';
 
@@ -45,6 +46,7 @@ export default function startSitewideComponents(commonStore) {
 
   // Start site-wide widgets.
   startUserNavWidget(commonStore);
+  startLogoutModal(commonStore);
   startAnnouncementWidget(commonStore);
   startMegaMenuWidget(window.VetsGov.headerFooter.megaMenuData, commonStore);
   startSideNav(window.sideNav, commonStore);

--- a/src/platform/site-wide/sass/modules/_m-layers.scss
+++ b/src/platform/site-wide/sass/modules/_m-layers.scss
@@ -11,8 +11,10 @@
 #preview-site-alert {
   z-index: $low-layer;
 }
-#session-timeout-modal {
+
+#logout-modal-root {
   // Needs to show up over everything because the user is about to get signed out
+  position: relative;
   z-index: 9999;
 }
 

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -7,7 +7,6 @@ import URLSearchParams from 'url-search-params';
 // Relative imports.
 import localStorage from 'platform/utilities/storage/localStorage';
 import FormSignInModal from 'platform/forms/save-in-progress/FormSignInModal';
-import SessionTimeoutModal from 'platform/user/authentication/components/SessionTimeoutModal';
 import SignInModal from 'platform/user/authentication/components/SignInModal';
 import AccountTransitionModal from 'platform/user/authentication/components/account-transition/TransitionModal';
 import AccountTransitionSuccessModal from 'platform/user/authentication/components/account-transition/TransitionSuccessModal';
@@ -318,12 +317,6 @@ export class Main extends Component {
         <AccountTransitionSuccessModal
           onClose={this.closeAccountTransitionSuccessModal}
           visible={this.props.showAccountTransitionSuccessModal}
-        />
-        <SessionTimeoutModal
-          isLoggedIn={this.props.currentlyLoggedIn}
-          onExtendSession={this.props.initializeProfile}
-          authenticatedWithOAuth={this.props.authenticatedWithOAuth}
-          serviceName={this.props.signInServiceName}
         />
         <AutoSSO />
       </div>

--- a/src/platform/site-wide/user-nav/startLogoutModal.js
+++ b/src/platform/site-wide/user-nav/startLogoutModal.js
@@ -1,0 +1,25 @@
+/**
+ * This application creates a widget for session logout modal on VA.gov
+ *
+ * @module platform/site-wide/logout
+ */
+
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import SessionTimeoutModal from 'platform/user/authentication/components/SessionTimeoutModal';
+import startReactApp from '../../startup/react';
+
+/**
+ * Sets up the session logout widget with the given store at logout-modal-root
+ *
+ * @param {Redux.Store} store The common store used on the site
+ */
+export default function startLogoutModal(store) {
+  startReactApp(
+    <Provider store={store}>
+      <SessionTimeoutModal />
+    </Provider>,
+    document.getElementById('logout-modal-root'),
+  );
+}

--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -19,7 +19,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 
 const MODAL_DURATION = 30; // seconds
 
-class SessionTimeoutModal extends React.Component {
+export class SessionTimeoutModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = { countdown: null };

--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import differenceInSeconds from 'date-fns/differenceInSeconds';
 import recordEvent from 'platform/monitoring/record-event';
 import { logout as IAMLogout } from 'platform/user/authentication/utilities';
@@ -6,6 +9,13 @@ import { refresh, logoutUrlSiS } from 'platform/utilities/oauth/utilities';
 import { teardownProfileSession } from 'platform/user/profile/utilities';
 import localStorage from 'platform/utilities/storage/localStorage';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
+
+import { initializeProfile } from 'platform/user/profile/actions';
+import {
+  signInServiceName as signInServiceNameSelector,
+  isAuthenticatedWithOAuth,
+} from 'platform/user/authentication/selectors';
+import { isLoggedIn } from 'platform/user/selectors';
 
 const MODAL_DURATION = 30; // seconds
 
@@ -124,4 +134,26 @@ class SessionTimeoutModal extends React.Component {
   }
 }
 
-export default SessionTimeoutModal;
+const mapStateToProps = state => {
+  return {
+    isLoggedIn: isLoggedIn(state),
+    authenticatedWithOAuth: isAuthenticatedWithOAuth(state),
+    serviceName: signInServiceNameSelector(state),
+  };
+};
+
+const mapDispatchToProps = {
+  initializeProfile,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SessionTimeoutModal);
+
+SessionTimeoutModal.propTypes = {
+  isLoggedIn: PropTypes.bool,
+  initializeProfile: PropTypes.func.isRequired,
+  authenticatedWithOAuth: PropTypes.bool,
+  serviceName: PropTypes.string,
+};

--- a/src/platform/user/tests/authentication/components/SessionTimeoutModal.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/SessionTimeoutModal.unit.spec.js
@@ -3,12 +3,11 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import SessionTimeoutModal from 'platform/user/authentication/components/SessionTimeoutModal';
+import { SessionTimeoutModal } from 'platform/user/authentication/components/SessionTimeoutModal';
 
 const defaultProps = {
   isLoggedIn: true,
-  onExtendSession: sinon.spy(),
-  signOut: sinon.spy(),
+  initializeProfile: sinon.spy(),
   authenticatedWithOAuth: false,
   serviceName: 'logingov',
 };


### PR DESCRIPTION
This PR addresses
## Summary
This PR addresses the issue that the session sign out modal being rendered behind other modals that may already be opened. The solution involves mounting the session sign out modal to a new element in the root context.

~~** PLEASE NOTE **: this PR relies on adding a mounting element to `content-build`. DO NOT MERGE UNTIL [CORRESPONDING CONTENT-BUILD PR ](https://github.com/department-of-veterans-affairs/content-build/pull/1545)HAS BEEN **DEPLOYED**~~

## Related issue(s)
[55731](https://app.zenhub.com/workspaces/platform-tech-team-2-633efe4ca5a428e5294d7ade/issues/gh/department-of-veterans-affairs/va.gov-team/55731)
## Testing done

local testing done. 
unit tests updated

## Screenshots
- Note: screenshots taken with unauthenticated user due to inability to login

**Before**:
<img width="1175" alt="Screenshot 2023-05-02 at 10 20 31 AM" src="https://user-images.githubusercontent.com/8867779/235711002-6c4afe2f-1ab6-41b7-9bda-29e9df1b2206.png">

**After**:
<img width="1216" alt="Screenshot 2023-05-02 at 10 20 40 AM" src="https://user-images.githubusercontent.com/8867779/235711048-0cbbc357-8ef5-4222-8a80-8b2bb2d44b53.png">

