### PR TITLE
Dhp 878 update platform to pathway

### DIFF
--- a/src/applications/dhp-connected-devices/components/FAQSections.jsx
+++ b/src/applications/dhp-connected-devices/components/FAQSections.jsx
@@ -20,13 +20,13 @@ export const FirstFAQSection = () => {
           aria-controls="dhp-faq-first-section-first-question"
           data-testid="faq-first-section-first-question"
         >
-          The VA Digital Health Platform Fitbit Pilot (i.e., the Pilot) is an
+          The VA Digital Health Pathway Fitbit Pilot (i.e., the Pilot) is an
           effort designed to evaluate how VA can provide you with an opportunity
           to share your patient-generated data (PGD) with your VA care team.
           This pilot is not meant to replace normal care activities between you
           and your VA care team. The estimated duration of this pilot is 6-12
           months, after which your ability to connect and share data through the
-          Digital Health Platform may be discontinued.
+          Digital Health Pathway may be discontinued.
         </va-accordion-item>
         <va-accordion-item
           header="What can I expect if I participate in this pilot?"

--- a/src/applications/dhp-connected-devices/tests/containers/DhpAppContainer.spec.jsx
+++ b/src/applications/dhp-connected-devices/tests/containers/DhpAppContainer.spec.jsx
@@ -4,7 +4,7 @@ import { renderInReduxProvider } from 'platform/testing/unit/react-testing-libra
 import { shallow } from 'enzyme';
 import { DhpAppContainer } from '../../containers/DhpAppContainer';
 
-describe('Digital Health Platform root page', () => {
+describe('Digital Health Pathway root page', () => {
   it('renders the not found page when feature is turned off', () => {
     const dhpContainer = renderInReduxProvider(
       <DhpAppContainer


### PR DESCRIPTION
## Summary

- We updated the name of our application to "Digital Health Pathway from Digital Health Platform"
- The solution was to replace "Platform" with "Pathway" in DHP page

## Related issue(s)

- https://jira.devops.va.gov/browse/DHP-878

## Testing done

- We manually tested that the change in application name is on the DHP page on a local instance of the website
- We ran tests locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![Screenshot 2023-06-02 at 9 48 04 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95510386/772e2f20-36f3-4258-bec5-23e4bad2e310)  |  ![Screenshot 2023-06-02 at 9 49 14 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95510386/febbaa6a-191c-414d-a4cb-67b2ebdd8251)   |
| Desktop | ![Screenshot 2023-06-02 at 9 46 11 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95510386/b7338538-e94e-4ce5-ac56-06dc1fadd278)  |  ![Screenshot 2023-06-02 at 9 47 18 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95510386/92f4d167-46b8-4bb3-b144-c09aed9dfcfb) |

## What areas of the site does it impact?

It only impacts the one page for DHP https://www.va.gov/health-care/connected-devices/

## Acceptance criteria

### Quality Assurance & Testing

We manually reviewed the changes that were made

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
