### PR TITLE
1798 - Upgrade formation version

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@department-of-veterans-affairs/component-library": "^16.3.0",
-    "@department-of-veterans-affairs/formation": "^7.0.7",
+    "@department-of-veterans-affairs/formation": "^7.0.8",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2545,10 +2545,10 @@
   dependencies:
     jsx-ast-utils "^3.3.3"
 
-"@department-of-veterans-affairs/formation@^7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.7.tgz#145db27b1d258ad62ef4aeddc65b79516e552da0"
-  integrity sha512-VivETxz+xEFPDYZ3r7WXGZCgPbeJOgrfTbfAIUWtueM67xZBpSfJ7onbL/I/AKjbbWY9FOEJ/UkZyoVZa2pGeA==
+"@department-of-veterans-affairs/formation@^7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-7.0.8.tgz#685612acc82b80ba6fe283d283fd9e0c848cf60a"
+  integrity sha512-PzDg0S/X0fhFw+gPnPv/bytZ2n02o6q2nXeLI45uq75ob2UGbFpkYRlqJQXpUgmObpyjXpv2HoIO7nj/8NLiQw==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Summary

- Upgrade formation version to ^7.0.8 in package.json
- Fixes a bug where buttons would sometimes overflow from their containers on mobile


## Related issue(s)
- Github Issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1798
- Related fix in veteran-facing-service-tools: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/936

## Testing done

- Manual testing

## Screenshots
Before:
![](https://user-images.githubusercontent.com/15200011/243775027-10ed6e53-4d53-4dba-9e9d-05a38071cf1c.png)


After:
![](https://user-images.githubusercontent.com/15200011/243775099-88f53b6c-65dc-4ad5-9757-55df01152727.png)


## What areas of the site does it impact?
- This seems to have mostly affected buttons when they are in the shadow DOM of web-components and viewed on mobile, however this could affect buttons in any narrow container

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
