### PR TITLE
Add analytics for the va-notification web component

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -356,6 +356,39 @@ const analyticsEvents = {
       prefix: 'modal',
     },
   ],
+  'va-notification': [
+    {
+      action: 'linkClick',
+      event: 'nav-notification-link-click',
+      prefix: 'notification',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-notification',
+        custom_string_1: 'component-library',
+        /* Component to GA4 parameters */
+        mapping: {
+          'notification-clickLabel': 'custom_string_2',
+          'notification-headline': 'heading_1',
+          'notification-type': 'type',
+        },
+      },
+    },
+    {
+      action: 'close',
+      event: 'int-notification-close',
+      prefix: 'notification',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-notification',
+        custom_string_1: 'component-library',
+        /* Component to GA4 parameters */
+        mapping: {
+          'notification-headline': 'heading_1',
+          'notification-type': 'type',
+        },
+      },
+    },
+  ],
   'va-number-input': [
     {
       action: 'blur',


### PR DESCRIPTION
## Summary

The design system has a new component [va-notification](https://design.va.gov/storybook/?path=/docs/components-va-notification--default) and this PR will add analytics to vets-website (GA and GA4) to update the datalayer during interactions.

## Related issue(s)

Related issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1803
Related PR: https://github.com/department-of-veterans-affairs/component-library/pull/738



## Testing done
locally with vets-website

## Screenshots

**Close - GA**
<img width="390" alt="Screenshot 2023-07-06 at 3 07 43 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/872479/0d62dc22-b308-443e-8543-35031ae9e0f0">

```
{
  event: "int-notification-close",
  event-source: "component-library",
  component_version: undefined,
  notification-type: "action-required",
}
```

**Close - GA4**

<img width="365" alt="Screenshot 2023-07-06 at 3 26 03 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/872479/9916a3f9-0a63-4f34-8e5f-493730dae112">

```
{
  event: "interaction",
  component_version: undefined,
  component_name: "va-notification",
  custom_string_1: "component-library",
  action: "int-notification-close",
  heading_1: "Notification heading",
  type: "action-required"
}
```

**Link Click - GA**

<img width="441" alt="Screenshot 2023-07-06 at 3 21 02 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/872479/7ce79abc-fe42-4c86-abe7-e00c0ef976d7">

```
{
  event: "nav-notification-link-click",
  event-source: "component-library",
  component_version: undefined,
  notification-clickLabel: "Manage your notifications",
  notification-type: "action-required",
  notification-headline: "Notification heading"
}
```

**Link Click - GA4**

<img width="413" alt="Screenshot 2023-07-06 at 3 27 17 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/872479/de6bcc0b-e67a-44d5-b4ab-497fc8e12e59">

```
{
  event: "interaction",
  component_version: undefined,
  component_name: "va-notification",
  custom_string_1: "component-library",
  action: "nav-notification-link-click",
  custom_string_2: "Manage your notifications",
  heading_1: "Notification heading",
  type: "action-required"
}
```

## What areas of the site does it impact?
None. It only sets up the analytics mapping for the web component.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
