### PR TITLE
Give Health Care Application ID Form page a loading state on submit

### DIFF
--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import recordEvent from 'platform/monitoring/record-event';
@@ -133,8 +133,6 @@ const IDPage = props => {
           </button>
           <div className="vads-u-margin-top--2p5">
             <SchemaForm
-              // `name` and `title` are required by SchemaForm, but are only used
-              // internally in the component
               name="ID Form"
               title="ID Form"
               schema={schema}
@@ -143,26 +141,24 @@ const IDPage = props => {
               onChange={formChange}
               data={idFormData}
             >
-              {
-                // NOTE: these components are nested in the SchemaForm component to
-                // prevent it from rendering its default SUBMIT button
-              }
               {showServerError && <ServerErrorAlert />}
-              {loginRequired ? (
+              {loginRequired && (
                 <LoginRequiredAlert handleLogin={showSignInModal} />
-              ) : (
-                <LoadingButton
-                  // override the `width: 100%` given to SchemaForm submit buttons
-                  className="vads-u-width--auto idform-submit-button"
-                  isLoading={isSubmittingIDForm}
-                  disabled={false}
-                  type="submit"
-                >
-                  Continue to the application
-                  <span className="button-icon" aria-hidden="false">
-                    &nbsp;»
-                  </span>
-                </LoadingButton>
+              )}
+              {!loginRequired &&
+                !isSubmittingIDForm && (
+                  <ProgressButton
+                    buttonClass="vads-u-width--auto idform-submit-button"
+                    buttonText="Continue to the application"
+                    afterText="»"
+                    submitButton
+                  />
+                )}
+              {isSubmittingIDForm && (
+                <va-loading-indicator
+                  message="Reviewing your information..."
+                  set-focus
+                />
               )}
             </SchemaForm>
           </div>
@@ -200,7 +196,7 @@ const mapStateToProps = state => {
   const {
     enrollmentStatus,
     hasServerError,
-    isLoading,
+    isLoadingApplicationStatus,
     isUserInMVI,
     loginRequired,
     noESRRecordFound,
@@ -208,7 +204,7 @@ const mapStateToProps = state => {
   return {
     enrollmentStatus,
     form: state.form,
-    isSubmittingIDForm: isLoading,
+    isSubmittingIDForm: isLoadingApplicationStatus,
     isUserInMVI,
     loginRequired,
     noESRRecordFound,


### PR DESCRIPTION
## Description
For the ID form page that unauthenticated users use to access the health care application, there is no loading state for form on submit. This PR adds a loading indicator on submit of the form that gives instruction on what is occurring while the enrollment status is being fetched.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#57836

## Acceptance criteria
 - Form gives a clear indication that an action is occurring after click of the continue button.
