### PR TITLE
#57748: Disable the Cancel link for C&P appointments in the UI

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -24,6 +24,7 @@ export default function DetailsVA({ appointment, facilityData }) {
   const isPhone = appointment.vaos.isPhoneAppointment;
   const { isPastAppointment, isCompAndPenAppointment } = appointment.vaos;
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
+  const isAppointmentCancellable = appointment.vaos.isCancellable;
 
   const typeOfCareName = selectTypeOfCareName(appointment);
   // we don't want to display the appointment type header for upcoming C&P appointments.
@@ -93,9 +94,13 @@ export default function DetailsVA({ appointment, facilityData }) {
       <VAInstructions appointment={appointment} />
       <CalendarLink appointment={appointment} facility={facility} />
       <PrintLink appointment={appointment} />
-      {!isCovid && <CancelLink appointment={appointment} />}
-      {isCovid && (
-        <NoOnlineCancelAlert appointment={appointment} facility={facility} />
+      {isAppointmentCancellable && <CancelLink appointment={appointment} />}
+      {!isAppointmentCancellable && (
+        <NoOnlineCancelAlert
+          appointment={appointment}
+          facility={facility}
+          isCompAndPenAppointment={isCompAndPenAppointment}
+        />
       )}
     </>
   );

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/NoOnlineCancelAlert.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/NoOnlineCancelAlert.jsx
@@ -4,9 +4,13 @@ import InfoAlert from '../../../components/InfoAlert';
 import { getFacilityPhone } from '../../../services/location';
 import { APPOINTMENT_STATUS } from '../../../utils/constants';
 
-export default function NoOnlineCancelAlert({ appointment, facility }) {
+export default function NoOnlineCancelAlert({
+  appointment,
+  facility,
+  isCompAndPenAppointment,
+}) {
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
-  const isPastAppointment = appointment.vaos.isPastAppointment;
+  const { isPastAppointment } = appointment.vaos;
 
   if (canceled || isPastAppointment) {
     return null;
@@ -23,21 +27,34 @@ export default function NoOnlineCancelAlert({ appointment, facility }) {
       backgroundOnly
     >
       {!facility &&
+        !isCompAndPenAppointment &&
         'To reschedule or cancel this appointment, contact the VA facility where you scheduled it.'}
       {!!facility &&
+        !isCompAndPenAppointment &&
         'Contact this facility if you need to reschedule or cancel your appointment.'}
+      {!!facility &&
+        isCompAndPenAppointment &&
+        `Contact the ${name} compensation and pension office if you need to reschedule or cancel your appointment:`}
       <br />
-      {!!facility && (
-        <span className="vads-u-display--block vads-u-margin-top--2">
-          {name}
-          {facilityPhone && (
-            <>
-              <br />
-              <FacilityPhone contact={facilityPhone} level={3} />
-            </>
-          )}
-        </span>
-      )}
+      {facilityPhone &&
+        isCompAndPenAppointment && (
+          <>
+            <br />
+            <FacilityPhone contact={facilityPhone} level={3} />
+          </>
+        )}
+      {!!facility &&
+        !isCompAndPenAppointment && (
+          <span className="vads-u-display--block vads-u-margin-top--2">
+            {name}
+            {facilityPhone && (
+              <>
+                <br />
+                <FacilityPhone contact={facilityPhone} level={3} />
+              </>
+            )}
+          </span>
+        )}
     </InfoAlert>
   );
 }

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -219,6 +219,7 @@ export function transformVAOSAppointment(appt) {
   const start = timezone ? moment(appt.start).tz(timezone) : moment(appt.start);
   const serviceCategoryName = appt.serviceCategory?.[0]?.text;
   const isCompAndPen = serviceCategoryName === 'COMPENSATION & PENSION';
+  const isCancellable = appt.cancellable;
 
   let videoData = { isVideo };
   if (isVideo) {
@@ -385,6 +386,7 @@ export function transformVAOSAppointment(appt) {
       isVideo,
       isPastAppointment: isPast,
       isCompAndPenAppointment: isCompAndPen,
+      isCancellable,
       appointmentType,
       isCommunityCare: isCC,
       isExpressCare: false,

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1293,7 +1293,7 @@
         "start": "2023-06-22T13:00:00Z",
         "end": "2023-06-22T14:00:00Z",
         "created": "2023-03-17T00:00:00Z",
-        "cancellable": true,
+        "cancellable": false,
         "extension": {
           "ccLocation": {
             "address": {}

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -187,6 +187,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       serviceType: 'primaryCare',
       start: futureDate.add(1, 'days').format(),
       status: 'booked',
+      cancellable: true,
     };
 
     mockSingleClinicFetchByVersion({
@@ -424,6 +425,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       serviceType: 'primaryCare',
       start: futureDate.format(),
       status: 'booked',
+      cancellable: true,
     };
 
     mockSingleVAOSAppointmentFetch({ appointment });
@@ -493,6 +495,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       serviceType: 'primaryCare',
       start: futureDate.format(),
       status: 'booked',
+      cancellable: true,
     };
 
     mockSingleClinicFetchByVersion({

--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -325,6 +325,7 @@ describe('VAOS appointment list', () => {
             kind: 'clinic',
             status: 'booked',
             start: moment().format('YYYY-MM-DDTHH:mm:ss'),
+            cancellable: true,
           },
         },
       ];


### PR DESCRIPTION
This PR:
removes cancel link for c&p appointments
<img width="1115" alt="Screenshot 2023-05-18 at 10 03 46 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/f60db580-67fe-49f1-8c52-fba36ead6ed3">
