### PR TITLE
Forms-Library address definition option max-lengths

### DIFF
--- a/src/platform/forms/definitions/address.js
+++ b/src/platform/forms/definitions/address.js
@@ -112,11 +112,27 @@ const requiredFields = ['street', 'city', 'country', 'state', 'postalCode'];
  * @param {boolean} isRequired - If the address is required or not, defaults to false
  * @param {string} addressProperty - The name of the address definition to use from the common
  *   definitions in currentSchema
+ * @param {object.<string, number>} maxLengths - An optional object with schema-property keys and custom max-lengths
+ * 
+ * @example
+ * schema(
+ *  fullSchema,
+ *  true, // optional [default: false]
+ *  'veteranAddress',  // optional [default: 'address']
+ *  {
+ *    street: 20,
+ *    street2: 20,
+ *    city: 20,
+ *    state: 2,
+ *    postalCode: 5,
+ *  }, // optional (max-length overrides) [default: {}]
+ * );
  */
 export function schema(
   currentSchema,
   isRequired = false,
   addressProperty = 'address',
+  maxLengths = {},
 ) {
   const addressSchema = currentSchema.definitions[addressProperty];
   return {
@@ -124,6 +140,18 @@ export function schema(
     required: isRequired ? requiredFields : [],
     properties: {
       ...addressSchema.properties,
+      street: {
+        ...addressSchema.properties.street,
+        maxLength: maxLengths?.street || 50,
+      },
+      street2: {
+        ...addressSchema.properties?.street2,
+        maxLength: maxLengths?.street2 || 50,
+      },
+      city: {
+        ...addressSchema.properties.city,
+        maxLength: maxLengths?.city || 30,
+      },
       country: {
         default: 'USA',
         type: 'string',
@@ -133,11 +161,11 @@ export function schema(
       state: {
         title: 'State',
         type: 'string',
-        maxLength: 51,
+        maxLength: maxLengths?.state || 51,
       },
       postalCode: {
         type: 'string',
-        maxLength: 10,
+        maxLength: maxLengths?.postalCode || 10,
       },
     },
   };

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -63,7 +63,7 @@ describe('Forms library address definition', () => {
     form.unmount();
   }).timeout(4000);
 
-  it('should optionally set maxLengths', () => {
+  it.skip('should optionally set maxLengths', () => {
     const expectedMaxLengths = {
       street: 18,
       city: 15,
@@ -82,7 +82,7 @@ describe('Forms library address definition', () => {
 
     expect(actualMaxLengths).to.eql(expectedMaxLengths);
     form.unmount();
-  });
+  }).timeout(4000);
 
   it('should update labels and state selection conditionally', () => {
     const s = schema(addressSchema, false);

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -15,10 +15,15 @@ import {
   requireStateWithData,
 } from '../../definitions/address';
 
-const { address } = definitions;
+const { address, usAddress } = definitions;
 const addressSchema = {
   definitions: {
     address,
+  },
+};
+const usAddressSchema = {
+  definitions: {
+    address: usAddress,
   },
 };
 
@@ -63,21 +68,24 @@ describe('Forms library address definition', () => {
     form.unmount();
   }).timeout(4000);
 
-  it.skip('should optionally set maxLengths', () => {
+  it('should optionally set maxLengths', () => {
+    // not setting state maxLength here because it's a select box.
+    // the definition still supports state maxLength, in case
+    // a form-schema renders a text-input for state.
     const expectedMaxLengths = {
       street: 18,
+      street2: 12,
       city: 15,
-      state: 2,
       postalCode: 5,
     };
-    const s = schema(addressSchema, true, 'address', expectedMaxLengths);
+    const s = schema(usAddressSchema, true, 'address', expectedMaxLengths);
     const uis = uiSchema();
     const form = mount(<DefinitionTester schema={s} uiSchema={uis} />);
     const actualMaxLengths = {
-      street: form.find('input#root_street').props('maxlength'),
-      city: form.find('input#root_city').props('maxlength'),
-      state: form.find('select#root_state').props('maxlength'),
-      postalCode: form.find('input#root_postalCode').props('maxlength'),
+      street: form.find('input#root_street').props().maxLength,
+      street2: form.find('input#root_street2').props().maxLength,
+      city: form.find('input#root_city').props().maxLength,
+      postalCode: form.find('input#root_postalCode').props().maxLength,
     };
 
     expect(actualMaxLengths).to.eql(expectedMaxLengths);

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -74,10 +74,10 @@ describe('Forms library address definition', () => {
     const uis = uiSchema();
     const form = mount(<DefinitionTester schema={s} uiSchema={uis} />);
     const actualMaxLengths = {
-      street: form.find('input#root_street').props('maxLength'),
-      city: form.find('input#root_city').props('maxLength'),
-      state: form.find('select#root_state').props('maxLength'),
-      postalCode: form.find('input#root_postalCode').props('maxLength'),
+      street: form.find('input#root_street').props('maxlength'),
+      city: form.find('input#root_city').props('maxlength'),
+      state: form.find('select#root_state').props('maxlength'),
+      postalCode: form.find('input#root_postalCode').props('maxlength'),
     };
 
     expect(actualMaxLengths).to.eql(expectedMaxLengths);

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -69,9 +69,10 @@ describe('Forms library address definition', () => {
   }).timeout(4000);
 
   it('should optionally set maxLengths', () => {
-    // not setting state maxLength here because it's a select box.
-    // the definition still supports state maxLength, in case
-    // a form-schema renders a text-input for state.
+    // not setting state maxLength here because we're rendering
+    // a <select> here, where maxlength attribute's not active.
+    // the definition still supports state maxLength overrides, in case
+    // a form-schema renders a text input for state.
     const expectedMaxLengths = {
       street: 18,
       street2: 12,
@@ -88,7 +89,7 @@ describe('Forms library address definition', () => {
       postalCode: form.find('input#root_postalCode').props().maxLength,
     };
 
-    expect(actualMaxLengths).to.eql(expectedMaxLengths);
+    expect(actualMaxLengths).to.deep.equal(expectedMaxLengths);
     form.unmount();
   }).timeout(4000);
 

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -208,7 +208,7 @@ describe('Forms library address definition', () => {
   }).timeout(4000);
 });
 
-describe.skip('Forms library address validation', () => {
+describe('Forms library address validation', () => {
   describe('requireStateWithCountry', () => {
     const validationTest = (requiredFields, country, errorFound) => {
       const s = schema(addressSchema, requiredFields);

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
+import definitions from 'vets-json-schema/dist/definitions.json';
 import {
   DefinitionTester,
   fillData,
@@ -13,7 +14,6 @@ import {
   requireStateWithCountry,
   requireStateWithData,
 } from '../../definitions/address';
-import definitions from 'vets-json-schema/dist/definitions.json';
 
 const { address } = definitions;
 const addressSchema = {
@@ -62,6 +62,27 @@ describe('Forms library address definition', () => {
     expect(requiredInputs.length).to.not.equal(0);
     form.unmount();
   }).timeout(4000);
+
+  it('should optionally set maxLengths', () => {
+    const expectedMaxLengths = {
+      street: 18,
+      city: 15,
+      state: 2,
+      postalCode: 5,
+    };
+    const s = schema(addressSchema, true, 'address', expectedMaxLengths);
+    const uis = uiSchema();
+    const form = mount(<DefinitionTester schema={s} uiSchema={uis} />);
+    const actualMaxLengths = {
+      street: form.find('input#root_street').props('maxLength'),
+      city: form.find('input#root_city').props('maxLength'),
+      state: form.find('select#root_state').props('maxLength'),
+      postalCode: form.find('input#root_postalCode').props('maxLength'),
+    };
+
+    expect(actualMaxLengths).to.eql(expectedMaxLengths);
+    form.unmount();
+  });
 
   it('should update labels and state selection conditionally', () => {
     const s = schema(addressSchema, false);
@@ -187,7 +208,7 @@ describe('Forms library address definition', () => {
   }).timeout(4000);
 });
 
-describe('Forms library address validation', () => {
+describe.skip('Forms library address validation', () => {
   describe('requireStateWithCountry', () => {
     const validationTest = (requiredFields, country, errorFound) => {
       const s = schema(addressSchema, requiredFields);


### PR DESCRIPTION
## Summary

- Add optional custom-max-lengths support to Forms Library's address definition (`src/platform/forms/definitions/address.js`):
  - Add an optional maxLengths schema() parameter for an object with field-keys & numeric values for max-lengths.
  - Update each schema-property's maxLengths to accept any overrides from this optional object before apply internal default values.
- Team: VA Product Forms
- Not using Flipper

## Related issue(s)

None specifically.  We often have to set maxLengths for fields in order to fit PDF-specific restrictions.

E.g., for Lay/Witness Statement (21-10210), the PDF's Street line has only 30 character-boxes, City has only 18, State has only 2, etc.


## Testing done

- All unit-tests for address definition, incl. my new maxLengths test, passed successfully.
- All unit-tests & e2e-tests Checks passed successfully here for this PR.


## What areas of the site does it impact?

N/A; this is a brand-new & optional feature.  I'll be using it first in my new (WIP) Lay/Witness Stmt (21-10210) form.

