### PR TITLE
Simple forms: 21-10210 automatically enable the form in localhost

### DIFF
--- a/src/applications/simple-forms/21-10210/containers/App.jsx
+++ b/src/applications/simple-forms/21-10210/containers/App.jsx
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import environment from 'platform/utilities/environment';
 import { WIP } from '../../shared/components/WIP';
 import formConfig from '../config/form';
 import { workInProgressContent } from '../definitions/constants';
 
 export function App({ location, children, show2110210 }) {
-  if (!show2110210) {
+  if (!show2110210 && !environment.isLocalhost()) {
     return <WIP content={workInProgressContent} />;
   }
 


### PR DESCRIPTION
With the flipper defaulting to off you had to enable it locally to test the form. Now it will automatically be enabled locally

## Summary

- Check env and if local don't show work in progress page (page meaning form is blocked by flipper)
