### PR TITLE
Increase specificity of aria-labels in HCA health insurance section

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/general.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/general.js
@@ -14,17 +14,14 @@ import {
   TricarePolicyDescription,
 } from '../../../components/FormDescriptions';
 import { ShortFormAlert } from '../../../components/FormAlerts';
-import { isShortFormEligible } from '../../../utils/helpers';
+import {
+  getInsuranceAriaLabel,
+  isShortFormEligible,
+} from '../../../utils/helpers';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { provider } = fullSchemaHca.definitions;
 const { isCoveredByHealthInsurance } = fullSchemaHca.properties;
-
-const ariaLabelfunc = data => {
-  const INSURANCE_TITLE = `${data.insuranceName} ${data.insurancePolicyNumber ??
-    data.insuranceGroupCode}`;
-  return data.insuranceName ? INSURANCE_TITLE : 'insurance policy';
-};
 
 export default {
   uiSchema: {
@@ -49,14 +46,14 @@ export default {
         itemName: 'insurance policy',
         hideTitle: true,
         viewField: InsuranceProviderViewField,
-        itemAriaLabel: ariaLabelfunc,
+        itemAriaLabel: formData => getInsuranceAriaLabel(formData),
       },
       'ui:errorMessages': {
         minItems: 'You need to at least one provider.',
       },
       items: {
         'ui:options': {
-          itemAriaLabel: ariaLabelfunc,
+          itemAriaLabel: formData => getInsuranceAriaLabel(formData),
         },
         insuranceName: {
           'ui:title': 'Name of insurance provider',

--- a/src/applications/hca/tests/utils/helpers.unit.spec.js
+++ b/src/applications/hca/tests/utils/helpers.unit.spec.js
@@ -7,6 +7,7 @@ import {
   prefillTransformer,
   isShortFormEligible,
   includeSpousalInformation,
+  getInsuranceAriaLabel,
 } from '../../utils/helpers';
 import { HIGH_DISABILITY_MINIMUM } from '../../utils/constants';
 
@@ -230,6 +231,31 @@ describe('hca helpers', () => {
           maritalStatus: 'separated',
         }),
       ).to.equal(true);
+    });
+  });
+
+  describe('getInsuranceAriaLabel', () => {
+    it('returns a generic label if the provider name is not provided', () => {
+      const formData = {};
+      expect(getInsuranceAriaLabel(formData)).to.equal('insurance policy');
+    });
+    it('returns the provider name with the policy number when provided', () => {
+      const formData = {
+        insuranceName: 'Aetna',
+        insurancePolicyNumber: '005588',
+      };
+      expect(getInsuranceAriaLabel(formData)).to.equal(
+        'Aetna, Policy number 005588',
+      );
+    });
+    it('returns the provider name with the group code when provided', () => {
+      const formData = {
+        insuranceName: 'Aetna',
+        insuranceGroupCode: '005588',
+      };
+      expect(getInsuranceAriaLabel(formData)).to.equal(
+        'Aetna, Group code 005588',
+      );
     });
   });
 

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -368,3 +368,23 @@ export function includeSpousalInformation(formData) {
     maritalStatus?.toLowerCase() === 'separated';
   return discloseFinancialInformation && hasSpouseToDeclare;
 }
+
+/**
+ * Helper that returns a descriptive aria label for the edit buttons on the
+ * health insurance information page
+ * @param {Object} formData - the current data object passed from the form
+ * @returns {String} - the name of the provider and either the policy number
+ * or group code.
+ */
+export function getInsuranceAriaLabel(formData) {
+  const { insuranceName, insurancePolicyNumber, insuranceGroupCode } = formData;
+  const labels = {
+    policy: insurancePolicyNumber
+      ? `Policy number ${insurancePolicyNumber}`
+      : null,
+    group: insuranceGroupCode ? `Group code ${insuranceGroupCode}` : null,
+  };
+  return insuranceName
+    ? `${insuranceName}, ${labels.policy ?? labels.group}`
+    : 'insurance policy';
+}


### PR DESCRIPTION
## Description
The current aria-label for the Edit button on added insurance plans is: `aria-label="Edit Provider 1234`. Where Provider is the insurance company and 1234 is the policy number. This label needs to be more informative for screen reader users. This PR adds the additional label text of `Policy number` or `Group code` ahead of the actual number/code to give the user a better idea of which value was provided

## Related issue(s)
department-of-veterans-affairs/va.gov-team#57563

## Testing done
- [x] Unit tests

## Screenshots
Policy number highlighted:
![Screenshot 2023-05-12 at 10 06 53 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/2947d564-75bd-43a6-a692-63c1e316ba26)

Group code highlighted:
![Screenshot 2023-05-12 at 10 07 11 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/5040c130-8913-46a5-a96f-80150cc7b8d6)

## Acceptance criteria
- [ ] Aria label includes the text for the policy number or group code based on the value.