### PR TITLE
[#951] Remove Virtual Agent JWT POC and associated feature flag

### DIFF
--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -1,10 +1,7 @@
 import React, { useMemo } from 'react';
 import environment from 'platform/utilities/environment';
-import { useSelector, connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 // import PropTypes from 'prop-types';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import axios from 'axios';
 import _ from 'lodash';
 import recordEvent from 'platform/monitoring/record-event';
 import StartConvoAndTrackUtterances from './startConvoAndTrackUtterances';
@@ -16,10 +13,9 @@ import {
   clearBotSessionStorage,
 } from '../chatbox/utils';
 
-const JWT_TOKEN = 'JWT_TOKEN';
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
-const WebChat = ({ token, WebChatFramework, apiSession, fetchJwtToken }) => {
+const WebChat = ({ token, WebChatFramework, apiSession }) => {
   const { ReactWebChat, createDirectLine, createStore } = WebChatFramework;
   const csrfToken = localStorage.getItem('csrfToken');
   const userFirstName = useSelector(state =>
@@ -28,20 +24,6 @@ const WebChat = ({ token, WebChatFramework, apiSession, fetchJwtToken }) => {
   const userUuid = useSelector(state => state.user.profile.accountUuid);
   const isLoggedIn = useSelector(state => state.user.login.currentlyLoggedIn);
 
-  const fetchJwtTokenAndSaveToSessionStorage = async () => {
-    try {
-      const JwtResponse = await axios.get(
-        'https://sqa.eauth.va.gov/MAP/users/v2/session/jwt',
-        { withCredentials: true },
-      );
-      sessionStorage.setItem(JWT_TOKEN, JwtResponse.data);
-    } catch (error) {
-      sessionStorage.setItem(JWT_TOKEN, error.message);
-    }
-  };
-  if (fetchJwtToken) {
-    fetchJwtTokenAndSaveToSessionStorage();
-  }
   const store = useMemo(
     () =>
       createStore(
@@ -148,17 +130,4 @@ const WebChat = ({ token, WebChatFramework, apiSession, fetchJwtToken }) => {
   );
 };
 
-// useVirtualAgentToken.propTypes = {
-//   virtualAgentFetchJwtToken: PropTypes.bool,
-// };
-
-const fetchVirtualAgentJwtToken = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.virtualAgentFetchJwtToken];
-
-// const virtualAgentFetchJwtToken = () => true;
-
-const mapStateToProps = state => ({
-  fetchJwtToken: fetchVirtualAgentJwtToken(state),
-});
-
-export default connect(mapStateToProps)(WebChat);
+export default WebChat;

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -180,6 +180,5 @@ export default Object.freeze({
   vaOnlineSchedulingConvertUtcToLocal: 'va_online_scheduling_convert_utc_to_local',
   vaViewDependentsAccess: 'va_view_dependents_access',
   virtualAgentShowFloatingChatbot: 'virtual_agent_show_floating_chatbot',
-  virtualAgentFetchJwtToken: 'virtual_agent_fetch_jwt_token',
   yellowRibbonEnhancements: 'yellow_ribbon_mvp_enhancement',
 });


### PR DESCRIPTION
Co-authored-by: Raina Huerta <raina.huerta@thoughtworks.com>

## Summary

- _(Summarize the changes that have been made to the platform)_
Removed the generation of a `jwt_token` session storage item
- _(Which team do you work for, does your team own the maintenance of this component?)_
Virtual Agent chatbot - yes

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va-virtual-agent#951

## Testing done

- _Describe what the old behavior was prior to the change_
`jwt_token` session storage item was created when chatbot is started
- _Describe the steps required to verify your changes are working as expected_
no longer see the session storage item when the chatbot is started
- _Describe the tests completed and the results_
 yarn tests

## What areas of the site does it impact?
Virtual agent chatbot

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
