### PR TITLE
1793 - Add GA4 mapping for va-checkbox, va-checkbox-group, va-date, and va-memorable-date

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -275,6 +275,18 @@ const analyticsEvents = {
       action: 'change',
       event: 'int-checkbox-option-click',
       prefix: 'checkbox',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-checkbox',
+        custom_string_1: 'component-library',
+        mapping: {
+          'checkbox-label': 'heading_1',
+          'checkbox-description': 'heading_2',
+          'checkbox-required': 'required',
+          'checkbox-checked': 'value',
+          version: 'component_version',
+        },
+      },
     },
   ],
   'va-checkbox-group': [
@@ -282,6 +294,17 @@ const analyticsEvents = {
       action: 'change',
       event: 'int-checkbox-group-option-click',
       prefix: 'checkbox-group',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-checkbox-group',
+        custom_string_1: 'component-library',
+        mapping: {
+          'checkbox-group-label': 'heading_1',
+          'checkbox-group-optionLabel': 'custom_string_2',
+          'checkbox-group-required': 'required',
+          version: 'component_version',
+        },
+      },
     },
   ],
   'va-date': [
@@ -289,6 +312,18 @@ const analyticsEvents = {
       action: 'blur',
       event: 'int-date-blur',
       prefix: 'date',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-date',
+        custom_string_1: 'component-library',
+        mapping: {
+          'date-year': 'value',
+          'date-month': 'custom_number_1',
+          'date-day': 'custom_number_2',
+          'date-month-year-only': 'status',
+          version: 'component_version',
+        },
+      },
     },
   ],
   'va-file-input': [
@@ -327,6 +362,18 @@ const analyticsEvents = {
       action: 'blur',
       event: 'int-memorable-date-blur',
       prefix: 'memorable-date',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-memorable-date',
+        custom_string_1: 'component-library',
+        mapping: {
+          'memorable-date-label': 'heading_1',
+          'memorable-date-year': 'value',
+          'memorable-date-month': 'custom_number_1',
+          'memorable-date-day': 'custom_number_2',
+          version: 'component_version',
+        },
+      },
     },
   ],
   'va-modal': [


### PR DESCRIPTION
## Summary

- Add GA4 mapping for va-checkbox, va-checkbox-group, va-date, and va-memorable-date

## Related issue(s)

closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1793

## Testing done

- Manual testing in local browser

## Screenshots
Below, I am listing the name of the component, the mappings from its GA4 properties to the web-component's properties, and a screenshot of the GA4 event logged to the browser

1. Va-checkbox
    - heading_1: label
    - heading_2: description
    - required: required
    - value: checked
    
![Screenshot 2023-06-23 at 1 25 44 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/8485e19c-89e4-4e7c-8b6c-70dcf8124b40)

2. Va-checkbox-group
    - heading_1: label
    - custom_string_2: optionLabel
    - required: required
    
![Screenshot 2023-06-23 at 12 55 23 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/ab876ccb-78a4-4466-b2c6-497ca68e30c6)

3. Va-date
    - value: year
    - custom_number_1: month
    - custom_number_2: day
    - status: month-year-only
    
Va-date without setting `month-year-only`:
![Screenshot 2023-06-23 at 12 56 00 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/e08f03c0-f781-4017-b985-bd789b58f53f)

Va-date with `month-year-only`
![Screenshot 2023-06-23 at 1 15 26 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/e9f684ed-066c-4998-bd41-84d379b86ec7)

4. Va-memorable-date
    - heading_1: label
    - value: year
    - custom_number_1: month
    - custom_number_2: day
    
![Screenshot 2023-06-23 at 12 56 50 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/fd2353ed-8bcc-4847-8607-4e48348a842e)

 

## What areas of the site does it impact?

- This change affects any forms/files using these components

## Acceptance criteria

- [ ] The `va-checkbox`, `va-checkbox-group`, `va-date`, and `va-memorable-date` web-components have the proper GA4 mappings

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
