### PR TITLE
Simple forms: update mock form cypress tests to use reusable methods

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/minimal-test.json
@@ -15,7 +15,8 @@
     "wcVaTileCompensationType": "none",
     "wcCurrentlyActiveDuty_yes": false,
     "wcCurrentlyActiveDuty": {
-      "yes": false
+      "yes": true,
+      "onTerminalLeave": false
     },
     "wcv3VaCompensationType": "lowDisability",
     "wcv3VaTileCompensationType": "highDisability",

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/minimal-test.json
@@ -15,8 +15,7 @@
     "wcVaTileCompensationType": "none",
     "wcCurrentlyActiveDuty_yes": false,
     "wcCurrentlyActiveDuty": {
-      "yes": true,
-      "onTerminalLeave": false
+      "yes": false
     },
     "wcv3VaCompensationType": "lowDisability",
     "wcv3VaTileCompensationType": "highDisability",

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/mocks/application-submit.json
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/mocks/application-submit.json
@@ -1,9 +1,0 @@
-{
-  "data": {
-    "id": "123456789",
-    "type": "mockData",
-    "attributes": {
-      "status": "processed"
-    }
-  }
-}

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,6 +1,0 @@
-{
-  "data": {
-    "type": "feature_toggles",
-    "features": []
-  }
-}

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-form-patterns-date.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-form-patterns-date.cypress.spec.js
@@ -1,10 +1,15 @@
 import path from 'path';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-import featureToggles from './fixtures/mocks/feature-toggles.json';
-import mockSubmit from './fixtures/mocks/application-submit.json';
+import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
+import { fillDateWebComponentPattern } from '../../../shared/tests/e2e/helpers';
+
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
+
+import pagePaths from './pagePaths';
+
+const testPagePath = `${manifest.rootUrl}/${pagePaths.date}`;
 
 const testConfig = createTestConfig(
   {
@@ -14,15 +19,16 @@ const testConfig = createTestConfig(
     pageHooks: {
       introduction: ({ afterHook }) => {
         afterHook(() => {
-          cy.visit('/mock-simple-forms-patterns/date');
+          cy.visit(testPagePath);
         });
       },
-      date: ({ afterHook }) => {
+      [pagePaths.date]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(async () => {
           cy.get('@testData').then(data => {
-            // unstable tests
-            let [year, month, day] = data.dateWC.split('-');
+            // web components
+            // v1
+            const [year, month, day] = data.dateWC.split('-');
             cy.get(`va-memorable-date[name="root_dateWC"]`)
               .shadow()
               .find('va-text-input.input-month')
@@ -46,29 +52,8 @@ const testConfig = createTestConfig(
                   });
               });
 
-            [year, month, day] = data.dateWCV3.split('-');
-            cy.get(`va-memorable-date[name="root_dateWCV3"]`)
-              .shadow()
-              .find('va-text-input.usa-form-group--month-input')
-              .shadow()
-              .find('input')
-              .type(month)
-              .then(() => {
-                cy.get(`va-memorable-date[name="root_dateWCV3"]`)
-                  .shadow()
-                  .find('va-text-input.usa-form-group--day-input')
-                  .shadow()
-                  .find('input')
-                  .type(day)
-                  .then(() => {
-                    cy.get(`va-memorable-date[name="root_dateWCV3"]`)
-                      .shadow()
-                      .find('va-text-input.usa-form-group--year-input')
-                      .shadow()
-                      .find('input')
-                      .type(year);
-                  });
-              });
+            // v3
+            fillDateWebComponentPattern('dateWCV3', data.dateWCV3);
 
             cy.axeCheck();
           });
@@ -77,7 +62,6 @@ const testConfig = createTestConfig(
     },
     setupPerTest: () => {
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
-      cy.intercept('POST', '/forms_api/v1/simple_forms', mockSubmit);
     },
     // TODO: memorable date web component has a bug where it sometimes
     // can't select the next field

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-forms-patterns.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-forms-patterns.cypress.spec.js
@@ -184,9 +184,10 @@ const testConfig = createTestConfig(
               'wcVaCompensationType',
               data.wcVaCompensationType,
             );
+            // use underscores to separate sub-property names
             selectYesNoWebComponent(
-              'wcCurrentlyActiveDuty',
-              data.wcCurrentlyActiveDuty,
+              'wcCurrentlyActiveDuty_yes',
+              data.wcCurrentlyActiveDuty.yes,
             );
             selectRadioWebComponent(
               'wcVaTileCompensationType',

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-forms-patterns.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-forms-patterns.cypress.spec.js
@@ -1,10 +1,26 @@
 import path from 'path';
+
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-import featureToggles from './fixtures/mocks/feature-toggles.json';
-import mockSubmit from './fixtures/mocks/application-submit.json';
+
+import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
+import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
+import {
+  fillAddressWebComponentPattern,
+  fillFullNameWebComponentPattern,
+  fillTextAreaWebComponent,
+  fillTextWebComponent,
+  introductionPageFlow,
+  selectCheckboxWebComponent,
+  selectDropdownWebComponent,
+  selectRadioWebComponent,
+  selectYesNoWebComponent,
+} from '../../../shared/tests/e2e/helpers';
+
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
+
+import pagePaths from './pagePaths';
 
 const testConfig = createTestConfig(
   {
@@ -14,71 +30,53 @@ const testConfig = createTestConfig(
     pageHooks: {
       introduction: ({ afterHook }) => {
         afterHook(() => {
-          cy.findByText(/start/i, { selector: 'button' });
-          cy.findByText(/without signing in/i).click({ force: true });
+          introductionPageFlow();
         });
       },
-      'text-input': ({ afterHook }) => {
+      [pagePaths.textInput]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
 
-            cy.get(`va-text-input[name="root_requiredNew"]`)
-              .shadow()
-              .find('input')
-              .type(data?.requiredNew);
-
-            cy.get(`va-text-input[name="root_requiredNewV3"]`)
-              .shadow()
-              .find('input')
-              .type(data?.requiredNewV3);
-
-            cy.get(`va-textarea[name="root_textAreaNewV3"]`)
-              .shadow()
-              .find('textarea')
-              .type(data?.textAreaNewV3);
+            // web components
+            fillTextWebComponent('requiredNew', data?.requiredNew);
+            fillTextWebComponent('requiredNewV3', data?.requiredNewV3);
+            fillTextAreaWebComponent('textAreaNewV3', data?.textAreaNewV3);
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
-      'text-input-full-name': ({ afterHook }) => {
+      [pagePaths.textInputFullName]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
 
-            cy.get(`va-text-input[name="root_spouseFullNameNew_first"]`)
-              .shadow()
-              .find('input')
-              .type(data.spouseFullNameNew.first);
-
-            cy.get(`va-text-input[name="root_spouseFullNameNew_last"]`)
-              .shadow()
-              .find('input')
-              .type(data.spouseFullNameNew.last);
-
-            cy.get(`va-text-input[name="root_spouseFullNameNewV3_first"]`)
-              .shadow()
-              .find('input')
-              .type(data.spouseFullNameNew.first);
-
-            cy.get(`va-text-input[name="root_spouseFullNameNewV3_last"]`)
-              .shadow()
-              .find('input')
-              .type(data.spouseFullNameNew.last);
+            // web components
+            fillFullNameWebComponentPattern(
+              'spouseFullNameNew',
+              data.spouseFullNameNew,
+            );
+            fillFullNameWebComponentPattern(
+              'spouseFullNameNewV3',
+              data.spouseFullNameNewV3,
+            );
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
-      'text-input-address': ({ afterHook }) => {
+      [pagePaths.textInputAddress]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
             // fillPage doesn't catch state select, so select state manually
             cy.get('select#root_addressOld_state').select(
@@ -96,126 +94,76 @@ const testConfig = createTestConfig(
             }
 
             // web components
-            cy.get(`va-select[name="root_addressNew_country"]`)
-              .shadow()
-              .find('select')
-              .select(data.addressNew.country);
-
-            cy.get(`va-text-input[name="root_addressNew_street"]`)
-              .shadow()
-              .find('input')
-              .type(data.addressNew.street);
-
-            cy.get(`va-text-input[name="root_addressNew_city"]`)
-              .shadow()
-              .find('input')
-              .type(data.addressNew.city);
-
-            cy.get(`va-text-input[name="root_addressNew_postalCode"]`)
-              .shadow()
-              .find('input')
-              .type(data.addressNew.postalCode);
-
-            cy.get(`va-select[name="root_addressNew_state"]`)
-              .shadow()
-              .find('select')
-              .select(data.addressNew.state);
+            fillAddressWebComponentPattern('addressNew', data.addressNew);
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
-      'ssn-pattern': ({ afterHook }) => {
+      [pagePaths.textInputSsn]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
 
-            cy.get(`va-text-input[name="root_ssnNew"]`)
-              .shadow()
-              .find('input')
-              .type(data.ssnNew);
-
-            cy.get(`va-text-input[name="root_ssnNewV3"]`)
-              .shadow()
-              .find('input')
-              .type(data.ssnNewV3);
+            // web components
+            fillTextWebComponent('ssnNew', data.ssnNew);
+            fillTextWebComponent('ssnNewV3', data.ssnNewV3);
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
-      'checkbox-and-text-input': ({ afterHook }) => {
+      [pagePaths.checkboxAndTextInput]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
 
-            cy.get(`va-text-input[name="root_wcSimpleText"]`)
-              .shadow()
-              .find('input')
-              .type(data.wcSimpleText);
+            // web components
+            fillTextWebComponent('wcSimpleText', data.wcSimpleText);
+            selectCheckboxWebComponent(
+              'wcRequiredCheckbox',
+              data.wcRequiredCheckbox,
+            );
+            fillTextWebComponent('wcSsn', data.wcSsn);
+            fillTextWebComponent('wcV3SimpleText', data.wcV3SimpleText);
 
-            cy.get(`va-checkbox[name="root_wcRequiredCheckbox"]`)
-              .shadow()
-              .find('input')
-              .check();
-
-            cy.get(`va-text-input[name="root_wcSsn"]`)
-              .shadow()
-              .find('input')
-              .type(data.wcSsn);
-
-            cy.get(`va-text-input[name="root_wcV3SimpleText"]`)
-              .shadow()
-              .find('input')
-              .type(data.wcV3SimpleText);
-
-            // if can't check checkbox, then click label.
+            // bug: if can't check checkbox, then click label.
             cy.get(`va-checkbox[name="root_wcV3RequiredCheckbox"]`)
               .shadow()
               .find('label')
               .click();
 
-            cy.get(`va-text-input[name="root_wcV3Ssn"]`)
-              .shadow()
-              .find('input')
-              .type(data.wcV3Ssn);
+            fillTextWebComponent('wcV3Ssn', data.wcV3Ssn);
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
-      select: ({ afterHook }) => {
+      [pagePaths.select]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
 
-            cy.get(`va-select[name="root_selectWC"]`)
-              .shadow()
-              .find('select')
-              .select(data.selectWC);
-
-            cy.get(`va-select[name="root_selectWC2"]`)
-              .shadow()
-              .find('select')
-              .select(data.selectWC2);
-
-            cy.get(`va-select[name="root_selectWC2V3"]`)
-              .shadow()
-              .find('select')
-              .select(data.selectWC2V3);
+            // web components
+            selectDropdownWebComponent('selectWC', data.selectWC);
+            selectDropdownWebComponent('selectWC2', data.selectWC2);
+            selectDropdownWebComponent('selectWC2V3', data.selectWC2V3);
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
-      date: ({ afterHook }) => {
+      [pagePaths.date]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(async () => {
           cy.get('@testData').then(() => {
@@ -224,49 +172,53 @@ const testConfig = createTestConfig(
           });
         });
       },
-      radio: ({ afterHook }) => {
+      [pagePaths.radio]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
+            // widgets
             cy.fillPage();
 
-            cy.get(
-              `va-radio-option[name="root_wcVaCompensationType"][value="${
-                data.wcVaCompensationType
-              }"]`,
-            ).click();
-
-            cy.get(
-              `va-radio-option[name="root_wcCurrentlyActiveDuty_yes"][value="N"]`,
-            ).click();
-
-            cy.get(
-              `va-radio-option[name="root_wcVaTileCompensationType"][value="${
-                data.wcVaTileCompensationType
-              }"]`,
-            ).click();
-
-            cy.get(
-              `va-radio-option[name="root_wcv3VaCompensationType"][value="${
-                data.wcv3VaCompensationType
-              }"]`,
-            ).click();
-
-            cy.get(
-              `va-radio-option[name="root_wcv3VaTileCompensationType"][value="${
-                data.wcv3VaTileCompensationType
-              }"]`,
-            ).click();
+            // web components
+            selectRadioWebComponent(
+              'wcVaCompensationType',
+              data.wcVaCompensationType,
+            );
+            selectYesNoWebComponent(
+              'wcCurrentlyActiveDuty',
+              data.wcCurrentlyActiveDuty,
+            );
+            selectRadioWebComponent(
+              'wcVaTileCompensationType',
+              data.wcVaTileCompensationType,
+            );
+            selectRadioWebComponent(
+              'wcv3VaCompensationType',
+              data.wcv3VaCompensationType,
+            );
+            selectRadioWebComponent(
+              'wcv3VaTileCompensationType',
+              data.wcv3VaTileCompensationType,
+            );
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            cy.findAllByText(/Submit application/i, {
+              selector: 'button',
+            }).click();
+          });
+        });
+      },
     },
     setupPerTest: () => {
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
-      cy.intercept('POST', '/forms_api/v1/simple_forms', mockSubmit);
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
     },
     skip: false,
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/pagePaths.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/pagePaths.js
@@ -1,0 +1,14 @@
+import formConfig from '../../config/form';
+
+const formChapters = formConfig.chapters;
+export default {
+  textInput: formChapters.textInput.pages.textInput.path,
+  textInputWidgets1: formChapters.textInput.pages.textInputWidgets1.path,
+  textInputFullName: formChapters.textInput.pages.textInputFullName.path,
+  textInputAddress: formChapters.textInput.pages.textInputAddress.path,
+  textInputSsn: formChapters.textInput.pages.textInputSsn.path,
+  checkboxAndTextInput: formChapters.checkbox.pages.checkboxAndTextInput.path,
+  select: formChapters.select.pages.select.path,
+  radio: formChapters.radio.pages.radio.path,
+  date: formChapters.date.pages.date.path,
+};

--- a/src/applications/simple-forms/shared/tests/e2e/helpers.js
+++ b/src/applications/simple-forms/shared/tests/e2e/helpers.js
@@ -26,10 +26,10 @@ export const selectRadioWebComponent = (fieldName, value) => {
 };
 
 export const selectYesNoWebComponent = (fieldName, value) => {
-  const selection = value.yes ? 'Y' : 'N';
+  const selection = value ? 'Y' : 'N';
   if (typeof value !== 'undefined') {
     cy.get(
-      `va-radio-option[name="root_${fieldName}_yes"][value="${selection}"]`,
+      `va-radio-option[name="root_${fieldName}"][value="${selection}"]`,
     ).click();
   }
 };

--- a/src/applications/simple-forms/shared/tests/e2e/helpers.js
+++ b/src/applications/simple-forms/shared/tests/e2e/helpers.js
@@ -27,11 +27,7 @@ export const selectRadioWebComponent = (fieldName, value) => {
 
 export const selectYesNoWebComponent = (fieldName, value) => {
   const selection = value ? 'Y' : 'N';
-  if (typeof value !== 'undefined') {
-    cy.get(
-      `va-radio-option[name="root_${fieldName}"][value="${selection}"]`,
-    ).click();
-  }
+  selectRadioWebComponent(fieldName, selection);
 };
 
 export const selectDropdownWebComponent = (fieldName, value) => {

--- a/src/applications/simple-forms/shared/tests/e2e/helpers.js
+++ b/src/applications/simple-forms/shared/tests/e2e/helpers.js
@@ -25,6 +25,15 @@ export const selectRadioWebComponent = (fieldName, value) => {
   }
 };
 
+export const selectYesNoWebComponent = (fieldName, value) => {
+  const selection = value.yes ? 'Y' : 'N';
+  if (typeof value !== 'undefined') {
+    cy.get(
+      `va-radio-option[name="root_${fieldName}_yes"][value="${selection}"]`,
+    ).click();
+  }
+};
+
 export const selectDropdownWebComponent = (fieldName, value) => {
   if (typeof value !== 'undefined') {
     cy.get(`va-select[name="root_${fieldName}"]`)
@@ -56,11 +65,18 @@ export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
     `${fieldName}_isMilitary`,
     addressObject.isMilitary,
   );
+  if (addressObject.city) {
+    if (addressObject.isMilitary) {
+      // there is a select dropdown instead when military is checked
+      selectDropdownWebComponent(`${fieldName}_city`, addressObject.city);
+    } else {
+      fillTextWebComponent(`${fieldName}_city`, addressObject.city);
+    }
+  }
   selectDropdownWebComponent(`${fieldName}_country`, addressObject.country);
   fillTextWebComponent(`${fieldName}_street`, addressObject.street);
   fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
   fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  fillTextWebComponent(`${fieldName}_city`, addressObject.city);
   selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
   fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
 };


### PR DESCRIPTION
## Summary

- Remove test fixtures and use shared ones
- Update mock date test using new pattern (still skipped until date is fixed)
- Update mock form cypress test to use new methods and patterns
- Add pagePaths for more dynamic form route testing
- Add `yesNo` reusable method
- Add `isMilitary` condition to address pattern

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/337

## Testing done

- Ran cypress tests locally
