### PR TITLE
Revert "modify CI workflow so that dependabot PRs don't fail"

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -278,7 +278,6 @@ jobs:
 
   testing-reports-prep:
     name: Testing Reports Prep
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
@@ -335,7 +334,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -343,7 +341,6 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get va-vsp-bot token
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
@@ -353,7 +350,6 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
 
       - name: Set Up BigQuery Creds
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/workflows/configure-bigquery
 
       - name: Fetch allow list
@@ -463,7 +459,7 @@ jobs:
       # the job to always run, and skips each step if no tests are selected.
       # Previously, the above conditional was included in the job's if statement.
       - name: Configure AWS credentials
-        if: needs.cypress-tests-prep.outputs.tests != '[]' && github.actor != 'dependabot[bot]'
+        if: needs.cypress-tests-prep.outputs.tests != '[]'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -543,8 +539,7 @@ jobs:
     if: |
       needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success' &&
-      needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' &&
-      github.actor != 'dependabot[bot]'
+      needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
@@ -641,7 +636,7 @@ jobs:
         stress-test-cypress-tests,
         fetch-e2e-allow-list,
       ]
-    if: ${{ always() && github.actor != 'dependabot[bot]' && needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' && (needs.stress-test-cypress-tests.result == 'success' || needs.stress-test-cypress-tests.result == 'failure') }}
+    if: ${{ always() && needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' && (needs.stress-test-cypress-tests.result == 'success' || needs.stress-test-cypress-tests.result == 'failure') }}
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
@@ -751,7 +746,7 @@ jobs:
     name: Testing Reports - Unit Tests
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() && github.actor != 'dependabot[bot]' }}
+    if: ${{ always() }}
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
@@ -871,7 +866,7 @@ jobs:
     name: Testing Reports - Unit Tests Coverage
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() && github.actor != 'dependabot[bot]' && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
+    if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
     continue-on-error: true
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
@@ -939,7 +934,7 @@ jobs:
     name: Testing Reports - Cypress E2E Tests
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
-    if: ${{ always() && github.actor != 'dependabot[bot]' && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     continue-on-error: true
@@ -1076,8 +1071,7 @@ jobs:
       needs.build.result == 'success' &&
       needs.unit-tests.result == 'success' &&
       needs.security-audit.result == 'success' &&
-      (needs.linting.result == 'success' || needs.linting.result == 'skipped') &&
-      github.actor != 'dependabot[bot]'
+      (needs.linting.result == 'success' || needs.linting.result == 'skipped')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#24426

Reverting because there is a better way to handle this issue than to modify the workflows - either push to the dependabot PR or add secrets to the dependabot section of the repo's settings.