### PR TITLE
Improve accessibility of FormNavButtons component children

### DIFF
--- a/src/applications/hca/components/FormPages/FinancialConfirmation.jsx
+++ b/src/applications/hca/components/FormPages/FinancialConfirmation.jsx
@@ -30,7 +30,6 @@ const DisabilityConfirmation = props => {
         <div className="small-5 medium-4 columns">
           {goBack && (
             <ProgressButton
-              aria-describedby="nav-form-header"
               buttonClass="hca-progress-button usa-button-secondary"
               onButtonClick={goBack}
               buttonText="Back"
@@ -40,7 +39,6 @@ const DisabilityConfirmation = props => {
         </div>
         <div className="small-5 medium-4 end columns">
           <ProgressButton
-            aria-describedby="nav-form-header"
             buttonClass="hca-progress-button usa-button-primary"
             onButtonClick={goForward}
             buttonText="Confirm"

--- a/src/platform/forms-system/src/js/components/FormNavButtons.jsx
+++ b/src/platform/forms-system/src/js/components/FormNavButtons.jsx
@@ -20,8 +20,6 @@ const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
           buttonText="Back"
           buttonClass="usa-button-secondary"
           beforeText="«"
-          // This button is described by the current form's header ID
-          ariaDescribedBy="nav-form-header"
         />
       )}
     </div>
@@ -32,8 +30,6 @@ const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
         buttonText="Continue"
         buttonClass="usa-button-primary"
         afterText="»"
-        // This button is described by the current form's header ID
-        ariaDescribedBy="nav-form-header"
       />
     </div>
   </div>


### PR DESCRIPTION
## Description
The continue and back buttons in the `FormNavButtons` component have an `aria-describedby` attribute that could be misleading. That attribute is linked to the form page `h2` which is the label on the stepper (i.e. Step 1 of 6: Veteran Information). 

That means if a person using a screen reader hits one of those buttons, they’ll hear something like “Continue [pause] Step 1 of 6: Veteran information”. This can be misleading because it is announcing the current step, not the one you would go forward or back to by hitting the buttons. Since the buttons don't know what the steps are, it would less confusing to just have a simple label that uses the button text.

This PR removes that attribute and lets the screenreader just read the button text.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#56858

## Screenshots
Before:
![Screenshot 2023-05-12 at 1 15 48 PM](https://images.zenhubusercontent.com/628e7b9093a9366153cb221c/dbcc8387-fcbf-478e-84b7-7c80b6301855)

After:
![Screenshot 2023-05-12 at 1 15 48 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/1f73f7e8-4dd1-4b89-810b-50c00e1460da)

## Acceptance criteria
- [ ] Child buttons do not contain misleading aria attributes.