### PR TITLE
[eFSR] Accessibility - Adding optional sensible aria-labels to mini summary cards 

### DIFF
--- a/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
+++ b/src/applications/financial-status-report/components/EmploymentHistorySummaryCard.jsx
@@ -123,6 +123,7 @@ const EmploymentHistorySummaryCard = ({
   return (
     (!job && <EmptyMiniSummaryCard content={emptyPrompt} />) || (
       <MiniSummaryCard
+        ariaLabel={`Job ${index + 1} ${employmentCardHeading}`}
         editDestination={handleClick(index)}
         heading={employmentCardHeading}
         body={cardBody}

--- a/src/applications/financial-status-report/components/EnhancedVehicleRecord.jsx
+++ b/src/applications/financial-status-report/components/EnhancedVehicleRecord.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
-import { setData } from 'platform/forms-system/src/js/actions';
+import PropTypes from 'prop-types';
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const defaultRecord = {
@@ -12,9 +11,7 @@ const defaultRecord = {
 
 const MAX_VEHICLE_MAKE_LENGTH = 32;
 
-const EnhancedVehicleRecord = props => {
-  const { data, goToPath, setFormData } = props;
-
+const EnhancedVehicleRecord = ({ data, goToPath, setFormData }) => {
   const { assets } = data;
   const { automobiles = [] } = assets;
 
@@ -79,11 +76,7 @@ const EnhancedVehicleRecord = props => {
 
   const handleBack = event => {
     event.preventDefault();
-    if (automobiles.length > 0) {
-      goToPath('/vehicles-summary');
-    } else {
-      goToPath('/vehicles');
-    }
+    goToPath('/vehicles-summary');
   };
 
   const updateFormData = e => {
@@ -110,13 +103,12 @@ const EnhancedVehicleRecord = props => {
           automobiles: newVehicleArray,
         },
       });
-
       goToPath('/vehicles-summary');
     }
   };
 
   return (
-    <form onSubmit={updateFormData}>
+    <form>
       <fieldset className="vads-u-margin-y--2">
         <legend className="schemaform-block-title">
           Your car or other vehicle
@@ -136,7 +128,6 @@ const EnhancedVehicleRecord = props => {
             value={vehicleRecord.make || ''}
           />
         </div>
-
         <div className="input-size-5">
           <VaTextInput
             className="no-wrap input-size-5"
@@ -151,7 +142,6 @@ const EnhancedVehicleRecord = props => {
             value={vehicleRecord.model || ''}
           />
         </div>
-
         <div className="input-size-2">
           <va-number-input
             error={(vehicleRecordIsDirty && yearIsDirty && yearError) || null}
@@ -164,7 +154,6 @@ const EnhancedVehicleRecord = props => {
             value={vehicleRecord.year || ''}
           />
         </div>
-
         <div className="input-size-2 no-wrap">
           <va-number-input
             error={
@@ -184,7 +173,6 @@ const EnhancedVehicleRecord = props => {
             value={vehicleRecord.resaleValue}
           />
         </div>
-
         <va-additional-info
           class="vads-u-margin-top--4"
           trigger="Why do I need to provide this information?"
@@ -216,7 +204,7 @@ const EnhancedVehicleRecord = props => {
             Cancel
           </button>
           <button
-            type="button"
+            type="submit"
             id="submit"
             className="vads-u-width--auto"
             onClick={updateFormData}
@@ -229,18 +217,21 @@ const EnhancedVehicleRecord = props => {
   );
 };
 
-const mapStateToProps = ({ form }) => {
-  return {
-    formData: form.data,
-    employmentHistory: form.data.personalData.employmentHistory,
-  };
+EnhancedVehicleRecord.propTypes = {
+  data: PropTypes.shape({
+    assets: PropTypes.shape({
+      automobiles: PropTypes.arrayOf(
+        PropTypes.shape({
+          make: PropTypes.string,
+          model: PropTypes.string,
+          resaleValue: PropTypes.string,
+          year: PropTypes.string,
+        }),
+      ),
+    }),
+  }),
+  goToPath: PropTypes.func,
+  setFormData: PropTypes.func,
 };
 
-const mapDispatchToProps = {
-  setFormData: setData,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(EnhancedVehicleRecord);
+export default EnhancedVehicleRecord;

--- a/src/applications/financial-status-report/components/shared/MiniSummaryCard.jsx
+++ b/src/applications/financial-status-report/components/shared/MiniSummaryCard.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 
 /**
  * MiniSummaryCard
+ * @param {String} ariaLabel - Optional - Aria label used in parent div, and postfixed to edit and delete buttons
  * @param {Object} editDestination - Object for react-router Link component { pathname: '/path-desination', search: `?index=${index-value}` }
  * @param {String} heading - h4 styled as h3 heading for component
  * @param {Object} body - body content for component (can be a react component)
@@ -12,6 +13,7 @@ import { Link } from 'react-router';
  * @return {React Component}
  */
 export const MiniSummaryCard = ({
+  ariaLabel,
   editDestination,
   heading,
   body,
@@ -19,10 +21,13 @@ export const MiniSummaryCard = ({
   showDelete = false,
   index,
 }) => {
+  const ariaButtonLabels = ariaLabel ? `${ariaLabel}` : `${heading} ${index}`;
+
   return (
     <div
       className="vads-u-border--1px vads-u-margin-y--2 vads-u-padding--0"
       data-testid="mini-summary-card"
+      aria-label={ariaLabel}
     >
       <div className="vads-u-padding-x--2 vads-u-padding-top--2 vads-u-display--flex vads-u-flex-direction--column">
         <h3 className="vads-u-margin-y--0 vads-u-font-size--h4">{heading}</h3>
@@ -30,7 +35,7 @@ export const MiniSummaryCard = ({
       </div>
       <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--center vads-u-padding-x--2 vads-u-padding-bottom--1">
         <Link
-          aria-label={`Edit ${heading} ${index}`}
+          aria-label={`Edit ${ariaButtonLabels}`}
           to={editDestination}
           className="vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--neg0p5"
         >
@@ -46,7 +51,7 @@ export const MiniSummaryCard = ({
         {showDelete && (
           <button
             type="button"
-            aria-label={`Delete ${heading} ${index}`}
+            aria-label={`Delete ${ariaButtonLabels}`}
             className="usa-button summary-card-delete-button vads-u-margin--0 vads-u-padding--1"
             onClick={onDelete}
           >
@@ -70,6 +75,7 @@ MiniSummaryCard.propTypes = {
     Proptypes.func,
   ]).isRequired,
   heading: Proptypes.string.isRequired,
+  ariaLabel: Proptypes.string,
   body: Proptypes.object,
   index: Proptypes.number,
   showDelete: Proptypes.bool,

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -758,6 +758,7 @@ const formConfig = {
           editModeOnReviewPage: true,
           CustomPage: EnhancedVehicleRecord,
           CustomPageReview: null,
+          returnUrl: '/vehicles-summary',
         },
         vehiclesSummary: {
           path: 'vehicles-summary',

--- a/src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx
+++ b/src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx
@@ -69,6 +69,9 @@ const VehicleSummaryWidget = ({
           ) : (
             automobiles.map((vehicle, index) => (
               <MiniSummaryCard
+                ariaLabel={`Vehicle ${index + 1} ${vehicle.year || ''} ${
+                  vehicle.make
+                } ${vehicle.model}`}
                 editDestination={{
                   pathname: '/your-vehicle-records',
                   search: `?index=${index}`,
@@ -76,7 +79,7 @@ const VehicleSummaryWidget = ({
                 heading={`${vehicle.year || ''} ${vehicle.make} ${
                   vehicle.model
                 }`}
-                key={vehicle.make + vehicle.model + vehicle.year}
+                key={index + vehicle.make + vehicle.model + vehicle.year}
                 onDelete={() => onDelete(index)}
                 showDelete
                 body={cardBody(vehicle.resaleValue)}

--- a/src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx
+++ b/src/applications/financial-status-report/pages/assets/vehicles/VehicleSummaryWidget.jsx
@@ -18,7 +18,7 @@ const VehicleSummaryWidget = ({
   contentAfterButtons,
 }) => {
   const { assets } = data;
-  const { automobiles } = assets || [];
+  const { automobiles = [] } = assets;
 
   useEffect(() => {
     clearJobIndex();
@@ -38,10 +38,6 @@ const VehicleSummaryWidget = ({
   const onDelete = deleteIndex => {
     setFormData({
       ...data,
-      questions: {
-        ...data.questions,
-        hasVehicle: deleteIndex !== 0,
-      },
       assets: {
         ...assets,
         automobiles: automobiles.filter(
@@ -109,7 +105,16 @@ VehicleSummaryWidget.propTypes = {
   contentAfterButtons: PropTypes.object,
   contentBeforeButtons: PropTypes.object,
   data: PropTypes.shape({
-    assets: PropTypes.array,
+    assets: PropTypes.shape({
+      automobiles: PropTypes.arrayOf(
+        PropTypes.shape({
+          make: PropTypes.string,
+          model: PropTypes.string,
+          year: PropTypes.string,
+          resaleValue: PropTypes.string,
+        }),
+      ),
+    }),
     questions: PropTypes.shape({
       hasVehicle: PropTypes.bool,
     }),

--- a/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/creditCardBills/CreditCardBillSummary.jsx
@@ -86,6 +86,7 @@ const CreditCardBillSummary = ({
           ) : (
             creditCardBills.map((bill, index) => (
               <MiniSummaryCard
+                ariaLabel={`Credit card bill ${index + 1}`}
                 editDestination={{
                   pathname: '/your-credit-card-bills',
                   search: `?index=${index}`,

--- a/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
+++ b/src/applications/financial-status-report/pages/expenses/repayments/InstallmentContractSummary.jsx
@@ -93,12 +93,13 @@ const InstallmentContractSummary = ({
           ) : (
             installmentContracts.map((bill, index) => (
               <MiniSummaryCard
+                ariaLabel={`Installment contract ${index + 1} ${bill.purpose}`}
                 editDestination={{
                   pathname: '/your-installment-contracts',
                   search: `?index=${index}`,
                 }}
                 heading={bill.purpose}
-                key={bill.minPaymentAmount + bill.unpaidBalance}
+                key={index + bill.minPaymentAmount + bill.unpaidBalance}
                 onDelete={() => onDelete(index)}
                 showDelete
                 body={billBody(bill)}


### PR DESCRIPTION
## Summary
Added the option for aria-labels on mini summary cards. Previously we just used `header + index`, this adds the option for custom labeling that edit and delete buttons also use (`Edit <custom-label>` & `Delete <custom-label>`). 

Also addressed some navigation issues with Vehicle/Vehicle Summary page. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#58973

## Testing done
Manual testing completed with inspecting element

## What areas of the site does it impact?
FSR - pages hidden behind efsr flag.
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user