### PR TITLE
Profile contact info | Add custom uiSchema option

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,5 @@
 {
-  
+
   "presets": [
     [
       "@babel/env",
@@ -29,12 +29,12 @@
   ],
   "plugins": [
     "lodash",
-     
+
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-numeric-separator",
     "@babel/plugin-proposal-throw-expressions",
-    
+
     "@babel/plugin-proposal-nullish-coalescing-operator",
     "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-syntax-dynamic-import",
@@ -141,7 +141,7 @@
           "@department-of-veterans-affairs/platform-user/profile/utilities": "./src/platform/user/profile/utilities/index.js",
           "@department-of-veterans-affairs/platform-user/local-vapsvc": "./src/platform/user/profile/vap-svc/util/local-vapsvc.js",
           "@department-of-veterans-affairs/platform-user/disableFTUXModals": "./src/platform/user/tests/disableFTUXModals.js",
-          
+
           "@department-of-veterans-affairs/platform-testing/exports" : "./src/platform/testing/exportsFile.js",
           "@department-of-veterans-affairs/platform-testing/contract": "./src/platform/testing/contract/index.js",
           "@department-of-veterans-affairs/platform-testing/form-tester": "./src/platform/testing/e2e/cypress/support/form-tester/index.js",
@@ -153,7 +153,7 @@
           "@department-of-veterans-affairs/platform-testing/schemaform-utils": "./src/platform/testing/unit/schemaform-utils.jsx",
           "@department-of-veterans-affairs/platform-testing/sentry": "./src/platform/testing/unit/sentry.js",
           "@department-of-veterans-affairs/platform-testing/unit/react-testing-library-helpers": "./src/platform/testing/unit/react-testing-library-helpers",
- 
+
           "@department-of-veterans-affairs/platform-site-wide/exports": "./src/platform/site-wide/exportsFile.js",
           "@department-of-veterans-affairs/platform-site-wide/showVaAlertExpandable": "./src/platform/site-wide/alerts/showVaAlertExpandable.js",
           "@department-of-veterans-affairs/platform-site-wide/EbenefitsLink": "./src/platform/site-wide/ebenefits/containers/EbenefitsLink.jsx",
@@ -256,6 +256,7 @@
           "@department-of-veterans-affairs/platform-forms-system/monthYearRange": "./src/platform/forms-system/src/js/definitions/monthYearRange.js",
           "@department-of-veterans-affairs/platform-forms-system/phone": "./src/platform/forms-system/src/js/definitions/phone.js",
           "@department-of-veterans-affairs/platform-forms-system/profileAddress": "./src/platform/forms-system/src/js/definitions/profileAddress.js",
+          "@department-of-veterans-affairs/platform-forms-system/profileContactInfo": "./src/platform/forms-system/src/js/definitions/profileContactInfo.js",
           "@department-of-veterans-affairs/platform-forms-system/ssn": "./src/platform/forms-system/src/js/definitions/ssn.js",
           "@department-of-veterans-affairs/platform-forms-system/year": "./src/platform/forms-system/src/js/definitions/year.js",
           "@department-of-veterans-affairs/platform-forms-system/FullNameField": "./src/platform/forms-system/src/js/fields/FullNameField.jsx",
@@ -299,7 +300,7 @@
       }
     ]
   ],
-  
+
   "env": {
     "test": {
       "presets": ["@babel/env", "@babel/preset-react"],
@@ -308,12 +309,12 @@
         "transform-class-properties",
         "dynamic-import-node",
         "transform-react-remove-prop-types",
-        
+
         "@babel/plugin-proposal-function-sent",
         "@babel/plugin-proposal-export-namespace-from",
         "@babel/plugin-proposal-numeric-separator",
         "@babel/plugin-proposal-throw-expressions",
-         
+
         "@babel/plugin-syntax-dynamic-import",
         "@babel/plugin-syntax-import-meta",
         ["@babel/plugin-proposal-class-properties", { "loose": false }],

--- a/src/platform/forms-system/src/js/definitions/profileContactInfo.js
+++ b/src/platform/forms-system/src/js/definitions/profileContactInfo.js
@@ -46,6 +46,8 @@ import {
  *  'email'] - array of ContactInfoKeys to show on the contact info page
  * @property {Function} depends=null - depends callback function; return true to
  *  make the main confirmation page visible
+ * @property {Object} contactInfoUiSchema={} - custom uiSchema for the contact
+ *  info page
  */
 /**
  * Add contact information page with 3-4 edit pages to config/form - spread the
@@ -84,6 +86,7 @@ const profileContactInfo = ({
 
   // depends callback for contact info page
   depends = null,
+  contactInfoUiSchema = {},
 } = {}) => {
   const config = {};
   const wrapperProperties = {};
@@ -171,7 +174,7 @@ const profileContactInfo = ({
           content,
           keys,
         }),
-      uiSchema: {},
+      uiSchema: contactInfoUiSchema,
       schema: {
         type: 'object',
         properties: {

--- a/src/platform/forms-system/test/js/definitions/profileContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/profileContactInfo.unit.spec.jsx
@@ -108,4 +108,17 @@ describe('profileContactInfo', () => {
     expect(veteran.properties.mobilePhone).to.be.undefined;
     expect(veteran.properties.email).to.be.undefined;
   });
+
+  it('should add custom uiSchema', () => {
+    const result = profileContactInfo({
+      contactInfoUiSchema: {
+        'ui:required': ['test1'],
+        'ui:options': { test2: true },
+      },
+    });
+    const { uiSchema } = result[pageKey];
+
+    expect(uiSchema['ui:required']).to.deep.equal(['test1']);
+    expect(uiSchema['ui:options'].test2).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While using the new platform profile contact info definition, I noticed that it's troublesome to include a custom `uiSchema` for the main contact info page (needed for adding `ui:required` and/or `ui:options`). So this PR adds a new `contactInfoUiSchema` property. For our Notice of Disagreement form, we need to make the mailing address only required if the Veteran chooses that they are not homeless.
  >
  > Additionally, it adds a new babel import definition for the `profileContactInfo` definition.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Using lots of spread operators to include properties into the `uiSchema` is troublesome, so including them as an option was the easiest/best solution
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews 
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#57816](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57816)

## Testing done

- _Describe what the old behavior was prior to the change_
  > An empty `uiSchema` was added to the main contact info page (it's using `CustomPage` so `uiSchema` is usually empty).
- _Describe the steps required to verify your changes are working as expected_
  > Manually tested & added unit test
- _Describe the tests completed and the results_
  > Unit test ensures that the custom `uiSchema` is added
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All forms that use the platform profile contact info definition, only the mock-form as of this PR

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
