### PR TITLE
Allow submit for form 21p-0847

### DIFF
--- a/src/applications/simple-forms/21P-0847/config/form.js
+++ b/src/applications/simple-forms/21P-0847/config/form.js
@@ -5,6 +5,7 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import getHelp from '../../shared/components/GetFormHelp';
+import transformForSubmit from '../../shared/config/submit-transformer';
 
 import preparerPersonalInformation from '../pages/preparerPersonalInformation';
 import preparerIdentificationInformation from '../pages/preparerIdentificationInformation';
@@ -27,9 +28,8 @@ const mockData = testData;
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  // submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
-  submit: () =>
-    Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
+  submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  transformForSubmit,
   trackingPrefix: '21P-0847-substitute-claimant-',
   dev: {
     showNavLinks: true,


### PR DESCRIPTION
Need [vets-api PR adding form](https://github.com/department-of-veterans-affairs/vets-api/pull/12960) to be merged first

## Summary

- Remove mock submit and allow full end-to-end submission
- Add shared `transformForSubmit` to config so that we add the form_number to the payload

## Testing done

- Tested locally with vets-api running

## What areas of the site does it impact?
21P-0847
