### PR TITLE
EFSR address submission bugfix

### DIFF
--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/cfsr-maximal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/cfsr-maximal.json
@@ -275,6 +275,7 @@
     "ssn": "1234",
     "fileNumber": "5678"
   },
+  "selectedDebts": [],
   "selectedDebtsAndCopays": [
     {
       "fileNumber": "796121200",

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/efsr-maximal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/efsr-maximal.json
@@ -340,6 +340,7 @@
     "ssn": "1234",
     "fileNumber": "5678"
   },
+  "selectedDebts": [],
   "selectedDebtsAndCopays": [
     {
       "fileNumber": "796121200",

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -223,7 +223,7 @@ export const transform = (formConfig, form) => {
   // Contact Information
   const submitAddress = {
     addresslineOne: enhancedFSRActive ? address.addressLine1 : street,
-    addresslineTwo: enhancedFSRActive ? address.addressLine2 : street2,
+    addresslineTwo: enhancedFSRActive ? address.addressLine2 || '' : street2,
     addresslineThree: enhancedFSRActive ? address.addressLine3 || '' : street3,
     city: enhancedFSRActive ? address.city : city,
     stateOrProvince: enhancedFSRActive ? address.stateCode : state,


### PR DESCRIPTION

## Summary

During user testing we had some issues with form submission.

**Sentry**:` http://sentry.vfs.va.gov/organizations/vsp/issues/205378/events/?environment=production&project=3&statsPeriod=14d`

**Error**: `NoMethodError: undefined method empty?' for nil:NilClass `

`address_key.values_at(*address_fields).reject(&:empty?).join(', ')`

**Investigate**: Address field in contact to ensure all of the required submit data is being passed to the server

```
address_fields = %w[
          addresslineOne
          addresslineTwo
          addresslineThree
          city
          stateOrProvince
          zipOrPostalCode
          countryName
]
```


**Resolved issue** by passing addressLineTwo with and empty string in the data transform

`addresslineTwo: enhancedFSRActive ? address.addressLine2 || '' : street2,`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#58979


## Testing done

- _Manual form submission
- _Ran automated tests


## Screenshots
n/a

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- [x] Issue is resolved and users can submit without errors.

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
