### PR TITLE
Formation - 1706

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@department-of-veterans-affairs/component-library": "^16.1.1",
-    "@department-of-veterans-affairs/formation": "^7.0.5",
+    "@department-of-veterans-affairs/formation": "^7.0.7",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,10 +2544,10 @@
   dependencies:
     jsx-ast-utils "^3.3.3"
 
-"@department-of-veterans-affairs/formation@^7.0.5":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.5.tgz#1c1ac701fe4cf79b4b957c2bbd7cb0500a368d16"
-  integrity sha512-NZUPdSOkjMhSM/BGPNBJo/6hWMhQ2nUjwxCrzEHVZLAB0Hvonwavkvj80pYlXHLeRFP2ezCes8mXoWadHMrLjA==
+"@department-of-veterans-affairs/formation@^7.0.7":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.7.tgz#145db27b1d258ad62ef4aeddc65b79516e552da0"
+  integrity sha512-VivETxz+xEFPDYZ3r7WXGZCgPbeJOgrfTbfAIUWtueM67xZBpSfJ7onbL/I/AKjbbWY9FOEJ/UkZyoVZa2pGeA==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Summary
- Update formation dependency to 7.0.7
- Fixes a bug with action link component, where the link icon was underlined

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1706

## Testing done

- Browser testing with Chrome and Safari

## Screenshots
Before

![](https://user-images.githubusercontent.com/1776069/239373897-42621f37-4023-40d9-974e-ed01ec802f19.png)

After

![](https://user-images.githubusercontent.com/1776069/239937728-b34ff54f-3240-471d-b686-f1df81353855.png)

## What areas of the site does it impact?

Pages using the action link component

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x ] Browser console contains no warnings or errors.
- [x ] Events are being sent to the appropriate logging solution
- [x ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
