### PR TITLE
Notice of Disagreement | Prevent JS error with undefined disagreement options

### DIFF
--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -249,6 +249,13 @@ describe('addAreaOfDisagreement', () => {
       'service connection,effective date,disability evaluation,this is an other entry',
     );
   });
+  it('should not throw a JS error with no disagreement options', () => {
+    const formData = {
+      areaOfDisagreement: [],
+    };
+    const result = addAreaOfDisagreement([issue1.result], formData);
+    expect(result[0].attributes.disagreementArea).to.equal('');
+  });
 });
 
 describe('addUploads', () => {

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -217,7 +217,7 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
   };
   return issues.map((issue, index) => {
     const entry = areaOfDisagreement[index];
-    const reasons = Object.entries(entry.disagreementOptions)
+    const reasons = Object.entries(entry?.disagreementOptions || {})
       .map(([key, value]) => value && keywords[key](entry))
       .concat((entry?.otherEntry || '').trim())
       .filter(Boolean);


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While review Sentry errors, we noticed a [`TypeError: Cannot read properties of undefined (reading `disagreementOptions`)](http://sentry.vfs.va.gov/organizations/vsp/discover/results/?display=top5&field=title&field=count%28%29&field=count_unique%28user%29&field=project&name=Errors+by+Title&query=event.type%3Aerror+disagreementOptions&sort=-count&statsPeriod=90d&widths=-1&widths=-1&widths=-1&widths=-1) while investigating, we were able to replicate this error, but still not sure how the end user got into this situation. This PR prevents a JS error. We also verified that the missing data will highlight the accordion to notify the Veteran that information is missing. 
- _(If bug, how to reproduce)_
  > No idea - the Veteran somehow bypassed the area of disagreement followup question page
- _(What is the solution, why is this the solution)_
  > Prevent JS error using optional chaining and a fallback empty object
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#59997](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59997)

## Testing done

- _Describe what the old behavior was prior to the change_
  > A missing `disagreementOptions` object would cause a JS error
- _Describe the steps required to verify your changes are working as expected_
  > Use the save in progress menu to bypass the area of disagreement page(s), then while attempting to submit, the area of disagreement pages should error highlight - and no JS error occurs that blocks page interaction
- _Describe the tests completed and the results_
  > Added unit test
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
