### PR TITLE
Profile/aw/55398/remove duplicate ga event mil info

### DIFF
--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { some } from 'lodash';
 import { connect } from 'react-redux';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library';
 
 import DowntimeNotification, {
   externalServices,

--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { some } from 'lodash';
 import { connect } from 'react-redux';
 
-import { CONTACTS } from '@department-of-veterans-affairs/component-library';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import DowntimeNotification, {
   externalServices,

--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -158,20 +158,20 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
 
       <div className="vads-u-margin-top--4">
         <va-additional-info trigger="What if I don't think my military service information is correct?">
-          <p>
+          <p className="vads-u-padding-bottom--2">
             Some Veterans have reported that their military service information
             in their VA.gov profiles doesn’t seem right. When this happens, it’s
             because there’s an error in the information we’re pulling into
             VA.gov from the Defense Enrollment Eligibility Reporting System
             (DEERS).
           </p>
-          <br />
-          <p>
+
+          <p className="vads-u-padding-bottom--2">
             If you don’t think your military service information is correct
             here, call the Defense Manpower Data Center (DMDC). They’ll work
             with you to update your information in DEERS.
           </p>
-          <br />
+
           <p>
             You can call the DMDC at{' '}
             <va-telephone contact={CONTACTS.DS_LOGON} /> (

--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/Telephone';
 
-import recordEvent from '~/platform/monitoring/record-event';
 import DowntimeNotification, {
   externalServices,
 } from '~/platform/monitoring/DowntimeNotification';
@@ -158,16 +157,7 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
       />
 
       <div className="vads-u-margin-top--4">
-        <va-additional-info
-          trigger="What if I don't think my military service information is correct?"
-          onClick={() => {
-            recordEvent({
-              event: 'profile-navigation',
-              'profile-action': 'view-link',
-              'profile-section': 'update-military-information',
-            });
-          }}
-        >
+        <va-additional-info trigger="What if I don't think my military service information is correct?">
           <p>
             Some Veterans have reported that their military service information
             in their VA.gov profiles doesn’t seem right. When this happens, it’s


### PR DESCRIPTION
## Summary

- Very minor PR. Removes a duplicate call to GA. The accordion already tracks clicks, so the custom event does not need to be in the code.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/55398

## Testing done

- Tested locally, no functionality added/removed other than GA events

## What areas of the site does it impact?

Analytics of Profile application

## Acceptance criteria
- [x] GA event removed

### Quality Assurance & Testing

- [x] GA event removed