### PR TITLE
VATEAM-56655 Remove New before My VA Health in Cerner widgets.

### DIFF
--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -55,8 +55,8 @@ const CernerAlertBox = ({
       <h2 slot="headline">Choose your health management portal</h2>
       <div>
         <p>
-          Your care team may now use our new My VA Health portal. Choose your
-          portal based on the facility for your appointment:
+          Your care team may now use our My VA Health portal. Choose your portal
+          based on the facility for your appointment:
         </p>
         <p className="vads-u-font-family--sans" data-testid="facilities">
           For{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -134,7 +134,7 @@ export class CernerCallToAction extends Component {
       >
         <div className="usa-alert-body">
           <h3 className="usa-alert-heading">
-            Your VA health care team may be using our new My VA Health portal
+            Your VA health care team may be using our My VA Health portal
           </h3>
           <h4 className="vads-u-margin-y--3">
             Our records show that you&apos;re registered at:


### PR DESCRIPTION
## Summary
My VA Health is not new anymore. Remove "new" from references to "our new My VA Health portal" in Cerner widgets. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/56655

## Testing done
Copy change only.
