### PR TITLE
hotfix: add institution name to request

### DIFF
--- a/src/applications/personalization/profile/util/direct-deposit.js
+++ b/src/applications/personalization/profile/util/direct-deposit.js
@@ -15,6 +15,8 @@ export class DirectDepositClient {
   }
 
   generateApiRequestOptions(payload) {
+    set(payload, 'financialInstitutionName', 'Hidden form field');
+
     const options = {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
The financial institution name was removed from PUT requests for direct deposit, as it was deemed un-needed, but unfortunately that was not the case, so it needs to be re-added.

Basically the field needs to be set to any string, but just cannot be missing or empty. I have adjust the code to send the same string as it did before it was removed.

Tested locally to verify that the request has the name now in it.

<img width="426" alt="Screenshot 2023-05-02 at 5 29 01 PM" src="https://user-images.githubusercontent.com/8332986/235806610-88909aff-a228-4029-a666-5c51dcdd6c4f.png">
