### PR TITLE
MHV-46063 SM: Draft Reply "To" field semantics

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -343,21 +343,20 @@ const ReplyForm = props => {
             />
             <EmergencyNote dropDownFlag />
             <div>
-              <h4
-                className="vads-u-display--flex vads-u-color--gray-dark vads-u-font-weight--bold"
-                style={{ whiteSpace: 'break-spaces' }}
+              <span
+                className="vads-u-display--flex vads-u-margin-top--3 vads-u-color--gray-dark vads-u-font-size--h4 vads-u-font-weight--bold"
+                style={{ whiteSpace: 'break-spaces', overflowWrap: 'anywhere' }}
               >
                 <i
-                  className="fas fa-reply vads-u-margin-right--0p5"
+                  className="fas fa-reply vads-u-margin-right--0p5 vads-u-margin-top--0p25"
                   aria-hidden="true"
                 />
-                <span className="vads-u-color--secondary-darkest">(Draft)</span>
-                {` To: ${draftToEdit?.replyToName ||
+                {`(Draft) To: ${draftToEdit?.replyToName ||
                   replyMessage?.senderName}\n(Team: ${
                   replyMessage.triageGroupName
                 })`}
                 <br />
-              </h4>
+              </span>
               <va-textarea
                 label="Message"
                 required

--- a/src/applications/mhv/secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
@@ -204,9 +204,11 @@ describe('Thread Details container', () => {
 
     expect(await screen.findByText(`${category}: ${subject}`, { exact: false }))
       .to.exist;
-    expect(document.querySelector('h4').textContent).to.equal(
-      '(Draft) To: MORGUN, OLEKSII\n(Team: SM_TO_VA_GOV_TRIAGE_GROUP_TEST)',
-    );
+    expect(
+      screen.getByText(
+        '(Draft) To: MORGUN, OLEKSII (Team: SM_TO_VA_GOV_TRIAGE_GROUP_TEST)',
+      ),
+    ).to.exist;
     const messageRepliedTo = screen.getByTestId('message-replied-to');
     const from = getByBrokenText(
       `From: ${replyMessage.senderName}`,
@@ -288,9 +290,11 @@ describe('Thread Details container', () => {
         'If you need help sooner, use one of these urgent communication options:',
       ),
     ).to.exist;
-    expect(document.querySelector('h4').textContent).to.equal(
-      `(Draft) To: MORGUN, OLEKSII\n(Team: ${triageGroupName})`,
-    );
+    expect(
+      screen.getByText(
+        `(Draft) To: MORGUN, OLEKSII (Team: ${triageGroupName})`,
+      ),
+    ).to.exist;
     expect(screen.getByTestId('message-body-field')).to.exist;
 
     expect(screen.getByTestId('Send-Button')).to.exist;


### PR DESCRIPTION
## Summary

- When opening a draft reply to a message thread (eg. [message ID 2825063 for test user 41](https://staging.va.gov/my-health/secure-messages/thread/2825063)), the "To" field is an H4 heading.
- This heading seems out of place. It doesn't really describe the section of content that follows it, and it skips several heading levels rather than incrementing up by 1 from the previous heading.
- Per feedback, the heading doesn't get us any benefit here. Styling as just regular text (styled however you like) should be fine.


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/59492
- https://jira.devops.va.gov/browse/MHV-46063

## Testing done

- SQA Testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

My Health - Secure Messages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
