### PR TITLE
Force preview environments to not be port 80

### DIFF
--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -18,7 +18,22 @@ import VSP_ENVIRONMENTS from 'site/constants/vsp-environments';
 const BUILDTYPE = __BUILDTYPE__;
 
 const environment = ENVIRONMENT_CONFIGURATIONS[BUILDTYPE];
-const isPort80 = location.port === '' || location.port === 80;
+
+function isHostnameAllowed(hostname, allowedHostnames) {
+  let hostnameAllowed = false;
+  for (const name of allowedHostnames) {
+    const pattern = name.replace(/\*/g, '[a-z0-9]+(-[a-z0-9]+)*');
+    const regex = new RegExp(`^${pattern}$`, 'i');
+    if (regex.test(hostname)) {
+      hostnameAllowed = true;
+    }
+  }
+  return hostnameAllowed;
+}
+
+const isPort80 =
+  (location.port === '' || location.port === 80) &&
+  !isHostnameAllowed(location.hostname, ['*.preview.va.gov', '*.vfs.va.gov']);
 
 if (!isPort80) {
   // It's possible that we're executing a certain build-type under a hostname

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -19,6 +19,9 @@ const BUILDTYPE = __BUILDTYPE__;
 
 const environment = ENVIRONMENT_CONFIGURATIONS[BUILDTYPE];
 
+/* eslint-disable no-restricted-globals */
+
+// allowedHostnames is an array of hostnames that are eligible
 function isHostnameAllowed(hostname, allowedHostnames) {
   let hostnameAllowed = false;
   for (const name of allowedHostnames) {
@@ -30,6 +33,7 @@ function isHostnameAllowed(hostname, allowedHostnames) {
   }
   return hostnameAllowed;
 }
+/* eslint-enable no-restricted-globals */
 
 const isPort80 =
   (location.port === '' || location.port === 80) &&

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -19,8 +19,6 @@ const BUILDTYPE = __BUILDTYPE__;
 
 const environment = ENVIRONMENT_CONFIGURATIONS[BUILDTYPE];
 
-/* eslint-disable no-restricted-globals */
-
 // allowedHostnames is an array of hostnames that are eligible
 function isHostnameAllowed(hostname, allowedHostnames) {
   let hostnameAllowed = false;
@@ -33,11 +31,12 @@ function isHostnameAllowed(hostname, allowedHostnames) {
   }
   return hostnameAllowed;
 }
-/* eslint-enable no-restricted-globals */
+/* eslint-disable no-restricted-globals */
 
 const isPort80 =
   (location.port === '' || location.port === 80) &&
   !isHostnameAllowed(location.hostname, ['*.preview.va.gov', '*.vfs.va.gov']);
+/* eslint-enable no-restricted-globals */
 
 if (!isPort80) {
   // It's possible that we're executing a certain build-type under a hostname


### PR DESCRIPTION
## Summary

- This PR adds a conditional to force a preview environment to be designated as "not port 80", forcing it to mimic a local setup configuration.
