### PR TITLE
59697 Update Max Length for Address Fields

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -233,7 +233,14 @@ export const addressUISchema = (
         'ui:autocomplete': 'address-line1',
         'ui:errorMessages': {
           required: 'Street address is required',
-          pattern: 'Street address must be under 100 characters',
+          pattern: 'Street address must be 35 characters or less',
+        },
+        'ui:options': {
+          updateSchema: (formData, schema) => {
+            return Object.assign(schema, {
+              maxLength: 35,
+            });
+          },
         },
       },
       addressLine2: {
@@ -255,7 +262,7 @@ export const addressUISchema = (
         'ui:autocomplete': 'address-level2',
         'ui:errorMessages': {
           required: 'City is required',
-          pattern: 'City must be under 100 characters',
+          pattern: 'City must be 30 characters or less',
         },
         'ui:options': {
           replaceSchema: (formData, schema, uiSchema, index) => {
@@ -279,7 +286,7 @@ export const addressUISchema = (
               type: 'string',
               title: 'City',
               minLength: 1,
-              maxLength: 100,
+              maxLength: 30,
               pattern: '^.*\\S.*',
             };
           },


### PR DESCRIPTION
## Summary

We've been seeing errors for the address_line1 and city fields when submitting data to RBPS/BIS indicating that the max length for these fields should be 35 and 30, respectively. This PR updates the max length accordingly.

I am on the benefits decision reviews team, which is currently responsible for the 686c form.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/59697

## Testing done

Tested locally and verified that these fields don't accept more than the max length of characters. Interestingly, the error messages configured in the address schema are never shown, because the UI prohibits the vet from including the excess of characters that would trigger the error message. This isn't a problem, but I figured that I would point it out.

Once deployed, I will test on staging, and monitor our prod logs to verify that this bug is resolved.

## Screenshots

N/A.

## What areas of the site does it impact?

All address fields within the 686c form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
