### PR TITLE
Revert "modify workflows to work with dependabot PRs"

### DIFF
--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   deploy-preview-environment:
     name: Deploy Preview Environment
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Set default source branch

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,6 @@ env:
 jobs:
   check-cross-app-imports:
     name: Check Cross App Imports
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,7 +32,7 @@ jobs:
   eslint-disable-check:
     name: ESLint Disable Check
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'}}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -89,7 +88,7 @@ jobs:
   icon-check:
     name: Icon Check
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'}}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -146,7 +145,7 @@ jobs:
   sentry-check:
     name: Sentry Check
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'}}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -202,7 +201,6 @@ jobs:
 
   linting:
     name: Linting (Files Changed)
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#24439

Reverting because there is a better way to handle this issue than to modify the workflows - either push to the dependabot PR or add secrets to the dependabot section of the repo's settings.