### PR TITLE
Add custom country required error message, as per other required address fields

### DIFF
--- a/src/platform/forms-system/src/js/definitions/profileAddress.js
+++ b/src/platform/forms-system/src/js/definitions/profileAddress.js
@@ -253,6 +253,9 @@ export default function addressUiSchema(
       'ui:required': uiRequiredCallback,
       'ui:title': 'Country',
       'ui:autocomplete': 'country',
+      'ui:errorMessages': {
+        required: 'Country is required',
+      },
       'ui:options': {
         /**
          * This is needed because the country dropdown needs to be set to USA and disabled if a


### PR DESCRIPTION
Our team noticed that there are custom required error messages for City and street like
`Street address is required`
`City is required`

Adding the same for country, which did not have one.

## Summary

- Add custom required error message to country field in platform's profileAddress

## Testing done

- Tested locally and message showed when tabbed past field without selecting a country

## Screenshots
BEFORE:
<img width="347" alt="Screenshot 2023-05-15 at 12 43 46 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/4ef189c9-d3bf-48b2-b5fd-df66885dc4e3">


AFTER:
<img width="373" alt="Screenshot 2023-05-15 at 12 43 12 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/6a83e612-ca03-4ad9-8646-2a9ba16e5cf9">

## What areas of the site does it impact?

All forms using profile address
