### PR TITLE
Simple forms: rename submission url to match update in vets-api

### DIFF
--- a/src/applications/simple-forms/21-0966/config/form.js
+++ b/src/applications/simple-forms/21-0966/config/form.js
@@ -8,7 +8,7 @@ import getHelp from '../../shared/components/GetFormHelp';
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  // submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  // submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: '21-0966-intent-to-file-a-claim-',

--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -8,7 +8,7 @@ import getHelp from '../../shared/components/GetFormHelp';
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  // submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  // submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: '21-0972-alternate-signer-',

--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -54,7 +54,7 @@ const witnessHasOtherRelationship = formData => {
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   trackingPrefix: 'lay-witness-10210-',
   dev: {
     showNavLinks: true,

--- a/src/applications/simple-forms/21-4142/config/form.js
+++ b/src/applications/simple-forms/21-4142/config/form.js
@@ -33,7 +33,7 @@ import {
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   trackingPrefix: 'medical-release-4142-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,

--- a/src/applications/simple-forms/21-4142/tests/e2e/4142-medial-release.cypress.spec.js
+++ b/src/applications/simple-forms/21-4142/tests/e2e/4142-medial-release.cypress.spec.js
@@ -110,7 +110,7 @@ const testConfig = createTestConfig(
     },
     setupPerTest: () => {
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
-      cy.intercept('POST', '/forms_api/v1/simple_forms', mockSubmit);
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
     },
     skip: false,
   },

--- a/src/applications/simple-forms/21P-0847/config/form.js
+++ b/src/applications/simple-forms/21P-0847/config/form.js
@@ -25,7 +25,7 @@ const mockData = testData;
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   transformForSubmit,
   trackingPrefix: '21P-0847-substitute-claimant-',
   dev: {

--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -34,7 +34,7 @@ import {
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   trackingPrefix: 'adapted-housing-4555-',
   transformForSubmit,
   introduction: IntroductionPage,

--- a/src/applications/simple-forms/26-4555/tests/e2e/4555-adapted-housing.cypress.spec.js
+++ b/src/applications/simple-forms/26-4555/tests/e2e/4555-adapted-housing.cypress.spec.js
@@ -71,7 +71,7 @@ const testConfig = createTestConfig(
     },
     setupPerTest: () => {
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
-      cy.intercept('POST', '/forms_api/v1/simple_forms', mockSubmit);
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
     },
     skip: false,
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
@@ -22,7 +22,7 @@ const formConfig = {
   dev: {
     showNavLinks: true,
   },
-  submitUrl: `${environment.API_URL}/forms_api/v1/simple_forms`,
+  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   trackingPrefix: 'mock-simple-forms-patterns-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,


### PR DESCRIPTION
The forms_api module in vets-api renamed so as not to overlap with the [Lighthouse Forms API](https://developer.va.gov/explore/vaForms)

[vets-api PR to rename forms_api to simple_forms_api](https://github.com/department-of-veterans-affairs/vets-api/pull/13035)

## Summary

- Rename all simple-forms submission endpoints to go to `/simple_forms_api/v1/simple_forms`

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/343

## Testing done

- Tested form 26-4555, 21-4142, and 21-10210 locally and they submitted successfully (see screenshots)
- Cypress tests pass

## Screenshots
<img width="1508" alt="Screenshot 2023-06-20 at 11 44 05 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/86255d1a-347c-486d-9f07-cf0746da51bc">
<img width="1512" alt="Screenshot 2023-06-20 at 11 45 29 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/b9bdfb5f-5803-4cd0-93da-48ca472c1395">
<img width="1507" alt="Screenshot 2023-06-20 at 11 47 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/4f048e7b-fd27-4f07-a93e-3411f26d6906">



## What areas of the site does it impact?
All simple forms (none in prod)
