### PR TITLE
Profile/aw/use generic downtime alert for dd

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -5,10 +5,10 @@ import { connect } from 'react-redux';
 import {
   cnpDirectDepositUiState,
   eduDirectDepositUiState,
-  selectHideDirectDepositCompAndPen,
 } from '@@profile/selectors';
 import { Prompt } from 'react-router-dom';
-import { CSP_IDS } from 'platform/user/authentication/constants';
+import { CSP_IDS } from '~/platform/user/authentication/constants';
+import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
 import DowntimeNotification, {
   externalServices,
 } from '~/platform/monitoring/DowntimeNotification';
@@ -210,7 +210,7 @@ const mapStateToProps = state => {
     isVerifiedUser: isLOA3 && isUsingEligibleSignInService && is2faEnabled,
     cnpUiState: cnpDirectDepositUiState(state),
     eduUiState: eduDirectDepositUiState(state),
-    hideDirectDepositCompAndPen: selectHideDirectDepositCompAndPen(state),
+    hideDirectDepositCompAndPen: toggleValues(state)?.profileUseExperimental,
     useOAuth: isAuthenticatedWithOAuth(state),
   };
 };

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import {
   cnpDirectDepositUiState,
   eduDirectDepositUiState,
+  selectHideDirectDepositCompAndPen,
 } from '@@profile/selectors';
 import { Prompt } from 'react-router-dom';
 import { CSP_IDS } from '~/platform/user/authentication/constants';
@@ -37,6 +38,8 @@ import DirectDepositWrapper from './DirectDepositWrapper';
 import TemporaryOutage from './alerts/TemporaryOutage';
 
 import { BANK_INFO_UPDATED_ALERT_SETTINGS } from '../../constants';
+
+import TOGGLE_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
 
 const DirectDeposit = ({
   cnpUiState,
@@ -210,7 +213,9 @@ const mapStateToProps = state => {
     isVerifiedUser: isLOA3 && isUsingEligibleSignInService && is2faEnabled,
     cnpUiState: cnpDirectDepositUiState(state),
     eduUiState: eduDirectDepositUiState(state),
-    hideDirectDepositCompAndPen: toggleValues(state)?.profileUseExperimental,
+    hideDirectDepositCompAndPen:
+      toggleValues(state)?.[TOGGLE_NAMES.profileUseExperimental] ||
+      selectHideDirectDepositCompAndPen(state),
     useOAuth: isAuthenticatedWithOAuth(state),
   };
 };

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
@@ -16,7 +16,7 @@ const TemporaryOutage = () => (
         available right now. We’re doing some maintenance work on this system.
       </p>
       <p className="vads-u-margin-bottom--0">
-        Check back on Monday, August 15, 2022, to review your information.
+        Refresh this page or try again later.
       </p>
     </va-alert>
   </div>

--- a/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
@@ -12,6 +12,7 @@ const defaultToggleValues = {
   profileUseFieldEditingPage: true,
   profileShowMhvNotificationSettings: false,
   profileLighthouseDirectDeposit: false,
+  profileUseExperimental: true,
 };
 
 const generateFeatureToggles = (values = defaultToggleValues) => {

--- a/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
@@ -12,7 +12,7 @@ const defaultToggleValues = {
   profileUseFieldEditingPage: true,
   profileShowMhvNotificationSettings: false,
   profileLighthouseDirectDeposit: false,
-  profileUseExperimental: true,
+  profileUseExperimental: false,
 };
 
 const generateFeatureToggles = (values = defaultToggleValues) => {


### PR DESCRIPTION
## Summary

- The downtime alert can now be triggered by the experimental profile toggle or the downtime toggle.
- The alert has also had it language updated to remove the date.

## Related issue(s)
Hotfix

## Testing done

- Tested locally and all tests pass


## What areas of the site does it impact?

Profile - Direct Deposit page

## Acceptance criteria
- [ ] Date removed from downtime alert
- [ ] Triggered via experimental flag or hide flag
