### PR TITLE
59041 - verify localData exists when rendering currentSchema

### DIFF
--- a/src/applications/hca/components/FormPages/DependentInformation.jsx
+++ b/src/applications/hca/components/FormPages/DependentInformation.jsx
@@ -157,7 +157,7 @@ const DependentInformation = props => {
   const currentUISchema = useMemo(
     () => {
       const name =
-        currentPage.id !== 'basic'
+        currentPage.id !== 'basic' && localData
           ? `${localData.fullName.first} ${localData.fullName.last}`
           : 'Dependent';
       return {


### PR DESCRIPTION
## Summary
- `localData` is reset when adding or update dependents if those actions are canceled via the cancel verification modal.  This happens on step 2 and beyond of the dependent creation process.  The result is a javascript error that stops page rendering.

## Related issue(s)
- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/59041](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59041)

## Testing done
- Manually tested the process for both adding and updating dependents. 

## What areas of the site does it impact?

- healthcare enrollment when adding dependents

### Error Handling

- [ x] Browser console contains no warnings or errors.

