### PR TITLE
Simple forms – remove WIP component from form 21-4142

### DIFF
--- a/src/applications/simple-forms/21-4142/containers/App.jsx
+++ b/src/applications/simple-forms/21-4142/containers/App.jsx
@@ -1,34 +1,12 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import environment from 'platform/utilities/environment';
-
 import formConfig from '../config/form';
-import { workInProgressContent } from '../definitions/constants';
 
-import { WIP } from '../../shared/components/WIP';
-
-export function App({ location, children, show214142 }) {
-  if (!show214142 && !environment.isLocalhost()) {
-    return <WIP content={workInProgressContent} />;
-  }
+export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
 }
-
-App.propTypes = {
-  show214142: PropTypes.bool,
-};
-
-const mapStateToProps = state => ({
-  show214142: toggleValues(state)[FEATURE_FLAG_NAMES.form214142] || false,
-});
-
-export default connect(mapStateToProps)(App);

--- a/src/applications/simple-forms/21-4142/definitions/constants.js
+++ b/src/applications/simple-forms/21-4142/definitions/constants.js
@@ -60,10 +60,3 @@ export const relationshipToVeteranEnum = [
   'Alternate signer (a person certified to file a claim forms for the Veteran or non-Veteran) ',
   'Third-party',
 ];
-
-export const workInProgressContent = {
-  description:
-    'We’re rolling out the Authorize the release of non-VA medical information to VA (VA Forms 21-4142 and 21-4142a) in stages. It’s not quite ready yet. Please check back again soon.',
-  redirectLink: '/',
-  redirectText: 'Return to VA home page',
-};

--- a/src/applications/simple-forms/shared/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/simple-forms/shared/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "form214142",
-        "value": true
-      },
-      {
         "name": "form264555",
         "value": true
       }


### PR DESCRIPTION
## Summary

- Remove configuration from `App.jsx` for WIP component
- Remove content for 21-4142 wip component
- Remove mock feature flag for 21-4142

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/358

## Testing done

- Tested locally

## What areas of the site does it impact?
Form 21-4142 will no longer hide form pages behind WIP component even when flipper is off
