### PR TITLE
VACMS-11482 Pull most footer data from Drupal

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -1,325 +1,554 @@
 {
-  "footerData": [
-    {
-      "column": 1,
-      "href": "https://www.va.gov/homeless/",
-      "order": 1,
-      "target": "",
-      "title": "Homeless Veterans"
+  "footerData": {
+    "footerColumnsData": {
+      "description": "Displayed in VA.gov global & injected footer; 3-column list of footer links.",
+      "links": [
+        {
+          "description": "Column 1",
+          "entity": {
+            "parent": null,
+            "linkedEntity": null,
+            "expanded": true,
+            "label": "Column 1",
+            "links": [
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/homeless/"
+                },
+                "description": "Homeless Veterans",
+                "label": "Homeless Veterans"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/womenvet/"
+                },
+                "description": "Women Veterans",
+                "label": "Women Veterans"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/centerforminorityveterans/"
+                },
+                "description": "Minority Veterans",
+                "label": "Minority Veterans"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.patientcare.va.gov/lgbt/"
+                },
+                "description": "LGBTQ+ Veterans",
+                "label": "LGBTQ+ Veterans"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.ptsd.va.gov"
+                },
+                "description": "PTSD",
+                "label": "PTSD"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.mentalhealth.va.gov"
+                },
+                "description": "Mental health",
+                "label": "Mental health"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/adaptivesports/"
+                },
+                "description": "Adaptive sports and special events",
+                "label": "Adaptive sports and special events"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/outreach-and-events/events/"
+                },
+                "description": "VA outreach events",
+                "label": "VA outreach events"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.nrd.gov"
+                },
+                "description": "National Resource Directory",
+                "label": "National Resource Directory"
+              }
+            ],
+            "url": {
+              "path": ""
+            }
+          }
+        },
+        {
+          "description": "Column 2",
+          "entity": {
+            "parent": null,
+            "linkedEntity": null,
+            "expanded": true,
+            "label": "Column 2",
+            "links": [
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/find-forms/"
+                },
+                "description": "VA forms"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.accesstocare.va.gov/"
+                },
+                "description": "VA health care access and quality",
+                "label": "VA health care access and quality"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/ogc/accreditation.asp"
+                },
+                "description": "Accredited claims representatives",
+                "label": "Accredited claims representatives"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.mobile.va.gov/appstore/"
+                },
+                "description": "VA mobile apps",
+                "label": "VA mobile apps"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/statedva.htm"
+                },
+                "description": "State Veterans Affairs offices",
+                "label": "State Veterans Affairs offices"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/landing2_business.htm"
+                },
+                "description": "Doing business with VA",
+                "label": "Doing business with VA"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/jobs/"
+                },
+                "description": "Careers at VA",
+                "label": "Careers at VA"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/outreach-and-events/outreach-materials/"
+                },
+                "description": "VA outreach materials",
+                "label": "VA outreach materials"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/welcome-kit/"
+                },
+                "description": "Your VA welcome kit",
+                "label": "Your VA welcome kit"
+              }
+            ],
+            "url": {
+              "path": ""
+            }
+          }
+        },
+        {
+          "description": "Column 3",
+          "entity": {
+            "parent": null,
+            "linkedEntity": null,
+            "expanded": true,
+            "label": "Column 3",
+            "links": [
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.news.va.gov/"
+                },
+                "description": "VA news",
+                "label": "VA news"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/opa/pressrel/"
+                },
+                "description": "Press releases",
+                "label": "Press releases"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://public.govdelivery.com/accounts/USVA/subscriber/new/"
+                },
+                "description": "Email updates",
+                "label": "Email updates"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.facebook.com/VeteransAffairs"
+                },
+                "description": "Facebook",
+                "label": "Facebook"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.instagram.com/deptvetaffairs/"
+                },
+                "description": "Instagram",
+                "label": "Instagram"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.twitter.com/DeptVetAffairs/"
+                },
+                "description": "Twitter",
+                "label": "Twitter"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.flickr.com/photos/VeteransAffairs/"
+                },
+                "description": "Flickr",
+                "label": "Flickr"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.youtube.com/user/DeptVetAffairs"
+                },
+                "description": "YouTube",
+                "label": "YouTube"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/opa/socialmedia.asp"
+                },
+                "description": "All VA social media",
+                "label": "All VA social media"
+              },
+              {
+                "entity": {
+                  "parent": null,
+                  "linkedEntity": null
+                },
+                "expanded": false,
+                "url": {
+                  "path": "https://www.va.gov/performance-dashboard/"
+                },
+                "description": "VA performance dashboard",
+                "label": "VA performance dashboard"
+              }
+            ],
+            "url": {
+              "path": ""
+            }
+          }
+        }
+      ],
+      "name": "VA.gov Footer"
     },
-    {
-      "column": 1,
-      "href": "https://www.va.gov/womenvet/",
-      "order": 2,
-      "target": "",
-      "title": "Women Veterans"
-    },
-    {
-      "column": 1,
-      "href": "https://www.va.gov/centerforminorityveterans/",
-      "order": 3,
-      "target": "",
-      "title": "Minority Veterans"
-    },
-    {
-      "column": 1,
-      "href": "https://www.patientcare.va.gov/lgbt/",
-      "order": 4,
-      "target": "",
-      "title": "LGBTQ+ Veterans",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 1,
-      "href": "https://www.ptsd.va.gov",
-      "order": 5,
-      "target": "",
-      "title": "PTSD",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 1,
-      "href": "https://www.mentalhealth.va.gov",
-      "order": 6,
-      "target": "",
-      "title": "Mental health",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 1,
-      "href": "https://www.va.gov/adaptivesports/",
-      "order": 7,
-      "target": "",
-      "title": "Adaptive sports and special events"
-    },
-    {
-      "column": 1,
-      "href": "https://www.va.gov/outreach-and-events/events/",
-      "order": 8,
-      "target": null,
-      "title": "VA outreach events"
-    },
-    {
-      "column": 1,
-      "href": "https://www.nrd.gov",
-      "order": 9,
-      "target": "_blank",
-      "title": "National Resource Directory",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/find-forms/",
-      "order": 1,
-      "target": null,
-      "title": "VA forms"
-    },
-    {
-      "column": 2,
-      "href": "https://www.accesstocare.va.gov/",
-      "order": 2,
-      "target": "_blank",
-      "title": "VA health care access and quality",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/ogc/accreditation.asp",
-      "order": 3,
-      "target": null,
-      "title": "Accredited claims representatives"
-    },
-    {
-      "column": 2,
-      "href": "https://www.mobile.va.gov/appstore/",
-      "order": 4,
-      "target": "_blank",
-      "title": "VA mobile apps",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/statedva.htm",
-      "order": 5,
-      "target": null,
-      "title": "State Veterans Affairs offices"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/landing2_business.htm",
-      "order": 6,
-      "target": null,
-      "title": "Doing business with VA"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/jobs/",
-      "order": 7,
-      "target": null,
-      "title": "Careers at VA"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/outreach-and-events/outreach-materials/",
-      "order": 8,
-      "target": null,
-      "title": "VA outreach materials"
-    },
-    {
-      "column": 2,
-      "href": "https://www.va.gov/welcome-kit/",
-      "order": 9,
-      "target": null,
-      "title": "Your VA welcome kit"
-    },
-    {
-      "column": 3,
-      "href": "https://www.news.va.gov/",
-      "order": 1,
-      "target": "_blank",
-      "title": "VA news",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.va.gov/opa/pressrel/",
-      "order": 2,
-      "target": null,
-      "title": "Press releases"
-    },
-    {
-      "column": 3,
-      "href": "https://public.govdelivery.com/accounts/USVA/subscriber/new/",
-      "order": 3,
-      "target": "_blank",
-      "title": "Email updates",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.facebook.com/VeteransAffairs",
-      "order": 4,
-      "target": "_blank",
-      "title": "Facebook",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.instagram.com/deptvetaffairs/",
-      "order": 5,
-      "target": "_blank",
-      "title": "Instagram",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.twitter.com/DeptVetAffairs/",
-      "order": 6,
-      "target": "_blank",
-      "title": "Twitter",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.flickr.com/photos/VeteransAffairs/",
-      "order": 7,
-      "target": "_blank",
-      "title": "Flickr",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.youtube.com/user/DeptVetAffairs",
-      "order": 8,
-      "target": "_blank",
-      "title": "YouTube",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 3,
-      "href": "https://www.va.gov/opa/socialmedia.asp",
-      "order": 9,
-      "target": null,
-      "title": "All VA social media"
-    },
-    {
-      "column": 3,
-      "href": "https://www.va.gov/performance-dashboard/",
-      "order": 10,
-      "target": null,
-      "title": "VA performance dashboard"
-    },
-    {
-      "column": 4,
-      "href": "https://www.va.gov/resources/",
-      "order": 1,
-      "target": null,
-      "title": "Resources and support"
-    },
-    {
-      "column": 4,
-      "href": "https://www.va.gov/contact-us/",
-      "order": 2,
-      "target": null,
-      "title": "Contact us"
-    },
-    {
-      "column": 4,
-      "label": "Call us",
-      "href": "tel:18006982411",
-      "order": 3,
-      "target": null,
-      "title": "800-698-2411"
-    },
-    {
-      "ariaLabel": "TTY: 7 1 1.",
-      "column": 4,
-      "href": "tel:+1711",
-      "order": 4,
-      "target": null,
-      "title": "TTY: 711"
-    },
-    {
-      "column": 4,
-      "label": "Visit a medical center or regional office",
-      "href": "https://www.va.gov/find-locations/",
-      "order": 5,
-      "target": null,
-      "title": "Find a VA location"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/accessibility-at-va",
-      "order": 1,
-      "target": null,
-      "title": "Accessibility",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint/",
-      "order": 2,
-      "target": null,
-      "title": "Civil Rights"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/foia/",
-      "order": 3,
-      "target": null,
-      "title": "Freedom of Information Act (FOIA)"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/oig/",
-      "order": 4,
-      "target": null,
-      "title": "Office of Inspector General"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/opa/Plain_Language.asp",
-      "order": 5,
-      "target": null,
-      "title": "Plain language"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/privacy-policy/",
-      "order": 6,
-      "target": null,
-      "title": "Privacy, policies, and legal information"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/privacy/",
-      "order": 7,
-      "target": null,
-      "title": "VA Privacy Service"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/ormdi/NOFEAR_Select.asp",
-      "order": 8,
-      "target": null,
-      "title": "No FEAR Act Data"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.usa.gov/",
-      "order": 9,
-      "target": "_blank",
-      "title": "USA.gov",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": "bottom_rail",
-      "href": "https://www.va.gov/veterans-portrait-project/",
-      "order": 10,
-      "target": null,
-      "title": "Veterans Portrait Project"
+    "hardCodedFooterData": [
+      {
+        "column": 4,
+        "href": "https://www.va.gov/resources/",
+        "order": 1,
+        "target": null,
+        "title": "Resources and support"
+      },
+      {
+        "column": 4,
+        "href": "https://www.va.gov/contact-us/",
+        "order": 2,
+        "target": null,
+        "title": "Contact us"
+      },
+      {
+        "column": 4,
+        "label": "Call us",
+        "href": "tel:18006982411",
+        "order": 3,
+        "target": null,
+        "title": "800-698-2411"
+      },
+      {
+        "ariaLabel": "TTY: 7 1 1.",
+        "column": 4,
+        "href": "tel:+1711",
+        "order": 4,
+        "target": null,
+        "title": "TTY: 711"
+      },
+      {
+        "column": 4,
+        "label": "Visit a medical center or regional office",
+        "href": "https://www.va.gov/find-locations/",
+        "order": 5,
+        "target": null,
+        "title": "Find a VA location"
+      }
+    ],
+    "bottomRailFooterData": {
+      "description": "Displayed in VA.gov global & injected footer; horizontal list of links at the bottom of the page.",
+      "links": [
+        {
+          "url": {
+            "path": "https://www.va.gov/accessibility-at-va"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Accessibility"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Civil Rights"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/foia/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Freedom of Information Act (FOIA)"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/oig/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Office of Inspector General"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/opa/Plain_Language.asp"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Plain language"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/privacy-policy/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Privacy, policies, and legal information"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/privacy/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "VA Privacy Service"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/ormdi/NOFEAR_Select.asp"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "No FEAR Act Data"
+        },
+        {
+          "url": {
+            "path": "https://www.usa.gov/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "USA.gov"
+        },
+        {
+          "url": {
+            "path": "https://www.va.gov/veterans-portrait-project/"
+          },
+          "entity": {
+            "parent": null,
+            "linkedEntity": null
+          },
+          "expanded": false,
+          "links": [],
+          "description": "Veterans Portrait Project"
+        }
+      ]
     }
-  ],
+  },
   "megaMenuData": [
     {
       "title": "VA benefits and health care",

--- a/src/platform/site-wide/va-footer/components/Footer.jsx
+++ b/src/platform/site-wide/va-footer/components/Footer.jsx
@@ -96,7 +96,7 @@ const mapStateToProps = state => ({
 });
 
 Footer.propTypes = {
-  footerData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  footerData: PropTypes.object.isRequired,
   minimalFooter: PropTypes.bool.isRequired,
   dispatchLanguageSelection: PropTypes.func,
   languageCode: PropTypes.string,

--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -83,8 +83,57 @@ function generateSuperLinks(groupedList) {
   );
 }
 
+const FOOTER_SECTIONS = {
+  BOTTOM_RAIL: 'bottomRailFooterData',
+  FOOTER_COLUMNS: 'footerColumnsData',
+  HARD_CODED: 'hardCodedFooterData',
+};
+
+export const formatLink = (link, linkIndex, columnNumber = null) => {
+  return {
+    column: columnNumber,
+    href: link?.url?.path,
+    order: linkIndex + 1,
+    target: null,
+    title: link?.description,
+  };
+};
+
+/**
+ * We're getting columns 1 - 3 and the bottom rail footer data from Drupal
+ * Column 4 (Need help column) is still coming hardcoded from content-build
+ * This utility helps consistently format the data for consumption
+ */
+export const reformatDrupalFooterData = sections => {
+  const formattedData = [];
+
+  Object.keys(sections).forEach(section => {
+    const sectionData = sections[section];
+
+    // Format columns 1 - 3 of data
+    if (section === FOOTER_SECTIONS.FOOTER_COLUMNS) {
+      sectionData?.links?.forEach((column, columnIndex) => {
+        column?.links?.forEach((link, linkIndex) => {
+          formattedData.push(formatLink(link, linkIndex, columnIndex + 1));
+        });
+      });
+      // Format bottom rail of data
+    } else if (section === FOOTER_SECTIONS.BOTTOM_RAIL) {
+      sectionData?.links?.forEach((link, linkIndex) => {
+        formattedData.push(formatLink(link, linkIndex, 'bottom_rail'));
+      });
+      // Format column 4 of data
+    } else {
+      formattedData.push(...sectionData);
+    }
+  });
+
+  return formattedData;
+};
+
 export function createLinkGroups(links) {
-  const groupedList = groupBy(replaceDomainsInData(links), 'column');
+  const formattedList = reformatDrupalFooterData(links);
+  const groupedList = groupBy(replaceDomainsInData(formattedList), 'column');
 
   return {
     [FOOTER_COLUMNS.PROGRAMS]: generateLinkItems(

--- a/src/platform/site-wide/va-footer/tests/helpers.unit.spec.js
+++ b/src/platform/site-wide/va-footer/tests/helpers.unit.spec.js
@@ -1,0 +1,120 @@
+import { expect } from 'chai';
+import { reformatDrupalFooterData } from '../helpers';
+
+describe('footer utilities', () => {
+  const links = {
+    bottomRailFooterData: {
+      description: 'bottom rail footer data',
+      links: [
+        {
+          description: 'Accessibility',
+          url: {
+            path: 'https://www.va.gov/accessibility-at-va',
+          },
+        },
+        {
+          description: 'Civil Rights',
+          url: {
+            path:
+              'https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint',
+          },
+        },
+      ],
+    },
+    footerColumnsData: {
+      description: 'footer columns data',
+      links: [
+        {
+          description: 'Column 1',
+          links: [
+            {
+              description: 'Women Veterans',
+              url: {
+                path: 'https://www.va.gov/womenvet',
+              },
+            },
+          ],
+        },
+        {
+          description: 'Column 2',
+          links: [
+            {
+              description: 'VA forms',
+              url: {
+                path: '/find-forms',
+              },
+            },
+          ],
+        },
+        {
+          description: 'Column 3',
+          links: [
+            {
+              description: 'VA news',
+              url: {
+                path: 'https://www.news.va.org',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    hardCodedFooterData: [
+      {
+        column: 4,
+        href: 'https://www.va.gov/resources',
+        order: 1,
+        title: 'Resources and support',
+      },
+    ],
+  };
+
+  describe('reformatDrupalFooterData', () => {
+    it('should properly return an array of formatted links for the footer', () => {
+      expect(reformatDrupalFooterData(links)).to.deep.equal([
+        {
+          column: 'bottom_rail',
+          href: 'https://www.va.gov/accessibility-at-va',
+          order: 1,
+          target: null,
+          title: 'Accessibility',
+        },
+        {
+          column: 'bottom_rail',
+          href:
+            'https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint',
+          order: 2,
+          target: null,
+          title: 'Civil Rights',
+        },
+        {
+          column: 1,
+          href: 'https://www.va.gov/womenvet',
+          order: 1,
+          target: null,
+          title: 'Women Veterans',
+        },
+        {
+          column: 2,
+          href: '/find-forms',
+          order: 1,
+          target: null,
+          title: 'VA forms',
+        },
+        {
+          column: 3,
+          href: 'https://www.news.va.org',
+          order: 1,
+          target: null,
+          title: 'VA news',
+        },
+        {
+          column: 4,
+          href: 'https://www.va.gov/resources',
+          order: 1,
+          title: 'Resources and support',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

We are now pulling in the first 3 columns and the bottom rail of footer data from Drupal. Changes are also being made to `content-build`. Modifications were made to the utility functions that transform footer data to accommodate the new structure coming from Drupal.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11482

## Testing done

- Run `vets-website` and `content-build` (both on `11482-drupalize-footer`) together
- First check va.gov (`localhost:3002`). Ensure all of the footer is correct and functional
- Then check injected footer scenario. Ensure all of the footer is correct and functional

## Screenshots

Before - Desktop 
<img width="800" alt="Screenshot 2023-05-08 at 12 10 45 PM" src="https://user-images.githubusercontent.com/19175324/236887435-7af011ea-4bf4-4453-b1f2-ef4cf54acb0e.png">

After - Desktop
<img width="800" alt="Screenshot 2023-05-08 at 12 11 01 PM" src="https://user-images.githubusercontent.com/19175324/236887460-795a6dc8-c05f-46a5-af35-05f890d4e500.png">

Before - Mobile
<img width="300" alt="Screenshot 2023-05-08 at 12 11 56 PM" src="https://user-images.githubusercontent.com/19175324/236887679-132b1d84-c101-488c-8932-8c57723e8d49.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 11 48 PM" src="https://user-images.githubusercontent.com/19175324/236887686-5719daf1-ec6d-4a0c-8495-34d9f05c6f25.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 11 42 PM" src="https://user-images.githubusercontent.com/19175324/236887688-6d0f71a7-025b-4240-8f92-08b639d92e22.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 11 35 PM" src="https://user-images.githubusercontent.com/19175324/236887691-644e8397-f31d-4129-b959-c223095c9dfa.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 11 28 PM" src="https://user-images.githubusercontent.com/19175324/236887694-118746c5-2844-449a-b59f-aca8cbf0ee3a.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 11 22 PM" src="https://user-images.githubusercontent.com/19175324/236887696-0e3562fa-6d82-42b0-a198-8502693fcc66.png">

After - Mobile
<img width="300" alt="Screenshot 2023-05-08 at 12 12 39 PM" src="https://user-images.githubusercontent.com/19175324/236889126-478ed93d-a8ac-4b92-a5ae-de5d3c7fd23f.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 12 34 PM" src="https://user-images.githubusercontent.com/19175324/236889130-603a21d7-e353-42cf-8fbf-7565fce427f5.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 12 26 PM" src="https://user-images.githubusercontent.com/19175324/236889131-32065339-5a4a-4b0a-97d0-742beb846675.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 12 20 PM" src="https://user-images.githubusercontent.com/19175324/236889134-4af03eb9-6080-4bba-b75b-090112206f90.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 12 14 PM" src="https://user-images.githubusercontent.com/19175324/236889138-a24412ec-9beb-4b44-b968-86ab9bf0e5f3.png">
<img width="300" alt="Screenshot 2023-05-08 at 12 12 07 PM" src="https://user-images.githubusercontent.com/19175324/236889142-e6729060-f5d2-45d0-b234-eec8b8904b77.png">

## What areas of the site does it impact?

Footer, both for va.gov sites and injected footer TeamSites.

## Acceptance criteria
- [x] All links work as expected in the current tab – this is different from production but consistent with design system guidelines
- [x] disabled menu links and unpublished nodes are not included in the footer
- [x] rel attributes do not include "noopener" (see https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11482#issuecomment-1319030535)
- [x] rel attributes do not include "noreferrer"
- [x] Column layout of footer matches current production, using Drupal va-gov-footer menu (Col 4 of top section not drupalized)
- [x] Bottom rail links of footer match current production, using Drupal footer-bottom-rail menu
- [x] Language selector links are rendered via existing React component

Mobile:
- [ ] Columns turn into accordions as they do in Prod, in same order
- [ ] Veteran Crisis Line is not part of Contact Us (which is where the rest of its column goes); instead it appears at top of footer as in Prod
- [ ] Bottom rail links of footer match current production, using Drupal footer-bottom-rail menu
- [ ] Language selector links behave as in Prod (accordion), look uniform with other accordions

Injection:
- [ ] Footer presents correctly in injected scenario

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling
- [x] Browser console contains no warnings or errors.