### PR TITLE
58531 Remove BDD SHA alerts from non BDD views

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -143,9 +143,16 @@ function mapStateToProps(state) {
 
 ConfirmationPoll.propTypes = {
   delayFailure: PropTypes.number,
+  disabilities: PropTypes.array,
+  fullName: PropTypes.shape({
+    first: PropTypes.string,
+    last: PropTypes.string,
+  }),
+  isSubmittingBDD: PropTypes.bool,
   jobId: PropTypes.string,
   longWaitTime: PropTypes.number,
   pollRate: PropTypes.number,
+  submittedAt: PropTypes.object,
 };
 
 // Using it as a prop for easy testing

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import get from 'platform/utilities/data/get';
-import { apiRequest } from 'platform/utilities/api';
-import { focusElement } from 'platform/utilities/ui';
+import get from '@department-of-veterans-affairs/platform-forms-system/get';
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/exports';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { pendingMessage } from '../content/confirmation-poll';
@@ -13,13 +14,6 @@ import { submissionStatuses, terminalStatuses } from '../constants';
 import { isBDD } from '../utils';
 
 export class ConfirmationPoll extends React.Component {
-  // Using it as a prop for easy testing
-  static defaultProps = {
-    pollRate: 5000,
-    delayFailure: 6000, // larger than pollRate
-    longWaitTime: 30000,
-  };
-
   constructor(props) {
     super(props);
 
@@ -146,5 +140,19 @@ function mapStateToProps(state) {
     isSubmittingBDD: isBDD(state.form.data) || false,
   };
 }
+
+ConfirmationPoll.propTypes = {
+  delayFailure: PropTypes.number,
+  jobId: PropTypes.string,
+  longWaitTime: PropTypes.number,
+  pollRate: PropTypes.number,
+};
+
+// Using it as a prop for easy testing
+ConfirmationPoll.defaultProps = {
+  pollRate: 5000,
+  delayFailure: 6000, // larger than pollRate
+  longWaitTime: 30000,
+};
 
 export default connect(mapStateToProps)(ConfirmationPoll);

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
-import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/exports';
+import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import ConfirmationPage from '../containers/ConfirmationPage';

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -143,7 +143,7 @@ function mapStateToProps(state) {
     disabilities: selectAllDisabilityNames(state),
     submittedAt: state.form.submission.timestamp,
     jobId: state.form.submission.response?.attributes?.jobId,
-    isSubmittingBDD: isBDD(state.form.data) || true,
+    isSubmittingBDD: isBDD(state.form.data) || false,
   };
 }
 

--- a/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
+++ b/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
@@ -3,12 +3,16 @@ import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.jso
 import { UploadDescription } from '../content/fileUploadDescriptions';
 import { ancillaryFormUploadUi } from '../utils/schemas';
 import { selfAssessmentAlert } from '../content/selfAssessmentAlert';
+import { isBDD } from '../utils';
 
 const { attachments } = full526EZSchema.properties;
 
 export const uiSchema = {
   'view:selfAssessmentAlert': {
     'ui:title': selfAssessmentAlert,
+    'ui:options': {
+      hideIf: formData => !isBDD(formData),
+    },
   },
   additionalDocuments: {
     ...ancillaryFormUploadUi(

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -11,8 +11,8 @@ import {
 import { createStore } from 'redux';
 import { render } from '@testing-library/react';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import formConfig from '../../config/form.js';
-import { SAVED_SEPARATION_DATE } from '../../constants.js';
+import formConfig from '../../config/form';
+import { SAVED_SEPARATION_DATE } from '../../constants';
 
 const invalidDocumentData = {
   additionalDocuments: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import { createStore } from 'redux';
 import { render } from '@testing-library/react';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
-
+import moment from 'moment';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
@@ -12,6 +12,7 @@ import { createStore } from 'redux';
 import { render } from '@testing-library/react';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import formConfig from '../../config/form.js';
+import { SAVED_SEPARATION_DATE } from '../../constants.js';
 
 const invalidDocumentData = {
   additionalDocuments: [
@@ -126,6 +127,14 @@ describe('526EZ document upload', () => {
     const fakeStore = createStore(() => ({
       featureToggles: {},
     }));
+
+    // mock BDD
+    sessionStorage.setItem(
+      SAVED_SEPARATION_DATE,
+      moment()
+        .add(90, 'days')
+        .format('YYYY-MM-DD'),
+    );
 
     const form = render(
       <Provider store={fakeStore}>


### PR DESCRIPTION
## Summary
New BDD Separation Health Assessment alerts are incorrectly showing on the evidence types page and confirmation page (see linked ticket for steps to reproduce)

_(Which team do you work for, does your team own the maintenance of this component?)_
Disability Experience Team

## Related issue(s)
[#58531](https://app.zenhub.com/workspaces/disability-experience-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/58531)

## Testing done
 _Describe the steps required to verify your changes are working as expected_
See steps to reproduce, expected vs actual, and url's in linked ticket

_Describe the tests completed and the results_
Unit test fixed, e2e successful, manual test successful

## Screenshots
This type of warning alert should no longer display on the evidence types or confirmation pages when user is filing a non BDD claim
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/81ddbb71-0667-4545-bc62-44125ea19f4f)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
[n/a] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
[n/a] Documentation has been updated ([link to documentation](#) \*if necessary)
[n/a] Screenshot of the developed feature is added
[n/a] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
[n/a] Events are being sent to the appropriate logging solution
[n/a] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

[n/a] Did you login to a local build and verify all authenticated routes work as expected with a test user


