### PR TITLE
Update saved form messages to use active voice

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -72,7 +72,7 @@ export default function FormNav(props) {
   if (isLoggedIn) {
     inProgressMessage = (
       <span className="vads-u-display--block vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base">
-        Your application will be saved on every change.{' '}
+        We&rsquo;ll save your application on every change.{' '}
         {inProgressFormId &&
           `Your application ID number is ${inProgressFormId}.`}
       </span>

--- a/src/platform/forms-system/src/js/constants.js
+++ b/src/platform/forms-system/src/js/constants.js
@@ -1,7 +1,7 @@
 export const START_NEW_APP_DEFAULT_MESSAGE = 'Start a new application';
 export const CONTINUE_APP_DEFAULT_MESSAGE = 'Continue your application';
 export const APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE =
-  'Your application has been saved.';
+  'We’ve saved your application.';
 export const FINISH_APP_LATER_DEFAULT_MESSAGE = 'Finish this application later';
 export const UNAUTH_SIGN_IN_DEFAULT_MESSAGE =
   'Sign in to start your application';

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -177,7 +177,7 @@ describe('Schemaform FormNav', () => {
       />,
     );
     expect(
-      tree.getByText('Your application will be saved on every change', {
+      tree.getByText('We’ll save your application on every change.', {
         exact: false,
       }),
     ).to.not.be.null;

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -23,7 +23,7 @@ function SaveStatus({
   let savedAtMessage;
   if (lastSavedDate) {
     const savedAt = new Date(lastSavedDate);
-    savedAtMessage = ` It was last saved on ${format(
+    savedAtMessage = ` We saved it on ${format(
       savedAt,
       "MMMM d, yyyy', at' h:mm aaaa z.",
     )}`;

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -27,7 +27,7 @@ describe('<SaveStatus>', () => {
   it('should show last saved date', () => {
     props.form.autoSavedStatus = SAVE_STATUSES.success;
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
-    expect(tree.text()).to.include('Your application has been saved.');
+    expect(tree.text()).to.include('We’ve saved your application.');
   });
   it('should show saving', () => {
     props.form.autoSavedStatus = SAVE_STATUSES.pending;
@@ -38,7 +38,7 @@ describe('<SaveStatus>', () => {
     props.form.autoSavedStatus = undefined;
     props.form.lastSavedDate = undefined;
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
-    expect(tree.text()).to.not.have.string('Your application has been saved.');
+    expect(tree.text()).to.not.have.string('We’ve saved your application.');
     expect(tree.text()).to.not.have.string('Saving...');
   });
   it('should show session expired error', () => {


### PR DESCRIPTION
## Summary
This pull request updates a couple saved form messages to use active voice. Forms using `customText` in their `formConfig` are unaffected by this change.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#55694
department-of-veterans-affairs/va.gov-team#55695

## Screenshots
<img width="255" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/4f3e611d-5b7e-46ba-85f4-34856c787d5a">
<img width="410" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/63cc2a87-5c30-422e-a532-a294c8f16029">
