### PR TITLE
58745 VAMC updates

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -337,5 +337,3 @@ export const CHAR_LIMITS = [
 
 // migration max string length
 export const MAX_HOUSING_STRING_LENGTH = 500;
-
-export const NO_FACILITY = 'Facility name not provided';

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -337,3 +337,5 @@ export const CHAR_LIMITS = [
 
 // migration max string length
 export const MAX_HOUSING_STRING_LENGTH = 500;
+
+export const NO_FACILITY = 'Facility name not provided';

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'platform/utilities/data';
-import { DATA_PATHS, NO_FACILITY } from '../constants';
+import { DATA_PATHS } from '../constants';
 
 export const summaryOfEvidenceDescription = ({ formData }) => {
   const vaEvidence = _.get('vaTreatmentFacilities', formData, []);
@@ -69,7 +69,7 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
 
   if (vaEvidence.length && vaEvidenceSelected) {
     const facilitiesList = vaEvidence.map((facility, index) => (
-      <li key={index}>{facility.treatmentCenterName || NO_FACILITY}</li>
+      <li key={index}>{facility.treatmentCenterName}</li>
     ));
     vaContent = (
       <div>

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'platform/utilities/data';
-import { DATA_PATHS } from '../constants';
+import { DATA_PATHS, NO_FACILITY } from '../constants';
 
 export const summaryOfEvidenceDescription = ({ formData }) => {
   const vaEvidence = _.get('vaTreatmentFacilities', formData, []);
@@ -69,9 +69,7 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
 
   if (vaEvidence.length && vaEvidenceSelected) {
     const facilitiesList = vaEvidence.map((facility, index) => (
-      <li key={index}>
-        {facility.treatmentCenterName || 'Facility name not provided'}
-      </li>
+      <li key={index}>{facility.treatmentCenterName || NO_FACILITY}</li>
     ));
     vaContent = (
       <div>

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -68,8 +68,10 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
   );
 
   if (vaEvidence.length && vaEvidenceSelected) {
-    const facilitiesList = vaEvidence.map(facility => (
-      <li key={facility.treatmentCenterName}>{facility.treatmentCenterName}</li>
+    const facilitiesList = vaEvidence.map((facility, index) => (
+      <li key={index}>
+        {facility.treatmentCenterName || 'Facility name not provided'}
+      </li>
     ));
     vaContent = (
       <div>
@@ -122,7 +124,7 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
     );
     serviceTreatmentRecordsContent = (
       <div>
-        <p>We'll submit the below service treatment records you uploaded:</p>
+        <p>We’ll submit the below service treatment records you uploaded:</p>
         <ul>{serviceTreatmentRecordsUploadsList}</ul>
       </div>
     );

--- a/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatDate } from '../utils';
+import { NO_FACILITY } from '../constants';
 
 const MONTH_YEAR = 'MMMM YYYY';
 
@@ -9,7 +10,7 @@ const replaceDay = date => date.replace('XX', '01');
 export const treatmentView = ({ formData }) => {
   const { from } = formData.treatmentDateRange;
 
-  const name = formData.treatmentCenterName || 'Facility name not provided';
+  const name = formData.treatmentCenterName || NO_FACILITY;
   let treatmentPeriod = '';
   if (from) {
     treatmentPeriod = formatDate(replaceDay(from), MONTH_YEAR);

--- a/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { formatDate } from '../utils';
-import { NO_FACILITY } from '../constants';
 
 const MONTH_YEAR = 'MMMM YYYY';
 
@@ -10,7 +9,7 @@ const replaceDay = date => date.replace('XX', '01');
 export const treatmentView = ({ formData }) => {
   const { from } = formData.treatmentDateRange;
 
-  const name = formData.treatmentCenterName || NO_FACILITY;
+  const name = formData.treatmentCenterName;
   let treatmentPeriod = '';
   if (from) {
     treatmentPeriod = formatDate(replaceDay(from), MONTH_YEAR);

--- a/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
@@ -9,7 +9,7 @@ const replaceDay = date => date.replace('XX', '01');
 export const treatmentView = ({ formData }) => {
   const { from } = formData.treatmentDateRange;
 
-  const name = formData.treatmentCenterName || '';
+  const name = formData.treatmentCenterName || 'Facility name not provided';
   let treatmentPeriod = '';
   if (from) {
     treatmentPeriod = formatDate(replaceDay(from), MONTH_YEAR);

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,6 +1,7 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateUI from 'platform/forms-system/src/js/definitions/monthYear';
 import { treatmentView } from '../content/vaMedicalRecords';
+import { hasVAEvidence } from '../utils';
 import { makeSchemaForAllDisabilities } from '../utils/schemas';
 
 import {
@@ -8,7 +9,7 @@ import {
   validateMilitaryTreatmentState,
   startedAfterServicePeriod,
 } from '../validations';
-import { USA } from '../constants';
+import { NO_FACILITY, USA } from '../constants';
 
 const { vaTreatmentFacilities } = fullSchema.properties;
 
@@ -23,10 +24,13 @@ export const uiSchema = {
   vaTreatmentFacilities: {
     'ui:options': {
       itemName: 'Facility',
-      itemAriaLabel: data =>
-        data.treatmentCenterName || 'Facility name not provided',
+      itemAriaLabel: data => data.treatmentCenterName || NO_FACILITY,
       viewField: treatmentView,
       showSave: true,
+      updateSchema: (formData, schema) => ({
+        ...schema,
+        minItems: hasVAEvidence(formData) ? 1 : 0,
+      }),
     },
     items: {
       'ui:order': [

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -8,23 +8,22 @@ import {
   validateMilitaryTreatmentCity,
   validateMilitaryTreatmentState,
   startedAfterServicePeriod,
+  validateBooleanGroup,
 } from '../validations';
-import { NO_FACILITY, USA } from '../constants';
+import { USA } from '../constants';
 
 const { vaTreatmentFacilities } = fullSchema.properties;
 
 export const uiSchema = {
-  'ui:description':
-    'First we’ll ask you about your VA medical records for your claimed disability.',
   'view:vaMedicalRecordsIntro': {
     'ui:title': 'VA medical records',
     'ui:description':
-      "Tell us where VA has treated you for your disability. We'll use the information you provide to search for your records",
+      'Tell us where VA has treated you for your disability. We’ll use the information you provide to help us locate your records and make decisions on your claim.',
   },
   vaTreatmentFacilities: {
     'ui:options': {
       itemName: 'Facility',
-      itemAriaLabel: data => data.treatmentCenterName || NO_FACILITY,
+      itemAriaLabel: data => data.treatmentCenterName,
       viewField: treatmentView,
       showSave: true,
       updateSchema: (formData, schema) => ({
@@ -52,6 +51,11 @@ export const uiSchema = {
           updateSchema: makeSchemaForAllDisabilities,
           itemAriaLabel: data => data.treatmentCenterName,
           showFieldLabel: true,
+        },
+        'ui:validations': [validateBooleanGroup],
+        'ui:errorMessages': {
+          atLeastOne: 'Please select at least one condition',
+          required: 'Please select at least one condition',
         },
       },
       treatmentDateRange: {
@@ -99,6 +103,7 @@ export const schema = {
       minItems: 0, // fixes validation issue
       items: {
         type: 'object',
+        required: ['treatmentCenterName', 'treatedDisabilityNames'],
         properties: {
           treatmentCenterName:
             vaTreatmentFacilities.items.properties.treatmentCenterName,

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,16 +1,12 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/definitions/autosuggest';
 import dateUI from 'platform/forms-system/src/js/definitions/monthYear';
-
 import { treatmentView } from '../content/vaMedicalRecords';
-import { queryForFacilities, hasVAEvidence } from '../utils';
 import { makeSchemaForAllDisabilities } from '../utils/schemas';
 
 import {
   validateMilitaryTreatmentCity,
   validateMilitaryTreatmentState,
   startedAfterServicePeriod,
-  validateBooleanGroup,
 } from '../validations';
 import { USA } from '../constants';
 
@@ -22,18 +18,15 @@ export const uiSchema = {
   'view:vaMedicalRecordsIntro': {
     'ui:title': 'VA medical records',
     'ui:description':
-      'Please tell us where VA treated you for your disability.',
+      "Tell us where VA has treated you for your disability. We'll use the information you provide to search for your records",
   },
   vaTreatmentFacilities: {
     'ui:options': {
       itemName: 'Facility',
-      itemAriaLabel: data => data.treatmentCenterName,
+      itemAriaLabel: data =>
+        data.treatmentCenterName || 'Facility name not provided',
       viewField: treatmentView,
       showSave: true,
-      updateSchema: (formData, schema) => ({
-        ...schema,
-        minItems: hasVAEvidence(formData) ? 1 : 0,
-      }),
     },
     items: {
       'ui:order': [
@@ -45,17 +38,9 @@ export const uiSchema = {
       'ui:options': {
         itemAriaLabel: data => data.treatmentCenterName,
       },
-      treatmentCenterName: autoSuggestUiSchema(
-        'Name of VA medical facility',
-        queryForFacilities,
-        {
-          'ui:options': { queryForResults: true, freeInput: true },
-          'ui:errorMessages': {
-            maxLength: 'Please enter a name with fewer than 100 characters.',
-            pattern: 'Please enter a valid name.',
-          },
-        },
-      ),
+      treatmentCenterName: {
+        'ui:title': 'Name of VA medical facility',
+      },
       treatedDisabilityNames: {
         'ui:title':
           'Please choose the conditions for which you received treatment at this facility.',
@@ -63,11 +48,6 @@ export const uiSchema = {
           updateSchema: makeSchemaForAllDisabilities,
           itemAriaLabel: data => data.treatmentCenterName,
           showFieldLabel: true,
-        },
-        'ui:validations': [validateBooleanGroup],
-        'ui:errorMessages': {
-          atLeastOne: 'Please select at least one condition',
-          required: 'Please select at least one condition',
         },
       },
       treatmentDateRange: {
@@ -115,7 +95,6 @@ export const schema = {
       minItems: 0, // fixes validation issue
       items: {
         type: 'object',
-        required: ['treatmentCenterName', 'treatedDisabilityNames'],
         properties: {
           treatmentCenterName:
             vaTreatmentFacilities.items.properties.treatmentCenterName,

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -77,6 +77,33 @@ describe('VA Medical Records', () => {
     form.unmount();
   });
 
+  it('should not submit without all required info', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          ratedDisabilities,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasVaMedicalRecords': true,
+            },
+          },
+          vaTreatmentFacilities: [],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    // Required fields: Facility name and related disability
+    expect(form.find('.usa-input-error-message').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
   it('should not submit when treatment start date precedes service start date', () => {
     const onSubmit = sinon.spy();
     const form = mount(
@@ -172,7 +199,7 @@ describe('VA Medical Records', () => {
           ratedDisabilities,
           vaTreatmentFacilities: [
             {
-              treatmentCenterName: 'Sommerset VA Clinic',
+              treatmentCenterName: 'Test clinic',
               treatedDisabilityNames: {
                 diabetesmelitus: true,
               },
@@ -182,40 +209,6 @@ describe('VA Medical Records', () => {
               treatmentCenterAddress: {
                 country: 'USA',
                 city: 'Sommerset',
-                state: 'VA',
-              },
-            },
-          ],
-        }}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
-    expect(onSubmit.calledOnce).to.be.true;
-    form.unmount();
-  });
-
-  it('should submit with sparse facility info', () => {
-    // Treatment facility is missing a name, date, and city (they are optional). VSRs look at all VAMCs in the
-    // system to assess if it’s relevant to the claim.
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{
-          ratedDisabilities,
-          vaTreatmentFacilities: [
-            {
-              treatedDisabilityNames: {
-                diabetesmelitus: true,
-              },
-
-              treatmentCenterAddress: {
-                country: 'USA',
                 state: 'VA',
               },
             },

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -43,7 +43,10 @@ describe('VA Medical Records', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(6);
+    // checking for treatmentCenterName, treatmentDateRange_fromYear, treatmentCenterAddress_city
+    expect(form.find('input').length).to.equal(3);
+
+    // checking for treatmentDateRange_fromMonth, treatmentCenterAddress_country, treatmentCenterAddress_state
     expect(form.find('select').length).to.equal(3);
     form.unmount();
   });
@@ -74,33 +77,6 @@ describe('VA Medical Records', () => {
     // Required fields: Facility name and related disability
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
-    form.unmount();
-  });
-
-  it('should not submit without all required info', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{
-          ratedDisabilities,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasVaMedicalRecords': true,
-            },
-          },
-          vaTreatmentFacilities: [],
-        }}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-    // Required fields: Facility name and related disability
-    expect(form.find('.usa-input-error-message').length).to.equal(2);
-    expect(onSubmit.called).to.be.false;
     form.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('VA Medical Records', () => {
     },
   ];
 
-  it('should render ', () => {
+  it('should render', () => {
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
@@ -43,10 +43,7 @@ describe('VA Medical Records', () => {
       />,
     );
 
-    // checking for treatmentCenterName, treatmentDateRange_fromYear, treatmentCenterAddress_city
-    expect(form.find('input').length).to.equal(3);
-
-    // checking for treatmentDateRange_fromMonth, treatmentCenterAddress_country, treatmentCenterAddress_state
+    expect(form.find('input').length).to.equal(6);
     expect(form.find('select').length).to.equal(3);
     form.unmount();
   });
@@ -74,7 +71,7 @@ describe('VA Medical Records', () => {
     );
 
     form.find('form').simulate('submit');
-    // Required fields: Facility name and related disability
+
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
     form.unmount();
@@ -185,6 +182,40 @@ describe('VA Medical Records', () => {
               treatmentCenterAddress: {
                 country: 'USA',
                 city: 'Sommerset',
+                state: 'VA',
+              },
+            },
+          ],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.calledOnce).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit with sparse facility info', () => {
+    // Treatment facility is missing a name, date, and city (they are optional). VSRs look at all VAMCs in the
+    // system to assess if it’s relevant to the claim.
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          ratedDisabilities,
+          vaTreatmentFacilities: [
+            {
+              treatedDisabilityNames: {
+                diabetesmelitus: true,
+              },
+
+              treatmentCenterAddress: {
+                country: 'USA',
                 state: 'VA',
               },
             },

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { minYear, maxYear } from 'platform/forms-system/src/js/helpers';
-import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import {
   SAVED_SEPARATION_DATE,
@@ -27,7 +26,6 @@ import {
   needsToEnter781a,
   needsToEnterUnemployability,
   newConditionsOnly,
-  queryForFacilities,
   ReservesGuardDescription,
   servedAfter911,
   viewifyFields,
@@ -179,56 +177,6 @@ describe('526 helpers', () => {
     });
     it('should return null when name is not a string', () => {
       expect(capitalizeEachWord(249481)).to.equal(null);
-    });
-  });
-
-  describe('queryForFacilities', () => {
-    beforeEach(() => {
-      mockFetch();
-      const response = [
-        { id: 0, attributes: { name: 'first' } },
-        { id: 1, attributes: { name: 'second' } },
-      ];
-      setFetchJSONResponse(global.fetch.onCall(0), response);
-    });
-
-    /* un-skip these once we get a new enpoint in place; see #14028 */
-    it.skip('should not call the api if the input length is < 3', () => {
-      queryForFacilities('12');
-      expect(global.fetch.called).to.be.false;
-    });
-
-    it.skip('should call the api if the input length is >= 3', () => {
-      queryForFacilities('123');
-      expect(global.fetch.called).to.be.true;
-    });
-
-    it.skip('should call the api with the input', () => {
-      queryForFacilities('asdf');
-      expect(global.fetch.firstCall.args[0]).to.contain(
-        '/facilities/suggested?type%5B%5D=health&type%5B%5D=dod_health&name_part=asdf',
-      );
-    });
-
-    it.skip('should return the mapped data for autosuggest if successful', () => {
-      // Doesn't matter what we call this with since our stub will always return the same thing
-      const requestPromise = queryForFacilities('asdf');
-      return requestPromise.then(result => {
-        expect(result).to.eql([
-          { id: 0, label: 'first' },
-          { id: 1, label: 'second' },
-        ]);
-      });
-    });
-
-    it('should return an empty array if unsuccessful', () => {
-      global.fetch.resolves({ ok: false });
-      // Doesn't matter what we call this with since our stub will always return the same thing
-      const requestPromise = queryForFacilities('asdf');
-      return requestPromise.then(result => {
-        // This .then() fires after the apiRequest failure callback returns []
-        expect(result).to.eql([]);
-      });
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
-// import appendQuery from 'append-query';
 import { createSelector } from 'reselect';
 import fastLevenshtein from 'fast-levenshtein';
 
@@ -211,41 +210,6 @@ export const hasForwardingAddress = formData =>
 
 export const forwardingCountryIsUSA = formData =>
   _.get('forwardingAddress.country', formData, '') === USA;
-
-export function queryForFacilities(input = '') {
-  // Only search if the input has a length >= 3, otherwise, return an empty array
-  if (input.length < 3) {
-    return Promise.resolve([]);
-  }
-
-  /**
-   * Facilities endpoint removed for now, but we may be able to use EVSS's
-   * endpoint /referencedata/v1/treatmentcenter
-   * See https://github.com/department-of-veterans-affairs/va.gov-team/issues/14028#issuecomment-765717797
-   * /
-  const url = appendQuery('/facilities/suggested', {
-    type: ['health', 'dod_health'],
-    name_part: input, // eslint-disable-line camelcase
-  });
-
-  return apiRequest(url)
-    .then(response =>
-      response.data.map(facility => ({
-        id: facility.id,
-        label: facility.attributes.name,
-      })),
-    )
-    .catch(error => {
-      Sentry.withScope(scope => {
-        scope.setExtra('input', input);
-        scope.setExtra('error', error);
-        Sentry.captureMessage('Error querying for facilities');
-      });
-      return [];
-    });
-    /* */
-  return Promise.resolve([]);
-}
 
 export function getSeparationLocations() {
   return apiRequest('/disability_compensation_form/separation_locations')


### PR DESCRIPTION
## Summary
-Remove text and update text on the va-medical-records page
-Make the Name of VA medical facility input field free form instead of autosuggest from pre-defined list
-Cleanup unused code

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/58745

## Testing done
- _Describe what the old behavior was prior to the change_
Prior to this change the facility name was using auto suggest, but users would get stuck here since the api is not working

- _Describe the steps required to verify your changes are working as expected_
1. Start fllling out an original claim
2. When you get to the supporting-evidence/evidence-types page, select 'VA medical records' for evidence types. Continue to the next page
3. Verify you can type in a facility name, other required fields and then save or continue
Note : the behavior of the array list component is to do a scroll up when clicking the save button (it will not collapse until you click 'Add another facility' button)
4. Complete the rest of the 526 form and verify you can submit successfully

- _Describe the tests completed and the results_
Manual: created and submitted (original) claims with both new and rated conditions
Unit: minor updates for unit tests
e2e tests: verified all tests still working

## Screenshots
<img width="1246" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/f5a5ee73-7bfa-486e-8907-308d738e64e5">
<img width="953" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/5cd5c1a1-5e5e-4644-87aa-223ad9ba11d8">


## What areas of the site does it impact?

526EZ form on the va-medical-records page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
