### PR TITLE
VACMS-12063: adds aria labels for "In this section" mobile secondary menu

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -162,7 +162,6 @@ class SideNav extends Component {
             'vads-u-margin-top--0',
             'vads-u-padding--0',
           )}
-          aria-hidden={!this.state.active}
         >
           {/* Render all the items recursively. */}
           {renderChildItems(parentMostID, 1)}

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 import { find, filter, get, map, orderBy } from 'lodash';
 // Relative
-import NavItem from './NavItem';
 import debounce from 'platform/utilities/data/debounce';
+import NavItem from './NavItem';
 
 class SideNav extends Component {
   static propTypes = {
@@ -148,6 +148,8 @@ class SideNav extends Component {
           onClick={this.toggleUlClass}
           id="sidenav-menu"
           aria-label="In this section menu"
+          aria-controls="va-sidenav-ul-container"
+          aria-expanded={this.state.active}
         >
           <span className="sr-only">View sub-navigation for </span>
           In this section
@@ -160,6 +162,7 @@ class SideNav extends Component {
             'vads-u-margin-top--0',
             'vads-u-padding--0',
           )}
+          aria-hidden={!this.state.active}
         >
           {/* Render all the items recursively. */}
           {renderChildItems(parentMostID, 1)}


### PR DESCRIPTION
closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12063

This PR adds `aria-controls` and `aria-expanded` to the "In this section" button, and `aria-hidden` to the content that it controls. When `aria-expanded` is `true` on the button, `aria-hidden` is `false` on the content it controls (and vice versa).

## Testing done/QA steps
- Visit `/boston-health-care/`
- Shrink screen to mobile size ("In this section" dropdown at top)
- Turn on screen reader
- [ ] Click on "In this section" button and ensure screen reader announces "expanded" 
- [ ] Click on "In this section" button again and ensure screen reader announces "collapsed"

## Acceptance criteria
[See original ticket.](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12063)