### PR TITLE
Simple forms: 21-0972 update confirmation and intro pages per design

### DIFF
--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -26,21 +26,21 @@ const statementOfTruthBody = (
         Social Security Number (SSN) or Taxpayer Identification Number (TIN);
       </li>
       <li>
-        a certificate or order from a court with competent jurisdiction showing
+        A certificate or order from a court with competent jurisdiction showing
         my authority to act for the veteran/claimant with a judge’s signature
         and date/time stamp;
       </li>
-      <li>copy of documentation showing appointment of fiduciary;</li>
+      <li>Copy of documentation showing appointment of fiduciary;</li>
       <li>
-        durable power of attorney showing the name and signature of the
+        Durable power of attorney showing the name and signature of the
         veteran/claimant and my authority as attorney in fact or agent;
       </li>
       <li>
-        health care power of attorney, affidavit or notarized statement from an
+        Health care power of attorney, affidavit or notarized statement from an
         institution or person responsible for the care of the veteran/claimant
         indicating the capacity or responsibility of care provided;
       </li>
-      <li>or any other documentation showing such authorization.</li>
+      <li>Or any other documentation showing such authorization.</li>
     </ul>
     <p>
       I certify that the identifying information in this form has been correctly

--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -1,9 +1,53 @@
+import React from 'react';
 import footerContent from 'platform/forms/components/FormFooter';
-import manifest from '../manifest.json';
 
+import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import getHelp from '../../shared/components/GetFormHelp';
+import transformForSubmit from '../../shared/config/submit-transformer';
+
+const statementOfTruthBody = (
+  <>
+    <p>
+      I understand that I may be asked to confirm the truthfulness of the
+      answers to the best of my knowledge under penalty of perjury.
+    </p>
+
+    <p>
+      I also understand that VA may request further documentation or evidence to
+      verify or confirm my authorization to sign or complete an application on
+      behalf of the veteran/claimant if necessary. Examples of evidence which VA
+      may request include:
+    </p>
+
+    <ul>
+      <li>
+        Social Security Number (SSN) or Taxpayer Identification Number (TIN);
+      </li>
+      <li>
+        a certificate or order from a court with competent jurisdiction showing
+        my authority to act for the veteran/claimant with a judge’s signature
+        and date/time stamp;
+      </li>
+      <li>copy of documentation showing appointment of fiduciary;</li>
+      <li>
+        durable power of attorney showing the name and signature of the
+        veteran/claimant and my authority as attorney in fact or agent;
+      </li>
+      <li>
+        health care power of attorney, affidavit or notarized statement from an
+        institution or person responsible for the care of the veteran/claimant
+        indicating the capacity or responsibility of care provided;
+      </li>
+      <li>or any other documentation showing such authorization.</li>
+    </ul>
+    <p>
+      I certify that the identifying information in this form has been correctly
+      represented.
+    </p>
+  </>
+);
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -11,9 +55,22 @@ const formConfig = {
   // submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
+  transformForSubmit,
   trackingPrefix: '21-0972-alternate-signer-',
+  dev: {
+    showNavLinks: true,
+  },
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  preSubmitInfo: {
+    statementOfTruth: {
+      body: statementOfTruthBody,
+      // TODO: figure out what to put in the label
+      messageAriaDescribedby:
+        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+      fullNamePath: 'preparerName',
+    },
+  },
   formId: '21-0972',
   saveInProgress: {
     // messages: {
@@ -30,6 +87,7 @@ const formConfig = {
       'Please sign in again to continue your application for alternate signer.',
   },
   title: 'Sign for benefits on behalf of another person',
+  subTitle: 'Alternate signer certification (VA Form 21-0972)',
   defaultDefinitions: {},
   chapters: {
     chapter1: {

--- a/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
@@ -1,101 +1,309 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format, isValid } from 'date-fns';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { focusElement } from 'platform/utilities/ui';
-import FormFooter from 'platform/forms/components/FormFooter';
+import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
 
-import GetFormHelp from '../../shared/components/GetFormHelp';
+const content = {
+  headlineText: 'Thank you for submitting your alternate signer certification',
+  nextStepsText:
+    'You are now able to submit for benefits on behalf of the Veteran or a non-veteran claimant you identified in your alternate signer certification.',
+};
 
-export class ConfirmationPage extends React.Component {
-  componentDidMount() {
-    focusElement('h2');
-    scrollToTop('topScrollElement');
-  }
+const childContent = (
+  <>
+    <h2>Which benefit forms can I sign?</h2>
+    <p>
+      You are now able to sign the following benefit applications on behalf of
+      the Veteran or a non-veteran claimant you identified in your alternate
+      signer certification.
+    </p>
+    <va-accordion
+      disable-analytics={{
+        value: 'false',
+      }}
+      section-heading={{
+        value: 'null',
+      }}
+    >
+      <va-accordion-item header="Accrued benefits" id="first">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21p-601">
+              Application for Accrued Amounts Due a Deceased Beneficiary (VA
+              Form 21P-601)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Appeals" id="second">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-20-0995">
+              Decision Review Request: Supplemental Claim (VA Form 20-0995)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-20-0996">
+              Decision Review Request: Higher-Level Review (VA Form 20-0996)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-10182">
+              Decision Review Request: Board Appeal (Notice of Disagreement) (VA
+              Form 20-10182)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Auto allowance" id="third">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-4502">
+              Application for Automobile or Other Conveyance and Adaptive
+              Equipment (VA Form 21-4502)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item
+        header="Benefits for certain children with disabilities"
+        id="fourth"
+      >
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-0304">
+              Application for Benefits for a Qualifying Veteran’s Child Born
+              with Disabilities (VA Form 21-0304)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Compensation" id="fifth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-526ez">
+              Application for Disability Compensation and Related Compensation
+              Benefits (VA Form 21-526EZ)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Compensation and/or Pension" id="sixth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-0966">
+              Intent to File a Claim for Compensation and/or Pension, or
+              Survivors Pension and/or DIC (VA Form 21-0966)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Dependents" id="seventh">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-686c">
+              Application Request to Add and/or Remove Dependents (VA Form
+              21-686c)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Dependent parent(s)" id="eighth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21p-509">
+              Statement of Dependency of Parent(s) (VA Form 21P-509)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Individual unemployability" id="ninth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-8940">
+              Veteran’s Application for Increased Compensation Based on
+              Unemployability (VA Form 21-8940)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Pension" id="tenth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21p-527ez">
+              Application for Pension (VA Form 21P-527EZ)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-0969">
+              Income and Asset Statement in Support of Claim for Pension or
+              Parents' Dependency and Indemnity Compensation (DIC) (VA Form
+              21P-0969)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-527">
+              Income, Net Worth, and Employment Statement (VA Form 21P-527)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-4165">
+              Pension Claim Questionnaire for Farm Income (VA Form 21P-4165)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-8416">
+              Medical Expense Report (VA Form 21P-8416)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-8049">
+              Request for Details of Expenses (VA Form 21P-8049)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21-526ez">
+              Application for Disability Compensation and Related Compensation
+              Benefits (VA Form 21-526EZ)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-4185">
+              Report of Income from Property or Business (VA Form 21P-4185)
+            </a>
+          </li>
+          <li>
+            ALL forms known as{' '}
+            <a href="find-forms/?q=Eligibility+Verification+Reports">
+              Eligibility Verification Reports
+            </a>{' '}
+            (EVR’s)
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Philippine claims" id="eleventh">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21p-0784">
+              Supplemental Income Questionnaire (VA Form 21-0784)
+            </a>
+          </li>
+          <li>
+            {/* 
+              TODO: Determine if we need this, 
+              cannot find form in va.gov/find-forms
+            */}
+            <a href="/find-forms">
+              Supplement to VA Forms 21-526EZ, 21P-534EZ, and 21P-535 (For
+              Philippine Claims) (VA Form 21-4169)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Post-tramatic stress disorder" id="twelfth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-0781">
+              Statement in Support of Claim for Service Connection for
+              Post-Traumatic Stress Disorder (PTSD) (VA Form 21-0781)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21-0781a">
+              Statement in Support of Claim for Service Connection for PTSD
+              Secondary to Personal Assault (VA Form 21-0781a)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item
+        header="School Age Child(ren) (Aged 18-23 Years and in School)"
+        id="thirteenth"
+      >
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21-674">
+              Request for Approval of School Attendance (VA Form 21-674)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item
+        header="Specially adapted housing or special home adaptation"
+        id="fourteenth"
+      >
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-26-4555">
+              Application in Acquiring Specially Adapted Housing or Special Home
+              Adaptation Grant (VA Form 26-4555)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+      <va-accordion-item header="Survivor benefits" id="fifteenth">
+        <ul>
+          <li>
+            <a href="/find-forms/about-form-21p-534ez">
+              Application for DIC, Death Pension, and/or Accrued Benefit (VA
+              Form 21P-534EZ)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-534">
+              Application for Dependency and Indemnity Compensation, Death
+              Pension, and Accrued Benefits by Surviving Spouse or Child (VA
+              Form 21P-534)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-534a">
+              Application for Dependency and Indemnity Compensation by a
+              Surviving Spouse or Child - In-Service Death Only (VA Form
+              21P-534a)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-535">
+              Application for Dependency and Indemnity Compensation by Parent(s)
+              (VA Form 21P-535)
+            </a>
+          </li>
+          <li>
+            <a href="/find-forms/about-form-21p-8924">
+              Application of Surviving Spouse or Child for REPS Benefits
+              (Restored Entitlement Program for Survivors) (VA Form 21P-8924)
+            </a>
+          </li>
+        </ul>
+      </va-accordion-item>
+    </va-accordion>
+    <br />
+  </>
+);
 
-  render() {
-    const { form } = this.props;
-    const { submission, data } = form;
+export const ConfirmationPage = () => {
+  const form = useSelector(state => state.form || {});
+  const { submission } = form;
+  // mock for testing
+  const fullName = {
+    first: 'first',
+    last: 'last',
+  };
+  const submitDate = submission.timestamp;
+  const confirmationNumber = submission.response?.confirmationNumber;
 
-    const { fullName } = data;
-    const submitDate = submission.timestamp;
-    const confirmationNumber = submission.response?.confirmationNumber;
-
-    return (
-      <div>
-        <div className="print-only">
-          <img
-            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-            alt="VA logo"
-            width="300"
-          />
-        </div>
-        <va-alert
-          close-btn-aria-label="Close notification"
-          status="success"
-          visible
-        >
-          <h2 slot="headline">
-            Thank you for submitting your certification request
-          </h2>
-          <p>
-            After we review your request we'll contact you to tell you what
-            happens next in the process.
-          </p>
-        </va-alert>
-        <div className="inset">
-          <h3 className="vads-u-margin-top--0">Your certification request</h3>
-          {fullName ? (
-            <>
-              <h4>Applicant</h4>
-              <p>
-                {fullName.first} {fullName.middle} {fullName.last}
-                {fullName.suffix ? `, ${fullName.suffix}` : null}
-              </p>
-            </>
-          ) : null}
-
-          {confirmationNumber ? (
-            <>
-              <h4>Confirmation number</h4>
-              <p>{confirmationNumber}</p>
-            </>
-          ) : null}
-
-          {isValid(submitDate) ? (
-            <>
-              <h4>Date submitted</h4>
-              <p>{format(submitDate, 'MMMM d, yyyy')}</p>
-            </>
-          ) : null}
-
-          <h4>Confirmation for your records</h4>
-          <p>You can print this confirmation page for your records</p>
-          <button
-            type="button"
-            className="usa-button vads-u-margin-top--0 screen-only"
-            onClick={window.print}
-          >
-            Print this page
-          </button>
-        </div>
-        <a
-          className="vads-c-action-link--green vads-u-margin-bottom--4"
-          href="/"
-        >
-          Go back to VA.gov
-        </a>
-        <h2>What are my next steps?</h2>
-        <p>a bunch of accordions</p>
-        <div>
-          <FormFooter formConfig={{ getHelp: GetFormHelp }} />
-        </div>
-      </div>
-    );
-  }
-}
+  return (
+    <ConfirmationPageView
+      submitterName={fullName}
+      submitDate={submitDate}
+      confirmationNumber={confirmationNumber}
+      content={content}
+      childContent={childContent}
+    />
+  );
+};
 
 ConfirmationPage.propTypes = {
   form: PropTypes.shape({

--- a/src/applications/simple-forms/21-0972/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0972/containers/IntroductionPage.jsx
@@ -1,91 +1,107 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+const content = {
+  formTitle: 'Sign for benefits on behalf of another person',
+  formSubTitle: 'Alternate signer certification (VA Form 21-0972)',
+  authStartFormText: 'Start the alternate signer application',
+  unauthStartText: 'Sign in to start your request',
+  saveInProgressText:
+    'Please complete the 21-0972 form to apply to be an alternate signer.',
+  displayNonVeteranMessaging: true,
+};
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="Sign for benefits on behalf of another person"
-          subtitle="Equal to VA Form 21-0972 (Sign for benefits on behalf of another person)"
-        />
-        <h2>When to use this form</h2>
-        <p>
-          This form is to be completed by the individual signing a benefits
-          application form on behalf of the veteran/claimant. For purposes of
-          this form, the individual signing the form on behalf of the
-          veteran/claimant is referred to as the "alternate signer." Your
-          accurate and complete answers to the questions on this form are
-          important to help VA complete the veteran/claimant's claim.
-        </p>
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the alternate signer application"
-        >
-          Please complete the 21-0972 form to apply for alternate signer.
-        </SaveInProgressIntro>
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          Follow the steps below to complete the alternate signer application
-        </h2>
-        <va-process-list>
-          <li>
-            <h3>Prepare</h3>
-            <h4>
-              To fill out this application you'll need the Veteran's and/or
-              Claimant's:
-            </h4>
-            <ul>
-              <li>Social Security number</li>
-              <li>Va file number (if they have one)</li>
-            </ul>
-            <p>
-              <strong>What if I need help filling out my application?</strong>{' '}
-              If you have trouble using this online form, call us at
-              800-698-2411 (TTY: 711). We’re here 24/7. If you need help
-              gathering your information or filling out your form, contact a
-              local Veterans Service Organization (VSO).
-              <a href="/vso">Find a local Veterans Service Organization</a>
-            </p>
-          </li>
-          <li>
-            <h3>Start your application</h3>
-            <p>Complete this form.</p>
-            <p>
-              After you submit the form, you'll get a confirmation message. You
-              can print this page for your records.
-            </p>
-          </li>
-        </va-process-list>
-        <SaveInProgressIntro
-          buttonOnly
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        />
-        <p />
-        <va-omb-info
-          res-burden="15"
-          omb-number="2900-0849"
-          exp-date="02/28/2026"
-        />
-      </article>
-    );
-  }
-}
+const ombInfo = {
+  resBurden: '15',
+  ombNumber: '2900-0849',
+  expDate: '02/28/2026',
+};
+
+const childContent = (
+  <>
+    <h2>When to use this form</h2>
+    <p>
+      This application certifies you as an alternate signer and allows the VA to
+      accept benefit applications signed by you on behalf of a Veteran or
+      claimant. For purposes of this form, the individual signing the form on
+      behalf of the veteran/claimant is referred to as the "alternate signer."
+      Your accurate and complete answers to the questions on this form are
+      important to help VA complete the veteran or claimant’s claim.
+    </p>
+  </>
+);
+
+export const IntroductionPage = ({ route }) => {
+  const additionalChildContent = (
+    <>
+      <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
+        Follow the steps below to complete the alternate signer application
+      </h2>
+      <va-process-list>
+        <li>
+          <h3>Prepare</h3>
+          <h4>
+            To fill out this application you’ll need the Veteran’s and/or
+            Claimant’s:
+          </h4>
+          <ul>
+            <li>Social Security number</li>
+            <li>Va file number (if they have one)</li>
+          </ul>
+          <p>
+            <strong>What if I need help filling out my application?</strong> If
+            you have trouble using this online form, call us at 800-698-2411
+            (TTY: 711). We’re here 24/7. If you need help gathering your
+            information or filling out your form, contact a local Veterans
+            Service Organization (VSO).
+          </p>
+          <p>
+            <a href="/vso">Find a local Veterans Service Organization</a>
+          </p>
+        </li>
+        <li>
+          <h3>Start your application</h3>
+          <p>Complete this form.</p>
+          <p>
+            After you submitting form, you’ll get a confirmation message. You
+            can print this for your records.
+          </p>
+        </li>
+      </va-process-list>
+      <SaveInProgressIntro
+        buttonOnly
+        headingLevel={2}
+        prefillEnabled={route.formConfig.prefillEnabled}
+        messages={route.formConfig.savedFormMessages}
+        pageList={route.pageList}
+        startText={content.authStartFormText}
+      />
+    </>
+  );
+
+  return (
+    <IntroductionPageView
+      route={route}
+      content={content}
+      ombInfo={ombInfo}
+      childContent={childContent}
+      additionalChildContent={additionalChildContent}
+    />
+  );
+};
+
+IntroductionPage.propTypes = {
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({
+      prefillEnabled: PropTypes.bool,
+      savedFormMessages: PropTypes.shape({}),
+    }),
+    pageList: PropTypes.array,
+  }),
+};
 
 export default IntroductionPage;


### PR DESCRIPTION
[Sketch files](https://www.sketch.com/s/2365576f-860a-40a7-8a18-8f1cfffaa1cc/p/2E3FABBF-AE27-4AB7-9FD6-FD3A7CE2266B/canvas)

## Summary

- Updated formConfig with expanded statement of truth content, some dev items
- Updated IntroductionPage with content from design
- Updated ConfirmationPage with content from design (note many accordions)

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/300

## Testing done

- Viewed pages locally

navigate to `/introduction`, `/review-and-submit`, and `/confirmation`

## Screenshots

Introduction
<img width="236" alt="Screenshot 2023-06-21 at 12 13 30 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/3c0f2eeb-e3e7-4346-92a7-489fc190647a">

Review and submit
<img width="350" alt="Screenshot 2023-06-21 at 12 13 04 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/8f193cf9-4a62-4928-9204-07900edabb9c">

Confirmation
<img width="221" alt="Screenshot 2023-06-21 at 12 13 23 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/6482d402-e546-4bba-9830-dc6c05cf2f16">


## What areas of the site does it impact?
Form 21-0972 (not prod)