### PR TITLE
Simple forms add flipper for 21-4142

### DIFF
--- a/src/applications/static-pages/simple-forms/21-4142/App.js
+++ b/src/applications/static-pages/simple-forms/21-4142/App.js
@@ -26,7 +26,7 @@ const App = ({ formEnabled }) => {
 
   return (
     <>
-      <h1>We’re still working on this feature</h1>
+      <p>We’re still working on this feature</p>
       <p>
         We’re rolling out the Authorization to the release non-VA medical
         information to VA (VA Form 21-4142 and 21-4142a) in stages. It’s not

--- a/src/applications/static-pages/simple-forms/21-4142/App.js
+++ b/src/applications/static-pages/simple-forms/21-4142/App.js
@@ -29,7 +29,7 @@ const App = ({ formEnabled }) => {
       <p>We’re still working on this feature</p>
       <p>
         We’re rolling out the Authorization to the release non-VA medical
-        information to VA (VA Form 21-4142 and 21-4142a) in stages. It’s not
+        information to VA (VA Forms 21-4142 and 21-4142a) in stages. It’s not
         quite ready yet. Please check back again soon.
       </p>
       <a className="vads-c-action-link--green" href="/">

--- a/src/applications/static-pages/simple-forms/21-4142/App.js
+++ b/src/applications/static-pages/simple-forms/21-4142/App.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+const App = ({ formEnabled }) => {
+  if (formEnabled === undefined) {
+    return <va-loading-indicator set-focus message="Loading..." />;
+  }
+
+  if (formEnabled) {
+    return (
+      <>
+        <p>You can apply online right now.</p>
+        <a
+          className="vads-c-action-link--green"
+          href="/supporting-forms-for-claims/release-records-to-va-form-21-4142"
+        >
+          Apply for an Authorization to Disclose Information to the department
+          of VA
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p>You can apply online right now on eBenefits.</p>
+      <p>
+        When you go to the eBenefits website, you may need to sign in with your{' '}
+        <strong>DS Logon</strong> account to access the application. If you
+        don’t have a <strong>DS Logon</strong> account, you can register for one
+        there.
+      </p>
+      <a
+        className="vads-c-action-link--green"
+        href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant"
+      >
+        Apply now on eBenefits
+      </a>
+    </>
+  );
+};
+
+App.propTypes = {
+  formEnabled: PropTypes.bool,
+};
+
+const mapStateToProps = store => ({
+  formEnabled: toggleValues(store)[FEATURE_FLAG_NAMES.form214142],
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/static-pages/simple-forms/21-4142/App.js
+++ b/src/applications/static-pages/simple-forms/21-4142/App.js
@@ -13,13 +13,12 @@ const App = ({ formEnabled }) => {
   if (formEnabled) {
     return (
       <>
-        <p>You can apply online right now.</p>
+        <p>You can start your authorization right now.</p>
         <a
           className="vads-c-action-link--green"
           href="/supporting-forms-for-claims/release-records-to-va-form-21-4142"
         >
-          Apply for an Authorization to Disclose Information to the department
-          of VA
+          Authorize the release of non-VA medical information to VA
         </a>
       </>
     );
@@ -27,18 +26,14 @@ const App = ({ formEnabled }) => {
 
   return (
     <>
-      <p>You can apply online right now on eBenefits.</p>
+      <h1>We’re still working on this feature</h1>
       <p>
-        When you go to the eBenefits website, you may need to sign in with your{' '}
-        <strong>DS Logon</strong> account to access the application. If you
-        don’t have a <strong>DS Logon</strong> account, you can register for one
-        there.
+        We’re rolling out the Authorization to the release non-VA medical
+        information to VA (VA Form 21-4142 and 21-4142a) in stages. It’s not
+        quite ready yet. Please check back again soon.
       </p>
-      <a
-        className="vads-c-action-link--green"
-        href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant"
-      >
-        Apply now on eBenefits
+      <a className="vads-c-action-link--green" href="/">
+        Return to VA home page
       </a>
     </>
   );

--- a/src/applications/static-pages/simple-forms/21-4142/entry.js
+++ b/src/applications/static-pages/simple-forms/21-4142/entry.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Provider } from 'react-redux';
+
+export default function create214142Access(store, widgetType) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "form-21-4142" */ './App.js').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+}

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -80,6 +80,7 @@ import create1095BDownloadCTA from './download-1095b';
 
 import createEnrollmentVerificationLoginWidget from './view-enrollment-verification-login/createEnrollmentVerificationLoginWidget';
 import createEducationLettersLoginWidget from './view-education-letters-login/createEducationLettersLoginWidget';
+import create214142Access from './simple-forms/21-4142/entry';
 import create264555Access from './simple-forms/26-4555/entry';
 
 // Set the app name header when using the apiRequest helper
@@ -214,6 +215,7 @@ createEducationLettersLoginWidget(
   store,
   widgetTypes.VIEW_EDUCATION_LETTERS_LOGIN,
 );
+create214142Access(store, widgetTypes.FORM_214142_CTA);
 create264555Access(store, widgetTypes.FORM_264555_CTA);
 
 // Create the My VA Login widget only on the homepage.

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -31,6 +31,7 @@ export default {
   FIND_VA_FORMS_INVALID_PDF_ALERT: 'find-va-forms-pdf-download-helper',
   FORM_10182_CTA: 'form-10182-cta',
   FORM_686_CTA: 'form-686-CTA',
+  FORM_214142_CTA: 'form214142',
   FORM_264555_CTA: 'form264555',
   GET_MEDICAL_RECORDS_PAGE: 'get-medical-records-page',
   HEALTH_CARE_APP_STATUS: 'health-care-app-status',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -68,6 +68,7 @@ export default Object.freeze({
   findFormsShowPdfModal: 'find_forms_show_pdf_modal',
   fileUploadShortWorkflowEnabled: 'file_upload_short_workflow_enabled',
   form10182Nod: 'form10182_nod',
+  form214142: 'form214142',
   form264555: 'form264555',
   fsrConfirmationEmail: 'fsr_confirmation_email',
   gibctEybBottomSheet: 'gibct_eyb_bottom_sheet',


### PR DESCRIPTION
Add flipper and static pages

## Summary

- Add feature flag (see [backend PR](https://github.com/department-of-veterans-affairs/vets-api/pull/12841))
- Add widget build
- Add static pages

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/301

## Testing done

- Static pages go to sitewide where they're implemented in Drupal, so we cannot test locally.
- Followed setup based on previous form 26-4555

## What areas of the site does it impact?
Form 21-4142 (not yet prod)