### PR TITLE
VACMS-14044 Focus management for iOS issue

### DIFF
--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -5,7 +5,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
 import { ROUTES } from '../constants';
@@ -28,7 +28,7 @@ const DependentsPage = ({
   const validDependents = dependents?.length > 0 && dependentsValid(dependents);
 
   useEffect(() => {
-    focusElement('h1');
+    waitForRenderThenFocus('h1');
     scrollToTop();
   }, []);
 

--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
 import {
@@ -27,7 +27,7 @@ const HomePage = ({
         updateZipCodeField('');
       };
 
-      focusElement('h1');
+      waitForRenderThenFocus('h1');
       scrollToTop();
       clearForm();
     },

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
 import {
@@ -29,7 +29,7 @@ const Results = ({ results, yearInput }) => {
   const currentYear = new Date().getFullYear();
 
   useEffect(() => {
-    focusElement('h1');
+    waitForRenderThenFocus('h1');
     scrollToTop();
   }, []);
 

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { VaButtonPair } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { connect } from 'react-redux';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
 import { getData } from '../api';
@@ -26,7 +26,7 @@ const ReviewPage = ({
   });
 
   useEffect(() => {
-    focusElement('h1');
+    waitForRenderThenFocus('h1');
     scrollToTop();
   }, []);
 

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -5,7 +5,7 @@ import {
   VaButtonPair,
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
 import { ROUTES } from '../constants';
@@ -22,7 +22,7 @@ const YearPage = ({
   const [submitted, setSubmitted] = useState(false);
 
   useEffect(() => {
-    focusElement('h1');
+    waitForRenderThenFocus('h1');
     scrollToTop();
   }, []);
 

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -5,7 +5,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { focusElement } from 'platform/utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
 import { ROUTES } from '../constants';
@@ -33,7 +33,7 @@ const ZipCodePage = ({
   };
 
   useEffect(() => {
-    focusElement('h1');
+    waitForRenderThenFocus('h1');
     scrollToTop();
   }, []);
 


### PR DESCRIPTION
## Summary
When using a screen reader, the `<h1>`s were being read out correctly from page to page on desktop and Android. But on iOS specifically the behavior was sort of erratic. We discovered that this seemed to be an issue with the elements not loading on the page in time for the `focusElement` to target the `<h1>`. After much troubleshooting and iterating, we reached out to the design system team, who referred us to #accessibility-help. The a11y team was able to point us in the right direction: to use `waitForRenderThenFocus` instead of `focusElement`. Worked like a charm.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14044

## Testing done
Tested with screen reader on desktop Chrome, Safari and Firefox. Tested with screen reader on Android. Laura tested with screen reader on iOS.

## Acceptance criteria
- [x] When using a mobile device, the H1 of the page is announced when navigating between screens within the Income Limits flow for the first time.