### PR TITLE
VACMS-14221 Income Limits results rounding

### DIFF
--- a/src/applications/income-limits/tests/results-accordions.unit.spec.js
+++ b/src/applications/income-limits/tests/results-accordions.unit.spec.js
@@ -20,6 +20,18 @@ const nonStandardLimits = {
   gmt_threshold: 33333,
 };
 
+const oddLimits = {
+  national_threshold: 30929,
+  pension_threshold: 40185,
+  gmt_threshold: 50611,
+};
+
+const oddLimitsNonStandard = {
+  national_threshold: 60929,
+  pension_threshold: 40185,
+  gmt_threshold: 50611,
+};
+
 describe('getFirstAccordionHeader', () => {
   it('should return the correct output', () => {
     expect(getFirstAccordionHeader(limits.pension_threshold)).to.equal(
@@ -47,7 +59,7 @@ describe('getThirdAccordionHeader', () => {
         nonStandardLimits.gmt_threshold,
         false,
       ),
-    ).to.equal('$44,445 - $48,888');
+    ).to.equal('$44,445 - $48,889');
   });
 
   it('should return the correct output for the standard case', () => {
@@ -59,6 +71,17 @@ describe('getThirdAccordionHeader', () => {
       ),
     ).to.equal('$44,445 - $77,777');
   });
+
+  // Extra formatting is only for the non-standard case on the third accordion header
+  it('should return the correct output for odd numbers for the non-standard case', () => {
+    expect(
+      getThirdAccordionHeader(
+        oddLimitsNonStandard.national_threshold,
+        oddLimitsNonStandard.gmt_threshold,
+        false,
+      ),
+    ).to.equal('$60,930 - $67,022');
+  });
 });
 
 describe('getFourthAccordionHeader', () => {
@@ -69,7 +92,7 @@ describe('getFourthAccordionHeader', () => {
         nonStandardLimits.gmt_threshold,
         false,
       ),
-    ).to.equal('$48,889 or more');
+    ).to.equal('$48,890 or more');
   });
 
   it('should return the correct output for the standard case', () => {
@@ -81,12 +104,39 @@ describe('getFourthAccordionHeader', () => {
       ),
     ).to.equal('$77,778 - $85,555');
   });
+
+  it('should return the correct output for odd numbers for the non-standard case', () => {
+    expect(
+      getFourthAccordionHeader(
+        oddLimitsNonStandard.national_threshold,
+        oddLimitsNonStandard.gmt_threshold,
+        false,
+      ),
+    ).to.equal('$67,023 or more');
+  });
+
+  it('should return the correct output for odd numbers for the standard case', () => {
+    expect(
+      getFourthAccordionHeader(
+        oddLimits.national_threshold,
+        oddLimits.gmt_threshold,
+        true,
+      ),
+    ).to.equal('$50,612 - $55,673');
+  });
 });
 
+// Only appears for standard case
 describe('getFifthAccordionHeader', () => {
-  it('should return the correct output', () => {
+  it('should return the correct output for even numbers', () => {
     expect(getFifthAccordionHeader(limits.gmt_threshold)).to.equal(
       '$85,556 or more',
+    );
+  });
+
+  it('should return the correct output for odd numbers', () => {
+    expect(getFifthAccordionHeader(oddLimits.gmt_threshold)).to.equal(
+      '$55,674 or more',
     );
   });
 });

--- a/src/applications/income-limits/utilities/results-accordions.js
+++ b/src/applications/income-limits/utilities/results-accordions.js
@@ -5,6 +5,10 @@ const formatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 0,
 });
 
+// Note: .toFixed(2) is used where we're multiplying to get the additional 10%
+// because of JavaScript's issue with multiplying decimals
+// https://techformist.com/problems-with-decimal-multiplication-javascript/
+
 // ACCORDION 1: pension_threshold "or less"
 export const getFirstAccordionHeader = pension => {
   return `${formatter.format(pension)} or less`;
@@ -21,7 +25,7 @@ export const getSecondAccordionHeader = (pension, national) => {
 export const getThirdAccordionHeader = (national, gmt, isStandard) => {
   if (!isStandard) {
     return `${formatter.format(national + 1)} - ${formatter.format(
-      national * 1.1,
+      Math.ceil(national * 1.1).toFixed(),
     )}`;
   }
 
@@ -33,14 +37,18 @@ export const getThirdAccordionHeader = (national, gmt, isStandard) => {
 // Standard: gmt_threshold + $1 through gmt_threshold + 10%
 export const getFourthAccordionHeader = (national, gmt, isStandard) => {
   if (!isStandard) {
-    return `${formatter.format(national * 1.1 + 1)} or more`;
+    return `${formatter.format(
+      Math.ceil((national * 1.1).toFixed(2)) + 1,
+    )} or more`;
   }
 
-  return `${formatter.format(gmt + 1)} - ${formatter.format(gmt * 1.1)}`;
+  return `${formatter.format(gmt + 1)} - ${formatter.format(
+    Math.ceil((gmt * 1.1).toFixed(2)),
+  )}`;
 };
 
 // ACCORDION 5 (does not appear for Non-standard case)
 // Geographic threshold + 10% + $1 "or more"
 export const getFifthAccordionHeader = gmt => {
-  return `${formatter.format(gmt * 1.1 + 1)} or more`;
+  return `${formatter.format(Math.ceil((gmt * 1.1).toFixed(2)) + 1)} or more`;
 };


### PR DESCRIPTION
## Summary
We have a business requirement to round all of the dollar values in the Income Limits results **up to the nearest dollar**. Of course this is only going to happen when odd numbers are multiplied by 10. The third, fourth and fifth accordions have rounding possibilities. 

[See this MURAL for bracket logic](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1683232214853/cfc6da5007d8f99ee0bc83e261e118e7074ffa85?wid=0-1683306939130&sender=ue51e6049230e03c1248b5078)

72401 (Jonesboro) is a good testing case for the third and fourth accordion rounding.

@wes and I were not able to find a zip code where the GMT number doesn't end in zero, so the standard case is going to be more difficult to test in the UI as it is way more unlikely to happen. So, I added thorough unit testing to cover this case.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14221

## Testing done
Go through the standard, non-standard, past or current flows.
Enter a year (for past flow only).
Enter a zip code.
Enter a number of dependents.
Check your inputs on the review screen. Continue to results.
Retrieve the numbers from the service call and validate the calculations are correct on the results screen.

## Acceptance criteria
- [x] "+10%" calculation for top income limit (aka relaxation threshold) always rounds up to next dollar

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).