### PR TITLE
Simple forms: Refactor IntroductionPage.jsx to be more reusable

### DIFF
--- a/src/applications/simple-forms/21-10210/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/IntroductionPage.jsx
@@ -1,80 +1,67 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-// import SaveInProgressIntro from '../components/SaveInProgressIntro';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
-class IntroductionPage extends React.Component {
-  // TODO: Uncomment componentDidMount after breadcrumbs are built
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+const content = {
+  formTitle: 'Submit a lay witness statement to support a VA claim',
+  formSubTitle: 'Lay/Witness Statement (VA Form 21-10210)',
+  startFormText: 'Start your statement',
+  unauthStartText: 'Sign in to start your statement',
+  saveInProgressText: 'Please complete the 21-10210 form to apply for claims.',
+  displayNonVeteranMessaging: true,
+};
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+const ombInfo = {
+  resBurden: '10',
+  ombNumber: '2900-0881',
+  expDate: '06/30/2024',
+};
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="Submit a lay witness statement to support a VA claim"
-          subTitle="Lay/Witness Statement (VA Form 21-10210)"
-        />
-        <h2>Here’s how to apply online</h2>
-        <p>
-          Use this form to submit a formal statement to support your VA claim—or
-          the claim of another Veteran or eligible family member. People also
-          sometimes call this statement a “buddy statement.”
-        </p>
-        <p>
-          A Veteran or a claimant may submit a lay/witness statement on their
-          own behalf. Alternatively, a witness may submit on behalf of a Veteran
-          or claimant.
-        </p>
-        <h2>What to know before you complete this form</h2>
-        <ul>
-          <li>
-            You can submit a statement to support your own or someone else’s VA
-            claim.
-          </li>
-          <li>
-            To submit a statement to support someone else’s claim, you’ll need
-            to give us information like their birth date, Social Security
-            number, VA file number (if you have it), and contact information.{' '}
-          </li>
-          <li>
-            Each statement needs its own form. If you want to submit more than
-            one statement about your claim, use a new form for each statement.
-            If you want more than one person to submit a statement to support
-            your claim, ask each person to use a separate form.
-          </li>
-        </ul>
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start your statement"
-          unauthStartText="Sign in to start your statement"
-          hideUnauthedStartLink={false}
-          displayNonVeteranMessaging
-        >
-          <p>Please complete the 21-10210 form to apply for claims.</p>
-        </SaveInProgressIntro>
-        <p />
+const childContent = (
+  <>
+    <h2>Here’s how to apply online</h2>
+    <p>
+      Use this form to submit a formal statement to support your VA claim—or the
+      claim of another Veteran or eligible family member. People also sometimes
+      call this statement a “buddy statement.”
+    </p>
+    <p>
+      A Veteran or a claimant may submit a lay/witness statement on their own
+      behalf. Alternatively, a witness may submit on behalf of a Veteran or
+      claimant.
+    </p>
+    <h2>What to know before you complete this form</h2>
+    <ul>
+      <li>
+        You can submit a statement to support your own or someone else’s VA
+        claim.
+      </li>
+      <li>
+        To submit a statement to support someone else’s claim, you’ll need to
+        give us information like their birth date, Social Security number, VA
+        file number (if you have it), and contact information.{' '}
+      </li>
+      <li>
+        Each statement needs its own form. If you want to submit more than one
+        statement about your claim, use a new form for each statement. If you
+        want more than one person to submit a statement to support your claim,
+        ask each person to use a separate form.
+      </li>
+    </ul>
+  </>
+);
 
-        <va-omb-info
-          res-burden={10}
-          omb-number="2900-0881"
-          exp-date="06/30/2024"
-        />
-      </article>
-    );
-  }
-}
+export const IntroductionPage = ({ route }) => {
+  return (
+    <IntroductionPageView
+      route={route}
+      content={content}
+      ombInfo={ombInfo}
+      childContent={childContent}
+    />
+  );
+};
 
 IntroductionPage.propTypes = {
   route: PropTypes.shape({

--- a/src/applications/simple-forms/21-10210/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/IntroductionPage.jsx
@@ -6,7 +6,7 @@ import { IntroductionPageView } from '../../shared/components/IntroductionPageVi
 const content = {
   formTitle: 'Submit a lay witness statement to support a VA claim',
   formSubTitle: 'Lay/Witness Statement (VA Form 21-10210)',
-  startFormText: 'Start your statement',
+  authStartFormText: 'Start your statement',
   unauthStartText: 'Sign in to start your statement',
   saveInProgressText: 'Please complete the 21-10210 form to apply for claims.',
   displayNonVeteranMessaging: true,

--- a/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
@@ -7,7 +7,7 @@ const content = {
   formTitle: 'Authorize the release of non-VA medical information to VA',
   formSubTitle:
     'Authorization to disclose information to the Department of Veterans Affairs (VA Forms 21-4142 and 21-4142a)',
-  startFormText: 'Start the medical records authorization',
+  authStartFormText: 'Start the medical records authorization',
   saveInProgressText:
     'Please complete the 21-4142 form to authorize the release of non-VA medical records to VA.',
   displayNonVeteranMessaging: true,

--- a/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
@@ -1,91 +1,88 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+const content = {
+  formTitle: 'Authorize the release of non-VA medical information to VA',
+  formSubTitle:
+    'Authorization to disclose information to the Department of Veterans Affairs (VA Forms 21-4142 and 21-4142a)',
+  startFormText: 'Start the medical records authorization',
+  saveInProgressText:
+    'Please complete the 21-4142 form to authorize the release of non-VA medical records to VA.',
+  displayNonVeteranMessaging: true,
+};
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+const ombInfo = {
+  resBurden: '10',
+  ombNumber: '2900-0858',
+  expDate: '07/31/2024',
+};
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="Authorize the release of non-VA medical information to VA"
-          subTitle="Authorization to disclose information to the Department of Veterans Affairs (VA Forms 21-4142 and 21-4142a)"
-        />
-        <p>
-          Complete this form if you want to give us permission to request your
-          medical records and information from non-VA sources to support your
-          benefit claim. You can use this form to authorize the release of
-          information on behalf of a Veteran you support.
-        </p>
-        <h2 className="vads-u-font-size--h3">
-          Non-VA sources we may request your medical records and information
-          from
-        </h2>
-        <ul className="vads-u-margin-bottom--4">
-          <li>
-            All sources of medical information (like hospitals, clinics, labs,
-            physicians, and psychologists)
-          </li>
-          <li>Social workers and rehabilitation counselors</li>
-          <li>Health care providers who conduct claim exams for us</li>
-          <li>
-            Employers, insurance companies, or workers’ compensation programs
-          </li>
-          <li>
-            People who may know about your condition (like family, neighbors,
-            friends, and public officials)
-          </li>
-        </ul>
+const childContent = (
+  <>
+    <p>
+      Complete this form if you want to give us permission to request your
+      medical records and information from non-VA sources to support your
+      benefit claim. You can use this form to authorize the release of
+      information on behalf of a Veteran you support.
+    </p>
+    <h2 className="vads-u-font-size--h3">
+      Non-VA sources we may request your medical records and information from
+    </h2>
+    <ul className="vads-u-margin-bottom--4">
+      <li>
+        All sources of medical information (like hospitals, clinics, labs,
+        physicians, and psychologists)
+      </li>
+      <li>Social workers and rehabilitation counselors</li>
+      <li>Health care providers who conduct claim exams for us</li>
+      <li>Employers, insurance companies, or workers’ compensation programs</li>
+      <li>
+        People who may know about your condition (like family, neighbors,
+        friends, and public officials)
+      </li>
+    </ul>
 
-        <h2 className="vads-u-font-size--h3">
-          What to know before you fill out this form
-        </h2>
-        <ul className="vads-u-margin-bottom--4">
-          <li>
-            If you already provided your private, non-VA medical records to us,
-            or if you intended to get them yourself, you don't need to submit
-            this form. Submitting the form in this case will add time to your
-            claim process.
-          </li>
-          <li>
-            You don't need to submit this form to request VA medical records.
-          </li>
-          <li>
-            By law, we can't pay any fees that a source may charge to release
-            your medical records. If a source charges a fee, we'll contact you
-            to tell you how to get the records.
-          </li>
-        </ul>
+    <h2 className="vads-u-font-size--h3">
+      What to know before you fill out this form
+    </h2>
+    <ul className="vads-u-margin-bottom--4">
+      <li>
+        If you already provided your private, non-VA medical records to us, or
+        if you intended to get them yourself, you don’t need to submit this
+        form. Submitting the form in this case will add time to your claim
+        process.
+      </li>
+      <li>You don’t need to submit this form to request VA medical records.</li>
+      <li>
+        By law, we can’t pay any fees that a source may charge to release your
+        medical records. If a source charges a fee, we’ll contact you to tell
+        you how to get the records.
+      </li>
+    </ul>
+  </>
+);
 
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the medical records authorization"
-          displayNonVeteranMessaging
-        >
-          Please complete the 21-4142 form to authorize the release of non-VA
-          medical records to VA.
-        </SaveInProgressIntro>
+export const IntroductionPage = ({ route }) => {
+  return (
+    <IntroductionPageView
+      route={route}
+      content={content}
+      ombInfo={ombInfo}
+      childContent={childContent}
+    />
+  );
+};
 
-        <p />
-        <va-omb-info
-          res-burden="10"
-          omb-number="2900-0858"
-          exp-date="07/31/2024"
-        />
-      </article>
-    );
-  }
-}
+IntroductionPage.propTypes = {
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({
+      prefillEnabled: PropTypes.bool,
+      savedFormMessages: PropTypes.shape({}),
+    }),
+    pageList: PropTypes.array,
+  }),
+};
 
 export default IntroductionPage;

--- a/src/applications/simple-forms/26-4555/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/IntroductionPage.jsx
@@ -7,7 +7,7 @@ const content = {
   formTitle: 'Apply for an adapted housing grant',
   formSubTitle:
     'Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant (VA Form 26-4555)',
-  startFormText: 'Start the housing grant application',
+  authStartFormText: 'Start the housing grant application',
   saveInProgressText:
     'Please complete the 26-4555 form to apply for adapted housing.',
 };

--- a/src/applications/simple-forms/26-4555/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/IntroductionPage.jsx
@@ -1,54 +1,48 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+const content = {
+  formTitle: 'Apply for an adapted housing grant',
+  formSubTitle:
+    'Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant (VA Form 26-4555)',
+  startFormText: 'Start the housing grant application',
+  saveInProgressText:
+    'Please complete the 26-4555 form to apply for adapted housing.',
+};
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+const ombInfo = {
+  resBurden: '10',
+  ombNumber: '2900-0132',
+  expDate: '6/20/2024',
+};
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="Apply for an adapted housing grant"
-          subTitle="Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant (VA Form 26-4555)"
-        />
-        <h2>Here&rsquo;s how to apply online</h2>
-        <p>
-          Complete this form. After you submit the form, you&rsquo;ll get a
-          confirmation message. You can print this page for your records.
-        </p>
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the housing grant application"
-        >
-          Please complete the 26-4555 form to apply for adapted housing.
-        </SaveInProgressIntro>
-        <p />
-        <va-omb-info
-          res-burden="10"
-          omb-number="2900-0132"
-          exp-date="6/20/2024"
-        />
-      </article>
-    );
-  }
-}
+const childContent = (
+  <>
+    <h2>Here’s how to apply online</h2>
+    <p>
+      Complete this form. After you submit the form, you’ll get a confirmation
+      message. You can print this page for your records.
+    </p>
+  </>
+);
+
+export const IntroductionPage = ({ route }) => {
+  return (
+    <IntroductionPageView
+      route={route}
+      content={content}
+      ombInfo={ombInfo}
+      childContent={childContent}
+    />
+  );
+};
 
 IntroductionPage.propTypes = {
   route: PropTypes.shape({
     formConfig: PropTypes.shape({
+      prefillEnabled: PropTypes.bool,
       savedFormMessages: PropTypes.shape({}),
     }),
     pageList: PropTypes.array,

--- a/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
+++ b/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
@@ -15,7 +15,7 @@ export const IntroductionPageView = ({
   const {
     formTitle,
     formSubTitle,
-    startFormText,
+    authStartFormText,
     saveInProgressText,
     unauthStartText,
     displayNonVeteranMessaging = false,
@@ -35,7 +35,7 @@ export const IntroductionPageView = ({
         prefillEnabled={formConfig.prefillEnabled}
         messages={formConfig.savedFormMessages}
         pageList={pageList}
-        startText={startFormText}
+        startText={authStartFormText}
         unauthStartText={unauthStartText}
         displayNonVeteranMessaging={displayNonVeteranMessaging}
       >

--- a/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
+++ b/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+
+import { focusElement } from 'platform/utilities/ui';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+
+export const IntroductionPageView = ({
+  route,
+  content,
+  ombInfo,
+  childContent,
+}) => {
+  const breadcrumbsRef = useRef('.va-nav-breadcrumbs-list');
+  const { formConfig, pageList } = route;
+  const {
+    formTitle,
+    formSubTitle,
+    startFormText,
+    saveInProgressText,
+    unauthStartText,
+    displayNonVeteranMessaging = false,
+  } = content;
+  const { resBurden, ombNumber, expDate } = ombInfo;
+
+  useEffect(() => {
+    focusElement(breadcrumbsRef.current);
+  }, []);
+
+  return (
+    <article className="schemaform-intro">
+      <FormTitle title={formTitle} subTitle={formSubTitle} />
+      {childContent}
+      <SaveInProgressIntro
+        headingLevel={2}
+        prefillEnabled={formConfig.prefillEnabled}
+        messages={formConfig.savedFormMessages}
+        pageList={pageList}
+        startText={startFormText}
+        unauthStartText={unauthStartText}
+        displayNonVeteranMessaging={displayNonVeteranMessaging}
+      >
+        {saveInProgressText}
+      </SaveInProgressIntro>
+
+      <p />
+      <va-omb-info
+        res-burden={resBurden}
+        omb-number={ombNumber}
+        exp-date={expDate}
+      />
+    </article>
+  );
+};


### PR DESCRIPTION
Paying off tech debt as we roll out more forms. This makes it easy to distinguish custom content and leave the rest to a reliable pattern.

_Note: I've only done this for 26-4555, 21-4142, and 21-10210 so far since those are the most active and almost all in prod. The others can easily be refactored later as they are built._

## Summary

- Move the copy pasta view portion of the IntroductionPage into a shared component
- Change the introductino page from a class to a functional component
- Extract form-specific content to be defined in the introductionpage containers
- Refactor introductino page containers to be functional components and refactor to just preparing information for the view component

## Testing done

Tested all three forms locally and confirmed introduction pages looked unchanged. See screenshots comparing staging and local.

26-4555
<img width="1157" alt="4555stagingvslocal" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/ec7334d6-b3b2-4b51-8391-1ecded722e9b">


21-10210
<img width="1121" alt="10210stagingvslocal" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/b3ca31f7-f4d9-49e7-b249-26b18de8b973">


21-4142
<img width="1091" alt="4142stagingvslocal" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/057e2252-9bab-44d1-9ebf-a2150fbef3f9">



## What areas of the site does it impact?
None: no actual changes
Under the hood: Forms 26-4555, 21-10210, 21-4142

## Requested Feedback
Let me know what you think!