### PR TITLE
VACMS-13590 GMT < NMT Jonesboro case (Income Limits)

### DIFF
--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -2,18 +2,28 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 0,
-});
+import {
+  getFirstAccordionHeader,
+  getSecondAccordionHeader,
+  getThirdAccordionHeader,
+  getFourthAccordionHeader,
+  getFifthAccordionHeader,
+} from '../utilities/results-accordions';
 
+/**
+ * There are two pathways to displaying income ranges on this page
+ * Both are mapped in this Mural: https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1683232214853/cfc6da5007d8f99ee0bc83e261e118e7074ffa85?wid=0-1683331066052&sender=ue51e6049230e03c1248b5078)
+ * 1) Standard: GMT > NMT
+ * 2) Non-standard: GMT < NMT  In some rural areas, the Geographic Means Test is lower than the National Means Test
+ */
 const Results = ({ limits }) => {
   const {
     gmt_threshold: gmt,
     national_threshold: national,
     pension_threshold: pension,
   } = limits;
+
+  const isStandard = gmt > national;
 
   return (
     <>
@@ -34,46 +44,47 @@ const Results = ({ limits }) => {
       <h3>Fusce risus lacus efficitur ac magna vitae</h3>
       <va-accordion bordered data-testid="il-results">
         <va-accordion-item
-          header={`${formatter.format(pension['0_dependent'])} or less`}
+          data-testid="il-results-1"
+          header={getFirstAccordionHeader(pension)}
         >
           In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
           justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
           Nam ac laoreet leo, nec fringilla libero.
         </va-accordion-item>
         <va-accordion-item
-          header={`${formatter.format(
-            pension['0_dependent'] + 1,
-          )} - ${formatter.format(national['0_dependent'])}`}
+          data-testid="il-results-2"
+          header={getSecondAccordionHeader(pension, national)}
         >
           In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
           justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
           Nam ac laoreet leo, nec fringilla libero.
         </va-accordion-item>
         <va-accordion-item
-          header={`${formatter.format(
-            national['0_dependent'] + 1,
-          )} - ${formatter.format(gmt)}`}
+          data-testid="il-results-3"
+          header={getThirdAccordionHeader(national, gmt, isStandard)}
         >
           In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
           justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
           Nam ac laoreet leo, nec fringilla libero.
         </va-accordion-item>
         <va-accordion-item
-          header={`${formatter.format(gmt + 1)} - ${formatter.format(
-            gmt * 1.1,
-          )}`}
+          data-testid="il-results-4"
+          header={getFourthAccordionHeader(national, gmt, isStandard)}
         >
           In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
           justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
           Nam ac laoreet leo, nec fringilla libero.
         </va-accordion-item>
-        <va-accordion-item
-          header={`${formatter.format(gmt * 1.1 + 1)} or more`}
-        >
-          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
-          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-          Nam ac laoreet leo, nec fringilla libero.
-        </va-accordion-item>
+        {isStandard && (
+          <va-accordion-item
+            data-testid="il-results-5"
+            header={getFifthAccordionHeader(gmt)}
+          >
+            In posuere, sem in ornare mattis, urna libero vulputate quam, a
+            justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
+            Nam ac laoreet leo, nec fringilla libero.
+          </va-accordion-item>
+        )}
       </va-accordion>
       <h2>Aliquam ut pulvinar sapien, eu gravida nisi</h2>
       <p>
@@ -84,31 +95,19 @@ const Results = ({ limits }) => {
   );
 };
 
+const mapStateToProps = state => ({
+  limits: state?.incomeLimits?.results?.limits,
+});
+
 Results.propTypes = {
-  form: PropTypes.object.isRequired,
   limits: PropTypes.shape({
     // eslint-disable-next-line camelcase
     gmt_threshold: PropTypes.number,
     // eslint-disable-next-line camelcase
-    national_threshold: PropTypes.shape({
-      '0_dependent': PropTypes.number,
-      '1_dependent': PropTypes.number,
-      // eslint-disable-next-line camelcase
-      additional_dependents: PropTypes.number,
-    }),
+    national_threshold: PropTypes.number,
     // eslint-disable-next-line camelcase
-    pension_threshold: PropTypes.shape({
-      '0_dependent': PropTypes.number,
-      '1_dependent': PropTypes.number,
-      // eslint-disable-next-line camelcase
-      additional_dependents: PropTypes.number,
-    }),
+    pension_threshold: PropTypes.number,
   }).isRequired,
 };
-
-const mapStateToProps = state => ({
-  form: state?.incomeLimits?.form,
-  limits: state?.incomeLimits?.results?.limits,
-});
 
 export default connect(mapStateToProps)(Results);

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -86,13 +86,11 @@ const ReviewPage = ({
   );
 };
 
-const mapStateToProps = state => {
-  return {
-    dependentsInput: state?.incomeLimits?.form?.dependents,
-    editMode: state?.incomeLimits?.editMode,
-    zipCodeInput: state?.incomeLimits?.form?.zipCode,
-  };
-};
+const mapStateToProps = state => ({
+  dependentsInput: state?.incomeLimits?.form?.dependents,
+  editMode: state?.incomeLimits?.editMode,
+  zipCodeInput: state?.incomeLimits?.form?.zipCode,
+});
 
 const mapDispatchToProps = {
   toggleEditMode: updateEditMode,

--- a/src/applications/income-limits/reducers/index.js
+++ b/src/applications/income-limits/reducers/index.js
@@ -5,6 +5,24 @@ import {
 } from '../constants';
 
 /* eslint-disable camelcase */
+// const initialState = {
+//   editMode: false,
+//   form: {
+//     dependents: null,
+//     zipCode: null,
+//   },
+//   results: {
+//     county_name: 'Some County, XX',
+//     income_year: 2023,
+//     limits: {
+//       national_threshold: 44444,
+//       pension_threshold: 22222,
+//       gmt_threshold: 77777,
+//     },
+//   },
+// };
+
+// Non-standard case (GMT < NMT)
 const initialState = {
   editMode: false,
   form: {
@@ -15,17 +33,9 @@ const initialState = {
     county_name: 'Some County, XX',
     income_year: 2023,
     limits: {
-      national_threshold: {
-        '0_dependent': 44444,
-        '1_dependent': 55555,
-        additional_dependents: 6666,
-      },
-      pension_threshold: {
-        '0_dependent': 11111,
-        '1_dependent': 22222,
-        additional_dependents: 3333,
-      },
-      gmt_threshold: 77777,
+      national_threshold: 55555,
+      pension_threshold: 22222,
+      gmt_threshold: 33333,
     },
   },
 };

--- a/src/applications/income-limits/tests/results-accordions.unit.spec.js
+++ b/src/applications/income-limits/tests/results-accordions.unit.spec.js
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import {
+  getFirstAccordionHeader,
+  getSecondAccordionHeader,
+  getThirdAccordionHeader,
+  getFourthAccordionHeader,
+  getFifthAccordionHeader,
+} from '../utilities/results-accordions';
+
+/* eslint-disable camelcase */
+const limits = {
+  national_threshold: 44444,
+  pension_threshold: 22222,
+  gmt_threshold: 77777,
+};
+
+const nonStandardLimits = {
+  national_threshold: 44444,
+  pension_threshold: 22222,
+  gmt_threshold: 33333,
+};
+
+describe('getFirstAccordionHeader', () => {
+  it('should return the correct output', () => {
+    expect(getFirstAccordionHeader(limits.pension_threshold)).to.equal(
+      '$22,222 or less',
+    );
+  });
+});
+
+describe('getSecondAccordionHeader', () => {
+  it('should return the correct output', () => {
+    expect(
+      getSecondAccordionHeader(
+        limits.pension_threshold,
+        limits.national_threshold,
+      ),
+    ).to.equal('$22,223 - $44,444');
+  });
+});
+
+describe('getThirdAccordionHeader', () => {
+  it('should return the correct output for the non-standard case', () => {
+    expect(
+      getThirdAccordionHeader(
+        nonStandardLimits.national_threshold,
+        nonStandardLimits.gmt_threshold,
+        false,
+      ),
+    ).to.equal('$44,445 - $48,888');
+  });
+
+  it('should return the correct output for the standard case', () => {
+    expect(
+      getThirdAccordionHeader(
+        limits.national_threshold,
+        limits.gmt_threshold,
+        true,
+      ),
+    ).to.equal('$44,445 - $77,777');
+  });
+});
+
+describe('getFourthAccordionHeader', () => {
+  it('should return the correct output for the non-standard case', () => {
+    expect(
+      getFourthAccordionHeader(
+        nonStandardLimits.national_threshold,
+        nonStandardLimits.gmt_threshold,
+        false,
+      ),
+    ).to.equal('$48,889 or more');
+  });
+
+  it('should return the correct output for the standard case', () => {
+    expect(
+      getFourthAccordionHeader(
+        limits.national_threshold,
+        limits.gmt_threshold,
+        true,
+      ),
+    ).to.equal('$77,778 - $85,555');
+  });
+});
+
+describe('getFifthAccordionHeader', () => {
+  it('should return the correct output', () => {
+    expect(getFifthAccordionHeader(limits.gmt_threshold)).to.equal(
+      '$85,556 or more',
+    );
+  });
+});

--- a/src/applications/income-limits/utilities/results-accordions.js
+++ b/src/applications/income-limits/utilities/results-accordions.js
@@ -1,0 +1,46 @@
+const formatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0,
+});
+
+// ACCORDION 1: pension_threshold "or less"
+export const getFirstAccordionHeader = pension => {
+  return `${formatter.format(pension)} or less`;
+};
+
+// ACCORDION 2: pension_threshold + $1 through national_threshold
+export const getSecondAccordionHeader = (pension, national) => {
+  return `${formatter.format(pension + 1)} - ${formatter.format(national)}`;
+};
+
+// ACCORDION 3
+// Non-standard: national_threshold + $1 through national_threshold + 10%
+// Standard: national_threshold + $1 through gmt_threshold
+export const getThirdAccordionHeader = (national, gmt, isStandard) => {
+  if (!isStandard) {
+    return `${formatter.format(national + 1)} - ${formatter.format(
+      national * 1.1,
+    )}`;
+  }
+
+  return `${formatter.format(national + 1)} - ${formatter.format(gmt)}`;
+};
+
+// ACCORDION 4
+// Non-standard: national_threshold + $1 + 10% "or more"
+// Standard: gmt_threshold + $1 through gmt_threshold + 10%
+export const getFourthAccordionHeader = (national, gmt, isStandard) => {
+  if (!isStandard) {
+    return `${formatter.format(national * 1.1 + 1)} or more`;
+  }
+
+  return `${formatter.format(gmt + 1)} - ${formatter.format(gmt * 1.1)}`;
+};
+
+// ACCORDION 5 (does not appear for Non-standard case)
+// Geographic threshold + 10% + $1 "or more"
+export const getFifthAccordionHeader = gmt => {
+  return `${formatter.format(gmt * 1.1 + 1)} or more`;
+};


### PR DESCRIPTION
## Summary
Adds logic for the GMT < NMT Jonesboro case.

Standard flow vs Jonesboro flow outlined in Mural: https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1683232214853/cfc6da5007d8f99ee0bc83e261e118e7074ffa85?wid=0-1683306939130&sender=ue51e6049230e03c1248b5078

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13590

## Testing done
Adjusted unit tests. Can't add to Cypress tests yet because we are still using hard-coded dummy data in the reducer vs. getting anything real from the service.

Tested manually through standard flow and Jonesboro flow by changing the reducer hard-coded data.

## Screenshots
**Note**: the income limits service is not hooked up yet. This flow is using hard-coded dummy data in the reducer that looks like this:

```
const initialState = {
  editMode: false,
  form: {
    dependents: null,
    zipCode: null,
  },
  results: {
    county_name: 'Some County, XX',
    income_year: 2023,
    limits: {
      national_threshold: 55555,
      pension_threshold: 22222,
      gmt_threshold: 33333,
    },
  },
};
```

<img width="500" alt="Screenshot 2023-05-25 at 12 13 49 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/860697ff-73e4-4d38-9749-c9fd10559e83">
<img width="500" alt="Screenshot 2023-05-25 at 12 13 57 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b8636e2e-aaed-4c01-962f-2daf976b58d7">
<img width="500" alt="Screenshot 2023-05-25 at 12 14 03 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/12362820-099c-4728-a3ae-14ccd81fd12a">
<img width="500" alt="Screenshot 2023-05-25 at 12 14 10 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/194102a5-3482-487e-8627-5bd2052602c3">

## Acceptance criteria
- [x] The accordion that would typically use GMT only is hidden – i.e., the 4th one, 80%-reduced copays) – i.e., this case's benefits go straight from "free health care" to "health care with full copay"
- [x] The threshold that sets the boundary between the bottom two ranges ("full copays" and "may not be eligible) is calculated based on NMT+10% instead of GMT+10%
- [x] Unit tests implemented

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.