### PR TITLE
4142 fixups Pt 1 – unauthed fixups

### DIFF
--- a/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
@@ -54,7 +54,7 @@ export class ConfirmationPage extends React.Component {
             <>
               <h4>Applicant</h4>
               <p>
-                {first} ${middle ? `${middle} ` : ''}
+                {first} {middle ? `${middle} ` : ''}
                 {last}
                 {suffix ? `, ${suffix}` : null}
               </p>

--- a/src/applications/simple-forms/21-4142/pages/contactInformation2.js
+++ b/src/applications/simple-forms/21-4142/pages/contactInformation2.js
@@ -24,8 +24,31 @@ export default {
           required:
             'Please enter a 10-digit phone number (with or without dashes)',
         },
+        'ui:options': {
+          ...phoneUI()['ui:options'],
+          updateSchema: () => ({
+            type: 'string',
+            maxLength: 10,
+          }),
+        },
       },
-      [veteranFields.internationalPhone]: phoneUI('International phone number'),
+      [veteranFields.internationalPhone]: {
+        ...phoneUI('International phone number'),
+        'ui:errorMessages': {
+          ...phoneUI()['ui:errorMessages'],
+          pattern:
+            'Please enter a valid international phone number (with or without dashes)',
+          minLength:
+            'Please enter a valid international phone number (with or without dashes)',
+        },
+        'ui:options': {
+          ...phoneUI()['ui:options'],
+          updateSchema: () => ({
+            type: 'string',
+            maxLength: 15,
+          }),
+        },
+      },
       [veteranFields.email]: {
         ...emailUI(),
         'ui:errorMessages': {

--- a/src/applications/simple-forms/21-4142/pages/preparerIdentification.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerIdentification.js
@@ -28,6 +28,9 @@ export default {
             it here
           </p>
         ),
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
     },
   },

--- a/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
@@ -22,6 +22,7 @@ const isNotThirdParty = formData => {
     ],
   );
 };
+const isThirdParty = formData => !isNotThirdParty(formData);
 
 /** @type {PageSchema} */
 export default {
@@ -33,12 +34,14 @@ export default {
         'ui:options': {
           hideIf: isNotThirdParty,
         },
+        'ui:required': formData => isThirdParty(formData),
       },
       [preparerIdentificationFields.preparerOrganization]: {
         'ui:title': 'Organization',
         'ui:options': {
           hideIf: isNotThirdParty,
         },
+        'ui:required': formData => isThirdParty(formData),
       },
       [preparerIdentificationFields.courtAppointmentInfo]: {
         'ui:title':

--- a/src/applications/simple-forms/21-4142/pages/recordsRequested.js
+++ b/src/applications/simple-forms/21-4142/pages/recordsRequested.js
@@ -2,24 +2,42 @@ import React from 'react';
 import dateUI from 'platform/forms-system/src/js/definitions/date';
 import * as address from 'platform/forms-system/src/js/definitions/address';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
-import { providerFacilityFields } from '../definitions/constants';
+
+import { convertToDateField } from 'platform/forms-system/src/js/validation';
+import { isValidDateRange } from 'platform/forms-system/src/js/utilities/validations';
+import {
+  patientIdentificationFields,
+  providerFacilityFields,
+} from '../definitions/constants';
 
 import RecordField from '../components/RecordField';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'ui:title': (
-      <h3 className="vads-u-color--gray-dark">
-        Where did you receive treatment?
-      </h3>
-    ),
     'ui:description': (
       <div className="vads-u-margin-bottom--4">
         Let us know where and when treatment was received. We'll request the
         private medical records for you.
       </div>
     ),
+    'ui:options': {
+      updateSchema: formData => {
+        let patientId = 'patient';
+        if (
+          formData[patientIdentificationFields.parentObject][
+            patientIdentificationFields.isRequestingOwnMedicalRecords
+          ]
+        )
+          patientId = 'Veteran';
+        const title = (
+          <h3 className="vads-u-color--gray-dark">
+            Where did the {patientId} receive treatment?
+          </h3>
+        );
+        return { title };
+      },
+    },
     [providerFacilityFields.parentObject]: {
       'ui:options': {
         itemName: 'Treatment record',
@@ -61,6 +79,22 @@ export default {
           from: dateUI('First treatment date (you can estimate)'),
           to: dateUI('Last treatment date (you can estimate)'),
         },
+        'ui:validations': [
+          (errors, field) => {
+            const treatmentDateFrom =
+              field[providerFacilityFields.treatmentDateRange].from;
+            const treatmentDateTo =
+              field[providerFacilityFields.treatmentDateRange].to;
+            const fromDate = convertToDateField(treatmentDateFrom);
+            const toDate = convertToDateField(treatmentDateTo);
+
+            if (!isValidDateRange(fromDate, toDate, true)) {
+              errors[providerFacilityFields.treatmentDateRange].to.addError(
+                'The end date must be after the start date',
+              );
+            }
+          },
+        ],
       },
     },
   },

--- a/src/applications/simple-forms/21-4142/tests/pages/preparerPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/pages/preparerPersonalInformation.unit.spec.jsx
@@ -60,7 +60,7 @@ testNumberOfErrorsOnSubmit(
   mockDataForDirectRelative,
 );
 
-const expectedNumberOfErrorsForThirdParty = 2;
+const expectedNumberOfErrorsForThirdParty = 4;
 testNumberOfErrorsOnSubmit(
   formConfig,
   schema,

--- a/src/applications/simple-forms/21-4142/tests/pages/recordsRequested.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/pages/recordsRequested.unit.spec.jsx
@@ -2,6 +2,7 @@ import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
 } from '../../../shared/tests/pages/pageTests.spec';
+import { patientIdentificationFields } from '../../definitions/constants';
 import formConfig from '../../config/form';
 
 const {
@@ -11,6 +12,12 @@ const {
 
 const pageTitle = 'records requested';
 
+const mockDataForVeteranIsSelf = {
+  [patientIdentificationFields.parentObject]: {
+    [patientIdentificationFields.isRequestingOwnMedicalRecords]: true,
+  },
+};
+
 const expectedNumberOfFields = 14;
 testNumberOfFields(
   formConfig,
@@ -18,6 +25,7 @@ testNumberOfFields(
   uiSchema,
   expectedNumberOfFields,
   pageTitle,
+  mockDataForVeteranIsSelf,
 );
 
 const expectedNumberOfErrors = 8;
@@ -27,4 +35,5 @@ testNumberOfErrorsOnSubmit(
   uiSchema,
   expectedNumberOfErrors,
   pageTitle,
+  mockDataForVeteranIsSelf,
 );


### PR DESCRIPTION
[See selected issues in document](https://docs.google.com/document/d/1BG5Mmv96rU9adSmyGfDDo_VGwEBxJ6vD_r4FYu3-XX8/edit#)

## Summary

- `ConfirmationPage` – Remove unwanted '$' from confirmation page text
- `contactInformation2` 
  - Allow for international phone to be 15 digits (max allowed by ITU-T E. 164)
  - Disallow home phone from being more than 10, and international from more than 15
- `preparerIdentification` – Hide 'other' text field on review page if empty
- `preparerPersonalInformation` – Require 'Title' and 'Organization' text fields for third parties
- `recordsRequested` 
  - custom header text dependent on who the patient is (veteran or other)
  - from/to date validation such that `to` cannot be before `from` (same day ok)

Tests:
- `preparerPersonalInformation.unit.spec.jsx` – fix expected number of errors to match new required fields
- `recordsRequested.unit.spec.jsx` – inject mock data to avoid react issue

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/143

## Testing done

- Test locally

## What areas of the site does it impact?

Form 21-4142 (non-prod)