### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^16.1.0",
+    "@department-of-veterans-affairs/component-library": "^16.1.1",
     "@department-of-veterans-affairs/formation": "^7.0.5",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,13 +2525,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^16.1.0":
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-16.1.0.tgz#6e4dde84766288f989aac34b317c74909273e95b"
-  integrity sha512-pKQ9gFz9LJVi7UFw3OA9GIa2JpySRBp3uJe4pyfh8Wf4CI7YCwS2LYdz9iCo9xickNjMMwCzfEQz+9E9C7tP6Q==
+"@department-of-veterans-affairs/component-library@^16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-16.1.1.tgz#3e6fad3c642547f600fcf72165e169aec98b23c4"
+  integrity sha512-bNerKtqS4btkPY+r211s+QhXFzDqJZPsszSOHliQCDeTRwT98otg2exsLVkHani0ExvwQASMh/P7Xw9fN6T/OQ==
   dependencies:
     "@department-of-veterans-affairs/react-components" "11.0.0"
-    "@department-of-veterans-affairs/web-components" "4.38.2"
+    "@department-of-veterans-affairs/web-components" "4.38.3"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2604,10 +2604,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.38.2":
-  version "4.38.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.38.2.tgz#65625b025c2f1dcad4f68ca3a5faa282bdada7f9"
-  integrity sha512-QvsboxrR1SWKJTcixtNEwOOygg5Ex5ikkf7zLqp++Jk+dGnkq1HduvVXJQEfqvc4meUWiT14tpYCbnmBaKjxBA==
+"@department-of-veterans-affairs/web-components@4.38.3":
+  version "4.38.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.38.3.tgz#77945c08d4ed21d783947d5b617fc8cdc4d41be9"
+  integrity sha512-YUWHphQF0VIDDF5e9PkgxEMIhMbE+kYtITtrEcH1i7vAQrSQS6fpygC0ke/DY2KAGceoNkxqUDSQd445hyIi9g==
   dependencies:
     "@stencil/core" "^2.19.2"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Summary

- Bringing in a hotfix to va-loading-indicator and its disposal of a MutationObserver that has been causing Sentry errors.
- DST

## Related issue(s)

- [Closes #1664](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1664)

## What areas of the site does it impact?

Anywhere va-loading-indicator is used.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions