### PR TITLE
Adds vaos-new-appointment-list GA event to new appointment list

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -135,13 +135,13 @@ export default function AppointmentsPageV2() {
       if (featureStatusImprovement) {
         document.title = `${pageTitle} | VA online scheduling | Veterans Affairs`;
         scrollAndFocus('h1');
-        recordEvent({
-          event: `${GA_PREFIX}-new-appointment-list`,
-        });
       } else {
         document.title = `${subPageTitle} | ${pageTitle} | Veterans Affairs`;
         scrollAndFocus('h1');
       }
+      recordEvent({
+        event: `${GA_PREFIX}-new-appointment-list`,
+      });
     },
     [
       subPageTitle,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -139,9 +139,6 @@ export default function AppointmentsPageV2() {
         document.title = `${subPageTitle} | ${pageTitle} | Veterans Affairs`;
         scrollAndFocus('h1');
       }
-      recordEvent({
-        event: `${GA_PREFIX}-new-appointment-list`,
-      });
     },
     [
       subPageTitle,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -136,13 +136,13 @@ export default function AppointmentsPageV2() {
       if (featureStatusImprovement) {
         document.title = `${pageTitle} | VA online scheduling | Veterans Affairs`;
         scrollAndFocus('h1');
+        recordEvent({
+          event: `${GA_PREFIX}-new-appointment-list`,
+        });
       } else {
         document.title = `${subPageTitle} | ${pageTitle} | Veterans Affairs`;
         scrollAndFocus('h1');
       }
-      recordEvent({
-        event: `${GA_PREFIX}-new-appointment-list`,
-      });
     },
     [
       subPageTitle,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -6,6 +6,7 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import PropTypes from 'prop-types';
+import recordEvent from 'platform/monitoring/record-event';
 import {
   selectFeatureStatusImprovement,
   selectFeatureAppointmentList,
@@ -19,7 +20,7 @@ import Select from '../../../components/Select';
 import ScheduleNewAppointment from '../ScheduleNewAppointment';
 import PageLayout from '../PageLayout';
 import { selectPendingAppointments } from '../../redux/selectors';
-import { APPOINTMENT_STATUS } from '../../../utils/constants';
+import { APPOINTMENT_STATUS, GA_PREFIX } from '../../../utils/constants';
 import AppointmentListNavigation from '../AppointmentListNavigation';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import RequestedAppointmentsListGroup from '../RequestedAppointmentsListGroup';
@@ -139,6 +140,9 @@ export default function AppointmentsPageV2() {
         document.title = `${subPageTitle} | ${pageTitle} | Veterans Affairs`;
         scrollAndFocus('h1');
       }
+      recordEvent({
+        event: `${GA_PREFIX}-new-appointment-list`,
+      });
     },
     [
       subPageTitle,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/index.jsx
@@ -6,7 +6,6 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import PropTypes from 'prop-types';
-import recordEvent from 'platform/monitoring/record-event';
 import {
   selectFeatureStatusImprovement,
   selectFeatureAppointmentList,
@@ -20,7 +19,7 @@ import Select from '../../../components/Select';
 import ScheduleNewAppointment from '../ScheduleNewAppointment';
 import PageLayout from '../PageLayout';
 import { selectPendingAppointments } from '../../redux/selectors';
-import { APPOINTMENT_STATUS, GA_PREFIX } from '../../../utils/constants';
+import { APPOINTMENT_STATUS } from '../../../utils/constants';
 import AppointmentListNavigation from '../AppointmentListNavigation';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import RequestedAppointmentsListGroup from '../RequestedAppointmentsListGroup';

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -68,6 +68,18 @@ export default function UpcomingAppointmentsList() {
   const featureAppointmentList = useSelector(state =>
     selectFeatureAppointmentList(state),
   );
+
+  useEffect(
+    () => {
+      if (featureAppointmentList) {
+        recordEvent({
+          event: `${GA_PREFIX}-new-appointment-list`,
+        });
+      }
+    },
+    [featureAppointmentList],
+  );
+
   useEffect(
     () => {
       if (futureStatus === FETCH_STATUS.notStarted) {


### PR DESCRIPTION
## Summary

Adds a new GA event/label (`vaos-new-appointment-list`) to the new appointment list view in order to track user views of the new appointment list.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/58630

## Testing done

- Unit testing
- e2e testing

## Acceptance criteria
- [ ] The new event shows up in GA when a user visits the new appointment list view

### Quality Assurance & Testing

- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
