### PR TITLE
Refactor 21-10210 witness-relationship fields/pages

### DIFF
--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -3,12 +3,17 @@ import footerContent from 'platform/forms/components/FormFooter';
 import manifest from '../manifest.json';
 
 import getHelp from '../../shared/components/GetFormHelp';
-import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../definitions/constants';
+import {
+  CLAIM_OWNERSHIPS,
+  CLAIMANT_TYPES,
+  OTHER_RELATIONSHIP,
+} from '../definitions/constants';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import claimOwnership from '../pages/claimOwnership';
+import claimOwnershipPg from '../pages/claimOwnership';
 import claimantType from '../pages/claimantType';
 import witnessPersInfo from '../pages/witnessPersInfo';
+import witnessOtherRelationship from '../pages/witnessOtherRelationship';
 import witnessContInfo from '../pages/witnessContInfo';
 import claimantPersInfo from '../pages/claimantPersInfo';
 import claimantIdInfo from '../pages/claimantIdInfo';
@@ -31,6 +36,20 @@ import transformForSubmit from './submit-transformer';
 import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
 
 const mockData = testData.data;
+
+const witnessHasOtherRelationship = formData => {
+  const { claimOwnership, witnessRelationshipToClaimant } = formData;
+
+  if (!!claimOwnership && !!witnessRelationshipToClaimant) {
+    return (
+      claimOwnership === CLAIM_OWNERSHIPS.THIRD_PARTY &&
+      witnessRelationshipToClaimant.includes(OTHER_RELATIONSHIP)
+    );
+  }
+
+  return false;
+};
+
 /** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -110,8 +129,8 @@ const formConfig = {
           // one single initialData prop here will suffice for entire form
           initialData:
             !!mockData && environment.isLocalhost() ? mockData : undefined,
-          uiSchema: claimOwnership.uiSchema,
-          schema: claimOwnership.schema,
+          uiSchema: claimOwnershipPg.uiSchema,
+          schema: claimOwnershipPg.schema,
         },
         claimantTypePage: {
           path: 'claimant-type',
@@ -127,8 +146,8 @@ const formConfig = {
       pages: {
         witnessPersInfoPageA: {
           // for Flow 2: 3rd-party claim, vet claimant
-          path: 'witness-personal-information',
-          title: 'Your personal information-a',
+          path: 'witness-personal-information-a',
+          title: 'Your personal information',
           depends: {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
             claimantType: CLAIMANT_TYPES.VETERAN,
@@ -146,6 +165,13 @@ const formConfig = {
           },
           uiSchema: witnessPersInfo.uiSchemaB,
           schema: witnessPersInfo.schema,
+        },
+        witnessOtherRelationshipPage: {
+          path: 'witness-other-relationship',
+          title: 'Your other relationship',
+          depends: witnessHasOtherRelationship,
+          uiSchema: witnessOtherRelationship.uiSchema,
+          schema: witnessOtherRelationship.schema,
         },
       },
     },

--- a/src/applications/simple-forms/21-10210/definitions/constants.js
+++ b/src/applications/simple-forms/21-10210/definitions/constants.js
@@ -12,20 +12,22 @@ export const SERVED_WITH_VETERAN = 'Served with Veteran';
 export const FAMILY_OR_FRIEND_OF_VETERAN = 'Family/Friend of Veteran';
 export const COWORKER_OR_SUPERVISOR_OF_VETERAN =
   'Coworker/Supervisor of Veteran';
+export const SERVED_WITH_CLAIMANT = 'Served with Claimant';
+export const FAMILY_OR_FRIEND_OF_CLAIMANT = 'Family/Friend of Claimant';
+export const COWORKER_OR_SUPERVISOR_OF_CLAIMANT =
+  'Coworker/Supervisor of Claimant';
+export const OTHER_RELATIONSHIP = 'A relationship not listed here';
 
 export const RELATIONSHIP_TO_VETERAN_OPTIONS = [
   SERVED_WITH_VETERAN,
   FAMILY_OR_FRIEND_OF_VETERAN,
   COWORKER_OR_SUPERVISOR_OF_VETERAN,
+  OTHER_RELATIONSHIP,
 ];
-
-export const SERVED_WITH_CLAIMANT = 'Served with Claimant';
-export const FAMILY_OR_FRIEND_OF_CLAIMANT = 'Family/Friend of Claimant';
-export const COWORKER_OR_SUPERVISOR_OF_CLAIMANT =
-  'Coworker/Supervisor of Claimant';
 
 export const RELATIONSHIP_TO_CLAIMANT_OPTIONS = [
   SERVED_WITH_CLAIMANT,
   FAMILY_OR_FRIEND_OF_CLAIMANT,
   COWORKER_OR_SUPERVISOR_OF_CLAIMANT,
+  OTHER_RELATIONSHIP,
 ];

--- a/src/applications/simple-forms/21-10210/pages/witnessOtherRelationship.js
+++ b/src/applications/simple-forms/21-10210/pages/witnessOtherRelationship.js
@@ -1,0 +1,55 @@
+import { CLAIMANT_TYPES, OTHER_RELATIONSHIP } from '../definitions/constants';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    witnessOtherRelationshipToClaimant: {
+      'ui:title':
+        'Since your relationship with the Veteran was not listed, please describe it here (30 characters maximum)',
+      'ui:autocomplete': 'off',
+      'ui:options': {
+        updateSchema: formData => {
+          const { claimantType, witnessRelationshipToClaimant } = formData;
+
+          if (
+            witnessRelationshipToClaimant &&
+            !witnessRelationshipToClaimant.includes(OTHER_RELATIONSHIP)
+          ) {
+            // Clear witnessOtherRelationshipToClaimant if User returns
+            // to previous page & deselects OTHER_RELATIONSHIP.
+            // eslint-disable-next-line no-param-reassign
+            formData.witnessOtherRelationshipToClaimant = undefined;
+          }
+
+          return {
+            title:
+              claimantType === CLAIMANT_TYPES.VETERAN
+                ? // Flow 2: vet claimant
+                  'Since your relationship with the Veteran was not listed, please describe it here (30 characters maximum)'
+                : // Flow 4: non-vet claimant
+                  'Since your relationship with the Claimant was not listed, please describe it here (30 characters maximum)',
+          };
+        },
+      },
+    },
+  },
+  // uiSchemaB: {
+  //   // Flow 4: non-vet claimant
+  //   ...commonUiSchema,
+  //   witnessOtherRelationshipToClaimant: {
+  //     ...commonUiSchema.witnessOtherRelationshipToClaimant,
+  //     'ui:title':
+  //       'Since your relationship with the Claimant was not listed, please describe it here (30 characters maximum)',
+  //   },
+  // },
+  schema: {
+    type: 'object',
+    required: ['witnessOtherRelationshipToClaimant'],
+    properties: {
+      witnessOtherRelationshipToClaimant: {
+        type: 'string',
+        maxLength: 30,
+      },
+    },
+  },
+};

--- a/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
@@ -13,29 +13,15 @@ const commonUiSchema = {
     // different ui:title between uiSchemaA & uiSchemaB
     'ui:description': 'Check all that apply',
     'ui:widget': GroupCheckboxWidget,
-    'ui:required': formData => !formData.witnessOtherRelationshipToClaimant,
+    'ui:errorMessages': {
+      required: 'Please select at least one option',
+    },
     'ui:options': {
       forceDivWrapper: true,
       showFieldLabel: true,
       // different labels between uiSchemaA & uiSchemaB
     },
   },
-  witnessOtherRelationshipToClaimant: {
-    // different ui:title between uiSchemaA & uiSchemaB
-    'ui:autocomplete': 'off',
-  },
-  'ui:validations': [
-    (errors, fields) => {
-      if (
-        (fields.witnessRelationshipToClaimant || '').trim() === '' &&
-        (fields.witnessOtherRelationshipToClaimant || '').trim() === ''
-      ) {
-        errors.witnessRelationshipToClaimant.addError(
-          'Please select at least one option here, or input a relationship in text-box below',
-        );
-      }
-    },
-  ],
 };
 export default {
   uiSchemaA: {
@@ -49,11 +35,6 @@ export default {
         labels: RELATIONSHIP_TO_VETERAN_OPTIONS,
       },
     },
-    witnessOtherRelationshipToClaimant: {
-      ...commonUiSchema.witnessOtherRelationshipToClaimant,
-      'ui:title':
-        'If your relationship with the Veteran is not listed, you can write it here (30 characters maximum)',
-    },
   },
   uiSchemaB: {
     // Flow 4: non-vet claimant
@@ -66,23 +47,14 @@ export default {
         labels: RELATIONSHIP_TO_CLAIMANT_OPTIONS,
       },
     },
-    witnessOtherRelationshipToClaimant: {
-      ...commonUiSchema.witnessOtherRelationshipToClaimant,
-      'ui:title':
-        'If your relationship with the Claimant is not listed, you can write it here (30 characters maximum)',
-    },
   },
   schema: {
     type: 'object',
-    required: ['witnessFullName'],
+    required: ['witnessFullName', 'witnessRelationshipToClaimant'],
     properties: {
       witnessFullName: formDefinitions.pdfFullNameNoSuffix,
       witnessRelationshipToClaimant: {
         type: 'string',
-      },
-      witnessOtherRelationshipToClaimant: {
-        type: 'string',
-        maxLength: 30,
       },
     },
   },

--- a/src/applications/simple-forms/21-10210/tests/e2e/10210-lay-witness-statement.cypress.spec.js
+++ b/src/applications/simple-forms/21-10210/tests/e2e/10210-lay-witness-statement.cypress.spec.js
@@ -34,6 +34,40 @@ const testConfig = createTestConfig(
           });
         });
       },
+      'witness-personal-information-a': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            const label = data.witnessRelationshipToClaimant;
+            cy.get(`va-checkbox[label="${label}"]`)
+              .shadow()
+              .get('#checkbox-element')
+              .first()
+              .click()
+              .then(() => {
+                cy.findByText('Continue')
+                  .first()
+                  .click();
+              });
+          });
+        });
+      },
+      'witness-personal-information-b': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            const label = data.witnessRelationshipToClaimant;
+            cy.get(`va-checkbox[label="${label}"]`)
+              .shadow()
+              .get('#checkbox-element')
+              .first()
+              .click()
+              .then(() => {
+                cy.findByText('Continue')
+                  .first()
+                  .click();
+              });
+          });
+        });
+      },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {

--- a/src/applications/simple-forms/21-10210/tests/e2e/fixtures/data/flow2.json
+++ b/src/applications/simple-forms/21-10210/tests/e2e/fixtures/data/flow2.json
@@ -7,7 +7,7 @@
       "middle": "",
       "last": "Witness"
     },
-    "witnessOtherRelationshipToClaimant": "Met at some bar.",
+    "witnessRelationshipToClaimant": "Served with Veteran",
     "witnessPhone": "555-555-5555",
     "witnessEmail": "jack.witness@example.com",
     "statement": "It was a dark and stormy night...",

--- a/src/applications/simple-forms/21-10210/tests/e2e/fixtures/data/flow4.json
+++ b/src/applications/simple-forms/21-10210/tests/e2e/fixtures/data/flow4.json
@@ -7,7 +7,7 @@
       "middle": "",
       "last": "Witness"
     },
-    "witnessOtherRelationshipToClaimant": "Met at some bar.",
+    "witnessRelationshipToClaimant": "Served with Claimant",
     "witnessPhone": "555-555-5555",
     "witnessEmail": "jack.witness@example.com",
     "statement": "It was a dark and stormy night...",

--- a/src/applications/simple-forms/21-10210/tests/pages/witnessOtherRelationship.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/witnessOtherRelationship.unit.spec.jsx
@@ -2,19 +2,13 @@ import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
 } from '../../../shared/tests/pages/pageTests.spec';
-import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 
 const {
   schema,
   uiSchema,
-} = formConfig.chapters.statementChapterD.pages.statementPageD;
-const pageTitle = 'Your statement';
-const mockData = {
-  claimOwnership: CLAIM_OWNERSHIPS.SELF,
-  claimantType: CLAIMANT_TYPES.VETERAN,
-  statement: 'It was a dark and stormy night...',
-};
+} = formConfig.chapters.witnessPersonalInfoChapter.pages.witnessOtherRelationshipPage;
+const pageTitle = 'Witness other relationship';
 
 const expectedNumberOfFields = 1;
 testNumberOfFields(
@@ -23,7 +17,7 @@ testNumberOfFields(
   uiSchema,
   expectedNumberOfFields,
   pageTitle,
-  mockData,
+  { witnessOtherRelationshipToClaimant: 'Met at a bar.' },
 );
 
 const expectedNumberOfErrors = 1;
@@ -33,8 +27,4 @@ testNumberOfErrorsOnSubmit(
   uiSchema,
   expectedNumberOfErrors,
   pageTitle,
-  {
-    claimOwnership: CLAIM_OWNERSHIPS.SELF,
-    claimantType: CLAIMANT_TYPES.VETERAN,
-  },
 );

--- a/src/applications/simple-forms/21-10210/tests/pages/witnessPersInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/witnessPersInfo.unit.spec.jsx
@@ -27,7 +27,7 @@ const mockData = {
 // Expect 4 fields instead of 7 fields.
 // witnessRelationshipToClaimant GroupCheckboxWidget's 3 fields are
 // in shadow-DOM and thus unselectable by test.
-const expectedNumberOfFields = 4;
+const expectedNumberOfFields = 3;
 testNumberOfFields(
   formConfig,
   schema,


### PR DESCRIPTION
## Summary

- Refactor Lay/Witness Statement (21-10210) witness-relationship fields & pages:
  - Add "A relationship not listed here" checkbox to witness-personal-info page.
  - If above option's selected, show new witness-other-relationship page with text-input.  Otherwise, show witness-contact-information page.
- Team: VA Product Forms
- Not using Flipper

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#298 [re-opened] &mdash; see [this Comment](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/298#issuecomment-1581394867) for final refactor.


## Testing done

- Local browser testing successful
- Local unit- & e2e-tests successful

## What areas of the site does it impact?

This new (WIP) form ONLY.

