### PR TITLE
Fix dependent forms showing error before input in HCA Household V2 section

### DIFF
--- a/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
+++ b/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
@@ -1,0 +1,57 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+
+import {
+  dependentSchema as schema,
+  dependentUISchema as uiSchema,
+} from '../../definitions/dependent';
+
+const DependentListLoopForm = props => {
+  const { children, data, page, onChange, onSubmit } = props;
+
+  // build the uiSchema title attribute based on available form data
+  const currentUISchema = useMemo(
+    () => {
+      const { fullName = {} } = data || {};
+      const name =
+        page.id !== 'basic'
+          ? `${fullName.first} ${fullName.last}`
+          : 'Dependent';
+      return {
+        ...uiSchema[page.id],
+        'ui:title': `${name} - ${page.title}`,
+      };
+    },
+    [page, data],
+  );
+
+  return (
+    <>
+      <SchemaForm
+        name="Dependent"
+        title="Dependent"
+        data={data}
+        uiSchema={currentUISchema}
+        schema={schema[page.id]}
+        onSubmit={onSubmit}
+        onChange={onChange}
+      >
+        {children}
+      </SchemaForm>
+    </>
+  );
+};
+
+DependentListLoopForm.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  data: PropTypes.object,
+  page: PropTypes.object,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+};
+
+export default DependentListLoopForm;

--- a/src/applications/hca/tests/components/FormFields/DependentListLoopForm.unit.spec.js
+++ b/src/applications/hca/tests/components/FormFields/DependentListLoopForm.unit.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import DependentListLoopForm from '../../../components/FormFields/DependentListLoopForm';
+
+describe('hca <DependentListLoopForm>', () => {
+  const defaultProps = {
+    data: {},
+    page: { id: 'basic', title: 'basic information' },
+    onChange: sinon.spy(),
+    onSubmit: sinon.spy(),
+  };
+
+  it('should render the basic form with a generic title', () => {
+    const view = render(<DependentListLoopForm {...defaultProps} />);
+    const form = view.container.querySelector('.rjsf');
+    const title = view.container.querySelector('#root__title');
+    expect(form).to.exist;
+    expect(title).to.contain.text(`Dependent - ${defaultProps.page.title}`);
+  });
+
+  it('should render the additional info form with a title specific to the dependent name', () => {
+    const props = {
+      ...defaultProps,
+      data: { fullName: { first: 'Mary', last: 'Smith' } },
+      page: { id: 'additional', title: 'additional information' },
+    };
+    const view = render(<DependentListLoopForm {...props} />);
+    const form = view.container.querySelector('.rjsf');
+    const title = view.container.querySelector('#root__title');
+    expect(form).to.exist;
+    expect(title).to.contain.text(
+      `${props.data.fullName.first} ${props.data.fullName.last} - ${
+        props.page.title
+      }`,
+    );
+  });
+});

--- a/src/applications/hca/tests/utils/helpers.unit.spec.js
+++ b/src/applications/hca/tests/utils/helpers.unit.spec.js
@@ -9,6 +9,7 @@ import {
   includeSpousalInformation,
   getInsuranceAriaLabel,
   isOfCollegeAge,
+  getDependentPageList,
 } from '../../utils/helpers';
 import { HIGH_DISABILITY_MINIMUM } from '../../utils/constants';
 
@@ -285,6 +286,32 @@ describe('hca helpers', () => {
       const birthdate = '2003-06-01';
       const testdate = '2023-06-01';
       expect(isOfCollegeAge(birthdate, testdate)).to.equal(true);
+    });
+  });
+
+  describe('getDependentPageList', () => {
+    const subpages = [
+      { id: 'page1', title: 'Page 1' },
+      { id: 'page2', title: 'Page 2', depends: { key: 'key1', value: false } },
+      { id: 'page3', title: 'Page 3' },
+      { id: 'page4', title: 'Page 4', depends: { key: 'key2', value: true } },
+      { id: 'page5', title: 'Page 5', depends: { key: 'key3', value: false } },
+    ];
+    it('returns a list of the two (2) pages that do not have a conditional dependency', () => {
+      const formData = {};
+      expect(getDependentPageList(subpages, formData)).to.have.lengthOf(2);
+    });
+    it('returns a list of four (3) pages when one conditional dependency does not match', () => {
+      const formData = { key1: true, key2: true, key3: true };
+      expect(getDependentPageList(subpages, formData)).to.have.lengthOf(3);
+    });
+    it('returns a list of four (4) pages when one conditional dependency does not match', () => {
+      const formData = { key1: false, key2: true, key3: true };
+      expect(getDependentPageList(subpages, formData)).to.have.lengthOf(4);
+    });
+    it('returns a list of all pages when the conditional dependencies match', () => {
+      const formData = { key1: false, key2: true, key3: false };
+      expect(getDependentPageList(subpages, formData)).to.have.lengthOf(5);
     });
   });
 

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -401,3 +401,28 @@ export function isOfCollegeAge(birthdate, testdate = new Date()) {
   const age = Math.abs(moment(birthdate).diff(moment(testdate), 'years'));
   return age >= 18 && age <= 23;
 }
+
+/**
+ * Helper that builds the list of active pages for use in the dependent
+ * information add/edit form
+ * @param {Array} subpages - the list of all available pages
+ * @param {Object} formData - the current data object for the dependent
+ * @returns {Array} - the array of pages to map through
+ */
+export function getDependentPageList(pages, formData = {}) {
+  return pages.reduce((acc, page) => {
+    if ('depends' in page) {
+      const { key, value } = page.depends;
+      if (value instanceof Function) {
+        if (value(formData[key])) {
+          acc.push(page);
+        }
+      } else if (formData[key] === value) {
+        acc.push(page);
+      }
+    } else {
+      acc.push(page);
+    }
+    return acc;
+  }, []);
+}


### PR DESCRIPTION
## Description
On the dependent information page of the new household section in the Health Care application, a bug was found when attempting to submit or "continue" in the form when not all form fields were valid. The bug showed the subsequent dependent form "pages" in their submitted state, with form field errors due to the fields being empty, even though the user has yet to interact with those fields. The previous solution swapped out the `schema` and `uiSchema` in the `SchemaForm`, but it was discovered that there is no available method to reset the submitted state.

This PR maps each "page" to its own unique form component and conditionally show/hide those based on the form data.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#59296

## Testing done
- [x] Unit tests
- [x] Cypress testing

## Acceptance criteria
- [ ] Form errors from one page do not affect subsequent form inputs from another page
