### PR TITLE
Update email format error message for 26-4555

### DIFF
--- a/src/applications/simple-forms/26-4555/pages/contactInformation2.js
+++ b/src/applications/simple-forms/26-4555/pages/contactInformation2.js
@@ -51,7 +51,7 @@ export default {
         ...emailUI(),
         'ui:errorMessages': {
           format:
-            'Enter a valid email address. Your address can only have letters, numbers, the @ symbol, and a period, with no spaces.',
+            'Enter a valid email address using the format email@domain.com. Your email address can only have letters, numbers, the @ symbol and a period, with no spaces.',
         },
       },
     },


### PR DESCRIPTION
## Summary

This is a quick PR to update the error messaging for the `format` of the email address field in the 26-4555 form.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#56733