### PR TITLE
Ensure all Caregiver application SSN fields in are properly masked

### DIFF
--- a/src/applications/caregivers/config/chapters/veteran/vetInfo.js
+++ b/src/applications/caregivers/config/chapters/veteran/vetInfo.js
@@ -1,3 +1,4 @@
+import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
 import { veteranFields } from '../../../definitions/constants';
 import {
@@ -17,10 +18,9 @@ const vetInfoPage = {
   uiSchema: {
     'ui:description': VeteranContactDescription({ showPageIntro: true }),
     [veteranFields.fullName]: fullNameUI(vetInputLabel),
-    [veteranFields.ssn]: {
-      ...ssnUI(vetInputLabel),
+    [veteranFields.ssn]: merge({}, ssnUI(vetInputLabel), {
       'ui:description': VeteranSSNDescription,
-    },
+    }),
     [veteranFields.dateOfBirth]: dateOfBirthUI(vetInputLabel),
     [veteranFields.gender]: genderUI(vetInputLabel),
   },


### PR DESCRIPTION
## Description
The SSN field behavior in the Caregiver application was discovered to be not consistent across all form pages. For the veteran SSN page, we are missing the masking when the field is blurred. For all other pages, the field gets masked as expected on blur. This PR addresses the declaration of the UI schema for the veteran field to correctly ensure masking function performs as expected.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#61311

## Screenshots
**Before:**
![Veteran.png](https://images.zenhubusercontent.com/62054990e6d52fbafd985d41/f22e2096-3dbf-4ea3-95cc-518957aba3a9)

**After - Chrome**
![Chrome Screenshot](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/a0e324c9-abd2-49df-98f3-01e3b9391df6)

**After - Safari**
![Safari Screenshot](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/8ee9b7b1-716e-4ea7-a83b-795aa783470f)

**After - Firefox**
<img width="1713" alt="Firefox Screenshot" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/f359d1a7-7c99-482c-b46f-df39584f90ae">

## Acceptance criteria
- [ ] SSN field on veteran information page is properly masked on blur