### PR TITLE
Add screen reader support for veterans statement of truth

### DIFF
--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -5,8 +5,16 @@ import environment from 'platform/utilities/environment';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-const statement =
-  'Veteran’s statement of truth: I’ve reviewed the information I provided in this request, including: my marital status and number of dependents, my income (and my spouse’s income if included), my household assets and expenses, my bankruptcy history.';
+const statementOfTruthItems = [
+  'My marital status and number of dependents',
+  'My income (and my spouse’s income if included)',
+  'My household assets and expenses',
+  'My bankruptcy history',
+];
+
+const statement = `Veteran’s statement of truth: I’ve reviewed the information I provided in this request, including: ${statementOfTruthItems.join(
+  ', ',
+)}`;
 
 const PreSubmitSignature = ({
   formData,
@@ -129,10 +137,9 @@ const PreSubmitSignature = ({
         I’ve reviewed the information I provided in this request, including:
       </p>
       <ul>
-        <li>My marital status and number of dependents</li>
-        <li>My income (and my spouse’s income if included)</li>
-        <li>My household assets and expenses</li>
-        <li>My bankruptcy history</li>
+        {statementOfTruthItems.map((item, index) => {
+          return <li key={index}>{item}</li>;
+        })}
       </ul>
     </div>
   );

--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -12,7 +12,7 @@ const statementOfTruthItems = [
   'My bankruptcy history',
 ];
 
-const statement = `Veteran’s statement of truth: I’ve reviewed the information I provided in this request, including: ${statementOfTruthItems.join(
+const veteranStatement = `Veteran’s statement of truth: I’ve reviewed the information I provided in this request, including: ${statementOfTruthItems.join(
   ', ',
 )}`;
 
@@ -129,20 +129,6 @@ const PreSubmitSignature = ({
       </div>
     );
   }
-  const statementOfTruth = (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    <div tabIndex={0}>
-      <h3>Veteran’s statement of truth</h3>
-      <p>
-        I’ve reviewed the information I provided in this request, including:
-      </p>
-      <ul>
-        {statementOfTruthItems.map((item, index) => {
-          return <li key={index}>{item}</li>;
-        })}
-      </ul>
-    </div>
-  );
 
   return (
     <>
@@ -154,7 +140,15 @@ const PreSubmitSignature = ({
       </p>
 
       <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--6 vads-u-padding-x--3 vads-u-padding-top--1px">
-        {statementOfTruth}
+        <h3>Veteran’s statement of truth</h3>
+        <p>
+          I’ve reviewed the information I provided in this request, including:
+        </p>
+        <ul>
+          {statementOfTruthItems.map((item, index) => {
+            return <li key={index}>{item}</li>;
+          })}
+        </ul>
 
         <VaTextInput
           label="Veteran's full name"
@@ -163,7 +157,7 @@ const PreSubmitSignature = ({
           name="veteran-signature"
           onInput={setNewSignature}
           type="text"
-          message-aria-describedby={statement}
+          messageAriaDescribedby={veteranStatement}
           required
           error={
             signatureError

--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -117,6 +117,21 @@ const PreSubmitSignature = ({
       </div>
     );
   }
+  const statementOfTruth = (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    <div tabIndex={0}>
+      <h3>Veteran’s statement of truth</h3>
+      <p>
+        I’ve reviewed the information I provided in this request, including:
+      </p>
+      <ul>
+        <li>My marital status and number of dependents</li>
+        <li>My income (and my spouse’s income if included)</li>
+        <li>My household assets and expenses</li>
+        <li>My bankruptcy history</li>
+      </ul>
+    </div>
+  );
 
   return (
     <>
@@ -128,16 +143,7 @@ const PreSubmitSignature = ({
       </p>
 
       <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--6 vads-u-padding-x--3 vads-u-padding-top--1px">
-        <h3>Veteran’s statement of truth</h3>
-        <p>
-          I’ve reviewed the information I provided in this request, including:
-        </p>
-        <ul>
-          <li>My marital status and number of dependents</li>
-          <li>My income (and my spouse’s income if included)</li>
-          <li>My household assets and expenses</li>
-          <li>My bankruptcy history</li>
-        </ul>
+        {statementOfTruth}
 
         <va-text-input
           label={"Veteran's full name"}

--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import environment from 'platform/utilities/environment';
 import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const statement =
+  'Veteran’s statement of truth: I’ve reviewed the information I provided in this request, including: my marital status and number of dependents, my income (and my spouse’s income if included), my household assets and expenses, my bankruptcy history.';
 
 const PreSubmitSignature = ({
   formData,
@@ -145,13 +149,14 @@ const PreSubmitSignature = ({
       <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--6 vads-u-padding-x--3 vads-u-padding-top--1px">
         {statementOfTruth}
 
-        <va-text-input
-          label={"Veteran's full name"}
+        <VaTextInput
+          label="Veteran's full name"
           class="signature-input"
           id="veteran-signature"
           name="veteran-signature"
           onInput={setNewSignature}
           type="text"
+          message-aria-describedby={statement}
           required
           error={
             signatureError


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

In our Staging Review on 6/9/23, this Accessibility feedback was provided as "launch-blocking" for our FSR enhancement work. Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/60036

Reference ticket [#57662](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57662)

Additional Context:

On Step 7 of 7 when reviewing your information prior to submitting, there's a difficult usability challenge that we identified with some other forms around the Veteran's Statement of Truth.

If you're a screen reader user, by the time you get to this point you've likely gotten into the rhythm of just hitting [tab] over and over again to move between interactive elements in the workflow. For the most part, there's no reason you would ever have your screen reader announce the full text of the page.

But when you reach this review page, there's a [tab] jump from the last accordion straight to the "Veteran's full name" input. If you're tabbing through the page, you'll hear "Veteran's full name" but you won't hear any of the statement of truth text that goes with it. The legal fine print is essentially hidden from screen reader users. It's there and technically accessible, but unlikely to be noticed.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#60087


## Testing done

- Manual testing
- Testing with google screen reader extention
- Cypress

## Screenshots
![Screenshot 2023-06-13 at 1 59 53 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/b17f24bc-d843-4f4f-bb04-4b04b005457e)


## What areas of the site does it impact?

Financial Status Report

## Acceptance criteria

### Quality Assurance & Testing

- [X] Tested fix with google screen reader extention
- [x] Tested that form is still able to submit

### Error Handling

- [x] Browser console contains no warnings or errors.



