### PR TITLE
Notice of Disagreement | Show confirmation modal when removing an issue

### DIFF
--- a/src/applications/appeals/10182/components/AddIssue.jsx
+++ b/src/applications/appeals/10182/components/AddIssue.jsx
@@ -6,12 +6,20 @@ import {
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 // updatePage isn't available for CustomPage on non-review pages, see
 // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33797
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { getSelected, calculateIndexOffset } from '../utils/helpers';
-import { SELECTED, MAX_LENGTH, LAST_NOD_ITEM } from '../constants';
+import {
+  SELECTED,
+  MAX_LENGTH,
+  LAST_ISSUE,
+  CONTESTABLE_ISSUES_PATH,
+  REVIEW_ISSUES,
+} from '../constants';
 
 import { validateDate } from '../validations/date';
 import {
@@ -20,19 +28,13 @@ import {
   maxNameLength,
   checkValidations,
 } from '../validations/issues';
-import {
-  addIssueTitle,
-  issueNameLabel,
-  issueNameHintText,
-  dateOfDecisionLabel,
-  dateOfDecisionHintText,
-} from '../content/addIssue';
+import { content } from '../content/addIssue';
 
-const ISSUES_PAGE = '/contestable-issues';
+const ISSUES_PAGE = `/${CONTESTABLE_ISSUES_PATH}`;
 const REVIEW_AND_SUBMIT = '/review-and-submit';
 
 const AddIssue = props => {
-  const { data, goToPath, onReviewPage, setFormData, testingIndex } = props;
+  const { data, goToPath, setFormData, testingIndex } = props;
   const { contestableIssues = [], additionalIssues = [] } = data || {};
 
   const allIssues = contestableIssues.concat(additionalIssues);
@@ -43,13 +45,19 @@ const AddIssue = props => {
   if (Number.isNaN(index) || index < contestableIssues.length) {
     index = allIssues.length;
   }
+  const setStorage = (type, value = '') => {
+    // set session storage of edited item. This enables focusing on the item
+    // upon return to the eligible issues page (a11y); when -1 is set, the add
+    // a new issue action link will be focused
+    window.sessionStorage.setItem(LAST_ISSUE, value || `${index},${type}`);
+    window.sessionStorage.removeItem(REVIEW_ISSUES);
+  };
   const offsetIndex = calculateIndexOffset(index, contestableIssues.length);
   const currentData = allIssues[index] || {};
 
-  // set session storage of edited item. This enables focusing on the item
-  // upon return to the eligible issues page (a11y)
-  window.sessionStorage.setItem(LAST_NOD_ITEM, index);
+  const addOrEdit = currentData.issue ? 'edit' : 'add';
 
+  const onReviewPage = window.sessionStorage.getItem(REVIEW_ISSUES) === 'true';
   const returnPath = onReviewPage ? REVIEW_AND_SUBMIT : ISSUES_PAGE;
 
   const nameValidations = [missingIssueName, maxNameLength, uniqueIssue];
@@ -117,10 +125,24 @@ const AddIssue = props => {
     },
     onCancel: event => {
       event.preventDefault();
+      recordEvent({
+        event: 'cta-button-click',
+        'button-type': 'secondary',
+        'button-click-label': 'Cancel',
+        'button-background-color': 'white',
+      });
+      setStorage('cancel', addOrEdit === 'add' ? -1 : '');
       goToPath(returnPath);
     },
     onUpdate: event => {
       event.preventDefault();
+      recordEvent({
+        event: 'cta-button-click',
+        'button-type': 'primary',
+        'button-click-label': 'Add issue',
+        'button-background-color': 'blue',
+      });
+      setStorage('updated');
       addOrUpdateIssue();
     },
   };
@@ -133,34 +155,33 @@ const AddIssue = props => {
           className="vads-u-font-family--serif"
           name="addIssue"
         >
-          {addIssueTitle}
+          <h3 className="vads-u-margin--0">{content.title[addOrEdit]}</h3>
         </legend>
         <VaTextInput
           id="add-nod-issue"
           name="add-nod-issue"
           type="text"
-          label={issueNameLabel}
+          label={content.name.label}
           required
           value={issueName}
           onInput={handlers.onIssueNameChange}
           onBlur={handlers.onInputBlur}
           error={((submitted || inputDirty) && showError) || null}
         >
-          {issueNameHintText}
+          {content.name.hint}
         </VaTextInput>
         <br />
         <VaMemorableDate
           name="decision-date"
-          label={dateOfDecisionLabel}
+          label={content.date.label}
+          hint={content.date.hint}
           required
           onDateChange={handlers.onDateChange}
           onDateBlur={handlers.onDateBlur}
           value={issueDate}
           error={((submitted || dateDirty) && dateErrorMessage[0]) || null}
           aria-describedby="decision-date-description"
-        >
-          {dateOfDecisionHintText}
-        </VaMemorableDate>
+        />
         <p>
           <va-button
             id="cancel"
@@ -173,7 +194,7 @@ const AddIssue = props => {
             id="submit"
             class="vads-u-width--auto"
             onClick={handlers.onUpdate}
-            text={`${currentData.issue ? 'Update' : 'Add'} issue`}
+            text={`${addOrEdit === 'add' ? 'Add' : 'Update'} issue`}
           />
         </p>
       </fieldset>

--- a/src/applications/appeals/10182/components/IssueCard.jsx
+++ b/src/applications/appeals/10182/components/IssueCard.jsx
@@ -1,11 +1,9 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Link } from 'react-router';
 
-import { scrollAndFocus } from 'platform/utilities/ui';
-
-import { SELECTED, FORMAT_READABLE, LAST_NOD_ITEM } from '../constants';
+import { SELECTED, FORMAT_YMD, FORMAT_READABLE } from '../constants';
 import { replaceDescriptionContent } from '../utils/replace';
 
 /** Copied from HLR v2 issue card */
@@ -20,6 +18,7 @@ import { replaceDescriptionContent } from '../utils/replace';
  * @return {React Component}
  */
 export const IssueCardContent = ({
+  id,
   description,
   ratingIssuePercentNumber,
   approxDecisionDate,
@@ -31,7 +30,7 @@ export const IssueCardContent = ({
   const date = approxDecisionDate || decisionDate;
 
   return (
-    <div className="widget-content-wrap">
+    <div id={id} className="widget-content-wrap">
       {description && (
         <p className="vads-u-margin-bottom--0">
           {replaceDescriptionContent(description)}
@@ -39,12 +38,13 @@ export const IssueCardContent = ({
       )}
       {showPercentNumber && (
         <p className="vads-u-margin-bottom--0">
-          Current rating: <strong>{ratingIssuePercentNumber}%</strong>
+          Current rating: <strong>{`${ratingIssuePercentNumber}%`}</strong>
         </p>
       )}
       {date && (
         <p>
-          Decision date: <strong>{moment(date).format(FORMAT_READABLE)}</strong>
+          Decision date:{' '}
+          <strong>{moment(date, FORMAT_YMD).format(FORMAT_READABLE)}</strong>
         </p>
       )}
     </div>
@@ -55,6 +55,7 @@ IssueCardContent.propTypes = {
   approxDecisionDate: PropTypes.string,
   decisionDate: PropTypes.string,
   description: PropTypes.string,
+  id: PropTypes.string,
   ratingIssuePercentNumber: PropTypes.string,
 };
 
@@ -92,6 +93,7 @@ export const IssueCard = ({
   onChange,
   showCheckbox,
   onRemove,
+  onReviewPage,
 }) => {
   // On the review & submit page, there may be more than one
   // of these components in edit mode with the same content, e.g. 526
@@ -100,39 +102,26 @@ export const IssueCard = ({
   // ui:options
   const appendId = options.appendId ? `_${options.appendId}` : '';
   const elementId = `${id}_${index}${appendId}`;
-  const scrollId = `issue-${window.sessionStorage.getItem(LAST_NOD_ITEM)}`;
-
-  const wrapRef = useRef(null);
-
-  useEffect(
-    () => {
-      if (scrollId === wrapRef?.current.id) {
-        scrollAndFocus(wrapRef.current);
-        window.sessionStorage.removeItem(LAST_NOD_ITEM);
-      }
-    },
-    [scrollId, wrapRef, index],
-  );
-
   const itemIsSelected = item[SELECTED];
   const isEditable = !!item.issue;
   const issueName = item.issue || item.ratingIssueSubjectText;
 
   const wrapperClass = [
-    'review-row',
     'widget-wrapper',
     isEditable ? 'additional-issue' : '',
     showCheckbox ? '' : 'checkbox-hidden',
     showCheckbox ? 'vads-u-padding-top--3' : '',
     'vads-u-padding-right--3',
     'vads-u-margin-bottom--0',
+    'vads-u-border-bottom--1px',
+    'vads-u-border-color--gray-light',
   ].join(' ');
 
   const titleClass = [
     'widget-title',
-    'vads-u-font-size--md',
-    'vads-u-font-weight--bold',
-    'vads-u-line-height--1',
+    'vads-u-font-size--h4',
+    'vads-u-margin--0',
+    'capitalize',
   ].join(' ');
 
   const removeButtonClass = [
@@ -145,7 +134,7 @@ export const IssueCard = ({
   const handlers = {
     onRemove: event => {
       event.preventDefault();
-      onRemove(index, item);
+      onRemove(index);
     },
     onChange: event => onChange(index, event),
   };
@@ -158,12 +147,13 @@ export const IssueCard = ({
             pathname: '/add-issue',
             search: `?index=${index}`,
           }}
-          className="change-issue-link"
-          aria-label={`Change ${issueName}`}
+          className="edit-issue-link"
+          aria-label={`Edit ${issueName}`}
         >
-          Change
+          Edit
         </Link>
         <va-button
+          secondary
           class={removeButtonClass}
           aria-label={`remove ${issueName}`}
           onClick={handlers.onRemove}
@@ -172,44 +162,44 @@ export const IssueCard = ({
       </div>
     ) : null;
 
+  // Issues h4 disappears in edit mode, so we need to match the page header
+  // level
+  const Header = onReviewPage ? 'h5' : 'h4';
+
   return (
-    <div
-      id={`issue-${index}`}
-      className={wrapperClass}
-      key={index}
-      ref={wrapRef}
-    >
-      <dt className="widget-checkbox-wrap">
+    <li id={`issue-${index}`} key={index}>
+      <div className={wrapperClass}>
         {showCheckbox ? (
-          <>
+          <div className="widget-checkbox-wrap">
+            {/* Using va-checkbox here causes alignment issues */}
             <input
               type="checkbox"
               id={elementId}
               name={elementId}
               checked={itemIsSelected}
               onChange={handlers.onChange}
+              aria-describedby={`issue-${index}-description`}
+              aria-labelledby={`issue-${index}-title`}
             />
             <label className="schemaform-label" htmlFor={elementId}>
-              <span className="vads-u-visibility--screen-reader">
-                {issueName}
-              </span>
+              {' '}
             </label>
-          </>
-        ) : (
-          <div />
-        )}
-      </dt>
-      <dd
-        className={`${
-          editControls ? 'widget-editable vads-u-padding-bottom--1' : ''
-        } widget-content vads-u-font-weight--normal`}
-        data-index={index}
-      >
-        <div className={titleClass}>{issueName}</div>
-        <IssueCardContent {...item} />
-        {editControls}
-      </dd>
-    </div>
+          </div>
+        ) : null}
+        <div
+          className={`widget-content ${
+            editControls ? 'widget-editable vads-u-padding-bottom--2' : ''
+          }`}
+          data-index={index}
+        >
+          <Header id={`issue-${index}-title`} className={titleClass}>
+            {issueName}
+          </Header>
+          <IssueCardContent id={`issue-${index}-description`} {...item} />
+          {editControls}
+        </div>
+      </div>
+    </li>
   );
 };
 
@@ -232,4 +222,5 @@ IssueCard.propTypes = {
   onChange: PropTypes.func,
   onEdit: PropTypes.func,
   onRemove: PropTypes.func,
+  onReviewPage: PropTypes.bool,
 };

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -62,6 +62,7 @@ export const SUBMITTED_DISAGREEMENTS = {
   evaluation: 'disability evaluation',
 };
 
-export const LAST_NOD_ITEM = 'lastNodItem'; // focus management across pages
+export const LAST_ISSUE = 'lastHlrItem'; // focus management across pages
+export const REVIEW_ISSUES = 'onReviewPageIssues';
 
 export const CONTESTABLE_ISSUES_PATH = 'contestable-issues';

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -62,7 +62,7 @@ export const SUBMITTED_DISAGREEMENTS = {
   evaluation: 'disability evaluation',
 };
 
-export const LAST_ISSUE = 'lastHlrItem'; // focus management across pages
+export const LAST_ISSUE = 'lastNodItem'; // focus management across pages
 export const REVIEW_ISSUES = 'onReviewPageIssues';
 
 export const CONTESTABLE_ISSUES_PATH = 'contestable-issues';

--- a/src/applications/appeals/10182/content/addIssue.jsx
+++ b/src/applications/appeals/10182/content/addIssue.jsx
@@ -17,23 +17,31 @@ export const issueErrorMessages = {
   newerDate: 'Please add an issue with a decision date less than a year old',
 };
 
-export const addIssueTitle = 'Add an issue and our decision date on this issue';
+export const content = {
+  title: {
+    add: 'Add an issue',
+    edit: 'Edit an issue',
+  },
 
-export const issueNameLabel = 'Name of issue';
-export const issueNameHintText = (
-  <p className="vads-u-font-weight--normal label-description">
-    You can only add an issue that you’ve already received a VA decision notice
-    for.
-  </p>
-);
-
-export const dateOfDecisionLabel = 'Date of notification of the decision';
-export const dateOfDecisionHintText = (
-  <p className="vads-u-font-weight--normal label-description">
-    You can find the decision date on your decision notice (the letter you
-    received physically in the mail from us).
-  </p>
-);
+  button: {
+    cancel: 'Cancel',
+    add: 'Add issue',
+    edit: 'Update issue',
+  },
+  name: {
+    label: 'Name of issue',
+    hint: (
+      <p className="vads-u-font-weight--normal label-description">
+        You can only add an issue that you’ve received a VA decision notice for.
+      </p>
+    ),
+  },
+  date: {
+    label: 'Date of decision',
+    hint:
+      'Enter the date on your decision notice (the letter you received in the mail from us).',
+  },
+};
 
 export const missingIssuesErrorMessageText =
   'Please add and select an issue, or select an eligible issue on the previous page';

--- a/src/applications/appeals/10182/content/contestableIssues.jsx
+++ b/src/applications/appeals/10182/content/contestableIssues.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
+import recordEvent from 'platform/monitoring/record-event';
 import { scrollAndFocus } from 'platform/utilities/ui';
 
 import { MAX_LENGTH } from '../constants';
@@ -9,50 +11,39 @@ import { MAX_LENGTH } from '../constants';
 // We shouldn't ever see the couldn't find contestable issues message since we
 // prevent the user from navigating past the intro page; but it's here just in
 // case we end up filtering out deferred and expired issues
-export const ContestableIssuesTitle = ({ formData = {} } = {}) => {
-  if (formData.contestableIssues?.length === 0) {
-    return (
-      <>
-        <h2
-          className="vads-u-font-size--h4 vads-u-margin-top--0"
-          name="eligibleScrollElement"
-        >
-          Sorry, we couldn’t find any eligible issues
-        </h2>
-        <p>
-          If you’d like to add an issue for review, please select "Add a new
-          issue" to get started.
-        </p>
-      </>
+export const ContestableIssuesLegend = ({ onReviewPage, inReviewMode }) => {
+  let Wrap = 'h3';
+  const wrapClassNames = ['vads-u-font-size--h3'];
+  if (onReviewPage) {
+    // Using a div in review mode, see
+    // https://dsva.slack.com/archives/C8E985R32/p1672863010797129?thread_ts=1672860474.162309&cid=C8E985R32
+    Wrap = inReviewMode ? 'div' : 'h4';
+    wrapClassNames.push(
+      'vads-u-font-family--serif',
+      `vads-u-margin-top--${inReviewMode ? '2' : '0'}`,
     );
+  } else {
+    wrapClassNames.push('vads-u-margin-top--0');
   }
   return (
     <>
-      <div className="vads-u-margin-bottom--2">
-        These issues are in your VA record. If an issue is missing from this
-        list, you can add it.
-      </div>
-      <legend
-        name="eligibleScrollElement"
-        className="vads-u-font-weight--normal vads-u-font-size--base"
-      >
-        Select the issue(s) you’d like us to review:
+      <legend className="vads-u-width--full">
+        <Wrap className={wrapClassNames.join(' ')}>
+          Select the issues you’d like us to review
+        </Wrap>
       </legend>
+      <div className="vads-u-margin-bottom--2">
+        These are the issues we have on file for you. If an issue is missing
+        from the list, you can add it here.
+      </div>
     </>
   );
 };
 
-// The ContestableIssuesTitle is first so screenreaders read it first, but visually
-// it is last to match the design (managed by CSS order)
-export const EligibleIssuesDescription = props => (
-  <>
-    <ContestableIssuesTitle {...props} />
-    <div>
-      These issues are in your VA record. If an issue is missing from this list,
-      you can add it on the next step.
-    </div>
-  </>
-);
+ContestableIssuesLegend.propTypes = {
+  inReviewMode: PropTypes.bool,
+  onReviewPage: PropTypes.bool,
+};
 
 export const maxSelectedErrorMessage =
   'You’ve reached the maximum number of allowed selected issues';
@@ -73,23 +64,59 @@ export const MaxSelectionsAlert = ({ closeModal }) => (
   </VaModal>
 );
 
-export const noneSelected = 'Please select at least one issue';
+MaxSelectionsAlert.propTypes = {
+  closeModal: PropTypes.func,
+};
 
-export const NotListedInfo = (
-  <va-additional-info trigger="Why aren’t all my issues listed here?">
-    <p className="vads-u-margin-top--0">
-      If you don’t see your issue or decision listed here, it may not be in our
-      system yet. This can happen if it’s a more recent claim decision. We may
-      still be processing it.
-    </p>
-  </va-additional-info>
-);
+export const NoIssuesLoadedAlert = ({ submitted }) => {
+  const wrapAlert = useRef(null);
+
+  useEffect(
+    () => {
+      if (wrapAlert?.current) {
+        scrollAndFocus(wrapAlert.current);
+      }
+    },
+    [wrapAlert, submitted],
+  );
+
+  recordEvent({
+    event: 'visible-alert-box',
+    'alert-box-type': 'error',
+    'alert-box-heading': 'Sorry, we couldn’t find any eligible issues',
+    'error-key': 'missing_eligible_issues',
+    'alert-box-full-width': false,
+    'alert-box-background-only': false,
+    'alert-box-closeable': false,
+    'reason-for-alert': 'Missing eligible issues',
+  });
+
+  return (
+    <div ref={wrapAlert}>
+      <va-alert status="error" class="vads-u-margin-bottom--2">
+        <h3 slot="headline">Sorry, we couldn’t find any eligible issues</h3>
+        <p>
+          If you’d like to add an issue for review, please select "Add a new
+          issue" to get started.
+        </p>
+      </va-alert>
+    </div>
+  );
+};
+
+NoIssuesLoadedAlert.propTypes = {
+  submitted: PropTypes.bool,
+};
+
+export const noneSelected =
+  'You must select at least 1 issue before you can continue filling out your request.';
 
 /**
  * Shows the alert box only if the form has been submitted
  */
-export const NoneSelectedAlert = ({ count }) => {
+export const NoneSelectedAlert = ({ count, headerLevel = 3 }) => {
   const wrapAlert = useRef(null);
+  const Header = `H${headerLevel}`;
 
   useEffect(
     () => {
@@ -99,26 +126,58 @@ export const NoneSelectedAlert = ({ count }) => {
     },
     [wrapAlert],
   );
+
+  const title = `You’ll need to ${
+    count === 0 ? 'add, and select,' : 'select'
+  } an issue`;
+
+  recordEvent({
+    event: 'visible-alert-box',
+    'alert-box-type': 'error',
+    'alert-box-heading': title,
+    'error-key': 'no_issues_selected',
+    'alert-box-full-width': false,
+    'alert-box-background-only': false,
+    'alert-box-closeable': false,
+    'reason-for-alert': 'Missing eligible issues',
+  });
+
   return (
     <div ref={wrapAlert}>
-      <va-alert status="error">
-        <h3
+      <va-alert status="error" class="vads-u-margin-bottom--2">
+        <Header
           slot="headline"
           className="eligible-issues-error vads-u-margin-x--2 vads-u-margin-y--1 vads-u-padding-x--3 vads-u-padding-y--2"
         >
-          {`Please ${
-            count === 0 ? 'add, and select,' : 'select'
-          } at least one issue, so we can process your request`}
-        </h3>
+          {title}
+        </Header>
+        <p>{noneSelected}</p>
       </va-alert>
     </div>
   );
 };
 
-export const disabilitiesExplanation = (
+NoneSelectedAlert.propTypes = {
+  count: PropTypes.number,
+  headerLevel: PropTypes.number,
+};
+
+export const ContestableIssuesAdditionalInfo = (
   <va-additional-info trigger="Why isn’t my issue listed here?">
     If you don’t see your issue or decision listed here, it may not be in our
     system yet. This can happen if it’s a more recent claim decision. We may
     still be processing it.
   </va-additional-info>
 );
+
+export const removeModalContent = {
+  title: 'Are you sure you want to remove this issue?',
+  description: issueName => (
+    <span>
+      We’ll remove <strong>{issueName}</strong> from the issues you’d like us to
+      review
+    </span>
+  ),
+  yesButton: 'Yes, remove this',
+  noButton: 'No, keep this',
+};

--- a/src/applications/appeals/10182/pages/contestableIssues.js
+++ b/src/applications/appeals/10182/pages/contestableIssues.js
@@ -1,9 +1,6 @@
 import ContestableIssuesWidget from '../components/ContestableIssuesWidget';
 
-import {
-  ContestableIssuesTitle,
-  disabilitiesExplanation,
-} from '../content/contestableIssues';
+import { ContestableIssuesAdditionalInfo } from '../content/contestableIssues';
 
 import { selectionRequired, maxIssues } from '../validations/issues';
 import { SELECTED } from '../constants';
@@ -13,21 +10,24 @@ import { SELECTED } from '../constants';
  */
 const contestableIssues = {
   uiSchema: {
-    'ui:title': ContestableIssuesTitle,
+    'ui:title': ' ',
     'ui:options': {
       itemName: 'issues eligible for review',
+      forceDivWrapper: true,
     },
     contestableIssues: {
       'ui:title': ' ',
       'ui:field': 'StringField',
       'ui:widget': ContestableIssuesWidget,
       'ui:options': {
+        forceDivWrapper: true,
         keepInPageOnReview: true,
+        customTitle: 'Issues', // override DL wrapper
       },
       'ui:validations': [selectionRequired, maxIssues],
     },
     'view:disabilitiesExplanation': {
-      'ui:description': disabilitiesExplanation,
+      'ui:description': ContestableIssuesAdditionalInfo,
     },
   },
 

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -18,15 +18,24 @@
   }
 }
 
-/* Contestable issue cards (contestable issue page & review/submit page) */
-dl.review {
+/* Contested issue cards (contested issue page & review/submit page)
+ * This could go in the schemaform css, it's used in form 526 & HLR
+ */
+ .issues {
+
   .widget-wrapper {
     display: flex;
+    flex-direction: row;
+    align-items: flex-start;
 
-    dt.widget-checkbox-wrap {
+    .widget-checkbox-wrap {
       margin: 0;
-      width: 5rem;
-      min-width: 5rem;
+      width: 4rem;
+      min-width: 4rem;
+
+      label {
+        margin-top: 0;
+      }
 
       [type="checkbox"] {
         width: 1.8rem;
@@ -35,26 +44,13 @@ dl.review {
       }
     }
 
-    dt label {
-      margin-top: 0;
-    }
-
-    .widget-title {
-      margin: 0;
-      white-space: nowrap;
-      text-transform: capitalize;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      width: calc(100% - 7rem);
-    }
-
-    dd.widget-content {
+    .widget-content {
       width: 100%;
       margin-inline-start: 0; /* override user agent */
       text-align: left;
       margin: 0;
     }
-    dd.widget-content.widget-edit {
+    .widget-content.widget-edit {
       margin-top: 0;
       margin-right: 0;
       display: flex;
@@ -73,27 +69,23 @@ dl.review {
         align-self: center;
       }
     }
-    .change-issue-link:visited {
+    .edit-issue-link:visited {
       color: inherit;
     }
   }
 
   .checkbox-hidden {
-    dt.widget-checkbox-wrap {
-      width: 0;
-    }
-
-    .widget-title {
-      margin-left: 0;
-      width: 100%;
-      overflow: visible;
-      white-space: normal;
-    }
-
     .widget-content {
       margin: 2rem 0 0 2rem;
     }
   }
+}
+
+ul.issues-summary,
+ul.issues,
+.usa-accordion-bordered ul li ul.issues {
+  list-style: none;
+  padding: 0;
 }
 
 @media screen and (min-width: 481px) {

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -60,10 +60,11 @@ const testConfig = createTestConfig(
             testData.contestableIssues.forEach(issue => {
               if (issue[SELECTED]) {
                 cy.get(
-                  `label:contains("${
-                    issue.attributes.ratingIssueSubjectText
-                  }")`,
-                ).click();
+                  `h4:contains("${issue.attributes.ratingIssueSubjectText}")`,
+                )
+                  .closest('li')
+                  .find('input[type="checkbox"]')
+                  .click();
               }
             });
             cy.findByText('Continue', { selector: 'button' }).click();

--- a/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
@@ -7,7 +7,7 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { AddIssue } from '../../components/AddIssue';
 import { issueErrorMessages } from '../../content/addIssue';
-import { MAX_LENGTH, LAST_NOD_ITEM } from '../../constants';
+import { MAX_LENGTH, LAST_ISSUE } from '../../constants';
 import { getDate } from '../../utils/dates';
 
 describe('<AddIssue>', () => {
@@ -29,9 +29,9 @@ describe('<AddIssue>', () => {
     onReviewPage = false,
   } = {}) => {
     if (index !== null) {
-      window.sessionStorage.setItem(LAST_NOD_ITEM, index);
+      window.sessionStorage.setItem(LAST_ISSUE, index);
     } else {
-      window.sessionStorage.removeItem(LAST_NOD_ITEM);
+      window.sessionStorage.removeItem(LAST_ISSUE);
     }
     return (
       <div>
@@ -48,7 +48,7 @@ describe('<AddIssue>', () => {
   };
 
   afterEach(() => {
-    window.sessionStorage.removeItem(LAST_NOD_ITEM);
+    window.sessionStorage.removeItem(LAST_ISSUE);
   });
 
   it('should render', () => {

--- a/src/applications/appeals/10182/tests/components/IssueCard.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/IssueCard.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('<IssueCard>', () => {
     expect($('.widget-content', container).textContent).to.contain(
       'Decision date: January 10, 2021',
     );
-    expect($$('a.change-issue-link').length).to.equal(0);
+    expect($$('a.edit-issue-link').length).to.equal(0);
   });
   it('should render an Additional issue', () => {
     const props = getProps({ onEdit: () => {} });
@@ -59,7 +59,7 @@ describe('<IssueCard>', () => {
     expect($('.widget-content', container).textContent).to.contain(
       'Decision date: February 22, 2021',
     );
-    expect($$('a.change-issue-link').length).to.equal(1);
+    expect($$('a.edit-issue-link').length).to.equal(1);
   });
   it('should render a selected issue with appendId included', () => {
     const props = getProps();
@@ -76,7 +76,7 @@ describe('<IssueCard>', () => {
     const issue = getAdditionalIssue('03', true);
     const { container } = render(<IssueCard {...props} item={issue} />);
     expect($$('input[type="checkbox"]', container).length).to.equal(0);
-    expect($$('.change-issue-link', container).length).to.equal(0);
+    expect($$('.edit-issue-link', container).length).to.equal(0);
   });
 
   it('should call onChange when the checkbox is toggled', () => {
@@ -109,7 +109,7 @@ describe('<IssueCardContent>', () => {
     expect($('.widget-content-wrap', container).textContent).to.contain(
       'Decision date: January 20, 2021',
     );
-    expect($$('a.change-issue-link').length).to.equal(0);
+    expect($$('a.edit-issue-link').length).to.equal(0);
   });
   it('should render AdditionalIssue content', () => {
     const issue = getAdditionalIssue('21');

--- a/src/applications/appeals/10182/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/focus.unit.spec.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import { focusIssue } from '../../utils/focus';
+import { LAST_ISSUE } from '../../constants';
+
+describe('focusIssue', () => {
+  afterEach(() => {
+    window.sessionStorage.removeItem(LAST_ISSUE);
+  });
+  const renderPage = () =>
+    render(
+      <div id="main">
+        <h3>Title</h3>
+        <ul>
+          <li id="issue-0">
+            <input />
+            <a href="#0" className="edit-issue-link">
+              Edit
+            </a>
+          </li>
+          <li id="issue-1">
+            <input />
+            <a href="#1" className="edit-issue-link">
+              Edit
+            </a>
+          </li>
+        </ul>
+        <a href="#new" className="add-new-issue">
+          Add
+        </a>
+      </div>,
+    );
+
+  it('should focus on header', async () => {
+    window.sessionStorage.removeItem(LAST_ISSUE);
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on add new issue link', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, -1);
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('.add-new-issue', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on second input', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, '1,updated');
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('#issue-1 input', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on second edit link', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, '1,cancel');
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('#issue-1 .edit-issue-link', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it.skip('should focus on second remove button', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, '1,remove-cancel');
+    const { container } = await renderPage();
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('#issue-1 .remove-issue', container);
+      // this won't work since RTL doesn't support shadowRoot
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});

--- a/src/applications/appeals/10182/utils/focus.js
+++ b/src/applications/appeals/10182/utils/focus.js
@@ -1,0 +1,36 @@
+import {
+  focusElement,
+  scrollTo,
+  scrollToTop,
+  waitForRenderThenFocus,
+} from 'platform/utilities/ui';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import { LAST_ISSUE } from '../constants';
+
+export const focusIssue = (_index, root, value) => {
+  setTimeout(() => {
+    const item = value || window.sessionStorage.getItem(LAST_ISSUE);
+    window.sessionStorage.removeItem(LAST_ISSUE);
+    const [id, type] = (item || '').toString().split(',');
+    if (id < 0) {
+      // focus on add new issue after removing or cancelling adding a new issue
+      scrollTo('.add-new-issue');
+      focusElement('.add-new-issue', null, root);
+    } else if (id) {
+      const card = $(`#issue-${id}`, root);
+      scrollTo(card);
+      if (type === 'remove-cancel') {
+        const remove = $('.remove-issue', card)?.shadowRoot;
+        waitForRenderThenFocus('button', remove);
+      } else if (type === 'updated') {
+        waitForRenderThenFocus('input', card);
+      } else {
+        focusElement('.edit-issue-link', null, card);
+      }
+    } else {
+      scrollToTop();
+      focusElement('h3');
+    }
+  });
+};


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > All destructive actions need to use a confirmation modal. This PR adds a modal to the contestable issues page. An warning confirmation modal is opened with a choice to yes remove the issue, no keep the issue or close the modal (and do nothing).
  > Also added an alert when API-loaded issues don't exist, or are all filtered out (past 1 year decision date limitation)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Collaboration cycle recommendation for Supplemental Claims; duplicating it in this form
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#56930](https://github.com/department-of-veterans-affairs/va.gov-team/issues/56930)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Prior to this change, removing an issues would immediately remove the entry
- _Describe the steps required to verify your changes are working as expected_
  > Remove added issues (API loaded issues cannot be removed) & observe the confirmation modal
- _Describe the tests completed and the results_
  > Added unit tests.
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile | N/A | <img width="342" alt="Screenshot 2023-06-07 at 11 38 47 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/647be1e3-4b08-4571-b1e9-c6a5f17ac085"> |
| Desktop | N/A | <img width="852" alt="Screenshot 2023-06-07 at 9 38 17 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d5968dcf-b741-4d06-a41d-6199dbf4c688"> |
| Mobile  | <img width="318" alt="Screenshot 2023-06-07 at 11 44 12 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d30234db-4979-4218-9f9e-e98058ba0b98"> | <img width="323" alt="Screenshot 2023-06-07 at 11 40 28 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/08b5d44d-e0b2-460b-a8a3-2fc5a6d2ad89"> |
| Desktop | <img width="635" alt="Screenshot 2023-06-07 at 11 44 00 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/5b92e097-def2-491d-a9f0-e794b8d8df0e"> | <img width="686" alt="Screenshot 2023-06-07 at 9 37 41 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/93c63696-f810-47c9-8c91-7eca9f19dc56"> |

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
