### PR TITLE
Notice of Disagreement | Add feature to disable submit for user testing

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -7,6 +7,11 @@ import { selectProfile, isLoggedIn } from 'platform/user/selectors';
 import { setData } from 'platform/forms-system/src/js/actions';
 import environment from 'platform/utilities/environment';
 
+// **** temporary code ****
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+// **** end temporary code ****
+
 import user from '../tests/fixtures/mocks/user.json';
 
 import formConfig from '../config/form';
@@ -35,6 +40,9 @@ export const FormApp = ({
   setFormData,
   getContestableIssues,
   contestableIssues = {},
+  // **** temporary code ****
+  disableSubmit,
+  // **** end temporary code ****
 }) => {
   // vapContactInfo is an empty object locally, so mock it
   const data = environment.isLocalhost()
@@ -42,6 +50,26 @@ export const FormApp = ({
     : profile?.vapContactInfo || {};
 
   const { email = {}, mobilePhone = {}, mailingAddress = {} } = data;
+
+  // **** temporary code ****
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/58229
+  useEffect(
+    () => {
+      if (loggedIn && location?.pathname === '/review-and-submit') {
+        const timer = setInterval(() => {
+          const submit = document.querySelector(
+            '.form-progress-buttons .usa-button-primary',
+          );
+          if (submit) {
+            submit.disabled = true;
+            clearInterval(timer);
+          }
+        }, 50);
+      }
+    },
+    [loggedIn, disableSubmit, location?.pathname],
+  );
+  // **** end temporary code ****
 
   // Update profile data changes in the form data dynamically
   useEffect(
@@ -134,6 +162,9 @@ FormApp.propTypes = {
     issues: PropTypes.array,
     status: PropTypes.string,
   }),
+  // **** temporary code ****
+  disableSubmit: PropTypes.bool,
+  // **** end temporary code ****
   formData: PropTypes.shape({
     areaOfDisagreement: PropTypes.array,
     contestableIssues: PropTypes.array,
@@ -158,7 +189,21 @@ const mapStateToProps = state => {
   const isLoading = state.featureToggles?.loading;
   const loggedIn = isLoggedIn(state);
   const { contestableIssues } = state;
-  return { profile, formData, showNod, contestableIssues, isLoading, loggedIn };
+  // **** temporary code ****
+  // accidently named the feature flag with HLR instead of NOD
+  const disableSubmit =
+    toggleValues(state)[FEATURE_FLAG_NAMES.hlrDisableSubmit] || false;
+  return {
+    disableSubmit,
+    profile,
+    formData,
+    showNod,
+    contestableIssues,
+    isLoading,
+    loggedIn,
+  };
+  // **** end temporary code ****
+  // return { profile, formData, showNod, contestableIssues, isLoading, loggedIn };
 };
 
 const mapDispatchToProps = {

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -8,6 +8,11 @@ import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import { setData } from 'platform/forms-system/src/js/actions';
 import environment from 'platform/utilities/environment';
 
+// **** temporary code ****
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+// **** end temporary code ****
+
 import user from '../tests/fixtures/mocks/user.json';
 
 import formConfig from '../config/form';
@@ -39,6 +44,9 @@ export const Form0996App = ({
   getContestableIssues,
   contestableIssues = {},
   legacyCount,
+  // **** temporary code ****
+  disableSubmit,
+  // **** end temporary code ****
 }) => {
   // vapContactInfo is an empty object locally, so mock it
   const contactInfo = environment.isLocalhost()
@@ -50,6 +58,26 @@ export const Form0996App = ({
   // Make sure we're only loading issues once - see
   // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
   const [isLoadingIssues, setIsLoadingIssues] = useState(false);
+
+  // **** temporary code ****
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/58229
+  useEffect(
+    () => {
+      if (loggedIn && location?.pathname === '/review-and-submit') {
+        const timer = setInterval(() => {
+          const submit = document.querySelector(
+            '.form-progress-buttons .usa-button-primary',
+          );
+          if (submit) {
+            submit.disabled = true;
+            clearInterval(timer);
+          }
+        }, 50);
+      }
+    },
+    [loggedIn, disableSubmit, location?.pathname],
+  );
+  // **** end temporary code ****
 
   useEffect(
     () => {
@@ -180,6 +208,9 @@ Form0996App.propTypes = {
   setFormData: PropTypes.func.isRequired,
   children: PropTypes.any,
   contestableIssues: PropTypes.shape({}),
+  // **** temporary code ****
+  disableSubmit: PropTypes.bool,
+  // **** end temporary code ****
   formData: PropTypes.shape({
     additionalIssues: PropTypes.array,
     areaOfDisagreement: PropTypes.array,
@@ -209,6 +240,10 @@ const mapStateToProps = state => ({
   savedForms: state.user?.profile?.savedForms || [],
   contestableIssues: state.contestableIssues || {},
   legacyCount: state.legacyCount || 0,
+  // **** temporary code ****
+  disableSubmit:
+    toggleValues(state)[FEATURE_FLAG_NAMES.hlrDisableSubmit] || false,
+  // **** end temporary code ****
 });
 
 const mapDispatchToProps = {

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -8,11 +8,6 @@ import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import { setData } from 'platform/forms-system/src/js/actions';
 import environment from 'platform/utilities/environment';
 
-// **** temporary code ****
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-// **** end temporary code ****
-
 import user from '../tests/fixtures/mocks/user.json';
 
 import formConfig from '../config/form';
@@ -44,9 +39,6 @@ export const Form0996App = ({
   getContestableIssues,
   contestableIssues = {},
   legacyCount,
-  // **** temporary code ****
-  disableSubmit,
-  // **** end temporary code ****
 }) => {
   // vapContactInfo is an empty object locally, so mock it
   const contactInfo = environment.isLocalhost()
@@ -58,26 +50,6 @@ export const Form0996App = ({
   // Make sure we're only loading issues once - see
   // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
   const [isLoadingIssues, setIsLoadingIssues] = useState(false);
-
-  // **** temporary code ****
-  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/58229
-  useEffect(
-    () => {
-      if (loggedIn && location?.pathname === '/review-and-submit') {
-        const timer = setInterval(() => {
-          const submit = document.querySelector(
-            '.form-progress-buttons .usa-button-primary',
-          );
-          if (submit) {
-            submit.disabled = true;
-            clearInterval(timer);
-          }
-        }, 50);
-      }
-    },
-    [loggedIn, disableSubmit, location?.pathname],
-  );
-  // **** end temporary code ****
 
   useEffect(
     () => {
@@ -208,9 +180,6 @@ Form0996App.propTypes = {
   setFormData: PropTypes.func.isRequired,
   children: PropTypes.any,
   contestableIssues: PropTypes.shape({}),
-  // **** temporary code ****
-  disableSubmit: PropTypes.bool,
-  // **** end temporary code ****
   formData: PropTypes.shape({
     additionalIssues: PropTypes.array,
     areaOfDisagreement: PropTypes.array,
@@ -240,10 +209,6 @@ const mapStateToProps = state => ({
   savedForms: state.user?.profile?.savedForms || [],
   contestableIssues: state.contestableIssues || {},
   legacyCount: state.legacyCount || 0,
-  // **** temporary code ****
-  disableSubmit:
-    toggleValues(state)[FEATURE_FLAG_NAMES.hlrDisableSubmit] || false,
-  // **** end temporary code ****
 });
 
 const mapDispatchToProps = {

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -77,6 +77,7 @@ export default Object.freeze({
   hcaEnrollmentStatusOverrideEnabled: 'hca_enrollment_status_override_enabled',
   hcaHouseholdV2Enabled: 'hca_household_v2_enabled',
   hcaUseFacilitiesApi: 'hca_use_facilities_API',
+  hlrDisableSubmit: 'hlr_disable_submit',
   loopPages: 'loop_pages',
   manageDependents: 'dependents_management',
   medicalCopaysHtmlMedicalStatementsViewEnabled: 'medical_copays_html_medical_statements_view_enabled',


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > We will be conducting user research, but we want to prevent Notice of Disagreement (NOD) submission during this testing, so we're adding a feature toggle that will disable the submit button on the review & submit page. This feature will only temporarily be enabled during the test. This feature will be removed once testing is done.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > We can't test in staging, so having Veterans test in production while preventing them from accidentally submitting an NOD is needed
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#58229](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58229)
- [#58333](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58833)
- [#12775](https://github.com/department-of-veterans-affairs/vets-api/pull/12775)

## Testing done

- _Describe what the old behavior was prior to the change_
 > Manual testing; then testing of this implementation in staging. Our first test will be with a team member.
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![disabled submit button](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/392ca86d-9347-4ae1-8e7f-41316530af1c)

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
