### PR TITLE
Remove phone instructions from past phone appointment

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -82,7 +82,7 @@ export default function DetailsVA({ appointment, facilityData }) {
       <StatusAlert appointment={appointment} facility={facility} />
       <ShowTypeOfCare />
       {displayTypeHeader && <TypeHeader>{header}</TypeHeader>}
-      <PhoneInstructions appointment={appointment} />
+      {!isPastAppointment && <PhoneInstructions appointment={appointment} />}
       <VAFacilityLocation
         facility={facility}
         facilityName={facility?.name}

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/PhoneInstructions.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/PhoneInstructions.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { APPOINTMENT_STATUS } from '../../../utils/constants';
 
 export default function PhoneInstructions({ appointment }) {
@@ -10,9 +11,13 @@ export default function PhoneInstructions({ appointment }) {
   }
 
   return (
-    <div className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
+    <div className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--3">
       Someone from your VA facility will call you at your phone number on file
       at the appointment time.
     </div>
   );
 }
+
+PhoneInstructions.propTypes = {
+  appointment: PropTypes.object.isRequired,
+};

--- a/src/applications/vaos/components/VAFacilityLocation.jsx
+++ b/src/applications/vaos/components/VAFacilityLocation.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { getRealFacilityId } from '../utils/appointment';
 import FacilityAddress from './FacilityAddress';
 import NewTabAnchor from './NewTabAnchor';
@@ -10,7 +11,6 @@ export default function VAFacilityLocation({
   facilityId,
   clinicFriendlyName,
   showCovidPhone,
-  isPhone,
 }) {
   let content = null;
 
@@ -50,17 +50,6 @@ export default function VAFacilityLocation({
 
   const name = clinicName || facilityName || facility?.name;
 
-  if (isPhone) {
-    return (
-      <>
-        <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
-          {name}
-        </h2>
-        <div>{content}</div>
-      </>
-    );
-  }
-
   return (
     <>
       {name}
@@ -68,3 +57,12 @@ export default function VAFacilityLocation({
     </>
   );
 }
+
+VAFacilityLocation.propTypes = {
+  clinicFriendlyName: PropTypes.string,
+  clinicName: PropTypes.string,
+  facility: PropTypes.object,
+  facilityId: PropTypes.string,
+  facilityName: PropTypes.string,
+  showCovidPhone: PropTypes.bool,
+};

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -308,6 +308,24 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       start: futureDate.format(),
       status: 'cancelled',
       cancelationReason: { coding: [{ code: 'pat' }] },
+      location: {
+        id: '983GC',
+        type: 'appointments',
+        attributes: {
+          id: '983GC',
+          vistaSite: '983GC',
+          name: 'Cheyenne VA Medical Center',
+          lat: 39.744507,
+          long: -104.830956,
+          phone: { main: '307-778-7550' },
+          physicalAddress: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+        },
+      },
     };
 
     mockSingleClinicFetchByVersion({
@@ -317,22 +335,6 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       version: 2,
     });
     mockSingleVAOSAppointmentFetch({ appointment });
-
-    mockFacilityFetchByVersion({
-      facility: createMockFacilityByVersion({
-        id: '442GC',
-        name: 'Cheyenne VA Medical Center',
-        phone: '970-224-1550',
-        address: {
-          postalCode: '82001-5356',
-          city: 'Cheyenne',
-          state: 'WY',
-          line: ['2360 East Pershing Boulevard'],
-        },
-        version: 0,
-      }),
-      version: 0,
-    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState: myInitialState,
@@ -371,9 +373,10 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       screen.queryByText(
         /Someone from your VA facility will call you at your phone number/i,
       ),
-    ).to.not.to.exist;
+    ).to.be.null;
 
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
+
     expect(await screen.findByText(/Cheyenne VA Medical Center/)).to.be.ok;
     expect(await screen.findByText(/Some fancy clinic name/)).to.be.ok;
     expect(screen.getByTestId('facility-telephone')).to.exist;

--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -157,9 +157,7 @@ describe('VAOS appointment list', () => {
       cy.get('[data-cy=va-appointment-details-header]')
         .should('exist')
         .contains('VA appointment over the phone');
-      cy.get('h2', { timeout: Timeouts.slow })
-        .should('be.visible')
-        .and('contain', 'Cheyenne VA Medical Center');
+      cy.findByText('Cheyenne VA Medical Center').should('exist');
 
       cy.axeCheckBestPractice();
     });


### PR DESCRIPTION

## Summary
Past phone appointment should not display phone instructions. The page details should match the [copy doc.](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/content/copy-docs/appointment-details.md#va-phone-booked-past) and the [design spec](https://www.figma.com/file/twogqAIoOL9WAFRqvUbwiS/VAOS-Templates?type=design&node-id=54-11449)

- Remove phone instructions from past phone appointment. 
- Facility Name should not styled in h2. It should be in plain text.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#59170


## Testing done

unit and e2e test

## Screenshots


**Past Phone Appt**

<img width="367" alt="Screenshot 2023-06-06 at 9 01 48 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/c8191e22-6566-45a0-94ab-7b2582d94083">

**Cancelled Phone Appt**

<img width="367" alt="Screenshot 2023-06-06 at 8 59 02 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/60b82014-2b1f-4202-8626-88b4497469b2">

**Upcoming Phone Appt**

<img width="365" alt="Screenshot 2023-06-06 at 8 57 40 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/876d1636-69f3-4f5a-b6f3-bfb9f9e67239">

## What areas of the site does it impact?

VAOS phone appointments

## Acceptance criteria

- [ ]  Remove phone instructions from past phone appointment. 
- [ ] Facility Name should not styled in h2. It should be in plain text.
- [ ] The page details should match the [copy doc.](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/content/copy-docs/appointment-details.md#va-phone-booked-past) and [design spec](https://www.figma.com/file/twogqAIoOL9WAFRqvUbwiS/VAOS-Templates?type=design&node-id=54-11449)


