### PR TITLE
Add intellisense for schemas

### DIFF
--- a/src/applications/simple-forms/21-4142/config/form.js
+++ b/src/applications/simple-forms/21-4142/config/form.js
@@ -31,6 +31,7 @@ import {
   veteranIsSelfText,
 } from '../definitions/constants';
 
+/** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',

--- a/src/applications/simple-forms/21-4142/pages/authorization.js
+++ b/src/applications/simple-forms/21-4142/pages/authorization.js
@@ -2,6 +2,7 @@ import React from 'react';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import { schemaFields } from '../definitions/constants';
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'view:legalText': {

--- a/src/applications/simple-forms/21-4142/pages/contactInformation1.js
+++ b/src/applications/simple-forms/21-4142/pages/contactInformation1.js
@@ -8,6 +8,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [veteranFields.address];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [veteranFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/contactInformation2.js
+++ b/src/applications/simple-forms/21-4142/pages/contactInformation2.js
@@ -13,6 +13,7 @@ const pageFields = [
   veteranFields.email,
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [veteranFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/limitations.js
+++ b/src/applications/simple-forms/21-4142/pages/limitations.js
@@ -2,6 +2,7 @@ import React from 'react';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import { schemaFields } from '../definitions/constants';
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [schemaFields.limitedConsent]: {

--- a/src/applications/simple-forms/21-4142/pages/patientIdentification1.js
+++ b/src/applications/simple-forms/21-4142/pages/patientIdentification1.js
@@ -8,6 +8,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [patientIdentificationFields.isRequestingOwnMedicalRecords];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [patientIdentificationFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/patientIdentification2.js
+++ b/src/applications/simple-forms/21-4142/pages/patientIdentification2.js
@@ -14,6 +14,7 @@ const pageFields = [
   patientIdentificationFields.patientVaFileNumber,
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [patientIdentificationFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/personalInformation1.js
+++ b/src/applications/simple-forms/21-4142/pages/personalInformation1.js
@@ -9,6 +9,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [veteranFields.fullName, veteranFields.dateOfBirth];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [veteranFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/personalInformation2.js
+++ b/src/applications/simple-forms/21-4142/pages/personalInformation2.js
@@ -10,6 +10,7 @@ const pageFields = [
   veteranFields.veteranServiceNumber,
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [veteranFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/preparerAddress1.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerAddress1.js
@@ -4,6 +4,7 @@ import {
   veteranFields,
 } from '../definitions/constants';
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [preparerIdentificationFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/preparerAddress2.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerAddress2.js
@@ -9,6 +9,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [preparerIdentificationFields.preparerAddress];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [preparerIdentificationFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/preparerIdentification.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerIdentification.js
@@ -4,6 +4,7 @@ import {
   relationshipToVeteranEnum,
 } from '../definitions/constants';
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [preparerIdentificationFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
@@ -23,6 +23,7 @@ const isNotThirdParty = formData => {
   );
 };
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [preparerIdentificationFields.parentObject]: {

--- a/src/applications/simple-forms/21-4142/pages/recordsRequested.js
+++ b/src/applications/simple-forms/21-4142/pages/recordsRequested.js
@@ -6,6 +6,7 @@ import { providerFacilityFields } from '../definitions/constants';
 
 import RecordField from '../components/RecordField';
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'ui:title': (

--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -31,6 +31,7 @@ import {
   livingSituationFields,
 } from '../definitions/constants';
 
+/** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',

--- a/src/applications/simple-forms/26-4555/pages/contactInformation1.js
+++ b/src/applications/simple-forms/26-4555/pages/contactInformation1.js
@@ -11,6 +11,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [veteranFields.address];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'ui:description': PrefillMessage,

--- a/src/applications/simple-forms/26-4555/pages/contactInformation2.js
+++ b/src/applications/simple-forms/26-4555/pages/contactInformation2.js
@@ -16,6 +16,7 @@ const pageFields = [
   veteranFields.email,
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'ui:description': PrefillMessage,

--- a/src/applications/simple-forms/26-4555/pages/livingSituation1.js
+++ b/src/applications/simple-forms/26-4555/pages/livingSituation1.js
@@ -9,6 +9,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [livingSituationFields.isInCareFacility];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [livingSituationFields.parentObject]: {

--- a/src/applications/simple-forms/26-4555/pages/livingSituation2.js
+++ b/src/applications/simple-forms/26-4555/pages/livingSituation2.js
@@ -14,6 +14,7 @@ const pageFields = [
   // omitted because unused, will be restored when vets-json-schema is changed
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [livingSituationFields.parentObject]: {

--- a/src/applications/simple-forms/26-4555/pages/personalInformation1.js
+++ b/src/applications/simple-forms/26-4555/pages/personalInformation1.js
@@ -12,6 +12,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [veteranFields.fullName, veteranFields.dateOfBirth];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'ui:description': PrefillMessage,

--- a/src/applications/simple-forms/26-4555/pages/personalInformation2.js
+++ b/src/applications/simple-forms/26-4555/pages/personalInformation2.js
@@ -11,6 +11,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [veteranFields.ssn, veteranFields.vaFileNumber];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'ui:description': PrefillMessage,

--- a/src/applications/simple-forms/26-4555/pages/previousHiApplication1.js
+++ b/src/applications/simple-forms/26-4555/pages/previousHiApplication1.js
@@ -9,6 +9,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [previousHiApplicationFields.hasPreviousHiApplication];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [previousHiApplicationFields.parentObject]: {

--- a/src/applications/simple-forms/26-4555/pages/previousHiApplication2.js
+++ b/src/applications/simple-forms/26-4555/pages/previousHiApplication2.js
@@ -15,6 +15,7 @@ const pageFields = [
   // omitted because unused, will be restored when vets-json-schema is changed
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [previousHiApplicationFields.parentObject]: {

--- a/src/applications/simple-forms/26-4555/pages/previousSahApplication1.js
+++ b/src/applications/simple-forms/26-4555/pages/previousSahApplication1.js
@@ -9,6 +9,7 @@ const { required, properties } = fullSchema.properties[
 ];
 const pageFields = [previousSahApplicationFields.hasPreviousSahApplication];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [previousSahApplicationFields.parentObject]: {

--- a/src/applications/simple-forms/26-4555/pages/previousSahApplication2.js
+++ b/src/applications/simple-forms/26-4555/pages/previousSahApplication2.js
@@ -15,6 +15,7 @@ const pageFields = [
   // omitted because unused, will be restored when vets-json-schema is changed
 ];
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     [previousSahApplicationFields.parentObject]: {

--- a/src/applications/simple-forms/26-4555/pages/remarks.js
+++ b/src/applications/simple-forms/26-4555/pages/remarks.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     'ui:title': (

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -1,0 +1,144 @@
+/**
+ * @typedef {{
+ *   ariaDescribedBySubmit: string,
+ *   chapters: Record<string, Chapter>,
+ *   confirmation: (props: any) => JSX.Element,
+ *   defaultDefinitions: Record<string, SchemaOptions>,
+ *   errorText: () => JSX.Element,
+ *   footerContent: (props: any) => JSX.Element,
+ *   formId: string,
+ *   getHelp: () => JSX.Element,
+ *   introduction:(props: any) => JSX.Element,
+ *   migrations: Array<Function>,
+ *   prefillEnabled: boolean,
+ *   prefillTransformer: Function,
+ *   preSubmitInfo: {
+ *     CustomComponent: (props: any) => JSX.Element,
+ *     field: string,
+ *     required: boolean,
+ *     notice: string | JSX.Element,
+ *     label: JSX.Element
+ *     error: string
+ *   },
+ *   rootUrl: string,
+ *   savedFormMessages: {
+ *     notFound: string,
+ *     noAuth: string
+ *   },
+ *   saveInProgress: {
+ *     messages: {
+ *       inProgress: string,
+ *       expired: string,
+ *       saved: string
+ *     }
+ *   },
+ *   schema: Object,
+ *   submit: (form: any, formConfig: any) => Promise<any>
+ *   submitUrl: string,
+ *   subTitle: string,
+ *   title: string,
+ *   trackingPrefix: string,
+ *   transformForSubmit: (form: any, formConfig: any) => any,
+ *   uiSchema: Object,
+ *   urlPrefix: string,
+ *   version: number
+ * }} FormConfig
+ */
+
+/**
+ * @typedef {{
+ *   pages: Record<string, Page>
+ *   title: string
+ * }} Chapter
+ */
+
+/**
+ * @typedef {{
+ *   path: string,
+ *   depends: (formData: Object) => boolean,
+ *   initialData: Object,
+ *   onContinue: (formData: any) => void,
+ *   schema: SchemaOptions
+ *   title: string,
+ *   uiSchema: UISchemaOptions,
+ * }} Page
+ */
+
+/**
+ * @typedef {Object} PageSchema
+ * @property {UISchemaOptions} uiSchema - The UI schema options for the form
+ * @property {SchemaOptions} schema - The schema for the form
+ * @property {Object} initialData - The initial data for the form
+ * @property {(formData: Object) => boolean} depends - A function that returns a boolean indicating whether the page should be shown
+ * @property {(formData: any) => void} onContinue - A function that is called when the user clicks the continue button
+ * @property {string} path - The path for the page
+ * @property {string} title - The title for the page
+ */
+
+/**
+ * @typedef {{
+ *   'ui:autocomplete': string,
+ *   'ui:description': string | JSX.Element,
+ *   'ui:disabled': boolean,
+ *   'ui:errorMessages': {
+ *     enum: string,
+ *     maxLength: string,
+ *     minLength: string,
+ *     pattern: string,
+ *     required: string,
+ *    },
+ *   'ui:field': (props: any) => JSX.Element,
+ *   'ui:hidden': boolean,
+ *   'ui:inputmode': string,
+ *   'ui:options': {
+ *     ariaDescribedby: string,
+ *     classNames: string,
+ *     customTitle: string,
+ *     expandUnder: string,
+ *     expandUnderCondition: boolean,
+ *     forceDivWrapper: boolean,
+ *     hideEmptyValueInReview: boolean,
+ *     hideIf: (formData: any) => boolean,
+ *     hideTitle: boolean,
+ *     hideOnReview: boolean,
+ *     hint: string,
+ *     itemName: string,
+ *     keepInPageOnReview: boolean,
+ *     replaceSchema: (formData: any) => any,
+ *     reviewTitle: string,
+ *     showFieldLabel: boolean,
+ *     updateSchema: (formData, addressSchema, addressUiSchema, index, path) => any,
+ *     viewComponent: (props: any) => JSX.Element,
+ *     viewField: (props: any) => JSX.Element,
+ *     widgetClassNames: string,
+ *     widgetProps: Record<string, any>
+ *   },
+ *   'ui:order': string[],
+ *   'ui:required': (formData: any) => boolean,
+ *   'ui:reviewField': (props: any) => JSX.Element,
+ *   'ui:reviewWidget': (props: any) => JSX.Element,
+ *   'ui:title': string,
+ *   'ui:validations': Array<((errors, value) => void)>,
+ *   'ui:webComponentField': (props: any) => JSX.Element
+ *   'ui:widget': 'yesNo' | 'radio' | 'email' | 'date' | 'textarea' | (props: any) => JSX.Element,
+ *   [key: string]: UISchemaOptions
+ * }} UISchemaOptions
+ */
+
+/**
+ * @typedef {{
+ *   $ref: string,
+ *   enum: string[],
+ *   enumNames: string[],
+ *   format: 'email' | 'date' | 'date-time' | 'uri' | 'data-url',
+ *   items: SchemaOptions,
+ *   maxLength: number,
+ *   minItems: number,
+ *   minLength: number,
+ *   pattern : string,
+ *   properties: Record<string, SchemaOptions>,
+ *   required: string[]
+ *   type: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array',
+ *   uniqueItems: boolean,
+ * }} SchemaOptions
+ */

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -1,121 +1,202 @@
 /**
- * @typedef {{
- *   ariaDescribedBySubmit: string,
- *   chapters: Record<string, FormConfigChapter>,
- *   confirmation: (props: any) => JSX.Element,
- *   defaultDefinitions: Record<string, SchemaOptions>,
- *   errorText: () => JSX.Element,
- *   footerContent: (props: any) => JSX.Element,
- *   formId: string,
- *   getHelp: () => JSX.Element,
- *   introduction:(props: any) => JSX.Element,
- *   migrations: Array<Function>,
- *   prefillEnabled: boolean,
- *   prefillTransformer: Function,
- *   preSubmitInfo: {
- *     CustomComponent: (props: any) => JSX.Element,
- *     field: string,
- *     required: boolean,
- *     notice: string | JSX.Element,
- *     label: JSX.Element
- *     error: string
- *   },
- *   rootUrl: string,
- *   savedFormMessages: {
- *     notFound: string,
- *     noAuth: string
- *   },
- *   saveInProgress: {
- *     messages: {
- *       inProgress: string,
- *       expired: string,
- *       saved: string
- *     }
- *   },
- *   submit: (form: any, formConfig: any) => Promise<any>
- *   submitUrl: string,
- *   subTitle: string,
- *   title: string,
- *   trackingPrefix: string,
- *   transformForSubmit: (form: any, formConfig: any) => any,
- *   urlPrefix: string,
- *   version: number
- * }} FormConfig
+ * @file Generic types for the form system
+ *
+ * Used for intellesense (autocompletion)
+ */
+
+// Example 1:
+// /** @type {FormConfig} */
+// const formConfig = {...};
+
+// Example 2:
+// /** @type {PageSchema} */
+// export default {
+//   uiSchema: {...},
+//   schema: {...},
+// };
+
+// Use @typedef ({{}}) format to use [key: string]: Type
+// Use @typedef {Object} format to be able to add comments to properties
+
+/**
+ * @typedef {Object} FormConfig
+ * @property {Array<Object>} additionalRoutes
+ * @property {string} ariaDescribedBySubmit
+ * @property {Record<string, FormConfigChapter>} chapters
+ * @property {(props: any) => JSX.Element} confirmation
+ * @property {CustomText} customText
+ * @property {Record<string, SchemaOptions>} defaultDefinitions
+ * @property {Downtime} downtime
+ * @property {(props: any) => JSX.Element} errorText
+ * @property {(props: any) => JSX.Element} footerContent
+ * @property {string} formId
+ * @property {(props: any) => JSX.Element} formSavedPage
+ * @property {() => JSX.Element} getHelp
+ * @property {(props: any) => JSX.Element} introduction
+ * @property {Array<Function>} migrations
+ * @property {(formConfig: any) => void} onFormLoaded
+ * @property {boolean} prefillEnabled
+ * @property {Function} prefillTransformer
+ * @property {PreSubmitInfo} preSubmitInfo
+ * @property {Object} reviewErrors
+ * @property {string} rootUrl
+ * @property {SavedFormMessages} savedFormMessages
+ * @property {SaveInProgress} saveInProgress
+ * @property {boolean} showReviewErrors
+ * @property {(props: any) => JSX.Element} submissionError
+ * @property {(form: any, formConfig: any) => Promise<any>} submit
+ * @property {(props: any) => JSX.Element} submitErrorText
+ * @property {string} submitUrl
+ * @property {string} subTitle
+ * @property {string} title
+ * @property {string} trackingPrefix
+ * @property {(form: any, formConfig: any) => any} transformForSubmit
+ * @property {string} urlPrefix
+ * @property {boolean} useCustomScrollAndFocus
+ * @property {boolean} verifyRequiredPrefill
+ * @property {number} version
+ * @property {string} wizardStorageKey
+ */
+
+/**
+ * @typedef {Object} CustomText
+ * @property {string} appSavedSuccessfullyMessage
+ * @property {string} appType
+ * @property {string} continueAppButtonText
+ * @property {string} reviewPageTitle
+ * @property {string} startNewAppButtonText
+ * @property {string} submitButtonText
+ */
+
+/**
+ * @typedef {Object} SavedFormMessages
+ * @property {string} notFound
+ * @property {string} noAuth
+ */
+
+/**
+ * @typedef {Object} Downtime
+ * @property {Array<string>} dependnecies
+ * @property {string} endTime
+ * @property {string} message
+ * @property {boolean} requiredForPrefill
+ * @property {'down' |'downtimeApproaching' | 'ok'} status
+ * @property {string} startTime
+ */
+
+/**
+ * @typedef {Object} PreSubmitInfo
+ * @property {(props: any) => JSX.Element} CustomComponent
+ * @property {string} error
+ * @property {string} field
+ * @property {JSX.Element} label
+ * @property {string | JSX.Element} notice
+ * @property {boolean} required
+ */
+
+/**
+ * @typedef {Object} SaveInProgress
+ * @property {Object} messages
+ * @property {string} messages.inProgress
+ * @property {string} messages.expired
+ * @property {string} messages.saved
+ */
+
+/**
+ * @typedef {Object} FormConfigChapter
+ * @property {Record<string, FormConfigPage>} pages
+ * @property {string | Function} title
+ */
+
+/**
+ * @typedef {Object} FormConfigPage
+ * @property {string} arrayPath
+ * @property {(props: any) => JSX.Element} CustomPage
+ * @property {(props: any) => JSX.Element} CustomPageReview
+ * @property {(formData: Object) => boolean} depends
+ * @property {Object} initialData
+ * @property {(formData: any) => void} onContinue
+ * @property {(data: any) => boolean} itemFilter
+ * @property {string} path
+ * @property {SchemaOptions} schema
+ * @property {string | Function} scrollAndFocusTarget
+ * @property {boolean} showPagePerItem
+ * @property {string | Function} title
+ * @property {UISchemaOptions} uiSchema
+ * @property {(item, index) => void} updateFormData
+ */
+
+/**
+ * @typedef {Object} PageSchema - The schema for a page (only uiSchema and schema). If you want all the page properties, use FormConfigPage
+ * @property {UISchemaOptions} uiSchema
+ * @property {SchemaOptions} schema
  */
 
 /**
  * @typedef {{
- *   pages: Record<string, FormConfigPage>
- *   title: string
- * }} FormConfigChapter
- */
-
-/**
- * @typedef {{
- *   path: string,
- *   depends: (formData: Object) => boolean,
- *   initialData: Object,
- *   onContinue: (formData: any) => void,
- *   schema: SchemaOptions
- *   title: string,
- *   uiSchema: UISchemaOptions,
- * }} FormConfigPage
- */
-
-/**
- * @typedef {Object} PageSchema
- * @property {UISchemaOptions} uiSchema - The UI schema options for the form
- * @property {SchemaOptions} schema - The schema for the form
- */
-
-/**
- * @typedef {{
+ *    items: UISchemaOptions,
  *   'ui:autocomplete': string,
  *   'ui:description': string | JSX.Element,
  *   'ui:disabled': boolean,
- *   'ui:errorMessages': {
- *     enum: string,
- *     maxLength: string,
- *     minLength: string,
- *     pattern: string,
- *     required: string,
- *    },
+ *   'ui:errorMessages': UIErrorMessages,
  *   'ui:field': (props: any) => JSX.Element,
  *   'ui:hidden': boolean,
- *   'ui:inputmode': string,
- *   'ui:options': {
- *     ariaDescribedby: string,
- *     classNames: string,
- *     customTitle: string,
- *     expandUnder: string,
- *     expandUnderCondition: boolean,
- *     forceDivWrapper: boolean,
- *     hideEmptyValueInReview: boolean,
- *     hideIf: (formData: any) => boolean,
- *     hideTitle: boolean,
- *     hideOnReview: boolean,
- *     hint: string,
- *     itemName: string,
- *     keepInPageOnReview: boolean,
- *     replaceSchema: (formData: any) => any,
- *     reviewTitle: string,
- *     showFieldLabel: boolean,
- *     updateSchema: (formData, addressSchema, addressUiSchema, index, path) => any,
- *     viewComponent: (props: any) => JSX.Element,
- *     viewField: (props: any) => JSX.Element,
- *     widgetClassNames: string,
- *     widgetProps: Record<string, any>
- *   },
+ *   'ui:objectViewField': (props: any) => JSX.Element,
+ *   'ui:options': UIOptions,
  *   'ui:order': string[],
  *   'ui:required': (formData: any) => boolean,
  *   'ui:reviewField': (props: any) => JSX.Element,
  *   'ui:reviewWidget': (props: any) => JSX.Element,
  *   'ui:title': string | JSX.Element,
  *   'ui:validations': Array<((errors, value) => void)>,
- *   'ui:webComponentField': (props: any) => JSX.Element
- *   'ui:widget': 'yesNo' | 'radio' | 'email' | 'date' | 'textarea' | (props: any) => JSX.Element,
+ *   'ui:widget': 'yesNo' | 'checkbox' | 'radio' | 'select' | 'email' | 'date' | 'textarea' | (props: any) => JSX.Element,
  *   [key: string]: UISchemaOptions
  * }} UISchemaOptions
+ */
+
+/**
+ * @typedef {{
+ *   atLeastOne: string,
+ *   enum: string,
+ *   maxItems: string,
+ *   maxLength: string,
+ *   minItems: string,
+ *   minLength: string,
+ *   pattern: string,
+ *   required: string,
+ *   [key: string]: string
+ * }} UIErrorMessages
+ */
+
+/**
+ * @typedef {Object} UIOptions
+ * @property {string} ariaDescribedby - The id of the element that describes the field
+ * @property {string} classNames
+ * @property {string} customTitle
+ * @property {number} debounceRate
+ * @property {string} duplicateKey
+ * @property {string} expandUnder
+ * @property {boolean} expandUnderCondition
+ * @property {boolean} forceDivWrapper
+ * @property {boolean} freeInput
+ * @property {boolean} hideEmptyValueInReview
+ * @property {(formData: any) => boolean} hideIf
+ * @property {boolean} hideTitle
+ * @property {boolean} hideOnReview
+ * @property {string} hint
+ * @property {boolean} includeRequiredLabelInTitle
+ * @property {Array<(input) => string>} inputTransformers
+ * @property {(item: any) => string} itemAriaLabel
+ * @property {string} itemName
+ * @property {boolean} keepInPageOnReview
+ * @property {Record<string, string>} labels
+ * @property {(formData: any) => any} replaceSchema
+ * @property {(formData, addressSchema, addressUiSchema, index, path) => any} updateSchema
+ * @property {boolean} useDlWrap
+ * @property {(props: any) => JSX.Element} viewComponent
+ * @property {(props: any) => JSX.Element} viewField
+ * @property {string} widgetClassNames
+ * @property {Record<string, any>} widgetProps
  */
 
 /**
@@ -127,11 +208,13 @@
  *   items: SchemaOptions,
  *   maxLength: number,
  *   minItems: number,
+ *   maxItems: number,
  *   minLength: number,
- *   pattern : string,
+ *   pattern: string,
  *   properties: Record<string, SchemaOptions>,
- *   required: string[]
+ *   required: string[],
  *   type: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array',
  *   uniqueItems: boolean,
+ *   [key: string]: SchemaOptions
  * }} SchemaOptions
  */

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -191,7 +191,7 @@
  * @property {boolean} keepInPageOnReview
  * @property {Record<string, string>} labels
  * @property {(formData: any) => any} replaceSchema
- * @property {(formData, addressSchema, addressUiSchema, index, path) => any} updateSchema
+ * @property {(formData, schema, uiSchema, index, path) => any} updateSchema
  * @property {boolean} useDlWrap
  * @property {(props: any) => JSX.Element} viewComponent
  * @property {(props: any) => JSX.Element} viewField

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {{
  *   ariaDescribedBySubmit: string,
- *   chapters: Record<string, Chapter>,
+ *   chapters: Record<string, FormConfigChapter>,
  *   confirmation: (props: any) => JSX.Element,
  *   defaultDefinitions: Record<string, SchemaOptions>,
  *   errorText: () => JSX.Element,
@@ -32,14 +32,12 @@
  *       saved: string
  *     }
  *   },
- *   schema: Object,
  *   submit: (form: any, formConfig: any) => Promise<any>
  *   submitUrl: string,
  *   subTitle: string,
  *   title: string,
  *   trackingPrefix: string,
  *   transformForSubmit: (form: any, formConfig: any) => any,
- *   uiSchema: Object,
  *   urlPrefix: string,
  *   version: number
  * }} FormConfig
@@ -47,9 +45,9 @@
 
 /**
  * @typedef {{
- *   pages: Record<string, Page>
+ *   pages: Record<string, FormConfigPage>
  *   title: string
- * }} Chapter
+ * }} FormConfigChapter
  */
 
 /**
@@ -61,18 +59,13 @@
  *   schema: SchemaOptions
  *   title: string,
  *   uiSchema: UISchemaOptions,
- * }} Page
+ * }} FormConfigPage
  */
 
 /**
  * @typedef {Object} PageSchema
  * @property {UISchemaOptions} uiSchema - The UI schema options for the form
  * @property {SchemaOptions} schema - The schema for the form
- * @property {Object} initialData - The initial data for the form
- * @property {(formData: Object) => boolean} depends - A function that returns a boolean indicating whether the page should be shown
- * @property {(formData: any) => void} onContinue - A function that is called when the user clicks the continue button
- * @property {string} path - The path for the page
- * @property {string} title - The title for the page
  */
 
 /**

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -110,7 +110,7 @@
  *   'ui:required': (formData: any) => boolean,
  *   'ui:reviewField': (props: any) => JSX.Element,
  *   'ui:reviewWidget': (props: any) => JSX.Element,
- *   'ui:title': string,
+ *   'ui:title': string | JSX.Element,
  *   'ui:validations': Array<((errors, value) => void)>,
  *   'ui:webComponentField': (props: any) => JSX.Element
  *   'ui:widget': 'yesNo' | 'radio' | 'email' | 'date' | 'textarea' | (props: any) => JSX.Element,

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -1,7 +1,7 @@
 /**
  * @file Generic types for the form system
  *
- * Used for intellesense (autocompletion)
+ * Used for intellisense (autocompletion)
  */
 
 // Example 1:


### PR DESCRIPTION
## Summary

- This will allow for auto-complete when typing schemas, UI schemas and form config options. 
- To use this, add `/** @type {PageSchema} */ ` directly above a `const` or `default export` which is an object including `schema` and `uiSchema`
- Or add `/** @type {FormConfig} */ ` directly above a `const formConfig` defining your form.
- You can also trigger intellisense manually in VSCode by pressing the default key combo (ctrl/command+space or possibly ctrl/command+i depending on your setup)
- This will not enforce types, detect eslint errors, or produce errors in any way. It is simply an suggestion/auto-complete aid.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#245

## Testing done

- Verified properties by looking at examples from every form, and also referencing the RJSF documentation in our node_modules.
- Tested on existing forms. Verified intellisense works in the editor. No changes to outputted form in the UI or in testing.

### Reliability
- The intellisense doesn't detect 100% of the time for some reason. I think because VSCode has to scan your editor to know where to find the type. But seems to work most of the time.

## Screenshots

![image](https://user-images.githubusercontent.com/123402053/235788596-59c8527f-a6c0-48b0-afbc-4e4e61a1b750.png)
![image](https://user-images.githubusercontent.com/123402053/235789496-fdf3a2df-e4c7-427d-87ae-2b222844d7f5.png)
![image](https://user-images.githubusercontent.com/123402053/235789636-c9d9cd6f-ca27-4dfb-8efb-0b2e23276849.png)

## What areas of the site does it impact?

Only local devs code editors

## Acceptance criteria

### Quality Assurance & Testing

- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.