### PR TITLE
Make similar named fields not error each other

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -2,12 +2,22 @@ import React from 'react';
 import classNames from 'classnames';
 import get from '../../../../utilities/data/get';
 import { isReactComponent } from '../../../../utilities/ui';
-// import environment from 'platform/utilities/environment';
+
+export function checkIsTouched(formContext, currentFieldId) {
+  return (
+    formContext.touched[currentFieldId] ||
+    Object.keys(formContext.touched).some(touchedFieldId =>
+      // if "root_field" is touched, then we consider
+      // "root_field_child" as also touched, but
+      // "root_fieldSibling" should not be.
+      currentFieldId.match(new RegExp(`^${touchedFieldId}(?=$|[^a-zA-Z0-9])`)),
+    )
+  );
+}
 
 /*
  * This is the template for each field (which in the schema library means label + widget)
  */
-
 export default function FieldTemplate(props) {
   const {
     id,
@@ -20,9 +30,7 @@ export default function FieldTemplate(props) {
     uiSchema,
   } = props;
 
-  const isTouched =
-    formContext.touched[id] ||
-    Object.keys(formContext.touched).some(touched => id.startsWith(touched));
+  const isTouched = checkIsTouched(formContext, id);
   const hasErrors =
     (formContext.submitted || isTouched) && rawErrors && rawErrors.length;
   const requiredSpan = required ? (

--- a/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
 
-import FieldTemplate from '../../../src/js/components/FieldTemplate';
+import FieldTemplate, {
+  checkIsTouched,
+} from '../../../src/js/components/FieldTemplate';
 
 describe('Schemaform <FieldTemplate>', () => {
   it('should render', () => {
@@ -426,5 +428,62 @@ describe('Schemaform <FieldTemplate>', () => {
     );
 
     expect(tree.text()).to.equal('<WebComponentField />');
+  });
+});
+
+describe('Element touched states', () => {
+  it('should be touched if current field is touched', () => {
+    const formContext = {
+      touched: {
+        // eslint-disable-next-line camelcase
+        root_field: true,
+      },
+    };
+    expect(checkIsTouched(formContext, 'root_field')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_fiel')).to.be.false;
+    expect(checkIsTouched(formContext, 'root_fielde')).to.be.false;
+    expect(checkIsTouched(formContext, 'root')).to.be.false;
+  });
+
+  it('should be touched if parent field is touched', () => {
+    // Assuming this is what we want. Because previous logic
+    // checked for startsWith, but now we are using a RegExp
+    const formContext = {
+      touched: {
+        // eslint-disable-next-line camelcase
+        root_field: true,
+      },
+    };
+    expect(checkIsTouched(formContext, 'root_field_one')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field-one')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field:one')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field_0')).to.be.true;
+  });
+
+  it('should be touched if parent parent field is touched', () => {
+    // Assuming this is what we want. Because previous logic
+    // checked for startsWith, but now we are using a RegExp
+    const formContext = {
+      touched: {
+        // eslint-disable-next-line camelcase
+        root_field: true,
+      },
+    };
+    expect(checkIsTouched(formContext, 'root_field_one_child')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field_one:child')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field_one-child')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field-one-child')).to.be.true;
+    expect(checkIsTouched(formContext, 'root_field_0_child')).to.be.true;
+  });
+
+  it('should not be touched if field with same start name is touched', () => {
+    const formContext = {
+      touched: {
+        // eslint-disable-next-line camelcase
+        root_field: true,
+      },
+    };
+    expect(checkIsTouched(formContext, 'root_fieldOne')).to.be.false;
+    expect(checkIsTouched(formContext, 'root_field2')).to.be.false;
   });
 });


### PR DESCRIPTION
## Summary

A field such as `root_field` would trigger errors on other fields named `root_fieldTwo` or `root_fieldOther`.
This change removes that behavior.
- field to not trigger error on `root_fieldOther`
- field still triggers error `root_field_other` and `root_field:other` and `root_0_field`

(Assuming this is what was intended by the original logic - but there were no tests for these scenarios)

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#60059

## Testing done

- Tested on mock form
- Wrote unit tests

## Screenshots

## What areas of the site does it impact?

All forms

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
