### PR TITLE
[CST] Migrate AddFilesForm to web component

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
-import Select from '@department-of-veterans-affairs/component-library/Select';
+
 import {
+  VaFileInput,
   VaModal,
+  VaSelect,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
-import FileInput from '@department-of-veterans-affairs/component-library/FileInput';
 
 import {
   readAndCheckFile,
@@ -186,17 +187,12 @@ class AddFilesForm extends React.Component {
         </va-additional-info>
         <Element name="filesList" />
         <div>
-          <FileInput
-            errorMessage={this.getErrorMessage()}
-            label={
-              // eslint-disable-next-line react/jsx-wrap-multilines
-              <span className="claims-upload-input-title">
-                Select files to upload
-              </span>
-            }
+          <VaFileInput
+            error={this.getErrorMessage()}
+            label="Select files to upload"
             accept={FILE_TYPES.map(type => `.${type}`).join(', ')}
-            onChange={this.add}
-            buttonText="Add Files"
+            onVaChange={e => this.add(e.detail.files)}
+            button-text="Add Files"
             name="fileUpload"
             additionalErrorClass="claims-upload-input-error-message"
             aria-describedby="file-requirements"
@@ -259,23 +255,29 @@ class AddFilesForm extends React.Component {
                     />
                   </>
                 )}
-                <div className="clearfix" />
-                <Select
+                <VaSelect
                   required
-                  errorMessage={
+                  error={
                     validateIfDirty(docType, isNotBlank)
                       ? undefined
                       : 'Please provide a response'
                   }
                   name="docType"
                   label="What type of document is this?"
-                  options={DOC_TYPES}
                   value={docType}
-                  emptyDescription="Select a description"
-                  onValueChange={update =>
-                    this.props.onFieldChange(`files[${index}].docType`, update)
+                  onVaSelect={e =>
+                    this.handleDocTypeChange(e.detail.value, index)
                   }
-                />
+                >
+                  <option disabled value="">
+                    Select a description
+                  </option>
+                  {DOC_TYPES.map(doc => (
+                    <option key={doc.value} value={doc.value}>
+                      {doc.label}
+                    </option>
+                  ))}
+                </VaSelect>
               </div>
             </div>
           ),
@@ -340,7 +342,7 @@ AddFilesForm.propTypes = {
   onFieldChange: PropTypes.func.isRequired,
   onRemoveFile: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  backUrl: PropTypes.string,
+  backUrl: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   mockReadAndCheckFile: PropTypes.bool,
   progress: PropTypes.number,
   uploading: PropTypes.bool,

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -342,7 +342,7 @@ AddFilesForm.propTypes = {
   onFieldChange: PropTypes.func.isRequired,
   onRemoveFile: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  backUrl: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  backUrl: PropTypes.string,
   mockReadAndCheckFile: PropTypes.bool,
   progress: PropTypes.number,
   uploading: PropTypes.bool,

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -188,6 +188,7 @@ class AddFilesForm extends React.Component {
         <Element name="filesList" />
         <div>
           <VaFileInput
+            id="file-upload"
             error={this.getErrorMessage()}
             label="Select files to upload"
             accept={FILE_TYPES.map(type => `.${type}`).join(', ')}

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -48,10 +48,11 @@ describe('<AddFilesForm>', () => {
         onDirtyFields={onDirtyFields}
       />,
     );
-    expect(tree.everySubTree('FileInput')).not.to.be.empty;
-    expect(tree.everySubTree('FileInput')[0].props['aria-describedby']).to.eq(
-      'file-requirements',
-    );
+
+    expect(tree.everySubTree('#file-upload')).not.to.be.empty;
+    expect(
+      tree.everySubTree('#file-upload')[0].props['aria-describedby'],
+    ).to.eq('file-requirements');
 
     // VaModal has an id of `upload-status` so we can use that as the selector here
     expect(tree.everySubTree('#upload-status')[0].props.visible).to.be.false;

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -284,14 +284,16 @@ class TrackClaimsPage {
     cy.get('[data-cy="submit-files-button"]')
       .click()
       .then(() => {
-        cy.get('.usa-input-error');
+        cy.get('va-file-input')
+          .shadow()
+          .find('#error-message');
         cy.injectAxeThenAxeCheck();
       });
 
-    cy.get('.usa-input-error-message').should(
-      'contain',
-      'Please select a file first',
-    );
+    cy.get('va-file-input')
+      .shadow()
+      .find('#error-message')
+      .should('contain', 'Please select a file first');
     // File uploads don't appear to work in Nightwatch/PhantomJS
     // TODO: switch to something that does support uploads or figure out the problem
     // The above comment lifted from the old Nightwatch test.  Cypress can test file uploads, however this would need to be written in a future effort after our conversion effort is complete.


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Updating the `AddFilesForm` component to remove usage of:
* `FileInput`
* `Select`

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
