### PR TITLE
VACMS-14049 Remove Expand all link from Income Limits Results page

### DIFF
--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -50,7 +50,7 @@ const Results = ({ results, yearInput }) => {
         ipsum, ut rutrum lacus. Aliquam ut pulvinar sapien, eu gravida nisi.
       </p>
       <h2>Fusce risus lacus efficitur ac magna vitae</h2>
-      <va-accordion bordered data-testid="il-results">
+      <va-accordion bordered data-testid="il-results" open-single>
         <va-accordion-item
           data-testid="il-results-1"
           header={getFirstAccordionHeader(pension)}


### PR DESCRIPTION
## Summary
Remove `Expand all` button on the Income Limits Results page by using `open-single` on the `va-accordion` component, per design system guidance.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14049

## Testing done
Tested locally both current and past flows.

## Screenshots
<img width="800" alt="Screenshot 2023-06-27 at 12 58 21 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1b6378d3-2caa-4aa2-8487-99cea4638801">
<img width="800" alt="Screenshot 2023-06-27 at 12 58 00 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/210b1ec0-effd-42d6-9be3-aa062a12b200">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- [ ] Each accordion on Results screen has to be tapped to open (no "expand all" option)