### PR TITLE
FormConfigChapter type-def update

### DIFF
--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -122,6 +122,7 @@
  * @typedef {Object} FormConfigChapter
  * @property {Record<string, FormConfigPage>} [pages]
  * @property {string | Function} [title]
+ * @property {boolean | undefined} [hideFormNavProgress]
  */
 
 /**

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -122,7 +122,7 @@
  * @typedef {Object} FormConfigChapter
  * @property {Record<string, FormConfigPage>} [pages]
  * @property {string | Function} [title]
- * @property {boolean | undefined} [hideFormNavProgress]
+ * @property {boolean} [hideFormNavProgress]
  */
 
 /**


### PR DESCRIPTION
## Summary

- Add new, optional hideFormNavProgress property to forms-system FormConfigChapter type definition.
- Team: VA Product Forms
- Not using Flipper

## Related issue(s)

- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/va.gov-team-forms#245
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#195


## Testing done

- Verified Intellisense popup successfully in VS Code when hovering over my form-config hideNavFormProgress prop.

## What areas of the site does it impact?

Dev-only affordance; does _not_ impact form functionality.
[Impacts any `form.js` form-config file that has type-def Intellisense enabled via `/** @type {FormConfig} */`]
