### PR TITLE
59264 note that SHA url opens in a new tab

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -127,6 +127,7 @@ class IntroductionPage extends React.Component {
                     this required form:{' '}
                     <a href={DBQ_URL} target="_blank" rel="noreferrer">
                       Separation Health Assessment - Part A Self-Assessment
+                      (opens in a new tab)
                     </a>
                     . We recommend you download and fill out this form on a
                     desktop computer or laptop. Then return to this page to

--- a/src/applications/disability-benefits/all-claims/content/bddEvidenceSubmitLater.jsx
+++ b/src/applications/disability-benefits/all-claims/content/bddEvidenceSubmitLater.jsx
@@ -5,7 +5,7 @@ const alertContent = (
   <p className="vads-u-font-size--base">
     You’ll need to submit your completed{' '}
     <a href={DBQ_URL} target="_blank" rel="noreferrer">
-      Separation Health Assessment - Part A Self-Assessment
+      Separation Health Assessment - Part A Self-Assessment (opens in a new tab)
     </a>{' '}
     so we can request your VA exams. You can submit this form on VA.gov after
     you file your BDD claim.

--- a/src/applications/disability-benefits/all-claims/content/common.jsx
+++ b/src/applications/disability-benefits/all-claims/content/common.jsx
@@ -53,7 +53,8 @@ export const bddAlertBegin = (
     <p className="vads-u-font-size--base">
       You’ll need to upload your completed{' '}
       <a href={DBQ_URL} target="_blank" rel="noreferrer">
-        Separation Health Assessment - Part A Self-Assessment
+        Separation Health Assessment - Part A Self-Assessment (opens in a new
+        tab)
       </a>{' '}
       so we can request your VA exams. Use a desktop computer or laptop to
       download and fill out the form.


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
Add "(opens in a new tab)" for all the new BDD SHA links. The links are on 4 different pages
```
/introduction
/supporting-evidence/evidence-types-bdd (when you select no)
/supporting-evidence/additional-evidence
/confirmation
```

- _(If bug, how to reproduce)_
Doc for BDD flow https://dsvavsp.testrail.io/index.php?/cases/view/37804&group_by=cases:section_id&group_order=asc&display_deleted_cases=0&group_id=9793

- _(What is the solution, why is this the solution)_
On several pages, the link to the Part A Self-Assessment opens in a new tab. That makes sense for this situation, but opening in a new tab without warning can be disorienting for screen reader users who don't see the visual cues that they've shifted to a new tab, and can create cognitive load issues more broadly.  We are now including a warning about this behavior in the link text

- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Experience Team

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
n/a

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59264)

## Testing done

- _Describe what the old behavior was prior to the change_
No indication for screen readers that a link opens in a new tab

- _Describe the steps required to verify your changes are working as expected_
See test rail linked above

- _Describe the tests completed and the results_
Manual testing to step through flow. Verify links are still functional, screen reader reads link text as expected, visual checks such as zoom 400%.

## Screenshots
<img width="507" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/f014dbdd-af9f-49f1-953c-f823221e41e0">

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/09fd82a6-41dc-4ad4-9be2-87799c550cc1)

<img width="445" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/91989a47-03f4-427b-928f-372579339394">

<img width="627" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/c26cea82-6aa3-40e6-8977-234322a37cea">



## What areas of the site does it impact?
526EZ form

## Acceptance criteria
Link text is updated on all 4 pages

### Quality Assurance & Testing

- [ ] ~~I fixed|updated|added unit tests and integration tests for each feature (if applicable).~~ n/a
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] ~~Documentation has been updated ([link to documentation](#) \*if necessary)~~ n/a
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] ~~Events are being sent to the appropriate logging solution~~ n/a
- [ ] ~~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~~ n/a

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
