### PR TITLE
26-4555 hide form if flipper off

### DIFF
--- a/src/applications/simple-forms/26-4555/components/WIP.jsx
+++ b/src/applications/simple-forms/26-4555/components/WIP.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export const WIP = () => (
+  <div className="row vads-u-margin-bottom--5">
+    <div className="usa-width-two-thirds medium-8 columns">
+      <va-alert status="warning">
+        <h1 slot="headline" className="vads-u-font-size--h3">
+          We’re still working on this feature
+        </h1>
+        <p>
+          We’re rolling out the Adapted Housing Form (26-4555) in stages. It’s
+          not quite ready yet. Please check back again soon.
+        </p>
+        <p>
+          <a href="/housing-assistance/disability-housing-grants">
+            Return to housing assistance information page
+          </a>
+        </p>
+      </va-alert>
+    </div>
+  </div>
+);

--- a/src/applications/simple-forms/26-4555/containers/App.jsx
+++ b/src/applications/simple-forms/26-4555/containers/App.jsx
@@ -1,12 +1,31 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import formConfig from '../config/form';
 
-export default function App({ location, children }) {
+import { WIP } from '../components/WIP';
+
+export function App({ location, children, show264555 }) {
+  if (!show264555) {
+    return <WIP />;
+  }
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
 }
+
+App.propTypes = {
+  show264555: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  show264555: toggleValues(state)[FEATURE_FLAG_NAMES.form264555] || false,
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/simple-forms/26-4555/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/simple-forms/26-4555/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,6 +1,11 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": []
+    "features": [
+      {
+        "name": "form264555",
+        "value": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
Hides form 26-4555 if the flipper is off

It defaults to off if no flipper is found, so you can 
  - test by running vets-api locally and toggling `form264555` at `http://localhost:3000/flipper/features`
  - test without vets-api, just won't be able to turn it on

## Summary
- Adds logic to hide the form

## Testing done
- Tested locally with flippers

## What areas of the site does it impact?
Form 26-4555

## Screenshots
Flipper off or not found:
![Screenshot 2023-05-09 at 4 34 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/4d015925-d208-442f-b043-dfd52274b099)
