### PR TITLE
Remove 21-10210 submission mock

### DIFF
--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -35,8 +35,6 @@ const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
-  submit: () =>
-    Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'lay-witness-10210-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Remove `submit: ...` prop from form.js
- Team: VA Product Forms
- Not using Flipper

## Related issue(s)

- No bug ticket; just discovered in Staging that submission's still mocked.

## Testing done

[Need to wait 'til this is in Staging]

## What areas of the site does it impact?

N/A; this form's new and un-published

## Requested Feedback

[Just the usual code review(s)]
