### PR TITLE
[MHV-44668] SM to VA.gov: Message action buttons on zoom

### DIFF
--- a/src/applications/mhv/secure-messaging/components/Navigation.jsx
+++ b/src/applications/mhv/secure-messaging/components/Navigation.jsx
@@ -70,7 +70,7 @@ const Navigation = () => {
   }
 
   function checkScreenSize() {
-    if (window.innerWidth <= 481 && setIsMobile !== false) {
+    if (window.innerWidth <= 768 && setIsMobile !== false) {
       setIsMobile(true);
     } else {
       setIsMobile(false);

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -64,6 +64,12 @@
   }
 
   .message-action-buttons {
+    @media (max-width: $xsmall-screen) {
+      flex-direction: column;
+      button {
+        margin: 0;
+      }
+    }
     list-style-type: none;
     display: flex;
     flex-direction: row;

--- a/src/applications/mhv/secure-messaging/sass/navigation.scss
+++ b/src/applications/mhv/secure-messaging/sass/navigation.scss
@@ -55,7 +55,7 @@
       color: $color-black;
       font-weight: bold;
       padding-left: units-px(1.5);
-      span{
+      span {
         margin-left: -4px;
       }
     }
@@ -75,7 +75,7 @@
       a {
         padding-top: 7px;
         color: $color-link-default;
-        &.is-active{
+        &.is-active {
           color: $color-black;
         }
         &:active {
@@ -95,7 +95,7 @@
     }
   }
 }
-@media (max-width: $small-screen) {
+@media (max-width: $medium-screen) {
   .va-btn-sidebarnav-trigger {
     z-index: 0;
     .button-wrapper {

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -179,7 +179,7 @@ va-alert button {
   background-color: rgba(0, 0, 0, 0.05);
 }
 
-@media (max-width: $small-screen) {
+@media (max-width: $medium-screen) {
   .secure-messaging-container {
     flex-direction: column;
     .main-content {


### PR DESCRIPTION
## Summary

- Setting a wider breakpoint for mobile view to 768 px to accommodate proper display of message action buttons on 200% zoom level
- On xsmall-screen width, stacking action buttons in a columns instead of a row to accommodate 400% zoom level

## Related issue(s)

- [SM to VA.gov: Message action buttons on zoom](https://vajira.max.gov/browse/MHV-44668)

## Testing done

- Tested manually + SQA

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img width="100" src="https://user-images.githubusercontent.com/87077843/236001050-8cf81ac7-5df8-4a63-b605-704a72055766.png"/> <img width="100" src="https://user-images.githubusercontent.com/87077843/236001335-eb736f2b-e06c-4536-85cc-206ddc4c2476.png"/>|<img width="100" src="https://user-images.githubusercontent.com/87077843/236001758-0c99bd9f-1cce-4a64-be72-e33b25d2f694.png"/> <img width="100" src="https://user-images.githubusercontent.com/87077843/236001978-a273ac6b-cfb6-4842-87f5-338fb714cdc4.png"/>|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
