### PR TITLE
Creation of a V3-only Playground

### DIFF
--- a/src/applications/ds-v3-playground/app-entry.jsx
+++ b/src/applications/ds-v3-playground/app-entry.jsx
@@ -1,0 +1,18 @@
+import 'platform/polyfills';
+// import 'platform/site-wide/sass/minimal.scss'; // Loads Formation
+import './sass/ds-v3-playground.scss';
+
+import startApp from 'platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+import './utils/defineWebComponents';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+  entryName: manifest.entryName,
+});

--- a/src/applications/ds-v3-playground/containers/App.jsx
+++ b/src/applications/ds-v3-playground/containers/App.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import V3BasePage from '../pages/V3BasePage';
+
+export default function App() {
+  return <V3BasePage />;
+}

--- a/src/applications/ds-v3-playground/manifest.json
+++ b/src/applications/ds-v3-playground/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "DS V3 Playground",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "ds-v3-playground",
+  "rootUrl": "/ds-v3-playground",
+  "productId": "63fa0a80-e79d-47e7-9cce-e03a8edb2535"
+}

--- a/src/applications/ds-v3-playground/pages/V3BasePage.jsx
+++ b/src/applications/ds-v3-playground/pages/V3BasePage.jsx
@@ -1,0 +1,52 @@
+/**
+ * This page is for testing the compatibility of running v3 components without Formation styling.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaTextarea } from '@department-of-veterans-affairs/web-components/react-bindings';
+
+export default function V3BasePage() {
+  /** @param {import('react').FormEvent | import('@department-of-veterans-affairs/web-components/dist/types/components').VaSelectCustomEvent } evt */
+  function updateValue(evt) {
+    const { value, name } = /** @type {HTMLInputElement} */ (evt.target);
+    const display = document.getElementById(`${name}Value`);
+    if (display) display.innerText = value;
+  }
+
+  const ValueDisplay = ({ id, label }) => {
+    return (
+      <p>
+        <b>{label} Value:</b> <span id={id} />
+      </p>
+    );
+  };
+  ValueDisplay.propTypes = { id: PropTypes.string, label: PropTypes.string };
+
+  return (
+    <>
+      <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
+        <div className="vads-l-row">
+          <h1>V3 Without Formation Demo</h1>
+        </div>
+
+        {/* Textarea */}
+        <div className="vads-l-row">
+          <h3>Textarea component</h3>
+          <div className="vads-l-col--12 vads-u-align-items--center vads-u-border-bottom--1px vads-u-border-color--primary medium-screen:vads-u-display--flex">
+            <div className="vads-l-col--12  vads-u-margin--1">
+              <VaTextarea
+                name="v3TextArea"
+                label="V3 Textarea"
+                hint="This is a hint"
+                onInput={e => updateValue(e)}
+                uswds
+              />
+              <ValueDisplay label="V3 Text Area" id="v3TextAreaValue" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/applications/ds-v3-playground/reducers/index.js
+++ b/src/applications/ds-v3-playground/reducers/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/applications/ds-v3-playground/routes.jsx
+++ b/src/applications/ds-v3-playground/routes.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Route } from 'react-router';
+import App from './containers/App';
+
+const routes = <Route path="/" component={App} />;
+
+export default routes;

--- a/src/applications/ds-v3-playground/sass/ds-v3-playground.scss
+++ b/src/applications/ds-v3-playground/sass/ds-v3-playground.scss
@@ -1,0 +1,1 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/src/applications/ds-v3-playground/tests/ds-v3-playground.cypress.spec.js
+++ b/src/applications/ds-v3-playground/tests/ds-v3-playground.cypress.spec.js
@@ -1,0 +1,15 @@
+import manifest from '../manifest.json';
+
+describe(manifest.appName, () => {
+  // Skip tests in CI until the app is released.
+  // Remove this block when the app has a content page in production.
+  before(function() {
+    if (Cypress.env('CI')) this.skip();
+  });
+
+  it('is accessible', () => {
+    cy.visit(manifest.rootUrl)
+      .injectAxe()
+      .axeCheck();
+  });
+});

--- a/src/applications/ds-v3-playground/utils/defineWebComponents.js
+++ b/src/applications/ds-v3-playground/utils/defineWebComponents.js
@@ -1,0 +1,4 @@
+import '@department-of-veterans-affairs/component-library/dist/main.css';
+import { defineCustomElementVaTextarea } from '@department-of-veterans-affairs/component-library/dist/components';
+
+defineCustomElementVaTextarea();

--- a/src/applications/registry.scaffold.json
+++ b/src/applications/registry.scaffold.json
@@ -121,5 +121,11 @@
     "appName": "DS Playground",
     "entryName": "ds-playground",
     "rootUrl": "/ds-playground"
+  },
+   {
+    "appName": "DS V3 Playground",
+    "entryName": "ds-v3-playground",
+    "rootUrl": "/ds-v3-playground",
+    "useLocalStylesAndComponents": true
   }
 ]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Introducing a "USWDS V3-only" Design System Playground, for use by the Design System Team to test "V3-mode" components on a page where Formation (V1 Styles) are not being loaded.
- This page utilizes the "useLocalStylesAndComponents" App Registry flag to prevent Formation styles from being loaded.
- I work for the Design System Team as Tech Lead

## Related issue(s)

- Closes #[1809](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1809)

## Testing done

- Tested locally using Brave

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    
<img width="551" alt="Screenshot 2023-06-26 at 4 28 57 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/147893/abe27720-e2f1-4f5f-a1d2-850aa4490c0e">
    |       |

## What areas of the site does it impact?

Creates a new V3-only playground which will not - at this time - be merged into main or production.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions
