### PR TITLE
Updated title string on details page to use hyphen key.

### DIFF
--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -128,7 +128,7 @@ describe('check-in experience', () => {
               <AppointmentDetails />
             </CheckInProvider>,
           );
-          expect(getByTestId('header')).to.have.text('In person appointment');
+          expect(getByTestId('header')).to.have.text('In-person appointment');
         });
         it('renders correct subtitle', () => {
           const { getByTestId } = render(

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -97,9 +97,11 @@ const AppointmentDetails = props => {
                 data-testid="header"
                 className="vads-u-font-size--h3"
               >
-                {`${isPhoneAppointment ? t('phone') : t('in-person')} ${t(
-                  'appointment',
-                )}`}
+                {`${
+                  isPhoneAppointment
+                    ? `${t('phone')} ${t('appointment')}`
+                    : t('in-person-appointment')
+                }`}
               </h1>
               {app === APP_NAMES.PRE_CHECK_IN ? (
                 preCheckInSubTitle

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -4,7 +4,7 @@ class AppointmentDetails {
   validatePageLoadedInPerson = () => {
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
-      .and('include.text', 'In person appointment');
+      .and('include.text', 'In-person appointment');
   };
 
   validatePageLoadedPhone = () => {


### PR DESCRIPTION
## Summary
Adds hyphen to `In-person Appointment` heading text on appointment details page.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#59082


## Testing done

Updates unit test for page component.

## Screenshots
![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/823e0a15-7a89-47ff-bdc6-bb2126bfbf5b)


## What areas of the site does it impact?

Check-in and Pre-check-in

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

