### PR TITLE
59798 Implement page migration for first pass of 526 sync

### DIFF
--- a/src/applications/disability-benefits/all-claims/migrations/08-paper-sync.js
+++ b/src/applications/disability-benefits/all-claims/migrations/08-paper-sync.js
@@ -11,25 +11,40 @@ export default function reorderHousingIllnessRemoveFdc(savedData) {
   if (
     returnUrl === '/veteran-information' ||
     returnUrl === '/contact-information'
-  )
+  ) {
     return savedData;
+  }
 
   const { formData } = savedData;
   if (formData.homelessOrAtRisk === undefined) {
-    return Object.assign({}, savedData, {
-      metadata: { returnUrl: '/housing-situation-1' },
-    });
+    return {
+      ...savedData,
+      metadata: {
+        ...savedData.metadata,
+        returnUrl: '/housing-situation-1', // TODO: #59003 Rename for prod launch
+      },
+    };
   }
 
   if (formData.isTerminallyIll === undefined) {
-    return Object.assign({}, savedData, {
-      metadata: { returnUrl: '/terminally-ill-1' },
-    });
+    return {
+      ...savedData,
+      metadata: {
+        ...savedData.metadata,
+        returnUrl: '/terminally-ill-1', // TODO: #59003 Rename for prod launch
+      },
+    };
   }
 
-  if (returnUrl === '/fully-developed-claim')
-    return Object.assign({}, savedData, {
-      metadata: { returnUrl: '/review-and-submit' },
-    });
+  if (returnUrl === '/fully-developed-claim') {
+    return {
+      ...savedData,
+      metadata: {
+        ...savedData.metadata,
+        returnUrl: '/review-and-submit',
+      },
+    };
+  }
+
   return savedData;
 }

--- a/src/applications/disability-benefits/all-claims/migrations/08-paper-sync.js
+++ b/src/applications/disability-benefits/all-claims/migrations/08-paper-sync.js
@@ -1,0 +1,35 @@
+/**
+ * Syncing 526 online form with paper form
+ *  Move housing-situation and terminally-ill pages from additionalInformation to veteranDetails chapter which
+ *    is from the last chapter to the first. If user has progressed beyond the first couple pages and hasn't
+ *    filled either of these out yet, redirect to them.
+ *  Fully developed claim page was removed. If they left off here, redirect to review and submit page.
+ */
+export default function reorderHousingIllnessRemoveFdc(savedData) {
+  const { returnUrl } = savedData.metadata;
+
+  if (
+    returnUrl === '/veteran-information' ||
+    returnUrl === '/contact-information'
+  )
+    return savedData;
+
+  const { formData } = savedData;
+  if (formData.homelessOrAtRisk === undefined) {
+    return Object.assign({}, savedData, {
+      metadata: { returnUrl: '/housing-situation-1' },
+    });
+  }
+
+  if (formData.isTerminallyIll === undefined) {
+    return Object.assign({}, savedData, {
+      metadata: { returnUrl: '/terminally-ill-1' },
+    });
+  }
+
+  if (returnUrl === '/fully-developed-claim')
+    return Object.assign({}, savedData, {
+      metadata: { returnUrl: '/review-and-submit' },
+    });
+  return savedData;
+}

--- a/src/applications/disability-benefits/all-claims/migrations/index.js
+++ b/src/applications/disability-benefits/all-claims/migrations/index.js
@@ -1,3 +1,4 @@
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import redirectToClaimTypePage from './01-require-claim-type';
 import convertCountryCode from './02-convert-country-code';
 import upgradeHasSeparationPay from './03-upgrade-hasSeparationPay';
@@ -5,13 +6,14 @@ import truncateOtherHomelessHousing from './04-truncate-otherHomelessHousing';
 import truncateOtherAtRiskHousing from './05-truncate-otherAtRiskHousing';
 import fixTreatedDisabilityNamesKey from './06-fix-treatedDisabilityNames';
 import mapServiceBranches from './07-map-service-branches';
+import reorderHousingIllnessRemoveFdc from './08-paper-sync';
 
 // We launched at version 1 and not version 0, so the first _real_ migration is at
 //  migrations[1]
 // NOTE: This will probably just get skipped over, but it's here to be safe
 const emptyMigration = savedData => savedData;
 
-export default [
+const migrations = [
   emptyMigration,
   redirectToClaimTypePage,
   convertCountryCode,
@@ -21,3 +23,10 @@ export default [
   fixTreatedDisabilityNamesKey,
   mapServiceBranches,
 ];
+
+// TODO: #59003 Remove for prod launch
+if (!environment.isProduction()) {
+  migrations.push(reorderHousingIllnessRemoveFdc);
+}
+
+export default migrations;

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -249,7 +249,9 @@ describe('526 v2 migrations', () => {
         },
       };
       const migratedData = reorderHousingIllnessRemoveFdc(savedData);
-      expect(migratedData.metadata.returnUrl).to.equal('/veteran-information');
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/veteran-information',
+      );
     });
 
     it('should not change returnUrl if user left off on the contact info page', () => {
@@ -261,7 +263,9 @@ describe('526 v2 migrations', () => {
         },
       };
       const migratedData = reorderHousingIllnessRemoveFdc(savedData);
-      expect(migratedData.metadata.returnUrl).to.deep.equal('/contact-information');
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/contact-information',
+      );
     });
 
     it('should change returnUrl to housing-situation when user could potentially skip it', () => {
@@ -295,7 +299,9 @@ describe('526 v2 migrations', () => {
       const migratedData = reorderHousingIllnessRemoveFdc(savedData);
 
       // TODO: #59003 Rename for prod launch
-      expect(migratedData.metadata.returnUrl).to.equal('/terminally-ill-1');
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/terminally-ill-1',
+      );
     });
 
     it('should change returnUrl to review and submit if on the fdc page', () => {
@@ -312,7 +318,9 @@ describe('526 v2 migrations', () => {
 
       const migratedData = reorderHousingIllnessRemoveFdc(savedData);
 
-      expect(migratedData.metadata.returnUrl).to.equal('/review-and-submit');
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/review-and-submit',
+      );
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -6,6 +6,7 @@ import truncateOtherHomelessHousing from '../../migrations/04-truncate-otherHome
 import truncateOtherAtRiskHousing from '../../migrations/05-truncate-otherAtRiskHousing';
 import fixTreatedDisabilityNamesKey from '../../migrations/06-fix-treatedDisabilityNames';
 import mapServiceBranches from '../../migrations/07-map-service-branches';
+import reorderHousingIllnessRemoveFdc from '../../migrations/08-paper-sync';
 
 import formConfig from '../../config/form';
 import { MAX_HOUSING_STRING_LENGTH } from '../../constants';
@@ -236,5 +237,71 @@ describe('526 v2 migrations', () => {
       const migratedData = mapServiceBranches(getData(Object.keys(list)));
       expect(migratedData).to.deep.equal(getData(Object.values(list)));
     });
+  });
+
+  describe('08-paper-sync', () => {
+    it('should not change returnUrl if user left off on the veteran info page', () => {
+      const savedData = {
+        formData: {},
+        metadata: {
+          returnUrl: '/veteran-information',
+        },
+      };
+      const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+      expect(migratedData.metadata.returnUrl).to.equal('/veteran-information');
+    });
+  });
+
+  it('should not change returnUrl if user left off on the contact info page', () => {
+    const savedData = {
+      formData: {},
+      metadata: {
+        returnUrl: '/contact-information',
+      },
+    };
+    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+    expect(migratedData.metadata.returnUrl).to.equal('/contact-information');
+  });
+
+  it('should change returnUrl to housing-situation when user could potentially skip it', () => {
+    const savedData = {
+      formData: {},
+      metadata: {
+        returnUrl: '/claim-type',
+      },
+    };
+
+    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+
+    // TODO: #59003 Rename for prod launch
+    expect(migratedData.metadata.returnUrl).to.equal('/housing-situation-1');
+  });
+
+  it('should change returnUrl to terminally-ill when user could potentially skip it', () => {
+    const savedData = {
+      formData: {},
+      metadata: {
+        returnUrl: '/payment-information',
+      },
+    };
+
+    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+
+    // TODO: #59003 Rename for prod launch
+    expect(migratedData.metadata.returnUrl).to.equal('/terminally-ill-1');
+  });
+
+  it('should change returnUrl review and submit if on the fdc page', () => {
+    const savedData = {
+      formData: {},
+      metadata: {
+        returnUrl: '/fully-developed-claim',
+      },
+    };
+
+    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+
+    // TODO: #59003 Rename for prod launch
+    expect(migratedData.metadata.returnUrl).to.equal('/review-and-submit');
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -244,69 +244,75 @@ describe('526 v2 migrations', () => {
       const savedData = {
         formData: {},
         metadata: {
+          version: 8,
           returnUrl: '/veteran-information',
         },
       };
       const migratedData = reorderHousingIllnessRemoveFdc(savedData);
       expect(migratedData.metadata.returnUrl).to.equal('/veteran-information');
     });
-  });
 
-  it('should not change returnUrl if user left off on the contact info page', () => {
-    const savedData = {
-      formData: {},
-      metadata: {
-        returnUrl: '/contact-information',
-      },
-    };
-    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
-    expect(migratedData.metadata.returnUrl).to.equal('/contact-information');
-  });
+    it('should not change returnUrl if user left off on the contact info page', () => {
+      const savedData = {
+        formData: {},
+        metadata: {
+          version: 8,
+          returnUrl: '/contact-information',
+        },
+      };
+      const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+      expect(migratedData.metadata.returnUrl).to.deep.equal('/contact-information');
+    });
 
-  it('should change returnUrl to housing-situation when user could potentially skip it', () => {
-    const savedData = {
-      formData: {},
-      metadata: {
-        returnUrl: '/claim-type',
-      },
-    };
+    it('should change returnUrl to housing-situation when user could potentially skip it', () => {
+      const savedData = {
+        formData: {},
+        metadata: {
+          version: 8,
+          returnUrl: '/claim-type',
+        },
+      };
 
-    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+      const migratedData = reorderHousingIllnessRemoveFdc(savedData);
 
-    // TODO: #59003 Rename for prod launch
-    expect(migratedData.metadata.returnUrl).to.equal('/housing-situation-1');
-  });
+      // TODO: #59003 Rename for prod launch
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/housing-situation-1',
+      );
+    });
 
-  it('should change returnUrl to terminally-ill when user could potentially skip it', () => {
-    const savedData = {
-      formData: {
-        homelessOrAtRisk: 'homeless',
-      },
-      metadata: {
-        returnUrl: '/payment-information',
-      },
-    };
+    it('should change returnUrl to terminally-ill when user could potentially skip it', () => {
+      const savedData = {
+        formData: {
+          homelessOrAtRisk: 'homeless',
+        },
+        metadata: {
+          version: 8,
+          returnUrl: '/housing-situation',
+        },
+      };
 
-    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+      const migratedData = reorderHousingIllnessRemoveFdc(savedData);
 
-    // TODO: #59003 Rename for prod launch
-    expect(migratedData.metadata.returnUrl).to.equal('/terminally-ill-1');
-  });
+      // TODO: #59003 Rename for prod launch
+      expect(migratedData.metadata.returnUrl).to.equal('/terminally-ill-1');
+    });
 
-  it('should change returnUrl to review and submit if on the fdc page', () => {
-    const savedData = {
-      formData: {
-        isTerminallyIll: false,
-        homelessOrAtRisk: 'no',
-      },
-      metadata: {
-        returnUrl: '/fully-developed-claim',
-      },
-    };
+    it('should change returnUrl to review and submit if on the fdc page', () => {
+      const savedData = {
+        formData: {
+          isTerminallyIll: false,
+          homelessOrAtRisk: 'no',
+        },
+        metadata: {
+          version: 8,
+          returnUrl: '/fully-developed-claim',
+        },
+      };
 
-    const migratedData = reorderHousingIllnessRemoveFdc(savedData);
+      const migratedData = reorderHousingIllnessRemoveFdc(savedData);
 
-    // TODO: #59003 Rename for prod launch
-    expect(migratedData.metadata.returnUrl).to.equal('/review-and-submit');
+      expect(migratedData.metadata.returnUrl).to.equal('/review-and-submit');
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -279,7 +279,9 @@ describe('526 v2 migrations', () => {
 
   it('should change returnUrl to terminally-ill when user could potentially skip it', () => {
     const savedData = {
-      formData: {},
+      formData: {
+        homelessOrAtRisk: 'homeless',
+      },
       metadata: {
         returnUrl: '/payment-information',
       },
@@ -291,9 +293,12 @@ describe('526 v2 migrations', () => {
     expect(migratedData.metadata.returnUrl).to.equal('/terminally-ill-1');
   });
 
-  it('should change returnUrl review and submit if on the fdc page', () => {
+  it('should change returnUrl to review and submit if on the fdc page', () => {
     const savedData = {
-      formData: {},
+      formData: {
+        isTerminallyIll: false,
+        homelessOrAtRisk: 'no',
+      },
       metadata: {
         returnUrl: '/fully-developed-claim',
       },


### PR DESCRIPTION
## Summary
Handle page migrations for the following 3 scenarios
-If user had a returnUrl for save in progress 526 form set to FDC, return the user to the review and submit page
-if user left off on veteran info or contact info page, business as usual
-if user has empty data for the housing situation or terminally ill pages, redirect them there (even though this puts them back closer to the beginning of the form and they may need to go through saved pages again)

Also see [this doc](https://docs.google.com/document/d/1OqmIKHlUKY6N78iYJADW3T_LNgKbjWvN69aKdaXbaJM/edit?usp=sharing) for notes on the page changes

- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Experience TRex Team

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
Not using toggles, but we are going through collab cycle which is why you'll see logic wrapped in environment checks (changes should only run in non prod env's as of now) and duplicate pages with todo's for later cleanup

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59798)

## Testing done
- _Describe what the old behavior was prior to the change_
Previously the housing-situation and terminally-ill pages were in the last chapter. They have been moved to the first chapter. We are adding this page migration logic to make sure user does not skip these pages. We are also handling the scenario for the removed fully-developed-claim page

- _Describe the steps required to verify your changes are working as expected_
This is very tricky to mock up for manual or e2e testing. I basically had to run the 526 app without any of the pages moved or the migration to certain points and then restart the app with the changes and see what happened.

- _Describe the tests completed and the results_
Three scenarios were run with videos saved [here](https://drive.google.com/file/d/1JdZaeSpBjGokCk1h10exRFutNvpmyzzG/view?usp=drive_link)
1. Fill out a 526 original claim up until the claim-type page which is somewhere in the middle of the 526 form. Upon returning after the pages have been moved, user is returned to the housing-situation page which is now in chapter 1, rather than claim-type so they don't skip filling out this page.

2. Fill out a 526 original claim up until the housing-situation page. Upon returning after the pages have been moved, user is returned to the terminally-ill page which is now in chapter 1.

3. Fill out a 526 original claim up until the fully-developed-claim page. Upon returning after the pages has been deleted, user is returned to the review-and-submit page. 


## Screenshots
n/a

## What areas of the site does it impact?
526 EZ form


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] ~~Screenshot of the developed feature is added~~ n/a
- [ ] ~~[Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed~~ n/a 

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user