### PR TITLE
Reenable address on appointment details

### DIFF
--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -21,7 +21,7 @@ import Wrapper from '../../layout/Wrapper';
 import BackButton from '../../BackButton';
 import AppointmentAction from '../../AppointmentDisplay/AppointmentAction';
 import AppointmentMessage from '../../AppointmentDisplay/AppointmentMessage';
-// import AddressBlock from '../../AddressBlock';
+import AddressBlock from '../../AddressBlock';
 
 const AppointmentDetails = props => {
   const { router } = props;
@@ -36,7 +36,7 @@ const AppointmentDetails = props => {
   const appointmentDay = new Date(appointment?.startTime);
   const isPhoneAppointment = appointment?.kind === 'phone';
   const { appointmentId } = router.params;
-  // const isPreCheckIn = app === 'preCheckIn';
+  const isPreCheckIn = app === 'preCheckIn';
 
   useLayoutEffect(
     () => {
@@ -138,7 +138,7 @@ const AppointmentDetails = props => {
                 {!isPhoneAppointment && (
                   <div data-testid="appointment-details--facility-value">
                     {appointment.facility}
-                    {/* <br />
+                    <br />
                     {appointment.facilityAddress?.street1 && (
                       <div className="vads-u-margin-bottom--2">
                         <AddressBlock
@@ -147,7 +147,7 @@ const AppointmentDetails = props => {
                           showDirections={isPreCheckIn}
                         />
                       </div>
-                    )} */}
+                    )}
                   </div>
                 )}
                 <div data-testid="appointment-details--clinic-value">

--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -60,8 +60,8 @@ describe('Check In Experience', () => {
       AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere();
-      // AppointmentDetails.validateFacilityAddress(true);
-      // AppointmentDetails.validateDirectionsLink(false);
+      AppointmentDetails.validateFacilityAddress(true);
+      AppointmentDetails.validateDirectionsLink(false);
       AppointmentDetails.validatePhone();
       AppointmentDetails.validateCheckInButton();
       AppointmentDetails.validateReturnToAppointmentsPageButton();

--- a/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -45,7 +45,7 @@ describe('Pre-Check In Experience', () => {
         window.sessionStorage.clear();
       });
     });
-    it('Appointment details page content loads for in person appointment', () => {
+    it('Appointment details page content loads for in person appointment with address', () => {
       Confirmation.clickDetails();
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateSubtitleInPerson();
@@ -53,60 +53,60 @@ describe('Pre-Check In Experience', () => {
       AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere('in-person');
-      // AppointmentDetails.validateFacilityAddress(true);
-      // AppointmentDetails.validateDirectionsLink(true);
+      AppointmentDetails.validateFacilityAddress(true);
+      AppointmentDetails.validateDirectionsLink(true);
       AppointmentDetails.validatePhone();
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Pre-check-in--Appointment-detail--in-person');
     });
   });
 
-  // describe('Appointment details in person no facility address', () => {
-  //   beforeEach(() => {
-  //     const {
-  //       initializeFeatureToggle,
-  //       initializeSessionGet,
-  //       initializeSessionPost,
-  //       initializePreCheckInDataGet,
-  //       initializePreCheckInDataPost,
-  //     } = ApiInitializer;
-  //     initializeFeatureToggle.withCurrentFeatures();
-  //     initializeSessionGet.withSuccessfulNewSession();
+  describe('Appointment details in person no facility address', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializePreCheckInDataGet,
+        initializePreCheckInDataPost,
+      } = ApiInitializer;
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
 
-  //     initializeSessionPost.withSuccess();
-  //     initializePreCheckInDataGet.withSuccess({
-  //       uuid: '5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3',
-  //     });
+      initializeSessionPost.withSuccess();
+      initializePreCheckInDataGet.withSuccess({
+        uuid: '5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3',
+      });
 
-  //     initializePreCheckInDataPost.withSuccess();
+      initializePreCheckInDataPost.withSuccess();
 
-  //     cy.visitPreCheckInWithUUID();
-  //     ValidateVeteran.validateVeteran();
-  //     ValidateVeteran.attemptToGoToNextPage();
-  //     Introduction.validatePageLoaded();
-  //     Introduction.attemptToGoToNextPage();
-  //     Demographics.validatePageLoaded();
-  //     Demographics.attemptToGoToNextPage();
-  //     EmergencyContact.validatePageLoaded();
-  //     EmergencyContact.attemptToGoToNextPage();
-  //     NextOfKin.validatePageLoaded();
-  //     NextOfKin.attemptToGoToNextPage();
-  //     Confirmation.validatePageContent();
-  //   });
-  //   afterEach(() => {
-  //     cy.window().then(window => {
-  //       window.sessionStorage.clear();
-  //     });
-  //   });
-  //   it('Appointment details displays without address when no address is present', () => {
-  //     Confirmation.clickDetails();
-  //     AppointmentDetails.validateFacilityAddress(false);
-  //     cy.injectAxeThenAxeCheck();
-  //     cy.createScreenshots(
-  //       'Pre-check-in--Appointment-detail--in-person--no-facility-address',
-  //     );
-  //   });
-  // });
+      cy.visitPreCheckInWithUUID();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Introduction.validatePageLoaded();
+      Introduction.attemptToGoToNextPage();
+      Demographics.validatePageLoaded();
+      Demographics.attemptToGoToNextPage();
+      EmergencyContact.validatePageLoaded();
+      EmergencyContact.attemptToGoToNextPage();
+      NextOfKin.validatePageLoaded();
+      NextOfKin.attemptToGoToNextPage();
+      Confirmation.validatePageContent();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('Appointment details displays without address when no address is present', () => {
+      Confirmation.clickDetails();
+      AppointmentDetails.validateFacilityAddress(false);
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Pre-check-in--Appointment-detail--in-person--no-facility-address',
+      );
+    });
+  });
 
   describe('Appointment details in phone', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- Re-enables the the address on appointment details

## Testing done

- Visual
- Cypress

## Screenshots
![Screen Shot 2023-05-19 at 2 46 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/16073c91-5dd8-472d-bb59-fcb44137cabe)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

The clinic address displays again on the Appointment details view

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
