### PR TITLE
Bumping component-library dependency to 16.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^16.2.0",
+    "@department-of-veterans-affairs/component-library": "^16.3.0",
     "@department-of-veterans-affairs/formation": "^7.0.7",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,13 +2526,13 @@
   dependencies:
     protobufjs "^6.10.2"
 
-"@department-of-veterans-affairs/component-library@^16.2.0":
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-16.2.0.tgz#9c7c1d5e7c1ab7760c7e28fa1a965144958e5138"
-  integrity sha512-zT1M2gckohTqG9fvtZ0xTxcFAqnfFTTB01rLSPqPMDM34wtO+F9d/8SbYmFNxFdQBq/yCxF+0IkiS8LUUtCQ8Q==
+"@department-of-veterans-affairs/component-library@^16.3.0":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-16.3.0.tgz#7ead4af6877f0fd5f3da5c61837310ccc04d4439"
+  integrity sha512-75mDs+6AqN4xVgLpUNxFPmHnJ8orO73G3eI5wnK4N+J+dvWBPEqUYl1xiga6owlqdLwqcDuK2eIzgZUpUSv+Yg==
   dependencies:
     "@department-of-veterans-affairs/react-components" "11.0.1"
-    "@department-of-veterans-affairs/web-components" "4.39.2"
+    "@department-of-veterans-affairs/web-components" "4.40.3"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2605,10 +2605,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.39.2":
-  version "4.39.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.39.2.tgz#92851f9b3cb64219bd7025674206325776f40f82"
-  integrity sha512-yIcxVZDQf3HDON3PkoQmMhkToeiE40m3QhwWeIAPB75ihJeFRUKS7Na/8qifgs/9EqTFVTVsXqC0b9VbPk4HjA==
+"@department-of-veterans-affairs/web-components@4.40.3":
+  version "4.40.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.40.3.tgz#2874f21624b0d793f5cc48091a90ba7fd165f835"
+  integrity sha512-lzwCdMCzrjBvbM/UsG92UOXftoiQgkXVNIBn78ycX/ueq2t4mqwxom14iGVcvG2v+z5f+euxBFslF+VghZHgXA==
   dependencies:
     "@stencil/core" "^2.19.2"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Summary

- Upgrading component-library dependency from 16.2.0 to 16.3.0
- Enables va-notification component, some bug fixes

## Related issue(s)

- [Closes #57714](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57714)

## Testing done

- Works locally.

## What areas of the site does it impact?

Updated component-library should not have any adverse effects anywhere, other than a few bug fixes.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions
