### PR TITLE
[#MHV-43441] open links in new tabs

### DIFF
--- a/src/applications/mhv/medical-records/containers/ShareRecordsPage.jsx
+++ b/src/applications/mhv/medical-records/containers/ShareRecordsPage.jsx
@@ -59,7 +59,11 @@ const ShareRecordsPage = () => {
             </li>
           </ul>
         </va-additional-info>
-        <a href="https://www.va.gov/resources/the-veterans-health-information-exchange-vhie/">
+        <a
+          href="https://www.va.gov/resources/the-veterans-health-information-exchange-vhie/"
+          target="_blank"
+          rel="noreferrer"
+        >
           Learn more about VHIE
         </a>
         <p>
@@ -192,7 +196,11 @@ const ShareRecordsPage = () => {
           office. It may take up to <strong>30 days</strong> to get your records
           this way.{' '}
         </p>
-        <a href="https://www.va.gov/resources/how-to-get-your-medical-records-from-your-va-health-facility/">
+        <a
+          href="https://www.va.gov/resources/how-to-get-your-medical-records-from-your-va-health-facility/"
+          target="_blank"
+          rel="noreferrer"
+        >
           Learn how to get records from your VA health facility
         </a>
       </section>


### PR DESCRIPTION
## Summary
Quick fix: Open links into new tabs from share your record page.

## Related issue(s)
https://vajira.max.gov/browse/MHV-43441

## Testing done
unit tests

## Screenshots
no visual change

## What areas of the site does it impact?
my-health/medical-records/share-your-medical-record

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
