### PR TITLE
21-10210 - Fix Veteran & Claimant Personal-info page Continue-btn bug

### DIFF
--- a/src/applications/simple-forms/21-10210/pages/claimantPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/claimantPersInfo.js
@@ -17,7 +17,7 @@ export default {
     type: 'object',
     required: ['claimantFullName', 'claimantDateOfBirth'],
     properties: {
-      witnessFullName: schema(),
+      claimantFullName: schema(),
       claimantDateOfBirth: definitions.date,
     },
   },

--- a/src/applications/simple-forms/21-10210/pages/vetPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/vetPersInfo.js
@@ -17,7 +17,7 @@ export default {
     type: 'object',
     required: ['veteranFullName', 'veteranDateOfBirth'],
     properties: {
-      witnessFullName: schema(),
+      veteranFullName: schema(),
       veteranDateOfBirth: definitions.date,
     },
   },


### PR DESCRIPTION
## Summary

- Fix Lay/Witness Stmt (21-10210) veteran-personal-info and claimant-personal-info page **Continue**-button bug &mdash; just correcting 2 schema typos in page-config.
- Team: VA Product Forms
- Flipper `form2110210` enabled in Staging ONLY

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#379


## Testing done

- Local browser testing & unit-tests all successful.


## What areas of the site does it impact?

This form ONLY
