### PR TITLE
Profile contact info | Fix you may continue alert always showing

### DIFF
--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -69,6 +69,7 @@ const ContactInfo = ({
 }) => {
   const wrapRef = useRef(null);
   window.sessionStorage.setItem(REVIEW_CONTACT, onReviewPage || false);
+  const [hasInitialized, setHasInitialized] = useState(false);
   const [hadError, setHadError] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [editState] = useState(getReturnState());
@@ -139,9 +140,6 @@ const ContactInfo = ({
           contactInfo.mailingAddress?.updatedAt !== address?.updatedAt)
       ) {
         const wrapper = { ...data[keys.wrapper] };
-        if (keys.email) {
-          wrapper[keys.email] = contactInfo.email?.emailAddress;
-        }
         if (keys.address) {
           wrapper[keys.address] = contactInfo.mailingAddress;
         }
@@ -184,8 +182,11 @@ const ContactInfo = ({
         // page had an error flag, so we know when to show a success alert
         setHadError(true);
       }
+      setTimeout(() => {
+        setHasInitialized(true);
+      });
     },
-    [missingInfo],
+    [missingInfo, hasInitialized],
   );
 
   const MainHeader = onReviewPage ? 'h4' : 'h3';
@@ -194,30 +195,27 @@ const ContactInfo = ({
     ' ',
   );
 
-  const showSuccessAlert = (id, text) => {
-    // keep alerts in DOM, so we don't have to delay focus; but keep the 100ms
-    // delay to move focus away from the h3
-    const isHidden =
-      editState === `${id},updated` ? '' : 'vads-u-display--none';
-    return (
-      <va-alert
-        id={`updated-${id}`}
-        class={`vads-u-margin-y--1 ${isHidden}`}
-        status="success"
-        background-only
-        role="alert"
-      >
-        {`${text} ${content.updated}`}
-      </va-alert>
-    );
-  };
+  // keep alerts in DOM, so we don't have to delay focus; but keep the 100ms
+  // delay to move focus away from the h3
+  const showSuccessAlert = (id, text) => (
+    <va-alert
+      id={`updated-${id}`}
+      visible={editState === `${id},updated`}
+      class="vads-u-margin-y--1"
+      status="success"
+      background-only
+      role="alert"
+    >
+      {`${text} ${content.updated}`}
+    </va-alert>
+  );
 
   const homePhoneString = getPhoneString(dataWrap[keys.homePhone]);
   const mobilePhoneString = getPhoneString(dataWrap[keys.mobilePhone]);
   const editText = content.edit.toLowerCase();
 
   // Loop to separate pages when editing
-  // Each Link includes an ID for focus managements on the review & submit page
+  // Each Link includes an ID for focus management on the review & submit page
   const contactSection = [
     keys.homePhone ? (
       <React.Fragment key="home">

--- a/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
@@ -84,9 +84,36 @@ describe('<ContactInfo>', () => {
     expect($('.blue-bar-block', container)).to.exist;
     expect($$('va-alert[status="error"]', container).length).to.equal(0);
     expect($$('va-alert[status="warning"]', container).length).to.equal(0);
+    expect(
+      $$('va-alert[status="success"][visible="true"]', container).length,
+    ).to.equal(0);
     expect($$('h3', container).length).to.equal(1);
     expect($$('h4', container).length).to.equal(4);
     expect($$('h5', container).length).to.equal(0);
+  });
+
+  it('should render contact data w/no success messages', () => {
+    const props = getData();
+    // data exists (no error) & shouldn't show success message after updating
+    const data = {
+      veteran: {
+        email: 'x@x.com',
+        mobilePhone: { ...vapProfile.mobilePhone, updatedAt: '' },
+        homePhone: { ...vapProfile.homePhone, updatedAt: '' },
+        mailingAddress: { ...vapProfile.mailingAddress, updatedAt: '' },
+      },
+    };
+    const { container } = render(
+      <Provider store={mockStore}>
+        <ContactInfo {...props} data={data} />
+      </Provider>,
+    );
+
+    expect($$('va-alert[status="error"]', container).length).to.equal(0);
+    expect($$('va-alert[status="warning"]', container).length).to.equal(0);
+    expect(
+      $$('va-alert[status="success"][visible="true"]', container).length,
+    ).to.equal(0);
   });
 
   describe('Successful edit', () => {
@@ -152,6 +179,27 @@ describe('<ContactInfo>', () => {
       expect(alert.innerHTML).to.contain('Mailing address updated');
       await waitFor(() => {
         expect(document.activeElement).to.eq(alert);
+      });
+    });
+
+    it('should render a success alert stating that missing info was added & user may continue', async () => {
+      const data = getData({ email: false });
+      const { container, rerender } = render(
+        <Provider store={mockStore}>
+          <ContactInfo {...data} />
+        </Provider>,
+      );
+
+      expect($('va-alert[status="warning"]', container)).to.exist;
+      rerender(
+        <Provider store={mockStore}>
+          <ContactInfo {...getData()} />
+        </Provider>,
+      );
+
+      await waitFor(() => {
+        const alert = $('va-alert[status="success"]', container);
+        expect(alert.innerHTML).to.contain('You may continue');
       });
     });
   });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > After merging [#24213](https://github.com/department-of-veterans-affairs/vets-website/pull/24213) and testing the component in staging, I noticed that the "you may continue" success alert displays immediately after arriving on the contact info page for the first time.
  > <img width="610" alt="The missing information has been added to your application. You may continue alert is showing immediately after getting to the contact info page for the first time" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/39a9bf0c-a1da-4892-aa2b-ce56bf6748a4">
- _(If bug, how to reproduce)_
  > - Go to https://staging.va.gov/mock-form
  > - log into any user
  > - Navigate to the contain info page & notice success alert
- _(What is the solution, why is this the solution)_
  > Because the initial data is an empty object, the `missingInfo` array is not empty. After the form data is updated, the `hadError` state is updated to reflect that an error existed. To fix it, an initialization flag was added and is only set after the  `missingInfo` array has updated.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews; no, this is platform code, but is part of the work I've been doing to centralize the contact info page
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#58638](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58638)

## Testing done

- _Describe what the old behavior was prior to the change_
  > You may continue success alert was always showing
- _Describe the steps required to verify your changes are working as expected_
  > Ignore initial missing info errors; at least until after the form data has been populated
- _Describe the tests completed and the results_
  > Added unit tests
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="610" alt="The missing information has been added to your application. You may continue alert is showing immediately after getting to the contact info page for the first time" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/39a9bf0c-a1da-4892-aa2b-ce56bf6748a4"> |  <img width="546" alt="no success alert see in screenshot" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/02fe5f82-30eb-4f7d-a083-4389aceffa77"> |

## What areas of the site does it impact?

Only the `mock-form` app is using this component, right now.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
