### PR TITLE
[EFSR](Bug)Credit card cancel button and installment contracts

### DIFF
--- a/src/applications/financial-status-report/components/CreditCardBill.jsx
+++ b/src/applications/financial-status-report/components/CreditCardBill.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { isValidCurrency } from '../utils/validations';
@@ -85,13 +86,17 @@ const CreditCardBill = props => {
     e.preventDefault();
     const newCreditCardBillArray = [...creditCardBills];
     newCreditCardBillArray[index] = creditCardBillRecord;
+
     if (
       creditCardBillRecord.amountDueMonthly &&
       creditCardBillRecord.unpaidBalance
     ) {
       // if amountPastDue is NaN, set it to 0 in order to satisfy va-number-input
       if (!isValidCurrency(creditCardBillRecord.amountPastDue)) {
-        creditCardBillRecord.amountPastDue = 0;
+        setCreditCardBillRecord(prevRecord => ({
+          ...prevRecord,
+          amountPastDue: 0,
+        }));
       }
 
       // update form data
@@ -209,7 +214,24 @@ const mapDispatchToProps = {
   setFormData: setData,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(CreditCardBill);
+CreditCardBill.propTypes = {
+  data: PropTypes.shape({
+    expenses: PropTypes.shape({
+      creditCardBills: PropTypes.arrayOf(
+        PropTypes.shape({
+          purpose: PropTypes.string,
+          creditorName: PropTypes.string,
+          originalAmount: PropTypes.string,
+          unpaidBalance: PropTypes.string,
+          amountDueMonthly: PropTypes.string,
+          dateStarted: PropTypes.string,
+          amountPastDue: PropTypes.string,
+        }),
+      ),
+    }),
+  }).isRequired,
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreditCardBill);

--- a/src/applications/financial-status-report/components/CreditCardBill.jsx
+++ b/src/applications/financial-status-report/components/CreditCardBill.jsx
@@ -238,4 +238,7 @@ CreditCardBill.propTypes = {
   setFormData: PropTypes.func.isRequired,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(CreditCardBill);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CreditCardBill);

--- a/src/applications/financial-status-report/components/CreditCardBill.jsx
+++ b/src/applications/financial-status-report/components/CreditCardBill.jsx
@@ -15,6 +15,8 @@ const defaultRecord = [
     amountPastDue: '',
   },
 ];
+export const SUMMARY_PATH = '/credit-card-bills-summary';
+export const START_PATH = '/credit-card-bills';
 
 const CreditCardBill = props => {
   const { data, goToPath, setFormData } = props;
@@ -79,8 +81,6 @@ const CreditCardBill = props => {
     handleChange('amountPastDue', event.target.value);
   };
 
-  const RETURN_PATH = '/credit-card-bills-summary';
-
   const updateFormData = e => {
     setSubmitted(true);
     e.preventDefault();
@@ -108,7 +108,7 @@ const CreditCardBill = props => {
         },
       });
 
-      goToPath(RETURN_PATH);
+      goToPath(SUMMARY_PATH);
     }
   };
 
@@ -116,7 +116,11 @@ const CreditCardBill = props => {
     onSubmit: event => event.preventDefault(),
     onCancel: event => {
       event.preventDefault();
-      goToPath(RETURN_PATH);
+      if (creditCardBills.length === 0) {
+        goToPath(START_PATH);
+      } else {
+        goToPath(SUMMARY_PATH);
+      }
     },
     onUpdate: event => {
       event.preventDefault();
@@ -124,7 +128,7 @@ const CreditCardBill = props => {
     },
     onBack: event => {
       event.preventDefault();
-      goToPath(RETURN_PATH);
+      goToPath(SUMMARY_PATH);
     },
   };
 

--- a/src/applications/financial-status-report/components/InstallmentContract.jsx
+++ b/src/applications/financial-status-report/components/InstallmentContract.jsx
@@ -22,7 +22,7 @@ const defaultRecord = [
 ];
 
 export const SUMMARY_PATH = '/installment-contracts-summary';
-export const START_PATH = '/installment-contracts-summary';
+export const START_PATH = '/installment-contracts';
 
 const InstallmentContract = props => {
   const { data, goToPath, setFormData } = props;

--- a/src/applications/financial-status-report/components/InstallmentContract.jsx
+++ b/src/applications/financial-status-report/components/InstallmentContract.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import {
@@ -19,6 +20,9 @@ const defaultRecord = [
     amountPastDue: '',
   },
 ];
+
+export const SUMMARY_PATH = '/installment-contracts-summary';
+export const START_PATH = '/installment-contracts-summary';
 
 const InstallmentContract = props => {
   const { data, goToPath, setFormData } = props;
@@ -82,10 +86,10 @@ const InstallmentContract = props => {
   const typeError = !purpose ? 'Please enter the contract type' : null;
 
   const handleChange = (key, value) => {
-    setContractRecord({
-      ...contractRecord,
+    setContractRecord(prevRecord => ({
+      ...prevRecord,
       [key]: value,
-    });
+    }));
   };
 
   const handlePurposeChange = event => {
@@ -114,8 +118,6 @@ const InstallmentContract = props => {
     handleChange('amountPastDue', event.target.value);
   };
 
-  const RETURN_PATH = '/installment-contracts-summary';
-
   const updateFormData = e => {
     setSubmitted(true);
     e.preventDefault();
@@ -125,21 +127,21 @@ const InstallmentContract = props => {
     }
 
     if (contractRecord.purpose && contractRecord.amountDueMonthly) {
-      // if amountPastDue is NaN, set it to 0 in order to satisfy va-number-input
-      if (!isValidCurrency(contractRecord.amountPastDue)) {
-        contractRecord.amountPastDue = 0;
-      }
-
-      if (!isValidCurrency(contractRecord.originalAmount)) {
-        contractRecord.originalAmount = 0;
-      }
-
-      if (!isValidCurrency(contractRecord.unpaidBalance)) {
-        contractRecord.unpaidBalance = 0;
-      }
+      const updatedContractRecord = {
+        ...contractRecord,
+        amountPastDue: isValidCurrency(contractRecord.amountPastDue)
+          ? contractRecord.amountPastDue
+          : 0,
+        originalAmount: isValidCurrency(contractRecord.originalAmount)
+          ? contractRecord.originalAmount
+          : 0,
+        unpaidBalance: isValidCurrency(contractRecord.unpaidBalance)
+          ? contractRecord.unpaidBalance
+          : 0,
+      };
 
       const newInstallmentContractArray = [...installmentContracts];
-      newInstallmentContractArray[index] = contractRecord;
+      newInstallmentContractArray[index] = updatedContractRecord;
 
       // update form data
       setFormData({
@@ -147,7 +149,7 @@ const InstallmentContract = props => {
         installmentContracts: newInstallmentContractArray,
       });
 
-      goToPath(RETURN_PATH);
+      goToPath(SUMMARY_PATH);
     }
   };
 
@@ -155,7 +157,11 @@ const InstallmentContract = props => {
     onSubmit: event => event.preventDefault(),
     onCancel: event => {
       event.preventDefault();
-      goToPath(RETURN_PATH);
+      if (installmentContracts.length === 0) {
+        goToPath(START_PATH);
+      } else {
+        goToPath(SUMMARY_PATH);
+      }
     },
     onUpdate: event => {
       event.preventDefault();
@@ -163,7 +169,7 @@ const InstallmentContract = props => {
     },
     onBack: event => {
       event.preventDefault();
-      goToPath(RETURN_PATH);
+      goToPath(SUMMARY_PATH);
     },
     handleDateChange: (key, monthYear) => {
       const dateString = `${monthYear}-XX`;
@@ -306,6 +312,14 @@ const mapStateToProps = ({ form }) => {
 
 const mapDispatchToProps = {
   setFormData: setData,
+};
+
+InstallmentContract.propTypes = {
+  data: PropTypes.shape({
+    installmentContracts: PropTypes.array,
+  }).isRequired,
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/src/applications/financial-status-report/components/InstallmentContract.jsx
+++ b/src/applications/financial-status-report/components/InstallmentContract.jsx
@@ -262,7 +262,7 @@ const InstallmentContract = props => {
               handlers.handleDateChange('dateStarted', e.target.value)
             }
             onDateBlur={e => validateLoanBegan(e.target.value)}
-            required={!contractRecord.amountDueMonthly}
+            required={!!contractRecord.amountDueMonthly}
             error={(submitted && fromDateError) || null}
           />
         </div>

--- a/src/applications/financial-status-report/components/InstallmentContract.jsx
+++ b/src/applications/financial-status-report/components/InstallmentContract.jsx
@@ -306,7 +306,6 @@ const InstallmentContract = props => {
 const mapStateToProps = ({ form }) => {
   return {
     formData: form.data,
-    employmentHistory: form.data.personalData.employmentHistory,
   };
 };
 

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -1010,7 +1010,7 @@ const formConfig = {
           schema: { type: 'object', properties: {} },
           depends: formData =>
             formData.questions.hasRepayments &&
-            !formData.expenses?.installmentContracts?.length &&
+            !formData?.installmentContracts?.length &&
             formData['view:enhancedFinancialStatusReport'],
           editModeOnReviewPage: true,
           CustomPage: InstallmentContract,

--- a/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useSelector, connect, useDispatch } from 'react-redux';
 import { Link } from 'react-router';
+import { setData } from 'platform/forms-system/src/js/actions';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { clearJobIndex } from '../../../utils/session';
 import {
@@ -119,6 +120,7 @@ const CreditCardBillSummary = ({
 
 const mapStateToProps = ({ form }) => {
   return {
+    setFormData: setData,
     formData: form.data,
     employmentHistory: form.data.personalData.employmentHistory,
   };

--- a/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
@@ -70,7 +70,7 @@ const CreditCardBillSummary = ({
           <strong>{currencyFormatter(bill.amountDueMonthly)}</strong>
           <br />
           Amount overdue:{' '}
-          <strong>{currencyFormatter(bill.amountPastDue)}</strong>
+          <strong>{currencyFormatter(bill.amountPastDue || 0.0)}</strong>
         </p>
       </>
     );

--- a/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useSelector, connect, useDispatch } from 'react-redux';
 import { Link } from 'react-router';
@@ -124,6 +125,16 @@ const mapStateToProps = ({ form }) => {
     formData: form.data,
     employmentHistory: form.data.personalData.employmentHistory,
   };
+};
+
+CreditCardBillSummary.propTypes = {
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+  data: PropTypes.shape({
+    questions: PropTypes.object,
+  }),
 };
 
 export default connect(mapStateToProps)(CreditCardBillSummary);

--- a/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
@@ -13,14 +13,12 @@ import {
 import { currency as currencyFormatter } from '../../../utils/helpers';
 
 const CreditCardBillSummary = ({
-  data,
   goToPath,
-  setFormData,
   contentBeforeButtons,
   contentAfterButtons,
 }) => {
   const dispatch = useDispatch();
-
+  const setFormData = newData => dispatch(setData(newData));
   const formData = useSelector(state => state.form.data);
   const { expenses } = formData;
   const { creditCardBills } = expenses || [];
@@ -41,22 +39,21 @@ const CreditCardBillSummary = ({
   };
 
   const onDelete = deleteIndex => {
-    dispatch(
-      setFormData({
-        ...formData,
-        questions: {
-          ...data.questions,
-          hasCreditCardBills: deleteIndex !== 0,
-        },
-        expenses: {
-          ...expenses,
-          creditCardBills: creditCardBills.filter(
-            (source, index) => index !== deleteIndex,
-          ),
-        },
-      }),
-    );
+    setFormData({
+      ...formData,
+      // questions: {
+      //   ...data.questions,
+      //   hasCreditCardBills: deleteIndex !== 0,
+      // },
+      expenses: {
+        ...expenses,
+        creditCardBills: creditCardBills.filter(
+          (_, index) => index !== deleteIndex,
+        ),
+      },
+    });
   };
+
   const emptyPrompt = `Select the 'add additional credit card bill' link to add another bill. Select the continue button to move on to the next question.`;
 
   const billBody = bill => {
@@ -121,9 +118,7 @@ const CreditCardBillSummary = ({
 
 const mapStateToProps = ({ form }) => {
   return {
-    setFormData: setData,
     formData: form.data,
-    employmentHistory: form.data.personalData.employmentHistory,
   };
 };
 
@@ -132,9 +127,6 @@ CreditCardBillSummary.propTypes = {
   setFormData: PropTypes.func.isRequired,
   contentAfterButtons: PropTypes.node,
   contentBeforeButtons: PropTypes.node,
-  data: PropTypes.shape({
-    questions: PropTypes.object,
-  }),
 };
 
 export default connect(mapStateToProps)(CreditCardBillSummary);

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -56,30 +56,65 @@ const InstallmentContractSummary = ({
   const emptyPrompt = `Select the 'add additional installment contract link to add another installment contract or other debt. Select the continue button to move on to the next question.`;
 
   const billBody = bill => {
+    const {
+      creditorName,
+      originalAmount,
+      unpaidBalance,
+      amountDueMonthly,
+      dateStarted,
+      amountPastDue,
+    } = bill;
+
+    const originalAmountFormatted =
+      originalAmount && currencyFormatter(originalAmount);
+    const unpaidBalanceFormatted =
+      unpaidBalance && currencyFormatter(unpaidBalance);
+    const amountDueMonthlyFormatted =
+      amountDueMonthly && currencyFormatter(amountDueMonthly);
+    const amountPastDueFormatted = amountPastDue
+      ? currencyFormatter(amountPastDue)
+      : currencyFormatter(0.0);
+
     return (
-      <>
-        <p>
-          {bill.creditorName.length > 0 ? (
-            <>
-              Creditor: <strong>{bill.creditorName} </strong>
-              <br />
-            </>
-          ) : null}
-          Original Loan Amount:{' '}
-          <strong>{currencyFormatter(bill.originalAmount)}</strong>
-          <br />
-          Unpaid balance:{' '}
-          <strong>{currencyFormatter(bill.unpaidBalance)}</strong>
-          <br />
-          Minimum monthly payment amount:{' '}
-          <strong>{currencyFormatter(bill.amountDueMonthly)}</strong>
-          <br />
-          Date received: <strong>{bill.dateStarted}</strong>
-          <br />
-          Amount overdue:{' '}
-          <strong>{currencyFormatter(bill.amountPastDue)}</strong>
-        </p>
-      </>
+      <p>
+        {creditorName && (
+          <>
+            <strong>Creditor:</strong> {creditorName}
+            <br />
+          </>
+        )}
+        {originalAmountFormatted && (
+          <>
+            <strong>Original Loan Amount:</strong> {originalAmountFormatted}
+            <br />
+          </>
+        )}
+        {unpaidBalanceFormatted && (
+          <>
+            <strong>Unpaid balance:</strong> {unpaidBalanceFormatted}
+            <br />
+          </>
+        )}
+        {amountDueMonthlyFormatted && (
+          <>
+            <strong>Minimum monthly payment amount:</strong>{' '}
+            {amountDueMonthlyFormatted}
+            <br />
+          </>
+        )}
+        {dateStarted && (
+          <>
+            <strong>Date started:</strong> {dateStarted}
+            <br />
+          </>
+        )}
+        {amountPastDueFormatted && (
+          <>
+            <strong>Amount overdue:</strong> {amountPastDueFormatted}
+            <br />
+          </>
+        )}
+      </p>
     );
   };
 

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, connect, useDispatch } from 'react-redux';
+import { setData } from 'platform/forms-system/src/js/actions';
 import { Link } from 'react-router';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { clearJobIndex } from '../../../utils/session';
@@ -140,6 +141,7 @@ const InstallmentContractSummary = ({
 
 const mapStateToProps = ({ form }) => {
   return {
+    setFormData: setData,
     formData: form.data,
     employmentHistory: form.data.personalData.employmentHistory,
   };

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -13,14 +13,12 @@ import {
 import { currency as currencyFormatter } from '../../../utils/helpers';
 
 const InstallmentContractSummary = ({
-  data,
   goToPath,
-  setFormData,
   contentBeforeButtons,
   contentAfterButtons,
 }) => {
   const dispatch = useDispatch();
-
+  const setFormData = newData => dispatch(setData(newData));
   const formData = useSelector(state => state.form.data);
   const { installmentContracts = [] } = formData;
 
@@ -40,19 +38,14 @@ const InstallmentContractSummary = ({
   };
 
   const onDelete = deleteIndex => {
-    dispatch(
-      setFormData({
-        ...formData,
-        questions: {
-          ...data.questions,
-          hasRepayments: deleteIndex !== 0,
-        },
-        installmentContracts: installmentContracts.filter(
-          (source, index) => index !== deleteIndex,
-        ),
-      }),
-    );
+    setFormData({
+      ...formData,
+      installmentContracts: installmentContracts.filter(
+        (source, index) => index !== deleteIndex,
+      ),
+    });
   };
+
   const emptyPrompt = `Select the 'add additional installment contract link to add another installment contract or other debt. Select the continue button to move on to the next question.`;
 
   const billBody = bill => {
@@ -177,7 +170,6 @@ const InstallmentContractSummary = ({
 
 const mapStateToProps = ({ form }) => {
   return {
-    setFormData: setData,
     formData: form.data,
   };
 };
@@ -187,9 +179,6 @@ InstallmentContractSummary.propTypes = {
   setFormData: PropTypes.func.isRequired,
   contentAfterButtons: PropTypes.node,
   contentBeforeButtons: PropTypes.node,
-  data: PropTypes.shape({
-    questions: PropTypes.object,
-  }),
 };
 
 export default connect(mapStateToProps)(InstallmentContractSummary);

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -48,64 +48,36 @@ const InstallmentContractSummary = ({
 
   const emptyPrompt = `Select the 'add additional installment contract link to add another installment contract or other debt. Select the continue button to move on to the next question.`;
 
-  const billBody = bill => {
-    const {
-      creditorName,
-      originalAmount,
-      unpaidBalance,
-      amountDueMonthly,
-      dateStarted,
-      amountPastDue,
-    } = bill;
-
-    const originalAmountFormatted =
-      originalAmount && currencyFormatter(originalAmount);
-    const unpaidBalanceFormatted =
-      unpaidBalance && currencyFormatter(unpaidBalance);
-    const amountDueMonthlyFormatted =
-      amountDueMonthly && currencyFormatter(amountDueMonthly);
-    const amountPastDueFormatted = amountPastDue
-      ? currencyFormatter(amountPastDue)
-      : currencyFormatter(0.0);
-
+  const billBody = ({
+    creditorName,
+    originalAmount,
+    unpaidBalance,
+    amountDueMonthly,
+    dateStarted,
+    amountPastDue,
+  }) => {
+    const formattedFields = {
+      Creditor: creditorName,
+      'Original Loan Amount':
+        originalAmount && currencyFormatter(originalAmount),
+      'Unpaid balance': unpaidBalance && currencyFormatter(unpaidBalance),
+      'Minimum monthly payment amount':
+        amountDueMonthly && currencyFormatter(amountDueMonthly),
+      'Date received': dateStarted,
+      'Amount overdue': amountPastDue
+        ? currencyFormatter(amountPastDue)
+        : currencyFormatter(0.0),
+    };
     return (
       <p>
-        {creditorName && (
-          <>
-            <strong>Creditor:</strong> {creditorName}
-            <br />
-          </>
-        )}
-        {originalAmountFormatted && (
-          <>
-            <strong>Original Loan Amount:</strong> {originalAmountFormatted}
-            <br />
-          </>
-        )}
-        {unpaidBalanceFormatted && (
-          <>
-            <strong>Unpaid balance:</strong> {unpaidBalanceFormatted}
-            <br />
-          </>
-        )}
-        {amountDueMonthlyFormatted && (
-          <>
-            <strong>Minimum monthly payment amount:</strong>{' '}
-            {amountDueMonthlyFormatted}
-            <br />
-          </>
-        )}
-        {dateStarted && (
-          <>
-            <strong>Date received:</strong> {dateStarted}
-            <br />
-          </>
-        )}
-        {amountPastDueFormatted && (
-          <>
-            <strong>Amount overdue:</strong> {amountPastDueFormatted}
-            <br />
-          </>
+        {Object.entries(formattedFields).map(
+          ([key, value]) =>
+            value && (
+              <React.Fragment key={key}>
+                <strong>{key}:</strong> {value}
+                <br />
+              </React.Fragment>
+            ),
         )}
       </p>
     );

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -104,7 +104,7 @@ const InstallmentContractSummary = ({
         )}
         {dateStarted && (
           <>
-            <strong>Date started:</strong> {dateStarted}
+            <strong>Date received:</strong> {dateStarted}
             <br />
           </>
         )}
@@ -179,7 +179,6 @@ const mapStateToProps = ({ form }) => {
   return {
     setFormData: setData,
     formData: form.data,
-    employmentHistory: form.data.personalData.employmentHistory,
   };
 };
 

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useSelector, connect, useDispatch } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
@@ -145,6 +146,16 @@ const mapStateToProps = ({ form }) => {
     formData: form.data,
     employmentHistory: form.data.personalData.employmentHistory,
   };
+};
+
+InstallmentContractSummary.propTypes = {
+  goToPath: PropTypes.func.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+  data: PropTypes.shape({
+    questions: PropTypes.object,
+  }),
 };
 
 export default connect(mapStateToProps)(InstallmentContractSummary);

--- a/src/applications/financial-status-report/tests/e2e/efsr-5655.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/efsr-5655.cypress.spec.js
@@ -453,7 +453,7 @@ const testConfig = createTestConfig(
             .and('contain', 'Original Loan Amount: $10,000.00')
             .and('contain', 'Unpaid balance: $1,000.00')
             .and('contain', 'Minimum monthly payment amount: $100.00')
-            .and('contain', 'Date started: 2010-01-XX')
+            .and('contain', 'Date received: 2010-01-XX')
             .and('contain', 'Amount overdue: $10.00');
           cy.get('.usa-button-primary').click();
         });

--- a/src/applications/financial-status-report/tests/e2e/efsr-5655.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/efsr-5655.cypress.spec.js
@@ -453,7 +453,7 @@ const testConfig = createTestConfig(
             .and('contain', 'Original Loan Amount: $10,000.00')
             .and('contain', 'Unpaid balance: $1,000.00')
             .and('contain', 'Minimum monthly payment amount: $100.00')
-            .and('contain', 'Date received: 2010-01-XX')
+            .and('contain', 'Date started: 2010-01-XX')
             .and('contain', 'Amount overdue: $10.00');
           cy.get('.usa-button-primary').click();
         });


### PR DESCRIPTION
## Summary

Clicking cancel resulted in a blank screen when bills === 0.

- [Parent Functionality Ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/55628)
- Cancel (back) button on adding first Credit Card bill should take the user back to the radio button question, and Mini Summary page should be able to display if length of list is zero (blank screen is page rendering but not map in component).

Investigate to see if this issues also applies to similar pages (Vehicle, Installment Contracts)
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#58977


## Testing done

- Old behavior resulted in an error if the user hit the cancel button when 0 contract-installments existed
- Manual testing
- Cypress Testing


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

 <table>
  <tr>
    <th>Credit card bill fix</th>
  </tr>
  <tr>
 <td>
      <img src="https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/727e1402-a22a-49d4-8571-e6d4d7715ae9" alt="Screenshot 1" width="300" />
    </td>
    <td>
      <img src="https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/ea9a9c0d-acf1-42ec-9de5-1c122655c023" alt="Screenshot 2" width="300" />
    </td>
</tr>
  
</table>


## What areas of the site does it impact?

EFSR form

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- [x] Update Cancel (back) navigation from first instance of new Credit Card Bill.
- [x]  Confirm Credit Card Bill mini summary page can handle empty list.
- [x] Confirm issue doesn't exist on related pages..





