### PR TITLE
My VA - replace notification component

### DIFF
--- a/src/applications/personalization/dashboard/components/notifications/TestNotification.jsx
+++ b/src/applications/personalization/dashboard/components/notifications/TestNotification.jsx
@@ -2,18 +2,9 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import recordEvent from '~/platform/monitoring/record-event';
-import CTALink from '../CTALink';
+import { VaNotification } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import DashboardWidgetWrapper from '../DashboardWidgetWrapper';
 import { dismissNotificationById } from '../../actions/notifications';
-
-function handleNotification() {
-  recordEvent({
-    event: 'dashboard-navigation',
-    'dashboard-action': 'view-link-from-notifications',
-    'dashboard-product': 'view-manage-va-debt',
-  });
-}
 
 export const TestNotification = ({ notification, dismissNotification }) => {
   const [visible, setVisible] = useState(true);
@@ -24,53 +15,36 @@ export const TestNotification = ({ notification, dismissNotification }) => {
 
   const closeNotification = () => {
     dismissNotification(notification.id);
-    setVisible(open => !open);
+    setVisible(false);
   };
 
   return (
     <DashboardWidgetWrapper>
       {visible && (
-        <div
+        <VaNotification
           data-testid="onsite-notification-card"
-          className="onsite-notification vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--2p5"
-          role="alert"
+          closeBtnAriaLabel="Close notification"
+          closeable
+          onCloseEvent={closeNotification}
+          has-border
+          has-close-text
+          headline="You have new debt."
+          headline-level="3"
+          href="/manage-va-debt/your-debt"
+          symbol="action-required"
+          text="Manage your VA debt"
+          visible
+          class="vads-u-margin-bottom--1p5"
         >
-          <div className="vads-u-margin-top--0 vads-u-display--flex">
-            <i
-              aria-hidden="true"
-              className="fas fa-exclamation-circle vads-u-color--secondary-darkest vads-u-font-size--xl
-            vads-u-margin-right--1"
-            />
-            <div className="body" role="presentation">
-              <h3 className="vads-u-margin-y--0 vads-u-font-size--md">
-                You have new debt.
-              </h3>
-              <div className="">{createdAtFormatted}</div>
-
-              <CTALink
-                ariaLabel=""
-                className="vads-u-margin-top--1 vads-u-font-weight--bold"
-                text="Manage your VA debt"
-                href="/manage-va-debt/your-debt"
-                onClick={handleNotification}
-                showArrow
-              />
-            </div>
-            <button
-              className="onsite-notification-close"
-              aria-label="Close notification"
-              type="button"
-              onClick={closeNotification}
-            >
-              <i
-                aria-hidden="true"
-                className="fas fa-times-circle vads-u-margin-right--1"
-                role="presentation"
-              />
-              <span>CLOSE</span>
-            </button>
-          </div>
-        </div>
+          <time
+            slot="date"
+            dateTime={moment(notification.attributes.createdAt).format(
+              'YYYY-MM-DD HH:mm:ss',
+            )}
+          >
+            {createdAtFormatted}
+          </time>
+        </VaNotification>
       )}
     </DashboardWidgetWrapper>
   );

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
@@ -190,7 +190,7 @@ describe('The My VA Dashboard - Notifications', () => {
       cy.wait(['@nameB', '@serviceB', '@notifications6']);
       cy.findByTestId('dashboard-notifications').should('exist');
       cy.findAllByTestId('onsite-notification-card').should('have.length', 1);
-      cy.get('button.onsite-notification-close').click();
+      cy.get('button.va-notification-close').click();
       cy.wait('@patch');
       cy.findByTestId('onsite-notification-card').should('not.exist');
       cy.findByTestId('dashboard-notifications').should('not.exist');


### PR DESCRIPTION
## Summary

This PR replaces the current Notification component on My VA staging with the new [`va-notification` web component](https://design.va.gov/storybook/?path=/docs/components-va-notification--default) from the Design System component library. Appropriate e2e tests have been updated.

This exists behind the `my_va_experimental` feature flag.

## Related issue(s)
- Issue for this PR: https://github.com/department-of-veterans-affairs/va.gov-team/issues/54812
- Previous build (for My VA only): https://github.com/department-of-veterans-affairs/va.gov-team/issues/48726
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/59398

## Testing done
- unit and e2e tests pass
- visually on local

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

 | Before | After |
| ------ | ----- |
|     ![Screenshot 2023-04-07 at 5 14 04 PM](https://user-images.githubusercontent.com/8542413/231493595-24c18c75-bc4d-4fc6-b94b-979c08cb3a84.png)   |    ![Screenshot 2023-06-20 at 11 36 29 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8542413/94347f58-8b59-4683-914d-2034ce94dc94)   |

## What areas of the site does it impact?
My VA only

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user