### PR TITLE
21-10210 - Un-mock Confirmation-page Applicant-name

### DIFF
--- a/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
@@ -3,6 +3,24 @@ import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 
 import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
+import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../definitions/constants';
+
+const getPreparerFullName = formData => {
+  const { claimOwnership, claimantType } = formData;
+  let fullName = formData.veteranFullName; // Flow 1: self claim, vet claimant
+
+  if (claimOwnership && claimOwnership === CLAIM_OWNERSHIPS.SELF) {
+    if (claimantType && claimantType === CLAIMANT_TYPES.NON_VETERAN) {
+      // Flow 3: self claim, non-vet claimant
+      fullName = formData.claimantFullName;
+    }
+  } else {
+    // Flows 2 & 4: third-party claim
+    fullName = formData.witnessFullName;
+  }
+
+  return fullName;
+};
 
 const content = {
   headlineText: 'You’ve successfully submitted your Lay/Witness Statement',
@@ -13,13 +31,13 @@ const content = {
 export const ConfirmationPage = () => {
   const form = useSelector(state => state.form || {});
   const { submission } = form;
-  const fullName = { first: 'John', middle: 'M', last: 'Doe', suffix: 'Jr.' };
+  const preparerFullName = getPreparerFullName(form.data);
   const submitDate = submission.timestamp;
   const confirmationNumber = submission.response?.confirmationNumber;
 
   return (
     <ConfirmationPageView
-      submitterName={fullName}
+      submitterName={preparerFullName}
       submitDate={submitDate}
       confirmationNumber={confirmationNumber}
       content={content}


### PR DESCRIPTION
## Summary

- Replace Lay/Witness Statement (21-10210) Confirmation page's mocked Applicant name with real name from form data.
- Team: VA Product Forms
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#316
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website-forms#298

## Testing done

- Local E2E-spec passed successfully

## What areas of the site does it impact?

ONLY this new (WIP) form.
