### PR TITLE
[eFSR] #59524 Content zoom and reflow fix for dependents input page 

### DIFF
--- a/src/applications/financial-status-report/components/CreditCardBill.jsx
+++ b/src/applications/financial-status-report/components/CreditCardBill.jsx
@@ -132,7 +132,7 @@ const CreditCardBill = props => {
           } a credit card bill`}
         </legend>
         <p>Enter your credit card bill’s information.</p>
-        <div className="input-size-3">
+        <div className="input-size-3 no-wrap">
           <va-number-input
             error={(submitted && unpaidBalanceError) || null}
             hint={null}
@@ -146,7 +146,7 @@ const CreditCardBill = props => {
             value={creditCardBillRecord.unpaidBalance}
           />
         </div>
-        <div className="input-size-3">
+        <div className="input-size-3 no-wrap">
           <va-number-input
             error={(submitted && minMonthlyPaymentError) || null}
             hint={null}
@@ -160,7 +160,7 @@ const CreditCardBill = props => {
             value={creditCardBillRecord.amountDueMonthly}
           />
         </div>
-        <div className="input-size-3">
+        <div className="input-size-3 no-wrap">
           <va-number-input
             error={(submitted && amountOverdueError) || null}
             hint={null}

--- a/src/applications/financial-status-report/components/EnhancedVehicleRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedVehicleRecord.jsx
@@ -152,7 +152,7 @@ const EnhancedVehicleRecord = props => {
           />
         </div>
 
-        <div className="input-size-1">
+        <div className="input-size-2">
           <va-number-input
             error={(vehicleRecordIsDirty && yearIsDirty && yearError) || null}
             hint={null}
@@ -165,7 +165,7 @@ const EnhancedVehicleRecord = props => {
           />
         </div>
 
-        <div className="input-size-4">
+        <div className="input-size-2 no-wrap">
           <va-number-input
             error={
               (vehicleRecordIsDirty &&

--- a/src/applications/financial-status-report/components/InstallmentContract.jsx
+++ b/src/applications/financial-status-report/components/InstallmentContract.jsx
@@ -173,105 +173,107 @@ const InstallmentContract = props => {
 
   return (
     <form onSubmit={updateFormData}>
-      <legend className="schemaform-block-title">
-        {`${
-          installmentContracts.length === index ? 'Add' : 'Update'
-        } an installment contract or other debt`}
-      </legend>
-      <p>
-        If you have more than one installment contract or other debt, enter the
-        information for one contract or debt below.
-      </p>
-      <div className="input-size-6">
-        <VaTextInput
-          className="no-wrap input-size-6"
-          id="contractType"
-          error={(submitted && typeError) || null}
-          label="Type of contract or debt"
-          name="contract-type"
-          onInput={handlePurposeChange}
-          required
-          type="text"
-          value={purpose || ''}
-        />
-      </div>
-      <div className="input-size-6">
-        <VaTextInput
-          className="no-wrap input-size-6"
-          id="creditorName"
-          label="Name of creditor who holds the contract or debt"
-          name="creditor-name"
-          onInput={handleCreditorNameChange}
-          type="text"
-          value={creditorName || ''}
-        />
-      </div>
-      <div className="input-size-4">
-        <va-number-input
-          hint={null}
-          currency
-          inputmode="numeric"
-          label="Original loan amount"
-          name="originalAmount"
-          id="originalAmount"
-          onInput={handleOriginalLoanAmountChange}
-          value={contractRecord.originalAmount}
-        />
-      </div>
-      <div className="input-size-4">
-        <va-number-input
-          hint={null}
-          currency
-          inputmode="numeric"
-          label="Unpaid balance"
-          name="unpaidBalance"
-          id="unpaidBalance"
-          onInput={handleUnpaidBalanceChange}
-          value={contractRecord.unpaidBalance}
-        />
-      </div>
-      <div className="input-size-4">
-        <va-number-input
-          error={(submitted && amountDueMonthlyError) || null}
-          hint={null}
-          currency
-          required
-          inputmode="numeric"
-          label="Minimum monthly payment amount"
-          name="amountDueMonthly"
-          id="amountDueMonthly"
-          onInput={handleAmountDueMonthlyChange}
-          value={contractRecord.amountDueMonthly}
-        />
-      </div>
+      <fieldset className="vads-u-margin-y--2">
+        <legend className="schemaform-block-title">
+          {`${
+            installmentContracts.length === index ? 'Add' : 'Update'
+          } an installment contract or other debt`}
+        </legend>
+        <p>
+          If you have more than one installment contract or other debt, enter
+          the information for one contract or debt below.
+        </p>
+        <div className="input-size-6">
+          <VaTextInput
+            className="no-wrap input-size-6"
+            id="contractType"
+            error={(submitted && typeError) || null}
+            label="Type of contract or debt"
+            name="contract-type"
+            onInput={handlePurposeChange}
+            required
+            type="text"
+            value={purpose || ''}
+          />
+        </div>
+        <div className="input-size-6">
+          <VaTextInput
+            className="no-wrap input-size-6"
+            id="creditorName"
+            label="Name of creditor who holds the contract or debt"
+            name="creditor-name"
+            onInput={handleCreditorNameChange}
+            type="text"
+            value={creditorName || ''}
+          />
+        </div>
+        <div className="input-size-4">
+          <va-number-input
+            hint={null}
+            currency
+            inputmode="numeric"
+            label="Original loan amount"
+            name="originalAmount"
+            id="originalAmount"
+            onInput={handleOriginalLoanAmountChange}
+            value={contractRecord.originalAmount}
+          />
+        </div>
+        <div className="input-size-4">
+          <va-number-input
+            hint={null}
+            currency
+            inputmode="numeric"
+            label="Unpaid balance"
+            name="unpaidBalance"
+            id="unpaidBalance"
+            onInput={handleUnpaidBalanceChange}
+            value={contractRecord.unpaidBalance}
+          />
+        </div>
+        <div className="input-size-4">
+          <va-number-input
+            error={(submitted && amountDueMonthlyError) || null}
+            hint={null}
+            currency
+            required
+            inputmode="numeric"
+            label="Minimum monthly payment amount"
+            name="amountDueMonthly"
+            id="amountDueMonthly"
+            onInput={handleAmountDueMonthlyChange}
+            value={contractRecord.amountDueMonthly}
+          />
+        </div>
+        <div>
+          <VaDate
+            monthYearOnly
+            data-testid="loanBegan"
+            value={`${fromYear}-${fromMonth}`}
+            label="Date the loan began"
+            name="loanBegan"
+            onDateChange={e =>
+              handlers.handleDateChange('dateStarted', e.target.value)
+            }
+            onDateBlur={e => validateLoanBegan(e.target.value)}
+            required={!contractRecord.amountDueMonthly}
+            error={(submitted && fromDateError) || null}
+          />
+        </div>
+        <div className="input-size-4">
+          <va-number-input
+            hint={null}
+            currency
+            inputmode="numeric"
+            label="Amount overdue"
+            name="amountPastDue"
+            id="amountPastDue"
+            onInput={handleAmountOverdueChange}
+            value={contractRecord.amountPastDue}
+          />
+        </div>
+      </fieldset>
       <div>
-        <VaDate
-          monthYearOnly
-          data-testid="loanBegan"
-          value={`${fromYear}-${fromMonth}`}
-          label="Date the loan began"
-          name="loanBegan"
-          onDateChange={e =>
-            handlers.handleDateChange('dateStarted', e.target.value)
-          }
-          onDateBlur={e => validateLoanBegan(e.target.value)}
-          required={!contractRecord.amountDueMonthly}
-          error={(submitted && fromDateError) || null}
-        />
-      </div>
-      <div className="input-size-4">
-        <va-number-input
-          hint={null}
-          currency
-          inputmode="numeric"
-          label="Amount overdue"
-          name="amountPastDue"
-          id="amountPastDue"
-          onInput={handleAmountOverdueChange}
-          value={contractRecord.amountPastDue}
-        />
-      </div>
-      <p>
         <button
           type="button"
           id="cancel"
@@ -290,7 +292,7 @@ const InstallmentContract = props => {
             installmentContracts.length === index ? 'Add' : 'Update'
           } an installment contract`}
         </button>
-      </p>
+      </div>
     </form>
   );
 };

--- a/src/applications/financial-status-report/components/ResolutionAmount.jsx
+++ b/src/applications/financial-status-report/components/ResolutionAmount.jsx
@@ -120,6 +120,7 @@ const ResolutionAmount = ({ formContext }) => {
         name="resolution-amount"
         onInput={onAmountChange}
         required
+        currency
         type="text"
         value={resolutionAmount || ''}
       />

--- a/src/applications/financial-status-report/components/ResolutionOptions.jsx
+++ b/src/applications/financial-status-report/components/ResolutionOptions.jsx
@@ -36,10 +36,10 @@ const ResolutionOptions = ({ formContext }) => {
   const renderWaiverText = useMemo(() => {
     return (
       <>
-        <span className="vads-u-display--block vads-u-font-weight--bold vads-u-margin-left--3 vads-u-margin-top--neg2p5">
+        <span className="vads-u-display--block vads-u-font-weight--bold vads-u-margin-left--3 vads-u-padding-left--0p25 vads-u-margin-top--neg2p5">
           Waiver
         </span>
-        <span className="vads-u-display--block vads-u-font-size--sm vads-u-margin-left--3">
+        <span className="vads-u-display--block vads-u-margin-left--3 vads-u-padding-left--0p25">
           If we approve your request, we’ll stop collection and waive the debt.
         </span>
       </>
@@ -49,10 +49,10 @@ const ResolutionOptions = ({ formContext }) => {
   const renderCompromiseText = useMemo(() => {
     return (
       <>
-        <span className="vads-u-display--block vads-u-font-weight--bold vads-u-margin-left--3 vads-u-margin-top--neg2p5">
+        <span className="vads-u-display--block vads-u-font-weight--bold vads-u-margin-left--3 vads-u-padding-left--0p25 vads-u-margin-top--neg2p5">
           Compromise
         </span>
-        <span className="vads-u-display--block vads-u-font-size--sm vads-u-margin-left--3">
+        <span className="vads-u-display--block vads-u-margin-left--3 vads-u-padding-left--0p25">
           If you can’t pay the debt in full or make smaller monthly payments, we
           can consider a smaller, one-time payment to resolve your debt.
         </span>
@@ -63,10 +63,10 @@ const ResolutionOptions = ({ formContext }) => {
   const renderMonthlyText = useMemo(() => {
     return (
       <>
-        <span className="vads-u-display--block vads-u-font-weight--bold vads-u-margin-left--3 vads-u-margin-top--neg2p5">
+        <span className="vads-u-display--block vads-u-font-weight--bold vads-u-margin-left--3 vads-u-padding-left--0p25 vads-u-margin-top--neg2p5">
           Extended monthly payments
         </span>
-        <span className="vads-u-display--block vads-u-font-size--sm vads-u-margin-left--3">
+        <span className="vads-u-display--block vads-u-margin-left--3 vads-u-padding-left--0p25">
           If we approve your request, you can make smaller monthly payments for
           up to 5 years with either monthly offsets or a monthly payment plan.
         </span>

--- a/src/applications/financial-status-report/components/shared/InputList.jsx
+++ b/src/applications/financial-status-report/components/shared/InputList.jsx
@@ -14,9 +14,8 @@ const InputList = ({
       {title && <legend className="schemaform-block-title">{title}</legend>}
       {prompt && <p>{prompt}</p>}
       {inputs?.map((input, key) => (
-        <div key={input.name + key} className="input-size-3">
+        <div key={input.name + key}>
           <va-number-input
-            className="no-wrap input-size-3"
             error={
               submitted && errorList.includes(input.name)
                 ? 'Enter valid dollar amount'
@@ -29,6 +28,7 @@ const InputList = ({
             onInput={onChange}
             required
             value={input.amount}
+            class="input-size-3 no-wrap"
             currency
           />
         </div>

--- a/src/applications/financial-status-report/components/utilityBills/UtilityBillSummary.jsx
+++ b/src/applications/financial-status-report/components/utilityBills/UtilityBillSummary.jsx
@@ -33,7 +33,7 @@ const UtilityBillSummary = ({
 
   const cardBody = text => (
     <p>
-      Monthly payment amount: <b>{currencyFormatter(text)}</b>
+      Monthly amount: <b>{currencyFormatter(text)}</b>
     </p>
   );
 

--- a/src/applications/financial-status-report/pages/income/dependents/index.js
+++ b/src/applications/financial-status-report/pages/income/dependents/index.js
@@ -41,7 +41,7 @@ export const uiSchemaEnhanced = {
         'How many dependents do you have who rely on you for financial support?',
       'ui:widget': 'TextWidget',
       'ui:options': {
-        classNames: 'dependent-count',
+        widgetClassNames: 'input-size-2',
       },
       'ui:required': () => true,
       'ui:errorMessages': {

--- a/src/applications/financial-status-report/pages/income/dependents/index.js
+++ b/src/applications/financial-status-report/pages/income/dependents/index.js
@@ -41,7 +41,7 @@ export const uiSchemaEnhanced = {
         'How many dependents do you have who rely on you for financial support?',
       'ui:widget': 'TextWidget',
       'ui:options': {
-        classNames: 'input-size-1 dependent-count ',
+        classNames: 'dependent-count',
       },
       'ui:required': () => true,
       'ui:errorMessages': {

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -34,14 +34,6 @@
   }
 }
 
-.dependent-count {
-  @include media($medium-screen) {
-    input {
-      max-width: fit-content;
-    }
-  }
-}
-
 .selected-debt {
   border: 4px solid $color-blue;
   padding: 20px;

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -35,9 +35,10 @@
 }
 
 .dependent-count {
-  label,
-  .usa-input-error-message {
-    width: $usa-form-width;
+  @include media($medium-screen) {
+    input {
+      max-width: fit-content;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixed dependents input width so it doesn't overflow at 300% zoom and also cleaned up the other input widths so the `label` doesn't wrap and look squished
- Cleaned up the resolution options padding and label size. 
- Added currency label to extended monthly payment resolution option

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#59524 contains the dependants' input 
- department-of-veterans-affairs/va.gov-team#57600 contains the other issues.

## Testing done

- Dependents input box would get cut off on 300% zoom and up on review and form page 
- Tested locally in browser with updated code

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Dependents count input page  |   <img width="843" alt="Dependents count input before form page" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/920c2d5e-3091-4a66-9c02-4d47b0f545f5"> | <img width="837" alt="Dependents count input after  form page" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/b0e9159d-7ad4-40a8-9f27-1d032b796f00"> |
| Dependents count review page | <img width="1170" alt="Dependents count input before review page" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/aa423615-4631-4ff4-a891-533bd8fbdd7b"> | <img width="827" alt="Dependents count input after review page" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/82e9497e-665b-487b-b3d9-fc2a900d4f4a"> |
| Resolution options | <img width="721" alt="Resolution options before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/5e4a6909-5fb4-41ac-a915-f720987497ca"> | <img width="714" alt="Resolution options after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/1eb89c53-a0f5-4db7-8a2d-41954f1e9d5c"> |
| Extended Monthly Payments  | <img width="710" alt="Extended Monthly Payments before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/64713106-6a28-4780-be3b-90a4e707345c"> | <img width="652" alt="Extended Monthly Payments after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/bf599d9b-212e-4bb2-a040-f5238c1abb19"> |
| Input width label wrapping  | <img width="633" alt="Input width label before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/adf3c6e6-98e6-44c0-9904-a025d2267c37"> | <img width="646" alt="Input width label after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/26e2cdf4-9751-42dd-96ca-545ebff0d6bc"> |


## What areas of the site does it impact?

Impacts text/number input pages of the eFSR and also the resolution options section.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
