### PR TITLE
update types for form/schemas

### DIFF
--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -174,14 +174,14 @@
 
 /**
  * @typedef {{
- *   atLeastOne:? string,
- *   enum:? string,
- *   maxItems:? string,
- *   maxLength:? string,
- *   minItems:? string,
- *   minLength:? string,
- *   pattern:? string,
- *   required:? string,
+ *   atLeastOne?: string,
+ *   enum?: string,
+ *   maxItems?: string,
+ *   maxLength?: string,
+ *   minItems?: string,
+ *   minLength?: string,
+ *   pattern?: string,
+ *   required?: string,
  * } | {
  *   [key: string]: string
  * }} UIErrorMessages

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -20,126 +20,126 @@
 
 /**
  * @typedef {Object} FormConfig
- * @property {Array<Object>} additionalRoutes
- * @property {string} ariaDescribedBySubmit
- * @property {Record<string, FormConfigChapter>} chapters
- * @property {(props: any) => JSX.Element} confirmation
- * @property {CustomText} customText
- * @property {Record<string, SchemaOptions>} defaultDefinitions
- * @property {Dev} dev - object of dev-only options
- * @property {Downtime} downtime
- * @property {(props: any) => JSX.Element} errorText
- * @property {(props: any) => JSX.Element} footerContent
- * @property {string} formId
- * @property {(props: any) => JSX.Element} formSavedPage
- * @property {() => JSX.Element} getHelp
- * @property {(props: any) => JSX.Element} introduction
- * @property {Array<Function>} migrations
- * @property {(formConfig: any) => void} onFormLoaded
- * @property {boolean} prefillEnabled
- * @property {Function} prefillTransformer
- * @property {PreSubmitInfo} preSubmitInfo
- * @property {Object} reviewErrors
- * @property {string} rootUrl
- * @property {SavedFormMessages} savedFormMessages
- * @property {SaveInProgress} saveInProgress
- * @property {boolean} showReviewErrors
- * @property {(props: any) => JSX.Element} submissionError
- * @property {(form: any, formConfig: any) => Promise<any>} submit
- * @property {(props: any) => JSX.Element} submitErrorText
- * @property {string} submitUrl
- * @property {string} subTitle
- * @property {string} title
- * @property {string} trackingPrefix
- * @property {(form: any, formConfig: any) => any} transformForSubmit
- * @property {string} urlPrefix
- * @property {boolean} useCustomScrollAndFocus
- * @property {boolean} verifyRequiredPrefill
- * @property {number} version
- * @property {string} wizardStorageKey
+ * @property {Array<Object>} [additionalRoutes]
+ * @property {string} [ariaDescribedBySubmit]
+ * @property {Record<string, FormConfigChapter>} [chapters]
+ * @property {(props: any) => JSX.Element} [confirmation]
+ * @property {CustomText} [customText]
+ * @property {Record<string, SchemaOptions>} [defaultDefinitions]
+ * @property {Dev} [dev] - object of dev-only options
+ * @property {Downtime} [downtime]
+ * @property {(props: any) => JSX.Element} [errorText]
+ * @property {(props: any) => JSX.Element} [footerContent]
+ * @property {string} [formId]
+ * @property {(props: any) => JSX.Element} [formSavedPage]
+ * @property {() => JSX.Element} [getHelp]
+ * @property {(props: any) => any} [introduction]
+ * @property {Array<Function>} [migrations]
+ * @property {(formConfig: any) => void} [onFormLoaded]
+ * @property {boolean} [prefillEnabled]
+ * @property {Function} [prefillTransformer]
+ * @property {PreSubmitInfo} [preSubmitInfo]
+ * @property {Object} [reviewErrors]
+ * @property {string} [rootUrl]
+ * @property {SavedFormMessages} [savedFormMessages]
+ * @property {SaveInProgress} [saveInProgress]
+ * @property {boolean} [showReviewErrors]
+ * @property {(props: any) => JSX.Element} [submissionError]
+ * @property {(form: any, formConfig: any) => Promise<any>} [submit]
+ * @property {(props: any) => JSX.Element} [submitErrorText]
+ * @property {string} [submitUrl]
+ * @property {string} [subTitle]
+ * @property {string} [title]
+ * @property {string} [trackingPrefix]
+ * @property {(form: any, formConfig: any) => any} [transformForSubmit]
+ * @property {string} [urlPrefix]
+ * @property {boolean} [useCustomScrollAndFocus]
+ * @property {boolean} [verifyRequiredPrefill]
+ * @property {number} [version]
+ * @property {string} [wizardStorageKey]
  */
 
 /**
  * @typedef {Object} CustomText
- * @property {string} appSavedSuccessfullyMessage
- * @property {string} appType
- * @property {string} continueAppButtonText
- * @property {string} reviewPageTitle
- * @property {string} startNewAppButtonText
- * @property {string} submitButtonText
+ * @property {string} [appSavedSuccessfullyMessage]
+ * @property {string} [appType]
+ * @property {string} [continueAppButtonText]
+ * @property {string} [reviewPageTitle]
+ * @property {string} [startNewAppButtonText]
+ * @property {string} [submitButtonText]
  */
 
 /**
  * @typedef {Object} Dev
- * @property {boolean} showNavLinks
+ * @property {boolean} [showNavLinks]
  */
 
 /**
  * @typedef {Object} SavedFormMessages
- * @property {string} notFound
- * @property {string} noAuth
+ * @property {string} [notFound]
+ * @property {string} [noAuth]
  */
 
 /**
  * @typedef {Object} Downtime
- * @property {Array<string>} dependnecies
- * @property {string} endTime
- * @property {string} message
- * @property {boolean} requiredForPrefill
- * @property {'down' |'downtimeApproaching' | 'ok'} status
- * @property {string} startTime
+ * @property {Array<string>} [dependnecies]
+ * @property {string} [endTime]
+ * @property {string} [message]
+ * @property {boolean} [requiredForPrefill]
+ * @property {'down' |'downtimeApproaching' | 'ok'} [status]
+ * @property {string} [startTime]
  */
 
 /**
  * @typedef {Object} PreSubmitInfo
- * @property {(props: any) => JSX.Element} CustomComponent
- * @property {string} error
- * @property {string} field
- * @property {JSX.Element} label
- * @property {string | JSX.Element} notice
- * @property {boolean} required
- * @property {StatementOfTruth} statementOfTruth
+ * @property {(props: any) => JSX.Element} [CustomComponent]
+ * @property {string} [error]
+ * @property {string} [field]
+ * @property {JSX.Element} [label]
+ * @property {string | JSX.Element} [notice]
+ * @property {boolean} [required]
+ * @property {StatementOfTruth} [statementOfTruth]
  */
 
 /**
  * @typedef {Object} SaveInProgress
- * @property {Object} messages
- * @property {string} messages.inProgress
- * @property {string} messages.expired
- * @property {string} messages.saved
+ * @property {Object} [messages]
+ * @property {string} [messages.inProgress]
+ * @property {string} [messages.expired]
+ * @property {string} [messages.saved]
  */
 
 /**
  * @typedef {Object} StatementOfTruth
- * @property {string | JSX.Element} body
- * @property {string} fullNamePath - defaults to 'veteran.fullName'
- * @property {string} heading - defaults to 'Statement of truth'
- * @property {string} messageAriaDescribedby - defaults to 'Statement of truth'
- * @property {string} textInputLabel - defaults to 'Your full name'
+ * @property {string | JSX.Element} [body]
+ * @property {string} [fullNamePath] - defaults to 'veteran.fullName'
+ * @property {string} [heading] - defaults to 'Statement of truth'
+ * @property {string} [messageAriaDescribedby] - defaults to 'Statement of truth'
+ * @property {string} [textInputLabel] - defaults to 'Your full name'
  */
 
 /**
  * @typedef {Object} FormConfigChapter
- * @property {Record<string, FormConfigPage>} pages
- * @property {string | Function} title
+ * @property {Record<string, FormConfigPage>} [pages]
+ * @property {string | Function} [title]
  */
 
 /**
  * @typedef {Object} FormConfigPage
- * @property {string} arrayPath
- * @property {(props: any) => JSX.Element} CustomPage
- * @property {(props: any) => JSX.Element} CustomPageReview
- * @property {(formData: Object) => boolean} depends
- * @property {Object} initialData
- * @property {(formData: any) => void} onContinue
- * @property {(data: any) => boolean} itemFilter
- * @property {string} path
- * @property {SchemaOptions} schema
- * @property {string | Function} scrollAndFocusTarget
- * @property {boolean} showPagePerItem
- * @property {string | Function} title
- * @property {UISchemaOptions} uiSchema
- * @property {(item, index) => void} updateFormData
+ * @property {string} [arrayPath]
+ * @property {(props: any) => JSX.Element} [CustomPage]
+ * @property {(props: any) => JSX.Element} [CustomPageReview]
+ * @property {(formData: Object) => boolean} [depends]
+ * @property {Object} [initialData]
+ * @property {(formData: any) => void} [onContinue]
+ * @property {(data: any) => boolean} [itemFilter]
+ * @property {string} [path]
+ * @property {SchemaOptions} [schema]
+ * @property {string | Function} [scrollAndFocusTarget]
+ * @property {boolean} [showPagePerItem]
+ * @property {string | Function} [title]
+ * @property {UISchemaOptions} [uiSchema]
+ * @property {(item, index) => void} [updateFormData]
  */
 
 /**
@@ -150,87 +150,93 @@
 
 /**
  * @typedef {{
- *    items: UISchemaOptions,
- *   'ui:autocomplete': string,
- *   'ui:description': string | JSX.Element,
- *   'ui:disabled': boolean,
- *   'ui:errorMessages': UIErrorMessages,
- *   'ui:field': (props: any) => JSX.Element,
- *   'ui:hidden': boolean,
- *   'ui:objectViewField': (props: any) => JSX.Element,
- *   'ui:options': UIOptions,
- *   'ui:order': string[],
- *   'ui:required': (formData: any) => boolean,
- *   'ui:reviewField': (props: any) => JSX.Element,
- *   'ui:reviewWidget': (props: any) => JSX.Element,
- *   'ui:title': string | JSX.Element,
- *   'ui:validations': Array<((errors, value) => void)>,
- *   'ui:widget': 'yesNo' | 'checkbox' | 'radio' | 'select' | 'email' | 'date' | 'textarea' | (props: any) => JSX.Element,
- *   [key: string]: UISchemaOptions
+ *    items?: UISchemaOptions,
+ *   'ui:autocomplete'?: string,
+ *   'ui:description'?: string | JSX.Element | ((props: any) => JSX.Element),
+ *   'ui:disabled'?: boolean,
+ *   'ui:errorMessages'?: UIErrorMessages,
+ *   'ui:field'?: (props: any) => JSX.Element,
+ *   'ui:hidden'?: boolean,
+ *   'ui:objectViewField'?: (props: any) => JSX.Element,
+ *   'ui:options'?: UIOptions,
+ *   'ui:order'?: string[],
+ *   'ui:required'?: (formData: any) => boolean,
+ *   'ui:reviewField'?: (props: any) => JSX.Element,
+ *   'ui:reviewWidget'?: (props: any) => JSX.Element,
+ *   'ui:title'?: string | JSX.Element,
+ *   'ui:validations'?: Array<((errors, value) => void)>,
+ *   'ui:webComponentField'?: (props: any) => JSX.Element,
+ *   'ui:widget'?: 'yesNo' | 'checkbox' | 'radio' | 'select' | 'email' | 'date' | 'textarea' | ((props: any) => JSX.Element),
+ * } | {
+ *  [key: string]: UISchemaOptions
  * }} UISchemaOptions
  */
 
 /**
  * @typedef {{
- *   atLeastOne: string,
- *   enum: string,
- *   maxItems: string,
- *   maxLength: string,
- *   minItems: string,
- *   minLength: string,
- *   pattern: string,
- *   required: string,
+ *   atLeastOne:? string,
+ *   enum:? string,
+ *   maxItems:? string,
+ *   maxLength:? string,
+ *   minItems:? string,
+ *   minLength:? string,
+ *   pattern:? string,
+ *   required:? string,
+ * } | {
  *   [key: string]: string
  * }} UIErrorMessages
  */
 
 /**
  * @typedef {Object} UIOptions
- * @property {string} ariaDescribedby - The id of the element that describes the field
- * @property {string} classNames
- * @property {string} customTitle
- * @property {number} debounceRate
- * @property {string} duplicateKey
- * @property {string} expandUnder
- * @property {boolean} expandUnderCondition
- * @property {boolean} forceDivWrapper
- * @property {boolean} freeInput
- * @property {boolean} hideEmptyValueInReview
- * @property {(formData: any) => boolean} hideIf
- * @property {boolean} hideTitle
- * @property {boolean} hideOnReview
- * @property {string} hint
- * @property {boolean} includeRequiredLabelInTitle
- * @property {Array<(input) => string>} inputTransformers
- * @property {(item: any) => string} itemAriaLabel
- * @property {string} itemName
- * @property {boolean} keepInPageOnReview
- * @property {Record<string, string>} labels
- * @property {(formData: any) => any} replaceSchema
- * @property {(formData, schema, uiSchema, index, path) => any} updateSchema
- * @property {boolean} useDlWrap
- * @property {(props: any) => JSX.Element} viewComponent
- * @property {(props: any) => JSX.Element} viewField
- * @property {string} widgetClassNames
- * @property {Record<string, any>} widgetProps
+ * @property {string} [ariaDescribedby] - The id of the element that describes the field
+ * @property {string} [classNames]
+ * @property {string} [customTitle]
+ * @property {number} [debounceRate]
+ * @property {string} [duplicateKey]
+ * @property {string} [expandUnder]
+ * @property {boolean} [expandUnderCondition]
+ * @property {boolean} [forceDivWrapper]
+ * @property {boolean} [freeInput]
+ * @property {boolean} [hideEmptyValueInReview]
+ * @property {(formData: any) => boolean} [hideIf]
+ * @property {boolean} [hideLabelText]
+ * @property {boolean} [hideTitle]
+ * @property {boolean} [hideOnReview]
+ * @property {string} [hint]
+ * @property {boolean} [includeRequiredLabelInTitle]
+ * @property {Array<(input) => string>} [inputTransformers]
+ * @property {(item: any) => string} [itemAriaLabel]
+ * @property {string} [itemName]
+ * @property {boolean} [keepInPageOnReview]
+ * @property {Record<string, string>} [labels]
+ * @property {(formData: any) => any} [replaceSchema]
+ * @property {(formData, schema, uiSchema, index, path) => any} [updateSchema]
+ * @property {boolean} [useDlWrap]
+ * @property {(props: any) => JSX.Element} [viewComponent]
+ * @property {(props: any) => JSX.Element} [viewField]
+ * @property {string} [widgetClassNames]
+ * @property {Record<string, any>} [widgetProps]
  */
 
 /**
  * @typedef {{
- *   $ref: string,
- *   enum: string[],
- *   enumNames: string[],
- *   format: 'email' | 'date' | 'date-time' | 'uri' | 'data-url',
- *   items: SchemaOptions,
- *   maxLength: number,
- *   minItems: number,
- *   maxItems: number,
- *   minLength: number,
- *   pattern: string,
- *   properties: Record<string, SchemaOptions>,
- *   required: string[],
- *   type: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array',
- *   uniqueItems: boolean,
+ *   $ref?: string,
+ *   default?: string,
+ *   enum?: string[],
+ *   enumNames?: string[],
+ *   format?: 'email' | 'date' | 'date-time' | 'uri' | 'data-url',
+ *   items?: SchemaOptions,
+ *   maxLength?: number,
+ *   minItems?: number,
+ *   maxItems?: number,
+ *   minLength?: number,
+ *   pattern?: string,
+ *   properties?: Record<string, SchemaOptions>,
+ *   required?: string[],
+ *   type?: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array',
+ *   uniqueItems?: boolean,
+ * } | {
  *   [key: string]: SchemaOptions
  * }} SchemaOptions
  */


### PR DESCRIPTION
Update to make almost all types optional in `src/js/types` by changing `<name>` to `[<name>]`   or   `<key>: ` to `<key>?:`

This file was added for intellisense purposes, and so all that will stay the same.

It turns out types can not only be used for intellisense, but also optionally be enforced by adding // @ts-check at the top of your file.
When I tried that, I realized, there were several errors - including all types should be optional.
Also discovered some types are not perfect, but can followup in a separate review for other cases.

## Summary

update types

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#245

## Testing done

tested using // @ts-check to show errors

## What areas of the site does it impact?

Should not affect anyone. intellisense stays the same.
This is only for dev environments that choose to use the types in this file.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
