### PR TITLE
Updated startingOver to isStartingOver

### DIFF
--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -1,7 +1,12 @@
 // eslint-disable-next-line no-restricted-imports
 import { merge } from 'lodash';
-import set from '../../utilities/data/set';
 
+import createSchemaFormReducer from 'platform/forms-system/src/js/state';
+import {
+  createInitialState,
+  recalculateSchemaAndData,
+} from 'platform/forms-system/src/js/state/helpers';
+import reducers from 'platform/forms-system/src/js/state/reducers';
 import {
   SET_SAVE_FORM_STATUS,
   SET_AUTO_SAVE_FORM_STATUS,
@@ -15,18 +20,12 @@ import {
   PREFILL_STATUSES,
   saveErrors,
 } from './actions';
-
-import createSchemaFormReducer from 'platform/forms-system/src/js/state';
-import {
-  createInitialState,
-  recalculateSchemaAndData,
-} from 'platform/forms-system/src/js/state/helpers';
-import reducers from 'platform/forms-system/src/js/state/reducers';
+import set from '../../utilities/data/set';
 
 export const saveInProgressReducers = {
   [SET_SAVE_FORM_STATUS]: (state, action) => {
     const newState = set('savedStatus', action.status, state);
-    newState.startingOver = false;
+    newState.isStartingOver = false;
     newState.prefillStatus = PREFILL_STATUSES.notAttempted;
 
     if (action.status === SAVE_STATUSES.success) {
@@ -98,22 +97,23 @@ export const saveInProgressReducers = {
 
     return recalculateSchemaAndData(newState);
   },
-  [SET_START_OVER]: state =>
-    Object.assign({}, state, {
-      isStartingOver: true,
-      data: state.initialData,
-      loadedStatus: LOAD_STATUSES.pending,
-    }),
-  [SET_PREFILL_UNFILLED]: state =>
-    Object.assign({}, state, {
-      prefillStatus: PREFILL_STATUSES.unfilled,
-      data: state.initialData,
-      loadedStatus: LOAD_STATUSES.notAttempted,
-    }),
+  [SET_START_OVER]: state => ({
+    ...state,
+    isStartingOver: true,
+    data: state.initialData,
+    loadedStatus: LOAD_STATUSES.pending,
+  }),
+  [SET_PREFILL_UNFILLED]: state => ({
+    ...state,
+    prefillStatus: PREFILL_STATUSES.unfilled,
+    data: state.initialData,
+    loadedStatus: LOAD_STATUSES.notAttempted,
+  }),
 };
 
 export function createSaveInProgressInitialState(formConfig, initialState) {
-  return Object.assign({}, initialState, {
+  return {
+    ...initialState,
     initialData: initialState.data,
     savedStatus: SAVE_STATUSES.notAttempted,
     autoSavedStatus: SAVE_STATUSES.notAttempted,
@@ -133,7 +133,7 @@ export function createSaveInProgressInitialState(formConfig, initialState) {
     prefillTransformer: formConfig.prefillTransformer,
     trackingPrefix: formConfig.trackingPrefix,
     additionalRoutes: formConfig.additionalRoutes,
-  });
+  };
 }
 
 export function createSaveInProgressFormReducer(formConfig) {
@@ -141,7 +141,7 @@ export function createSaveInProgressFormReducer(formConfig) {
   let initialState = createInitialState(formConfig);
 
   if (!formConfig.disableSave) {
-    formReducers = Object.assign({}, formReducers, saveInProgressReducers);
+    formReducers = { ...formReducers, ...saveInProgressReducers };
     initialState = createSaveInProgressInitialState(formConfig, initialState);
   }
 

--- a/src/platform/forms/tests/save-in-progress/reducers.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/reducers.unit.spec.js
@@ -1,5 +1,5 @@
-import set from '../../../utilities/data/set';
 import { expect } from 'chai';
+import set from '../../../utilities/data/set';
 
 import {
   SET_SAVE_FORM_STATUS,
@@ -107,7 +107,7 @@ describe('schemaform createSaveInProgressInitialState', () => {
       );
 
       expect(state.savedStatus).to.equal(SAVE_STATUSES.success);
-      expect(state.startingOver).to.be.false;
+      expect(state.isStartingOver).to.be.false;
       expect(state.prefillStatus).to.equal(PREFILL_STATUSES.notAttempted);
     });
 


### PR DESCRIPTION
## Summary
Noticed `isStartingOver` was never getting reset to false if restart was triggered multiple times in the same session. Found `startingOver` flag being set in the `SET_SAVE_FORM_STATUS` reducer that isn't referenced anywhere else except a test. Thinking this is just a minor naming bug. 

Other changes outside of variable rename are linting changes!

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#[58681](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/58681)

## Testing done
Local testing completed

## Screenshots
N/A

## What areas of the site does it impact?
All forms that use `startingOver` variable (couldn't find other references, but just in case)
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
