### PR TITLE
Global | Add scroll element below form nav

### DIFF
--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import { Element } from 'react-scroll';
 
 import {
   focusElement,
@@ -314,7 +313,6 @@ const ContactInfo = ({
 
   return (
     <div className="vads-u-margin-y--2">
-      <Element name="topScrollElement" />
       <form onSubmit={handlers.onSubmit}>
         <MainHeader
           id="confirmContactInformationHeader"

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -9,7 +9,7 @@ import FormTitle from '../components/FormTitle';
 import { isInProgress } from '../helpers';
 import { setGlobalScroll } from '../utilities/ui';
 
-const Element = Scroll.Element;
+const { Element } = Scroll;
 
 /*
  * Primary component for a schema generated form app.
@@ -86,6 +86,7 @@ class FormApp extends React.Component {
             <Element name="topScrollElement" />
             {formTitle}
             {formNav}
+            <Element name="topContentElement" />
             {renderedChildren}
           </div>
         </div>

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -526,6 +526,7 @@ describe('Schemaform <FormPage>', () => {
         <div id="main" className="nav-header">
           <div name="topScrollElement" />
           <h2>H2</h2>
+          <div name="topContentElement" />
           <h3>H3</h3>
         </div>
       );
@@ -550,6 +551,7 @@ describe('Schemaform <FormPage>', () => {
         <div id="main">
           <div name="topScrollElement" />
           <h2>H2</h2>
+          <div name="topContentElement" />
           <h3>H3</h3>
         </div>
       );

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -96,7 +96,7 @@ export function customScrollAndFocus(scrollAndFocusTarget, pageIndex) {
   } else if (typeof scrollAndFocusTarget === 'function') {
     scrollAndFocusTarget(pageIndex);
   } else {
-    scrollToTop('topScrollElement', getScrollOptions());
+    scrollTo('topContentElement', getScrollOptions());
     // h3 should be a unique header on the page
     focusByOrder(['#main h3', defaultFocusSelector]);
   }


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While adding `H3`s to our form pages and using the `useCustomScrollAndFocus` setting, the `H3` on each page would receive focus, but the page would scroll to the `topScrollElement` (except the the contact info page) which is added above the `H1` and doesn't match up with the focus target on small screens. This PR adds a `topContentElement` scroll anchor to move the `H3` to the top of the page.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > To maintain backwards compatibility with the current scroll (to `topScrollElement`) & focus (to `H2` breadcrumb) behavior, this new scroll element was added below the form nav
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#57046](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57046)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Scroll to `topScrollElement` above the `H1`
- _Describe the steps required to verify your changes are working as expected_
  > Test these changes in our Supplemental Claims form locally
- _Describe the tests completed and the results_
  > Updated unit tests, but none actually check the scroll position
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![scroll brings H1 into view](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/3fdd8023-a778-41e1-bf69-7253e14f6090) | ![scroll brings H3 into view](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/956f799c-5f87-44c4-bd71-e5a87439c8e0) |

## What areas of the site does it impact?

Forms with the `useCustomScrollAndFocus` form config setting

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
