### PR TITLE
Supplemental Claims | Combine duplicate VA locations

### DIFF
--- a/src/applications/appeals/995/tests/actions/actions.unit.spec.js
+++ b/src/applications/appeals/995/tests/actions/actions.unit.spec.js
@@ -100,7 +100,7 @@ describe('ITF actions', () => {
         expect(dispatch.secondCall.args[0].type).to.equal(ITF_FETCH_FAILED);
 
         const sentryReports = testkit.reports();
-        expect(sentryReports.length).to.be.above(1);
+        expect(sentryReports.length).to.be.gte(1);
         expect(sentryReports[1].extra.accountUuid).to.equal(
           mockExtraProps.accountUuid,
         );
@@ -141,7 +141,7 @@ describe('ITF actions', () => {
         expect(dispatch.secondCall.args[0].type).to.eql(ITF_CREATION_FAILED);
 
         const sentryReports = testkit.reports();
-        expect(sentryReports.length).to.be.above(1);
+        expect(sentryReports.length).to.be.gte(1);
         expect(sentryReports[1].extra.accountUuid).to.equal(
           mockExtraProps.accountUuid,
         );


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Our Supplemental Claims form asks the Veteran to include the issue that was treated for each location. If a Veteran adds the same location and same treatment dates for multiple entries, but selects different treated issues, these entries are considered to be unique; but once the form is submitted, the treated issues are not included (they are not on the form, but asked in the online form to keep the UI consistent), and thus the entries may no longer be unique - same location & dates.
  >
  > To fix this problem, we plan to combine entries with the same location & dates (ignoring treated issues) so that Lighthouse doesn't reject the submission
- _(If bug, how to reproduce)_
  > Log into and fill out Supplemental Claims and include VA evidence. Add 2 VA locations with the same name, and start and end evidence date; but have different treated conditions. 
- _(What is the solution, why is this the solution)_
  > Discussed this solution with the team - it's the easiest and most straight-forward fix
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#58804](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58804)

## Testing done

- _Describe what the old behavior was prior to the change_
  > A Veteran could add a VA location with the same name and treatment dates, but different conditions treated; on the FE we check that _all_ of this information is unique, but we then discard the issues prior to submission.
- _Describe the steps required to verify your changes are working as expected_
  > Add "duplicate" VA locations and check submitted data to ensure that the duplicate(s) have been combined
- _Describe the tests completed and the results_
  > Find and ignore/combine duplicate VA evidence entries unit tests added
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A - no visual change

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
