### PR TITLE
Add "update" to Recreational vehicles estimate on review & submit page

### DIFF
--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -790,7 +790,7 @@ const formConfig = {
           depends: formData =>
             formData.questions.hasRecreationalVehicle &&
             formData['view:combinedFinancialStatusReport'],
-          editModeOnReviewPage: true,
+          editModeOnReviewPage: false,
         },
         recreationalVehicleRecordsListLoop: {
           path: 'recreational-vehicle-records',


### PR DESCRIPTION

## Summary

This PR adds the update button to recreational vehicles on the review and submit page


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#59851


## Testing done

- Prior to this PR the user was unable to update the estimated value of their recreational vehicles
- Manual Testing
- Cypress Runs


## Screenshots



_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
![Screenshot 2023-06-12 at 1 18 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/6ba47da5-6e9a-4cde-a942-60f2354b5fa2)

![Screenshot 2023-06-12 at 1 18 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/d7b71463-248d-4046-8ac4-d0dabfe1b857)


## What areas of the site does it impact?

Financial Status Report

## Acceptance criteria

### Quality Assurance & Testing

- [x] User is able to add an estimated value and update the review and submit page on the FSR form


