### PR TITLE
[eFSR] Fix - Edit address missing fields

### DIFF
--- a/src/applications/financial-status-report/components/contactInfo/EditContactInfo.jsx
+++ b/src/applications/financial-status-report/components/contactInfo/EditContactInfo.jsx
@@ -64,7 +64,7 @@ const BuildPage = ({ title, field, id, goToPath }) => {
 
 BuildPage.propTypes = {
   field: PropTypes.string,
-  goToPath: PropTypes.string,
+  goToPath: PropTypes.func,
   id: PropTypes.string,
   title: PropTypes.string,
 };

--- a/src/applications/financial-status-report/components/contactInfo/EditContactInfo.jsx
+++ b/src/applications/financial-status-report/components/contactInfo/EditContactInfo.jsx
@@ -43,7 +43,11 @@ const BuildPage = ({ title, field, id, goToPath }) => {
   };
 
   return (
-    <div className="va-profile-wrapper" onSubmit={handlers.onSubmit}>
+    <div
+      className="va-profile-wrapper"
+      onSubmit={handlers.onSubmit}
+      id={`edit-${FIELD_NAMES[field]}`}
+    >
       <InitializeVAPServiceID>
         <h3 ref={headerRef}>{title}</h3>
         <ProfileInformationFieldController

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -338,6 +338,8 @@
 }
 
 /* Hide mobile phone extension entry, per design */
-form[name="Contact Info Form"] .schemaform-field-template:not(.schemaform-first-field) {
-  display: none;
+#edit-mobilePhone {
+  form[name="Contact Info Form"] .schemaform-field-template:not(.schemaform-first-field) {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
Edit address fields were missing due to previous css implementation to hide mobile phone extension input.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#60249
- _Link to previous change of the bug_ 
department-of-veterans-affairs/vets-website#24435

## Testing done
Manual testing completed. Existing tests passing.

## Screenshots
**Note:** Empty edit fields due to local screenshot when leveraging platform component. Edit mobile number still hiding extension field. 

| Before | After |
| ------ | ----- |
| ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/d276e6c1-4061-4dc6-abb1-8af90dc8742d) | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/076a53be-7bbf-4c6b-a807-eeccfd03e9b9) |
| ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/f93471d5-bca1-49cb-b250-426fde2c4b91) | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/90751c82-c8db-4edf-a816-050ad2adc636) |

## What areas of the site does it impact?
FSR behind enhanced feature flag

## Acceptance criteria
Edit address fields available, and edit number extension field hidden. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user