### PR TITLE
Change update mobile link for edit page

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
@@ -53,6 +54,14 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
       <hr aria-hidden="true" />
     </>
   );
+};
+
+ContactInfoOnFile.propTypes = {
+  emailAddress: PropTypes.string,
+  mobilePhoneNumber: PropTypes.shape({
+    areaCode: PropTypes.string,
+    phoneNumber: PropTypes.string,
+  }),
 };
 
 export default ContactInfoOnFile;

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -4,8 +4,11 @@ import { Link } from 'react-router-dom';
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
 import { FIELD_NAMES } from '@@vap-svc/constants';
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { useContactInfoDeepLink } from '../../hooks';
+import { PROFILE_PATHS } from '../../constants';
 
 const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
+  const { generateContactInfoLink } = useContactInfoDeepLink();
   return (
     <>
       <p className="vads-u-margin-bottom--0">
@@ -32,7 +35,13 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
               notClickable
             />{' '}
             <Link
-              to={getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true)}
+              to={generateContactInfoLink({
+                fieldName: FIELD_NAMES.MOBILE_PHONE,
+                focusOnEditButton: true,
+                returnPath: encodeURIComponent(
+                  PROFILE_PATHS.NOTIFICATION_SETTINGS,
+                ),
+              })}
               className="small-screen:vads-u-display--block medium-screen:vads-u-display--inline"
               aria-label="mobile number"
             >


### PR DESCRIPTION
## Summary

- Small change to the update mobile link when the new edit page is toggled on
- When the toggle is on the link takes you to the `/profile/edit` route, instead of the `profile/contact-information` route.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/57408

## Testing done

- Tested locally and all tests passing

## Screenshots

No UI changes, just changing the link destination

## What areas of the site does it impact?

Profile - Notification Settings

## Acceptance criteria

- [x] Link destination is conditional on `profileUseFieldEditingPage` feature toggle

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution