### PR TITLE
Add CustomPage noop navigation functions on review & submit

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -260,6 +260,8 @@ class ReviewCollapsibleChapter extends React.Component {
 
   getCustomPageContent = (page, props, editing) => {
     if (editing) {
+      // noop defined as a function for unit tests
+      const noop = function noop() {};
       return (
         <page.CustomPage
           key={page.pageKey}
@@ -272,6 +274,10 @@ class ReviewCollapsibleChapter extends React.Component {
           data={props.form.data}
           updatePage={() => this.handleEdit(page.pageKey, false, page.index)}
           pagePerItemIndex={page.index}
+          // noop for navigation to prevent JS error
+          goBack={noop}
+          goForward={noop}
+          goToPath={noop}
         />
       );
     }

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -1104,6 +1104,32 @@ describe('<ReviewCollapsibleChapter>', () => {
       expect(queryByTestId('custom-page-review')).not.to.exist;
     });
 
+    it('should include noop navigation functions when rendering CustomPage in edit mode', () => {
+      const { pages, chapterKey, chapter, form } = getProps();
+      let result;
+      const CustomPage = props => {
+        result = props;
+        return <div data-testid="custom-page" />;
+      };
+      form.pages.test.editMode = true;
+      form.pages.test.CustomPage = CustomPage;
+      pages[0].CustomPage = CustomPage;
+      render(
+        <ReviewCollapsibleChapter
+          viewedPages={new Set()}
+          expandedPages={pages}
+          chapterKey={chapterKey}
+          chapterFormConfig={chapter}
+          form={form}
+          open
+        />,
+      );
+
+      expect(result.goBack.toString()).to.contain('noop()');
+      expect(result.goForward.toString()).to.contain('noop()');
+      expect(result.goToPath.toString()).to.contain('noop()');
+    });
+
     it('should render a CustomPageReview for each item in an array when showPagePerItem is true', () => {
       const { pages, chapterKey, chapter, form } = getProps();
       pages[0].index = 0;


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While looking at Sentry logs from the past week, it appears that the `goForward`, `goBack`, and `goToPath` functions are sometimes undefined within the `CustomPage` properties. These functions are not included when the `CustomPage` is rendered on the review & submit page (see `ReviewCollapsibleChapter`) _as expected_ since the back and continue buttons are not rendered within the accordion. So, it's not clear why these functions would be called.
  >
  > Please refer to the related issue for Sentry errors & links
- _(If bug, how to reproduce)_
  > Unknown - A `CustomPage` on the review & submit page _should not_ render the navigation buttons
- _(What is the solution, why is this the solution)_
  > Pass in no-op functions for `goForward`, `goBack`, and `goToPath` to do nothing and not cause JS errors if called
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#60858](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60858)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Calling one of the navigation functions would cause a JS error
- _Describe the steps required to verify your changes are working as expected_
  > Not sure how to duplicate this issue, so not sure how to verify
- _Describe the tests completed and the results_
  > Added unit tests to check that the no-op functions are being passed into the component on the review & submit page
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All `CustomPage` components rendered on the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
