### PR TITLE
bugfix fsr expense name undefined

### DIFF
--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -146,17 +146,18 @@ export const transform = (formConfig, form) => {
 
   // food expenses for box 19
   const foodExpenses = otherExpenses?.find(expense =>
-    expense.name.includes('Food'),
+    expense?.name?.includes('Food'),
   ) || { amount: 0 };
 
   // other living expenses box 21
   // Including options from expoenseRecords (living expenses) w/o rent & mortgage
   const filteredExpenses = [
     ...otherExpenses?.filter(
-      expense => !expense.name.toLowerCase().includes('food'),
+      expense => expense?.name?.toLowerCase().includes('food') === false,
     ),
     ...expenseRecords.filter(
-      expense => expense.name !== 'Rent' && expense.name !== 'Mortgage payment',
+      expense =>
+        expense?.name !== 'Rent' && expense?.name !== 'Mortgage payment',
     ),
   ];
 


### PR DESCRIPTION
## Summary

This ticket addresses a the `undefined(reading 'includes') bug that is preventing submissions when expenses.name is undefined

![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3633626462323130363536623966656466333832316438642f36373161313163372d326531322d346437322d613138362d326534323962343633663630](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/9e3d3dd9-03fa-46e9-831e-043cd5963c50)


this is the error message

```
Uncaught TypeError: Cannot read properties of undefined (reading 'includes')
    at request-debt-help-form-5655.entry.js:63665:25
    at Array.find (<anonymous>)
    at Object.transform [as transformForSubmit] (request-debt-help-form-5655.entry.js:63664:99)
    at Object.submitForm [as submit] (request-debt-help-form-5655.entry.js:55079:57)
    at request-debt-help-form-5655.entry.js:70994:28
    at request-debt-help-form-5655.entry.js:208416:18
    at boundActionCreators.<computed> [as submitForm] (request-debt-help-form-5655.entry.js:189493:16)
    at request-debt-help-form-5655.entry.js:76869:19
    at HTMLUnknownElement.callCallback (request-debt-help-form-5655.entry.js:161435:14)
    at Object.invokeGuardedCallbackDev (request-debt-help-form-5655.entry.js:161484:16)
    
```
The error is on line 154 in the transform.js

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61354


## Testing done

- Before the update submissions were blocked when expenses.name was undefined_
- Test by using scrubbed data from linked ticket on the review and submit form and submit the form
- Manual



## What areas of the site does it impact?

*Financial Status Report eFSR*

## Acceptance criteria

### Quality Assurance & Testing

- [x] Linting warnings have been addressed

