### PR TITLE
Add custom tracking names to GA4

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
 
@@ -770,8 +771,10 @@ export function submitAppointmentOrRequest(history) {
     });
 
     let additionalEventData = {
-      'health-TypeOfCare': typeOfCare,
-      'health-ReasonForAppointment': data?.reasonForAppointment,
+      custom_string_1: `health-TypeOfCare: ${typeOfCare}`,
+      custom_string_2: `health-ReasonForAppointment: ${
+        data?.reasonForAppointment
+      }`,
     };
 
     if (newAppointment.flowType === FLOW_TYPES.DIRECT) {

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Functions related to fetching Apppointment data and pulling information from that data
  * @module services/Appointment
@@ -619,11 +620,13 @@ async function cancelRequestedAppointment(request) {
 
 async function cancelV2Appointment(appointment, useAcheron) {
   const additionalEventData = {
-    appointmentType:
+    custom_string_1:
       appointment.status === APPOINTMENT_STATUS.proposed
-        ? 'pending'
-        : 'confirmed',
-    facilityType: appointment.vaos?.isCommunityCare ? 'cc' : 'va',
+        ? 'appointmentType: pending'
+        : 'appointmentType: confirmed',
+    custom_string_2: appointment.vaos?.isCommunityCare
+      ? 'facilityType: cc'
+      : 'facilityType: va',
   };
 
   recordEvent({

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React from 'react';
 import moment from 'moment';
 import { expect } from 'chai';
@@ -659,8 +660,8 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
     expect(global.window.dataLayer[1]).to.deep.include({
       event: 'vaos-community-care-submission-successful',
       flow: 'cc-request',
-      'health-TypeOfCare': 'Primary care',
-      'health-ReasonForAppointment': undefined,
+      custom_string_1: 'health-TypeOfCare: Primary care',
+      custom_string_2: 'health-ReasonForAppointment: undefined',
       'vaos-community-care-preferred-language': 'english',
       'vaos-number-of-preferred-providers': 1,
       'vaos-number-of-days-from-preference': '1-1-null',
@@ -718,8 +719,8 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
     expect(global.window.dataLayer[1]).to.deep.include({
       event: 'vaos-community-care-submission-failed',
       flow: 'cc-request',
-      'health-TypeOfCare': 'Primary care',
-      'health-ReasonForAppointment': undefined,
+      custom_string_1: 'health-TypeOfCare: Primary care',
+      custom_string_2: 'health-ReasonForAppointment: undefined',
       'vaos-community-care-preferred-language': 'english',
       'vaos-number-of-preferred-providers': 1,
       'vaos-number-of-days-from-preference': '1-1-null',

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React from 'react';
 import moment from 'moment';
 import { expect } from 'chai';
@@ -208,8 +209,8 @@ describe('VAOS <ReviewPage> VA request', () => {
     expect(global.window.dataLayer[2]).to.deep.include({
       event: 'vaos-request-submission-failed',
       flow: 'va-request',
-      'health-TypeOfCare': 'Primary care',
-      'health-ReasonForAppointment': 'routine-follow-up',
+      custom_string_1: 'health-TypeOfCare: Primary care',
+      custom_string_2: 'health-ReasonForAppointment: routine-follow-up',
       'vaos-preferred-combination': 'afternoon-evening-morning',
     });
     expect(global.window.dataLayer[3]).to.deep.equal({
@@ -262,8 +263,8 @@ describe('VAOS <ReviewPage> VA request', () => {
     expect(window.dataLayer[1]).to.deep.equal({
       event: 'vaos-request-submission-successful',
       flow: 'va-request',
-      'health-TypeOfCare': 'Primary care',
-      'health-ReasonForAppointment': 'routine-follow-up',
+      custom_string_1: 'health-TypeOfCare: Primary care',
+      custom_string_2: 'health-ReasonForAppointment: routine-follow-up',
       'vaos-preferred-combination': 'afternoon-evening-morning',
       'vaos-number-of-days-from-preference': '1-1-null',
     });
@@ -477,8 +478,8 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
     expect(window.dataLayer[1]).to.deep.equal({
       event: 'vaos-request-submission-successful',
       flow: 'va-request',
-      'health-TypeOfCare': 'Primary care',
-      'health-ReasonForAppointment': 'routine-follow-up',
+      custom_string_1: 'health-TypeOfCare: Primary care',
+      custom_string_2: 'health-ReasonForAppointment: routine-follow-up',
       'vaos-preferred-combination': 'afternoon-evening-morning',
       'vaos-number-of-days-from-preference': '1-1-null',
     });
@@ -530,8 +531,8 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
     expect(window.dataLayer[1]).to.deep.include({
       event: 'vaos-request-submission-failed',
       flow: 'va-request',
-      'health-TypeOfCare': 'Primary care',
-      'health-ReasonForAppointment': 'routine-follow-up',
+      custom_string_1: 'health-TypeOfCare: Primary care',
+      custom_string_2: 'health-ReasonForAppointment: routine-follow-up',
       'vaos-preferred-combination': 'afternoon-evening-morning',
     });
   });


### PR DESCRIPTION
## Summary
GA4 uses pre-defined labels for tracking. For each `action`, there are two custom string assignments available (at this present time - Jeff will ask Analytic Team  to create more). This PR makes use of `custom_string_1` and `custom_string_2` to pass in values. 

Below is the sample data layer code from the Analytics team. The required fields are event and action. We are using custom_string_1 and custom_string_2 as additional labels to pass data into GA4. 

event: 'interaction',
action: 'enter event name'
custom_string_1: '<custom_string_1>',
custom_string_2: '<custom_string_2>',
custom_number_1: <custom_number_1>,
custom_number_2: <custom_number_2>,
selected: '',
status: ,
previous_value: '<previous_value>',
value: '',
selected: '',
type: '',
required: '',
heading_1: <heading_1>,
heading_2: <heading_2>,
component_name: <component_name>,
component_version: <component_version>



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#58468


## Testing done

unit test

## Screenshots
**Update the custom names and values for the action name** `vaos-cancel-appointment-submission`
<img width="532" alt="Screenshot 2023-05-31 at 8 02 04 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/ca6b4851-8cf4-4017-ad3c-3c7b8ebc2ea9">

**Update the custom names and values for the action name** `vaos-direct-submission`
Presently, the object value pair for `flow: direct` does not match the GA4 parameter. It will be replaced when more custom string labels are created.
<img width="651" alt="Screenshot 2023-05-31 at 7 53 36 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/a0803476-d3d5-43a8-aee7-bc11cb9c1c2a">




## What areas of the site does it impact?

Google Analytic

## Acceptance criteria


