### PR TITLE
Form 21-4142 update schema to allow lowercase in veteran service number

### DIFF
--- a/src/applications/simple-forms/21-4142/pages/personalInformation2.js
+++ b/src/applications/simple-forms/21-4142/pages/personalInformation2.js
@@ -35,6 +35,14 @@ export default {
           pattern:
             'Your Veteran service number must start with 0, 1, or 2 letters followed by 5 to 8 digits',
         },
+        'ui:options': {
+          replaceSchema: () => {
+            return {
+              type: 'string',
+              pattern: '^[a-zA-Z]{0,2}\\d{5,8}$',
+            };
+          },
+        },
       },
     },
   },

--- a/src/applications/simple-forms/21-4142/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/simple-forms/21-4142/tests/e2e/fixtures/data/maximal-test.json
@@ -115,7 +115,7 @@
       },
       "ssn": "789456122",
       "vaFileNumber": "789456123",
-      "veteranServiceNumber": "AA7894561",
+      "veteranServiceNumber": "aA7894561",
       "fullName": {
         "first": "First",
         "middle": "Middle",


### PR DESCRIPTION
See title

## Summary

- Allow lowercase letters
- Modify test value to try both upper and lowercase

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/143

## Testing done

- Tested locally

## Screenshots

BEFORE:
![image (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/cf7920e9-c671-4b6b-a12f-f63bee678710)

AFTER:
![Screenshot 2023-05-16 at 1 06 08 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/4790b9ad-5bf8-4d0d-95ba-7a8d19430fca)


## What areas of the site does it impact?
Form 21-4142 (non prod)
