### PR TITLE
VACMS-13507: Converts Facilities-owned <Pagination> to <VaPagination>

### DIFF
--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -1,4 +1,4 @@
-import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
+import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { LocationType } from '../constants';
@@ -26,7 +26,7 @@ export class PaginationWrapper extends Component {
       results.length > 0
     ) {
       return (
-        <Pagination
+        <VaPagination
           onPageSelect={handlePageSelect}
           page={currentPage}
           pages={totalPages}

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -214,7 +214,9 @@ const FacilitiesMap = props => {
     });
   };
 
-  const handlePageSelect = page => {
+  const handlePageSelect = e => {
+    const { page } = e.detail;
+
     resetMapElements();
     const { currentQuery } = props;
     const coords = currentQuery.position;
@@ -438,11 +440,8 @@ const FacilitiesMap = props => {
           <div id="search-result-emergency-care-info">
             <p className="search-result-emergency-care-subheader">
               <strong>Note:</strong> If you think your life or health is in
-              danger, call{' '}
-              <a aria-label="9 1 1" href="tel:911">
-                911
-              </a>{' '}
-              or go to the nearest emergency department right away.
+              danger, call <va-telephone contact="911" /> or go to the nearest
+              emergency department right away.
             </p>
           </div>
         )}

--- a/src/applications/facility-locator/tests/components/PaginationWrapper.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/PaginationWrapper.unit.spec.jsx
@@ -1,7 +1,7 @@
-import { PaginationWrapper } from '../../components/PaginationWrapper';
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import { PaginationWrapper } from '../../components/PaginationWrapper';
 
 const handlePageSelect = () => {};
 
@@ -22,7 +22,7 @@ describe('PaginationWrapper', () => {
       />,
     );
 
-    expect(wrapper.find('Pagination').length).to.equal(1);
+    expect(wrapper.find('ForwardRef(VaPagination)').length).to.equal(1);
     wrapper.unmount();
   });
 
@@ -42,7 +42,7 @@ describe('PaginationWrapper', () => {
       />,
     );
 
-    expect(wrapper.find('Pagination').length).to.equal(0);
+    expect(wrapper.find('ForwardRef(VaPagination)').length).to.equal(0);
     wrapper.unmount();
   });
 
@@ -62,7 +62,7 @@ describe('PaginationWrapper', () => {
       />,
     );
 
-    expect(wrapper.find('Pagination').length).to.equal(0);
+    expect(wrapper.find('ForwardRef(VaPagination)').length).to.equal(0);
     wrapper.unmount();
   });
 
@@ -80,7 +80,7 @@ describe('PaginationWrapper', () => {
       />,
     );
 
-    expect(wrapper.find('Pagination').length).to.equal(0);
+    expect(wrapper.find('ForwardRef(VaPagination)').length).to.equal(0);
     wrapper.unmount();
   });
 
@@ -100,7 +100,7 @@ describe('PaginationWrapper', () => {
       />,
     );
 
-    expect(wrapper.find('Pagination').length).to.equal(0);
+    expect(wrapper.find('ForwardRef(VaPagination)').length).to.equal(0);
     wrapper.unmount();
   });
 
@@ -118,7 +118,7 @@ describe('PaginationWrapper', () => {
       />,
     );
 
-    expect(wrapper.find('Pagination').length).to.equal(0);
+    expect(wrapper.find('ForwardRef(VaPagination)').length).to.equal(0);
     wrapper.unmount();
   });
 });

--- a/src/applications/facility-locator/tests/e2e/serverErrors.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/serverErrors.cypress.spec.js
@@ -45,6 +45,8 @@ describe('Facility Locator error handling', () => {
     cy.get('h4.usa-alert-heading').contains(
       'Find VA locations isn’t working right now',
     );
-    cy.get('#search-result-emergency-care-info').contains('call 911');
+    cy.get('#search-result-emergency-care-info')
+      .contains('call')
+      .contains('911');
   });
 });


### PR DESCRIPTION
## Summary
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13507

The `<Pagination>` React component is deprecated. This PR converts the one usage in Facilities-owned code to the React binding for the corresponding Web Component (`<VaPagination>`).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13507

## Testing done/QA Steps
- `yarn watch --env api=https://dev-api.va.gov entry=facilities`
- Visit [this page](http://localhost:3001/find-locations/?address=New%20Jersey%2C%20United%20States&bounds%5B%5D%5B%5D=-75.1393168105238&bounds%5B%5D%5B%5D=39.4002478924773&bounds%5B%5D%5B%5D=-73.6393168105238&bounds%5B%5D%5B%5D=40.9002478924773&bounds%5B%5D%5B%5D%5B%5D=-76.21120193546238&bounds%5B%5D%5B%5D%5B%5D=37.24380843261896&bounds%5B%5D%5B%5D%5B%5D=-71.8063853822911&bounds%5B%5D%5B%5D%5B%5D=42.17439947352861&bounds%5B%5D%5B%5D%5B%5D%5B%5D=-76.95020571898303&bounds%5B%5D%5B%5D%5B%5D%5B%5D=38.16036509610859&bounds%5B%5D%5B%5D%5B%5D%5B%5D=-72.97257272220605&bounds%5B%5D%5B%5D%5B%5D%5B%5D=42.570704262401534&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-74.3842457571798&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.80822191393244&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-72.6609908469449&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=41.695730586233395&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-74.395066&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=39.907419&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-72.895066&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=41.407419&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-74.17276464564513&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=40.088711815229374&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-73.13452977595205&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=41.2275918318841&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-74.252068&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=40.07621&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-72.752068&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=41.57621&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-74.26822341147579&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=40.02908026641424&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=-72.81475222741824&bounds%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D%5B%5D=41.619410339700266&context=New%20Jersey%2C%20United%20States&facilityType=health&latitude=40.1502478924773&longitude=-74.3893168105238&page=1&radius=195&searchString=New%20Jersey%2C%20United%20States&serviceType&bounds%5B%5D=-75.1393168105238&bounds%5B%5D=39.4002478924773&bounds%5B%5D=-73.6393168105238&bounds%5B%5D=40.9002478924773) locally.
- Interact with the pagination element at the bottom of the map to ensure that it works as expected.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/236248241-97866525-f77e-4ef4-9a83-339a4b0aaae7.png)

Then, after clicking on "next" page.

![image](https://user-images.githubusercontent.com/6863534/236248389-a9e0e02f-05c9-4345-aa52-13c6597e950d.png)

Then, after clicking on page "6"

![image](https://user-images.githubusercontent.com/6863534/236249010-d96751b3-2356-4415-81c4-14a33fe21284.png)



## What areas of the site does it impact?
Facility Locator.

## Acceptance criteria
See original issue.

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- ~[ ] Documentation has been updated ([link to documentation](#) \*if necessary)~
- [x] Screenshot of the developed feature is added
- ~[ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed~

### Error Handling

- [x] Browser console contains no warnings or errors.
- ~[ ] Events are being sent to the appropriate logging solution~
- ~[ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)~
