### PR TITLE
VAOS - fixes linting errors

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import {
   renderWithStoreAndRouter,
   getTimezoneTestDate,

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import { fireEvent } from '@testing-library/react';

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import { fireEvent, waitFor } from '@testing-library/react';

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent } from '@testing-library/react';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import {

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent } from '@testing-library/react';
 import { within, waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { getVideoAppointmentMock } from '../../mocks/v0';
 import {
   mockPastAppointmentInfo,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import {
   mockMessagesFetch,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import MockDate from 'mockdate';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { expect } from 'chai';
 import RequestedAppointmentsListGroup from '../../../appointment-list/components/RequestedAppointmentsListGroup';
 import { getVAOSRequestMock } from '../../mocks/v2';

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { getCCAppointmentMock } from '../../mocks/v0';
 import { mockAppointmentInfo } from '../../mocks/helpers';

--- a/src/applications/vaos/tests/components/EnrolledRoute.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/EnrolledRoute.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Switch } from 'react-router-dom';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { createTestStore, renderWithStoreAndRouter } from '../mocks/setup';

--- a/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { render } from '@testing-library/react';
 
-import TextareaWidget from '../../components/TextareaWidget';
 import userEvent from '@testing-library/user-event';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
+import TextareaWidget from '../../components/TextareaWidget';
 
 describe('VAOS <TextareaWidget>', () => {
   beforeEach(() => mockFetch());

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,
   setVaccineFacility,
 } from '../../mocks/setup';
-import userEvent from '@testing-library/user-event';
 
 import ClinicChoicePage from '../../../covid-19-vaccine/components/ClinicChoicePage';
 import { mockEligibilityFetches } from '../../mocks/helpers';
 import { getClinicMock } from '../../mocks/v0';
-import { mockFetch } from 'platform/testing/unit/helpers';
 import { TYPE_OF_CARE_ID } from '../../../covid-19-vaccine/utils';
 
 const initialState = {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import ContactFacilitiesPage from '../../../covid-19-vaccine/components/ContactFacilitiesPage';
 import {
   getRequestEligibilityCriteriaMock,

--- a/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.jsx
@@ -4,13 +4,14 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,
   setVaccineFacility,
   setVaccineClinic,
 } from '../../mocks/setup';
-import userEvent from '@testing-library/user-event';
 
 import SelectDate1Page from '../../../covid-19-vaccine/components/SelectDate1Page';
 import {
@@ -18,7 +19,6 @@ import {
   mockAppointmentSlotFetch,
 } from '../../mocks/helpers';
 import { getClinicMock, getAppointmentSlotMock } from '../../mocks/v0';
-import { mockFetch } from 'platform/testing/unit/helpers';
 import { TYPE_OF_CARE_ID } from '../../../covid-19-vaccine/utils';
 
 const initialState = {

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,

--- a/src/applications/vaos/tests/new-appointment/components/ClosestCityStatePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClosestCityStatePage.unit.spec.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { expect } from 'chai';
+import userEvent from '@testing-library/user-event';
+
+import { waitFor } from '@testing-library/dom';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
+import ClosestCityStatePage from '../../../new-appointment/components/ClosestCityStatePage';
 import {
   renderWithStoreAndRouter,
   setCommunityCareFlow,
 } from '../../mocks/setup';
-import userEvent from '@testing-library/user-event';
-
-import ClosestCityStatePage from '../../../new-appointment/components/ClosestCityStatePage';
-import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
 
 describe('VAOS <ClosestCityStatePage>', () => {
   beforeEach(() => mockFetch());

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareLanguagePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareLanguagePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 import { fireEvent, waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import CommunityCareLanguagePage from '../../../new-appointment/components/CommunityCareLanguagePage';
 

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 import { waitFor } from '@testing-library/dom';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/react';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { waitFor } from '@testing-library/dom';
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage/index.unit.spec.jsx
@@ -2,18 +2,18 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
+import userEvent from '@testing-library/user-event';
+
+import { waitFor, within } from '@testing-library/dom';
+import { Route } from 'react-router-dom';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
+import { FETCH_STATUS } from '../../../../utils/constants';
+import DateTimeRequestPage from '../../../../new-appointment/components/DateTimeRequestPage';
 import {
   createTestStore,
   renderWithStoreAndRouter,
   setCommunityCareFlow,
 } from '../../../mocks/setup';
-import userEvent from '@testing-library/user-event';
-
-import DateTimeRequestPage from '../../../../new-appointment/components/DateTimeRequestPage';
-import { FETCH_STATUS } from '../../../../utils/constants';
-import { waitFor, within } from '@testing-library/dom';
-import { Route } from 'react-router-dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
 
 async function chooseMorningRequestSlot(screen) {
   const currentMonth = moment()

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import moment from 'moment';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import userEvent from '@testing-library/user-event';
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
 
-import PreferredDatePage from '../../../new-appointment/components/PreferredDatePage';
-import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import PreferredDatePage from '../../../new-appointment/components/PreferredDatePage';
 
 const initialState = {
   featureToggles: {

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';

--- a/src/applications/vaos/tests/new-appointment/components/ScheduleCernerPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ScheduleCernerPage.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
@@ -5,7 +5,7 @@ import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import { getParentSiteMock } from '../../mocks/v0';
 import {

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
-import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
-import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';
+import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 
 const initialState = {
   featureToggles: {

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
-import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import { Route } from 'react-router-dom';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 
 import TypeOfVisitPage from '../../../new-appointment/components/TypeOfVisitPage';
 

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import VAFacilityPage from '../../../../new-appointment/components/VAFacilityPage/VAFacilityPageV2';
 import {

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 
-// eslint-disable-next-line import/no-unresolved
-import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 import { fireEvent, waitFor, within } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import VAFacilityPage from '../../../../new-appointment/components/VAFacilityPage/VAFacilityPageV2';

--- a/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.v2.unit.spec.js
@@ -6,8 +6,7 @@ import {
   mockFetch,
   setFetchJSONFailure,
   setFetchJSONResponse,
-  // eslint-disable-next-line import/no-unresolved
-} from '@department-of-veterans-affairs/platform-testing/helpers';
+} from '@department-of-veterans-affairs/platform-testing/unit/helpers';
 
 import {
   fetchBookedAppointment,


### PR DESCRIPTION
This just changes the way the `mockFetch` imports in `src/applications/vaos/tests/` are done. The linting warning was annoying. This fixes the annoying linting error.

## Summary

Changed `import { mockFetch } from 'platform/testing/unit/helpers';` to `import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';`

## Testing done

- Unit testing
- Cypress e2e testing

## What areas of the site does it impact?

This impacts the VAOS unit testing suite.

## Acceptance criteria

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No error nor warning in the console.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature
- [ ] [Accessibility foundational testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
