### PR TITLE
Simple forms: Refactor confirmation page view to be reusable

### DIFF
--- a/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
@@ -1,105 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format, isValid } from 'date-fns';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { focusElement } from 'platform/utilities/ui';
+import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
 
-export class ConfirmationPage extends React.Component {
-  componentDidMount() {
-    focusElement('h2');
-    scrollToTop('topScrollElement');
-  }
+const content = {
+  headlineText: 'You’ve successfully submitted your Lay/Witness Statement',
+  nextStepsText:
+    'Once we’ve reviewed your submission, a coordinator will contact you to discuss next steps.',
+};
 
-  render() {
-    const { form } = this.props;
-    // TODO: Once form-pages are built, include formId and data in form prop
-    // [uncomment line below and delete line below that]
-    // const { submission, formId, data } = form;
-    const { submission } = form;
-    const submitDate = new Date(submission?.timestamp);
+export const ConfirmationPage = () => {
+  const form = useSelector(state => state.form || {});
+  const { submission } = form;
+  const fullName = { first: 'John', middle: 'M', last: 'Doe', suffix: 'Jr.' };
+  const submitDate = submission.timestamp;
+  const confirmationNumber = submission.response?.confirmationNumber;
 
-    // TODO: Once form-pages are built, grab fullName from form data
-    // [uncomment line below and delete line below that]
-    // const { fullName } = data;
-    const fullName = { first: 'John', middle: 'M', last: 'Doe', suffix: 'Jr.' };
-
-    const confirmationNumber =
-      submission?.response?.attributes?.confirmationNumber;
-
-    return (
-      <div>
-        <div className="print-only">
-          <img
-            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-            alt="VA logo"
-            width="300"
-          />
-        </div>
-        <va-alert
-          close-btn-aria-label="Close notification"
-          status="success"
-          visible
-        >
-          <h2 slot="headline" className="vads-u-font-size--h3">
-            You've successfully submitted your Lay/Witness Statement
-          </h2>
-          <p className="vads-u-margin-bottom--0">
-            Once we’ve reviewed your submission, a coordinator will contact you
-            to discuss next steps.
-          </p>
-        </va-alert>
-        <div className="inset">
-          <h2 className="vads-u-margin-top--0 vads-u-font-size--h3">
-            Your application information
-          </h2>
-          {fullName && (
-            <>
-              <h3 className="vads-u-font-size--h4">Applicant</h3>
-              <p>
-                {fullName.first} {fullName.middle} {fullName.last}
-                {fullName.suffix ? `, ${fullName.suffix}` : null}
-              </p>
-            </>
-          )}
-
-          {confirmationNumber && (
-            <>
-              <h3 className="vads-u-font-size--h4">Confirmation number</h3>
-              <p>{confirmationNumber}</p>
-            </>
-          )}
-
-          {isValid(submitDate) && (
-            <>
-              <h3 className="vads-u-font-size--h4">Date submitted</h3>
-              <p>{format(submitDate, 'MMMM d, yyyy')}</p>
-            </>
-          )}
-
-          <h3 className="vads-u-font-size--h4">
-            Confirmation for your records
-          </h3>
-          <p>You can print this confirmation page for your records</p>
-          <button
-            type="button"
-            className="usa-button screen-only"
-            onClick={window.print}
-          >
-            Print this page
-          </button>
-        </div>
-        <a
-          className="vads-c-action-link--green vads-u-margin-bottom--4"
-          href="/"
-        >
-          Go back to VA.gov
-        </a>
-      </div>
-    );
-  }
-}
+  return (
+    <ConfirmationPageView
+      submitterName={fullName}
+      submitDate={submitDate}
+      confirmationNumber={confirmationNumber}
+      content={content}
+    />
+  );
+};
 
 ConfirmationPage.propTypes = {
   form: PropTypes.shape({

--- a/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/ConfirmationPage.jsx
@@ -1,102 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format, isValid } from 'date-fns';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { waitForRenderThenFocus } from 'platform/utilities/ui';
+import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
 
-import GetFormHelp from '../../shared/components/GetFormHelp';
+const content = {
+  headlineText: 'Thank you for submitting your authorization request',
+  nextStepsText:
+    'After we review your authorization, we’ll contact the private provider or hospital to get the requested records. If we can’t get the records within 15 days we’ll send you a follow-up letter by mail.',
+};
 
-export class ConfirmationPage extends React.Component {
-  componentDidMount() {
-    scrollToTop('topScrollElement');
-    waitForRenderThenFocus('va-alert h2');
-  }
+export const ConfirmationPage = () => {
+  const form = useSelector(state => state.form || {});
+  const { submission, data } = form;
+  const preparerNameDefined =
+    data.preparerIdentification?.preparerFullName?.first &&
+    data.preparerIdentification?.preparerFullName?.last;
+  const preparerName = preparerNameDefined
+    ? data.preparerIdentification.preparerFullName
+    : data.veteran.fullName;
+  const submitDate = submission.timestamp;
+  const confirmationNumber = submission.response?.confirmationNumber;
 
-  render() {
-    const { form } = this.props;
-    const { submission, data } = form;
-    const preparerNameDefined =
-      data.preparerIdentification?.preparerFullName?.first &&
-      data.preparerIdentification?.preparerFullName?.last;
-    const { first, middle, last, suffix } = preparerNameDefined
-      ? data.preparerIdentification.preparerFullName
-      : data.veteran.fullName;
-    const submitDate = submission.timestamp;
-    const confirmationNumber = submission.response?.confirmationNumber;
-
-    return (
-      <div>
-        <div className="print-only">
-          <img
-            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-            alt="VA logo"
-            width="300"
-          />
-        </div>
-        <va-alert status="success">
-          <h2 slot="headline">
-            Thank you for submitting your authorization request
-          </h2>
-          <p>
-            After we review your authorization, we'll contact the private
-            provider or hospital to get the requested records. If we can't get
-            the records within 15 days we'll send you a follow-up letter by
-            mail.
-          </p>
-        </va-alert>
-        <div className="inset">
-          <h3 className="vads-u-margin-top--0">Your application information</h3>
-          {first && last ? (
-            <>
-              <h4>Applicant</h4>
-              <p>
-                {first} {middle ? `${middle} ` : ''}
-                {last}
-                {suffix ? `, ${suffix}` : null}
-              </p>
-            </>
-          ) : null}
-
-          {confirmationNumber ? (
-            <>
-              <h4>Confirmation number</h4>
-              <p>{confirmationNumber}</p>
-            </>
-          ) : null}
-
-          {isValid(submitDate) ? (
-            <>
-              <h4>Date submitted</h4>
-              <p>{format(submitDate, 'MMMM d, yyyy')}</p>
-            </>
-          ) : null}
-
-          <h4>Confirmation for your records</h4>
-          <p>You can print this confirmation page for your records</p>
-          <button
-            type="button"
-            className="usa-button vads-u-margin-top--0 screen-only"
-            onClick={window.print}
-          >
-            Print this page
-          </button>
-        </div>
-        <a
-          className="vads-c-action-link--green vads-u-margin-bottom--4"
-          href="/"
-        >
-          Go back to VA.gov
-        </a>
-        <div className="help-footer-box">
-          <h2 className="help-heading">Need help?</h2>
-          <GetFormHelp />
-        </div>
-      </div>
-    );
-  }
-}
+  return (
+    <ConfirmationPageView
+      submitterName={preparerName}
+      submitDate={submitDate}
+      confirmationNumber={confirmationNumber}
+      content={content}
+    />
+  );
+};
 
 ConfirmationPage.propTypes = {
   form: PropTypes.shape({

--- a/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
@@ -1,88 +1,31 @@
-/* eslint-disable no-undef */
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format, isValid } from 'date-fns';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { focusElement } from 'platform/utilities/ui';
+import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
 
-export class ConfirmationPage extends React.Component {
-  componentDidMount() {
-    focusElement('h2');
-    scrollToTop('topScrollElement');
-  }
+const content = {
+  headlineText: 'Thank you for completing your benefit application',
+  nextStepsText:
+    'After we review your application, we’ll contact you to tell you what happens next in the application process.',
+};
 
-  render() {
-    const { form } = this.props;
-    const { submission, formId, data } = form;
-    const { fullName } = data.veteran;
-    const submitDate = submission.timestamp;
-    const confirmationNumber = submission.response?.confirmationNumber;
+export const ConfirmationPage = () => {
+  const form = useSelector(state => state.form || {});
+  const { submission, data } = form;
+  const { fullName } = data.veteran;
+  const submitDate = submission.timestamp;
+  const confirmationNumber = submission.response?.confirmationNumber;
 
-    return (
-      <div>
-        <div className="print-only">
-          <img
-            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-            alt="VA logo"
-            width="300"
-          />
-        </div>
-        <va-alert
-          close-btn-aria-label="Close notification"
-          status="success"
-          visible
-        >
-          <h2 slot="headline">
-            Thank you for completing your benefit application
-          </h2>
-          <p className="vads-u-margin-y--0">
-            After we review your application, we&rsquo;ll contact you to tell
-            you what happens next in the application process.
-          </p>
-        </va-alert>
-        <div className="inset">
-          <h3 className="vads-u-margin-top--0">Your application information</h3>
-          {fullName ? (
-            <>
-              <h4>Applicant</h4>
-              <p>
-                {fullName.first} {fullName.middle} {fullName.last}
-                {fullName.suffix ? `, ${fullName.suffix}` : null}
-              </p>
-            </>
-          ) : null}
-
-          {confirmationNumber ? (
-            <>
-              <h4>Confirmation number</h4>
-              <p>{confirmationNumber}</p>
-            </>
-          ) : null}
-
-          {isValid(submitDate) ? (
-            <>
-              <h4>Date submitted</h4>
-              <p>{format(submitDate, 'MMMM d, yyyy')}</p>
-            </>
-          ) : null}
-
-          <h4>Confirmation for your records</h4>
-          <p>You can print this confirmation page for your records</p>
-          <button
-            type="button"
-            className="usa-button vads-u-margin-top--0 screen-only"
-            onClick={window.print}
-          >
-            Print this page
-          </button>
-        </div>
-      </div>
-    );
-  }
-}
+  return (
+    <ConfirmationPageView
+      submitterName={fullName}
+      submitDate={submitDate}
+      confirmationNumber={confirmationNumber}
+      content={content}
+    />
+  );
+};
 
 ConfirmationPage.propTypes = {
   form: PropTypes.shape({
@@ -109,5 +52,3 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps)(ConfirmationPage);
-/* eslint-enable no-undef */
-/* eslint-enable no-unused-vars */

--- a/src/applications/simple-forms/shared/components/ConfirmationPageView.jsx
+++ b/src/applications/simple-forms/shared/components/ConfirmationPageView.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef } from 'react';
+import { format, isValid } from 'date-fns';
+
+import scrollTo from 'platform/utilities/ui/scrollTo';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
+
+import GetFormHelp from './GetFormHelp';
+
+export const ConfirmationPageView = ({
+  submitterName,
+  submitDate,
+  confirmationNumber,
+  content,
+}) => {
+  const alertRef = useRef(null);
+
+  useEffect(
+    () => {
+      if (alertRef?.current) {
+        scrollTo('topScrollElement');
+        // delay focus for Safari
+        waitForRenderThenFocus('h2', alertRef.current);
+      }
+    },
+    [alertRef],
+  );
+
+  const { first, middle, last, suffix } = submitterName;
+  const { headlineText, nextStepsText } = content;
+
+  return (
+    <div>
+      <div className="print-only">
+        <img
+          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+          alt="VA logo"
+          width="300"
+        />
+      </div>
+      <va-alert status="success" ref={alertRef}>
+        <h2 slot="headline">{headlineText}</h2>
+        <p>{nextStepsText}</p>
+      </va-alert>
+      <div className="inset">
+        <h3 className="vads-u-margin-top--0">Your application information</h3>
+        {first && last ? (
+          <>
+            <h4>Applicant</h4>
+            <p>
+              {first} {middle ? `${middle} ` : ''}
+              {last}
+              {suffix ? `, ${suffix}` : null}
+            </p>
+          </>
+        ) : null}
+
+        {confirmationNumber ? (
+          <>
+            <h4>Confirmation number</h4>
+            <p>{confirmationNumber}</p>
+          </>
+        ) : null}
+
+        {isValid(submitDate) ? (
+          <>
+            <h4>Date submitted</h4>
+            <p>{format(submitDate, 'MMMM d, yyyy')}</p>
+          </>
+        ) : null}
+
+        <h4>Confirmation for your records</h4>
+        <p>You can print this confirmation page for your records</p>
+        <button
+          type="button"
+          className="usa-button vads-u-margin-top--0 screen-only"
+          onClick={window.print}
+        >
+          Print this page
+        </button>
+      </div>
+      <a className="vads-c-action-link--green vads-u-margin-bottom--4" href="/">
+        Go back to VA.gov
+      </a>
+      <div className="help-footer-box">
+        <h2 className="help-heading">Need help?</h2>
+        <GetFormHelp />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Paying off tech debt as we roll out more forms. I noticed we were fixing some a11y issues on the confirmation page so it's best to fix it once for all of them. Those fixes are reflected in this PR.

_Note: I've only done this for 26-4555, 21-4142, and 21-10210 so far since those are the most active and almost all in prod. The others can easily be refactored later as they are built._

## Summary

- Move the copy pasta view portion of the ConfirmationPage into a shared component
- Change the confirmation page from a class to a functional component
  - The logic for the useEffect + focus came from [appeals 995 confirmation page](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/appeals/995/containers/ConfirmationPage.jsx#L16-L30)
- Extract form-specific content to be defined in the confirmationpage containers
- Refactor confirmation page containers to be functional components and refactor to just preparing information for the view component

## Testing done

Tested all three forms locally and confirmation pages looked unchanged. See screenshots.

26-4555
<img width="491" alt="Screenshot 2023-06-05 at 1 17 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/01c0f790-1c2b-46d6-87d0-4b896cf46fd1">

21-10210
<img width="475" alt="Screenshot 2023-06-05 at 1 23 16 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/873aff6a-d23f-4acb-858e-313950660246">

21-4142
<img width="520" alt="Screenshot 2023-06-05 at 1 28 40 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/c4a88b88-f7a7-4443-8d8f-c586a278e5f8">


## What areas of the site does it impact?
None: no actual changes
Under the hood: Forms 26-4555, 21-10210, 21-4142

## Requested Feedback
Let me know what you think!