### PR TITLE
Add logic to process expiration days in scheduled PE cleanup job prop…

### DIFF
--- a/script/github-actions/pe-cleanup.js
+++ b/script/github-actions/pe-cleanup.js
@@ -85,7 +85,8 @@ if (process.env.TRIGGERING_EVENT === 'schedule') {
           !fileContents.podAnnotations ||
           !fileContents.podAnnotations.last_updated ||
           (fileContents.podAnnotations.last_updated &&
-            daysSinceUpdate(fileContents.podAnnotations.last_updated) >= 7)
+            daysSinceUpdate(fileContents.podAnnotations.last_updated) >=
+              parseInt(fileContents.podAnnotations.expiration_days, 10))
         );
       }
       return false;


### PR DESCRIPTION
## Summary

- This removes the test value of 7 in the PE scheduled cleanup job and replaces it with the real value as recorded in the values file that is being removed.

## Related issue(s)

https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/57401

## Testing done

- Testing has been done prior, however testing of this change will not be able to be done until a later date due to external factors.

