### PR TITLE
21-10210 - Remove PDF-download links from static-page

### DIFF
--- a/src/applications/static-pages/simple-forms/21-10210/App.js
+++ b/src/applications/static-pages/simple-forms/21-10210/App.js
@@ -24,11 +24,7 @@ const App = ({ formEnabled }) => {
     );
   }
 
-  return (
-    <>
-      <p>You can submit this form by mail.</p>
-    </>
-  );
+  return <p>You can submit this form by mail.</p>;
 };
 
 App.propTypes = {

--- a/src/applications/static-pages/simple-forms/21-10210/App.js
+++ b/src/applications/static-pages/simple-forms/21-10210/App.js
@@ -20,12 +20,6 @@ const App = ({ formEnabled }) => {
         >
           Submit a lay witness statement online to support a claim
         </a>
-        <a
-          className="vads-c-action-link--green"
-          href="/find-forms/about-form-21-10210/"
-        >
-          Get VA Form 21-10210 to download
-        </a>
       </>
     );
   }
@@ -33,12 +27,6 @@ const App = ({ formEnabled }) => {
   return (
     <>
       <p>You can submit this form by mail.</p>
-      <a
-        className="vads-c-action-link--green"
-        href="/find-forms/about-form-21-10210/"
-      >
-        Get VA Form 21-10210 to download
-      </a>
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Delete PDF-download links from Lay/Witness Stmt (21-10210) static-page.
- Team: VA Product Forms
- Flipper `form2110210` enabled in Staging ONLY

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#359

## Testing done

- N/A &mdash; just a content change.  No functional/logic changes in the app.
