### PR TITLE
Notice of Disagreement | Add review errors

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -14,6 +14,7 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../content/GetFormHelp';
 import AddIssue from '../components/AddIssue';
+import reviewErrors from '../content/reviewErrors';
 
 import {
   canUploadEvidence,
@@ -76,6 +77,8 @@ const formConfig = {
   transformForSubmit: transform,
   preSubmitInfo,
   submit: submitForm,
+  // showReviewErrors: true,
+  reviewErrors,
 
   // SaveInProgress messages
   customText,

--- a/src/applications/appeals/10182/content/reviewErrors.js
+++ b/src/applications/appeals/10182/content/reviewErrors.js
@@ -1,0 +1,17 @@
+/**
+ * Error messages on the review & submit page
+ * See github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/docs/reviewErrors.md
+ */
+const reviewErrors = {
+  _override: err => {
+    if (typeof err === 'string' && err.startsWith('veteran')) {
+      return {
+        chapterKey: 'infoPages',
+        pageKey: 'confirmContactInfo',
+      };
+    }
+    return null;
+  },
+};
+
+export default reviewErrors;


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When contact information is missing, the review & submit accordion is not highlighting as expected. Adding `reviewErrors` override fixes this issue
- _(If bug, how to reproduce)_
  > In staging, get to the review & submit page of the Notice of Disagreement form. Open the save in progress menu and remove a contact information data field. Apply and continue form, then try to submit. A generic error message shows, and the accordion is not highlighted.
- _(What is the solution, why is this the solution)_
  > The `reviewErrors` override is already in place ([awaiting documentation](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1615)) and the built-in override callback needs to be used to properly assign the chapter & page error keys
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#57816](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57816)

## Testing done

- _Describe what the old behavior was prior to the change_
  > No accordion highlighting
- _Describe the steps required to verify your changes are working as expected_
  > Test this PR in review instance
- _Describe the tests completed and the results_
  > Manually tested. We don't have tests for the review & submit page in each app
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="688" alt="Screenshot 2023-06-06 at 9 03 32 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/5ca5ff5e-84df-4f6b-96ef-3b46b1a31a0b"> | <img width="685" alt="Screenshot 2023-06-06 at 8 55 04 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/30488774-f392-4601-8ac6-a6753efacd57"> |

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
