### PR TITLE
[eFSR] Fix - NaN benefits card 

### DIFF
--- a/src/applications/financial-status-report/components/EnhancedBenefits.jsx
+++ b/src/applications/financial-status-report/components/EnhancedBenefits.jsx
@@ -42,7 +42,7 @@ const NoBenefits = React.memo(() => {
   );
 });
 
-const EnhancedBenefits = ({ pending, income }) => {
+const EnhancedBenefits = ({ income, pending }) => {
   const eduReceived = income?.reduce((a, b) => a + Number(b.education), 0);
   const compReceived = income?.reduce(
     (a, b) => a + Number(b.compensationAndPension),
@@ -52,7 +52,7 @@ const EnhancedBenefits = ({ pending, income }) => {
   return !pending && (eduReceived || compReceived) ? (
     <>
       <p>This is the VA benefit information we have on file for you.</p>
-      {compReceived && (
+      {compReceived ? (
         <MiniSummaryCard
           heading="Disability compensation and pension benefits"
           showDelete={false}
@@ -63,8 +63,8 @@ const EnhancedBenefits = ({ pending, income }) => {
           body={<BenefitCard received={compReceived} />}
           index={0}
         />
-      )}
-      {eduReceived && (
+      ) : null}
+      {eduReceived ? (
         <MiniSummaryCard
           heading="Education benefits"
           editDestination={{
@@ -75,7 +75,7 @@ const EnhancedBenefits = ({ pending, income }) => {
           body={<BenefitCard received={eduReceived} />}
           index={1}
         />
-      )}
+      ) : null}
       <HotlineInfo />
     </>
   ) : (

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -338,6 +338,7 @@ const formConfig = {
           uiSchema: {},
           schema: { type: 'object', properties: {} },
           depends: () => false, // only accessible from benefits page
+          returnUrl: 'your-benefits',
         },
         socialSecurity: {
           path: 'social-security',


### PR DESCRIPTION
## Summary
Logical `&&` for conditionally rendering benefit card causing `NaN` to render to screen. Updated to ternary to explicitly return `null` if the condition is falsy
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#58978

## Testing done
Manual testing completed. Existing tests passing. 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/80799dcc-1319-4ab5-ad89-d6eda9a72458) | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/df7766d9-e68c-4069-a395-3cfcf02ee17b) |

## What areas of the site does it impact?
FSR behind enhancements flag

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
