### PR TITLE
My VA - use Lighthouse claims api instead of EVSS api

### DIFF
--- a/src/applications/personalization/dashboard/actions/claims.jsx
+++ b/src/applications/personalization/dashboard/actions/claims.jsx
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/browser';
-import recordEvent from 'platform/monitoring/record-event';
-import { apiRequest } from 'platform/utilities/api';
-import get from 'platform/utilities/data/get';
+import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
+import {
+  apiRequest,
+  replacementFunctions as dataUtils,
+} from '@department-of-veterans-affairs/platform-utilities/exports';
 
 import {
   getErrorStatus,
@@ -28,6 +30,8 @@ export const FETCH_STEM_CLAIMS_SUCCESS = 'FETCH_STEM_CLAIMS_SUCCESS';
 export const FETCH_STEM_CLAIMS_ERROR = 'FETCH_STEM_CLAIMS_ERROR';
 export const FILTER_CLAIMS = 'FILTER_CLAIMS';
 export const SORT_CLAIMS = 'SORT_CLAIMS';
+
+const { get } = dataUtils;
 
 export function fetchAppealsSuccess(response) {
   const appeals = response.data;
@@ -120,10 +124,15 @@ export function getSyncStatus(claimsAsyncResponse) {
   return get('meta.syncStatus', claimsAsyncResponse, null);
 }
 
-const recordClaimsAPIEvent = ({ startTime, success, error }) => {
+const recordClaimsAPIEvent = ({
+  startTime,
+  success,
+  error,
+  apiName = 'GET claims',
+}) => {
   const event = {
     event: 'api_call',
-    'api-name': 'GET claims',
+    'api-name': apiName,
     'api-status': success ? 'successful' : 'failed',
   };
   if (error) {
@@ -142,6 +151,15 @@ const recordClaimsAPIEvent = ({ startTime, success, error }) => {
       'error-key': undefined,
     });
   }
+};
+
+const recordLighthouseClaimsAPIEvent = ({ startTime, success, error }) => {
+  recordClaimsAPIEvent({
+    startTime,
+    success,
+    error,
+    apiName: 'GET /benefits_claims',
+  });
 };
 
 export function getClaimsV2(options = {}) {
@@ -203,5 +221,37 @@ export function getClaimsV2(options = {}) {
       shouldSucceed: response => getSyncStatus(response) === 'SUCCESS',
       target: '/evss_claims_async',
     });
+  };
+}
+
+export function getLighthouseClaims() {
+  const startTimestampMs = Date.now();
+
+  return dispatch => {
+    dispatch({ type: FETCH_CLAIMS_PENDING });
+
+    return apiRequest('/benefits_claims')
+      .then(response => {
+        recordLighthouseClaimsAPIEvent({
+          startTime: startTimestampMs,
+          success: true,
+        });
+        dispatch(fetchClaimsSuccess(response));
+      })
+      .catch(response => {
+        const errorCode = getErrorStatus(response);
+        Sentry.withScope(scope => {
+          scope.setFingerprint(['{{default}}', errorCode]);
+          Sentry.captureException(
+            `va-dashboard_claims_v2_err_get_lighthouse_claims ${errorCode}`,
+          );
+        });
+        recordLighthouseClaimsAPIEvent({
+          startTime: startTimestampMs,
+          success: false,
+          error: errorCode,
+        });
+        return dispatch({ type: FETCH_CLAIMS_ERROR });
+      });
   };
 }

--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -100,6 +100,7 @@ const Dashboard = ({
   showNameTag,
   showNotInMPIError,
   showNotifications,
+  useLighthouseClaims,
   isVAPatient,
   ...props
 }) => {
@@ -228,7 +229,9 @@ const Dashboard = ({
                   ]}
                   render={RenderClaimsWidgetDowntimeNotification}
                 >
-                  <ClaimsAndAppealsV2 />
+                  <ClaimsAndAppealsV2
+                    useLighthouseClaims={useLighthouseClaims}
+                  />
                 </DowntimeNotification>
               ) : null}
 
@@ -266,6 +269,11 @@ const Dashboard = ({
 const isClaimsAvailableSelector = createIsServiceAvailableSelector(
   backendServices.EVSS_CLAIMS,
 );
+
+const isLighthouseClaimsAvailableSelector = createIsServiceAvailableSelector(
+  backendServices.LIGHTHOUSE,
+);
+
 const isAppealsAvailableSelector = createIsServiceAvailableSelector(
   backendServices.APPEALS_STATUS,
 );
@@ -277,7 +285,9 @@ const mapStateToProps = state => {
   const isVAPatient = isVAPatientSelector(state);
   const hero = state.vaProfile?.hero;
   const hasClaimsOrAppealsService =
-    isAppealsAvailableSelector(state) || isClaimsAvailableSelector(state);
+    isAppealsAvailableSelector(state) ||
+    isClaimsAvailableSelector(state) ||
+    isLighthouseClaimsAvailableSelector(state);
 
   const hasMHVAccount = ['OK', 'MULTIPLE'].includes(
     state.user?.profile?.mhvAccountState,
@@ -323,6 +333,10 @@ const mapStateToProps = state => {
     FEATURE_FLAG_NAMES.showMyVADashboardV2
   ];
 
+  const useLighthouseClaims = toggleValues(state)[
+    FEATURE_FLAG_NAMES.myVaUseLighthouseClaims
+  ];
+
   const showNotifications =
     !showMPIConnectionError && !showNotInMPIError && isLOA3;
 
@@ -340,6 +354,7 @@ const mapStateToProps = state => {
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
     totalDisabilityRatingServerError: hasTotalDisabilityServerError(state),
+    useLighthouseClaims,
     user: state.user,
     shouldShowV2Dashboard,
     showMPIConnectionError,
@@ -382,6 +397,7 @@ Dashboard.propTypes = {
   showValidateIdentityAlert: PropTypes.bool,
   totalDisabilityRating: PropTypes.number,
   totalDisabilityRatingServerError: PropTypes.bool,
+  useLighthouseClaims: PropTypes.bool,
   user: PropTypes.object,
 };
 

--- a/src/applications/personalization/dashboard/components/claims-and-appeals-v2/ClaimV2.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals-v2/ClaimV2.jsx
@@ -28,14 +28,34 @@ function handleViewClaim() {
   });
 }
 
-const ClaimV2 = ({ claim }) => {
+const claimInfo = (claim, useLighthouseClaims) => {
+  if (useLighthouseClaims) {
+    return {
+      inProgress:
+        claim.attributes.decisionLetterSent ||
+        claim.attributes.status === 'COMPLETE',
+      claimDate: claim.attributes.claimDate,
+      status: capitalizeFirstLetter(claim.attributes.status?.toLowerCase()),
+    };
+  }
+  return {
+    inProgress: !isClaimComplete(claim),
+    claimDate: claim.attributes.dateFiled,
+    status: listPhase(claim.attributes.phase),
+  };
+};
+
+const ClaimV2 = ({ claim, useLighthouseClaims = false }) => {
   if (!claim.attributes) {
     throw new TypeError(
       '`claim` prop is malformed; it should have an `attributes` property.',
     );
   }
-  const inProgress = !isClaimComplete(claim);
-  const dateRecd = moment(claim.attributes.dateFiled).format('MMMM D, YYYY');
+  const { inProgress, claimDate, status } = claimInfo(
+    claim,
+    useLighthouseClaims,
+  );
+  const dateRecd = moment(claimDate).format('MMMM D, YYYY');
   return (
     <div className="vads-u-padding-y--2p5 vads-u-padding-x--2p5 vads-u-background-color--gray-lightest">
       <h3 className="vads-u-margin-top--0">
@@ -47,9 +67,7 @@ const ClaimV2 = ({ claim }) => {
           className="fas fa-fw fa-check-circle vads-u-margin-right--1 vads-u-margin-top--0p5 vads-u-color--green"
         />
         <div>
-          <p className="vads-u-margin-y--0">
-            {listPhase(claim.attributes.phase)}
-          </p>
+          <p className="vads-u-margin-y--0">{status}</p>
           {inProgress && claim.attributes.developmentLetterSent ? (
             <p className="vads-u-margin-y--0">
               We sent you a development letter
@@ -77,6 +95,7 @@ const ClaimV2 = ({ claim }) => {
 
 ClaimV2.propTypes = {
   claim: PropTypes.object.isRequired,
+  useLighthouseClaims: PropTypes.bool,
 };
 
 export default ClaimV2;

--- a/src/applications/personalization/dashboard/components/claims-and-appeals-v2/ClaimsAndAppealsV2.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals-v2/ClaimsAndAppealsV2.jsx
@@ -11,6 +11,7 @@ import IconCTALink from '../IconCTALink';
 import {
   getAppealsV2 as getAppealsAction,
   getClaimsV2 as getClaimsAction,
+  getLighthouseClaims as getLighthouseClaimsAction,
 } from '../../actions/claims';
 import {
   appealsAvailability,
@@ -103,9 +104,11 @@ const ClaimsAndAppealsV2 = ({
   hasAPIError,
   loadAppeals,
   loadClaims,
+  loadLighthouseClaims,
   shouldLoadAppeals,
   shouldLoadClaims,
   shouldShowLoadingIndicator,
+  useLighthouseClaims,
 }) => {
   React.useEffect(
     () => {
@@ -120,10 +123,21 @@ const ClaimsAndAppealsV2 = ({
     () => {
       if (!dataLoadingDisabled && shouldLoadClaims) {
         // stop polling the claims API after 45 seconds
-        loadClaims({ pollingExpiration: Date.now() + 45 * 1000 });
+        const pollingExpiration = Date.now() + 45 * 1000;
+        if (useLighthouseClaims) {
+          loadLighthouseClaims({ pollingExpiration });
+        } else {
+          loadClaims({ pollingExpiration });
+        }
       }
     },
-    [dataLoadingDisabled, loadClaims, shouldLoadClaims],
+    [
+      dataLoadingDisabled,
+      loadClaims,
+      loadLighthouseClaims,
+      shouldLoadClaims,
+      useLighthouseClaims,
+    ],
   );
 
   // the most recently updated open claim or appeal or
@@ -158,6 +172,7 @@ const ClaimsAndAppealsV2 = ({
               {highlightedClaimOrAppeal ? (
                 <HighlightedClaimAppealV2
                   claimOrAppeal={highlightedClaimOrAppeal}
+                  useLighthouseClaims={useLighthouseClaims}
                 />
               ) : (
                 <>
@@ -181,11 +196,13 @@ const ClaimsAndAppealsV2 = ({
 ClaimsAndAppealsV2.propTypes = {
   dataLoadingDisabled: PropTypes.bool.isRequired,
   hasAPIError: PropTypes.bool.isRequired,
-  loadAppeals: PropTypes.bool.isRequired,
-  loadClaims: PropTypes.bool.isRequired,
+  loadAppeals: PropTypes.func.isRequired,
+  loadClaims: PropTypes.func.isRequired,
+  loadLighthouseClaims: PropTypes.func.isRequired,
   shouldLoadAppeals: PropTypes.bool.isRequired,
   shouldLoadClaims: PropTypes.bool.isRequired,
   shouldShowLoadingIndicator: PropTypes.bool.isRequired,
+  useLighthouseClaims: PropTypes.bool.isRequired,
   userFullName: PropTypes.string.isRequired,
   appealsData: PropTypes.arrayOf(PropTypes.object),
   claimsData: PropTypes.arrayOf(PropTypes.object),
@@ -235,6 +252,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
   loadAppeals: getAppealsAction,
   loadClaims: getClaimsAction,
+  loadLighthouseClaims: getLighthouseClaimsAction,
 };
 
 export default connect(

--- a/src/applications/personalization/dashboard/components/claims-and-appeals-v2/HighlightedClaimAppealV2.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals-v2/HighlightedClaimAppealV2.jsx
@@ -5,19 +5,26 @@ import { appealTypes } from '../../utils/appeals-v2-helpers';
 import Claim from './ClaimV2';
 import Appeal from './AppealV2';
 
-const HighlightedClaimAppealV2 = ({ claimOrAppeal, name }) => {
+const HighlightedClaimAppealV2 = ({
+  claimOrAppeal,
+  name,
+  useLighthouseClaims = false,
+}) => {
   if (!claimOrAppeal) {
     return <p>You have no claims or appeals updates in the last 30 days.</p>;
   }
   if (appealTypes.includes(claimOrAppeal.type)) {
     return <Appeal appeal={claimOrAppeal} name={name} />;
   }
-  return <Claim claim={claimOrAppeal} />;
+  return (
+    <Claim claim={claimOrAppeal} useLighthouseClaims={useLighthouseClaims} />
+  );
 };
 
 HighlightedClaimAppealV2.propTypes = {
   claimOrAppeal: PropTypes.object.isRequired,
   name: PropTypes.string,
+  useLighthouseClaims: PropTypes.bool,
 };
 
 export default HighlightedClaimAppealV2;

--- a/src/applications/personalization/dashboard/components/claims-and-appeals-v2/hooks/useHighlightedClaimOrAppealV2.js
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals-v2/hooks/useHighlightedClaimOrAppealV2.js
@@ -16,8 +16,10 @@ const getAppealUpdateDate = appeal => {
 
 const getClaimUpdateDate = claim => {
   let updateDate;
-  const filedDate = claim?.attributes.dateFiled;
-  const changeDate = claim?.attributes.phaseChangeDate;
+  const filedDate = claim?.attributes.dateFiled || claim?.attributes.claimDate;
+  const changeDate =
+    claim?.attributes.phaseChangeDate ||
+    claim?.attributes.claimPhaseDates?.phaseChangeDate;
   if (changeDate && filedDate) {
     updateDate =
       new Date(filedDate).getTime() > new Date(changeDate).getTime()

--- a/src/applications/personalization/dashboard/mocks/feature-toggles/index.js
+++ b/src/applications/personalization/dashboard/mocks/feature-toggles/index.js
@@ -1,5 +1,9 @@
 const generateFeatureToggles = (toggles = {}) => {
-  const { myVaUseExperimental = true, showMyVADashboardV2 = true } = toggles;
+  const {
+    myVaUseExperimental = true,
+    showMyVADashboardV2 = true,
+    myVaUseLighthouseClaims = true,
+  } = toggles;
 
   return {
     data: {
@@ -12,6 +16,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'show_myva_dashboard_2_0',
           value: showMyVADashboardV2,
+        },
+        {
+          name: 'my_va_lighthouse_claims',
+          value: myVaUseLighthouseClaims,
         },
       ],
     },

--- a/src/applications/personalization/dashboard/mocks/lighthouse-claims/index.js
+++ b/src/applications/personalization/dashboard/mocks/lighthouse-claims/index.js
@@ -1,0 +1,72 @@
+const subDays = require('date-fns/addDays');
+const format = require('date-fns/format');
+
+const createLighthouseClaimsSuccess = (updatedDaysAgo = 1, open = true) => {
+  const daysAgo = subDays(new Date(), updatedDaysAgo);
+  const formattedDaysAgo = format(daysAgo, 'yyyy-MM-dd');
+  return {
+    data: [
+      {
+        id: '266374',
+        type: 'claim',
+        attributes: {
+          claimDate: '2013-10-18',
+          claimPhaseDates: {
+            phaseChangeDate: formattedDaysAgo,
+          },
+          claimType: 'Dependency',
+          closeDate: null,
+          decisionLetterSent: false,
+          developmentLetterSent: true,
+          documentsNeeded: false,
+          endProductCode: '404',
+          evidenceWaiverSubmitted5103: false,
+          lighthouseId: 266374,
+          status: open ? 'Initial review' : 'Complete',
+        },
+      },
+      {
+        id: '600121251',
+        type: 'claim',
+        attributes: {
+          claimDate: '2018-01-10',
+          claimPhaseDates: {
+            phaseChangeDate: '2018-06-12',
+          },
+          claimType: 'Dependency',
+          closeDate: null,
+          decisionLetterSent: false,
+          developmentLetterSent: false,
+          documentsNeeded: false,
+          endProductCode: '404',
+          evidenceWaiverSubmitted5103: false,
+          lighthouseId: 600121251,
+          status: 'Complete',
+        },
+      },
+      {
+        id: '600090417',
+        type: 'claim',
+        attributes: {
+          claimDate: '2017-01-02',
+          claimPhaseDates: {
+            phaseChangeDate: '2016-12-06',
+          },
+          claimType: 'Compensation',
+          closeDate: null,
+          decisionLetterSent: false,
+          developmentLetterSent: false,
+          documentsNeeded: false,
+          endProductCode: '404',
+          evidenceWaiverSubmitted5103: false,
+          lighthouseId: 600090417,
+          status: 'Complete',
+        },
+      },
+    ],
+  };
+};
+
+module.exports = {
+  createLighthouseClaimsSuccess,
+};

--- a/src/applications/personalization/dashboard/mocks/server.js
+++ b/src/applications/personalization/dashboard/mocks/server.js
@@ -5,6 +5,7 @@ const { createSuccessPayment } = require('./payment-history');
 const { createAppealsSuccess } = require('./appeals-success');
 const { createDebtsSuccess, createNoDebtsSuccess } = require('./debts');
 const { createClaimsSuccess } = require('./evss-claims');
+const { createLighthouseClaimsSuccess } = require('./lighthouse-claims');
 const { createHealthCareStatusSuccess } = require('./health-care');
 const { createUnreadMessagesSuccess } = require('./messaging');
 const notifications = require('./notifications');
@@ -19,6 +20,7 @@ const responses = {
   'GET /v0/feature_toggles': generateFeatureToggles({
     myVaUseExperimental: true,
     showMyVADashboardV2: true,
+    myVaUseLighthouseClaims: true,
   }),
   'GET /v0/user': user.cernerUser,
   'OPTIONS /v0/maintenance_windows': 'OK',
@@ -27,6 +29,7 @@ const responses = {
   'GET /v0/profile/payment_history': createSuccessPayment(false),
   'GET /v0/appeals': createAppealsSuccess(),
   'GET /v0/evss_claims_async': createClaimsSuccess(),
+  'GET /v0/benefits_claims': createLighthouseClaimsSuccess(),
   'GET /v0/health_care_applications/enrollment_status': createHealthCareStatusSuccess(),
   'GET /v0/messaging/health/folders/0': createUnreadMessagesSuccess(),
   'GET /v0/profile/full_name': {

--- a/src/applications/personalization/dashboard/tests/unit/ClaimsAndAppealsV2Lighthouse.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/unit/ClaimsAndAppealsV2Lighthouse.unit.spec.jsx
@@ -1,0 +1,531 @@
+import React from 'react';
+import { expect } from 'chai';
+import { daysAgo } from '@@profile/tests/helpers';
+import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
+
+import reducers from '~/applications/personalization/dashboard/reducers';
+
+import ClaimsAndAppealsV2 from '../../components/claims-and-appeals-v2/ClaimsAndAppealsV2';
+
+function claimsAppealsUser() {
+  return {
+    profile: {
+      services: ['appeals-status', 'evss-claims'],
+    },
+  };
+}
+
+function makeAppealObject({ updateDate, closed = false }) {
+  return {
+    id: '2765759',
+    type: 'legacyAppeal',
+    attributes: {
+      appealIds: ['2765759'],
+      updated: '2021-03-04T19:55:21-05:00',
+      incompleteHistory: false,
+      type: 'original',
+      active: !closed,
+      description: 'Benefits as a result of VA error (Section 1151)',
+      aod: false,
+      location: 'bva',
+      aoj: 'vba',
+      programArea: 'compensation',
+      status: { type: 'on_docket', details: {} },
+      alerts: [],
+      docket: {
+        front: false,
+        total: 140135,
+        ahead: 101381,
+        ready: 16432,
+        month: '2012-04-01',
+        docketMonth: '2011-01-01',
+        eta: null,
+      },
+      issues: [
+        {
+          description: 'Benefits as a result of VA error (Section 1151)',
+          diagnosticCode: null,
+          active: true,
+          lastAction: null,
+          date: null,
+        },
+      ],
+      events: [
+        { type: 'nod', date: '2012-02-02' },
+        { type: 'soc', date: '2012-03-03' },
+        { type: 'form9', date: '2012-04-04' },
+        { type: 'hearing_held', date: updateDate },
+      ],
+      evidence: [],
+    },
+  };
+}
+
+function makeClaimObject({ claimDate, updateDate, status = 'Claim received' }) {
+  return {
+    id: '600214206',
+    type: 'claim',
+    attributes: {
+      claimDate: claimDate || '2021-01-21',
+      claimPhaseDates: {
+        phaseChangeDate: updateDate,
+      },
+      claimType: 'Compensation',
+      closeDate: null,
+      decisionLetterSent: false,
+      developmentLetterSent: false,
+      documentsNeeded: false,
+      endProductCode: '404',
+      evidenceWaiverSubmitted5103: false,
+      lighthouseId: 600214206,
+      status,
+    },
+  };
+}
+
+function loadingErrorAlertExists(view) {
+  expect(
+    view.getByRole('heading', {
+      name: /^We can’t access your claims or appeals information$/i,
+    }),
+  ).to.exist;
+  expect(
+    view.getByText(
+      'We’re sorry. Something went wrong on our end. If you have any claims and appeals, you won’t be able to access your claims and appeals information right now. Please refresh or try again later.',
+    ),
+  ).to.exist;
+}
+
+describe('ClaimsAndAppealsV2 component', () => {
+  let view;
+  let initialState;
+
+  describe('error states', () => {
+    context('when there is an error fetching appeals data', () => {
+      beforeEach(() => {
+        initialState = {
+          user: claimsAppealsUser(),
+          claims: {
+            appealsLoading: false,
+            claimsLoading: false,
+            appeals: [],
+            claims: [],
+            v2Availability: 'ERROR',
+          },
+        };
+        view = renderInReduxProvider(
+          <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+          {
+            initialState,
+            reducers,
+          },
+        );
+      });
+
+      it('should render an error alert', () => {
+        expect(view.queryByRole('progressbar')).to.not.exist;
+        expect(view.queryByRole('heading', { name: /^claims and appeals$/i }))
+          .to.exist;
+        loadingErrorAlertExists(view);
+      });
+
+      it('should not show a CTA', () => {
+        expect(
+          view.queryByRole('link', {
+            name: /check your claim or appeal status/i,
+          }),
+        ).to.not.exist;
+      });
+    });
+
+    context('when there is an error fetching claims data', () => {
+      beforeEach(() => {
+        initialState = {
+          user: claimsAppealsUser(),
+          claims: {
+            appealsLoading: false,
+            claimsLoading: false,
+            appeals: [],
+            claims: [],
+            v2Availability: 'AVAILABLE',
+            claimsAvailability: 'UNAVAILABLE',
+          },
+        };
+        view = renderInReduxProvider(
+          <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+          {
+            initialState,
+            reducers,
+          },
+        );
+      });
+
+      it('should render an error alert', () => {
+        expect(view.queryByRole('progressbar')).to.not.exist;
+        expect(view.queryByRole('heading', { name: /^claims and appeals$/i }))
+          .to.exist;
+        loadingErrorAlertExists(view);
+      });
+
+      it('should not show a CTA', () => {
+        expect(
+          view.queryByRole('link', {
+            name: /check your claim or appeal status/i,
+          }),
+        ).to.not.exist;
+      });
+    });
+  });
+
+  describe('happy path render logic', () => {
+    context('when the user has no claims or appeals on file', () => {
+      beforeEach(() => {
+        initialState = {
+          user: claimsAppealsUser(),
+          claims: {
+            appealsLoading: false,
+            claimsLoading: false,
+            appeals: [],
+            claims: [],
+          },
+        };
+        view = renderInReduxProvider(
+          <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+          {
+            initialState,
+            reducers,
+          },
+        );
+      });
+
+      it('does not render anything except a headline', () => {
+        expect(view.queryByRole('progressbar')).to.not.exist;
+        expect(view.queryByRole('heading', { name: /^claims and appeals$/i }))
+          .to.exist;
+      });
+    });
+
+    context(
+      'when the user has 3 claims that were all updated in the past 60 days',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [],
+              claims: [
+                makeClaimObject({
+                  updateDate: daysAgo(34),
+                  status: 'Evidence gathering, review, and decision',
+                }),
+                makeClaimObject({
+                  updateDate: daysAgo(1),
+                  status: 'Preparation for notification',
+                }),
+                makeClaimObject({ updateDate: daysAgo(15) }),
+              ],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+
+        it('shows the CTA', () => {
+          expect(view.queryByRole('progressbar')).to.not.exist;
+          expect(view.getByRole('heading', { name: /^claims and appeals$/i }))
+            .to.exist;
+          expect(view.getByRole('link', { name: /^review claim received/i })).to
+            .exist;
+        });
+      },
+    );
+
+    context(
+      'when the user has 2 claims (1 closed) and 2 appeals (1 closed) that were all updated in the past 60 days',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [
+                // closed appeal updated 5 days ago
+                makeAppealObject({ updateDate: daysAgo(5), closed: true }),
+                // appeal updated one day ago
+                makeAppealObject({ updateDate: daysAgo(1) }),
+              ],
+              claims: [
+                // closed claim updated 5 days ago
+                makeClaimObject({
+                  updateDate: daysAgo(5),
+                  status: 'Closed',
+                }),
+                // open claim updated 40 days ago
+                makeClaimObject({
+                  updateDate: daysAgo(40),
+                  status: 'Preparation for notification',
+                }),
+              ],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+
+        it('shows the CTA', () => {
+          expect(view.queryByRole('progressbar')).to.not.exist;
+          expect(view.getByRole('heading', { name: /^claims and appeals$/i }))
+            .to.exist;
+          expect(view.getByRole('link', { name: /^review details/i })).to.exist;
+        });
+      },
+    );
+
+    context(
+      'when user has two open claims (one recently updated), one open appeal, and one closed claim',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [
+                // open appeal that changed 31 days ago
+                makeAppealObject({ updateDate: daysAgo(31) }),
+              ],
+              claims: [
+                // open claim updated 29 days ago
+                makeClaimObject({
+                  updateDate: daysAgo(29),
+                  status: 'Preparation for notification',
+                }),
+                // closed claim without recent activity
+                makeClaimObject({
+                  updateDate: daysAgo(61),
+                  status: 'Closed',
+                }),
+                // open claim without recent activity
+                makeClaimObject({
+                  updateDate: daysAgo(5),
+                  status: 'Claim received',
+                }),
+              ],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+
+        it('shows the CTA', () => {
+          expect(view.queryByRole('progressbar')).to.not.exist;
+          expect(view.getByRole('heading', { name: /^claims and appeals$/i }))
+            .to.exist;
+          expect(
+            view.getByRole('link', {
+              name: /review claim/i,
+            }),
+          ).to.exist;
+        });
+
+        it('shows details for the most recently updated claim', () => {
+          expect(view.getByRole('link', { name: /^review claim received/i })).to
+            .exist;
+        });
+      },
+    );
+
+    context(
+      'when the user has no open claims or appeals, but does have an appeal that closed within the past 60 days',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [
+                // closed appeal that was closed 10 days ago
+                makeAppealObject({ updateDate: daysAgo(10), closed: true }),
+              ],
+              claims: [
+                // closed claim with no recent activity
+                makeClaimObject({
+                  updateDate: daysAgo(3000),
+                  status: 'Closed',
+                }),
+                // closed claim without recent activity
+                makeClaimObject({
+                  updateDate: daysAgo(31),
+                  status: 'Closed',
+                }),
+              ],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+
+        it('shows the CTA', () => {
+          expect(
+            view.getByRole('link', {
+              name: /review details/i,
+            }),
+          ).to.exist;
+        });
+
+        it('shows details about the recently closed appeal', () => {
+          expect(view.getByRole('heading', { name: /updated on/i })).to.exist;
+        });
+      },
+    );
+
+    context(
+      'the user has one open appeal that was updated over 60 days ago',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [makeAppealObject({ updateDate: daysAgo(61) })],
+              claims: [],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+
+        it('shows the CTA', () => {
+          expect(view.getByRole('heading', { name: /^claims and appeals$/i }))
+            .to.exist;
+          expect(
+            view.getByRole('link', {
+              name: /review details/i,
+            }),
+          ).to.exist;
+        });
+
+        it('does not show details about the open appeal', () => {
+          expect(view.queryByRole('link', { name: /^view details of/i })).to.not
+            .exist;
+        });
+      },
+    );
+
+    context(
+      'the user only has claims and appeals that closed over 60 days ago',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [
+                makeAppealObject({
+                  updateDate: daysAgo(1000),
+                  closed: true,
+                }),
+              ],
+              claims: [
+                makeClaimObject({
+                  updateDate: daysAgo(100),
+                  status: 'Closed',
+                }),
+                makeClaimObject({
+                  updateDate: daysAgo(85),
+                  status: 'Closed',
+                }),
+                makeClaimObject({
+                  updateDate: daysAgo(61),
+                  status: 'Closed',
+                }),
+              ],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+      },
+    );
+
+    context(
+      'the user has claims that closed over 60 days ago and got a 404 from the appeals endpoint because they have no appeals on file',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            claims: {
+              appealsLoading: false,
+              claimsLoading: false,
+              appeals: [],
+              v2Availability: 'RECORD_NOT_FOUND_ERROR',
+              claims: [
+                makeClaimObject({
+                  updateDate: daysAgo(100),
+                  status: 'Closed',
+                }),
+                makeClaimObject({
+                  updateDate: daysAgo(85),
+                  status: 'Closed',
+                }),
+                makeClaimObject({
+                  updateDate: daysAgo(61),
+                  status: 'Closed',
+                }),
+              ],
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppealsV2 dataLoadingDisabled useLighthouseClaims />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+
+        it('does not render anything', () => {
+          expect(view.queryByRole('progressbar')).to.not.exist;
+          expect(view.queryByTestId('dashboard-section-claims-and-appeals')).to
+            .not.exist;
+        });
+      },
+    );
+  });
+});

--- a/src/applications/personalization/profile/tests/fixtures/claims-lighthouse-success.js
+++ b/src/applications/personalization/profile/tests/fixtures/claims-lighthouse-success.js
@@ -1,0 +1,68 @@
+import { daysAgo } from '../helpers';
+
+const claimsSuccess = (updatedDaysAgo = 1, open = true) => {
+  return {
+    data: [
+      {
+        id: '266374',
+        type: 'claim',
+        attributes: {
+          claimDate: '2013-10-18',
+          claimPhaseDates: {
+            phaseChangeDate: daysAgo(updatedDaysAgo),
+          },
+          claimType: 'Dependency',
+          closeDate: null,
+          decisionLetterSent: false,
+          developmentLetterSent: false,
+          documentsNeeded: false,
+          endProductCode: '404',
+          evidenceWaiverSubmitted5103: false,
+          lighthouseId: 266374,
+          status: open ? 'Initial review' : 'Closed',
+        },
+      },
+      {
+        id: '600121251',
+        type: 'claim',
+        attributes: {
+          claimDate: '2018-01-10',
+          claimPhaseDates: {
+            phaseChangeDate: '2018-06-12',
+          },
+          claimType: 'Dependency',
+          closeDate: null,
+          decisionLetterSent: false,
+          developmentLetterSent: false,
+          documentsNeeded: false,
+          endProductCode: '404',
+          evidenceWaiverSubmitted5103: false,
+          lighthouseId: 600121251,
+          status: 'Closed',
+        },
+      },
+      {
+        id: '600090417',
+        type: 'claim',
+        attributes: {
+          claimDate: '2017-01-02',
+          claimPhaseDates: {
+            phaseChangeDate: '2016-12-06',
+          },
+          claimType: 'Compensation',
+          closeDate: null,
+          decisionLetterSent: false,
+          developmentLetterSent: false,
+          documentsNeeded: false,
+          endProductCode: '404',
+          evidenceWaiverSubmitted5103: false,
+          lighthouseId: 600090417,
+          status: 'Closed',
+        },
+      },
+    ],
+    meta: { syncStatus: 'SUCCESS' },
+  };
+};
+
+export default claimsSuccess;

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -87,6 +87,7 @@ export default Object.freeze({
   mhvToLogingovAccountTransition: 'mhv_to_logingov_account_transition',
   mhvToLogingovAccountTransitionModal: 'mhv_to_logingov_account_transition_modal',
   myVaUseExperimental: 'my_va_experimental',
+  myVaUseLighthouseClaims: 'my_va_lighthouse_claims',
   omniChannelLink: 'omni_channel_link',
   pdfWarningBanner: 'pdf_warning_banner',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',


### PR DESCRIPTION
Switch to use the Lighthouse `v0/benefits_claims` endpoint for Claims instead of the EVSS `v0/evss_claims_async` endpoint

## Related issue(s)

[59410](https://github.com/department-of-veterans-affairs/va.gov-team/issues/59410)

## Testing done

- Enabled the [feature flag](https://github.com/department-of-veterans-affairs/vets-api/pull/13095) locally
- Created a local mock server with expected data from `v0/benefits_claims`
- Confirmed that the claims section on My VA renders as expected when using the new endpoint
- Confirmed that the claims section renders if the feature flag is disabled, using the original `v0/evss_claims_async` endpoint

## What areas of the site does it impact?

My VA Dashboard

## Screenshot
Claims and appeals section will have no UI changes. But here is what that section looks like:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/534756/c80cb3ca-7d09-4488-9fb5-737469d8a4db)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
