### PR TITLE
EFSR - Resolution Amount - Copay Description Text

### DIFF
--- a/src/applications/financial-status-report/components/ResolutionAmount.jsx
+++ b/src/applications/financial-status-report/components/ResolutionAmount.jsx
@@ -15,7 +15,7 @@ const content = {
   },
   debtCompromise: {
     type: 'Compromise',
-    description: `If you can't pay the debt in full or make smaller monthly payments, we can consider a smaller, one-time payment to resolve your debt`,
+    description: `If you can't pay the debt in full or make smaller monthly payments, we can consider a smaller, one-time payment to resolve your debt.`,
     label: 'How much can you afford to pay as a one-time payment?',
   },
 };
@@ -74,6 +74,17 @@ const ResolutionAmount = ({ formContext }) => {
     formContext.submitted,
   );
 
+  const getResolutionText = () => {
+    if (currentDebt.debtType === 'COPAY') {
+      return `If you can't pay the debt in full, we can consider a smaller, one-time payment to resolve your debt.`;
+    }
+    if (currentDebt.debtType === 'DEBT' && resolutionOption === 'monthly') {
+      return content.debtMonthly.description;
+    }
+
+    return content.debtCompromise.description;
+  };
+
   return (
     <div>
       <div className="vads-u-margin-y--0">
@@ -86,9 +97,7 @@ const ResolutionAmount = ({ formContext }) => {
           </span>
         </p>
         <span className="vads-u-display--block vads-u-font-size--sm vads-u-margin-bottom--1">
-          {resolutionOption === 'monthly'
-            ? content.debtMonthly.description
-            : content.debtCompromise.description}
+          {getResolutionText()}
         </span>
       </div>
       <VaNumberInput

--- a/src/applications/financial-status-report/components/ResolutionAmount.jsx
+++ b/src/applications/financial-status-report/components/ResolutionAmount.jsx
@@ -18,6 +18,11 @@ const content = {
     description: `If you can't pay the debt in full or make smaller monthly payments, we can consider a smaller, one-time payment to resolve your debt.`,
     label: 'How much can you afford to pay as a one-time payment?',
   },
+  copayCompromise: {
+    type: 'Compromise',
+    description: `If you can't pay the debt in full, we can consider a smaller, one-time payment to resolve your debt.`,
+    label: 'How much can you afford to pay as a one-time payment?',
+  },
 };
 
 const getError = (debt, resolutionAmount, submitted) => {
@@ -76,7 +81,7 @@ const ResolutionAmount = ({ formContext }) => {
 
   const getResolutionText = () => {
     if (currentDebt.debtType === 'COPAY') {
-      return `If you can't pay the debt in full, we can consider a smaller, one-time payment to resolve your debt.`;
+      return content.copayCompromise.description;
     }
     if (currentDebt.debtType === 'DEBT' && resolutionOption === 'monthly') {
       return content.debtMonthly.description;


### PR DESCRIPTION
## Summary

Joe noticed that we needed to update copay text on resolution amount during user testing.

## Screenshots
<img width="1052" alt="Screenshot 2023-05-18 at 3 07 11 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/29178824/b4cde705-3e58-464d-bdbe-87774782ab3c">

## What areas of the site does it impact?

FSR

## Acceptance criteria

### Quality Assurance & Testing

- [X  ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ X ] Linting warnings have been addressed
- [ X ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ X ] Screenshot of the developed feature is added
- [ X ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ X ] Browser console contains no warnings or errors.
- [ X ] Events are being sent to the appropriate logging solution
- [ X ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ X ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
