### PR TITLE
58700 - Fixes spacing issue on past appointments list

### DIFF
--- a/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/index.jsx
@@ -276,6 +276,7 @@ export default function PastAppointmentsListNew() {
               className={classNames(
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',
+                'vads-u-margin-bottom--4',
                 {
                   'vads-u-border-bottom--1px': featureAppointmentList,
                   'vads-u-border-color--gray-medium': featureAppointmentList,


### PR DESCRIPTION
## Summary
This fixes a spacing issue on the new past appointments list, see screenshots and linked issue for reference.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/58700

## Testing done
- Manual local testing
- e2e testing
- Unit testing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="309" alt="239345522-532a2332-7e92-4f06-ab24-2c30af445f14" src="https://github.com/department-of-veterans-affairs/vets-website/assets/587812/cc89495e-8bd4-4603-8c9d-4e426a2bb17f">|![localhost_3001_health-care_schedule-view-va-appointments_appointments_past($xsmall-screen)](https://github.com/department-of-veterans-affairs/vets-website/assets/587812/1f1fb3f7-5f8b-4c38-ad85-dded5d75eb6c)|
| Desktop |<img width="971" alt="239345596-433c7898-cf6d-4c45-826e-3ed9cbfbca5e" src="https://github.com/department-of-veterans-affairs/vets-website/assets/587812/ea51ffc9-3a1b-4a2a-ba1e-da5c7815f41d">|![localhost_3001_health-care_schedule-view-va-appointments_appointments_past($large-screen)](https://github.com/department-of-veterans-affairs/vets-website/assets/587812/72031d2c-a9d8-4bfa-94da-0531ec1e6ee3)|


## Acceptance criteria

### Quality Assurance & Testing

- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Screenshot of the developed feature is added

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
