### PR TITLE
[MHV-41713] SM to VA.gov: "Show Messages in this order"-label description change

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageList/MessageList.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/MessageList.jsx
@@ -32,6 +32,8 @@ const SENDER_ALPHA_ASCENDING = 'sender-alpha-asc';
 const SENDER_ALPHA_DESCENDING = 'sender-alpha-desc';
 const RECEPIENT_ALPHA_ASCENDING = 'recepient-alpha-asc';
 const RECEPIENT_ALPHA_DESCENDING = 'recepient-alpha-desc';
+const SORT_MESSAGES_LABEL = 'Show messages in this order';
+
 // Arbitrarily set because the VaPagination component has a required prop for this.
 // This value dictates how many pages are displayed in a pagination component
 const MAX_PAGE_LIST_LENGTH = 5;
@@ -146,7 +148,7 @@ const MessageList = props => {
       <div className="message-list-sort">
         <VaSelect
           id="sort-order-dropdown"
-          label="Sort by"
+          label={SORT_MESSAGES_LABEL}
           name="sort-order"
           value={sortOrderSelection}
           onVaSelect={e => {

--- a/src/applications/mhv/secure-messaging/components/ThreadList/ThreadListSort.jsx
+++ b/src/applications/mhv/secure-messaging/components/ThreadList/ThreadListSort.jsx
@@ -9,6 +9,7 @@ const SENDER_ALPHA_ASCENDING = 'sender-alpha-asc';
 const SENDER_ALPHA_DESCENDING = 'sender-alpha-desc';
 const RECEPIENT_ALPHA_ASCENDING = 'recepient-alpha-asc';
 const RECEPIENT_ALPHA_DESCENDING = 'recepient-alpha-desc';
+const SORT_CONVERSATIONS_LABEL = 'Show conversations in this order';
 
 const ThreadListSort = props => {
   const { defaultSortOrder, setSortOrder, setSortBy, sortCallback } = props;
@@ -62,7 +63,7 @@ const ThreadListSort = props => {
     <div className="thread-list-sort">
       <VaSelect
         id="sort-order-dropdown"
-        label="Sort by"
+        label={SORT_CONVERSATIONS_LABEL}
         name="sort-order"
         value={defaultSortOrder}
         onVaSelect={e => {

--- a/src/applications/mhv/secure-messaging/tests/components/ThreadListComponents/ThreadListSort.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/ThreadListComponents/ThreadListSort.unit.spec.jsx
@@ -27,7 +27,9 @@ describe('Thread List Sort component', () => {
     const sortSelectDropdown = document.querySelector('va-select');
     const sortButton = document.querySelector('va-button');
 
-    expect(sortSelectDropdown.label).to.equal('Sort by');
+    expect(sortSelectDropdown.label).to.equal(
+      'Show conversations in this order',
+    );
     expect(sortSelectDropdown.value).to.equal('DESC');
     expect(sortButton.getAttribute('label')).to.equal('Sort');
 
@@ -48,7 +50,9 @@ describe('Thread List Sort component', () => {
     const sortSelectDropdown = document.querySelector('va-select');
     const sortButton = document.querySelector('va-button');
 
-    expect(sortSelectDropdown.label).to.equal('Sort by');
+    expect(sortSelectDropdown.label).to.equal(
+      'Show conversations in this order',
+    );
     expect(sortSelectDropdown.value).to.equal('DESC');
     expect(sortButton.getAttribute('label')).to.equal('Sort');
 
@@ -69,7 +73,9 @@ describe('Thread List Sort component', () => {
     const sortSelectDropdown = document.querySelector('va-select');
     const sortButton = document.querySelector('va-button');
 
-    expect(sortSelectDropdown.label).to.equal('Sort by');
+    expect(sortSelectDropdown.label).to.equal(
+      'Show conversations in this order',
+    );
     expect(sortSelectDropdown.value).to.equal('DESC');
     expect(sortButton.getAttribute('label')).to.equal('Sort');
 
@@ -90,7 +96,9 @@ describe('Thread List Sort component', () => {
     const sortSelectDropdown = document.querySelector('va-select');
     const sortButton = document.querySelector('va-button');
 
-    expect(sortSelectDropdown.label).to.equal('Sort by');
+    expect(sortSelectDropdown.label).to.equal(
+      'Show conversations in this order',
+    );
     expect(sortSelectDropdown.value).to.equal('DESC');
     expect(sortButton.getAttribute('label')).to.equal('Sort');
 
@@ -111,7 +119,9 @@ describe('Thread List Sort component', () => {
     const sortSelectDropdown = document.querySelector('va-select');
     const sortButton = document.querySelector('va-button');
 
-    expect(sortSelectDropdown.label).to.equal('Sort by');
+    expect(sortSelectDropdown.label).to.equal(
+      'Show conversations in this order',
+    );
     expect(sortSelectDropdown.value).to.equal('DESC');
     expect(sortButton.getAttribute('label')).to.equal('Sort');
 


### PR DESCRIPTION
changed sort label on both thread list and message list components

## Summary

This PR only changes the label on the sort drop down 

## Related issue(s)

[SM to VA.gov: "Show Messages in this order"-label description change](https://vajira.max.gov/browse/MHV-41713)

## Testing done
Unit test
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="736" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107279507/97f123f8-1452-4015-b5cf-05f4a025149f">|<img width="736" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107279507/37b83ed7-a9cb-4c6d-ade3-cba81f053907">|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
