### PR TITLE
VACMS-13955 Homepage post-launch cleanup

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -1,13 +1,10 @@
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import React from 'react';
-import { connect } from 'react-redux';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
-function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
+function HomepageRedesignModal({ dismiss }) {
   const noscriptElements = document.getElementsByTagName('noscript');
   const ariaExcludeArray = Array.from(noscriptElements);
   const skipLinkElement = document.getElementsByClassName('show-on-focus')[0];
@@ -22,86 +19,78 @@ function HomepageRedesignModal({ dismiss, vaHomePreviewModal }) {
 
   return (
     <>
-      {vaHomePreviewModal &&
-        !hasRedirectParam && (
-          <VaModal
-            role="dialog"
-            cssClass="va-modal announcement-brand-consolidation"
-            visible
-            onCloseEvent={() => {
-              recordEvent({
-                event: 'int-modal-click',
-                'modal-status': 'closed',
-                'modal-title': 'Try our new VA.gov homepage',
-              });
-              dismiss();
-            }}
-            id="modal-announcement"
-            modalTitle=""
-            ariaHiddenNodeExceptions={ariaExcludeArray}
-            aria-describedby="homepage-modal-description"
-            aria-labelledby="homepage-modal-label-title"
-            secondary-button-text="Not today, go to the current homepage"
-            onSecondaryButtonClick={() => {
-              recordEvent({
-                event: 'cta-button-click',
-                'button-type': 'secondary',
-                'button-click-label': 'Not today, go to the current homepage',
-              });
-              dismiss();
-            }}
+      {!hasRedirectParam && (
+        <VaModal
+          role="dialog"
+          cssClass="va-modal announcement-brand-consolidation"
+          visible
+          onCloseEvent={() => {
+            recordEvent({
+              event: 'int-modal-click',
+              'modal-status': 'closed',
+              'modal-title': 'Try our new VA.gov homepage',
+            });
+            dismiss();
+          }}
+          id="modal-announcement"
+          modalTitle=""
+          ariaHiddenNodeExceptions={ariaExcludeArray}
+          aria-describedby="homepage-modal-description"
+          aria-labelledby="homepage-modal-label-title"
+          secondary-button-text="Not today, go to the current homepage"
+          onSecondaryButtonClick={() => {
+            recordEvent({
+              event: 'cta-button-click',
+              'button-type': 'secondary',
+              'button-click-label': 'Not today, go to the current homepage',
+            });
+            dismiss();
+          }}
+        >
+          <img
+            src="/img/design/logo/va-logo.png"
+            alt="VA logo and Seal, U.S. Department of Veterans Affairs"
+            width="300"
+          />
+          <h1
+            id="homepage-modal-label-title"
+            className="vads-u-font-size--lg vads-u-margin-top--2p5"
           >
-            <img
-              src="/img/design/logo/va-logo.png"
-              alt="VA logo and Seal, U.S. Department of Veterans Affairs"
-              width="300"
-            />
-            <h1
-              id="homepage-modal-label-title"
-              className="vads-u-font-size--lg vads-u-margin-top--2p5"
-            >
-              Try our new VA.gov homepage
-            </h1>
-            <div
-              id="homepage-modal-description"
-              className="vads-u-margin-bottom--2"
-            >
-              <p>
-                We're redesigning the VA.gov homepage to help you get the tools
-                and information you need faster.
-              </p>
-              <p>And we want your feedback to help us make it even better.</p>
+            Try our new VA.gov homepage
+          </h1>
+          <div
+            id="homepage-modal-description"
+            className="vads-u-margin-bottom--2"
+          >
+            <p>
+              We're redesigning the VA.gov homepage to help you get the tools
+              and information you need faster.
+            </p>
+            <p>And we want your feedback to help us make it even better.</p>
 
-              <a
-                className="vads-c-action-link--green"
-                href="/new-home-page"
-                onClick={() => {
-                  dismiss();
-                  recordEvent({
-                    event: 'cta-button-click',
-                    'button-click-label': 'Try the new home page',
-                    'button-type': 'link',
-                  });
-                }}
-              >
-                Try the new home page
-              </a>
-            </div>
-          </VaModal>
-        )}
+            <a
+              className="vads-c-action-link--green"
+              href="/new-home-page"
+              onClick={() => {
+                dismiss();
+                recordEvent({
+                  event: 'cta-button-click',
+                  'button-click-label': 'Try the new home page',
+                  'button-type': 'link',
+                });
+              }}
+            >
+              Try the new home page
+            </a>
+          </div>
+        </VaModal>
+      )}
     </>
   );
 }
 
 HomepageRedesignModal.propTypes = {
   dismiss: PropTypes.func,
-  vaHomePreviewModal: PropTypes.bool,
 };
 
-const mapStateToProps = state => ({
-  vaHomePreviewModal: toggleValues(state)[
-    FEATURE_FLAG_NAMES.vaHomePreviewModal
-  ],
-});
-
-export default connect(mapStateToProps)(HomepageRedesignModal);
+export default HomepageRedesignModal;

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -9,7 +9,7 @@ const config = {
       // Homepage only
       paths: /^\/$/,
       component: HomepageRedesignModal,
-      disabled: false,
+      disabled: true,
       show: AnnouncementBehavior.SHOW_ONCE_PER_SESSION,
       returnFocusDivContent: 'Current Homepage',
     },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -148,8 +148,6 @@ export default Object.freeze({
   subform89404192: 'subform_8940_4192',
   supplementalClaim: 'supplemental_claim',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
-  vaHomePreviewModal:
-    'va_home_preview_modal',
   vaOnlineScheduling: 'va_online_scheduling',
   vaOnlineSchedulingCancel: 'va_online_scheduling_cancel',
   vaOnlineSchedulingCheetah: 'va_online_scheduling_cheetah',


### PR DESCRIPTION
## Summary
Disabled the new homepage modal in announcements config. The modal code is all still there, but should not show up anymore. It will remain for the next use case when someone needs to put a modal on the homepage. Feature flagging for the modal has been cleaned up.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13955

## Testing done
Tested on the home page and `/new-home-page` to ensure the modal does not appear.

## Screenshots

<img width="800" alt="Screenshot 2023-06-05 at 2 38 50 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/61c79559-6f7a-429b-a837-0f8d376aef12">
<img width="800" alt="Screenshot 2023-06-05 at 2 38 42 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/a30a037f-17cd-4947-93c4-fa24cccea151">

## What areas of the site does it impact?
Home page.

## Acceptance criteria
- [ ]  Remove New Homepage invitation's modal markup from "announcement framework," but leave framework intact for future

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed

### Error Handling
- [x] Browser console contains no warnings or errors.