### PR TITLE
Add confirmation functionality via VaModal to the ArrayField

### DIFF
--- a/src/applications/simple-forms/21-4142/pages/recordsRequested.js
+++ b/src/applications/simple-forms/21-4142/pages/recordsRequested.js
@@ -46,6 +46,9 @@ export default {
         keepInPageOnReview: true,
         useDlWrap: true,
         customTitle: ' ',
+        confirmRemove: true,
+        confirmRemoveDescription:
+          'This will remove the facility and all of the treatment records associated from your authorization request.',
       },
       items: {
         'ui:options': {


### PR DESCRIPTION
## Summary
This pull request adds additional functionality to the ArrayField to support an additional confirmation step when attempting to remove an element in the array. This confirmation happens in a modal. 

By default, forms will not have this functionality added to their arrays, so already existing forms will not be affected. 

To use this new functionality, the `ui:options` for the array object in the `uiSchema` must include `keepInPageOnReview: true` and `confirmRemove: true`. Additionally, `confirmRemoveDescription` can be provided to `ui:options` with a string as the value to add text to the body of the modal.

The provided `itemName` in the `ui:options` of the array object is used in a couple different locations in the modal to for title and buttons texts, but it is not required to have an `itemName` to use this functionality. Without an `itemName`, the text "item" will be used instead.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#59193

## Screenshots
<img width="534" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/c1a2a984-87b1-426e-b3f0-76197696e293">
