### PR TITLE
modify CI workflow so that dependabot PRs don't fail

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -278,6 +278,7 @@ jobs:
 
   testing-reports-prep:
     name: Testing Reports Prep
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
@@ -334,6 +335,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS credentials
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -341,6 +343,7 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get va-vsp-bot token
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
@@ -350,6 +353,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/workflows/configure-bigquery
 
       - name: Fetch allow list
@@ -459,7 +463,7 @@ jobs:
       # the job to always run, and skips each step if no tests are selected.
       # Previously, the above conditional was included in the job's if statement.
       - name: Configure AWS credentials
-        if: needs.cypress-tests-prep.outputs.tests != '[]'
+        if: needs.cypress-tests-prep.outputs.tests != '[]' & github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -539,7 +543,8 @@ jobs:
     if: |
       needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success' &&
-      needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'
+      needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' &&
+      github.actor != 'dependabot[bot]'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
@@ -636,7 +641,7 @@ jobs:
         stress-test-cypress-tests,
         fetch-e2e-allow-list,
       ]
-    if: ${{ always() && needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' && (needs.stress-test-cypress-tests.result == 'success' || needs.stress-test-cypress-tests.result == 'failure') }}
+    if: ${{ always() && github.actor != 'dependabot[bot]' && needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' && (needs.stress-test-cypress-tests.result == 'success' || needs.stress-test-cypress-tests.result == 'failure') }}
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
@@ -746,7 +751,7 @@ jobs:
     name: Testing Reports - Unit Tests
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() }}
+    if: ${{ always() && github.actor != 'dependabot[bot]' }}
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
@@ -866,7 +871,7 @@ jobs:
     name: Testing Reports - Unit Tests Coverage
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
+    if: ${{ always() && github.actor != 'dependabot[bot]' && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
@@ -934,7 +939,7 @@ jobs:
     name: Testing Reports - Cypress E2E Tests
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
-    if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    if: ${{ always() && github.actor != 'dependabot[bot]' && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     continue-on-error: true
@@ -1071,7 +1076,8 @@ jobs:
       needs.build.result == 'success' &&
       needs.unit-tests.result == 'success' &&
       needs.security-audit.result == 'success' &&
-      (needs.linting.result == 'success' || needs.linting.result == 'skipped')
+      (needs.linting.result == 'success' || needs.linting.result == 'skipped') &&
+      github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -463,7 +463,7 @@ jobs:
       # the job to always run, and skips each step if no tests are selected.
       # Previously, the above conditional was included in the job's if statement.
       - name: Configure AWS credentials
-        if: needs.cypress-tests-prep.outputs.tests != '[]' & github.actor != 'dependabot[bot]'
+        if: needs.cypress-tests-prep.outputs.tests != '[]' && github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The purpose of this PR is to modify the CI workflow so that it will not fail during PRs opened by `dependabot`. Currently, the workflow will fail on PRs opened by `dependabot` because `secrets` [are not accessible](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544), eg trying to authenticate to AWS.

Resolving this issue will pave the way to updating many dependencies.
