### PR TITLE
Improve accessibility for HCA Service History title

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -116,12 +116,12 @@ export const SIGIGenderDescription = (
 
 /** CHAPTER 2: Military Service */
 export const ServiceHistoryTitle = (
-  <legend className="schemaform-block-title" id="root__title">
+  <>
     Service history
     <span className="vads-u-display--block vads-u-margin-y--2 vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-color--base">
       Check all that apply to you.
     </span>
-  </legend>
+  </>
 );
 
 /** CHAPTER 3: VA Benefits */

--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -114,6 +114,16 @@ export const SIGIGenderDescription = (
   </>
 );
 
+/** CHAPTER 2: Military Service */
+export const ServiceHistoryTitle = (
+  <legend className="schemaform-block-title" id="root__title">
+    Service history
+    <span className="vads-u-display--block vads-u-margin-y--2 vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-color--base">
+      Check all that apply to you.
+    </span>
+  </legend>
+);
+
 /** CHAPTER 3: VA Benefits */
 export const CompensationInfoDescription = (
   <p className="vads-u-margin-bottom-4">

--- a/src/applications/hca/config/chapters/militaryService/additionalInformation.js
+++ b/src/applications/hca/config/chapters/militaryService/additionalInformation.js
@@ -1,6 +1,6 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import MilitaryPrefillMessage from 'platform/forms/save-in-progress/MilitaryPrefillMessage';
-import { emptyObjectSchema } from '../../../definitions';
+import { ServiceHistoryTitle } from '../../../components/FormDescriptions';
 
 const {
   campLejeune,
@@ -16,11 +16,8 @@ const {
 
 export default {
   uiSchema: {
-    'ui:title': 'Service history',
+    'ui:title': ServiceHistoryTitle,
     'ui:description': MilitaryPrefillMessage,
-    'view:textObject': {
-      'ui:description': 'Check all that apply to you.',
-    },
     purpleHeartRecipient: {
       'ui:title': 'Purple Heart award recipient',
     },
@@ -57,7 +54,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:textObject': emptyObjectSchema,
       purpleHeartRecipient,
       isFormerPow,
       postNov111998Combat,


### PR DESCRIPTION
## Description
This is a small change that could improve the experience for Veterans who use screen readers. The "Check all that apply" sits outside of the `<legend>` element, meaning that it doesn't get announced when the `<legend>` text ("Service history") does. Moving the "Check all that apply" into the legend would announce "Service history [pause] check all that apply to you." It's a better experience because it sets expectations better for the Veteran.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#57515

## Screenshots
Before: 
![Screenshot 2023-05-12 at 11 06 27 AM](https://images.zenhubusercontent.com/628e7b9093a9366153cb221c/7cd38030-d3ea-43df-954c-2e363a0d2e52)

After:
![Screenshot 2023-05-12 at 11 06 27 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/0101a742-4b04-4394-a58a-d5cdd881c7a4)

## Acceptance criteria
- [ ] Screenreader reads "Service history [pause] check all that apply to you."
