### PR TITLE
MHV-41390 SM to VA.gov: Message Body URL parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,6 +286,7 @@
     "react-focus-lock": "^2.6.0",
     "react-is": "^17.0.2",
     "react-leaflet": "^3.2.2",
+    "react-linkify": "^1.0.0-alpha",
     "react-meta-tags": "^1.0.1",
     "react-redux": "^7.2.6",
     "react-router": "3",

--- a/src/applications/mhv/secure-messaging/actions/messages.js
+++ b/src/applications/mhv/secure-messaging/actions/messages.js
@@ -185,8 +185,10 @@ export const retrieveMessageThread = (
             replyToName,
             threadFolderId,
             replyToMessageId: msgResponse.data.attributes.messageId,
-            ...msgResponse.data,
-            ...response.data[0],
+            attributes: {
+              ...response.data[0].attributes,
+              ...msgResponse.data.attributes,
+            },
           },
           included: msgResponse.included,
         },

--- a/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageThread/MessageThreadBody.jsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { urlRegex, httpRegex } from '../../util/helpers';
+import Linkify from 'react-linkify';
 
 const MessageThreadBody = props => {
   const { text } = props;
-  const words = text?.split(/[^\S\r\n]+/g);
+
+  const componentDecorator = (href, linkText) => (
+    <a href={href} target="_blank" rel="noreferrer">
+      {linkText}
+    </a>
+  );
 
   return (
     <div className="vads-u-padding-y--1 ">
       <>
-        <span data-testid="message-body" className="vads-u-margin-y--0">
-          {words?.map((word, i) => {
-            return (word.match(urlRegex) || word.match(httpRegex)) &&
-              words.length >= 1 ? (
-              <a key={i} href={word} target="_blank" rel="noreferrer">
-                {`${word} `}
-              </a>
-            ) : (
-              `${word} `
-            );
-          })}
-        </span>
+        <pre data-testid="message-body" className="vads-u-margin-y--0">
+          <Linkify componentDecorator={componentDecorator}>{text}</Linkify>
+        </pre>
       </>
     </div>
   );

--- a/src/applications/mhv/secure-messaging/tests/components/MessageThreadComponents/MessageThreadBody.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageThreadComponents/MessageThreadBody.unit.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import MessageThreadBody from '../../../components/MessageThread/MessageThreadBody';
+
+describe('Message Thread Body', () => {
+  const url = 'https://vajira.max.gov/browse/MHV-41390';
+  const text = `Hello, This is a test message to see how these urls ${url} are 
+    displayed in message body when parsed from the text. Hopefully 
+    they are showing up properly formatted when inside a paragraph or on 
+    an individual line as below. ${url} Thank you! `;
+
+  it('renders properly', () => {
+    const screen = render(<MessageThreadBody text={text} />);
+    expect(screen.getByTestId('message-body').textContent).to.equal(text);
+    const links = screen.getAllByText(url, { selector: 'a' });
+    links.forEach(link => {
+      expect(link.getAttribute('href')).to.equal(url);
+      expect(link.getAttribute('target')).to.equal('_blank');
+      expect(link.getAttribute('rel')).to.equal('noreferrer');
+    });
+  });
+});

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-specialcharacter-search.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-specialcharacter-search.cypress.spec.js
@@ -47,7 +47,7 @@ describe('Secure Messaging - Search Special Characters', () => {
       mockSpeciaCharMessage,
       defaultMockThread,
     );
-    cy.get('span').should('contain', 'special %$#');
+    cy.get('pre').should('contain', 'special %$#');
 
     cy.injectAxe();
     cy.axeCheck();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12260,6 +12260,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-it@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 linkify-it@^3.0.1:
   version "3.0.2"
   resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz"
@@ -15790,6 +15797,14 @@ react-lifecycles-compat@^3.0.2:
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-linkify@^1.0.0-alpha:
+  version "1.0.0-alpha"
+  resolved "https://registry.yarnpkg.com/react-linkify/-/react-linkify-1.0.0-alpha.tgz#b391c7b88e3443752fafe76a95ca4434e82e70d5"
+  integrity sha512-7gcIUvJkAXXttt1fmBK9cwn+1jTa4hbKLGCZ9J1U6EOkyb2/+LKL1Z28d9rtDLMnpvImlNlLPdTPooorl5cpmg==
+  dependencies:
+    linkify-it "^2.0.3"
+    tlds "^1.199.0"
+
 react-meta-tags@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-meta-tags/-/react-meta-tags-1.0.1.tgz#be18e88adafca280d6bd12839b530f9cfb7edbab"
@@ -18317,6 +18332,11 @@ titleize@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz"
   integrity sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew==
+
+tlds@^1.199.0:
+  version "1.238.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.238.0.tgz#ffe7c19c8940c35b497cda187a6927f9450325a4"
+  integrity sha512-lFPF9pZFhLrPodaJ0wt9QIN0l8jOxqmUezGZnm7BfkDSVd9q667oVIJukLVzhF+4oW7uDlrLlfJrL5yu9RWwew==
 
 tmp@^0.0.29:
   version "0.0.29"


### PR DESCRIPTION
## Summary

- Resolving an issue where URL were incorrectly parsed from a message body
- Instead of using regex, using `react-linkify` package 

## Related issue(s)

- [VA Jira MHV-41390 SM to VA.gov: Message Body URL parsing](https://vajira.max.gov/browse/MHV-41390)

## Testing done

- SQA testing
- Unit test coverage

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img width="250" alt="image" src="https://user-images.githubusercontent.com/87077843/236467777-eb73a983-adab-44a1-9a67-04f45c4b26ab.png">|<img width="250" alt="image" src="https://user-images.githubusercontent.com/87077843/236469640-53f004bd-ea05-4d18-baba-0abd3136a075.png">|

## What areas of the site does it impact?

My-Health / Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
