### PR TITLE
Update Health Care Application disability rating API

### DIFF
--- a/src/applications/hca/reducers/total-disabilities.js
+++ b/src/applications/hca/reducers/total-disabilities.js
@@ -27,7 +27,7 @@ function totalRating(state = initialState, action) {
       return {
         ...state,
         loading: false,
-        totalDisabilityRating: action.response.userPercentOfDisability,
+        totalDisabilityRating: action.response.user_percent_of_disability,
         disabilityDecisionTypeName: action.response.disabilityDecisionTypeName,
       };
     default:

--- a/src/applications/hca/tests/e2e/hca-identity-dob-data.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-identity-dob-data.cypress.spec.js
@@ -16,13 +16,14 @@ describe('HCA-User-Authenticated-Identity-Without-DOB', () => {
       statusCode: 404,
       body: mockEnrollmentStatus,
     }).as('mockEnrollmentStatus');
-    cy.intercept('/v0/disability_compensation_form/rating_info', {
+    cy.intercept('/v0/health_care_applications/rating_info', {
       statusCode: 200,
       body: {
         data: {
           id: '',
-          type: 'evss_disability_compensation_form_rating_info_responses',
-          attributes: { userPercentOfDisability: 0 },
+          type: 'hash',
+          // eslint-disable-next-line camelcase
+          attributes: { user_percent_of_disability: 0 },
         },
       },
     }).as('mockDisabilityRating');
@@ -80,13 +81,14 @@ describe('HCA-User-Authenticated-Identity-With-DOB', () => {
       statusCode: 404,
       body: mockEnrollmentStatus,
     }).as('mockEnrollmentStatus');
-    cy.intercept('/v0/disability_compensation_form/rating_info', {
+    cy.intercept('/v0/health_care_applications/rating_info', {
       statusCode: 200,
       body: {
         data: {
           id: '',
-          type: 'evss_disability_compensation_form_rating_info_responses',
-          attributes: { userPercentOfDisability: 0 },
+          type: 'hash',
+          // eslint-disable-next-line camelcase
+          attributes: { user_percent_of_disability: 0 },
         },
       },
     }).as('mockDisabilityRating');

--- a/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-shortform.cypress.spec.js
@@ -9,7 +9,6 @@ import minTestData from './fixtures/data/minimal-test.json';
 import * as shortformHelpers from './helpers';
 
 const testData = minTestData.data;
-
 const disabilityRating = 90;
 
 describe('HCA-Shortform-Authenticated-High-Disability', () => {
@@ -26,13 +25,14 @@ describe('HCA-Shortform-Authenticated-High-Disability', () => {
       statusCode: 200,
       body: prefillAiq,
     }).as('mockSip');
-    cy.intercept('/v0/disability_compensation_form/rating_info', {
+    cy.intercept('/v0/health_care_applications/rating_info', {
       statusCode: 200,
       body: {
         data: {
           id: '',
-          type: 'evss_disability_compensation_form_rating_info_responses',
-          attributes: { userPercentOfDisability: disabilityRating },
+          type: 'hash',
+          // eslint-disable-next-line camelcase
+          attributes: { user_percent_of_disability: disabilityRating },
         },
       },
     }).as('mockDisabilityRating');
@@ -183,13 +183,14 @@ describe('HCA-Shortform-Authenticated-Low-Disability', () => {
       statusCode: 404,
       body: mockEnrollmentStatus,
     }).as('mockEnrollmentStatus');
-    cy.intercept('/v0/disability_compensation_form/rating_info', {
+    cy.intercept('/v0/health_care_applications/rating_info', {
       statusCode: 200,
       body: {
         data: {
           id: '',
-          type: 'evss_disability_compensation_form_rating_info_responses',
-          attributes: { userPercentOfDisability: 40 },
+          type: 'hash',
+          // eslint-disable-next-line camelcase
+          attributes: { user_percent_of_disability: 40 },
         },
       },
     }).as('mockDisabilityRating');

--- a/src/applications/hca/tests/reducers/total-disabilities.unit.spec.js
+++ b/src/applications/hca/tests/reducers/total-disabilities.unit.spec.js
@@ -40,7 +40,8 @@ describe('totalDisabilities reducer', () => {
       type: FETCH_TOTAL_RATING_SUCCEEDED,
       response: {
         disabilityDecisionTypeName: 'Service Connected',
-        userPercentOfDisability: 80,
+        // eslint-disable-next-line camelcase
+        user_percent_of_disability: 80,
       },
     });
     expect(state.loading).to.equal(false);

--- a/src/applications/hca/utils/actions.js
+++ b/src/applications/hca/utils/actions.js
@@ -32,7 +32,7 @@ export const SET_DISMISSED_HCA_NOTIFICATION = 'SET_DISMISSED_HCA_NOTIFICATION';
 
 export const SHOW_HCA_REAPPLY_CONTENT = 'SHOW_HCA_REAPPLY_CONTENT';
 
-// action types related to calling GET /disability_compensation_form/rating_info'
+// action types related to calling GET health_care_applications/rating_info'
 export const FETCH_TOTAL_RATING_STARTED = 'FETCH_TOTAL_RATING_STARTED';
 export const FETCH_TOTAL_RATING_SUCCEEDED = 'FETCH_TOTAL_RATING_SUCCEEDED';
 export const FETCH_TOTAL_RATING_FAILED = 'FETCH_TOTAL_RATING_FAILED';
@@ -225,7 +225,7 @@ export function fetchTotalDisabilityRating() {
     dispatch({
       type: FETCH_TOTAL_RATING_STARTED,
     });
-    const response = await getData('/disability_compensation_form/rating_info');
+    const response = await getData('/health_care_applications/rating_info');
 
     const error = getResponseError(response);
     if (error) {


### PR DESCRIPTION
## Discription
The current EVSS disability rating API has been deprecated and migrated to BGS. This PR updates this API endpoint in the fetch action in the 1010EZ in order to get the correct value for use with short form functions in the form. 

## Related issue(s)
department-of-veterans-affairs/va.gov-team#57546

## Testing done
- [x] Unit tests
- [x] Cypress tests

## Acceptance criteria
- [ ] Total disability rating comes through as an integer between 0 and 100
- [ ] Endpoint does not spit out any errors relating to rating found or internal error