### PR TITLE
21-10210 - Remove WIP conditional-page from app

### DIFF
--- a/src/applications/simple-forms/21-10210/containers/App.jsx
+++ b/src/applications/simple-forms/21-10210/containers/App.jsx
@@ -1,36 +1,13 @@
 import React from 'react';
 
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import environment from 'platform/utilities/environment';
-import { WIP } from '../../shared/components/WIP';
+
 import formConfig from '../config/form';
-import { workInProgressContent } from '../definitions/constants';
 
-export function App({ location, children, show2110210 }) {
-  if (!show2110210 && !environment.isLocalhost()) {
-    return <WIP content={workInProgressContent} />;
-  }
-
+export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
 }
-
-App.propTypes = {
-  children: PropTypes.element.isRequired,
-  location: PropTypes.object.isRequired,
-  show2110210: PropTypes.bool,
-};
-
-const mapStateToProps = state => ({
-  show2110210: toggleValues(state)[FEATURE_FLAG_NAMES.form2110210] || false,
-});
-
-export default connect(mapStateToProps)(App);

--- a/src/applications/simple-forms/21-10210/definitions/constants.js
+++ b/src/applications/simple-forms/21-10210/definitions/constants.js
@@ -33,10 +33,3 @@ export const RELATIONSHIP_TO_CLAIMANT_OPTIONS = [
   COWORKER_OR_SUPERVISOR_OF_CLAIMANT,
   OTHER_RELATIONSHIP,
 ];
-
-export const workInProgressContent = {
-  description:
-    'We’re rolling out the Lay/Witness Statement (VA Form 21-10210) in stages. It’s not quite ready yet. Please check back again soon.',
-  redirectLink: '/',
-  redirectText: 'Return to VA home page',
-};

--- a/src/applications/simple-forms/shared/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/simple-forms/shared/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -3,10 +3,6 @@
     "type": "feature_toggles",
     "features": [
       {
-        "name": "form2110210",
-        "value": true
-      },
-      {
         "name": "form264555",
         "value": true
       }


### PR DESCRIPTION
## Summary

- Remove WIP conditional-page from Lay/Witness Stmt (21-10210) form-app
- Team: VA Product Forms
- Flipper enabled in Staging ONLY.

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#364


## Testing done

- Local browser testing and unit-tests successful.

