### PR TITLE
Save-in-progress | Validate returnUrl metadata

### DIFF
--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -23,15 +23,15 @@ class FormStartControls extends React.Component {
     this.state = { modalOpen: false };
   }
 
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillReceiveProps = newProps => {
-    if (!this.props.returnUrl && newProps.returnUrl) {
-      // TODO: Remove this; it doesn't actually run
-      // The redirect is instead done in RoutedSavableApp
-      // Navigate to the last page they were on
-      this.props.router.push(newProps.returnUrl);
-    }
-  };
+  // /* eslint-disable-next-line camelcase */
+  // UNSAFE_componentWillReceiveProps = newProps => {
+  //   if (!this.props.returnUrl && newProps.returnUrl) {
+  //     // TODO: Remove this; it doesn't actually run
+  //     // The redirect is instead done in RoutedSavableApp
+  //     // Navigate to the last page they were on
+  //     this.props.router.push(newProps.returnUrl);
+  //   }
+  // };
 
   goToBeginning = () => {
     this.props.router.push(this.props.startPage);

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -4,7 +4,10 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 
 import FormApp from 'platform/forms-system/src/js/containers/FormApp';
-import { getNextPagePath } from 'platform/forms-system/src/js/routing';
+import {
+  getNextPagePath,
+  checkValidPagePath,
+} from 'platform/forms-system/src/js/routing';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import environment from 'platform/utilities/environment';
@@ -97,7 +100,18 @@ class RoutedSavableApp extends React.Component {
         // The onFormLoaded callback should handle navigating to the start of the form
         newProps.formConfig.onFormLoaded(newProps);
       } else {
-        newProps.router.push(newProps.returnUrl);
+        // Check that returnUrl is an active page. If not, return to first page
+        // after intro page
+        const isValidReturnUrl = checkValidPagePath(
+          newProps.routes[newProps.routes.length - 1].pageList,
+          newProps.formData,
+          newProps.returnUrl,
+        );
+        newProps.router.push(
+          isValidReturnUrl
+            ? newProps.returnUrl
+            : this.getFirstNonIntroPagePath(newProps),
+        );
       }
       // Set loadedStatus in redux to not-attempted to not show the loading page
       newProps.setFetchFormStatus(LOAD_STATUSES.notAttempted);

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableApp.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableApp.unit.spec.jsx
@@ -37,6 +37,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [{ path: currentLocation.pathname }],
       },
@@ -67,6 +68,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [{ path: currentLocation.pathname }],
       },
@@ -95,6 +97,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [
           {
@@ -148,6 +151,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [
           {
@@ -194,10 +198,11 @@ describe('Schemaform <RoutedSavableApp>', () => {
       title: 'Testing',
     };
     const currentLocation = {
-      pathname: 'test',
+      pathname: '/test-path',
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [{ path: currentLocation.pathname }],
       },
@@ -205,7 +210,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
     const router = {
       push: sinon.spy(),
     };
-    const returnUrl = 'test-path';
+    const returnUrl = '/test-path';
     const setFetchFormStatus = sinon.spy();
 
     const tree = SkinDeep.shallowRender(
@@ -223,6 +228,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
     tree.getMountedInstance().UNSAFE_componentWillReceiveProps({
       formConfig,
       router,
+      routes,
       returnUrl,
       loadedStatus: LOAD_STATUSES.success,
       setFetchFormStatus,
@@ -241,6 +247,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [{ path: currentLocation.pathname }],
       },
@@ -278,6 +285,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [
           { path: '/introduction' },
@@ -307,6 +315,49 @@ describe('Schemaform <RoutedSavableApp>', () => {
 
     expect(router.replace.calledWith('/introduction')).to.be.true;
   });
+  it('should route to the first page if returnUrl is not to an active page', () => {
+    const formConfig = {
+      title: 'Testing',
+    };
+    const currentLocation = {
+      pathname: '/test-path',
+      search: '',
+    };
+    const routes = [
+      { path: '/' },
+      {
+        pageList: [{ path: currentLocation.pathname }],
+      },
+    ];
+    const router = {
+      push: sinon.spy(),
+    };
+    const returnUrl = '/test-99';
+    const setFetchFormStatus = sinon.spy();
+
+    const tree = SkinDeep.shallowRender(
+      <RoutedSavableApp
+        formConfig={formConfig}
+        routes={routes}
+        currentLocation={currentLocation}
+        loadedStatus={LOAD_STATUSES.pending}
+        updateLogInUrl={() => {}}
+      >
+        <div className="child" />
+      </RoutedSavableApp>,
+    );
+
+    tree.getMountedInstance().UNSAFE_componentWillReceiveProps({
+      formConfig,
+      router,
+      routes,
+      returnUrl,
+      loadedStatus: LOAD_STATUSES.success,
+      setFetchFormStatus,
+    });
+
+    expect(router.push.calledWith(currentLocation.pathname)).to.be.true;
+  });
   it('should load a saved form when starting in the middle of a form and logged in', () => {
     const formConfig = {
       title: 'Testing',
@@ -317,6 +368,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [
           { path: '/introduction' },
@@ -376,6 +428,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [
           { path: '/introduction' },
@@ -435,6 +488,7 @@ describe('Schemaform <RoutedSavableApp>', () => {
       search: '',
     };
     const routes = [
+      { path: '/' },
       {
         pageList: [
           { path: '/introduction' },


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In some situations, the `returnUrl` in the save-in-progress metadata may return the Veteran to a page that isn't visible (`depends` hides it). In this situation, the path isn't valid, so the Veteran is "reset" back to the form introduction page. Continued clicks on the continue application button return them back to the introduction page indefinitely. The _only_ way to get out of this situation is to restart the form anew 😿 
- _(If bug, how to reproduce)_
  > It is difficult to reproduce. In staging, the save-in-progress menu return url will refresh to only show active form pages. You would have to intercept the save-in-progress metadata to modify the `returnUrl`
- _(What is the solution, why is this the solution)_
  > Within the `RoutedSavableApp` component, a check to ensure the `returnUrl` targets a valid page path. If valid, the Veteran is sent to that page and if not valid, the Veteran is sent to the first page within the form - this seemed like the safest point of re-entry.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#60332](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60332)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Infinite loop back to the introduction page when the "continue your application" button is used.
- _Describe the steps required to verify your changes are working as expected_
  > Difficult to reproduce
- _Describe the tests completed and the results_
  > Added unit test for the `RouterSavableApp`; all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All forms that use save-in-progress

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
