### PR TITLE
VACMS-13585 Income Limits application MVP

### DIFF
--- a/src/applications/income-limits/actions/index.js
+++ b/src/applications/income-limits/actions/index.js
@@ -1,0 +1,15 @@
+import { IL_UPDATE_DEPENDENTS, IL_UPDATE_ZIP } from '../constants';
+
+export const updateDependents = value => {
+  return {
+    type: IL_UPDATE_DEPENDENTS,
+    payload: value,
+  };
+};
+
+export const updateZipCode = value => {
+  return {
+    type: IL_UPDATE_ZIP,
+    payload: value,
+  };
+};

--- a/src/applications/income-limits/components/IncomeLimitsApp.jsx
+++ b/src/applications/income-limits/components/IncomeLimitsApp.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const IncomeLimitsApp = ({ children }) => {
+  return (
+    <div className="row vads-u-padding-top--4 vads-u-padding-bottom--8">
+      <div className="usa-width-two-thirds medium-8 columns">{children}</div>
+    </div>
+  );
+};
+
+IncomeLimitsApp.propTypes = {
+  children: PropTypes.any,
+};
+
+export default IncomeLimitsApp;

--- a/src/applications/income-limits/constants/index.js
+++ b/src/applications/income-limits/constants/index.js
@@ -1,0 +1,9 @@
+export const IL_UPDATE_ZIP = 'income-limits/UPDATE_ZIP';
+export const IL_UPDATE_DEPENDENTS = 'income-limits/UPDATE_DEPENDENTS';
+
+export const ROUTES = {
+  DEPENDENTS: 'dependents',
+  REVIEW: 'review',
+  RESULTS: 'results',
+  ZIPCODE: '/',
+};

--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import {
+  VaButtonPair,
+  VaNumberInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { ROUTES } from '../constants';
+import { updateDependents } from '../actions';
+
+const DependentsPage = ({ dependents, router, updateDependentsField }) => {
+  const [error, setError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const dependentsValid = deps => {
+    return deps?.match(/^[0-9]+$/);
+  };
+
+  const validDependents = dependents?.length > 0 && dependentsValid(dependents);
+
+  const onContinueClick = () => {
+    setSubmitted(true);
+
+    if (!validDependents) {
+      setError(true);
+    } else {
+      setError(false);
+      updateDependentsField(dependents);
+      router.push(ROUTES.REVIEW);
+    }
+  };
+
+  const onBlurInput = () => {
+    if (validDependents) {
+      setError(false);
+    }
+  };
+
+  const onDependentsInput = event => {
+    updateDependentsField(event.target.value);
+  };
+
+  const onBackClick = () => {
+    router.push(ROUTES.ZIPCODE);
+  };
+
+  return (
+    <>
+      <h1>Donec nec venenatis neque etiam ac nisi orci?</h1>
+      <form>
+        <VaNumberInput
+          data-testid="il-dependents"
+          error={
+            (submitted && error && 'Please enter a number for dependents') ||
+            null
+          }
+          hint="Dependents hint text"
+          id="numberOfDependents"
+          inputmode="numeric"
+          label="Number of dependents"
+          max={99}
+          min={0}
+          name="numberOfDependents"
+          onBlur={onBlurInput}
+          onInput={onDependentsInput}
+          required
+          value={dependents || ''}
+        />
+        <VaButtonPair
+          data-testid="il-buttonPair"
+          onPrimaryClick={onContinueClick}
+          onSecondaryClick={onBackClick}
+          continue
+        />
+      </form>
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  dependents: state?.incomeLimits?.form?.dependents,
+});
+
+const mapDispatchToProps = {
+  updateDependentsField: updateDependents,
+};
+
+DependentsPage.propTypes = {
+  updateDependentsField: PropTypes.func.isRequired,
+  dependents: PropTypes.string,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DependentsPage);

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+const formatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+
+const Results = ({ limits }) => {
+  const {
+    gmt_threshold: gmt,
+    national_threshold: national,
+    pension_threshold: pension,
+  } = limits;
+
+  return (
+    <>
+      <h1>Vivamus varius sem eget</h1>
+      <p>
+        In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
+        justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra. Nam
+        ac laoreet leo, nec fringilla libero. Maecenas ac felis non augue
+        malesuada iaculis id sit amet tellus. Etiam molestie auctor neque, eu
+        pharetra lacus rhoncus at.
+      </p>
+      <p>
+        Morbi placerat nibh augue, sit amet aliquam ipsum mattis sed. Morbi
+        pellentesque fermentum tortor, ac vestibulum ligula suscipit sit amet.
+        Donec scelerisque lectus a eros pellentesque rutrum. Sed sit amet varius
+        ipsum, ut rutrum lacus. Aliquam ut pulvinar sapien, eu gravida nisi.
+      </p>
+      <h3>Fusce risus lacus efficitur ac magna vitae</h3>
+      <va-accordion bordered data-testid="il-results">
+        <va-accordion-item
+          header={`${formatter.format(pension['0_dependent'])} or less`}
+        >
+          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
+          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
+          Nam ac laoreet leo, nec fringilla libero.
+        </va-accordion-item>
+        <va-accordion-item
+          header={`${formatter.format(
+            pension['0_dependent'] + 1,
+          )} - ${formatter.format(national['0_dependent'])}`}
+        >
+          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
+          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
+          Nam ac laoreet leo, nec fringilla libero.
+        </va-accordion-item>
+        <va-accordion-item
+          header={`${formatter.format(
+            national['0_dependent'] + 1,
+          )} - ${formatter.format(gmt)}`}
+        >
+          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
+          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
+          Nam ac laoreet leo, nec fringilla libero.
+        </va-accordion-item>
+        <va-accordion-item
+          header={`${formatter.format(gmt + 1)} - ${formatter.format(
+            gmt * 1.1,
+          )}`}
+        >
+          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
+          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
+          Nam ac laoreet leo, nec fringilla libero.
+        </va-accordion-item>
+        <va-accordion-item
+          header={`${formatter.format(gmt * 1.1 + 1)} or more`}
+        >
+          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
+          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
+          Nam ac laoreet leo, nec fringilla libero.
+        </va-accordion-item>
+      </va-accordion>
+      <h2>Aliquam ut pulvinar sapien, eu gravida nisi</h2>
+      <p>
+        Aenean tortor lorem, commodo quis est at, interdum mollis ipsum.
+        Suspendisse et nulla nisi.
+      </p>
+    </>
+  );
+};
+
+Results.propTypes = {
+  form: PropTypes.object.isRequired,
+  limits: PropTypes.shape({
+    // eslint-disable-next-line camelcase
+    gmt_threshold: PropTypes.number,
+    // eslint-disable-next-line camelcase
+    national_threshold: PropTypes.number,
+    // eslint-disable-next-line camelcase
+    pension_threshold: PropTypes.number,
+  }).isRequired,
+};
+
+const mapStateToProps = state => ({
+  form: state?.incomeLimits?.form,
+  limits: state?.incomeLimits?.results?.limits,
+});
+
+export default connect(mapStateToProps)(Results);

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaButtonPair } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { ROUTES } from '../constants';
+
+const ReviewPage = ({ router }) => {
+  const onContinueClick = () => {
+    router.push(ROUTES.RESULTS);
+  };
+
+  const onBackClick = () => {
+    router.push(ROUTES.DEPENDENTS);
+  };
+  return (
+    <>
+      <h1>Aenean tristique mollis</h1>
+      <p>Fusce risus lacus, efficitur ac magna vitae, cursus lobortis dui.</p>
+      <table className="usa-table-borderless" data-testid="il-review">
+        <tbody>
+          <tr>
+            <td>
+              <strong>Curabitur dictum:</strong>
+              <br aria-hidden="true" /> Yes
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Nulla at mauris non:</strong>
+              <br aria-hidden="true" /> No
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Class aptent:</strong>
+              <br aria-hidden="true" /> No
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Nisci orci:</strong>
+              <br aria-hidden="true" /> 00000
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Malesuada felis ultrices:</strong>
+              <br aria-hidden="true" /> 0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <VaButtonPair
+        data-testid="il-buttonPair"
+        onPrimaryClick={onContinueClick}
+        onSecondaryClick={onBackClick}
+        continue
+      />
+    </>
+  );
+};
+
+ReviewPage.propTypes = {
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+};
+
+export default ReviewPage;

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import {
+  VaButtonPair,
+  VaNumberInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { ROUTES } from '../constants';
+import { updateZipCode } from '../actions';
+
+const ZipCodePage = ({ router, updateZipCodeField, zipCode }) => {
+  const [error, setError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const zipCodeValid = zip => {
+    return zip.match(/^[0-9]+$/) && zip.length === 5;
+  };
+
+  const validZip = zipCode && zipCodeValid(zipCode);
+
+  const onContinueClick = () => {
+    setSubmitted(true);
+
+    if (!validZip) {
+      setError(true);
+    } else {
+      setError(false);
+      router.push(ROUTES.DEPENDENTS);
+    }
+  };
+
+  const onBlurInput = () => {
+    if (validZip) {
+      setError(false);
+    }
+  };
+
+  const onZipInput = event => {
+    updateZipCodeField(event.target.value);
+  };
+
+  const onBackClick = () => {
+    router.push('/');
+  };
+
+  return (
+    <>
+      <h1>Donec id elit vitae sapien finibus sagittis?</h1>
+      <form>
+        <VaNumberInput
+          className="input-size-3"
+          data-testid="il-zipCode"
+          error={
+            (submitted && error && 'Please enter a 5 digit zip code') || null
+          }
+          hint="Zip code hint text"
+          id="zipCode"
+          inputmode="numeric"
+          label="Zip code"
+          max={99999}
+          min={0}
+          name="zipCode"
+          onBlur={onBlurInput}
+          onInput={onZipInput}
+          required
+          value={zipCode || ''}
+        />
+        <VaButtonPair
+          data-testid="il-buttonPair"
+          onPrimaryClick={onContinueClick}
+          onSecondaryClick={onBackClick}
+          continue
+        />
+      </form>
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  zipCode: state?.incomeLimits?.form?.zipCode,
+});
+
+const mapDispatchToProps = {
+  updateZipCodeField: updateZipCode,
+};
+
+ZipCodePage.propTypes = {
+  updateZipCodeField: PropTypes.func.isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+  zipCode: PropTypes.string,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ZipCodePage);

--- a/src/applications/income-limits/income-limits-entry.jsx
+++ b/src/applications/income-limits/income-limits-entry.jsx
@@ -1,0 +1,14 @@
+import 'platform/polyfills';
+import './sass/income-limits.scss';
+
+import startApp from 'platform/startup';
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  entryName: manifest.entryName,
+  reducer,
+  routes,
+});

--- a/src/applications/income-limits/manifest.json
+++ b/src/applications/income-limits/manifest.json
@@ -1,0 +1,6 @@
+{
+  "appName": "Income Limits",
+  "entryFile": "./income-limits-entry.jsx",
+  "entryName": "income-limits",
+  "rootUrl": "/health-care/income-limits-temp"
+}

--- a/src/applications/income-limits/reducers/index.js
+++ b/src/applications/income-limits/reducers/index.js
@@ -1,0 +1,53 @@
+import { IL_UPDATE_ZIP, IL_UPDATE_DEPENDENTS } from '../constants';
+
+/* eslint-disable camelcase */
+const initialState = {
+  form: {
+    dependents: null,
+    zipCode: null,
+  },
+  results: {
+    county_name: 'Some County, XX',
+    income_year: 2023,
+    limits: {
+      national_threshold: {
+        '0_dependent': 44444,
+        '1_dependent': 55555,
+        additional_dependents: 6666,
+      },
+      pension_threshold: {
+        '0_dependent': 11111,
+        '1_dependent': 22222,
+        additional_dependents: 3333,
+      },
+      gmt_threshold: 77777,
+    },
+  },
+};
+
+const incomeLimits = (state = initialState, action) => {
+  switch (action.type) {
+    case IL_UPDATE_DEPENDENTS:
+      return {
+        ...state,
+        form: {
+          ...state.form,
+          dependents: action.payload,
+        },
+      };
+    case IL_UPDATE_ZIP:
+      return {
+        ...state,
+        form: {
+          ...state.form,
+          zipCode: action.payload,
+        },
+      };
+    default:
+      return state;
+  }
+};
+
+export default {
+  incomeLimits,
+};

--- a/src/applications/income-limits/routes.jsx
+++ b/src/applications/income-limits/routes.jsx
@@ -1,0 +1,20 @@
+import DependentsPage from './containers/DependentsPage';
+import IncomeLimitsApp from './components/IncomeLimitsApp';
+import ResultsPage from './containers/ResultsPage';
+import ReviewPage from './containers/ReviewPage';
+import ZipCodePage from './containers/ZipCodePage';
+import { ROUTES } from './constants';
+
+const routes = {
+  path: '/',
+  component: IncomeLimitsApp,
+  indexRoute: { component: ZipCodePage },
+  childRoutes: [
+    { path: ROUTES.DEPENDENTS, component: DependentsPage },
+    { path: ROUTES.REVIEW, component: ReviewPage },
+    { path: ROUTES.RESULTS, component: ResultsPage },
+    { path: ROUTES.ZIPCODE, component: ZipCodePage },
+  ],
+};
+
+export default routes;

--- a/src/applications/income-limits/sass/income-limits.scss
+++ b/src/applications/income-limits/sass/income-limits.scss
@@ -1,0 +1,1 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/src/applications/income-limits/tests/income-limits.cypress.spec.js
+++ b/src/applications/income-limits/tests/income-limits.cypress.spec.js
@@ -1,0 +1,74 @@
+// These tests work locally, but they will not succeed in the CI
+// until the content-build changes have been merged in to register the application
+xdescribe('Income Limits', () => {
+  const clickBack = () =>
+    cy
+      .findByTestId('il-buttonPair')
+      .shadow()
+      .get('button')
+      .first()
+      .click();
+
+  const clickContinue = () =>
+    cy
+      .findByTestId('il-buttonPair')
+      .shadow()
+      .get('button')
+      .eq(1)
+      .click();
+
+  const typeZip = () =>
+    cy
+      .findByTestId('il-zipCode')
+      .shadow()
+      .get('input')
+      .first()
+      .type('10108');
+
+  const typeDependents = () =>
+    cy
+      .findByTestId('il-dependents')
+      .shadow()
+      .get('input')
+      .first()
+      .type('2');
+
+  const verifyElement = selector => cy.findByTestId(selector).should('exist');
+
+  it('navigates through the flow successfully forward and backward', () => {
+    cy.visit('/health-care/income-limits-temp');
+
+    // Zip code
+    verifyElement('il-zipCode');
+    typeZip();
+    cy.injectAxeThenAxeCheck();
+    clickContinue();
+
+    // Dependents
+    verifyElement('il-dependents');
+    typeDependents();
+    cy.injectAxeThenAxeCheck();
+    clickContinue();
+
+    // Review
+    verifyElement('il-review');
+    cy.injectAxeThenAxeCheck();
+    clickContinue();
+
+    // Results
+    verifyElement('il-results');
+    cy.injectAxeThenAxeCheck();
+
+    // Review
+    cy.go('back');
+    verifyElement('il-review');
+    clickBack();
+
+    // Dependents
+    verifyElement('il-dependents');
+    clickBack();
+
+    // Zip code
+    verifyElement('il-zipCode');
+  });
+});


### PR DESCRIPTION
## Summary
Adding Income Limits MVP. This includes the zip code screen, dependents screen, review screen and results screen. Pages are responsive and you can navigate forward and backward. Error states on the inputs are present. All dummy data is used, including the dollar amounts for the results screen. One end-to-end Cypress test has been added for basic functionality.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13585

## Testing done
This is a new application. You can navigate directly to `/health-care/income-limits-temp` to load the application to the zip code entry page. After entering a zip code, you should see the dependents page. After entering a number of dependents, the review screen will show with dummy data. After clicking through to the results page, you will see more dummy data organized into accordions. You should be able to navigate backward through the app completely (use the browser back button from the results page).

## Screenshots
Desktop
<img width="700" alt="Screenshot 2023-05-18 at 11 04 35 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b9e405e2-aa5a-4c74-8996-a53db8e72435">
<img width="700" alt="Screenshot 2023-05-18 at 11 04 43 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e65411b0-7719-42f2-ab6c-57d47d863a2c">
<img width="700" alt="Screenshot 2023-05-18 at 11 04 50 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0e990dcc-bec0-4b26-a654-9734955a832c">
<img width="700" alt="Screenshot 2023-05-18 at 11 04 57 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/effd8564-a3f8-454d-aa3f-f649be2282b8">
<img width="700" alt="Screenshot 2023-05-18 at 11 05 06 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/37a115d5-bc9d-44ef-bec5-f24eaa397eff">

Mobile
<img width="300" alt="Screenshot 2023-05-18 at 11 05 17 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/4817fc8e-ecd0-4e02-ac3c-8bab51e2daf8">
<img width="300" alt="Screenshot 2023-05-18 at 11 05 26 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/685b9edc-8fa7-4769-8e54-7ea5e0f10625">
<img width="300" alt="Screenshot 2023-05-18 at 11 05 33 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b013d24b-0b86-4c83-87c0-5adf26033e3d">
<img width="300" alt="Screenshot 2023-05-18 at 11 05 42 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/d60b3d0c-d674-42c4-9188-f9760b8b1540">

## What areas of the site does it impact?
No existing parts of the site are affected. This is a new application.

## Acceptance criteria
- [x] All of the below responds to both mobile and desktop layouts using default design system behavior
- [x] Flipper is created
- [ ] Experience is hidden by a flipper (flipper is not needed; the content-build published state controls whether it is visible in production
- [x] Results screen is data-driven based on a mock API response (i.e., inputs don't affect results screen yet) - 
  - [x] mock data has shape of future API response, documented in [this comment](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12584#issuecomment-1446629888) (but definitely cross-check with the mock response built into the initial version of the income limits API)
  - [x] mock data should be of "typical" shape, where GMT > NMT
- [x] Screens exist _with placeholder/junk content_ for the "core" app screens, which _do not include any yes/no questions_:
  - [x] Zip code input
  - [x] Dependents input 
  - [x] Review Info screen (read-only, no edit links)
  - [x] Results screen
- [x] URLs for each screen are as follows:
  - [x] Base url of app is `/health-care/income-limits-temp' ("temp" path will be updated by Content team later)
  - [x] Screens have unique URLs – _discuss with Wes, may need a little research into how other form flows do urls – temps would be okay, e.g. "/zip"_
- [x] Continue and Back buttons function navigate between screens when present
  - [x] On results screen, only the browser Back button can take me to the previous screen (Results)
- [x] All income ranges are displayed correctly in accordion header text _for the typical GMT > NMT case_ – refer to this [annotated screenshot in Mural](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1683232214853/cfc6da5007d8f99ee0bc83e261e118e7074ffa85?wid=0-1683306939130)
  - [x] accordions themselves have placeholder content
  - [x] accordions default to closed
- [x] Placeholder content _which is obviously fake_ is in place on each screen

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed