### PR TITLE
Update HCA Household V2 dependent list card from horizontal to vertical stack view

### DIFF
--- a/src/applications/hca/components/FormFields/DependentList.jsx
+++ b/src/applications/hca/components/FormFields/DependentList.jsx
@@ -92,17 +92,23 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
         key={index}
         id={`hca-dependent-item--${index}`}
         ref={el => listItemsRef.current.push(el)}
-        className="hca-dependent-list--tile vads-u-display--flex vads-u-align-items--center vads-u-border--2px vads-u-border-color--gray-light"
+        className="hca-dependent-list--tile vads-u-border--2px vads-u-border-color--gray-light"
       >
         <span
-          className="vads-u-flex--1 vads-u-padding-right--2"
+          className="vads-u-display--block vads-u-line-height--2 vads-u-font-weight--bold"
           data-testid="hca-dependent-tile-name"
         >
-          <strong>{normalizedFullName}</strong>, {dependentRelation}
+          {normalizedFullName}
         </span>
-        <span className="vads-u-flex--auto">
+        <span
+          className="vads-u-display--block vads-u-line-height--2"
+          data-testid="hca-dependent-tile-relationship"
+        >
+          {dependentRelation}
+        </span>
+        <span className="vads-l-row vads-u-justify-content--space-between vads-u-margin-top--2">
           <Link
-            className="va-button-link hca-button-link vads-u-margin-left--2p5 vads-u-font-weight--bold"
+            className="va-button-link hca-button-link vads-u-font-weight--bold"
             to={{
               pathname: DEPENDENT_PATHS.info,
               search: `?index=${index}&action=${mode}`,
@@ -116,7 +122,7 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
           </Link>
           <button
             type="button"
-            className="va-button-link hca-button-action vads-u-color--secondary-dark vads-u-margin-left--2p5 vads-u-font-weight--bold"
+            className="va-button-link hca-button-action vads-u-color--secondary-dark vads-u-font-weight--bold"
             onClick={() =>
               handlers.showConfirm({ index, name: normalizedFullName })
             }

--- a/src/applications/hca/sass/_dependentList.scss
+++ b/src/applications/hca/sass/_dependentList.scss
@@ -1,5 +1,5 @@
-.hca-dependent-list { list-style: none; margin: 0; padding: 0; }
-.hca-dependent-list--tile { border-radius: 0.25em; margin-bottom: 1em; padding: 1em 0.75em; }
+.hca-dependent-list { list-style: none; margin: 0; max-width: 26em; padding: 0; }
+.hca-dependent-list--tile { border-radius: 0.25em; margin-bottom: 1em; padding: 0.75em; }
 .hca-dependent-list--tile .fas { font-size: .875em; }
 .hca-dependent-list--tile .hca-button-action { text-decoration: none; }
 

--- a/src/applications/hca/tests/components/FormFields/DependentList.unit.spec.js
+++ b/src/applications/hca/tests/components/FormFields/DependentList.unit.spec.js
@@ -48,16 +48,20 @@ describe('hca <DependentList>', () => {
       const tiles = view.container.querySelectorAll(
         '.hca-dependent-list--tile',
       );
-      const selector = tiles[0].querySelector(
-        '[data-testid="hca-dependent-tile-name"]',
-      );
+      const selectors = {
+        name: tiles[0].querySelector('[data-testid="hca-dependent-tile-name"]'),
+        relationship: tiles[0].querySelector(
+          '[data-testid="hca-dependent-tile-relationship"]',
+        ),
+      };
       const dependent = defaultProps.list[0];
       const normalizedText = `${dependent.fullName.first} ${
         dependent.fullName.last
-      } ${dependent.fullName.suffix || ''}, ${
-        dependent.dependentRelation
-      }`.replace(/ +(?= )/g, '');
-      expect(selector).to.contain.text(normalizedText);
+      } ${dependent.fullName.suffix || ''}`.replace(/ +(?= )/g, '');
+      expect(selectors.name).to.contain.text(normalizedText);
+      expect(selectors.relationship).to.contain.text(
+        dependent.dependentRelation,
+      );
     });
 
     it('should render the last list item with the correct name and relationship', () => {
@@ -65,16 +69,20 @@ describe('hca <DependentList>', () => {
       const tiles = view.container.querySelectorAll(
         '.hca-dependent-list--tile',
       );
-      const selector = tiles[1].querySelector(
-        '[data-testid="hca-dependent-tile-name"]',
-      );
+      const selectors = {
+        name: tiles[1].querySelector('[data-testid="hca-dependent-tile-name"]'),
+        relationship: tiles[1].querySelector(
+          '[data-testid="hca-dependent-tile-relationship"]',
+        ),
+      };
       const dependent = defaultProps.list[1];
       const normalizedText = `${dependent.fullName.first} ${
         dependent.fullName.last
-      } ${dependent.fullName.suffix || ''}, ${
-        dependent.dependentRelation
-      }`.replace(/ +(?= )/g, '');
-      expect(selector).to.contain.text(normalizedText);
+      } ${dependent.fullName.suffix || ''}`.replace(/ +(?= )/g, '');
+      expect(selectors.name).to.contain.text(normalizedText);
+      expect(selectors.relationship).to.contain.text(
+        dependent.dependentRelation,
+      );
     });
   });
 });


### PR DESCRIPTION
## Description
Per a recent Design Council meeting, it was recommended that the team consider magnification used by Veterans, and how information and action links/buttons can be missed when aligned horizontally across the page. This PR updates the dependents list in the v2 household section to have a stacked, vertical layout, instead of horizontal layout.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#59397

## Testing done
- [x] Unit tests

## Screenshots
![Screenshot 2023-06-06 at 12 05 39 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/c74deb53-2316-4055-aca1-87842ef9d2a4)

## Acceptance criteria
- [ ] Dependents are displayed in a stacked, vertical layout with action links spaced to each end of the card
