### PR TITLE
21-4142 confirmation page fixes

### DIFF
--- a/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
-import FormFooter from 'platform/forms/components/FormFooter';
 
 import GetFormHelp from '../../shared/components/GetFormHelp';
 
@@ -94,8 +93,9 @@ export class ConfirmationPage extends React.Component {
         >
           Go back to VA.gov
         </a>
-        <div>
-          <FormFooter formConfig={{ getHelp: GetFormHelp }} />
+        <div className="help-footer-box">
+          <h2 className="help-heading">Need help?</h2>
+          <GetFormHelp />
         </div>
       </div>
     );

--- a/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
@@ -4,14 +4,14 @@ import { format, isValid } from 'date-fns';
 import { connect } from 'react-redux';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import GetFormHelp from '../../shared/components/GetFormHelp';
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
-    focusElement('h2');
     scrollToTop('topScrollElement');
+    waitForRenderThenFocus('va-alert h2');
   }
 
   render() {
@@ -35,11 +35,7 @@ export class ConfirmationPage extends React.Component {
             width="300"
           />
         </div>
-        <va-alert
-          close-btn-aria-label="Close notification"
-          status="success"
-          visible
-        >
+        <va-alert status="success">
           <h2 slot="headline">
             Thank you for submitting your authorization request
           </h2>


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_

Fixes for form 21-4142
- "Need help" block was not full width of the form
- Focus was lost on the h2

- _(Which team do you work for, does your team own the maintenance of this component?)_
Veteran Facing Forms

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/59616

- _Link to epic if not included in ticket_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/34

## Testing done

- _Describe what the old behavior was prior to the change_
See https://github.com/department-of-veterans-affairs/va.gov-team/issues/59616

- _Describe the steps required to verify your changes are working as expected_
Turn on  a screen reader, on the confirmation page the h2 should be the first thing read aloud.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Focus State  |   <img width="250" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/117098918/3d32b001-d4b1-42f9-bd0c-7cd115ceddc7">     |   <img width="250" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/117098918/a3899f79-2c4c-4972-b47b-ae0b3c50b9cc">     |
| Need help |   <img width="250" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/117098918/4db6df24-f005-4db5-a663-0cd0508046f8">      |   <img width="250" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/117098918/d243d92e-3782-43c6-8072-74055f4fc71c">   |

## What areas of the site does it impact?
Only form 21-4142

## Acceptance criteria

### Quality Assurance & Testing

- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.


## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
