### PR TITLE
MBMS-37684 Pre-need content is not logically organized

### DIFF
--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -123,8 +123,8 @@ class IntroductionPage extends React.Component {
                   </ul>
                 </li>
               </ul>
+              <h4>What if I need help filling out my application?</h4>
               <p>
-                <h4>What if I need help filling out my application?</h4>
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.
                 <br />
@@ -140,13 +140,15 @@ class IntroductionPage extends React.Component {
                 After submitting the form, you’ll get a confirmation message.
                 You can print this for your records.
               </p>
-              <SaveInProgressIntro
-                buttonOnly
-                prefillEnabled={this.props.route.formConfig.prefillEnabled}
-                messages={this.props.route.formConfig.savedFormMessages}
-                pageList={this.props.route.pageList}
-                startText="Start the pre-need eligibility application"
-              />
+              <div style={{ marginBottom: '-25px' }}>
+                <SaveInProgressIntro
+                  buttonOnly
+                  prefillEnabled={this.props.route.formConfig.prefillEnabled}
+                  messages={this.props.route.formConfig.savedFormMessages}
+                  pageList={this.props.route.pageList}
+                  startText="Start the pre-need eligibility application"
+                />
+              </div>
             </li>
             <li className="process-step list-three">
               <h3>VA review</h3>

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -32,7 +32,7 @@ class IntroductionPage extends React.Component {
           pageList={this.props.route.pageList}
           startText="Start the pre-need eligibility application"
         />
-        <h2 className="vads-u-font-size--h4">
+        <h2 className="vads-u-font-size--h3">
           Follow the steps below to apply for a pre-need eligibility
           determination
         </h2>
@@ -40,7 +40,7 @@ class IntroductionPage extends React.Component {
           <ol>
             <li className="process-step list-one">
               <h3>Prepare</h3>
-              <strong>When you apply, be sure to have these on hand:</strong>
+              <h4>When you apply, be sure to have these on hand:</h4>
               <ul>
                 <li>
                   The name of the VA national cemetery where you’d prefer to be
@@ -69,12 +69,10 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               <h4>You’ll need to upload:</h4>
-              <ul>
-                <li>
-                  A copy of your or your sponsor’s DD214 or other separation
-                  documents
-                </li>
-              </ul>
+              <p>
+                A copy of your or your sponsor’s DD214 or other separation
+                documents
+              </p>
               <h4>
                 Additional information and documents needed for certain
                 applicants:
@@ -126,8 +124,8 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               <p>
-                <strong>What if I need help filling out my application?</strong>{' '}
-                An accredited representative, like a Veterans Service Officer
+                <h4>What if I need help filling out my application?</h4> An
+                accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.
                 <br />
                 <a href="/disability/get-help-filing-claim/">
@@ -142,6 +140,13 @@ class IntroductionPage extends React.Component {
                 After submitting the form, you’ll get a confirmation message.
                 You can print this for your records.
               </p>
+              <SaveInProgressIntro
+                buttonOnly
+                prefillEnabled={this.props.route.formConfig.prefillEnabled}
+                messages={this.props.route.formConfig.savedFormMessages}
+                pageList={this.props.route.pageList}
+                startText="Start the pre-need eligibility application"
+              />
             </li>
             <li className="process-step list-three">
               <h3>VA review</h3>
@@ -156,13 +161,6 @@ class IntroductionPage extends React.Component {
             </li>
           </ol>
         </div>
-        <SaveInProgressIntro
-          buttonOnly
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
-          messages={this.props.route.formConfig.savedFormMessages}
-          pageList={this.props.route.pageList}
-          startText="Start the pre-need eligibility application"
-        />
         <div className="omb-info--container">
           {environment.isProduction() ? (
             <OMBInfo

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -124,8 +124,8 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               <p>
-                <h4>What if I need help filling out my application?</h4> An
-                accredited representative, like a Veterans Service Officer
+                <h4>What if I need help filling out my application?</h4>
+                An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.
                 <br />
                 <a href="/disability/get-help-filing-claim/">


### PR DESCRIPTION
# [MBMS-37684](https://vajira.max.gov/browse/MBMS-37684)

## Summary

Steps to reproduce:

- [Go to the apply for pre-need page](https://www.va.gov/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/introduction)

- Using [headingsmap](https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi?hl=en) or a screen reader, confirm that headings are missing from the page

 

Expected results: (Solution): REFERENCE THE WIREFRAMES FOR UI/UX DESIGN

Note: Changes apply to Pre-Need Form Introduction Page: https://www.va.gov/burials-and-memorials/pre-need/form-10007-apply-for-eligibility. There are button differences on the page when a user is signed in v. not signed in, which are noted below. 

1. The heading for Follow the steps below to apply for a pre-need eligibility determination  
        1. continues to read as H2 heading for screen readers
        2. Is updated to have H3 styling instead
     
2. Within the process list/subway, under Step 1: Prepare:
        1. The bold text for When you apply, be sure to have these on hand: is updated to be an H4 heading.
        2. Under the heading for You’ll need to upload:
                    - The bullet is removed, for the body text, for A copy of your or your sponsor’s DD214 or other separation documents.
                    - The bold text for What if I need help filling out my application? is updated to be an H4 heading. 

3. Button changes for signed-in experience: Within the process list/subway, under Step 2: Apply:
        1. The green button, at the bottom of the Introduction page to Start the pre-need eligibility application, is updated to be placed within Step 2 under the body text in that step.

4. Button changes for signed-out experience: Within the process list/subway, under Step 2: Apply:
        1. The blue button, at the bottom of the Introduction page to Sign in to start your application, is updated to be placed within Step 2 under the body text in that step.
        2. The link to Start your application without signing in is be relocated within Step 2 to be placed under the blue button.

## Related issue(s)

- [Github Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/47355)

## Testing done

- [x] Local Testing 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Headings Map  | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/fab1483c-c7cb-4187-b025-e2b8e4476d71)  |  ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/28c3f776-b96c-46f1-8c9d-43c1eb05a5d3)|
| Start Button Signed In | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/eebd1514-9bb3-4715-a19a-23783c57ffb3)  |  ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/5e2344bf-617b-4dd3-a4fe-6816c807fafd) |
| Start Button Signed Out | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/21af3c86-9cd7-41ab-89ba-e09c915f885e)  | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/7433ba7a-80fc-4010-a4f2-e7b3bcd83129)|


