### PR TITLE
MHV-41786, 41789 SM remove disclosure, paperclip styling

### DIFF
--- a/src/applications/mhv/secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv/secure-messaging/components/AttachmentsList.jsx
@@ -79,7 +79,6 @@ const AttachmentsList = props => {
               )}
               {!editingEnabled && (
                 <>
-                  <i className="fas fa-paperclip" aria-hidden="true" />
                   <a
                     className="attachment"
                     href={file.link}
@@ -93,6 +92,7 @@ const AttachmentsList = props => {
                       });
                     }}
                   >
+                    <i className="fas fa-paperclip" aria-hidden="true" />
                     <span ref={attachmentReference}>{file.name} </span>(
                     {getSize(file.size || file.attachmentSize)})
                   </a>

--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -407,15 +407,6 @@ const ReplyForm = props => {
               </div>
             </div>
             <DraftSavedInfo userSaved={userSaved} />
-            <div className="message-detail-note vads-u-text-align--center">
-              <p>
-                <i>
-                  Note: This message may not be from the person you intially
-                  contacted. It may have been reassigned to efficiently address
-                  your original message
-                </i>
-              </p>
-            </div>
           </form>
         </section>
         <section

--- a/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageDetailBlock.jsx
@@ -128,16 +128,6 @@ const MessageDetailBlock = props => {
               <AttachmentsList attachments={attachments} />
             </>
           )}
-
-        <div className="message-detail-note vads-u-text-align--center">
-          <p>
-            <i>
-              Note: This message may not be from the person you intially
-              contacted. It may have been reassigned to efficiently address your
-              original message
-            </i>
-          </p>
-        </div>
       </main>
     </section>
   );

--- a/src/applications/mhv/secure-messaging/sass/message-details.scss
+++ b/src/applications/mhv/secure-messaging/sass/message-details.scss
@@ -44,10 +44,6 @@
       margin-top: 1em;
     }
 
-    .message-detail-note {
-      margin-top: 3em;
-      margin-bottom: 3em;
-    }
     .message-body-attachments-label {
       margin-bottom: 7px;
     }

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -207,6 +207,7 @@ va-alert button {
     }
     i {
       margin: 5px 8px 0 0;
+      color: $color-link-default;
       @media (min-width: $medium-screen) {
         margin-top: 0;
       }


### PR DESCRIPTION
## Summary

- The disclosure reads: Note: This message may not be from the person you initially contacted. It may have been reassigned to efficiently address your original message. Disclosure has been removed from all current thread detail pages in SM.
- Change color of paperclip on the Message Details page from black to blue font. The paperclip should also be clickable--part of the link to open attachment. **Note**: The paperclip should be black in the thread--meaning it should match whatever text follows the paperclip.

## Related issue(s)

- [VA Jira SM to VA.gov: Change the color of the paperclip on the Message Details page from Black to Blue font ](https://vajira.max.gov/browse/MHV-41786)
- [VA Jira SM to VA.gov: Remove disclosure from all pages of SM (message details)](https://vajira.max.gov/browse/MHV-41789)

## Testing done

- SQA Testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="100" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/373ff9a6-3ef0-4ddd-9fa1-7ef9d5e02257"><img width="100" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/3760d1d6-c408-46e7-a443-b8e1b20a0561">|<img width="100" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/88b18234-83ad-49e2-90c0-827fb75b7e66"><img width="100" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/4740e69f-cb6f-4629-8dca-97ea6d328d84">|
| Desktop |<img width="200" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/f1de7a9e-46ac-4a67-9b13-3cc2f369fd33"><img width="200" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/6646197e-a8fa-48a8-b181-bdbcde4fd2e6">|<img width="200" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/b124ee6f-5d42-447f-adca-e6ebefa7b764"><img width="200" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/a5c10c00-f621-4949-b2f0-c5ef42ca3519">|

## What areas of the site does it impact?

My Health - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
