### PR TITLE
Add custom `returnUrl` for hidden pages

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -172,6 +172,7 @@ const formConfig = {
           CustomPage: AddIssue,
           uiSchema: addIssue.uiSchema,
           schema: addIssue.schema,
+          returnUrl: `/${CONTESTABLE_ISSUES_PATH}`,
         },
         areaOfDisagreementFollowUp: {
           title: getIssueName,

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -206,6 +206,7 @@ const formConfig = {
           CustomPageReview: null,
           uiSchema: {},
           schema: blankSchema,
+          returnUrl: `/${CONTESTABLE_ISSUES_PATH}`,
         },
         issueSummary: {
           title: 'Issue summary',

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -174,6 +174,7 @@ const formConfig = {
           CustomPage: AddIssue,
           uiSchema: addIssue.uiSchema,
           schema: addIssue.schema,
+          returnUrl: `/${CONTESTABLE_ISSUES_PATH}`,
         },
         areaOfDisagreementFollowUp: {
           title: getIssueTitle,

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -147,6 +147,7 @@
  * @property {(formData: any) => void} [onContinue]
  * @property {(data: any) => boolean} [itemFilter]
  * @property {string} [path]
+ * @property {string} [returnUrl]
  * @property {SchemaOptions} [schema]
  * @property {string | Function} [scrollAndFocusTarget]
  * @property {boolean} [showPagePerItem]

--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -31,11 +31,11 @@ class RoutedSavablePage extends React.Component {
   };
 
   autoSave() {
-    const { form, user } = this.props;
+    const { form, user, route } = this.props;
     if (user.login.currentlyLoggedIn) {
-      const data = form.data;
-      const { formId, version, submission } = form;
-      const returnUrl = this.props.location.pathname;
+      const { data, formId, version, submission } = form;
+      const returnUrl =
+        route.pageConfig?.returnUrl || this.props.location.pathname;
       this.props.autoSaveForm(formId, data, version, returnUrl, submission);
     }
   }
@@ -104,6 +104,15 @@ const mapDispatchToProps = {
 
 RoutedSavablePage.propTypes = {
   form: PropTypes.object.isRequired,
+  autoSaveForm: PropTypes.func,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      finishAppLaterMessage: PropTypes.string,
+    }),
+  }),
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
   route: PropTypes.shape({
     pageConfig: PropTypes.shape({
       pageKey: PropTypes.string.isRequired,
@@ -116,12 +125,11 @@ RoutedSavablePage.propTypes = {
       }),
     ),
   }),
+  saveAndRedirectToReturnUrl: PropTypes.func,
   setData: PropTypes.func,
-  formConfig: PropTypes.shape({
-    customText: PropTypes.shape({
-      finishAppLaterMessage: PropTypes.string,
-    }),
-  }),
+  showLoginModal: PropTypes.func,
+  toggleLoginModal: PropTypes.func,
+  user: PropTypes.object,
 };
 
 export default withRouter(

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -5,9 +5,9 @@ import { withRouter } from 'react-router';
 
 import ReviewChapters from 'platform/forms-system/src/js/review/ReviewChapters';
 import SubmitController from 'platform/forms-system/src/js/review/SubmitController';
-
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement, getScrollOptions } from 'platform/utilities/ui';
+
 import DowntimeNotification, {
   externalServiceStatus,
 } from '../../monitoring/DowntimeNotification';
@@ -33,11 +33,12 @@ class RoutedSavableReviewPage extends React.Component {
   }
 
   autoSave = () => {
-    const { form, user } = this.props;
+    const { form, user, route } = this.props;
     if (user.login.currentlyLoggedIn) {
       const { data } = form;
       const { formId, version, submission } = form;
-      const returnUrl = this.props.location.pathname;
+      const returnUrl =
+        route.pageConfig?.returnUrl || this.props.location.pathname;
 
       this.props.autoSaveForm(formId, data, version, returnUrl, submission);
     }
@@ -122,17 +123,37 @@ const mapDispatchToProps = {
 RoutedSavableReviewPage.propTypes = {
   autoSaveForm: PropTypes.func.isRequired,
   form: PropTypes.object.isRequired,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      finishAppLaterMessage: PropTypes.string,
+      appType: PropTypes.string,
+    }),
+    downtime: PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  }).isRequired,
+  formContext: PropTypes.object.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }).isRequired,
+  pageList: PropTypes.array.isRequired,
+  path: PropTypes.string.isRequired,
   route: PropTypes.shape({
     formConfig: PropTypes.shape({
       customText: PropTypes.shape({
         finishAppLaterMessage: PropTypes.string,
         appType: PropTypes.string,
       }),
+      downtime: PropTypes.shape({
+        message: PropTypes.string,
+      }),
+    }),
+    pageConfig: PropTypes.shape({
+      returnUrl: PropTypes.string,
     }),
   }).isRequired,
-  formContext: PropTypes.object.isRequired,
-  pageList: PropTypes.array.isRequired,
-  path: PropTypes.string.isRequired,
+  showLoginModal: PropTypes.func.isRequired,
+  toggleLoginModal: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired,
 };
 

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -21,10 +21,10 @@ class SaveFormLink extends React.Component {
 
   handleSave = event => {
     event.preventDefault();
-    const { route, form, locationPathname } = this.props;
+    const { route = {}, form, locationPathname } = this.props;
     const { formId, version, data, submission } = form;
-    const returnUrl = route.pageConfig.returnUrl || locationPathname;
 
+    const returnUrl = route.pageConfig?.returnUrl || locationPathname;
     this.props.saveAndRedirectToReturnUrl(
       formId,
       data,

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -21,8 +21,10 @@ class SaveFormLink extends React.Component {
 
   handleSave = event => {
     event.preventDefault();
-    const { formId, version, data, submission } = this.props.form;
-    const returnUrl = this.props.locationPathname;
+    const { route, form, locationPathname } = this.props;
+    const { formId, version, data, submission } = form;
+    const returnUrl = route.pageConfig.returnUrl || locationPathname;
+
     this.props.saveAndRedirectToReturnUrl(
       formId,
       data,
@@ -104,6 +106,11 @@ SaveFormLink.propTypes = {
   formConfig: PropTypes.shape({
     customText: PropTypes.shape({
       appType: PropTypes.string,
+    }),
+  }),
+  route: PropTypes.shape({
+    pageConfig: PropTypes.shape({
+      returnUrl: PropTypes.string,
     }),
   }),
   savedStatus: PropTypes.string,

--- a/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
@@ -189,4 +189,61 @@ describe('Schemaform <RoutedSavablePage>', () => {
     expect(setData.called).to.be.true;
     tree.unmount();
   });
+
+  it('should auto save and include returnUrl from page config on change', () => {
+    const route = {
+      pageConfig: {
+        pageKey: 'testPage',
+        schema: {},
+        uiSchema: {},
+        errorMessages: {},
+        title: '',
+        returnUrl: '/testing2',
+      },
+      pageList: [
+        {
+          path: 'testing',
+        },
+      ],
+    };
+    const form = {
+      disableSave: false,
+      pages: {
+        testPage: {
+          schema: {},
+          uiSchema: {},
+        },
+      },
+      data: {},
+    };
+    const user = {
+      profile: {
+        savedForms: [],
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    };
+    const autoSaveForm = sinon.spy();
+    const setData = sinon.spy();
+
+    const tree = shallow(
+      <RoutedSavablePage
+        setData={setData}
+        form={form}
+        route={route}
+        user={user}
+        location={location}
+        autoSaveForm={autoSaveForm}
+        formConfig={formConfigDefaultData}
+      />,
+    );
+    tree.instance().debouncedAutoSave = tree.instance().autoSave;
+
+    tree.instance().onChange({ tests: 1 });
+    expect(autoSaveForm.called).to.be.true;
+    expect(autoSaveForm.args[0][3]).to.eq('/testing2');
+    expect(setData.called).to.be.true;
+    tree.unmount();
+  });
 });

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
@@ -132,6 +132,68 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
     tree.unmount();
   });
 
+  it('should auto save and include returnUrl from page config after change', () => {
+    const location = {
+      pathname: '/testing',
+    };
+    const route = {
+      pageConfig: {
+        pageKey: 'testPage',
+        schema: {},
+        uiSchema: {},
+        errorMessages: {},
+        title: '',
+        returnUrl: '/testing2',
+      },
+      pageList: [
+        {
+          path: 'testing',
+        },
+      ],
+    };
+    const form = {
+      disableSave: false,
+      pages: {
+        testPage: {
+          schema: {},
+          uiSchema: {},
+        },
+      },
+      data: {},
+    };
+    const user = {
+      profile: {
+        savedForms: [],
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    };
+
+    const autoSaveForm = sinon.spy();
+
+    const tree = shallow(
+      <RoutedSavableReviewPage
+        form={form}
+        user={user}
+        formConfig={{}}
+        route={route}
+        autoSaveForm={autoSaveForm}
+        location={location}
+        setPrivacyAgreement={f => f}
+      />,
+    );
+
+    const instance = tree.instance();
+    instance.debouncedAutoSave = instance.autoSave;
+
+    instance.debouncedAutoSave();
+
+    expect(autoSaveForm.called).to.be.true;
+    expect(autoSaveForm.args[0][3]).to.eq('/testing2');
+    tree.unmount();
+  });
+
   describe('downtime banner', () => {
     const setData = sinon.spy();
     const onSubmit = sinon.spy();

--- a/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
@@ -123,6 +123,44 @@ describe('Schemaform <SaveFormLink>', () => {
     expect(tree.text()).to.contain('Sorry, you’re signed out.');
     expect(tree.subTree('a')).not.to.be.null;
   });
+  it('should call saveAndRedirectToReturnUrl and include returnUrl from page config if logged in', () => {
+    const saveAndRedirectToReturnUrl = sinon.spy();
+    const route = {
+      pageConfig: {
+        pageKey: 'testPage',
+        schema: {},
+        uiSchema: {},
+        errorMessages: {},
+        title: '',
+        returnUrl: '/testing2',
+      },
+      pageList: [
+        {
+          path: 'testing',
+        },
+      ],
+    };
+    const tree = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SaveFormLink
+          user={loggedInUser}
+          form={form}
+          route={route}
+          saveAndRedirectToReturnUrl={saveAndRedirectToReturnUrl}
+          toggleLoginModal={toggleLoginModalSpy}
+          formConfig={formConfig}
+        />
+      </div>,
+    );
+    const findDOM = findDOMNode(tree);
+
+    // "Save" the form
+    findDOM.querySelector('.schemaform-sip-save-link').click();
+
+    expect(saveAndRedirectToReturnUrl.called);
+    expect(saveAndRedirectToReturnUrl.args[0][3]).to.eq('/testing2');
+  });
+
   it.skip('should call saveInProgressForm if logged in', () => {
     saveInProgressForm.reset(); // Just because it's good practice for a shared spy
     const tree = ReactTestUtils.renderIntoDocument(
@@ -133,7 +171,7 @@ describe('Schemaform <SaveFormLink>', () => {
           user={loggedInUser}
           form={form}
           saveInProgressForm={saveInProgressForm}
-          toggleLoginModal={toggleLoginModalSpy}
+          toggleLoginModal={() => {}}
           formConfig={formConfig}
         />
       </div>,


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In a `CustomPage`, the `setFormData` function also triggers an auto save which sets the `returnUrl` to the current path. If that `CustomPage` is usually hidden (`depends` callback always returns `false`), then if the user closes the browser and later returns, the `returnUrl` will point to a hidden page and the save in progress continuation will cause the button click to return to the introduction page. There is no way to fix this "broken" `returnUrl` without restarting the form.
  > 
  > This PR allows the developer to add a `returnUrl` to their page within the form config. And it works with save form link as well as auto save when the form data changes.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#59012](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59012)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Auto-saving or using the "Finish this application later" link on hidden pages would save the current path in the save in progress `returnUrl` metadata. Upon returning to the form, the path wouldn't exist and cause the continue button to return the user to the introduction page.
- _Describe the steps required to verify your changes are working as expected_
  > Add a page `returnUrl` to the form config of any form, then while on the page, change a value in the form field and note the network request includes the custom `returnUrl` in it's metadata.
- _Describe the tests completed and the results_
  > Added unit test for the 3 component changes - all passing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Form system, but the developer would need to add the option for any changes to take effect.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated (link to documentation \*if necessary) ([see #1787](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1787))
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
