### PR TITLE
59319 unorder lists

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -52,7 +52,7 @@ const AppointmentBlock = props => {
         </p>
       )}
 
-      <ol
+      <ul
         className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
         data-testid="appointment-list"
       >
@@ -68,7 +68,7 @@ const AppointmentBlock = props => {
             />
           );
         })}
-      </ol>
+      </ul>
     </div>
   );
 };

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -119,7 +119,7 @@ const CheckInConfirmation = props => {
     return (
       <Wrapper pageTitle={pageTitle} testID="multiple-appointments-confirm">
         <p className="vads-u-font-family--serif">{t('your-appointment')}</p>
-        <ol
+        <ul
           className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list"
           data-testid="appointment-list"
         >
@@ -132,7 +132,7 @@ const CheckInConfirmation = props => {
             page="confirmation"
             app={APP_NAMES.CHECK_IN}
           />
-        </ol>
+        </ul>
 
         <va-alert
           background-only

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
@@ -55,7 +55,7 @@ class Introduction {
   };
 
   countAppointmentList = expectedLength => {
-    cy.get('ol[data-testid="appointment-list"] li').should(
+    cy.get('ul[data-testid="appointment-list"] li').should(
       'have.length',
       expectedLength,
     );

--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -22,7 +22,7 @@ ul.check-in--definition-list {
   padding: 0;
 }
 
-ol.check-in--appointment-list {
+ul.check-in--appointment-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -52,7 +52,7 @@ ol.check-in--appointment-list {
   }
 }
 
-ol.appointment-list{
+ul.appointment-list{
   list-style: none;
 }// DS removes label margin now, this maintains it.
 va-text-input[error]:not([error=""])::part(label) ,


### PR DESCRIPTION
## Summary

Changing ordered lists to unordered lists, this should have zero to minimal impact. Discovered one area did not display list icons (so no change) and other area likely didn't either.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/59306

## Testing done

Verified old and new styles match, no other changes done except removing ol and replacing with ul, changed stylesheet to match
 
## Screenshots

![Screenshot 2023-06-16 at 2 08 03 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/135059743/c36d10c3-5b1b-4258-b7f1-b92ff36a871e)

![Screenshot 2023-06-16 at 2 09 27 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/135059743/ca5cc469-39c4-4526-9cd5-151bea6dd568)

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Should be no impact, touching on displaying check-in lists for appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
