### PR TITLE
58914 Add GA onClick handlers to breadcrumb links in VAOS

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { NavLink, useLocation } from 'react-router-dom';
+import recordEvent from 'platform/monitoring/record-event';
 import { useSelector } from 'react-redux';
 import { selectFeatureStatusImprovement } from '../redux/selectors';
+import { GA_PREFIX } from '../utils/constants';
 
 export default function VAOSBreadcrumbs({ children }) {
   const featureStatusImprovement = useSelector(state =>
@@ -35,6 +37,14 @@ export default function VAOSBreadcrumbs({ children }) {
     [location, breadcrumbsRef],
   );
 
+  const handleClick = gaEvent => {
+    return () => {
+      recordEvent({
+        event: `${GA_PREFIX}-breadcrumb-${gaEvent}-clicked`,
+      });
+    };
+  };
+
   // The va-breadcrumbs component only allows for either Link components or anchor links,
   // it will not work with the va-link component currently
   return (
@@ -44,15 +54,20 @@ export default function VAOSBreadcrumbs({ children }) {
       ref={breadcrumbsRef}
       class="vaos-hide-for-print"
     >
-      <a href="/" key="home">
+      <a href="/" key="home" onClick={handleClick('home')}>
         Home
       </a>
-      <a href="/health-care" key="health-care">
+      <a
+        href="/health-care"
+        key="health-care"
+        onClick={handleClick('health-care')}
+      >
         Health care
       </a>
       <a
         href="/health-care/schedule-view-va-appointments"
         key="schedule-view-va-appointments"
+        onClick={handleClick('schedule-managed')}
       >
         Schedule and manage health appointments
       </a>


### PR DESCRIPTION
## Summary

This PR adds three new Google Analytic tracking events to the VAOS breadcrumb component. It now tracks clicks for:

- Home (`vaos-breadcrumb-home-clicked`)
- Health care = (`vaos-breadcrumb-health-care-clicked`)
- Schedule and manage health appointments = (`vaos-breadcrumb-schedule-manage-clicked`)

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/58914

## Testing done

- e2e Cypress Testing
- Unit testing
- Manual `console.log` testing

## Acceptance criteria

### Quality Assurance & Testing

- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution


### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
