### PR TITLE
VACMS-11598: Removes facility_locator_show_community_cares Flipper references

### DIFF
--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "facilityLocatorShowCommunityCares",
-        "value": true
-      },
-      {
         "name": "facilitiesPpmsSuppressPharmacies",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -7,10 +7,6 @@
         "value": false
       },
       {
-        "name": "facilityLocatorShowCommunityCares",
-        "value": false
-      },
-      {
         "name": "facilitiesPpmsSuppressPharmacies",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "facilityLocatorShowCommunityCares",
-        "value": true
-      },
-      {
         "name": "facilitiesPpmsSuppressPharmacies",
         "value": true
       },

--- a/src/applications/static-pages/homepage/tests/mocks/features.js
+++ b/src/applications/static-pages/homepage/tests/mocks/features.js
@@ -2,7 +2,6 @@ const features = {
   data: {
     type: 'feature_toggles',
     features: [
-      { name: 'facilityLocatorShowCommunityCares', value: true },
       { name: 'profile_show_profile_2.0', value: false },
       { name: 'vaOnlineScheduling', value: true },
       { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -603,7 +603,6 @@ const responses = {
     data: {
       type: 'feature_toggles',
       features: [
-        { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
         { name: 'vaOnlineScheduling', value: true },
         { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -65,7 +65,6 @@ const responses = {
       type: 'feature_toggles',
       features: [
         { name: 'showExpandableVamcAlert', value: true },
-        { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
         { name: 'vaOnlineScheduling', value: true },
         { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -62,7 +62,6 @@ export default Object.freeze({
   facilityLocatorRailsEngine: 'facility_locator_rails_engine',
   facilityLocatorRestoreCommunityCarePagination:
     'facility_locator_restore_community_care_pagination',
-  facilityLocatorShowCommunityCares: 'facility_locator_show_community_cares', // Facilities team has deprecated this flag for the frontEnd logic, there is still backend support though.
   facilityLocatorShowOperationalHoursSpecialInstructions:
     'facility_locator_show_operational_hours_special_instructions',
   findFormsShowPdfModal: 'find_forms_show_pdf_modal',


### PR DESCRIPTION
## Summary
Deletes all references to `facility_locator_show_community_cares` Flipper feature flag. Gating based on this feature flag was previously removed. This PR simply removes the entry from `src/platform/utilities/feature-toggles/featureFlagNames.js`, as well as references to this flag from test files.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11598

## Testing done
Ensured all existing unit and E2E tests pass.

## What areas of the site does it impact?
This should have no effect on any functionality. This is cleanup.

## Acceptance criteria
- [ ] All references to `facility_locator_show_community_cares` and `facilityLocatorShowCommunityCares` are removed from vets-website.
