### PR TITLE
VACMS-13738 Add year screen (Income Limits)

### DIFF
--- a/src/applications/income-limits/actions/index.js
+++ b/src/applications/income-limits/actions/index.js
@@ -1,6 +1,8 @@
 import {
   IL_EDIT_MODE,
+  IL_PAST_MODE,
   IL_UPDATE_DEPENDENTS,
+  IL_UPDATE_YEAR,
   IL_UPDATE_ZIP,
 } from '../constants';
 
@@ -14,6 +16,20 @@ export const updateDependents = value => {
 export const updateZipCode = value => {
   return {
     type: IL_UPDATE_ZIP,
+    payload: value,
+  };
+};
+
+export const updateYear = value => {
+  return {
+    type: IL_UPDATE_YEAR,
+    payload: value,
+  };
+};
+
+export const updatePastMode = value => {
+  return {
+    type: IL_PAST_MODE,
     payload: value,
   };
 };

--- a/src/applications/income-limits/constants/index.js
+++ b/src/applications/income-limits/constants/index.js
@@ -1,11 +1,14 @@
 export const IL_UPDATE_ZIP = 'income-limits/UPDATE_ZIP';
 export const IL_UPDATE_DEPENDENTS = 'income-limits/UPDATE_DEPENDENTS';
+export const IL_UPDATE_YEAR = 'income-limits/UPDATE_YEAR';
 export const IL_EDIT_MODE = 'income-limits/EDIT_MODE';
+export const IL_PAST_MODE = 'income-limits/PAST_MODE';
 
 export const ROUTES = {
   DEPENDENTS: 'dependents',
   HOME: '/',
   REVIEW: 'review',
   RESULTS: 'results',
+  YEAR: 'year',
   ZIPCODE: 'zip',
 };

--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -103,12 +103,12 @@ const mapDispatchToProps = {
 
 DependentsPage.propTypes = {
   editMode: PropTypes.bool.isRequired,
-  updateDependentsField: PropTypes.func.isRequired,
-  dependents: PropTypes.string,
   router: PropTypes.shape({
     push: PropTypes.func,
-  }),
-  toggleEditMode: PropTypes.func,
+  }).isRequired,
+  toggleEditMode: PropTypes.func.isRequired,
+  updateDependentsField: PropTypes.func.isRequired,
+  dependents: PropTypes.string,
 };
 
 export default connect(

--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -1,19 +1,30 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import { ROUTES } from '../constants';
 
-const HomePage = ({ router }) => {
+const HomePage = ({ pastMode, router }) => {
   useEffect(() => {
-    router.push(ROUTES.ZIPCODE);
+    if (pastMode) {
+      router.push(ROUTES.YEAR);
+    } else {
+      router.push(ROUTES.ZIPCODE);
+    }
   });
 
   return <div />;
 };
 
+const mapStateToProps = state => ({
+  pastMode: state?.incomeLimits?.pastMode,
+});
+
 HomePage.propTypes = {
+  pastMode: PropTypes.bool.isRequired,
   router: PropTypes.shape({
     push: PropTypes.func,
-  }),
+  }).isRequired,
 };
 
-export default HomePage;
+export default connect(mapStateToProps)(HomePage);

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -16,7 +16,7 @@ import {
  * 1) Standard: GMT > NMT
  * 2) Non-standard: GMT < NMT  In some rural areas, the Geographic Means Test is lower than the National Means Test
  */
-const Results = ({ limits }) => {
+const Results = ({ limits, yearInput }) => {
   const {
     gmt_threshold: gmt,
     national_threshold: national,
@@ -24,10 +24,11 @@ const Results = ({ limits }) => {
   } = limits;
 
   const isStandard = gmt > national;
+  const currentYear = new Date().getFullYear();
 
   return (
     <>
-      <h1>Vivamus varius sem eget</h1>
+      <h1>Your income limits for {yearInput || currentYear}</h1>
       <p>
         In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
         justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra. Nam
@@ -41,7 +42,7 @@ const Results = ({ limits }) => {
         Donec scelerisque lectus a eros pellentesque rutrum. Sed sit amet varius
         ipsum, ut rutrum lacus. Aliquam ut pulvinar sapien, eu gravida nisi.
       </p>
-      <h3>Fusce risus lacus efficitur ac magna vitae</h3>
+      <h2>Fusce risus lacus efficitur ac magna vitae</h2>
       <va-accordion bordered data-testid="il-results">
         <va-accordion-item
           data-testid="il-results-1"
@@ -97,6 +98,7 @@ const Results = ({ limits }) => {
 
 const mapStateToProps = state => ({
   limits: state?.incomeLimits?.results?.limits,
+  yearInput: state?.incomeLimits?.form?.year,
 });
 
 Results.propTypes = {
@@ -108,6 +110,7 @@ Results.propTypes = {
     // eslint-disable-next-line camelcase
     pension_threshold: PropTypes.number,
   }).isRequired,
+  yearInput: PropTypes.string,
 };
 
 export default connect(mapStateToProps)(Results);

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -9,8 +9,10 @@ import { updateEditMode } from '../actions';
 const ReviewPage = ({
   dependentsInput,
   editMode,
+  pastMode,
   router,
   toggleEditMode,
+  yearInput,
   zipCodeInput,
 }) => {
   useEffect(() => {
@@ -38,8 +40,28 @@ const ReviewPage = ({
       <p>Fusce risus lacus, efficitur ac magna vitae, cursus lobortis dui.</p>
       <table className="usa-table-borderless" data-testid="il-review">
         <tbody>
+          {pastMode && (
+            <tr>
+              <td data-testid="review-year">
+                <strong>Vitae:</strong>
+                <br aria-hidden="true" /> {yearInput}
+              </td>
+              <td className="income-limits-edit">
+                <button
+                  aria-label="Edit year"
+                  className="va-button-link"
+                  href="#"
+                  onClick={() => handleEditClick(ROUTES.YEAR)}
+                  name="year"
+                  type="button"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+          )}
           <tr>
-            <td>
+            <td data-testid="review-zip">
               <strong>Nisci orci:</strong>
               <br aria-hidden="true" /> {zipCodeInput}
             </td>
@@ -57,7 +79,7 @@ const ReviewPage = ({
             </td>
           </tr>
           <tr>
-            <td>
+            <td data-testid="review-dependents">
               <strong>Malesuada felis ultrices:</strong>
               <br aria-hidden="true" /> {dependentsInput}
             </td>
@@ -89,6 +111,8 @@ const ReviewPage = ({
 const mapStateToProps = state => ({
   dependentsInput: state?.incomeLimits?.form?.dependents,
   editMode: state?.incomeLimits?.editMode,
+  pastMode: state?.incomeLimits?.pastMode,
+  yearInput: state?.incomeLimits?.form?.year,
   zipCodeInput: state?.incomeLimits?.form?.zipCode,
 });
 
@@ -97,13 +121,15 @@ const mapDispatchToProps = {
 };
 
 ReviewPage.propTypes = {
-  dependentsInput: PropTypes.string,
+  dependentsInput: PropTypes.string.isRequired,
   editMode: PropTypes.bool.isRequired,
+  pastMode: PropTypes.bool.isRequired,
   router: PropTypes.shape({
     push: PropTypes.func,
-  }),
-  toggleEditMode: PropTypes.func,
-  zipCodeInput: PropTypes.string,
+  }).isRequired,
+  toggleEditMode: PropTypes.func.isRequired,
+  zipCodeInput: PropTypes.string.isRequired,
+  yearInput: PropTypes.string,
 };
 
 export default connect(

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  VaButtonPair,
+  VaSelect,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import { ROUTES } from '../constants';
+import { updateEditMode, updateYear } from '../actions';
+
+const YearPage = ({
+  editMode,
+  router,
+  toggleEditMode,
+  updateYearField,
+  yearInput,
+}) => {
+  const [error, setError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const onContinueClick = () => {
+    setSubmitted(true);
+
+    if (!yearInput) {
+      setError(true);
+    } else if (editMode) {
+      setError(false);
+      toggleEditMode(false);
+      router.push(ROUTES.REVIEW);
+    } else {
+      router.push(ROUTES.ZIPCODE);
+    }
+  };
+
+  const onBackClick = () => {
+    // don't do anything yet
+  };
+
+  const onYearInput = event => {
+    updateYearField(event.target.value);
+  };
+
+  const makeYearArray = () => {
+    const years = [];
+    let currentYear = new Date().getFullYear();
+    const earliestYear = 2015;
+
+    while (currentYear >= earliestYear) {
+      years.push(currentYear);
+
+      currentYear -= 1;
+    }
+
+    const options = years.map(year => (
+      <option key={year} value={year}>
+        {year}
+      </option>
+    ));
+
+    options.unshift(
+      <option key="Select a year" value="">
+        Select a year
+      </option>,
+    );
+
+    return options;
+  };
+
+  return (
+    <>
+      <h1>Ipsum quia dolor sit amet consectetur adipisci velit</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non
+        tortor massa. Fusce eros mi, porttitor eu neque nec, mattis vehicula
+        urna. Integer consectetur urna ex, ac tempor urna feugiat ut.
+      </p>{' '}
+      <p>
+        Curabitur euismod fermentum ante, non maximus ex feugiat quis. Fusce
+        dignissim commodo mauris. Duis posuere congue elit. Aenean ut fermentum
+        quam. Morbi faucibus lacus eu tristique tempor. Fusce at leo ipsum.
+        Maecenas at augue arcu. Duis eu lacinia ligula, quis sodales felis.
+        Praesent aliquet dictum nisl, vel rhoncus eros luctus vulputate. Nullam
+        a massa ut tellus consectetur porttitor.
+      </p>
+      <VaSelect
+        autocomplete="false"
+        data-testid="il-year"
+        error={(submitted && error && 'Please select a year') || null}
+        id="year"
+        label="Year"
+        name="year"
+        required
+        value={yearInput}
+        onVaSelect={onYearInput}
+      >
+        {makeYearArray()}
+      </VaSelect>
+      <VaButtonPair
+        data-testid="il-buttonPair"
+        onPrimaryClick={onContinueClick}
+        onSecondaryClick={onBackClick}
+        continue
+      />
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  editMode: state?.incomeLimits?.editMode,
+  yearInput: state?.incomeLimits?.form?.year,
+});
+
+const mapDispatchToProps = {
+  toggleEditMode: updateEditMode,
+  updateYearField: updateYear,
+};
+
+YearPage.propTypes = {
+  editMode: PropTypes.bool.isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+  updateYearField: PropTypes.func.isRequired,
+  toggleEditMode: PropTypes.func,
+  yearInput: PropTypes.string,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(YearPage);

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -11,6 +11,7 @@ import { updateEditMode, updateZipCode } from '../actions';
 
 const ZipCodePage = ({
   editMode,
+  pastMode,
   router,
   toggleEditMode,
   updateZipCodeField,
@@ -55,7 +56,11 @@ const ZipCodePage = ({
       toggleEditMode(false);
     }
 
-    router.push('/');
+    if (pastMode) {
+      router.push(ROUTES.YEAR);
+    } else {
+      router.push(ROUTES.HOME);
+    }
   };
 
   return (
@@ -93,6 +98,7 @@ const ZipCodePage = ({
 
 const mapStateToProps = state => ({
   editMode: state?.incomeLimits?.editMode,
+  pastMode: state?.incomeLimits?.pastMode,
   zipCode: state?.incomeLimits?.form?.zipCode,
 });
 
@@ -103,6 +109,7 @@ const mapDispatchToProps = {
 
 ZipCodePage.propTypes = {
   editMode: PropTypes.bool.isRequired,
+  pastMode: PropTypes.bool.isRequired,
   updateZipCodeField: PropTypes.func.isRequired,
   router: PropTypes.shape({
     push: PropTypes.func,

--- a/src/applications/income-limits/reducers/index.js
+++ b/src/applications/income-limits/reducers/index.js
@@ -1,6 +1,8 @@
 import {
   IL_EDIT_MODE,
   IL_UPDATE_DEPENDENTS,
+  IL_PAST_MODE,
+  IL_UPDATE_YEAR,
   IL_UPDATE_ZIP,
 } from '../constants';
 
@@ -27,8 +29,10 @@ const initialState = {
   editMode: false,
   form: {
     dependents: null,
+    year: null,
     zipCode: null,
   },
+  pastMode: true,
   results: {
     county_name: 'Some County, XX',
     income_year: 2023,
@@ -50,6 +54,14 @@ const incomeLimits = (state = initialState, action) => {
           dependents: action.payload,
         },
       };
+    case IL_UPDATE_YEAR:
+      return {
+        ...state,
+        form: {
+          ...state.form,
+          year: action.payload,
+        },
+      };
     case IL_UPDATE_ZIP:
       return {
         ...state,
@@ -62,6 +74,11 @@ const incomeLimits = (state = initialState, action) => {
       return {
         ...state,
         editMode: action.payload,
+      };
+    case IL_PAST_MODE:
+      return {
+        ...state,
+        pastMode: action.payload,
       };
     default:
       return state;

--- a/src/applications/income-limits/routes.jsx
+++ b/src/applications/income-limits/routes.jsx
@@ -3,6 +3,7 @@ import HomePage from './containers/HomePage';
 import IncomeLimitsApp from './components/IncomeLimitsApp';
 import ResultsPage from './containers/ResultsPage';
 import ReviewPage from './containers/ReviewPage';
+import YearPage from './containers/YearPage';
 import ZipCodePage from './containers/ZipCodePage';
 import { ROUTES } from './constants';
 
@@ -14,6 +15,7 @@ const routes = {
     { path: ROUTES.DEPENDENTS, component: DependentsPage },
     { path: ROUTES.REVIEW, component: ReviewPage },
     { path: ROUTES.RESULTS, component: ResultsPage },
+    { path: ROUTES.YEAR, component: YearPage },
     { path: ROUTES.ZIPCODE, component: ZipCodePage },
   ],
 };

--- a/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
@@ -7,41 +7,119 @@ import sinon from 'sinon';
 
 import ReviewPage from '../containers/ReviewPage';
 
-describe('Review Page', () => {
-  const pushSpy = sinon.spy();
+const pushSpyStandard = sinon.spy();
+const pushSpyPast = sinon.spy();
 
-  const mockStore = {
-    getState: () => ({
-      incomeLimits: {
-        editMode: false,
-        form: {
-          dependents: '2',
-          zipCode: '10108',
-        },
-      },
-    }),
-    subscribe: () => {},
-    dispatch: () => {},
-  };
-
-  it('should correctly render the review page', () => {
-    const props = {
-      dependentsInput: '2',
+const mockStoreStandard = {
+  getState: () => ({
+    incomeLimits: {
       editMode: false,
-      router: {
-        push: pushSpy,
+      pastMode: false,
+      form: {
+        dependents: '2',
+        zipCode: '10108',
       },
-      toggleEditMode: () => {},
-      zipCodeInput: '10108',
-    };
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
 
+const propsStandard = {
+  dependentsInput: '2',
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: pushSpyStandard,
+  },
+  toggleEditMode: () => {},
+  zipCodeInput: '10108',
+};
+
+const mockStorePast = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      pastMode: true,
+      form: {
+        dependents: '3',
+        year: '2016',
+        zipCode: '60507',
+      },
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsPast = {
+  dependentsInput: '3',
+  editMode: false,
+  pastMode: true,
+  router: {
+    push: pushSpyPast,
+  },
+  toggleEditMode: () => {},
+  yearInput: '2016',
+  zipCodeInput: '60507',
+};
+
+describe('Review Page', () => {
+  it('should correctly load the review page in the standard flow', () => {
     const screen = render(
-      <Provider store={mockStore}>
-        <ReviewPage {...props} />
+      <Provider store={mockStoreStandard}>
+        <ReviewPage {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('review-zip').textContent).to.equal(
+      'Nisci orci: 10108',
+    );
+
+    expect(screen.getByTestId('review-dependents').textContent).to.equal(
+      'Malesuada felis ultrices: 2',
+    );
+  });
+
+  it('should correctly load the review page in the past flow', () => {
+    const screen = render(
+      <Provider store={mockStorePast}>
+        <ReviewPage {...propsPast} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('review-year').textContent).to.equal(
+      'Vitae: 2016',
+    );
+
+    expect(screen.getByTestId('review-zip').textContent).to.equal(
+      'Nisci orci: 60507',
+    );
+
+    expect(screen.getByTestId('review-dependents').textContent).to.equal(
+      'Malesuada felis ultrices: 3',
+    );
+  });
+
+  it('should call the correct function when the Edit link is used in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <ReviewPage {...propsStandard} />
+      </Provider>,
+    );
+
+    userEvent.click(screen.getAllByText('Edit')[1]);
+    expect(pushSpyStandard.withArgs('dependents').calledOnce).to.be.true;
+  });
+
+  it('should call the correct function when the Edit link is used in the past flow', () => {
+    const screen = render(
+      <Provider store={mockStorePast}>
+        <ReviewPage {...propsPast} />
       </Provider>,
     );
 
     userEvent.click(screen.getAllByText('Edit')[0]);
-    expect(pushSpy.called).to.be.true;
+    expect(pushSpyPast.withArgs('year').calledOnce).to.be.true;
   });
 });

--- a/src/applications/income-limits/tests/helpers.js
+++ b/src/applications/income-limits/tests/helpers.js
@@ -1,3 +1,7 @@
+export const YEAR = '2017';
+export const NEWYEAR = '2015';
+export const YEARINPUT = 'il-year';
+
 export const ZIP = '10108';
 export const NEWZIP = '90210';
 export const ZIPINPUT = 'il-zipCode';
@@ -34,6 +38,7 @@ export const typeInInput = (selector, value) =>
     .shadow()
     .get('input')
     .first()
+    .click()
     .type(value, { force: true });
 
 export const clearInput = selector =>
@@ -43,6 +48,14 @@ export const clearInput = selector =>
     .get('input')
     .first()
     .clear();
+
+export const selectFromDropdown = (selector, value) =>
+  cy
+    .findByTestId(selector)
+    .shadow()
+    .get('select')
+    .first()
+    .select(value);
 
 export const checkInputText = (selector, expectedValue) =>
   cy.findByTestId(selector).should('have.value', expectedValue);

--- a/src/applications/income-limits/tests/income-limits.cypress.spec.js
+++ b/src/applications/income-limits/tests/income-limits.cypress.spec.js
@@ -2,9 +2,12 @@ import {
   DEPINPUT,
   DEPENDENTS,
   NEWDEPS,
+  NEWYEAR,
   NEWZIP,
   RESULTSPAGE,
   REVIEWPAGE,
+  YEAR,
+  YEARINPUT,
   ZIP,
   ZIPINPUT,
   checkInputText,
@@ -13,6 +16,7 @@ import {
   clickContinue,
   getEditLink,
   getTdCell,
+  selectFromDropdown,
   typeInInput,
   verifyElement,
 } from './helpers';
@@ -21,16 +25,24 @@ describe('Income Limits', () => {
   it('navigates through the flow successfully forward and backward', () => {
     cy.visit('/health-care/income-limits-temp');
 
+    // Temporarily adding year for all flows because we're defaulting to past flow
+    // until we have a URL governing where we're coming from
+    // Year
+    verifyElement(YEARINPUT);
+    cy.injectAxeThenAxeCheck();
+    selectFromDropdown(YEARINPUT, YEAR);
+    clickContinue();
+
     // Zip code
     verifyElement(ZIPINPUT);
-    typeInInput(ZIPINPUT, ZIP);
     cy.injectAxeThenAxeCheck();
+    typeInInput(ZIPINPUT, ZIP);
     clickContinue();
 
     // Dependents
     verifyElement(DEPINPUT);
-    typeInInput(DEPINPUT, DEPENDENTS);
     cy.injectAxeThenAxeCheck();
+    typeInInput(DEPINPUT, DEPENDENTS);
     clickContinue();
 
     // Review
@@ -55,29 +67,79 @@ describe('Income Limits', () => {
     // Zip code
     verifyElement(ZIPINPUT);
     checkInputText(ZIPINPUT, ZIP);
+    clickBack();
+
+    // Year
+    verifyElement(YEARINPUT);
+    checkInputText(YEARINPUT, YEAR);
   });
 
-  it('navigates correctly through editing zip code', () => {
+  it('navigates correctly through editing year', () => {
     cy.visit('/health-care/income-limits-temp');
+
+    // Temporarily adding year for all flows because we're defaulting to past flow
+    // until we have a URL governing where we're coming from
+    // Year
+    verifyElement(YEARINPUT);
+    cy.injectAxeThenAxeCheck();
+    selectFromDropdown(YEARINPUT, YEAR);
+    clickContinue();
 
     // Zip code
     verifyElement(ZIPINPUT);
     typeInInput(ZIPINPUT, ZIP);
-    cy.injectAxeThenAxeCheck();
     clickContinue();
 
     // Dependents
     verifyElement(DEPINPUT);
     typeInInput(DEPINPUT, DEPENDENTS);
-    cy.injectAxeThenAxeCheck();
     clickContinue();
 
     // Review
     verifyElement(REVIEWPAGE);
-    cy.injectAxeThenAxeCheck();
-    getTdCell(0).contains(ZIP);
-    getTdCell(2).contains(DEPENDENTS);
+    getTdCell(0).contains(YEAR);
+    getTdCell(2).contains(ZIP);
+    getTdCell(4).contains(DEPENDENTS);
     getEditLink(0).click();
+
+    // Dependents
+    verifyElement(YEARINPUT);
+    selectFromDropdown(YEARINPUT, NEWYEAR);
+    clickContinue();
+
+    // Review
+    verifyElement(REVIEWPAGE);
+    getTdCell(0).contains(NEWYEAR);
+    getTdCell(2).contains(ZIP);
+    getTdCell(4).contains(DEPENDENTS);
+  });
+
+  it('navigates correctly through editing zip code', () => {
+    cy.visit('/health-care/income-limits-temp');
+
+    // Temporarily adding year for all flows because we're defaulting to past flow
+    // until we have a URL governing where we're coming from
+    // Year
+    verifyElement(YEARINPUT);
+    cy.injectAxeThenAxeCheck();
+    selectFromDropdown(YEARINPUT, YEAR);
+    clickContinue();
+
+    // Zip code
+    verifyElement(ZIPINPUT);
+    typeInInput(ZIPINPUT, ZIP);
+    clickContinue();
+
+    // Dependents
+    verifyElement(DEPINPUT);
+    typeInInput(DEPINPUT, DEPENDENTS);
+    clickContinue();
+
+    // Review
+    verifyElement(REVIEWPAGE);
+    getTdCell(2).contains(ZIP);
+    getTdCell(4).contains(DEPENDENTS);
+    getEditLink(1).click();
 
     // Zip code
     verifyElement(ZIPINPUT);
@@ -87,31 +149,37 @@ describe('Income Limits', () => {
 
     // Review
     verifyElement(REVIEWPAGE);
-    getTdCell(0).contains(NEWZIP);
-    getTdCell(2).contains(DEPENDENTS);
+    getTdCell(0).contains(YEAR);
+    getTdCell(2).contains(NEWZIP);
+    getTdCell(4).contains(DEPENDENTS);
   });
 
   it('navigates correctly through editing dependents', () => {
     cy.visit('/health-care/income-limits-temp');
 
+    // Temporarily adding year for all flows because we're defaulting to past flow
+    // until we have a URL governing where we're coming from
+    // Year
+    verifyElement(YEARINPUT);
+    cy.injectAxeThenAxeCheck();
+    selectFromDropdown(YEARINPUT, YEAR);
+    clickContinue();
+
     // Zip code
     verifyElement(ZIPINPUT);
     typeInInput(ZIPINPUT, ZIP);
-    cy.injectAxeThenAxeCheck();
     clickContinue();
 
     // Dependents
     verifyElement(DEPINPUT);
     typeInInput(DEPINPUT, DEPENDENTS);
-    cy.injectAxeThenAxeCheck();
     clickContinue();
 
     // Review
     verifyElement(REVIEWPAGE);
-    cy.injectAxeThenAxeCheck();
-    getTdCell(0).contains(ZIP);
-    getTdCell(2).contains(DEPENDENTS);
-    getEditLink(1).click();
+    getTdCell(2).contains(ZIP);
+    getTdCell(4).contains(DEPENDENTS);
+    getEditLink(2).click();
 
     // Dependents
     verifyElement(DEPINPUT);
@@ -121,7 +189,8 @@ describe('Income Limits', () => {
 
     // Review
     verifyElement(REVIEWPAGE);
-    getTdCell(0).contains(ZIP);
-    getTdCell(2).contains(NEWDEPS);
+    getTdCell(0).contains(YEAR);
+    getTdCell(2).contains(ZIP);
+    getTdCell(4).contains(NEWDEPS);
   });
 });


### PR DESCRIPTION
## Summary
Added year screen to the Past Income Limits flow. This requires hard-coding `pastMode` because we don't have an intro screen to help determine whether the flow should be Current Income Limits or Past Income Limits.

Sketch file: https://www.sketch.com/s/a8506c94-a5bd-4a69-91ff-fe06545f3126

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13738

## Testing done
Manually tested the entire standard and past flow from start to finish and backward. Checked each Edit flow. Confirmed the year selected on the first screen is displayed on the results screen.

## Screenshots
<img width="800" alt="Screenshot 2023-06-01 at 2 08 36 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/7c5d6d9d-c965-4e9f-bac2-a9e79f4fbfd0">
<img width="800" alt="Screenshot 2023-06-01 at 2 08 44 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/91cebb2c-ee8b-487e-9c71-d928555e4de9">
<img width="800" alt="Screenshot 2023-06-01 at 2 08 56 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f9f1755b-8e07-4dbc-a796-1b0d00f76ea5">
<img width="800" alt="Screenshot 2023-06-01 at 2 09 03 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/206e3887-d008-4ed7-8fd7-2e5e2b136d93">
<img width="800" alt="Screenshot 2023-06-01 at 2 10 06 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f8146125-5906-4b4b-a63b-064ff8277a8b">

## What areas of the site does it impact?
Only `/health-care/income-limits-temp`

## Acceptance criteria

- [x] The Year screen is the first screen in the past income limits flow (url /year)
- [x] Available years 2015-2023 are offered in the dropdown
- [x] Continue button goes to Zip screen
- [x] Back button not hooked up yet
- [x] add year to Review Info screen
- [x] enable edit flow for year
- [x] unit tests cover appropriate functions: when app is in edit state, continue button goes to correct destination
- [x] e2e tests cover: full flow (based on incoming url), edit flow

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.