### PR TITLE
Fix undefined contestable issues error

### DIFF
--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -138,6 +138,9 @@ describe('getContestableIssues', () => {
     };
     expect(getContestableIssues(formData)).to.deep.equal([issue2.result]);
   });
+  it('should return empty array', () => {
+    expect(getContestableIssues()).to.deep.equal([]);
+  });
 });
 
 describe('addIncludedIssues', () => {

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -134,8 +134,8 @@ export const createIssueName = ({ attributes } = {}) => {
  * @param {ContestableIssues}
  * @returns {ContestableIssue~Submittable}
  */
-export const getContestableIssues = ({ contestableIssues }) =>
-  contestableIssues.filter(issue => issue[SELECTED]).map(issue => {
+export const getContestableIssues = ({ contestableIssues } = {}) =>
+  (contestableIssues || []).filter(issue => issue[SELECTED]).map(issue => {
     const attr = issue.attributes;
     const attributes = [
       'decisionIssueId',

--- a/src/applications/appeals/995/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/submit.unit.spec.js
@@ -118,6 +118,9 @@ describe('getContestedIssues', () => {
     };
     expect(getContestedIssues(formData)).to.deep.equal([issue2.result]);
   });
+  it('should return empty array', () => {
+    expect(getContestedIssues()).to.deep.equal([]);
+  });
 });
 
 describe('removeEmptyEntries', () => {

--- a/src/applications/appeals/995/utils/submit.js
+++ b/src/applications/appeals/995/utils/submit.js
@@ -98,8 +98,8 @@ export const createIssueName = ({ attributes } = {}) => {
   }
 }]
 */
-export const getContestedIssues = ({ contestedIssues = [] }) =>
-  contestedIssues.filter(issue => issue[SELECTED]).map(issue => {
+export const getContestedIssues = ({ contestedIssues } = {}) =>
+  (contestedIssues || []).filter(issue => issue[SELECTED]).map(issue => {
     const attr = issue.attributes;
     const attributes = [
       'decisionIssueId',

--- a/src/applications/appeals/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/submit.unit.spec.js
@@ -102,6 +102,9 @@ describe('getContestedIssues', () => {
     };
     expect(getContestedIssues(formData)).to.deep.equal([issue2.result]);
   });
+  it('should return empty array', () => {
+    expect(getContestedIssues()).to.deep.equal([]);
+  });
 });
 
 describe('addAreaOfDisagreement', () => {

--- a/src/applications/appeals/996/utils/submit.js
+++ b/src/applications/appeals/996/utils/submit.js
@@ -96,8 +96,8 @@ export const createIssueName = ({ attributes } = {}) => {
   }
 }]
 */
-export const getContestedIssues = ({ contestedIssues = [] }) =>
-  contestedIssues.filter(issue => issue[SELECTED]).map(issue => {
+export const getContestedIssues = ({ contestedIssues } = {}) =>
+  (contestedIssues || []).filter(issue => issue[SELECTED]).map(issue => {
     const attr = issue.attributes;
     const attributes = [
       'decisionIssueId',


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Sentry events show that the Notice of Disagreement form has some of the following errors:
  > - `Cannot read properties of undefined (reading 'filter')`
  > - `undefined is not an object (evaluating 'e.contestableIssues.filter') TypeError`
  > When this happens the Veteran's contestable issues are either not loaded or they do not have any eligible issues, according to the business rules. This may be `undefined` in the form data. To prevent this JS error, we need to ensure the submit transformer has an empty array to fall back on. The similar code in our HLR & SC forms has also been updated; but they never showed this error in the past.
- _(If bug, how to reproduce)_
  > Log into a user without any contestable issues (e.g. user 0); attempt to submit a NOD - a JS error will block submision.
- _(What is the solution, why is this the solution)_
  > Fallback to an empty array
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#59997](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59997)

## Testing done

- _Describe what the old behavior was prior to the change_
 > JS error prevents submission
- _Describe the steps required to verify your changes are working as expected_
  > Added unit tests, all passing
- _Describe the tests completed and the results_
  > Call transformer function with no parameters, return an empty array
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement, but HLR & Supplemental Claims code was also updated to ensure they never have this error

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
