### PR TITLE
VACMS-13593 redirect

### DIFF
--- a/src/applications/income-limits/api/index.js
+++ b/src/applications/income-limits/api/index.js
@@ -25,7 +25,7 @@ export const validateZip = async zip => {
   const CONTEXT_ROOT = '/income_limits/v1/validateZipCode';
   const REQUEST_URL = `${environment.API_URL}${CONTEXT_ROOT}/${zip}`;
   // For testing locally, use the below REQUEST_URL and comment out the CONTEXT_ROOT and REQUEST_URL above
-  // const REQUEST_URL = `https://api.va.gov/income_limits/v1/validateZipCod/${zip}`;
+  // const REQUEST_URL = `https://api.va.gov/income_limits/v1/validateZipCode/${zip}`;
 
   return new Promise((resolve, reject) => {
     fetch(REQUEST_URL)

--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -14,9 +14,12 @@ import { updateDependents, updateEditMode } from '../actions';
 const DependentsPage = ({
   dependents,
   editMode,
+  pastMode,
   router,
   toggleEditMode,
   updateDependentsField,
+  year,
+  zipCode,
 }) => {
   const [error, setError] = useState(false);
   const [submitted, setSubmitted] = useState(false);
@@ -27,10 +30,24 @@ const DependentsPage = ({
 
   const validDependents = dependents?.length > 0 && dependentsValid(dependents);
 
-  useEffect(() => {
-    waitForRenderThenFocus('h1');
-    scrollToTop();
-  }, []);
+  useEffect(
+    () => {
+      let shouldRedirectToHome = !zipCode;
+
+      if (pastMode) {
+        shouldRedirectToHome = !zipCode && !year;
+      }
+
+      if (shouldRedirectToHome) {
+        router.push(ROUTES.HOME);
+        return;
+      }
+
+      waitForRenderThenFocus('h1');
+      scrollToTop();
+    },
+    [pastMode, router, year, zipCode],
+  );
 
   const onContinueClick = () => {
     setSubmitted(true);
@@ -101,6 +118,9 @@ const DependentsPage = ({
 const mapStateToProps = state => ({
   dependents: state?.incomeLimits?.form?.dependents,
   editMode: state?.incomeLimits?.editMode,
+  pastMode: state?.incomeLimits?.pastMode,
+  year: state?.incomeLimits?.form?.year,
+  zipCode: state?.incomeLimits?.form?.zipCode,
 });
 
 const mapDispatchToProps = {
@@ -110,12 +130,15 @@ const mapDispatchToProps = {
 
 DependentsPage.propTypes = {
   editMode: PropTypes.bool.isRequired,
+  pastMode: PropTypes.bool.isRequired,
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
   toggleEditMode: PropTypes.func.isRequired,
   updateDependentsField: PropTypes.func.isRequired,
+  zipCode: PropTypes.string.isRequired,
   dependents: PropTypes.string,
+  year: PropTypes.string,
 };
 
 export default connect(

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -11,6 +11,7 @@ import {
   getFourthAccordionHeader,
   getFifthAccordionHeader,
 } from '../utilities/results-accordions';
+import { redirectIfFormIncomplete } from '../utilities/utils';
 
 /**
  * There are two pathways to displaying income ranges on this page
@@ -18,97 +19,125 @@ import {
  * 1) Standard: GMT > NMT
  * 2) Non-standard: GMT < NMT  In some rural areas, the Geographic Means Test is lower than the National Means Test
  */
-const Results = ({ results, yearInput }) => {
-  const {
-    gmt_threshold: gmt,
-    national_threshold: national,
-    pension_threshold: pension,
-  } = results;
+const Results = ({
+  dependentsInput,
+  pastMode,
+  results,
+  router,
+  yearInput,
+  zipCodeInput,
+}) => {
+  useEffect(
+    () => {
+      redirectIfFormIncomplete(
+        dependentsInput,
+        pastMode,
+        router,
+        yearInput,
+        zipCodeInput,
+      );
 
-  const isStandard = gmt > national;
-  const currentYear = new Date().getFullYear();
+      waitForRenderThenFocus('h1');
+      scrollToTop();
+    },
+    [dependentsInput, pastMode, router, yearInput, zipCodeInput],
+  );
 
-  useEffect(() => {
-    waitForRenderThenFocus('h1');
-    scrollToTop();
-  }, []);
+  if (results) {
+    const {
+      gmt_threshold: gmt,
+      national_threshold: national,
+      pension_threshold: pension,
+    } = results;
 
-  return (
-    <>
-      <h1>Your income limits for {yearInput || currentYear}</h1>
-      <p>
-        In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
-        justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra. Nam
-        ac laoreet leo, nec fringilla libero. Maecenas ac felis non augue
-        malesuada iaculis id sit amet tellus. Etiam molestie auctor neque, eu
-        pharetra lacus rhoncus at.
-      </p>
-      <p>
-        Morbi placerat nibh augue, sit amet aliquam ipsum mattis sed. Morbi
-        pellentesque fermentum tortor, ac vestibulum ligula suscipit sit amet.
-        Donec scelerisque lectus a eros pellentesque rutrum. Sed sit amet varius
-        ipsum, ut rutrum lacus. Aliquam ut pulvinar sapien, eu gravida nisi.
-      </p>
-      <h2>Fusce risus lacus efficitur ac magna vitae</h2>
-      <va-accordion bordered data-testid="il-results" open-single>
-        <va-accordion-item
-          data-testid="il-results-1"
-          header={getFirstAccordionHeader(pension)}
-        >
+    const isStandard = gmt > national;
+    const currentYear = new Date().getFullYear();
+
+    return (
+      <>
+        <h1>Your income limits for {yearInput || currentYear}</h1>
+        <p>
           In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
           justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-          Nam ac laoreet leo, nec fringilla libero.
-        </va-accordion-item>
-        <va-accordion-item
-          data-testid="il-results-2"
-          header={getSecondAccordionHeader(pension, national)}
-        >
-          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
-          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-          Nam ac laoreet leo, nec fringilla libero.
-        </va-accordion-item>
-        <va-accordion-item
-          data-testid="il-results-3"
-          header={getThirdAccordionHeader(national, gmt, isStandard)}
-        >
-          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
-          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-          Nam ac laoreet leo, nec fringilla libero.
-        </va-accordion-item>
-        <va-accordion-item
-          data-testid="il-results-4"
-          header={getFourthAccordionHeader(national, gmt, isStandard)}
-        >
-          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
-          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-          Nam ac laoreet leo, nec fringilla libero.
-        </va-accordion-item>
-        {isStandard && (
+          Nam ac laoreet leo, nec fringilla libero. Maecenas ac felis non augue
+          malesuada iaculis id sit amet tellus. Etiam molestie auctor neque, eu
+          pharetra lacus rhoncus at.
+        </p>
+        <p>
+          Morbi placerat nibh augue, sit amet aliquam ipsum mattis sed. Morbi
+          pellentesque fermentum tortor, ac vestibulum ligula suscipit sit amet.
+          Donec scelerisque lectus a eros pellentesque rutrum. Sed sit amet
+          varius ipsum, ut rutrum lacus. Aliquam ut pulvinar sapien, eu gravida
+          nisi.
+        </p>
+        <h2>Fusce risus lacus efficitur ac magna vitae</h2>
+        <va-accordion bordered data-testid="il-results" open-single>
           <va-accordion-item
-            data-testid="il-results-5"
-            header={getFifthAccordionHeader(gmt)}
+            data-testid="il-results-1"
+            header={getFirstAccordionHeader(pension)}
           >
             In posuere, sem in ornare mattis, urna libero vulputate quam, a
-            justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-            Nam ac laoreet leo, nec fringilla libero.
+            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
+            pharetra. Nam ac laoreet leo, nec fringilla libero.
           </va-accordion-item>
-        )}
-      </va-accordion>
-      <h2>Aliquam ut pulvinar sapien, eu gravida nisi</h2>
-      <p>
-        Aenean tortor lorem, commodo quis est at, interdum mollis ipsum.
-        Suspendisse et nulla nisi.
-      </p>
-    </>
-  );
+          <va-accordion-item
+            data-testid="il-results-2"
+            header={getSecondAccordionHeader(pension, national)}
+          >
+            In posuere, sem in ornare mattis, urna libero vulputate quam, a
+            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
+            pharetra. Nam ac laoreet leo, nec fringilla libero.
+          </va-accordion-item>
+          <va-accordion-item
+            data-testid="il-results-3"
+            header={getThirdAccordionHeader(national, gmt, isStandard)}
+          >
+            In posuere, sem in ornare mattis, urna libero vulputate quam, a
+            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
+            pharetra. Nam ac laoreet leo, nec fringilla libero.
+          </va-accordion-item>
+          <va-accordion-item
+            data-testid="il-results-4"
+            header={getFourthAccordionHeader(national, gmt, isStandard)}
+          >
+            In posuere, sem in ornare mattis, urna libero vulputate quam, a
+            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
+            pharetra. Nam ac laoreet leo, nec fringilla libero.
+          </va-accordion-item>
+          {isStandard && (
+            <va-accordion-item
+              data-testid="il-results-5"
+              header={getFifthAccordionHeader(gmt)}
+            >
+              In posuere, sem in ornare mattis, urna libero vulputate quam, a
+              justo nisl non tortor. Nulla at mauris non dolor dignissim
+              pharetra. Nam ac laoreet leo, nec fringilla libero.
+            </va-accordion-item>
+          )}
+        </va-accordion>
+        <h2>Aliquam ut pulvinar sapien, eu gravida nisi</h2>
+        <p>
+          Aenean tortor lorem, commodo quis est at, interdum mollis ipsum.
+          Suspendisse et nulla nisi.
+        </p>
+      </>
+    );
+  }
+
+  return null;
 };
 
 const mapStateToProps = state => ({
+  dependentsInput: state?.incomeLimits?.form?.dependents,
+  pastMode: state?.incomeLimits?.pastMode,
   results: state?.incomeLimits?.results,
   yearInput: state?.incomeLimits?.form?.year,
+  zipCodeInput: state?.incomeLimits?.form?.zipCode,
 });
 
 Results.propTypes = {
+  dependentsInput: PropTypes.string.isRequired,
+  pastMode: PropTypes.bool.isRequired,
   results: PropTypes.shape({
     // eslint-disable-next-line camelcase
     gmt_threshold: PropTypes.number,
@@ -117,6 +146,10 @@ Results.propTypes = {
     // eslint-disable-next-line camelcase
     pension_threshold: PropTypes.number,
   }).isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+  zipCodeInput: PropTypes.string.isRequired,
   yearInput: PropTypes.string,
 };
 

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
+import { redirectIfFormIncomplete } from '../utilities/utils';
 import { getData } from '../api';
 import { ROUTES } from '../constants';
 import { updateEditMode, updateResults } from '../actions';
@@ -25,10 +26,21 @@ const ReviewPage = ({
     }
   });
 
-  useEffect(() => {
-    waitForRenderThenFocus('h1');
-    scrollToTop();
-  }, []);
+  useEffect(
+    () => {
+      redirectIfFormIncomplete(
+        dependentsInput,
+        pastMode,
+        router,
+        yearInput,
+        zipCodeInput,
+      );
+
+      waitForRenderThenFocus('h1');
+      scrollToTop();
+    },
+    [dependentsInput, pastMode, router, yearInput, zipCodeInput],
+  );
 
   const onContinueClick = async () => {
     const year = yearInput || new Date().getFullYear();
@@ -70,16 +82,15 @@ const ReviewPage = ({
               <br /> {yearInput}
             </span>
             <span className="income-limits-edit">
-              <button
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+              <a
                 aria-label="Edit year"
-                className="va-button-link"
                 href="#"
                 onClick={() => handleEditClick(ROUTES.YEAR)}
                 name="year"
-                type="button"
               >
                 Edit
-              </button>
+              </a>
             </span>
           </li>
         )}
@@ -89,16 +100,15 @@ const ReviewPage = ({
             <br /> {zipCodeInput}
           </span>
           <span className="income-limits-edit">
-            <button
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a
               aria-label="Edit zip code"
-              className="va-button-link"
               href="#"
               onClick={() => handleEditClick(ROUTES.ZIPCODE)}
               name="zipCode"
-              type="button"
             >
               Edit
-            </button>
+            </a>
           </span>
         </li>
         <li>
@@ -107,16 +117,15 @@ const ReviewPage = ({
             <br /> {dependentsInput}
           </span>
           <span className="income-limits-edit">
-            <button
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a
               aria-label="Edit number of dependents"
-              className="va-button-link"
               href="#"
               onClick={() => handleEditClick(ROUTES.DEPENDENTS)}
               name="dependents"
-              type="button"
             >
               Edit
-            </button>
+            </a>
           </span>
         </li>
       </ul>

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -13,6 +13,7 @@ import { updateEditMode, updateYear } from '../actions';
 
 const YearPage = ({
   editMode,
+  pastMode,
   router,
   toggleEditMode,
   updateYearField,
@@ -21,10 +22,21 @@ const YearPage = ({
   const [error, setError] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  useEffect(() => {
-    waitForRenderThenFocus('h1');
-    scrollToTop();
-  }, []);
+  useEffect(
+    () => {
+      // If pastMode is null, the home screen hasn't been used yet
+      const shouldRedirectToHome = pastMode === null;
+
+      if (shouldRedirectToHome) {
+        router.push(ROUTES.HOME);
+        return;
+      }
+
+      waitForRenderThenFocus('h1');
+      scrollToTop();
+    },
+    [pastMode, router],
+  );
 
   const onContinueClick = () => {
     setSubmitted(true);
@@ -51,7 +63,7 @@ const YearPage = ({
   const makeYearArray = () => {
     const years = [];
     let currentYear = new Date().getFullYear();
-    const earliestYear = 2015;
+    const earliestYear = 2001;
 
     while (currentYear >= earliestYear) {
       years.push(currentYear);
@@ -115,6 +127,7 @@ const YearPage = ({
 
 const mapStateToProps = state => ({
   editMode: state?.incomeLimits?.editMode,
+  pastMode: state?.incomeLimits?.pastMode,
   yearInput: state?.incomeLimits?.form?.year,
 });
 
@@ -125,6 +138,7 @@ const mapDispatchToProps = {
 
 YearPage.propTypes = {
   editMode: PropTypes.bool.isRequired,
+  pastMode: PropTypes.bool.isRequired,
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -23,6 +23,7 @@ const ZipCodePage = ({
   toggleEditMode,
   updateZipCodeField,
   updateZipValError,
+  year,
   zipCode,
 }) => {
   const [formError, setFormError] = useState(false);
@@ -32,10 +33,25 @@ const ZipCodePage = ({
     return zipCode && zip.match(/^[0-9]+$/) && zip.length === 5;
   };
 
-  useEffect(() => {
-    waitForRenderThenFocus('h1');
-    scrollToTop();
-  }, []);
+  useEffect(
+    () => {
+      // If pastMode is null, the home screen hasn't been used yet
+      let shouldRedirectToHome = pastMode === null;
+
+      if (pastMode) {
+        shouldRedirectToHome = !year;
+      }
+
+      if (shouldRedirectToHome) {
+        router.push(ROUTES.HOME);
+        return;
+      }
+
+      waitForRenderThenFocus('h1');
+      scrollToTop();
+    },
+    [pastMode, router, year],
+  );
 
   const onContinueClick = async () => {
     // Zip meets input criteria
@@ -134,6 +150,7 @@ const ZipCodePage = ({
 const mapStateToProps = state => ({
   editMode: state?.incomeLimits?.editMode,
   pastMode: state?.incomeLimits?.pastMode,
+  year: state?.incomeLimits?.form?.year,
   zipCode: state?.incomeLimits?.form?.zipCode,
 });
 
@@ -152,6 +169,7 @@ ZipCodePage.propTypes = {
   }),
   toggleEditMode: PropTypes.func,
   updateZipValError: PropTypes.func,
+  year: PropTypes.string,
   zipCode: PropTypes.string,
 };
 

--- a/src/applications/income-limits/reducers/index.js
+++ b/src/applications/income-limits/reducers/index.js
@@ -15,7 +15,7 @@ const initialState = {
     year: null,
     zipCode: null,
   },
-  pastMode: false,
+  pastMode: null,
   results: null,
   zipValidationServiceError: false,
 };

--- a/src/applications/income-limits/tests/DependentsPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/DependentsPage.unit.spec.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import DependentsPage from '../containers/DependentsPage';
+
+const pushSpyZipIsEmpty = sinon.spy();
+const pushSpyYearIsEmpty = sinon.spy();
+
+const mockStoreStandard = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        dependents: '',
+        year: '',
+        zipCode: '10108',
+      },
+      pastMode: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsStandard = {
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: () => {},
+  },
+  updateZipCodeField: () => {},
+  toggleEditMode: () => {},
+  dependents: '',
+  year: '',
+  zipCode: '10108',
+};
+
+const mockStoreZipIsEmpty = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        dependents: '',
+        year: '',
+        zipCode: '',
+      },
+      pastMode: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsZipIsEmpty = {
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: pushSpyZipIsEmpty,
+  },
+  updateZipCodeField: () => {},
+  toggleEditMode: () => {},
+  dependents: '',
+  year: '',
+  zipCode: '',
+};
+
+const mockStoreZipYearAreEmpty = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        dependents: '',
+        year: '',
+        zipCode: '',
+      },
+      pastMode: true,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsZipYearAreEmpty = {
+  editMode: false,
+  pastMode: true,
+  router: {
+    push: pushSpyYearIsEmpty,
+  },
+  updateZipCodeField: () => {},
+  toggleEditMode: () => {},
+  dependents: '',
+  year: '',
+  zipCode: '',
+};
+
+describe('Dependents Page', () => {
+  it('should correctly load the dependents page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <DependentsPage {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('il-dependents')).to.exist;
+  });
+
+  it('should not allow deep linking to this page if zip is empty', () => {
+    render(
+      <Provider store={mockStoreZipIsEmpty}>
+        <DependentsPage {...propsZipIsEmpty} />
+      </Provider>,
+    );
+
+    expect(pushSpyZipIsEmpty.withArgs('/').calledOnce).to.be.true;
+  });
+
+  it('should not allow deep linking to this page if the year field and zip field are empty and pastMode is true', () => {
+    render(
+      <Provider store={mockStoreZipYearAreEmpty}>
+        <DependentsPage {...propsZipYearAreEmpty} />
+      </Provider>,
+    );
+
+    expect(pushSpyYearIsEmpty.withArgs('/').calledOnce).to.be.true;
+  });
+});

--- a/src/applications/income-limits/tests/ResultsPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ResultsPage.unit.spec.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ResultsPage from '../containers/ResultsPage';
+
+const pushSpyFormIncomplete = sinon.spy();
+
+const mockStoreStandard = {
+  getState: () => ({
+    incomeLimits: {
+      form: {
+        dependents: '2',
+        year: '2015',
+        zipCode: '10108',
+      },
+      pastMode: false,
+      results: {
+        // eslint-disable-next-line camelcase
+        gmt_threshold: 56000,
+        // eslint-disable-next-line camelcase
+        national_threshold: 48000,
+        // eslint-disable-next-line camelcase
+        pension_threshold: 34000,
+      },
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsStandard = {
+  dependentsInput: '2',
+  pastMode: false,
+  results: {
+    // eslint-disable-next-line camelcase
+    gmt_threshold: 56000,
+    // eslint-disable-next-line camelcase
+    national_threshold: 48000,
+    // eslint-disable-next-line camelcase
+    pension_threshold: 34000,
+  },
+  router: {
+    push: () => {},
+  },
+  zipCodeInput: '10108',
+  yearInput: '2015',
+};
+
+const mockStoreFormIncomplete = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      pastMode: false,
+      form: {
+        dependents: '',
+        year: '',
+        zipCode: '',
+      },
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsFormIncomplete = {
+  dependentsInput: '',
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: pushSpyFormIncomplete,
+  },
+  toggleEditMode: () => {},
+  yearInput: '',
+  zipCodeInput: '',
+};
+
+describe('Results Page', () => {
+  it('should correctly load the results page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <ResultsPage {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('il-results')).to.exist;
+  });
+
+  it('should not allow deep linking to this page if the form is not complete', () => {
+    render(
+      <Provider store={mockStoreFormIncomplete}>
+        <ResultsPage {...propsFormIncomplete} />
+      </Provider>,
+    );
+
+    expect(pushSpyFormIncomplete.withArgs('/').calledOnce).to.be.true;
+  });
+});

--- a/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
@@ -9,6 +9,7 @@ import ReviewPage from '../containers/ReviewPage';
 
 const pushSpyStandard = sinon.spy();
 const pushSpyPast = sinon.spy();
+const pushSpyFormIncomplete = sinon.spy();
 
 const mockStoreStandard = {
   getState: () => ({
@@ -62,6 +63,34 @@ const propsPast = {
   toggleEditMode: () => {},
   yearInput: '2016',
   zipCodeInput: '60507',
+};
+
+const mockStoreFormIncomplete = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      pastMode: false,
+      form: {
+        dependents: '',
+        year: '',
+        zipCode: '',
+      },
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsFormIncomplete = {
+  dependentsInput: '',
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: pushSpyFormIncomplete,
+  },
+  toggleEditMode: () => {},
+  yearInput: '',
+  zipCodeInput: '',
 };
 
 describe('Review Page', () => {
@@ -121,5 +150,15 @@ describe('Review Page', () => {
 
     userEvent.click(screen.getAllByText('Edit')[0]);
     expect(pushSpyPast.withArgs('year').calledOnce).to.be.true;
+  });
+
+  it('should not allow deep linking to this page if the form is not complete', () => {
+    render(
+      <Provider store={mockStoreFormIncomplete}>
+        <ReviewPage {...propsFormIncomplete} />
+      </Provider>,
+    );
+
+    expect(pushSpyFormIncomplete.withArgs('/').calledOnce).to.be.true;
   });
 });

--- a/src/applications/income-limits/tests/YearPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/YearPage.unit.spec.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import YearPage from '../containers/YearPage';
+
+const pushSpyPastIsNull = sinon.spy();
+
+const mockStoreStandard = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        year: '2015',
+      },
+      pastMode: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsStandard = {
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: () => {},
+  },
+  updateYearField: () => {},
+  toggleEditMode: () => {},
+  yearInput: '2015',
+};
+
+const mockStorePastIsNull = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        year: '2015',
+      },
+      pastMode: null,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsPastIsNull = {
+  editMode: false,
+  pastMode: null,
+  router: {
+    push: pushSpyPastIsNull,
+  },
+  updateYearField: () => {},
+  toggleEditMode: () => {},
+  yearInput: '2015',
+};
+
+describe('Year Page', () => {
+  it('should correctly load the year page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <YearPage {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('il-year')).to.exist;
+  });
+
+  it('should not allow deep linking to this page if pastMode is null', () => {
+    render(
+      <Provider store={mockStorePastIsNull}>
+        <YearPage {...propsPastIsNull} />
+      </Provider>,
+    );
+
+    expect(pushSpyPastIsNull.withArgs('/').calledOnce).to.be.true;
+  });
+});

--- a/src/applications/income-limits/tests/ZipCodePage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ZipCodePage.unit.spec.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ZipCodePage from '../containers/ZipCodePage';
+
+const pushSpyPastIsNull = sinon.spy();
+const pushSpyYearIsEmpty = sinon.spy();
+
+const mockStoreStandard = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        year: '',
+        zipCode: '',
+      },
+      pastMode: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsStandard = {
+  editMode: false,
+  pastMode: false,
+  router: {
+    push: () => {},
+  },
+  updateZipCodeField: () => {},
+  toggleEditMode: () => {},
+  year: '',
+  zipCode: '',
+};
+
+const mockStorePastIsNull = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        year: '',
+        zipCode: '',
+      },
+      pastMode: null,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsPastIsNull = {
+  editMode: false,
+  pastMode: null,
+  router: {
+    push: pushSpyPastIsNull,
+  },
+  updateZipCodeField: () => {},
+  toggleEditMode: () => {},
+  year: '',
+  zipCode: '',
+};
+
+const mockStoreYearIsEmpty = {
+  getState: () => ({
+    incomeLimits: {
+      editMode: false,
+      form: {
+        year: '',
+        zipCode: '',
+      },
+      pastMode: true,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsYearIsEmpty = {
+  editMode: false,
+  pastMode: true,
+  router: {
+    push: pushSpyYearIsEmpty,
+  },
+  updateZipCodeField: () => {},
+  toggleEditMode: () => {},
+  year: '',
+  zipCode: '',
+};
+
+describe('Zip Code Page', () => {
+  it('should correctly load the zip code page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <ZipCodePage {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('il-zipCode')).to.exist;
+  });
+
+  it('should not allow deep linking to this page if pastMode is null', () => {
+    render(
+      <Provider store={mockStorePastIsNull}>
+        <ZipCodePage {...propsPastIsNull} />
+      </Provider>,
+    );
+
+    expect(pushSpyPastIsNull.withArgs('/').calledOnce).to.be.true;
+  });
+
+  it('should not allow deep linking to this page if the year field is empty and pastMode is true', () => {
+    render(
+      <Provider store={mockStoreYearIsEmpty}>
+        <ZipCodePage {...propsYearIsEmpty} />
+      </Provider>,
+    );
+
+    expect(pushSpyYearIsEmpty.withArgs('/').calledOnce).to.be.true;
+  });
+});

--- a/src/applications/income-limits/tests/helpers.js
+++ b/src/applications/income-limits/tests/helpers.js
@@ -113,6 +113,6 @@ export const verifyAlertNotShown = selector =>
     .get('span[role="alert"]')
     .should('not.be.visible');
 
-export const getEditLink = index => cy.get('.va-button-link').eq(index);
+export const getEditLink = index => cy.get('.income-limits-edit a').eq(index);
 export const checkListItemText = (selector, expectedValue) =>
   cy.findByTestId(selector).should('contain.text', expectedValue);

--- a/src/applications/income-limits/utilities/utils.js
+++ b/src/applications/income-limits/utilities/utils.js
@@ -1,0 +1,19 @@
+import { ROUTES } from '../constants';
+
+export const redirectIfFormIncomplete = (
+  dependentsInput,
+  pastMode,
+  router,
+  yearInput,
+  zipCodeInput,
+) => {
+  let shouldRedirect = !dependentsInput || !zipCodeInput;
+
+  if (pastMode) {
+    shouldRedirect = !dependentsInput || !yearInput || !zipCodeInput;
+  }
+
+  if (shouldRedirect) {
+    router.push(ROUTES.HOME);
+  }
+};


### PR DESCRIPTION
## Summary
Prevent deep-linking to pages in Income Limits.

Specifics:
- Defaults `pastMode` to `null` so we can detect whether the home page has been used to navigate through the flow
- Each page checks values of the page(s) before it to make sure the data exists
- Every page redirects to home when those values are missing
- Also updates the Review page `Edit` `<button>` to `<a>` per a11y request

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13593

## Testing done
Tested manually that every page redirects to home when values are missing. Also tested at various points in form completion that redirects behaved as expected.

## Screenshots
Demonstrating deep-linking prevention:
https://www.loom.com/share/7171cafa1fce41a0a92b4a93e67fcf53?sid=e7bf9d8e-dbb7-4a75-8def-63a435fc2a6a

Demonstrating conversion of Edit button (Review page) to link
https://www.loom.com/share/472e96197a8a4a75b7a069b7b75f1ecd?sid=e8cfd0da-94a0-4e38-a3be-e702da44e985

## Acceptance criteria
- [x] It's not possible to link directly to a later page in the app with a broken state due to missing data, non-linear flow through app, etc.
- [x] Edit action is a link if possible (a11y)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.