### PR TITLE
VACMS-13136 Accessibility fix for Resources and Support search

### DIFF
--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -44,11 +44,14 @@ export const SearchResult = ({
 
   return (
     <div className="vads-u-padding-y--4 vads-u-border-top--1px vads-u-border-color--gray-lighter">
-      <div className="vads-u-margin-bottom--1p5">
+      <div id={article.entityUrl.path} className="vads-u-margin-bottom--1p5">
         <dfn className="sr-only">Article type: </dfn>
         {articleTypes[article.entityBundle]}
       </div>
-      <h3 className="vads-u-margin-top--0 vads-u-font-size--md">
+      <h3
+        aria-describedby={article.entityUrl.path}
+        className="vads-u-margin-top--0 vads-u-font-size--md"
+      >
         <a onClick={onSearchResultClick} href={article.entityUrl.path}>
           {article.title}
         </a>


### PR DESCRIPTION
## Summary
Context: Resources and Support search page

Screen reader users who navigate search results using headings shortcuts or the tab key will likely miss metadata descriptions that are placed above each link heading search result.

Since screen reader users read a page top to bottom, the metadata tags (e.g. "Multiple FAQs") will likely be undetected if they use the tab key since it's unnatural to read backwards. For example, someone might tab to the first result "Veteran Identification Card" and then read the line below it-- but they likely won't tab to the first result and read the line above it.

<img width="1471" alt="Screenshot 2023-06-14 at 1 11 28 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0418709b-74cc-4139-8d8f-8b713fcfc372">

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13136

## Testing done
Opened Mac VoiceOver and tabbed by header to confirm "additional content" existed.