### PR TITLE
Simple forms: Enable save in progress for form 21-0972

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -7,6 +7,7 @@ import recordEvent from '~/platform/monitoring/record-event';
 import { getAppUrl } from '~/platform/utilities/registry-helpers';
 
 export const formBenefits = {
+  [VA_FORM_IDS.FORM_21_0972]: 'alternate signer',
   [VA_FORM_IDS.FORM_21_10210]: 'lay/witness statement',
   [VA_FORM_IDS.FORM_21_4142]: 'authorization to release medical information',
   [VA_FORM_IDS.FORM_21_526EZ]: 'disability compensation',
@@ -77,6 +78,7 @@ export const formLinks = {
   [VA_FORM_IDS.FORM_10182]: `${getAppUrl('10182-board-appeal')}/`,
   [VA_FORM_IDS.FORM_20_0995]: `${getAppUrl('995-supplemental-claim')}/`,
   [VA_FORM_IDS.FORM_20_0996]: `${getAppUrl('0996-higher-level-review')}/`,
+  [VA_FORM_IDS.FORM_21_0972]: `${getAppUrl('21-0972-alternate-signer')}/`,
   [VA_FORM_IDS.FORM_21_10210]: `${getAppUrl('10210-lay-witness-statement')}/`,
   [VA_FORM_IDS.FORM_21_4142]: `${getAppUrl('21-4142-medical-release')}/`,
   [VA_FORM_IDS.FORM_21_526EZ]: `${getAppUrl('526EZ-all-claims')}/`,
@@ -101,6 +103,7 @@ export const formLinks = {
 };
 
 export const trackingPrefixes = {
+  [VA_FORM_IDS.FORM_21_0972]: '21-0972-alternate-signer-',
   [VA_FORM_IDS.FORM_21_10210]: 'lay-witness-10210-',
   [VA_FORM_IDS.FORM_21_4142]: 'medical-release-4142-',
   [VA_FORM_IDS.FORM_21_526EZ]: 'disability-526EZ-',
@@ -131,6 +134,7 @@ export const trackingPrefixes = {
 
 export const sipEnabledForms = new Set([
   VA_FORM_IDS.FORM_10_10EZ,
+  VA_FORM_IDS.FORM_21_0972,
   VA_FORM_IDS.FORM_21_10210,
   VA_FORM_IDS.FORM_21_4142,
   VA_FORM_IDS.FORM_21_686C,

--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -101,11 +101,12 @@ const formConfig = {
   },
   formId: '21-0972',
   saveInProgress: {
-    // messages: {
-    //   inProgress: 'Your alternate signer application (21-0972) is in progress.',
-    //   expired: 'Your saved alternate signer application (21-0972) has expired. If you want to apply for alternate signer, please start a new application.',
-    //   saved: 'Your alternate signer application has been saved.',
-    // },
+    messages: {
+      inProgress: 'Your alternate signer application (21-0972) is in progress.',
+      expired:
+        'Your saved alternate signer application (21-0972) has expired. If you want to apply for alternate signer, please start a new application.',
+      saved: 'Your alternate signer application has been saved.',
+    },
   },
   version: 0,
   prefillEnabled: true,


### PR DESCRIPTION
enable save in progress for form 21-0972 as [per docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-set-up-save-in-progress-si)


## Summary

- Enable configuration for save in progress
- Note: form already added to [platform form constants](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms/constants.js#L14)

## Related issue(s)
- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/348


## Testing done

- Tested locally with vets-api running


## Screenshots

Attached screenshot of sip message seen locally
![Screenshot 2023-07-03 at 11 03 11 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/610c881b-2494-4f0d-be3f-68ebc4d43453)


Confirmed that be leaving and returning to the form it still had my filled information


## What areas of the site does it impact?
Form 21-0972 (not yet prod)
