### PR TITLE
Adds the main Wilkes-Barre facility to the travel pilot list.

### DIFF
--- a/src/applications/check-in/utils/appConstants/index.js
+++ b/src/applications/check-in/utils/appConstants/index.js
@@ -241,6 +241,7 @@ const travelAllowList = {
   '693B4': {},
   '693GA': {},
   '693GB': {},
+  '693': {},
 };
 
 const isInAllowList = appointment => {


### PR DESCRIPTION
## Summary
Adds main facility station for Wilkes-barre travel claim pilot in day of check-in

## Related issue(s)

department-of-veterans-affairs/va.gov-team#60186

## What areas of the site does it impact?
Travel claims in day-of check-in

## Acceptance criteria
 [ ] - Add Wilkes-barre locations 693.