### PR TITLE
Supplemental Claims | Notify empty email

### DIFF
--- a/src/applications/appeals/995/components/ContactInfoReview.jsx
+++ b/src/applications/appeals/995/components/ContactInfoReview.jsx
@@ -37,8 +37,16 @@ const ContactInfoReview = ({ data, editPage }) => {
   const display = [
     [content.home, () => getFormattedPhone(homePhone)],
     [content.mobile, () => getFormattedPhone(mobilePhone)],
-    [content.email, () => email],
-    [content.country, () => (isUS ? '' : address.countryName)],
+    [
+      content.email,
+      () =>
+        email || (
+          <span className="usa-input-error-message">
+            {content.missingEmail}
+          </span>
+        ),
+    ],
+    [content.country, () => address.countryName],
     [content.address1, () => address.addressLine1],
     [content.address2, () => address.addressLine2],
     [content.address3, () => address.addressLine3],

--- a/src/applications/appeals/995/content/contactInfo.jsx
+++ b/src/applications/appeals/995/content/contactInfo.jsx
@@ -35,6 +35,8 @@ export const content = {
   province: 'Province',
   postal: 'Postal code',
 
+  missingEmail: 'Missing email address',
+
   alertContent:
     'The missing information has been added to your application. You may continue.',
 };

--- a/src/applications/appeals/995/pages/contactInformation.js
+++ b/src/applications/appeals/995/pages/contactInformation.js
@@ -19,6 +19,7 @@ const contactInfo = {
     properties: {
       veteran: {
         type: 'object',
+        required: ['address', 'email'],
         properties: {
           address: {
             type: 'object',

--- a/src/applications/appeals/995/tests/components/ContactInfoReview.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ContactInfoReview.unit.spec.jsx
@@ -36,16 +36,26 @@ describe('<ContactInfoReview>', () => {
 
     expect($('button.edit-page', container)).to.exist;
     expect($('h4', container).textContent).to.eq(content.title);
-    expect($$('dt', container).length).to.eq(8);
+    expect($$('dt', container).length).to.eq(9);
     expect(container.innerHTML).to.contain('Home phone');
   });
-  it('should render all contact data, except home phone on review page', () => {
+  it('should render all contact data, and en empty home phone on review page', () => {
     const data = getData({ home: false });
     const { container } = render(<ContactInfoReview {...data} />);
 
     expect($('h4', container).textContent).to.eq(content.title);
-    expect($$('dt', container).length).to.eq(7);
+    expect($$('dt', container).length).to.eq(8);
     expect(container.innerHTML).to.not.contain('Home phone');
+  });
+  it('should render error message for missing email', () => {
+    const data = getData({ email: false });
+    const { container } = render(<ContactInfoReview {...data} />);
+
+    expect($('h4', container).textContent).to.eq(content.title);
+    expect($$('dt', container).length).to.eq(9);
+    expect($('.usa-input-error-message', container).textContent).to.eq(
+      content.missingEmail,
+    );
   });
 
   it('should call editPage callback', () => {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While monitoring Supplemental Claim submissions, we noted one rejected submission with a missing email (empty string) address. This should have been caught prior to form submission. We need to make changes to show a specific error message informing the Veteran that the email is missing, and ensure submission is blocked until it is rectified.
- _(If bug, how to reproduce)_
  > - Fill out a Supplemental Claim form & get to the review & submit page.
  > - Use finish this application later
  > - In a new tab, go to the profile and remove the email
  > - Return to the form & continue
  > - Submit the form; it _shouldn't_ let you submit and should highlight the Veteran information accordion; but not indication of the missing info
- _(What is the solution, why is this the solution)_
  > - Add an error message to the email entry on the review & submit page. Previously empty field rows were hidden.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#58096](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58096)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Empty email fields were not rendered on the review & submit page
- _Describe the steps required to verify your changes are working as expected_
  > Follow bug steps, and the accordion should now highlight and show an error message for an empty email field
- _Describe the tests completed and the results_
  > Added unit test; all passing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Mobile| Desktop |
| ------- | ------ |
| <img width="296" alt="Screenshot 2023-05-09 at 10 39 28 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/6f2fe7bd-07d0-429e-bb11-cbd8558e6baa"> | <img width="630" alt="Screenshot 2023-05-09 at 10 39 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4c0a86c1-ca79-4e3b-aa84-835f37ea065d"> |

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
