### PR TITLE
Update GA4 appointment events

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/CancelLink.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/CancelLink.jsx
@@ -35,7 +35,8 @@ export default function CancelLink({ appointment }) {
       <button
         onClick={() => {
           recordEvent({
-            event: `${GA_PREFIX}-cancel-booked-clicked`,
+            event: 'interaction',
+            action: `${GA_PREFIX}-cancel-booked-clicked`,
           });
           dispatch(startAppointmentCancel(appointment));
         }}

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -208,7 +208,10 @@ export function updateFacilityType(facilityType) {
 }
 
 export function startDirectScheduleFlow() {
-  recordEvent({ event: 'vaos-direct-path-started' });
+  recordEvent({
+    event: 'interaction',
+    action: 'vaos-direct-path-started',
+  });
 
   return {
     type: START_DIRECT_SCHEDULE_FLOW,
@@ -774,7 +777,8 @@ export function submitAppointmentOrRequest(history) {
     if (newAppointment.flowType === FLOW_TYPES.DIRECT) {
       const flow = GA_FLOWS.DIRECT;
       recordEvent({
-        event: `${GA_PREFIX}-direct-submission`,
+        event: 'interaction',
+        action: `${GA_PREFIX}-direct-submission`,
         flow,
         ...additionalEventData,
       });

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -700,7 +700,8 @@ async function cancelRequestedAppointment(request) {
   };
 
   recordEvent({
-    event: eventPrefix,
+    event: 'interaction',
+    action: eventPrefix,
     ...additionalEventData,
   });
 

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -391,7 +391,8 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     userEvent.click(screen.getByText(/cancel appointment/i));
     await screen.findByRole('alertdialog');
     expect(window.dataLayer[15]).to.deep.equal({
-      event: 'vaos-cancel-booked-clicked',
+      event: 'interaction',
+      action: 'vaos-cancel-booked-clicked',
     });
     //  And clicks on 'yes, cancel this appointment' to confirm
     userEvent.click(screen.getByText(/yes, cancel this appointment/i));
@@ -1634,7 +1635,8 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
     await screen.findByRole('alertdialog');
 
     expect(window.dataLayer[0]).to.deep.equal({
-      event: 'vaos-cancel-booked-clicked',
+      event: 'interaction',
+      action: 'vaos-cancel-booked-clicked',
     });
     // And click on 'yes, cancel this appointment' to confirm
     userEvent.click(screen.getByText(/yes, cancel this appointment/i));

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -13,7 +13,8 @@ export function recordEligibilityFailure(
   facilityId = null,
 ) {
   recordEvent({
-    event: `vaos-eligibility${errorKey ? `-${errorKey}` : ''}-failed`,
+    event: 'interaction',
+    action: `vaos-eligibility${errorKey ? `-${errorKey}` : ''}-failed`,
     'health-TypeOfCare': typeOfCare,
     'health-FacilityID': facilityId,
   });


### PR DESCRIPTION

## Summary
We will need to migrate the appointments analytics code to match the data layer code from the Analytics team for its GA4 (Google Analytics) standard. Our team partnered with the Analytics team and they have provided the configuration of the GA4 properties and will need to validate if it is working as expected [(see ticket #57685)](https://app.zenhub.com/workspaces/vaos---productdesign-5fff340c2d80a4000fb6f69c/issues/gh/department-of-veterans-affairs/va.gov-team/57685)



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#58468


## Testing done

unit test

## Screenshots

N/A


## What areas of the site does it impact?

VAOS Google Analytics

## Acceptance criteria

1. Update the vaos-cancel-appointment-submission event

- [ ]  The event will be 'interaction'
- [ ]  The action will be 'vaos-cancel-appointment-submission'

2. Update the vaos-cancel-booked-clicked event

- [ ]  The event will be 'interaction'
- [ ]  The action will be 'vaos-cancel-booked-clicked'

3. Update the vaos-direct-path-started event

- [ ]  The event will be 'interaction'
- [ ]  The action will be 'vaos-direct-path-started'

4. Update the vaos-direct-submission event

- [ ]  The event will be 'interaction'
- [ ]  The action will be 'vaos-direct-submission'

4. Update the vaos-eligibility-direct-check-past-visits-failed event

- [ ]  The event will be 'interaction'
- [ ]  The action will be 'vaos-eligibility-direct-check-past-visits-failed'



