### PR TITLE
VA-13505: Replace facilities breadcrumbs React with web component

### DIFF
--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -6,7 +6,6 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import { validateIdString } from '../utils/helpers';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 class FacilityLocatorApp extends React.Component {
   renderBreadcrumbs(location, selectedResult) {
@@ -42,18 +41,22 @@ class FacilityLocatorApp extends React.Component {
 
     if (validateIdString(location.pathname, '/facility') && selectedResult) {
       crumbs.push(
-        <Link to={`/${selectedResult.id}`} key={selectedResult.id}>
-          {selectedResult.attributes?.name}
-        </Link>,
+        <li>
+          <Link to={`/${selectedResult.id}`} key={selectedResult.id}>
+            {selectedResult.attributes?.name}
+          </Link>
+        </li>,
       );
     } else if (
       validateIdString(location.pathname, '/provider') &&
       selectedResult
     ) {
       crumbs.push(
-        <Link to={`/${selectedResult.id}`} key={selectedResult.id}>
-          Provider Details
-        </Link>,
+        <li>
+          <Link to={`/${selectedResult.id}`} key={selectedResult.id}>
+            Provider Details
+          </Link>
+        </li>,
       );
     }
 
@@ -65,9 +68,9 @@ class FacilityLocatorApp extends React.Component {
 
     return (
       <div>
-        <Breadcrumbs selectedFacility={selectedResult}>
+        <va-breadcrumbs>
           {this.renderBreadcrumbs(location, selectedResult)}
-        </Breadcrumbs>
+        </va-breadcrumbs>
         <div className="row">
           <DowntimeNotification
             appTitle="facility locator tool"


### PR DESCRIPTION
## Summary

This replaces the React `Breadcrumbs` components with the [`va-breadcrumbs` web components.](https://design.va.gov/storybook/?path=/docs/components-va-breadcrumbs--default). The `selectedFacility` property is not needed, and any breadcrumbs after the third need to be wrapped in `li` tags to be properly marked if they're active.

## Related issue(s)

Closes [13505](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13505)
Relates to [13179](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13179)

## Testing done

Visual, checked the [facility search page](http://localhost:3001/find-locations/) and a [facility listing page](http://localhost:3001/find-locations/facility/vba_314i) to make sure the right breadcrumbs still appear, and the last breadcrumb (that matches with the current page) is plain text instead of a link.

<img width="1093" alt="Screen Shot 2023-05-05 at 4 38 09 PM" src="https://user-images.githubusercontent.com/10790736/236565084-6cc70dfe-6768-4f15-898b-1b3bd80550a9.png">
<img width="1080" alt="Screen Shot 2023-05-05 at 4 38 14 PM" src="https://user-images.githubusercontent.com/10790736/236565085-a4499a5b-ce8c-4d96-ab44-9457ddd065d2.png">

## What areas of the site does it impact?

Facility search and facility details.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.go header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
