### PR TITLE
Increase character limit on the comments field for direct schedule

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -880,10 +880,7 @@ export function submitAppointmentOrRequest(history) {
           requestBody = transformFormToVAOSCCRequest(getState());
           requestData = await createAppointment({ appointment: requestBody });
         } else if (featureVAOSServiceRequests) {
-          requestBody = transformFormToVAOSVARequest(
-            getState(),
-            featureAcheronVAOSServiceRequests,
-          );
+          requestBody = transformFormToVAOSVARequest(getState());
           requestData = await createAppointment({
             appointment: requestBody,
             useAcheron: featureAcheronVAOSServiceRequests,

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -1,14 +1,3 @@
-/**
- * Creates a reasonCode text, based on the appointment data and booleans
- *
- * @export
- * @param {Object} appointment parameters needed to create the comment text
- * @param {boolean} params.isCC whether the appointment is Community Care
- * @param {boolean} params.isAcheron whether Acheron Service is used
- * @param {boolean} params.isDS whether the appointment is direct schedule
- * @returns {string} The created reason text
- */
-
 import titleCase from 'platform/utilities/data/titleCase';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import moment from '../../../lib/moment-tz';

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.v2.js
@@ -1,11 +1,18 @@
+/**
+ * Creates a reasonCode text, based on the appointment data and booleans
+ *
+ * @export
+ * @param {Object} appointment parameters needed to create the comment text
+ * @param {boolean} params.isCC whether the appointment is Community Care
+ * @param {boolean} params.isAcheron whether Acheron Service is used
+ * @param {boolean} params.isDS whether the appointment is direct schedule
+ * @returns {string} The created reason text
+ */
+
 import titleCase from 'platform/utilities/data/titleCase';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import moment from '../../../lib/moment-tz';
-import {
-  LANGUAGES,
-  PURPOSE_TEXT_V2,
-  TYPE_OF_VISIT,
-} from '../../../utils/constants';
+import { LANGUAGES } from '../../../utils/constants';
 import {
   getTypeOfCare,
   getFormData,
@@ -15,64 +22,8 @@ import {
 } from '../selectors';
 import { getClinicId } from '../../../services/healthcare-service';
 import { getTimezoneByFacilityId } from '../../../utils/timezone';
-
-function getReasonCode({ data, isCC, isAcheron, isDS }) {
-  const apptReasonCode = PURPOSE_TEXT_V2.find(
-    purpose => purpose.id === data.reasonForAppointment,
-  )?.commentShort;
-  const code = PURPOSE_TEXT_V2.filter(purpose => purpose.id !== 'other').find(
-    purpose => purpose.id === data.reasonForAppointment,
-  )?.serviceName;
-  let reasonText = null;
-  let appointmentInfo = null;
-  const visitMode = TYPE_OF_VISIT.filter(
-    visit => visit.id === data.visitType,
-  ).map(visit => visit.vsGUI);
-
-  if (isCC && data.reasonAdditionalInfo) {
-    reasonText = data.reasonAdditionalInfo.slice(0, 250);
-  }
-  if (!isCC) {
-    reasonText = data.reasonAdditionalInfo.slice(0, 100);
-  }
-  if (!isCC && isAcheron) {
-    const formattedDates = data.selectedDates.map(
-      date =>
-        `${moment(date).format('MM/DD/YYYY')}${
-          moment(date).hour() >= 12 ? ' PM' : ' AM'
-        }`,
-    );
-    const facility = `station id: ${data.vaFacility}`;
-    const modality = `preferred modality: ${visitMode}`;
-    const phone = `phone number: ${data.phoneNumber}`;
-    const email = `email: ${data.email}`;
-    const preferredDates = `preferred dates:${formattedDates.toString()}`;
-    const reasonCode = `reason code:${apptReasonCode}`;
-    reasonText = `comments:${data.reasonAdditionalInfo.slice(0, 250)}`;
-    // Add station id, preferred modality, phone number, email, preferred Date, reason Code to
-    // appointmentInfo string in this order: [0]station id, [1]preferred modality, [2]phone number,
-    // [3]email, [4]preferred Date, [5]reason Code
-    appointmentInfo = `${facility}|${modality}|${phone}|${email}|${preferredDates}|${reasonCode}`;
-  }
-  if (isDS) {
-    appointmentInfo = `reasonCode:${apptReasonCode}`;
-    reasonText = `comments:${data.reasonAdditionalInfo.slice(0, 250)}`;
-  }
-  const reasonCodeBody = {
-    text:
-      data.reasonAdditionalInfo && isAcheron
-        ? `${appointmentInfo}|${reasonText}`
-        : null,
-  };
-  if (isAcheron) return reasonCodeBody;
-  return {
-    coding: code ? [{ code }] : undefined,
-    // Per Brad - All comments should be sent in the reasonCode.text field and should should be
-    // truncated to 100 char for both VA appointment types only. CC appointments will continue
-    // to be truncated to 250 char
-    text: data.reasonAdditionalInfo ? reasonText : null,
-  };
-}
+import { selectFeatureAcheronService } from '../../../redux/selectors';
+import { getReasonCode } from './getReasonCode';
 
 export function transformFormToVAOSCCRequest(state) {
   const data = getFormData(state);
@@ -127,7 +78,12 @@ export function transformFormToVAOSCCRequest(state) {
     locationId: data.communityCareSystemId,
     serviceType: typeOfCare.idV2 || typeOfCare.ccId,
     // comment: data.reasonAdditionalInfo,
-    reasonCode: getReasonCode({ data, isCC: true, isDS: false }),
+    reasonCode: getReasonCode({
+      data,
+      isCC: true,
+      isAcheron: false,
+      isDS: false,
+    }),
     contact: {
       telecom: [
         {
@@ -164,10 +120,8 @@ export function transformFormToVAOSCCRequest(state) {
   };
 }
 
-export function transformFormToVAOSVARequest(
-  state,
-  featureAcheronVAOSServiceRequests,
-) {
+export function transformFormToVAOSVARequest(state) {
+  const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(state);
   const data = getFormData(state);
   const typeOfCare = getTypeOfCare(data);
 
@@ -230,6 +184,7 @@ export function transformFormToVAOSVARequest(
 }
 
 export function transformFormToVAOSAppointment(state) {
+  const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(state);
   const data = getFormData(state);
   const clinic = getChosenClinicInfo(state);
   const slot = getChosenSlot(state);
@@ -247,13 +202,11 @@ export function transformFormToVAOSAppointment(state) {
       desiredDate: `${data.preferredDate}T00:00:00+00:00`,
     },
     locationId: data.vaFacility,
-    // removing this for now, it's preventing QA from testing, will re-introduce when the team figures out how we're handling the comment field
-    // comment: getUserMessage(data),
     reasonCode: getReasonCode({
       data,
       isCC: false,
+      isAcheron: featureAcheronVAOSServiceRequests,
       isDS: true,
-      isAcheron: true,
     }),
   };
 }

--- a/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
@@ -1,3 +1,14 @@
+/**
+ * Transforms the reason text based on the appointment data and booleans
+ *
+ * @export
+ * @param {Object} appointment parameters needed to create the comment text
+ * @param {boolean} params.isCC whether the appointment is Community Care
+ * @param {boolean} params.isAcheron whether Acheron Service is used
+ * @param {boolean} params.isDS whether the appointment is direct schedule
+ * @returns {string} The created reason text
+ */
+
 import moment from '../../../lib/moment-tz';
 import { PURPOSE_TEXT_V2, TYPE_OF_VISIT } from '../../../utils/constants';
 

--- a/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
@@ -1,0 +1,60 @@
+import moment from '../../../lib/moment-tz';
+import { PURPOSE_TEXT_V2, TYPE_OF_VISIT } from '../../../utils/constants';
+
+export function getReasonCode({ data, isCC, isAcheron, isDS }) {
+  const apptReasonCode = PURPOSE_TEXT_V2.find(
+    purpose => purpose.id === data.reasonForAppointment,
+  )?.commentShort;
+  const code = PURPOSE_TEXT_V2.filter(purpose => purpose.id !== 'other').find(
+    purpose => purpose.id === data.reasonForAppointment,
+  )?.serviceName;
+  let reasonText = null;
+  let appointmentInfo = null;
+  const visitMode = TYPE_OF_VISIT.filter(
+    visit => visit.id === data.visitType,
+  ).map(visit => visit.vsGUI);
+
+  if (isCC && data.reasonAdditionalInfo) {
+    reasonText = data.reasonAdditionalInfo.slice(0, 250);
+  }
+  if (!isCC) {
+    reasonText = data.reasonAdditionalInfo.slice(0, 250);
+  }
+  if (!isCC && isAcheron) {
+    const formattedDates = data.selectedDates.map(
+      date =>
+        `${moment(date).format('MM/DD/YYYY')}${
+          moment(date).hour() >= 12 ? ' PM' : ' AM'
+        }`,
+    );
+    const facility = `station id: ${data.vaFacility}`;
+    const modality = `preferred modality: ${visitMode}`;
+    const phone = `phone number: ${data.phoneNumber}`;
+    const email = `email: ${data.email}`;
+    const preferredDates = `preferred dates:${formattedDates.toString()}`;
+    const reasonCode = `reason code:${apptReasonCode}`;
+    reasonText = `comments:${data.reasonAdditionalInfo.slice(0, 250)}`;
+    // Add station id, preferred modality, phone number, email, preferred Date, reason Code to
+    // appointmentInfo string in this order: [0]station id, [1]preferred modality, [2]phone number,
+    // [3]email, [4]preferred Date, [5]reason Code
+    appointmentInfo = `${facility}|${modality}|${phone}|${email}|${preferredDates}|${reasonCode}`;
+  }
+  if (isDS) {
+    appointmentInfo = `reasonCode:${apptReasonCode}`;
+    reasonText = `comments:${data.reasonAdditionalInfo.slice(0, 250)}`;
+  }
+  const reasonCodeBody = {
+    text:
+      data.reasonAdditionalInfo && isAcheron
+        ? `${appointmentInfo}|${reasonText}`
+        : null,
+  };
+  if (isAcheron) return reasonCodeBody;
+  return {
+    coding: code ? [{ code }] : undefined,
+    // Per Brad - All comments should be sent in the reasonCode.text field and should should be
+    // truncated to 300 char for both VA appointment types only. CC appointments will continue
+    // to be truncated to 250 char
+    text: data.reasonAdditionalInfo ? reasonText : null,
+  };
+}

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -61,8 +61,6 @@ import {
   FACILITY_TYPES,
   FLOW_TYPES,
   FETCH_STATUS,
-  PURPOSE_TEXT,
-  PURPOSE_TEXT_V2,
 } from '../../utils/constants';
 
 import { getTypeOfCare } from './selectors';
@@ -149,8 +147,6 @@ function resetFormDataOnTypeOfCareChange(pages, oldData, data) {
 }
 
 export default function formReducer(state = initialState, action) {
-  const { useV2, useAcheron } = action;
-
   switch (action.type) {
     case FORM_PAGE_OPENED: {
       const { data, schema } = setupFormData(
@@ -621,29 +617,7 @@ export default function formReducer(state = initialState, action) {
     }
     case FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED: {
       const formData = state.data;
-
-      // Default char limit for CC appointment request is 250 and
-      // VA direct schedule and appointment request is 100.
-      let reasonMaxChars =
-        formData.facilityType === FACILITY_TYPES.COMMUNITY_CARE ? 250 : 100;
-      if (state.flowType === FLOW_TYPES.REQUEST) {
-        if (useV2 && useAcheron) {
-          reasonMaxChars = REASON_MAX_CHARS.request;
-        }
-      } else if (state.flowType === FLOW_TYPES.DIRECT) {
-        if (useV2) {
-          const prependText = PURPOSE_TEXT_V2.find(
-            purpose => purpose.id === formData.reasonForAppointment,
-          )?.short;
-          reasonMaxChars = reasonMaxChars - (prependText?.length || 0) - 2;
-        } else {
-          const prependText = PURPOSE_TEXT.find(
-            purpose => purpose.id === formData.reasonForAppointment,
-          )?.short;
-          reasonMaxChars =
-            REASON_MAX_CHARS.direct - (prependText?.length || 0) - 2;
-        }
-      }
+      const reasonMaxChars = 250;
 
       let reasonSchema = set(
         'properties.reasonAdditionalInfo.maxLength',
@@ -682,37 +656,7 @@ export default function formReducer(state = initialState, action) {
       };
     }
     case FORM_REASON_FOR_APPOINTMENT_CHANGED: {
-      let newSchema = state.pages.reasonForAppointment;
-
-      if (state.flowType === FLOW_TYPES.DIRECT) {
-        if (useV2) {
-          // Default char limit for CC appointment request is 250 and
-          // VA direct schedule and appointment request is 100.
-          const formData = state.data;
-          const reasonMaxChars =
-            formData.facilityType === FACILITY_TYPES.COMMUNITY_CARE ? 250 : 100;
-
-          const prependText = PURPOSE_TEXT_V2.filter(purpose => {
-            return purpose.id !== 'other';
-          }).find(purpose => {
-            return purpose.id === action.data.reasonForAppointment;
-          })?.short;
-          newSchema = set(
-            'properties.reasonAdditionalInfo.maxLength',
-            reasonMaxChars - (prependText?.length || 0) - 2,
-            newSchema,
-          );
-        } else {
-          const prependText = PURPOSE_TEXT.find(
-            purpose => purpose.id === action.data.reasonForAppointment,
-          )?.short;
-          newSchema = set(
-            'properties.reasonAdditionalInfo.maxLength',
-            REASON_MAX_CHARS.direct - (prependText?.length || 0) - 2,
-            newSchema,
-          );
-        }
-      }
+      const newSchema = state.pages.reasonForAppointment;
 
       const { data, schema } = updateSchemaAndData(
         newSchema,

--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -68,6 +68,7 @@ describe('VAOS direct schedule flow using VAOS service', () => {
       v2Requests: true,
       v2Facilities: true,
       v2DirectSchedule: true,
+      acheron: true,
     });
     mockUserTransitionAvailabilities();
   });

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -211,6 +211,7 @@ export function mockFeatureToggles({
   v2Requests = false,
   v2Facilities = false,
   v2DirectSchedule = false,
+  acheron = false,
 } = {}) {
   cy.intercept(
     {
@@ -266,6 +267,10 @@ export function mockFeatureToggles({
             {
               name: 'vaOnlineSchedulingVAOSServiceCCAppointments',
               value: true,
+            },
+            {
+              name: 'vaOnlineSchedulingAcheronService',
+              value: acheron,
             },
           ],
         },

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
     expect(textBox).to.exist;
     expect(textBox)
       .to.have.attribute('maxlength')
-      .to.equal('100');
+      .to.equal('250');
 
     expect((await screen.findAllByRole('radio')).length).to.equal(4);
 
@@ -147,7 +147,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
     expect(textBox).to.exist;
     expect(textBox)
       .to.have.attribute('maxlength')
-      .to.equal('131');
+      .to.equal('250');
 
     expect(
       screen.getByRole('heading', {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -338,6 +338,7 @@ describe('VAOS <ReviewPage> direct scheduling with v2 api', () => {
       featureToggles: {
         vaOnlineSchedulingFacilitiesServiceV2: true,
         vaOnlineSchedulingVAOSServiceVAAppointments: true,
+        vaOnlineSchedulingAcheronService: true,
       },
       newAppointment: {
         pages: {},


### PR DESCRIPTION
## Summary
When the user selects any of the reasons, user will be able to enter up to 250 characters in the comments in the direct schedule flow.

-  The PR also refactors the `getReasonCode.js` function to its own helper file for reuse

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#57111
- _Link to previous change of the code/bug (if applicable)_


## Testing done
- unit and e2e test

## Screenshots
<img width="280" alt="Screenshot 2023-06-15 at 2 21 51 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/19474d95-86f4-46fe-9d86-696208b7b75f">


## What areas of the site does it impact?

VAOS direct scheduling

## Acceptance criteria

- When user select any of the available reason, the comments sections shows "250 characters remaining"

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


