### PR TITLE
VACMS-14021 Focus management for Income Limits headers

### DIFF
--- a/src/applications/income-limits/components/IncomeLimitsApp.jsx
+++ b/src/applications/income-limits/components/IncomeLimitsApp.jsx
@@ -5,7 +5,7 @@ import Breadcrumbs from './Breadcrumbs';
 
 const IncomeLimitsApp = ({ children }) => {
   return (
-    <div className="row vads-u-padding-top--4 vads-u-padding-bottom--8">
+    <div className="income-limits-app row vads-u-padding-top--4 vads-u-padding-bottom--8">
       <Breadcrumbs />
       <div className="usa-width-two-thirds medium-8 columns">{children}</div>
     </div>

--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   VaButtonPair,
   VaNumberInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { focusElement } from 'platform/utilities/ui';
 
 import { ROUTES } from '../constants';
 import { updateDependents, updateEditMode } from '../actions';
@@ -24,6 +25,10 @@ const DependentsPage = ({
   };
 
   const validDependents = dependents?.length > 0 && dependentsValid(dependents);
+
+  useEffect(() => {
+    focusElement('h1');
+  }, []);
 
   const onContinueClick = () => {
     setSubmitted(true);

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { focusElement } from 'platform/utilities/ui';
 
 import {
   getFirstAccordionHeader,
@@ -25,6 +26,10 @@ const Results = ({ limits, yearInput }) => {
 
   const isStandard = gmt > national;
   const currentYear = new Date().getFullYear();
+
+  useEffect(() => {
+    focusElement('h1');
+  }, []);
 
   return (
     <>

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { VaButtonPair } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { connect } from 'react-redux';
+import { focusElement } from 'platform/utilities/ui';
 
 import { ROUTES } from '../constants';
 import { updateEditMode } from '../actions';
@@ -20,6 +21,10 @@ const ReviewPage = ({
       updateEditMode(false);
     }
   });
+
+  useEffect(() => {
+    focusElement('h1');
+  }, []);
 
   const onContinueClick = () => {
     router.push(ROUTES.RESULTS);

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   VaButtonPair,
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from 'platform/utilities/ui';
 
 import { ROUTES } from '../constants';
 import { updateEditMode, updateYear } from '../actions';
@@ -18,6 +19,10 @@ const YearPage = ({
 }) => {
   const [error, setError] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    focusElement('h1');
+  }, []);
 
   const onContinueClick = () => {
     setSubmitted(true);

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   VaButtonPair,
   VaNumberInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { focusElement } from 'platform/utilities/ui';
 
 import { ROUTES } from '../constants';
 import { updateEditMode, updateZipCode } from '../actions';
@@ -25,6 +26,10 @@ const ZipCodePage = ({
   };
 
   const validZip = zipCode && zipCodeValid(zipCode);
+
+  useEffect(() => {
+    focusElement('h1');
+  }, []);
 
   const onContinueClick = () => {
     setSubmitted(true);

--- a/src/applications/income-limits/sass/income-limits.scss
+++ b/src/applications/income-limits/sass/income-limits.scss
@@ -1,5 +1,11 @@
-.usa-table-borderless {
-  .income-limits-edit {
-    width: 54px;
+.income-limits-app {
+  .usa-table-borderless {
+    .income-limits-edit {
+      width: 54px;
+    }
+  }
+
+  h1:focus {
+    outline: none;
   }
 }


### PR DESCRIPTION
## Summary
We had an accessibility finding for the Income Limits flow that the `h1` headers were not being focused/read aloud for screen readers when navigating between pages. This should fix that issue.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14021

## Testing done
Tested locally with Mac VoiceOver.

## Acceptance criteria
- [ ] When using a screen reader, the H1 of the page is announced when navigating between screens within the Income Limits flow, either by using the Back/Continue buttons, an Edit button on the Review screen, etc.