### PR TITLE
Reduce pe image size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: dsva/preview-environment/vets-website
-        IMAGE_TAG: front-end-latest
+        IMAGE_TAG: rework-pe-frontend
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image to ECR
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "pe_route_api_over_service_name" ]
     
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image to ECR
 
 on:
   push:
-    branches: [ "pe_route_api_over_service_name" ]
+    branches: [ "main" ]
     
 jobs:
 
@@ -31,7 +31,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: dsva/preview-environment/vets-website
-        IMAGE_TAG: rework-pe-frontend
+        IMAGE_TAG: front-end-latest
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           build-args: |
             "AWS_URL=${{ env.AWS_URL }}"
+            "SOURCE_REF=${{ env.SOURCE_REF}}"
           context: .
           file: src/platform/utilities/preview-environment/Dockerfile
           # target: production

--- a/src/platform/utilities/preview-environment/Dockerfile
+++ b/src/platform/utilities/preview-environment/Dockerfile
@@ -11,6 +11,9 @@ EXPOSE 3002
 ARG AWS_URL
 ENV AWS_URL $AWS_URL
 
+ARG SOURCE_REF
+ENV SOURCE_REF $SOURCE_REF
+
 # Configure image to execute a script on startup with ENTRYPOINT/CMD
 ENTRYPOINT ["./start.sh"]
-CMD ["$AWS_URL"]
+CMD ["$AWS_URL", "$SOURCE_REF"]

--- a/src/platform/utilities/preview-environment/Dockerfile
+++ b/src/platform/utilities/preview-environment/Dockerfile
@@ -1,29 +1,5 @@
 FROM public.ecr.aws/bitnami/node:14.15.5
 
-
-
-RUN mkdir -p /website
-WORKDIR /website
-
-# Clone vagov-content
-RUN git clone --depth 1 https://github.com/department-of-veterans-affairs/vagov-content
-
-# Clone vets-gov-json schema
-RUN git clone --depth 1 https://github.com/department-of-veterans-affairs/vets-json-schema.git
-
-# Clone veteran-facing-services-tools
-RUN git clone --depth 1 https://github.com/department-of-veterans-affairs/veteran-facing-services-tools
-
-# Clone content-build
-RUN git clone --depth 1 https://github.com/department-of-veterans-affairs/content-build.git
-
-# Setup a working directory for vets-website
-RUN mkdir -p /website/vets-website
-WORKDIR /website/vets-website
-
-# Copy vets-website files into Docker image
-COPY . .
-
 # Copy startup script into place
 COPY src/platform/utilities/preview-environment/start.sh .
 RUN chmod +x start.sh

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -20,7 +20,7 @@ echo "Install, build, and watch vets-website"
 cd vets-website
 yarn install
 yarn build:webpack:local
-yarn watch --env api="http://localhost:3000" &
+yarn watch --env api="http://vets-api-web.preview-environment:3000" &
 
 # Serve the content-build
 echo "Install and serve content-build"

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -52,11 +52,11 @@ echo "Install, build, and watch vets-website"
 cd vets-website
 yarn install
 yarn build:webpack:local
-yarn watch --env api="http://vets-api-web.preview-environment:3000" &
+yarn watch --env api="http://vets-api-web:3004" &
 
 # Serve the content-build
 echo "Install and serve content-build"
 cd ../content-build
 yarn install
-ln -s /website/vets-website/build/localhost/generated /website/content-build/build/localhost/generated
+ln -s /app/website/vets-website/build/localhost/generated /app/website/content-build/build/localhost/generated
 yarn serve

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -29,6 +29,7 @@ echo "Download dev content-build to website dir"
 
 # if AWS_URL then use it
 # else use default cache URL
+# To-do -- change the fallback cache to something that is not hardcoded to a file that will eventually be cleaned up
 if [ -z ${AWS_URL} ] ;
 then
     echo "AWS_URL is NULL; using default" ;
@@ -59,4 +60,4 @@ echo "Install and serve content-build"
 cd ../content-build
 yarn install
 ln -s /app/website/vets-website/build/localhost/generated /app/website/content-build/build/localhost/generated
-yarn serve
+yarn watch --env api="http://vets-api-web:3004"

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -60,4 +60,4 @@ echo "Install and serve content-build"
 cd ../content-build
 yarn install
 ln -s /app/website/vets-website/build/localhost/generated /app/website/content-build/build/localhost/generated
-yarn watch --env api="http://vets-api-web:3004"
+yarn serve

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -16,8 +16,14 @@ git clone --depth 1 https://github.com/department-of-veterans-affairs/veteran-fa
 git clone --depth 1 https://github.com/department-of-veterans-affairs/content-build.git
 
 # Clone vets-website
-git clone --depth 1 https://github.com/department-of-veterans-affairs/vets-website.git
-
+if [ -z ${SOURCE_REF} ] ;
+then
+    echo "SOURCE_REF is NULL; using main" ;
+    git clone --depth 1 https://github.com/department-of-veterans-affairs/vets-website.git ;
+else
+    echo "AWS_URL is not NULL; using workflow env var" ;
+    git clone -b ${SOURCE_REF} --single-branch https://github.com/department-of-veterans-affairs/vets-website.git
+fi
 
 echo "Download dev content-build to website dir"
 

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -1,10 +1,36 @@
 #!/bin/sh
+echo "Creating directory structure"
+mkdir -p website
+cd website
+
+# Clone vagov-content
+git clone --depth 1 https://github.com/department-of-veterans-affairs/vagov-content
+
+# Clone vets-gov-json schema
+git clone --depth 1 https://github.com/department-of-veterans-affairs/vets-json-schema.git
+
+# Clone veteran-facing-services-tools
+git clone --depth 1 https://github.com/department-of-veterans-affairs/veteran-facing-services-tools
+
+# Clone content-build
+git clone --depth 1 https://github.com/department-of-veterans-affairs/content-build.git
+
+# Clone vets-website
+git clone --depth 1 https://github.com/department-of-veterans-affairs/vets-website.git
 
 
 echo "Download dev content-build to website dir"
 
-cd ..
-curl -LO ${AWS_URL}
+# if AWS_URL then use it
+# else use default cache URL
+if [ -z ${AWS_URL} ] ;
+then
+    echo "AWS_URL is NULL; using default" ;
+    curl -LO https://vetsgov-website-builds-s3-upload.s3-us-gov-west-1.amazonaws.com/content-build/0008051ce15e731cc01289933dfb060d6f0d4df6/vagovdev.tar.bz2 ;
+else
+    echo "AWS_URL is not NULL; using workflow env var" ;
+    curl -LO ${AWS_URL} ;
+fi
 
 echo "Setup content-build and extract pre-built content into content-build/build/localhost"
 echo "make the build folder"

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -33,7 +33,7 @@ echo "Download dev content-build to website dir"
 if [ -z ${AWS_URL} ] ;
 then
     echo "AWS_URL is NULL; using default" ;
-    curl -LO https://vetsgov-website-builds-s3-upload.s3-us-gov-west-1.amazonaws.com/content-build/0008051ce15e731cc01289933dfb060d6f0d4df6/vagovdev.tar.bz2 ;
+    curl -LO https://vetsgov-website-builds-s3-upload.s3-us-gov-west-1.amazonaws.com/content-build/0008051ce15e731cc01289933dfb060d6f0d4df6/vagovprod.tar.bz2 ;
 else
     echo "AWS_URL is not NULL; using workflow env var" ;
     curl -LO ${AWS_URL} ;

--- a/src/platform/utilities/preview-environment/start.sh
+++ b/src/platform/utilities/preview-environment/start.sh
@@ -21,7 +21,7 @@ then
     echo "SOURCE_REF is NULL; using main" ;
     git clone --depth 1 https://github.com/department-of-veterans-affairs/vets-website.git ;
 else
-    echo "AWS_URL is not NULL; using workflow env var" ;
+    echo "SOURCE_REF is not NULL; using workflow env var" ;
     git clone -b ${SOURCE_REF} --single-branch https://github.com/department-of-veterans-affairs/vets-website.git
 fi
 
@@ -43,7 +43,7 @@ echo "Setup content-build and extract pre-built content into content-build/build
 echo "make the build folder"
 mkdir -p content-build/build/localhost
 echo "untar the build into content-build/build/localhost/"
-tar -xf vagovdev.tar.bz2 -C content-build/build/localhost/
+tar -xf vagovprod.tar.bz2 -C content-build/build/localhost/
 
 echo "set yarn to allow self-signed cert for install"
 yarn config set "strict-ssl" false


### PR DESCRIPTION
## Summary

This change is meant to reduce the size of the frontend images for preview environments. In order to accomplish this I

1. Moved the vets-website cloning into the startup script
2. Pass the branch name from the `Preview Environment Deployment` workflow through to the startup script
3. Use a conditional in the startup script to fall back to `main` if no branch value is found
4. Use a conditional in the startup script to fall back to a hardcoded value for the `content-build` cache if none is found (need a better solution for this fallback)

## Related issue(s)
- [Reduce the filesystem space used for PE](https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/57924)

## Testing done
- Prior to the change, the image contained the `vets-website` clone
- Now, `vets-website` is cloned into the container after it starts
- We set and pass in a GHA variable to clone the right branch
- I pulled the image generated by the workflow for this PR down from ECR and started it locally
- I saw that the variable was successfully passed through and used in the start script
   - AWS_URL is set correctly
   - SOURCE_REF is set correctly

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/52456633/31c66130-6f5c-439a-9707-fa0ed1876899)

## What areas of the site does it impact?

No impact to production site

## Acceptance criteria

### Quality Assurance & Testing
See testing above

### Error Handling
- Fall back to defaults if GHA variable not set
- log out errors

### Authentication
N/A

## Requested Feedback
N/A
