### PR TITLE
Fix FileReader global restoration

### DIFF
--- a/src/platform/forms-system/test/js/utilities/file.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/file.unit.spec.js
@@ -25,8 +25,15 @@ const encryptedMockFile = [
 describe('readAndCheckFile', () => {
   let oldFileReader;
 
-  const setup = async (ext = 'pdf', isEncrypted) => {
+  before(() => {
     oldFileReader = global.FileReader;
+  });
+
+  after(() => {
+    global.FileReader = oldFileReader;
+  });
+
+  const setup = async (ext = 'pdf', isEncrypted) => {
     const fileType = fileTypeSignatures[ext] || {};
 
     const result = [
@@ -61,10 +68,6 @@ describe('readAndCheckFile', () => {
       slice: () => result,
     };
   };
-
-  after(() => {
-    global.FileReader = oldFileReader;
-  });
 
   it('should resolve if no checks are included', async () => {
     const file = await setup('pdf');


### PR DESCRIPTION
## Summary

This PR fixes an overwrite of the `FileReader` global that will cause other tests using it to fail when run after this test runs.
