### PR TITLE
Supplemental Claims | Normalize entry string before uniqueness comparison

### DIFF
--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -104,7 +104,8 @@ export const errorMessages = {
     locationMissing: 'You must enter a treatment location',
     locationMaxLength: 'You can enter a maximum of 255 characters',
     issuesMissing: 'You must select 1 or more conditions',
-    unique: 'You must enter a location you haven’t already entered',
+    uniqueVA:
+      'You must enter a location, condition and dates you haven’t already entered',
 
     // private evidence
     facilityMissing: 'You must add a provider or facility name',
@@ -114,6 +115,8 @@ export const errorMessages = {
     state: 'You must choose a state',
     postal: 'You must enter a postal code',
     overMaxLength: max => `You can enter a maximum of ${max} characters`,
+    uniquePrivate:
+      'You must enter a provider, address, condition and dates you haven’t already entered',
 
     upload: 'You must provide a password to decrypt this file',
   },

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -76,7 +76,7 @@ export const MAX_LENGTH = {
 };
 
 export const REGEX_COMMA = /[, ]/g;
-export const REGEX_EMPTY_DATE = /--/;
+export const REGEX_EMPTY_DATE = /(--|-00-00)/;
 
 export const errorMessages = {
   contestedIssue: 'You must select an eligible issue',

--- a/src/applications/appeals/995/tests/components/EvidencePrivateRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidencePrivateRecords.unit.spec.jsx
@@ -552,7 +552,7 @@ describe('<EvidencePrivateRecords>', () => {
       fireEvent.blur(input);
 
       await waitFor(() => {
-        expect(input.error).to.contain(errorMessages.evidence.unique);
+        expect(input.error).to.contain(errorMessages.evidence.uniquePrivate);
       });
     });
   });

--- a/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
@@ -548,7 +548,7 @@ describe('<EvidenceVaRecords>', () => {
       fireEvent.blur(input);
 
       await waitFor(() => {
-        expect(input.error).to.contain(errorMessages.evidence.unique);
+        expect(input.error).to.contain(errorMessages.evidence.uniqueVA);
       });
     });
   });

--- a/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
@@ -170,13 +170,13 @@ describe('VA evidence', () => {
       locations: [
         {
           locationAndName: 'Location 1',
-          issues: ['Ankylosis of knee'],
+          issues: ['test 1', 'test 2'],
           evidenceDates: { from: '2001-01-01', to: '2011-01-01' },
         },
         {},
         {
           locationAndName: 'Location 2',
-          issues: ['Ankylosis of knees'],
+          issues: ['test 1', 'test 2'],
           evidenceDates: { from: '2002-02-02', to: '2012-02-02' },
         },
         {
@@ -186,8 +186,8 @@ describe('VA evidence', () => {
         },
         {
           locationAndName: name3,
-          issues: ['AnKyLoSiS of KNEE'],
-          evidenceDates: { from: '2001-01-01', to: '2011-01-01' },
+          issues: ['TeSt 2', 'tEsT 1'],
+          evidenceDates: { from: '2001-1-01', to: '2011-01-1' },
         },
       ],
     });
@@ -199,19 +199,19 @@ describe('VA evidence', () => {
     it('should NOT show an error for duplicate locations when on the first duplicate', () => {
       const errors = { addError: sinon.spy() };
       validateVaUnique(errors, {}, getLocations('LOCATION 1'), _, _, 0);
-      expect(errors.addError.calledWith(errorMessages.evidence.unique)).to.be
+      expect(errors.addError.calledWith(errorMessages.evidence.uniqueVA)).to.be
         .false;
     });
     it('should SHOW an error for duplicate locations when not on the first duplicate index', () => {
       const errors = { addError: sinon.spy() };
       validateVaUnique(errors, {}, getLocations('LOCATION 1'), _, _, 4);
-      expect(errors.addError.calledWith(errorMessages.evidence.unique)).to.be
+      expect(errors.addError.calledWith(errorMessages.evidence.uniqueVA)).to.be
         .true;
     });
     it('should NOT show an error for duplicate locations when on a different index', () => {
       const errors = { addError: sinon.spy() };
       validateVaUnique(errors, {}, getLocations('LOCATION 2'), _, _, 0);
-      expect(errors.addError.calledWith(errorMessages.evidence.unique)).to.be
+      expect(errors.addError.calledWith(errorMessages.evidence.uniqueVA)).to.be
         .false;
     });
 
@@ -549,14 +549,14 @@ describe('Private evidence', () => {
         {
           providerFacilityName: 'Facility 1',
           providerFacilityAddress,
-          issues: ['Ankylosis of knee'],
+          issues: ['test 1', 'test 2'],
           treatmentDateRange: { from: '2001-01-01', to: '2011-01-01' },
         },
         {},
         {
           providerFacilityName: 'Facility 2',
           providerFacilityAddress,
-          issues: ['Ankylosis of knee'],
+          issues: ['test 1', 'test 2'],
           treatmentDateRange: { from: '2002-02-02', to: '2012-02-02' },
         },
         {
@@ -568,7 +568,7 @@ describe('Private evidence', () => {
         {
           providerFacilityName: name3,
           providerFacilityAddress,
-          issues: ['AnKyLoSiS of KNEE'],
+          issues: ['TeSt 2', 'tEsT 1'],
           treatmentDateRange: { from: '2001-01-01', to: '2011-01-01' },
         },
       ],
@@ -586,8 +586,8 @@ describe('Private evidence', () => {
     it('should SHOW an error for duplicate Facilities on the indexed page', () => {
       const errors = { addError: sinon.spy() };
       validatePrivateUnique(errors, _, getFacilities('FACILITY 1'), _, _, 4);
-      expect(errors.addError.calledWith(errorMessages.evidence.unique)).to.be
-        .true;
+      expect(errors.addError.calledWith(errorMessages.evidence.uniquePrivate))
+        .to.be.true;
     });
     it('should NOT show a duplicate Facility error on a different index', () => {
       const errors = { addError: sinon.spy() };

--- a/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
@@ -133,6 +133,10 @@ describe('VA evidence', () => {
       expect(isEmptyVaEntry({ evidenceDates: {} })).to.be.true;
       expect(isEmptyVaEntry({ evidenceDates: { from: '--', to: '--' } })).to.be
         .true;
+      expect(isEmptyVaEntry({ evidenceDates: { from: '-0-0', to: '-0-0' } })).to
+        .be.true;
+      expect(isEmptyVaEntry({ evidenceDates: { from: '-00-00', to: '--' } })).to
+        .be.true;
       expect(
         isEmptyVaEntry({
           locationAndName: '',
@@ -443,6 +447,18 @@ describe('Private evidence', () => {
       expect(
         isEmptyPrivateEntry({ treatmentDateRange: { from: '--', to: '--' } }),
       ).to.be.true;
+
+      expect(
+        isEmptyPrivateEntry({
+          treatmentDateRange: { from: '-0-0', to: '-0-0' },
+        }),
+      ).to.be.true;
+      expect(
+        isEmptyPrivateEntry({
+          treatmentDateRange: { from: '-00-00', to: '--' },
+        }),
+      ).to.be.true;
+
       expect(
         isEmptyPrivateEntry({
           providerFacilityName: '',

--- a/src/applications/appeals/995/validations/evidence.js
+++ b/src/applications/appeals/995/validations/evidence.js
@@ -10,6 +10,7 @@ import {
 } from '../constants';
 import { getSelected, getIssueName } from '../utils/helpers';
 import { validateDate } from './date';
+import { fixDateFormat } from '../utils/replace';
 
 /* *** VA *** */
 export const validateVaLocation = (errors, data) => {
@@ -61,8 +62,8 @@ const buildVaLocationString = (data, joiner = '') =>
   [
     data.locationAndName || '',
     ...(data.issues || []),
-    (data.evidenceDates?.from || '').replace(REGEX_EMPTY_DATE, ''),
-    (data.evidenceDates?.to || '').replace(REGEX_EMPTY_DATE, ''),
+    fixDateFormat(data.evidenceDates?.from || '').replace(REGEX_EMPTY_DATE, ''),
+    fixDateFormat(data.evidenceDates?.to || '').replace(REGEX_EMPTY_DATE, ''),
   ].join(joiner);
 
 // Check if VA evidence object is empty
@@ -180,8 +181,14 @@ const buildPrivateString = (data, joiner = '') =>
     data.providerFacilityName || '',
     ...Object.values(data.providerFacilityAddress || {}),
     ...(data.issues || []),
-    (data.treatmentDateRange?.from || '').replace(REGEX_EMPTY_DATE, ''),
-    (data.treatmentDateRange?.to || '').replace(REGEX_EMPTY_DATE, ''),
+    fixDateFormat(data.treatmentDateRange?.from || '').replace(
+      REGEX_EMPTY_DATE,
+      '',
+    ),
+    fixDateFormat(data.treatmentDateRange?.to || '').replace(
+      REGEX_EMPTY_DATE,
+      '',
+    ),
   ].join(joiner);
 
 export const isEmptyPrivateEntry = (checkData = {}) => {

--- a/src/applications/appeals/995/validations/evidence.js
+++ b/src/applications/appeals/995/validations/evidence.js
@@ -12,6 +12,10 @@ import { getSelected, getIssueName } from '../utils/helpers';
 import { validateDate } from './date';
 import { fixDateFormat } from '../utils/replace';
 
+// Needed for uniqueness string comparison
+const sortIssues = issues =>
+  issues.map(issue => (issue || '').toLowerCase()).sort();
+
 /* *** VA *** */
 export const validateVaLocation = (errors, data) => {
   const { locationAndName } = data || {};
@@ -61,7 +65,7 @@ export const validateVaToDate = (errors, data) => {
 const buildVaLocationString = (data, joiner = '') =>
   [
     data.locationAndName || '',
-    ...(data.issues || []),
+    ...sortIssues(data.issues || []),
     fixDateFormat(data.evidenceDates?.from || '').replace(REGEX_EMPTY_DATE, ''),
     fixDateFormat(data.evidenceDates?.to || '').replace(REGEX_EMPTY_DATE, ''),
   ].join(joiner);
@@ -94,7 +98,7 @@ export const validateVaUnique = (
       return firstIndex !== lastIndex && lastIndex === currentIndex;
     });
     if (hasDuplicate) {
-      errors.addError(errorMessages.evidence.unique);
+      errors.addError(errorMessages.evidence.uniqueVA);
     }
   }
 };
@@ -180,7 +184,7 @@ const buildPrivateString = (data, joiner = '') =>
   [
     data.providerFacilityName || '',
     ...Object.values(data.providerFacilityAddress || {}),
-    ...(data.issues || []),
+    ...sortIssues(data.issues || []),
     fixDateFormat(data.treatmentDateRange?.from || '').replace(
       REGEX_EMPTY_DATE,
       '',
@@ -222,7 +226,7 @@ export const validatePrivateUnique = (
       return firstIndex !== lastIndex && lastIndex === currentIndex;
     });
     if (hasDuplicate) {
-      errors.addError(errorMessages.evidence.unique);
+      errors.addError(errorMessages.evidence.uniquePrivate);
     }
   }
 };


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > A recent submission showed that a Veteran was attempting to submit a duplicate VA location entry. They tried 7 times before discovering and removing the duplicate, then made a successful submission. We don't retain the data, so this is a best guess that they may have entered a duplicate treatment date because the front end does allow entering single digit month and days. A duplication may have occurred when one entry included a single digit format and the other included leading zeros, e.g. `1-1-2023` and `01-01-2023`. Additionally, the selected conditions need to be normalized and sorted prior to string comparison.
  >
  > To prevent confusion, the error message for non-unique entries was updated to include all fields to check since only the name field is showing as having an error
- _(If bug, how to reproduce)_
  > In staging, check to see if you're allowed to enter the same VA or private evidence entry but only vary the treatment date leading zeros
- _(What is the solution, why is this the solution)_
  > To check uniqueness, a combined string comparison of all field is done, so normalizing the dates will prevent entries with and without leading zeros from getting around this check
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#57927](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57927)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Without normalization, non-unique entries were being submitted - the dates were normalized prior to submission
- _Describe the steps required to verify your changes are working as expected_
  > Apply date normalization prior to string comparison
- _Describe the tests completed and the results_
  > Updated unit tests; all passing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Updated error messages to include all fields

<img width="555" alt="non-unique VA location showing an error message of You must enter a location, condition and dates you haven't already entered" src="https://user-images.githubusercontent.com/136959/236485815-bea0cfea-923d-4ac1-9308-a37f02f43577.png">

<img width="552" alt="non-unique private facility showing an error message of You must enter a provider, address, condition and dates you haven't already entered" src="https://user-images.githubusercontent.com/136959/236485813-786873e7-f6b3-43d1-9ae5-8a317c4f2be3.png">

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
