### PR TITLE
Notice of Disagreement | Add Google Analytics to radios

### DIFF
--- a/src/applications/appeals/10182/pages/boardReview.js
+++ b/src/applications/appeals/10182/pages/boardReview.js
@@ -10,6 +10,7 @@ const boardReview = {
       'ui:widget': 'radio',
       'ui:options': {
         labels: boardReviewContent,
+        enableAnalytics: true,
       },
       'ui:errorMessages': {
         required: boardReviewErrorMessage,

--- a/src/applications/appeals/10182/pages/evidenceIntro.js
+++ b/src/applications/appeals/10182/pages/evidenceIntro.js
@@ -15,6 +15,7 @@ const contactInfo = {
         labels: {
           N: 'No, I’ll submit it later.',
         },
+        enableAnalytics: true,
       },
     },
   },

--- a/src/applications/appeals/10182/pages/hearingType.js
+++ b/src/applications/appeals/10182/pages/hearingType.js
@@ -12,6 +12,7 @@ const hearingType = {
       'ui:required': needsHearingType,
       'ui:options': {
         labels: hearingTypeContent,
+        enableAnalytics: true,
       },
       'ui:errorMessages': {
         required: missingHearingTypeErrorMessage,

--- a/src/applications/appeals/10182/pages/homeless.js
+++ b/src/applications/appeals/10182/pages/homeless.js
@@ -7,6 +7,9 @@ export default {
     homeless: {
       'ui:title': 'Are you experiencing homelessness?',
       'ui:widget': 'yesNo',
+      'ui:options': {
+        enableAnalytics: true,
+      },
     },
   },
   schema: {

--- a/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import { isReactComponent } from '../../../../utilities/ui';
+import recordEvent from '../../../../monitoring/record-event';
 
 import ExpandingGroup from '../components/ExpandingGroup';
 
@@ -16,6 +19,7 @@ export default function RadioWidget({
     nestedContent = {},
     widgetProps = {},
     selectedProps = {},
+    enableAnalytics = false,
   } = options;
 
   const getProps = (key, checked) => ({
@@ -29,6 +33,23 @@ export default function RadioWidget({
     const NestedContent = content;
     content = <NestedContent />;
   }
+
+  const onChangeEvent = option => {
+    if (enableAnalytics) {
+      // title may be a React component
+      const title = options.title?.props?.children || options.title || '';
+      // this check isn't ideal since the message may exist and the question
+      // may be dynamically toggled between being required or not
+      const required = !!options.errorMessages?.required;
+      recordEvent({
+        event: 'int-radio-button-option-click',
+        'radio-button-label': title,
+        'radio-button-optionLabel': option.label,
+        'radio-button-required': required,
+      });
+    }
+    onChange(option.value);
+  };
 
   return (
     <div>
@@ -44,7 +65,7 @@ export default function RadioWidget({
               name={`${id}`}
               value={option.value}
               disabled={disabled}
-              onChange={_ => onChange(option.value)}
+              onChange={_ => onChangeEvent(option)}
               {...getProps(option.value, checked)}
             />
             <label htmlFor={`${id}_${i}`}>
@@ -67,3 +88,20 @@ export default function RadioWidget({
     </div>
   );
 }
+
+RadioWidget.propTypes = {
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  options: PropTypes.shape({
+    enumOptions: PropTypes.array,
+    labels: PropTypes.shape({}),
+    nestedContent: PropTypes.shape({}),
+    widgetProps: PropTypes.shape({}),
+    selectedProps: PropTypes.shape({}),
+    enableAnalytics: PropTypes.bool,
+    title: PropTypes.string,
+    errorMessages: PropTypes.shape({}),
+  }),
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+};

--- a/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
@@ -1,55 +1,60 @@
 import React from 'react';
 import { expect } from 'chai';
-import SkinDeep from 'skin-deep';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 
 import YesNoWidget from '../../../src/js/widgets/YesNoWidget';
+import { $, $$ } from '../../../src/js/utilities/ui';
 
 describe('Schemaform <YesNoWidget>', () => {
   it('should render', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
-      <YesNoWidget value onChange={onChange} />,
-    );
-    expect(tree.everySubTree('input').length).to.equal(2);
-    expect(tree.everySubTree('input')[0].props.checked).to.be.true;
-    expect(tree.everySubTree('input')[1].props.checked).not.to.be.true;
+    const { container } = render(<YesNoWidget value onChange={onChange} />);
+    const inputs = $$('input', container);
+    expect(inputs.length).to.equal(2);
+    expect(inputs[0].checked).to.be.true;
+    expect(inputs[1].checked).not.to.be.true;
   });
+
   it('should render undefined', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(<YesNoWidget onChange={onChange} />);
-    expect(tree.everySubTree('input').length).to.equal(2);
-    expect(tree.everySubTree('input')[0].props.checked).not.to.be.true;
-    expect(tree.everySubTree('input')[1].props.checked).not.to.be.true;
+    const { container } = render(<YesNoWidget onChange={onChange} />);
+    const inputs = $$('input', container);
+    expect(inputs.length).to.equal(2);
+    expect(inputs[0].checked).not.to.be.true;
+    expect(inputs[1].checked).not.to.be.true;
   });
+
   it('should render false', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
+    const { container } = render(
       <YesNoWidget value={false} onChange={onChange} />,
     );
-    expect(tree.everySubTree('input').length).to.equal(2);
-    expect(tree.everySubTree('input')[0].props.checked).not.to.be.true;
-    expect(tree.everySubTree('input')[1].props.checked).to.be.true;
+    const inputs = $$('input', container);
+    expect(inputs.length).to.equal(2);
+    expect(inputs[0].checked).not.to.be.true;
+    expect(inputs[1].checked).to.be.true;
   });
+
   it('should handle change', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
+    const { container } = render(
       <YesNoWidget value={false} onChange={onChange} />,
     );
-    tree.everySubTree('input')[0].props.onChange();
+    fireEvent.click($('input', container));
     expect(onChange.calledWith(true)).to.be.true;
   });
+
   it('should handle false change', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
-      <YesNoWidget value={false} onChange={onChange} />,
-    );
-    tree.everySubTree('input')[1].props.onChange();
+    const { container } = render(<YesNoWidget value onChange={onChange} />);
+    fireEvent.click($$('input', container)[1]);
     expect(onChange.calledWith(false)).to.be.true;
   });
+
   it('should render labels', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
+    const { container } = render(
       <YesNoWidget
         value
         options={{
@@ -61,12 +66,14 @@ describe('Schemaform <YesNoWidget>', () => {
         onChange={onChange}
       />,
     );
-    expect(tree.everySubTree('label')[0].text()).to.equal('Whatever');
-    expect(tree.everySubTree('label')[1].text()).to.equal('Testing');
+    const labels = $$('label', container);
+    expect(labels[0].textContent).to.equal('Whatever');
+    expect(labels[1].textContent).to.equal('Testing');
   });
+
   it('should reverse value', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
+    const { container } = render(
       <YesNoWidget
         value
         options={{
@@ -76,12 +83,14 @@ describe('Schemaform <YesNoWidget>', () => {
       />,
     );
 
-    expect(tree.everySubTree('input')[0].props.checked).to.be.false;
-    expect(tree.everySubTree('input')[1].props.checked).to.be.true;
+    const inputs = $$('input', container);
+    expect(inputs[0].checked).to.be.false;
+    expect(inputs[1].checked).to.be.true;
   });
+
   it('should add custom props', () => {
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
+    const { container } = render(
       <YesNoWidget
         value
         options={{
@@ -95,14 +104,12 @@ describe('Schemaform <YesNoWidget>', () => {
       />,
     );
 
-    expect(tree.everySubTree('input')[0].props['data-test']).to.equal(
-      'yes-input',
-    );
-    expect(tree.everySubTree('input')[1].props['data-test']).to.equal(
-      'no-input',
-    );
+    const inputs = $$('input', container);
+    expect(inputs[0].dataset.test).to.equal('yes-input');
+    expect(inputs[1].dataset.test).to.equal('no-input');
   });
-  it('should update selected props', () => {
+
+  it('should update selected props', async () => {
     const options = {
       widgetProps: {
         Y: { 'data-test': 'yes-input' },
@@ -114,23 +121,76 @@ describe('Schemaform <YesNoWidget>', () => {
       },
     };
     const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
+    const { container, rerender } = render(
       <YesNoWidget value options={options} onChange={onChange} />,
     );
 
     // "Yes" selected
-    const inputsYes = tree.everySubTree('input');
-    expect(inputsYes[0].props['data-test']).to.equal('yes-input');
-    expect(inputsYes[0].props['data-selected']).to.equal('yes-selected');
-    expect(inputsYes[1].props['data-test']).to.equal('no-input');
-    expect(inputsYes[1].props['data-selected']).to.be.undefined;
+    const inputs = $$('input', container);
+    expect(inputs[0].dataset.test).to.equal('yes-input');
+    expect(inputs[0].dataset.selected).to.equal('yes-selected');
+    expect(inputs[1].dataset.test).to.equal('no-input');
+    expect(inputs[1].dataset.selected).to.be.undefined;
 
     // "No" selected
-    tree.reRender({ value: false, options, onChange });
-    const inputsNo = tree.everySubTree('input');
-    expect(inputsNo[0].props['data-test']).to.equal('yes-input');
-    expect(inputsNo[0].props['data-selected']).to.be.undefined;
-    expect(inputsNo[1].props['data-test']).to.equal('no-input');
-    expect(inputsNo[1].props['data-selected']).to.equal('no-selected');
+    rerender(
+      <YesNoWidget value={false} options={options} onChange={onChange} />,
+    );
+
+    await waitFor(() => {
+      expect(inputs[0].dataset.test).to.equal('yes-input');
+      expect(inputs[0].dataset.selected).to.be.undefined;
+      expect(inputs[1].dataset.test).to.equal('no-input');
+      expect(inputs[1].dataset.selected).to.equal('no-selected');
+    });
+  });
+
+  it('should log events to google analytics', () => {
+    global.window.dataLayer = [];
+    const onChange = sinon.spy();
+    const options = {
+      title: 'YesNo title',
+      labels: {
+        N: 'Nope',
+      },
+      enableAnalytics: true,
+    };
+    const { container } = render(
+      <YesNoWidget value options={options} onChange={onChange} />,
+    );
+
+    fireEvent.click($('input[value="N"]', container));
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label': options.title,
+      'radio-button-optionLabel': options.labels.N,
+      'radio-button-required': false,
+    });
+  });
+
+  it('should log events to google analytics', () => {
+    global.window.dataLayer = [];
+    const onChange = sinon.spy();
+    const options = {
+      title: <div>Test YesNo</div>,
+      labels: {
+        N: 'Nope',
+      },
+      errorMessages: { required: 'yep' },
+      enableAnalytics: true,
+    };
+    const { container } = render(
+      <YesNoWidget options={options} onChange={onChange} />,
+    );
+
+    fireEvent.click($('input[value="Y"]', container));
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label': 'Test YesNo',
+      'radio-button-optionLabel': 'Yes',
+      'radio-button-required': true,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Google analytics were missing from the Notice of Disagreement radio button questions. After investigating, it was noted that the widgets in the form library did not include any event logging. Usually GA is disabled for form elements to prevent making PII public, but in this case, the questions being answered will not expose any PII.
  > Adding GA to:
  > - Homeless question
  > - Board review option
  > - Evidence submission (upload)
  > - Hearing type
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Added GA event recording into the `RadioWidget` and `YesNoWidget`, but it is only activated when a `enableAnalytics` `ui:option` is set.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#58705](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58705)

## Testing done

- _Describe what the old behavior was prior to the change_
  > No GA events recorded
- _Describe the steps required to verify your changes are working as expected_
  > Test checking radio selections in staging or in a review instance
- _Describe the tests completed and the results_
  > Updated widget unit tests; all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

| GA events |
| ------- |
| <img width="429" alt="Screenshot 2023-06-16 at 10 53 23 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/39408089-ca1a-46ef-9c94-ad35fe2dc1df"> |
| <img width="432" alt="Screenshot 2023-06-16 at 10 54 17 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2f1e2670-d3a1-4d9a-b710-c9ac53f9d1ac"> |
| <img width="513" alt="Screenshot 2023-06-16 at 10 54 41 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e4337955-b73d-43e7-a361-9943cf301cc4"> |
| <img width="507" alt="Screenshot 2023-06-16 at 10 55 32 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4e960807-bfbe-4fc7-a624-81653a7b74d4"> |

## What areas of the site does it impact?

Notice of Disagreement (so far). Code is in place for any other form app that uses radio widgets.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) (pending)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
