### PR TITLE
VACMS-14047 Income Limits: Make Review page an unordered list

### DIFF
--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -59,67 +59,67 @@ const ReviewPage = ({
   return (
     <>
       <h1>Aenean tristique mollis</h1>
-      <p>Fusce risus lacus, efficitur ac magna vitae, cursus lobortis dui.</p>
-      <table className="usa-table-borderless" data-testid="il-review">
-        <tbody>
-          {pastMode && (
-            <tr>
-              <td data-testid="review-year">
-                <strong>Vitae:</strong>
-                <br aria-hidden="true" /> {yearInput}
-              </td>
-              <td className="income-limits-edit">
-                <button
-                  aria-label="Edit year"
-                  className="va-button-link"
-                  href="#"
-                  onClick={() => handleEditClick(ROUTES.YEAR)}
-                  name="year"
-                  type="button"
-                >
-                  Edit
-                </button>
-              </td>
-            </tr>
-          )}
-          <tr>
-            <td data-testid="review-zip">
-              <strong>Nisci orci:</strong>
-              <br aria-hidden="true" /> {zipCodeInput}
-            </td>
-            <td className="income-limits-edit">
+      <p className="il-review">
+        Fusce risus lacus, efficitur ac magna vitae, cursus lobortis dui.
+      </p>
+      <ul data-testid="il-review">
+        {pastMode && (
+          <li>
+            <span data-testid="review-year">
+              <strong>Vitae:</strong>
+              <br /> {yearInput}
+            </span>
+            <span className="income-limits-edit">
               <button
-                aria-label="Edit zip code"
+                aria-label="Edit year"
                 className="va-button-link"
                 href="#"
-                onClick={() => handleEditClick(ROUTES.ZIPCODE)}
-                name="zipCode"
+                onClick={() => handleEditClick(ROUTES.YEAR)}
+                name="year"
                 type="button"
               >
                 Edit
               </button>
-            </td>
-          </tr>
-          <tr>
-            <td data-testid="review-dependents">
-              <strong>Malesuada felis ultrices:</strong>
-              <br aria-hidden="true" /> {dependentsInput}
-            </td>
-            <td className="income-limits-edit">
-              <button
-                aria-label="Edit number of dependents"
-                className="va-button-link"
-                href="#"
-                onClick={() => handleEditClick(ROUTES.DEPENDENTS)}
-                name="dependents"
-                type="button"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </span>
+          </li>
+        )}
+        <li>
+          <span data-testid="review-zip">
+            <strong>Nisci orci:</strong>
+            <br /> {zipCodeInput}
+          </span>
+          <span className="income-limits-edit">
+            <button
+              aria-label="Edit zip code"
+              className="va-button-link"
+              href="#"
+              onClick={() => handleEditClick(ROUTES.ZIPCODE)}
+              name="zipCode"
+              type="button"
+            >
+              Edit
+            </button>
+          </span>
+        </li>
+        <li>
+          <span data-testid="review-dependents">
+            <strong>Malesuada felis ultrices:</strong>
+            <br /> {dependentsInput}
+          </span>
+          <span className="income-limits-edit">
+            <button
+              aria-label="Edit number of dependents"
+              className="va-button-link"
+              href="#"
+              onClick={() => handleEditClick(ROUTES.DEPENDENTS)}
+              name="dependents"
+              type="button"
+            >
+              Edit
+            </button>
+          </span>
+        </li>
+      </ul>
       <VaButtonPair
         data-testid="il-buttonPair"
         onPrimaryClick={onContinueClick}

--- a/src/applications/income-limits/sass/income-limits.scss
+++ b/src/applications/income-limits/sass/income-limits.scss
@@ -1,7 +1,23 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
 .income-limits-app {
-  .usa-table-borderless {
+  p.il-review {
+    margin-bottom: 32px;
+  }
+
+  ul[data-testid="il-review"] {
+    padding-left: 0;
+
+    li {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 0;
+      padding: 12px 0;
+      border-top: 1px solid $color-gray-light;
+    }
+
     .income-limits-edit {
-      width: 54px;
+      width: 46px;
     }
   }
 


### PR DESCRIPTION
## Summary
The Review page was previously using a `<table>`, but we need to change it to an unordered list for accessibility. Those changes and the related style adjustments are here.

`/health-care/income-limits-temp`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14047

## Testing done
Tested locally by going through the flow from Home > Zip > Dependents > Review and verified it matches what is in staging right now.

## Screenshots
Note that the design comp has changed a bit to remove the left padding on the "rows" and the underline underneath the bottom row. Also, the border color is lighter now.

Design comp: https://www.sketch.com/s/a8506c94-a5bd-4a69-91ff-fe06545f3126/a/ellZqzx#Inspect

New review page:
<img width="1077" alt="Screenshot 2023-06-26 at 4 30 31 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/c2f30734-3d3b-470c-994d-99776fecf0b5">

Review page in staging:
<img width="1091" alt="Screenshot 2023-06-26 at 4 30 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/c86e4ad2-af21-4e81-91a7-416e950ff323">

## Acceptance criteria
- [x] All information the user is expected to review is wrapped in an unordered list
- [x] No aria-hidden attributes are used
- [x] Order of each list item is Label, value, Edit link
- [ ] Edit action is a link if possible - This is not possible because the app is not intended to support deep-linking (i.e. navigating straight to `/zip`)