### PR TITLE
rename prop to session timeout modal

### DIFF
--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -143,7 +143,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-  initializeProfile,
+  onExtendSession: initializeProfile,
 };
 
 export default connect(
@@ -152,8 +152,8 @@ export default connect(
 )(SessionTimeoutModal);
 
 SessionTimeoutModal.propTypes = {
-  isLoggedIn: PropTypes.bool,
-  initializeProfile: PropTypes.func.isRequired,
+  onExtendSession: PropTypes.func.isRequired,
   authenticatedWithOAuth: PropTypes.bool,
+  isLoggedIn: PropTypes.bool,
   serviceName: PropTypes.string,
 };


### PR DESCRIPTION
## Summary

This PR fixes a bug in SessionTimeoutModal in which a prop had the wrong name and was therefore not found when called.

## Related issue(s)
[55731](https://app.zenhub.com/workspaces/platform-tech-team-2-633efe4ca5a428e5294d7ade/issues/gh/department-of-veterans-affairs/va.gov-team/55731)

## Testing done
local testing