### PR TITLE
EFSR (Bug) Allow user to continue with 0 dependents

### DIFF
--- a/src/applications/financial-status-report/components/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/DependentAges.jsx
@@ -47,6 +47,8 @@ const DependentAges = ({ goToPath, isReviewMode = false }) => {
         );
         if (isReviewMode) {
           setHasDependentsChanged(true);
+        } else {
+          setHasDependentsChanged(false); // Reset the hasDependentsChanged state variable
         }
       }
     },

--- a/src/applications/financial-status-report/components/DependentAgesReview.jsx
+++ b/src/applications/financial-status-report/components/DependentAgesReview.jsx
@@ -1,9 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import DependentAges from './DependentAges';
 
+const isValidDependentsCount = hasDependents => {
+  const parsedDependents = parseInt(hasDependents, 10);
+  return !Number.isNaN(parsedDependents) && parsedDependents > 0;
+};
+
 const DependentAgesReview = ({ isReviewMode = true, ...props }) => {
-  return <DependentAges isReviewMode={isReviewMode} {...props} />;
+  const hasDependents = useSelector(
+    state => state.form.data.questions?.hasDependents,
+  );
+  const [shouldRender, setShouldRender] = useState(
+    isValidDependentsCount(hasDependents),
+  );
+
+  useEffect(
+    () => {
+      setShouldRender(isValidDependentsCount(hasDependents));
+    },
+    [hasDependents],
+  );
+
+  return (
+    shouldRender && <DependentAges isReviewMode={isReviewMode} {...props} />
+  );
 };
 
 DependentAgesReview.propTypes = {

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -661,7 +661,8 @@ const formConfig = {
           schema: pages.dependentRecords.schemaEnhanced,
           depends: formData =>
             formData['view:enhancedFinancialStatusReport'] &&
-            formData.questions?.hasDependents,
+            formData.questions?.hasDependents &&
+            formData.questions.hasDependents !== '0',
           CustomPage: DependentAges,
           CustomPageReview: DependentAgesReview,
           editModeOnReviewPage: false,

--- a/src/applications/financial-status-report/pages/income/dependents/index.js
+++ b/src/applications/financial-status-report/pages/income/dependents/index.js
@@ -40,10 +40,10 @@ export const uiSchemaEnhanced = {
       'ui:title':
         'How many dependents do you have who rely on you for financial support?',
       'ui:widget': 'TextWidget',
-      'ui:required': () => true,
       'ui:options': {
         classNames: 'input-size-2 dependent-count ',
       },
+      'ui:required': () => true,
       'ui:errorMessages': {
         required: 'Please enter your dependent(s) information.',
       },
@@ -55,6 +55,7 @@ export const schemaEnhanced = {
   type: 'object',
   properties: {
     questions: {
+      required: ['hasDependents'],
       type: 'object',
       properties: {
         hasDependents: {

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -34,10 +34,11 @@
   }
 }
 
-.dependent-count  {
-  label {
-    width: $usa-form-width
-   }
+.dependent-count {
+  label,
+  .usa-input-error-message {
+    width: $usa-form-width;
+  }
 }
 
 .selected-debt {


### PR DESCRIPTION
### Summary

This PR resolves an issue related to a user entering 0 for their number of dependents. 


## Related issue(s)
- department-of-veterans-affairs/va.gov-team#54028


## Testing done

- Manual testing
- Navigate to `/manage-va-debt/request-debt-help-form-5655/review-and-submit` after filling out the employment form to test adding and removing dependents.


## Screenshots

### Desktop - Add/Edit Dependents (Veteran)

<table>
  <tr>
    <th>Dependent ages readOnly</th>
    <th>Dependents ages with edit</th>
    <th>Dependents ages editing</th>
  </tr>
  <tr>
 <td>
      <img src="https://user-images.githubusercontent.com/3916436/236366453-fdfa4ea5-e9c3-4617-9f6e-767720fdaac2.png" alt="Screenshot 1" width="300" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/236366558-9c341d7d-2a9f-4794-9926-01cb18451dee.png" alt="Screenshot 2" width="300" />
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/3916436/236366637-0a20d83d-cafd-4530-8ff6-a758f37ab62b.png" alt="Screenshot 3" width="300" />
    </td>
  </tr>
</table>




## What areas of the site does it impact?
Financial status report employment history form

## Acceptance criteria
- [x]  Dependents ages added to review and submit form.
- [x]  Unit and e2e test are updated and passing

