### PR TITLE
Supplemental Claims | Fix confirmation page focus

### DIFF
--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -77,7 +77,7 @@ import fullSchema from './form-0995-schema.json';
 
 import {
   focusRadioH3,
-  focusAlertH3,
+  focusH3,
   focusIssue,
   focusEvidence,
   focusUploads,
@@ -234,7 +234,7 @@ const formConfig = {
           CustomPageReview: null, // reviewField renders this!
           uiSchema: notice5103.uiSchema,
           schema: notice5103.schema,
-          scrollAndFocusTarget: focusAlertH3,
+          scrollAndFocusTarget: focusH3,
           initialData: {
             form5103Acknowledged: false,
           },
@@ -244,6 +244,7 @@ const formConfig = {
           path: EVIDENCE_VA_REQUEST,
           uiSchema: evidenceVaRecordsRequest.uiSchema,
           schema: evidenceVaRecordsRequest.schema,
+          scrollAndFocusTarget: focusH3,
         },
         evidenceVaRecords: {
           title: 'VA medical records',
@@ -298,6 +299,7 @@ const formConfig = {
           path: EVIDENCE_ADDITIONAL_PATH,
           uiSchema: evidenceWillUpload.uiSchema,
           schema: evidenceWillUpload.schema,
+          scrollAndFocusTarget: focusH3,
         },
         evidenceUpload: {
           title: 'Uploaded evidence',

--- a/src/applications/appeals/995/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/containers/ConfirmationPage.jsx
@@ -14,8 +14,10 @@ import GetFormHelp from '../content/GetFormHelp';
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
-    focusElement('h2');
     scrollTo('topScrollElement');
+    setTimeout(() => {
+      focusElement('va-alert h2');
+    });
   }
 
   render() {

--- a/src/applications/appeals/995/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import { render, waitFor } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
 import moment from 'moment';
+
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 
 import ConfirmationPage from '../../containers/ConfirmationPage';
 import { SELECTED } from '../../constants';
 
-const data = {
+const getData = () => ({
   user: {
     profile: {
       userFullName: {
@@ -40,36 +45,57 @@ const data = {
       ],
     },
   },
-};
+});
 
 describe('Confirmation page', () => {
-  const fakeStore = {
-    getState: () => data,
-    subscribe: () => {},
-    dispatch: () => {},
-  };
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
 
   it('should render the confirmation page', () => {
-    const tree = mount(<ConfirmationPage store={fakeStore} />);
-    expect(tree).not.to.be.undefined;
-    tree.unmount();
+    const { container } = render(
+      <Provider store={mockStore(getData())}>
+        <ConfirmationPage />
+      </Provider>,
+    );
+    expect($('va-alert[status="success"]', container)).to.exist;
   });
   it('should render the user name', () => {
-    const tree = mount(<ConfirmationPage store={fakeStore} />);
-    expect(tree.text()).to.contain('Foo Man Choo');
-    tree.unmount();
+    const { container } = render(
+      <Provider store={mockStore(getData())}>
+        <ConfirmationPage />
+      </Provider>,
+    );
+    expect($('.inset', container).textContent).to.contain('Foo Man Choo');
   });
   it('should render the submit date', () => {
+    const data = getData();
     const date = moment(data.form.submission.response).format('MMMM D, YYYY');
-    const tree = mount(<ConfirmationPage store={fakeStore} />);
-    expect(tree.text()).to.contain(date);
-    tree.unmount();
+    const { container } = render(
+      <Provider store={mockStore(data)}>
+        <ConfirmationPage />
+      </Provider>,
+    );
+    expect($('.inset', container).textContent).to.contain(date);
   });
   it('should render the selected contested issue', () => {
-    const tree = mount(<ConfirmationPage store={fakeStore} />);
-    const list = tree.find('ul').text();
-    expect(list).to.contain('test 543');
-    expect(list).not.to.contain('test 987');
-    tree.unmount();
+    const { container } = render(
+      <Provider store={mockStore(getData())}>
+        <ConfirmationPage />
+      </Provider>,
+    );
+    const list = $('ul', container);
+    expect(list.textContent).to.contain('test 543');
+    expect(list.textContent).not.to.contain('test 987');
+  });
+  it('should focus on H2 inside va-alert', async () => {
+    const { container } = render(
+      <Provider store={mockStore(getData())}>
+        <ConfirmationPage />
+      </Provider>,
+    );
+    const h2 = $('va-alert h2', container);
+    await waitFor(() => {
+      expect(document.activeElement).to.eq(h2);
+    });
   });
 });

--- a/src/applications/appeals/995/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/focus.unit.spec.js
@@ -6,7 +6,7 @@ import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 import {
   // focusRadioH3,
-  focusAlertH3,
+  focusH3,
   focusIssue,
   focusEvidence,
   focusUploads,
@@ -24,7 +24,7 @@ import { LAST_SC_ITEM } from '../../constants';
      });
   }); */
 
-describe('focusAlertH3', () => {
+describe('focusH3', () => {
   it('should focus on H3 inside alert', async () => {
     const { container } = render(
       <div>
@@ -34,7 +34,7 @@ describe('focusAlertH3', () => {
       </div>,
     );
 
-    focusAlertH3();
+    focusH3();
 
     await waitFor(() => {
       const h3 = $('h3', container);

--- a/src/applications/appeals/995/utils/focus.js
+++ b/src/applications/appeals/995/utils/focus.js
@@ -42,7 +42,7 @@ export const focusRadioH3 = () => {
   }
 };
 
-export const focusAlertH3 = () => {
+export const focusH3 = () => {
   scrollToTop();
   // va-alert header is not in the shadow DOM, but still the content doesn't
   // immediately render


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Focus on the confirmation page was set to the first `H2`, which turns out to be an `H2` that is hidden for printing the page, so the focus aborts and defaults to the page `body`. To fix this problem, the selector was changed to `va-alert H2` to ensure that the header within the success alert is focused.
- _(If bug, how to reproduce)_
  > Submit a Supplemental Claim form and check the focused element when confirmation page is visible
- _(What is the solution, why is this the solution)_
  > The `va-alert` header is the second `H2` on the page
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#59546](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59546)

## Testing done

- _Describe what the old behavior was prior to the change_
  > The wrong `H2` was targeted leading to the page body getting focus
- _Describe the steps required to verify your changes are working as expected_
  > Submit a Supplemental Claim form
- _Describe the tests completed and the results_
  > Checking the focus element in a unit test
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

After
<img width="669" alt="Focus outline shown on header inside the va-alert" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/a1d47efa-0cc0-4da5-93e2-1e0c1f3e8e08">

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
