### PR TITLE
HLR & SC | Set up radio button tracking

### DIFF
--- a/src/applications/appeals/995/components/EvidencePrivateRecordsRequest.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecordsRequest.jsx
@@ -5,6 +5,7 @@ import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/
 
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { focusElement } from 'platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
 
 import {
   EVIDENCE_VA_PATH,
@@ -35,11 +36,18 @@ const EvidencePrivateRequest = ({
 
   const handlers = {
     onSelected: event => {
+      const val = event.detail.value === 'y';
       setFormData({
         ...data,
-        [EVIDENCE_PRIVATE]: event.detail.value === 'y',
+        [EVIDENCE_PRIVATE]: val,
       });
       setError(null);
+      recordEvent({
+        event: 'int-radio-button-option-click',
+        'radio-button-label': privateRecordsRequestTitle,
+        'radio-button-optionLabel': val ? 'Yes' : 'No',
+        'radio-button-required': true,
+      });
     },
     onGoBack: () => {
       if (data[EVIDENCE_VA]) {

--- a/src/applications/appeals/995/components/PrimaryPhone.jsx
+++ b/src/applications/appeals/995/components/PrimaryPhone.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import recordEvent from 'platform/monitoring/record-event';
 
 import { getFormattedPhone } from '../utils/contactInfo';
 import { checkValidations, missingPrimaryPhone } from '../validations';
@@ -49,6 +50,12 @@ export const PrimaryPhone = ({
         setFormData(formData);
         // setFormData lags a little, so check updated data
         checkErrors(formData);
+        recordEvent({
+          event: 'int-radio-button-option-click',
+          'radio-button-label': content.label,
+          'radio-button-optionLabel': content[`${value}Label`],
+          'radio-button-required': false,
+        });
       }
     },
   };
@@ -71,7 +78,7 @@ export const PrimaryPhone = ({
         <div name="topScrollElement" />
         <VaRadio
           class="vads-u-margin-y--2"
-          label="What is your primary phone number?"
+          label={content.label}
           label-header-level="3"
           hint="We may need to contact you if we have questions about your Supplemental Claim."
           error={hasError && errorMessages.missingPrimaryPhone}

--- a/src/applications/appeals/995/content/evidenceWillUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceWillUpload.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const evidenceWillUploadTitle =
+export const evidenceWillUploadTitle =
   'Do you want to upload your records or other documents to support your claim?';
 
 export const evidenceWillUploadHeader = (

--- a/src/applications/appeals/995/pages/evidencePrivateRequest.js
+++ b/src/applications/appeals/995/pages/evidencePrivateRequest.js
@@ -1,22 +1,8 @@
-import {
-  privateRecordsRequestTitle,
-  privateRecordsRequestInfo,
-} from '../content/evidencePrivateRecordsRequest';
 import { EVIDENCE_PRIVATE } from '../constants';
 
 export default {
   uiSchema: {
-    'ui:description': privateRecordsRequestInfo,
-    'ui:options': {
-      forceDivWrapper: true,
-    },
-    [EVIDENCE_PRIVATE]: {
-      'ui:title': privateRecordsRequestTitle,
-      'ui:options': {
-        forceDivWrapper: true,
-        hideOnReview: true,
-      },
-    },
+    [EVIDENCE_PRIVATE]: {},
   },
   schema: {
     type: 'object',

--- a/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
+++ b/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
@@ -19,6 +19,7 @@ export default {
       },
       'ui:options': {
         hideOnReview: true,
+        enableAnalytics: true,
       },
     },
     'view:vaEvidenceInfo': {

--- a/src/applications/appeals/995/pages/evidenceWillUpload.js
+++ b/src/applications/appeals/995/pages/evidenceWillUpload.js
@@ -19,6 +19,7 @@ export default {
       },
       'ui:options': {
         hideOnReview: true,
+        enableAnalytics: true,
       },
     },
     'view:otherEvidenceInfo': {

--- a/src/applications/appeals/995/tests/components/EvidencePrivateRecordsRequest.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidencePrivateRecordsRequest.unit.spec.jsx
@@ -4,6 +4,7 @@ import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 
 import EvidencePrivateRecordsRequest from '../../components/EvidencePrivateRecordsRequest';
+import { privateRecordsRequestTitle } from '../../content/evidencePrivateRecordsRequest';
 import {
   errorMessages,
   EVIDENCE_PRIVATE,
@@ -23,6 +24,27 @@ describe('<EvidencePrivateRecordsRequest>', () => {
     expect($('va-radio', container)).to.exist;
     expect($('va-additional-info', container)).to.exist;
     expect($$('button', container).length).to.eq(2);
+  });
+
+  it('should capture google analytics', () => {
+    const { container } = render(
+      <div>
+        <EvidencePrivateRecordsRequest setFormData={() => {}} />
+      </div>,
+    );
+
+    const changeEvent = new CustomEvent('selected', {
+      detail: { value: 'y' },
+    });
+    $('va-radio', container).__events.vaValueChange(changeEvent);
+
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label': privateRecordsRequestTitle,
+      'radio-button-optionLabel': 'Yes',
+      'radio-button-required': true,
+    });
   });
 
   it('should submit page with error (required question)', () => {

--- a/src/applications/appeals/995/tests/components/PrimaryPhone.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/PrimaryPhone.unit.spec.jsx
@@ -34,20 +34,39 @@ describe('<PrimaryPhone>', () => {
     );
   };
 
+  const veteran = {
+    homePhone: { areaCode: '123', phoneNumber: '4567890' },
+    mobilePhone: { areaCode: '123', phoneNumber: '4567891' },
+  };
+
   it('should render', () => {
     const { container } = render(setup());
     expect($$('va-radio-option', container).length).to.eq(2);
   });
+
+  it('should capture google analytics', async () => {
+    global.window.dataLayer = [];
+    const { container } = render(setup({ data: { veteran } }));
+
+    const changeEvent = new CustomEvent('selected', {
+      detail: { value: 'home' },
+    });
+    $('va-radio', container).__events.vaValueChange(changeEvent);
+
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label': 'What is your primary phone number?',
+      'radio-button-optionLabel': 'Home phone number',
+      'radio-button-required': false,
+    });
+  });
+
   it('should prevent submission when empty', () => {
     const goForwardSpy = sinon.spy();
     const data = setup({
       goForward: goForwardSpy,
-      data: {
-        veteran: {
-          homePhone: { areaCode: '123', phoneNumber: '4567890' },
-          mobilePhone: { areaCode: '123', phoneNumber: '4567891' },
-        },
-      },
+      data: { veteran },
     });
     const { container } = render(data);
     fireEvent.click($('button[type="submit"]', container));

--- a/src/applications/appeals/995/tests/pages/evidenceVaRecordsRequest.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceVaRecordsRequest.unit.spec.jsx
@@ -65,4 +65,29 @@ describe('Supplemental Claims VA evidence request page', () => {
     expect($('.usa-input-error', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
   });
+
+  it('should capture google analytics', () => {
+    global.window.dataLayer = [];
+    const { container } = render(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    fireEvent.click($('input[value="Y"]', container));
+
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label':
+        'Would you like us to request your VA medical records for you?',
+      'radio-button-optionLabel': 'Yes',
+      'radio-button-required': true,
+    });
+  });
 });

--- a/src/applications/appeals/995/tests/pages/evidenceWillUpload.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceWillUpload.unit.spec.jsx
@@ -8,6 +8,7 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 import { errorMessages, EVIDENCE_OTHER } from '../../constants';
+import { evidenceWillUploadTitle } from '../../content/evidenceWillUpload';
 
 describe('Supplemental Claims evidence upload request page', () => {
   const {
@@ -64,5 +65,29 @@ describe('Supplemental Claims evidence upload request page', () => {
     expect(container.innerHTML).to.contain('value="Y" checked');
     expect($('.usa-input-error', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
+  });
+
+  it('should capture google analytics', () => {
+    global.window.dataLayer = [];
+    const { container } = render(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    fireEvent.click($('input[value="Y"]', container));
+
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label': evidenceWillUploadTitle,
+      'radio-button-optionLabel': 'Yes',
+      'radio-button-required': true,
+    });
   });
 });

--- a/src/applications/appeals/996/content/InformalConference.jsx
+++ b/src/applications/appeals/996/content/InformalConference.jsx
@@ -74,7 +74,6 @@ export const InformalConferenceTimesDescriptionV2 = (
   </>
 );
 
-export const informalConferenceTimeSelectTitles = {
-  first: <>Choose the best time for us to call {contacts}</>,
-  second: 'Choose another time for us to call',
-};
+export const informalConferenceTimeSelectTitle = (
+  <>Choose the best time for us to call {contacts}</>
+);

--- a/src/applications/appeals/996/pages/homeless.js
+++ b/src/applications/appeals/996/pages/homeless.js
@@ -8,6 +8,9 @@ export default {
       'ui:title':
         'Are you experiencing homelessness or at risk of becoming homeless?',
       'ui:widget': 'yesNo',
+      'ui:options': {
+        enableAnalytics: true,
+      },
     },
   },
   schema: {

--- a/src/applications/appeals/996/pages/informalConference.js
+++ b/src/applications/appeals/996/pages/informalConference.js
@@ -31,6 +31,7 @@ const informalConference = {
           me: { 'aria-describedby': 'choose-conference-notice' },
           rep: { 'aria-describedby': 'choose-conference-notice' },
         },
+        enableAnalytics: true,
       },
       'ui:errorMessages': {
         required: errorMessages.informalConferenceContactChoice,

--- a/src/applications/appeals/996/pages/informalConferenceTimeV2.js
+++ b/src/applications/appeals/996/pages/informalConferenceTimeV2.js
@@ -4,7 +4,7 @@ import { errorMessages, CONFERENCE_TIMES_V2 } from '../constants';
 import {
   InformalConferenceTimesTitle,
   InformalConferenceTimesDescriptionV2,
-  informalConferenceTimeSelectTitles,
+  informalConferenceTimeSelectTitle,
 } from '../content/InformalConference';
 
 // HLR version 2
@@ -13,12 +13,15 @@ export default {
     'ui:title': InformalConferenceTimesTitle,
     'ui:description': InformalConferenceTimesDescriptionV2,
     informalConferenceTime: {
-      'ui:title': informalConferenceTimeSelectTitles.first,
+      'ui:title': informalConferenceTimeSelectTitle,
       'ui:widget': 'radio',
       'ui:required': formData => formData?.informalConference !== 'no',
       'ui:validations': [checkConferenceTimes],
       'ui:errorMessages': {
         required: errorMessages.informalConferenceTimes,
+      },
+      'ui:options': {
+        enableAnalytics: true,
       },
     },
   },

--- a/src/applications/appeals/996/tests/pages/InformalConference.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/pages/InformalConference.unit.spec.jsx
@@ -1,24 +1,20 @@
 import React from 'react';
 import { expect } from 'chai';
+import { fireEvent, render } from '@testing-library/react';
 import sinon from 'sinon';
-import ReactTestUtils from 'react-dom/test-utils';
 
-import {
-  DefinitionTester,
-  submitForm,
-  getFormDOM,
-} from 'platform/testing/unit/schemaform-utils';
-
-import { $$ } from '../../utils/ui';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 import informalConference from '../../pages/informalConference';
+import { InformalConferenceTitle } from '../../content/InformalConference';
 
 const { schema, uiSchema } = informalConference;
 
 describe('Higher-Level Review 0996 informal conference', () => {
   it('should render informal conference form', () => {
-    const form = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
@@ -28,14 +24,13 @@ describe('Higher-Level Review 0996 informal conference', () => {
       />,
     );
 
-    const formDOM = getFormDOM(form);
-    expect($$('input[type="radio"]', formDOM).length).to.equal(3);
+    expect($$('input[type="radio"]', container).length).to.equal(3);
   });
 
   /* Successful submits */
   it('successfully submits when no informal conference is selected', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
@@ -46,16 +41,15 @@ describe('Higher-Level Review 0996 informal conference', () => {
       />,
     );
 
-    const formDOM = getFormDOM(form);
-    submitForm(form);
-    expect($$('.usa-input-error', formDOM).length).to.equal(0);
+    fireEvent.submit($('form', container));
+    expect($$('.usa-input-error', container).length).to.equal(0);
     expect(onSubmit.called).to.be.true;
   });
 
   /* Unsuccessful submits */
   it('prevents submit when informal conference is not selected', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
@@ -66,9 +60,32 @@ describe('Higher-Level Review 0996 informal conference', () => {
       />,
     );
 
-    const formDOM = getFormDOM(form);
-    submitForm(form);
-    expect($$('.usa-input-error', formDOM).length).to.equal(1);
+    fireEvent.submit($('form', container));
+    expect($$('.usa-input-error', container).length).to.equal(1);
     expect(onSubmit.called).not.to.be.true;
+  });
+
+  it('should capture google analytics', () => {
+    global.window.dataLayer = [];
+    const { container } = render(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    fireEvent.click($('input[value="me"]', container));
+
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label': InformalConferenceTitle,
+      'radio-button-optionLabel': 'me',
+      'radio-button-required': true,
+    });
   });
 });

--- a/src/applications/appeals/996/tests/pages/homeless.unit.spec.js
+++ b/src/applications/appeals/996/tests/pages/homeless.unit.spec.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import sinon from 'sinon';
 
-import {
-  DefinitionTester,
-  selectRadio,
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 
@@ -14,7 +12,7 @@ describe('HLR homeless page', () => {
   const { schema, uiSchema } = formConfig.chapters.infoPages.pages.homeless;
 
   it('should render', () => {
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         schema={schema}
@@ -24,13 +22,12 @@ describe('HLR homeless page', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(2);
-    form.unmount();
+    expect($$('input', container).length).to.equal(2);
   });
 
   it('should allow submit', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         schema={schema}
@@ -41,17 +38,16 @@ describe('HLR homeless page', () => {
       />,
     );
 
-    selectRadio(form, 'root_homeless', 'N');
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    fireEvent.click($('input[value="N"]', container));
+    fireEvent.submit($('form', container));
+    expect($('.usa-input-error-message', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
-    form.unmount();
   });
 
   // board option is required
   it('should prevent continuing', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         schema={schema}
@@ -62,9 +58,33 @@ describe('HLR homeless page', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    fireEvent.submit($('form', container));
+    expect($$('.usa-input-error-message', container).length).to.equal(1);
     expect(onSubmit.called).to.be.false;
-    form.unmount();
+  });
+
+  it('should capture google analytics', () => {
+    global.window.dataLayer = [];
+    const { container } = render(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    fireEvent.click($('input[value="Y"]', container));
+
+    const event = global.window.dataLayer.slice(-1)[0];
+    expect(event).to.deep.equal({
+      event: 'int-radio-button-option-click',
+      'radio-button-label':
+        'Are you experiencing homelessness or at risk of becoming homeless?',
+      'radio-button-optionLabel': 'Yes',
+      'radio-button-required': false,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Analytics for form system radio buttons was recently added (by adding `enableAnalytics: true` to the `ui:options`) in our Notice of Disagreement form. We also noted that our other appeals forms - Higher-Level Review and Supplemental Claim - needed analytics added to all radio buttons.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#60431](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60431)

## Testing done

- _Describe what the old behavior was prior to the change_
  > No GA events recorded
- _Describe the steps required to verify your changes are working as expected_
  > Test checking radio selections in staging or in a review instance
- _Describe the tests completed and the results_
  > Updated component & page unit tests; all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| GA events |
| ------- |
| HLR |
| <img width="616" alt="homeless event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c39c4550-14e4-427e-976a-225e5e486bf0"> |
| <img width="513" alt="informal conference event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/878bc86b-a4ba-40c2-9f30-dff437c51da4"> |
| <img width="504" alt="informal conference time event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/7857ce8a-d887-4034-9ea0-78c67c823e1d"> |
| SC |
| <img width="423" alt="primary phone event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/8f274522-955c-407a-ac19-4dbe3aad2b3e"> |
| <img width="585" alt="Include VA evidence event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/6f99442c-aaae-448d-8c39-69c7d354dee3"> |
| <img width="557" alt="Private evidence event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/1324d94b-7747-403e-853a-a231dd92df45"> |
| <img width="667" alt="upload evidence event" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b958f1b5-e7a7-4607-a51b-13384fa4a0d2"> |

## What areas of the site does it impact?

HLR & Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
