### PR TITLE
MHV-44573: Medical records pdf padding fixes for ucd

### DIFF
--- a/src/platform/pdf/templates/medical_records.js
+++ b/src/platform/pdf/templates/medical_records.js
@@ -91,6 +91,35 @@ const generateDetailsContent = async (doc, parent, data) => {
   details.end();
 };
 
+const generateResultItemContent = async (
+  item,
+  doc,
+  results,
+  hasHorizontalRule,
+) => {
+  const headingOptions = { paragraphGap: 10, x: 30 };
+  if (item.header) {
+    results.add(
+      await createHeading(doc, 'H3', config, item.header, headingOptions),
+    );
+  }
+
+  for (const resultItem of item.items) {
+    const structs = await createDetailItem(doc, config, 40, resultItem);
+    for (const struct of structs) {
+      results.add(struct);
+    }
+  }
+
+  if (hasHorizontalRule) {
+    results.add(
+      doc.struct('Artifact', () => {
+        addHorizontalRule(doc, 30, 1.5);
+      }),
+    );
+  }
+};
+
 const generateResultsContent = async (doc, parent, data) => {
   const results = doc.struct('Sect', {
     title: 'Results',
@@ -102,44 +131,29 @@ const generateResultsContent = async (doc, parent, data) => {
       createHeading(doc, 'H2', config, data.results.header, headingOptions),
     );
   }
+
   if (data.results.preface) {
     const prefaceOptions = { paragraphGap: 12, x: 20 };
     results.add(
       createSubHeading(doc, config, data.results.preface, prefaceOptions),
     );
   }
-  let initialBlock = true;
-  for (const item of data.results.items) {
-    // Insert a pagebreak if the next block will not fit on the current page,
-    // taking the footer height into account.
-    const blockHeight = getTestResultBlockHeight(doc, item, initialBlock);
-    if (doc.y + blockHeight > 750) {
-      initialBlock = true;
-      await doc.addPage();
-    }
 
-    const headingOptions = { paragraphGap: 10, x: 30 };
-    if (item.header) {
-      results.add(
-        await createHeading(doc, 'H3', config, item.header, headingOptions),
+  const hasHorizontalRule = data.results.sectionSeparators !== false;
+  if (data.results.items.length === 1) {
+    await generateResultItemContent(data.results.items[0], doc, results, false);
+  } else {
+    for (const item of data.results.items) {
+      // Insert a pagebreak if the next block will not fit on the current page,
+      // taking the footer height into account.
+      const blockHeight = getTestResultBlockHeight(
+        doc,
+        item,
+        hasHorizontalRule,
       );
-    }
+      if (doc.y + blockHeight > 750) await doc.addPage();
 
-    for (const resultItem of item.items) {
-      const structs = await createDetailItem(doc, config, 40, resultItem);
-      for (const struct of structs) {
-        results.add(struct);
-      }
-    }
-    if (data.results.items.length > 1) {
-      initialBlock = false;
-      if (data.results.sectionSeparators !== false) {
-        results.add(
-          doc.struct('Artifact', () => {
-            addHorizontalRule(doc, 30, 1.5);
-          }),
-        );
-      }
+      await generateResultItemContent(item, doc, results, hasHorizontalRule);
     }
   }
   results.end();

--- a/src/platform/pdf/templates/medical_records.js
+++ b/src/platform/pdf/templates/medical_records.js
@@ -109,22 +109,13 @@ const generateResultsContent = async (doc, parent, data) => {
     );
   }
   let initialBlock = true;
-  for (const [idx, item] of data.results.items.entries()) {
+  for (const item of data.results.items) {
     // Insert a pagebreak if the next block will not fit on the current page,
     // taking the footer height into account.
     const blockHeight = getTestResultBlockHeight(doc, item, initialBlock);
     if (doc.y + blockHeight > 750) {
       initialBlock = true;
       await doc.addPage();
-    } else if (idx > 0) {
-      initialBlock = false;
-      if (data.results.sectionSeparators !== false) {
-        results.add(
-          doc.struct('Artifact', () => {
-            addHorizontalRule(doc, 30, 1.5);
-          }),
-        );
-      }
     }
 
     const headingOptions = { paragraphGap: 10, x: 30 };
@@ -138,6 +129,16 @@ const generateResultsContent = async (doc, parent, data) => {
       const structs = await createDetailItem(doc, config, 40, resultItem);
       for (const struct of structs) {
         results.add(struct);
+      }
+    }
+    if (data.results.items.length > 1) {
+      initialBlock = false;
+      if (data.results.sectionSeparators !== false) {
+        results.add(
+          doc.struct('Artifact', () => {
+            addHorizontalRule(doc, 30, 1.5);
+          }),
+        );
       }
     }
   }

--- a/src/platform/pdf/templates/medical_records.js
+++ b/src/platform/pdf/templates/medical_records.js
@@ -53,9 +53,7 @@ const config = {
 };
 
 const generateIntroductionContent = async (doc, parent, data) => {
-  // The y position must be specified to prevent defaulting to the current document position
-  // which doesn't respect the configured top margin of the page.
-  const headOptions = { x: 20, y: config.margins.top, paragraphGap: 5 };
+  const headOptions = { x: 20, paragraphGap: 5 };
   const subHeadOptions = { paragraphGap: 0 };
   const introduction = doc.struct('Sect', {
     title: 'Introduction',

--- a/src/platform/pdf/templates/medical_records.js
+++ b/src/platform/pdf/templates/medical_records.js
@@ -53,8 +53,10 @@ const config = {
 };
 
 const generateIntroductionContent = async (doc, parent, data) => {
-  const headOptions = { x: 20, paragraphGap: 16 };
-  const subHeadOptions = { paragraphGap: 12 };
+  // The y position must be specified to prevent defaulting to the current document position
+  // which doesn't respect the configured top margin of the page.
+  const headOptions = { x: 20, y: config.margins.top, paragraphGap: 5 };
+  const subHeadOptions = { paragraphGap: 0 };
   const introduction = doc.struct('Sect', {
     title: 'Introduction',
   });
@@ -121,7 +123,7 @@ const generateResultsContent = async (doc, parent, data) => {
       if (data.results.sectionSeparators !== false) {
         results.add(
           doc.struct('Artifact', () => {
-            addHorizontalRule(doc, 20, 0.5);
+            addHorizontalRule(doc, 30, 1.5);
           }),
         );
       }

--- a/src/platform/pdf/templates/medical_records.js
+++ b/src/platform/pdf/templates/medical_records.js
@@ -141,7 +141,12 @@ const generateResultsContent = async (doc, parent, data) => {
 
   const hasHorizontalRule = data.results.sectionSeparators !== false;
   if (data.results.items.length === 1) {
-    await generateResultItemContent(data.results.items[0], doc, results, false);
+    await generateResultItemContent(
+      data.results.items[0],
+      doc,
+      results,
+      hasHorizontalRule,
+    );
   } else {
     for (const item of data.results.items) {
       // Insert a pagebreak if the next block will not fit on the current page,

--- a/src/platform/pdf/templates/utils.js
+++ b/src/platform/pdf/templates/utils.js
@@ -124,6 +124,8 @@ const createDetailItem = async (doc, config, x, item) => {
       }),
     );
   } else {
+    const blockValueOptions = { lineGap: 6 };
+    paragraphOptions.lineGap = 2;
     if (titleText) {
       titleText += ' ';
       content.push(
@@ -140,7 +142,7 @@ const createDetailItem = async (doc, config, x, item) => {
         doc
           .font(config.text.font)
           .fontSize(config.text.size)
-          .text(item.value, x);
+          .text(item.value, x, doc.y, blockValueOptions);
       }),
     );
   }

--- a/src/platform/pdf/templates/utils.js
+++ b/src/platform/pdf/templates/utils.js
@@ -10,6 +10,38 @@ const pdfkit = require('pdfkit');
 const PDFDocument = pdfkit.default ?? pdfkit;
 
 /**
+ * Return the current X position, limited to the configured page margins.
+ *
+ * @param {Object} doc
+ *
+ * @returns {int} x position
+ */
+const getBoundedXPosition = doc => {
+  if (doc.x < doc.page.margins.left) return doc.page.margins.left;
+
+  const rightMargin = doc.page.width - doc.page.margins.right;
+  if (doc.x > rightMargin) return rightMargin;
+
+  return doc.x;
+};
+
+/**
+ * Return the current Y position, limited to the configured page margins.
+ *
+ * @param {Object} doc
+ *
+ * @returns {int} y position
+ */
+const getBoundedYPosition = doc => {
+  if (doc.y < doc.page.margins.top) return doc.page.margins.top;
+
+  const bottomMargin = doc.page.height - doc.page.margins.bottom;
+  if (doc.y > bottomMargin) return bottomMargin;
+
+  return doc.y;
+};
+
+/**
  * Add a structure to the given PDFKit document.
  *
  * @param {Object} doc
@@ -22,8 +54,8 @@ const PDFDocument = pdfkit.default ?? pdfkit;
  * @returns {Object} doc
  */
 const createStruct = (doc, struct, font, fontSize, text, options) => {
-  const x = options.x ?? doc.x;
-  const y = options.y ?? doc.y;
+  const x = options.x ?? getBoundedXPosition(doc);
+  const y = options.y ?? getBoundedYPosition(doc);
   unset(options.x);
   unset(options.y);
   return doc.struct(struct, () => {

--- a/src/platform/pdf/test/templates/medical_records/template.unit.spec.js
+++ b/src/platform/pdf/test/templates/medical_records/template.unit.spec.js
@@ -83,7 +83,7 @@ describe('Medical records PDF template', () => {
       expect(text).to.equal(data.results.items[0].items[0].value);
     });
 
-    it('Horizontal rules are added between result sections by default', async () => {
+    it('Horizontal rules are added below result sections by default', async () => {
       const data = require('./fixtures/result_sections_with_horizontal_rules.json');
       const { pdf } = await generateAndParsePdf(data);
 
@@ -100,10 +100,10 @@ describe('Medical records PDF template', () => {
         }
       }
 
-      expect(artifactCount).to.eq(8);
+      expect(artifactCount).to.eq(10);
     });
 
-    it('Horizontal rules between result sections may be suppressed', async () => {
+    it('Horizontal rules below result sections may be suppressed', async () => {
       const data = require('./fixtures/result_sections_with_no_horizontal_rules.json');
       const { pdf } = await generateAndParsePdf(data);
 


### PR DESCRIPTION
## Summary
The medical records pdf generator template has been updated to account for ucd mockups. Padding changes were made to the heading, subheading, results items with block elements and horizontal rule elements. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-44573

## Testing done
One test was fixed due to a change in functionality. There are now more horizontal rules because UCD required them after each item, including the item at the end of each page and the last item. 

## Screenshots
Before:
<img width="833" alt="Screenshot 2023-07-05 at 1 51 27 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/e850484f-d27b-4173-b74f-473cd833ff1f">

After:
<img width="827" alt="Screenshot 2023-07-05 at 1 52 04 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/9b0b34f4-1d4b-4398-b5d0-f4475ac7d7a2">
![Screenshot 2023-07-06 at 1 43 21 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/879df33f-ff6b-4ad8-a7b4-0789b46b4637)

## What areas of the site does it impact?
MHV medical records pdf generator template

## Acceptance criteria
Medical records PDFs align with UCD mockups
https://www.sketch.com/s/4c2728ff-649d-4212-98d2-04c9b3fff9d4/v/e9Me8p/p/948A0CC5-6470-4732-83AB-EEEE67C9EFAB/canvas?posX=-21490.01837329304&posY=-6937.815245824599&zoom=0.8368328809738159

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
