### PR TITLE
Change travel pay success message

### DIFF
--- a/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/TravelPayAlert.jsx
@@ -50,7 +50,7 @@ const TravelPayAlert = props => {
             >
               <div>
                 <p
-                  className="vads-u-margin-top--0"
+                  className="vads-u-margin-y--0"
                   data-testid="travel-pay-eligible-success-message"
                 >
                   <Trans

--- a/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('check in', () => {
       expect(
         component.getByTestId('travel-pay-eligible-success-message'),
       ).to.have.text(
-        'We’re processing your travel reimbursement claim request. We’ll send you a text message with the submission status of your travel reimbursement claim.',
+        'We’re processing your travel reimbursement claim. We’ll send you a text to let you know the status of your claim.',
       );
     });
     it('renders a not eligible message', () => {

--- a/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/Confirmation.js
@@ -31,10 +31,7 @@ class Confirmation {
     cy.get('h1', { timeout: Timeouts.slow }).should('be.visible');
     cy.get('[data-testid="travel-pay-message"]', { timeout: Timeouts.slow })
       .should('be.visible')
-      .and(
-        'include.text',
-        'We’re processing your travel reimbursement claim request.',
-      );
+      .and('include.text', 'We’re processing your travel reimbursement claim.');
   };
 
   validatePageLoadedWithBtsssIneligible = () => {

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -226,5 +226,5 @@
   "were-sorry-this-link-has-expired": "We’re sorry. This link has expired.",
   "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>.",
   "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment.",
-  "processing-travel-claim": "<0>We’re processing your travel reimbursement claim request.</0> We’ll send you a text message with the submission status of your travel reimbursement claim."
+  "processing-travel-claim": "<0>We're processing your travel reimbursement claim.</0> We'll send you a text to let you know the status of your claim."
 }

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -226,5 +226,5 @@
   "were-sorry-this-link-has-expired": "We’re sorry. This link has expired.",
   "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>.",
   "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment.",
-  "processing-travel-claim": "<0>We're processing your travel reimbursement claim.</0> We'll send you a text to let you know the status of your claim."
+  "processing-travel-claim": "<0>We’re processing your travel reimbursement claim.</0> We’ll send you a text to let you know the status of your claim."
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Changes the travel pay success message
- Adjusts spacing around message

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/57878

## Testing done

- Visual
- Unit

## Screenshots
![Screen Shot 2023-05-19 at 10 13 58 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/37d58c24-b073-456e-a826-e043d9ed4a33)

## What areas of the site does it impact?

Check In Experience -> Day of -> Complete

## Acceptance criteria

- [ ] Text matches `We're processing your travel reimbursement claim. We'll send you a text to let you know the status of your claim.`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

