### PR TITLE
Remove HCA spousal condition conflict

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -472,6 +472,7 @@ const formConfig = {
           depends: formData =>
             !isShortFormEligible(formData) &&
             includeSpousalInformation(formData) &&
+            !formData.cohabitedLastYear &&
             formData['view:isHouseholdV2Enabled'],
           uiSchema: v2SpouseFinancialSupport.uiSchema,
           schema: v2SpouseFinancialSupport.schema,

--- a/src/applications/hca/tests/e2e/hca-household-v2.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household-v2.cypress.spec.js
@@ -16,10 +16,6 @@ import {
 const { data: testData } = maxTestData;
 
 describe('HCA-Household-V2-Non-Disclosure', () => {
-  before(function skipInCI() {
-    if (Cypress.env('CI')) this.skip();
-  });
-
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles).as(
@@ -167,10 +163,6 @@ describe('HCA-Household-V2-Non-Disclosure', () => {
 });
 
 describe('HCA-Household-V2-Spousal-Disclosure', () => {
-  before(function skipInCI() {
-    if (Cypress.env('CI')) this.skip();
-  });
-
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles).as(
@@ -227,7 +219,6 @@ describe('HCA-Household-V2-Spousal-Disclosure', () => {
     cy.get('[name="root_cohabitedLastYear"]').check('Y');
     cy.get('[name="root_sameAddress"]').check('Y');
 
-    goToNextPage('/household-information-v2/spouse-financial-support');
     goToNextPage('/household-information-v2/dependents');
     cy.get('[type="radio"]')
       .last()
@@ -384,10 +375,6 @@ describe('HCA-Household-V2-Spousal-Disclosure', () => {
 });
 
 describe('HCA-Household-V2-Dependent-Disclosure', () => {
-  before(function skipInCI() {
-    if (Cypress.env('CI')) this.skip();
-  });
-
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles).as(
@@ -746,10 +733,6 @@ describe('HCA-Household-V2-Dependent-Disclosure', () => {
 });
 
 describe('HCA-Household-V2-Full-Disclosure', () => {
-  before(function skipInCI() {
-    if (Cypress.env('CI')) this.skip();
-  });
-
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles).as(
@@ -805,8 +788,6 @@ describe('HCA-Household-V2-Full-Disclosure', () => {
     goToNextPage('/household-information-v2/spouse-additional-information');
     cy.get('[name="root_cohabitedLastYear"]').check('Y');
     cy.get('[name="root_sameAddress"]').check('Y');
-
-    goToNextPage('/household-information-v2/spouse-financial-support');
 
     goToNextPage('/household-information-v2/dependents');
     cy.get('[name="root_view:reportDependents"]').check('Y');


### PR DESCRIPTION
## Description
In the household V2 upgrade, when selecting yes to both spouse questions (Did your spouse live with you last year, and Does your spouse have the same address), the next step in the form indicates conflicting information. The spousal support question should not appear if the answer to the "Did your spouse live with you last year" question is answered "yes". This PR updates the conditional on the support page to exclude it from the form when appropriate.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#59034

## Acceptance criteria

- [ ] The Spousal support question will appear only when the Veteran indicates that their spouse DID NOT live with them (or if the question is left unanswered).
