### PR TITLE
Check in/59401/fix tty link

### DIFF
--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -45,7 +45,8 @@ const Footer = ({ router, isPreCheckIn }) => {
             {t('and-select-0-were-here-24-7')}
           </p>
           <p>
-            {t('if-you-have-hearing-loss-call')} <va-telephone contact="711" />.
+            {t('if-you-have-hearing-loss-call')}{' '}
+            <va-telephone contact="711" tty />.
           </p>
         </div>
       ) : (

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -59,7 +59,7 @@
   "how-can-i-update-my-information": "How can I update my information?",
   "husband": "Husband",
   "i-live-on-a-united-states-military-base-outside-of-the-united-states": "I live on a United States military base outside of the United States.",
-  "if-you-have-hearing-loss-call": "If you have hearing loss, call TTY:",
+  "if-you-have-hearing-loss-call": "If you have hearing loss, call",
   "if-you-have-questions-please-call-us-were-here-24-7": "If you have questions, please call us at <0></0> (<1></1>). We’re here 24/7.",
   "if-you-need-to-make-changes-please-talk-to-a-staff-member-when-you-check-in": "If you need to make changes, please talk to a staff member when you check in.",
   "if-you-need-to-submit-receipts-for-other-expenses--helptext": "If you need to submit receipts for other expenses like tolls, meals, or lodging, you can’t file a claim now. But you can file your claim online 24/7 through the Beneficiary Travel Self Service System (BTSSS). Or you can use VA Form 10-3542 to submit a claim by mail, fax, email, or in person.",


### PR DESCRIPTION
## Summary

- Fixes the TTY link in the needs help section by removing the text `TTY:` and passing in a prop to the web component to display as a tty link

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#59401](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59401)

## Testing done

- Visual

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/2f1508f3-583b-4836-b046-f33c6c632b32)


## What areas of the site does it impact?

Check-in - Pre-Check-In - Need help section of the footer

## Acceptance criteria

-  [  ] Link displays properly with the TTY: being part of the clickable link text

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
