### PR TITLE
Remove prefill message placeholder in HCA for guest users

### DIFF
--- a/src/applications/hca/config/chapters/veteranInformation/birthSex.js
+++ b/src/applications/hca/config/chapters/veteranInformation/birthSex.js
@@ -18,6 +18,9 @@ export default {
     },
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
+      'ui:options': {
+        hideIf: formData => !formData['view:isLoggedIn'],
+      },
     },
     gender: {
       'ui:title': 'What sex were you assigned at birth?',

--- a/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/contactInformation.js
@@ -21,6 +21,9 @@ export default {
     },
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
+      'ui:options': {
+        hideIf: formData => !formData['view:isLoggedIn'],
+      },
     },
     'view:contactInfoDescription': {
       'ui:description': ContactInfoDescription,

--- a/src/applications/hca/config/chapters/veteranInformation/demographicInformation.js
+++ b/src/applications/hca/config/chapters/veteranInformation/demographicInformation.js
@@ -27,6 +27,9 @@ export default {
     },
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
+      'ui:options': {
+        hideIf: formData => !formData['view:isLoggedIn'],
+      },
     },
     'view:demographicCategories': {
       'ui:title': ' ',

--- a/src/applications/hca/config/chapters/veteranInformation/veteranAddress.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranAddress.js
@@ -21,6 +21,9 @@ export default {
     },
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
+      'ui:options': {
+        hideIf: formData => !formData['view:isLoggedIn'],
+      },
     },
     veteranAddress: merge({}, addressUI('Mailing address', true), {
       'ui:description': MailingAddressDescription,

--- a/src/applications/hca/config/chapters/veteranInformation/veteranGender.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranGender.js
@@ -18,6 +18,9 @@ export default {
     },
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
+      'ui:options': {
+        hideIf: formData => !formData['view:isLoggedIn'],
+      },
     },
     'view:genderIdentity': {
       'ui:title': 'Gender identity',

--- a/src/applications/hca/config/chapters/veteranInformation/veteranHomeAddress.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranHomeAddress.js
@@ -21,6 +21,9 @@ export default {
     },
     'view:prefillMessage': {
       'ui:description': PrefillMessage,
+      'ui:options': {
+        hideIf: formData => !formData['view:isLoggedIn'],
+      },
     },
     veteranHomeAddress: merge({}, addressUI('Home address', true), {
       'ui:description': HomeAddressDescription,


### PR DESCRIPTION
## Description
While performing an accessibility audit, an inconsistency was noticed in markup on certain pages of the veteran information section. On these pages there is an empty `<div>` that looks like maybe it's there for spacing. It was discovered this container is a placeholder for the prefill message that displays to authenticated users, but if the user is filling the form out as a guest, the placeholder stays in place. This PR adds conditionals to those view fields to remove these empty containers for guest users.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#57403

## Screenshots
Before:
![Screen Shot 2023-04-10 at 5.49.43 PM.png](https://images.zenhubusercontent.com/628e7b9093a9366153cb221c/b9fbcbca-d424-4f83-a417-d120686a9218)

After: 
![Screenshot 2023-05-12 at 11 19 49 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/5bdcf447-514a-4543-9627-19ea176bba84)

## Acceptance criteria
- [ ] For guest users, no placeholder containers exist for the prefill message.