### PR TITLE
VACMS-13593 Update Income Limits URL

### DIFF
--- a/src/applications/income-limits/components/Breadcrumbs.jsx
+++ b/src/applications/income-limits/components/Breadcrumbs.jsx
@@ -9,7 +9,7 @@ const Breadcrumbs = () => {
       <a href="/health-care" key="health-care">
         Health Care
       </a>
-      <a href="/health-care/income-limits-temp" key="income-limits">
+      <a href="/health-care/income-limits" key="income-limits">
         Check income limits
       </a>
     </va-breadcrumbs>

--- a/src/applications/income-limits/manifest.json
+++ b/src/applications/income-limits/manifest.json
@@ -2,5 +2,5 @@
   "appName": "Income Limits",
   "entryFile": "./income-limits-entry.jsx",
   "entryName": "income-limits",
-  "rootUrl": "/health-care/income-limits-temp"
+  "rootUrl": "/health-care/income-limits"
 }


### PR DESCRIPTION
## Summary
Updating Income Limits' URL to its final URL.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13593

## Testing done
Tested locally with the matching `content-build` changes. `/health-care/income-limits`
<img width="1076" alt="Screenshot 2023-06-27 at 9 08 54 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e219f0fb-ed46-4c61-9f48-4555bbe35a5f">