### PR TITLE
Remove a line of text from see staff page

### DIFF
--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -40,12 +40,7 @@ const Demographics = props => {
       dispatch(recordAnswer({ demographicsUpToDate: 'no' }));
       setShouldSendDemographicsFlags(window, true);
       const seeStaffMessage = (
-        <>
-          <p>{t('our-staff-can-help-you-update-your-contact-information')}</p>
-          <p className="vads-u-margin-bottom--0">
-            {t('if-you-dont-live-at-a-fixed-address')}
-          </p>
-        </>
+        <p>{t('our-staff-can-help-you-update-your-contact-information')}</p>
       );
       updateSeeStaffMessage(seeStaffMessage);
       jumpToPage(URLS.SEE_STAFF);

--- a/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
+++ b/src/applications/check-in/day-of/tests/e2e/pages/SeeStaff.js
@@ -8,7 +8,7 @@ class SeeStaff {
   };
 
   validateMessage = (
-    message = 'Our staff can help you update your contact information.If you don’t live at a fixed address right now, we’ll help you find the best way to stay connected with us.',
+    message = 'Our staff can help you update your contact information.',
   ) => {
     cy.get('h1')
       .next()

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -59,7 +59,6 @@
   "how-can-i-update-my-information": "How can I update my information?",
   "husband": "Husband",
   "i-live-on-a-united-states-military-base-outside-of-the-united-states": "I live on a United States military base outside of the United States.",
-  "if-you-dont-live-at-a-fixed-address": "If you don’t live at a fixed address right now, we’ll help you find the best way to stay connected with us.",
   "if-you-have-hearing-loss-call": "If you have hearing loss, call TTY:",
   "if-you-have-questions-please-call-us-were-here-24-7": "If you have questions, please call us at <0></0> (<1></1>). We’re here 24/7.",
   "if-you-need-to-make-changes-please-talk-to-a-staff-member-when-you-check-in": "If you need to make changes, please talk to a staff member when you check in.",

--- a/src/applications/check-in/locales/es/translation.json
+++ b/src/applications/check-in/locales/es/translation.json
@@ -69,7 +69,6 @@
   "how-can-i-update-my-information": "¿Cómo puedo actualizar mi información?",
   "husband": "Esposo",
   "i-live-on-a-united-states-military-base-outside-of-the-united-states": "Vivo en una base militar de los Estados Unidos ubicada fuera de los Estados Unidos.",
-  "if-you-dont-live-at-a-fixed-address": "Si no reside actualmente en una dirección fija, le ayudaremos a encontrar la mejor manera de mantenerse en contacto con nosotros.",
   "if-you-have-hearing-loss-call": "Si tiene pérdida auditiva, llame a",
   "if-you-have-questions-please-call-us-were-here-24-7": "Si tiene preguntas, llámenos al <0></0> (<1></1>). Estamos aquí 24 horas al día, siete días a la semana.",
   "if-you-need-to-make-changes-please-talk-to-a-staff-member-when-you-check-in": "Si necesita hacer cambios, comuníquese con un miembro del personal cuando se registre.",

--- a/src/applications/check-in/locales/tl/translation.json
+++ b/src/applications/check-in/locales/tl/translation.json
@@ -87,7 +87,6 @@
   "how-can-i-update-my-information": "Paano ko maia-update ang aking impormasyon?",
   "husband": "Asawa (Lalaki)",
   "i-live-on-a-united-states-military-base-outside-of-the-united-states": "Nakatira ako sa United States military base na nasa labas ng Estados Unidos.",
-  "if-you-dont-live-at-a-fixed-address": "Kung wala kang permanenteng address sa kasalukuyan, tutulungan ka naming makahanap ng pinakamahusay na paraan upang manatiling konektado sa amin.",
   "if-you-have-hearing-loss-call": "Kung mahina ang iyong pandinig, tumawag sa",
   "if-you-have-questions-please-call-us-were-here-24-7": "Kung mayroon kang mga katanungan, mangyaring tawagan kami sa <0></0> (<1></1>). Nandito kami 24/7.",
   "if-you-need-to-make-changes-please-talk-to-a-staff-member-when-you-check-in": "Kung mayroon kang kailangang baguhin, mangyaring kausapin ang isang staff member kapag nag-check in ka.",


### PR DESCRIPTION
## Summary

- Removes a line of text from the see staff page. When you answer no to one of the demographics questions.

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#58428](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58428)

## Testing done

- Visual
- Cypress

## Screenshots
### Before:
![Screen Shot 2023-05-22 at 11 31 17 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/a3f53863-d3a5-42e8-ab90-6e7b8e4838e6)
### After:
![Screen Shot 2023-05-22 at 11 30 30 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/36c3243b-1b0a-4bbb-9c23-1eca813d994b)


## What areas of the site does it impact?

CIE -> day of -> see staff(answer no to a demographics question)

## Acceptance criteria

- [ ] The line is removed
- [ ] Tests pass

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

