### PR TITLE
#VFEP-565 #comment replaced deprecated Pagination and Loading indicat…

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import classNames from 'classnames';
-import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import {
+  VaPagination,
+  VaLoadingIndicator,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 import Scroll from 'react-scroll';
 import { connect } from 'react-redux';
@@ -34,7 +36,7 @@ import {
 } from '../selectors/schoolSearch';
 import { transformSearchToolAddress } from '../helpers';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 export class SchoolSelectField extends React.Component {
   constructor(props) {
@@ -114,7 +116,8 @@ export class SchoolSelectField extends React.Component {
     });
   };
 
-  handlePageSelect = page => {
+  handlePageSelect = e => {
+    const { page } = e.detail;
     this.resultCount.focus();
 
     this.debouncedSearchInstitutions({
@@ -248,9 +251,7 @@ export class SchoolSelectField extends React.Component {
             >
               {'School Information'}
               {!manualSchoolEntryChecked && (
-                <span className="schemaform-required-span">
-                  {'(*Required)'}
-                </span>
+                <span className="schemaform-required-span">(*Required)</span>
               )}
             </label>
             {showErrors && (
@@ -268,7 +269,7 @@ export class SchoolSelectField extends React.Component {
               </span>
             )}
             <span>
-              {'Enter your school’s name or city to search for your school'}
+              Enter your school’s name or city to search for your school
             </span>
             <div className="search-controls">
               <Element name="schoolSearch" />
@@ -288,7 +289,7 @@ export class SchoolSelectField extends React.Component {
                   className="search-schools-button usa-button-primary"
                   onClick={this.handleSearchClick}
                 >
-                  {'Search Schools'}
+                  Search Schools
                 </button>
               </div>
               <div className="clear-search">
@@ -296,7 +297,7 @@ export class SchoolSelectField extends React.Component {
                   className="va-button-link start-over"
                   onClick={this.handleStartOver}
                 >
-                  {'Start Over'}
+                  Start Over
                 </button>
               </div>
             </div>
@@ -389,9 +390,9 @@ export class SchoolSelectField extends React.Component {
                                 </span>
                               )}
                               {(city || state) && (
-                                <span className="institution-city-state">{`${city}${city &&
-                                  state &&
-                                  ', '}${state}`}</span>
+                                <span className="institution-city-state">
+                                  {`${city}${city && state && ', '}${state}`}
+                                </span>
                               )}
                               {!city &&
                                 !state && (
@@ -407,10 +408,11 @@ export class SchoolSelectField extends React.Component {
                   )}
                 </div>
               )}
+            ={' '}
             {showSearchResults &&
               showInstitutionsLoading && (
                 <div>
-                  <LoadingIndicator
+                  <VaLoadingIndicator
                     message={`Searching ${institutionQuery}...`}
                   />
                 </div>
@@ -419,18 +421,19 @@ export class SchoolSelectField extends React.Component {
               showNoResultsFound && (
                 <div className="no-results-box">
                   <p>
-                    <strong>{'We can’t find your school'}</strong>
+                    <strong>We can’t find your school</strong>
                     <br />
-                    {
-                      'We’re sorry. We can’t find any school that matches your entry. Please try entering a different school name or city. Or, you can check the box to enter your school information yourself.'
-                    }
+                    We’re sorry. We can’t find any school that matches your
+                    entry. Please try entering a different school name or city.
+                    Or, you can check the box to enter your school information
+                    yourself.
                   </p>
                 </div>
               )}
             {showSearchResults &&
               showPaginationLoading && (
                 <div>
-                  <LoadingIndicator
+                  <VaLoadingIndicator
                     message={`Loading page ${currentPageNumber} results for ${institutionQuery}...`}
                   />
                 </div>
@@ -438,11 +441,13 @@ export class SchoolSelectField extends React.Component {
           </div>
           {showSearchResults &&
             showPagination && (
-              <Pagination
+              <VaPagination
                 page={currentPageNumber}
                 pages={pagesCount}
                 ariaLabelSuffix="of school results"
                 onPageSelect={this.handlePageSelect}
+                maxPageListLength={10}
+                showLastPage
               />
             )}
         </div>

--- a/src/applications/edu-benefits/tests/feedback-tool/components/SchoolSelectField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/feedback-tool/components/SchoolSelectField.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('<SchoolSelectField>', () => {
     expect(tree.find('#root_school_view:manualSchoolEntry_name').exists()).to.be
       .false;
     expect(tree.find('.institution-name').exists()).to.be.false;
-    expect(tree.find('.loading-indicator-container').exists()).to.be.false;
+    expect(tree.find('va-loading-indicator').exists()).to.be.false;
     expect(tree.find('.va-pagination').exists()).to.be.false;
     tree.unmount();
   });
@@ -63,8 +63,8 @@ describe('<SchoolSelectField>', () => {
       'testCity, testState',
     );
     expect(tree.find('.institution-address').length).to.eql(3);
-    expect(tree.find('.va-pagination').exists()).to.be.true;
-    expect(tree.find('.loading-indicator-container').exists()).to.be.false;
+    expect(tree.find('va-pagination').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.false;
     expect(tree.find('#root_school_view:manualSchoolEntry_name').exists()).to.be
       .false;
     tree.unmount();
@@ -148,12 +148,13 @@ describe('<SchoolSelectField>', () => {
       />,
     );
 
+    const vaLoadingIndicatorMessage = tree.find('va-loading-indicator');
     expect(tree.find('.search-controls').exists()).to.be.true;
     expect(tree.find('.institution-name').exists()).to.be.false;
     expect(tree.find('.institution-city-state').exists()).to.be.false;
-    expect(tree.find('.va-pagination').exists()).to.be.false;
-    expect(tree.find('.loading-indicator-container').exists()).to.be.true;
-    expect(tree.find('.loading-indicator-container').text()).to.eql(
+    expect(tree.find('va-pagination').exists()).to.be.false;
+    expect(vaLoadingIndicatorMessage.exists()).to.be.true;
+    expect(vaLoadingIndicatorMessage.prop('message')).to.eql(
       'Searching test...',
     );
     expect(tree.find('#root_school_view:manualSchoolEntry_name').exists()).to.be
@@ -181,9 +182,9 @@ describe('<SchoolSelectField>', () => {
     expect(tree.find('.search-controls').exists()).to.be.true;
     expect(tree.find('.institution-name').exists()).to.be.false;
     expect(tree.find('.institution-city-state').exists()).to.be.false;
-    expect(tree.find('.va-pagination').exists()).to.be.true;
-    expect(tree.find('.loading-indicator-container').exists()).to.be.true;
-    expect(tree.find('.loading-indicator-container').text()).to.eql(
+    expect(tree.find('va-pagination').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').exists()).to.be.true;
+    expect(tree.find('va-loading-indicator').prop('message')).to.eql(
       'Loading page 1 results for test...',
     );
     expect(tree.find('#root_school_view:manualSchoolEntry_name').exists()).to.be
@@ -252,7 +253,7 @@ describe('<SchoolSelectField>', () => {
     expect(tree.find('.institution-name').exists()).to.be.false;
     expect(tree.find('.institution-city-state').exists()).to.be.false;
     expect(tree.find('.va-pagination').exists()).to.be.false;
-    expect(tree.find('.loading-indicator-container').exists()).to.be.false;
+    expect(tree.find('va-loading-indicator').exists()).to.be.false;
     expect(tree.find('#root_school_view:manualSchoolEntry_name').exists()).to.be
       .false;
     tree.unmount();

--- a/src/applications/gi/containers/search/NameSearchResults.jsx
+++ b/src/applications/gi/containers/search/NameSearchResults.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { VaLoadingIndicator } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
+import {
+  VaLoadingIndicator,
+  VaPagination,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from 'platform/utilities/ui';
 import recordEvent from 'platform/monitoring/record-event';
 import { fetchSearchByNameResults } from '../../actions/index';
@@ -88,7 +90,8 @@ export function NameSearchResults({
     [results, name, totalPages, count],
   );
 
-  const fetchPage = page => {
+  const fetchPage = e => {
+    const { page } = e.detail;
     dispatchFetchSearchByNameResults(name, page, filters, version);
     updateUrlParams(
       history,
@@ -159,7 +162,7 @@ export function NameSearchResults({
                 )}
 
               {!inProgress && (
-                <Pagination
+                <VaPagination
                   className="vads-u-border-top--0"
                   onPageSelect={fetchPage}
                   page={currentPage}


### PR DESCRIPTION
…or code

## Summary

Removed deprecated Pagination code and replaced it with  {VaPagination} from '@department-of-veterans-affairs/component-library/dist/react-bindings' in locations:

  1. vets-website/src/applications/gi/containers/search/NameSearchResults.jsx
  2. vets-website/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
 
Removed deprecated LoadingIndicator code and replaced it with {VaLoadingIndicator} from '@department-of-veterans-affairs/component-library/dist/react-bindings' in location:

  1. vets-website/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx

- _(If bug, how to reproduce)_ Not a bug
- _(What is the solution, why is this the solution)_
- -The solution was to replace the deprecated code with the newly approved code.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- -I work for GOVCIO and we are the code owners
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- -No flipper used, code changes will go directly to prod after staging

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://vajira.max.gov/browse/VFEP-565
- _Link to previous change of the code/bug (if applicable)_NA
- _Link to epic if not included in ticket_NA

## Testing done

- _Describe what the old behavior was prior to the change_
- -The behavior is the same as it was previously, the change was to the code base but visually it is the same.
- _Describe the steps required to verify your changes are working as expected_
- - To ensure it is working correctly, go to the [Comparison Tool](https://www.va.gov/education/gi-bill-comparison-tool/?search=name&name=rose&excludedSchoolTypes%5B%5D=PUBLIC&excludedSchoolTypes%5B%5D=FOR%20PROFIT&excludedSchoolTypes%5B%5D=PRIVATE&excludedSchoolTypes%5B%5D=FOREIGN&excludedSchoolTypes%5B%5D=FLIGHT&excludedSchoolTypes%5B%5D=CORRESPONDENCE&excludedSchoolTypes%5B%5D=HIGH%20SCHOOL) and search for an institution. At the bottom of the page you will se pagination, click on a page and as long as the page refreshes with new institution cards and the pagination is highlighted on the page clicked, the changes is working. 
In the [Feedback tool](https://www.va.gov/education/submit-school-feedback/introduction), work through the form until you get to the School Selection section. In here enter in an institution and once you see the results, scroll below the institution cards and you will see the pagination. Test the same way you test the comparison tool's pagination.
Also in the Feedback tool when searching for an institution, is where you will see the updated loading indicator. It displays briefly when search for an institution. Visually it will look the same, only the code has changed. 

- _Describe the tests completed and the results_
- -Testing done with unit test and testing on local machine. Testing will be conducted with QA when on staging before going to prod.
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_NA

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Comparison Tool Before/After
(No change visually to the Comparison Tool
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/483adbdf-cedf-4791-8614-a0aedf8177d9)

Feedback tool Before (Pagination)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/e0267b4d-ae1e-472c-9bec-cfd1145b521b)

Feedback tool After (Slight change to Pagination, pages now show the last page and have a limit of 10 pages to be show at once)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/2d6cbfcf-8dc9-4698-8c98-13c99937bf1e)

Feedback Too Before/After (Loading Indicator)
No visual Change to the loading indicator
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/eee5dc50-4365-4c6c-8aeb-bbd73709f233)



## What areas of the site does it impact?
Changes where made to the edu-benefits folder and the gi folder in vets-website repo. The changes can be seen in the comparison tool and the feedback tool

*(Describe what parts of the site are impacted **if** code touched other areas)*NA

## Acceptance criteria
Pagination allows the user to skip to the selected page. Loading indicator briefly shows then results are shown on screen.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_NA
