### PR TITLE
VACMS-14200 Income Limits: add spinner for service validation

### DIFF
--- a/src/applications/income-limits/actions/index.js
+++ b/src/applications/income-limits/actions/index.js
@@ -1,6 +1,8 @@
 import {
   IL_EDIT_MODE,
   IL_PAST_MODE,
+  IL_RESULTS_VAL_ERROR,
+  IL_RESULTS_VAL_ERROR_TEXT,
   IL_UPDATE_DEPENDENTS,
   IL_UPDATE_RESULTS,
   IL_UPDATE_YEAR,
@@ -53,6 +55,20 @@ export const updateResults = value => {
 export const updateZipValidationServiceError = value => {
   return {
     type: IL_ZIP_VAL_ERROR,
+    payload: value,
+  };
+};
+
+export const updateResultsValidationServiceError = value => {
+  return {
+    type: IL_RESULTS_VAL_ERROR,
+    payload: value,
+  };
+};
+
+export const updateResultsValidationErrorText = value => {
+  return {
+    type: IL_RESULTS_VAL_ERROR_TEXT,
     payload: value,
   };
 };

--- a/src/applications/income-limits/components/IncomeLimitsApp.jsx
+++ b/src/applications/income-limits/components/IncomeLimitsApp.jsx
@@ -1,36 +1,92 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Breadcrumbs from './Breadcrumbs';
+import {
+  updateResultsValidationServiceError,
+  updateZipValidationServiceError,
+} from '../actions';
+import { ROUTES } from '../constants';
 
-const IncomeLimitsApp = ({ children, zipValidationError }) => {
+const IncomeLimitsApp = ({
+  children,
+  resultsValidationError,
+  resultsValidationErrorText,
+  router,
+  updateResultsServiceError,
+  updateZipValError,
+  zipValidationError,
+}) => {
+  const location = router?.getCurrentLocation()?.pathname;
+  const GENERAL_ERROR =
+    'We’re sorry. Something went wrong on our end. Please try again.';
+
+  useEffect(
+    () => {
+      if (zipValidationError && location !== `/${ROUTES.ZIPCODE}`) {
+        updateZipValError(false);
+      }
+
+      if (resultsValidationError && location !== `/${ROUTES.REVIEW}`) {
+        updateResultsServiceError(false);
+      }
+    },
+    [
+      location,
+      resultsValidationError,
+      updateResultsServiceError,
+      updateZipValError,
+      zipValidationError,
+    ],
+  );
+
+  const alertBanner = message => {
+    return (
+      <va-alert data-testid="il-service-error" status="error">
+        <h2 className="vads-u-margin-bottom--2" slot="headline">
+          We&#8217;ve run into a problem
+        </h2>
+        <p className="vads-u-margin--0">{message}</p>
+      </va-alert>
+    );
+  };
+
   return (
     <div className="income-limits-app row vads-u-padding-bottom--8">
-      {zipValidationError && (
-        <va-alert data-testid="il-service-error" status="error">
-          <h2 className="vads-u-margin-bottom--2" slot="headline">
-            We&#8217;ve run into a problem
-          </h2>
-          <p className="vads-u-margin--0">
-            We&#8217;re sorry, something went wrong on our end. Please try
-            again.
-          </p>
-        </va-alert>
-      )}
+      {zipValidationError && alertBanner(GENERAL_ERROR)}
+      {resultsValidationError &&
+        alertBanner(resultsValidationErrorText || GENERAL_ERROR)}
       <Breadcrumbs />
       <div className="usa-width-two-thirds medium-8 columns">{children}</div>
     </div>
   );
 };
 
+const mapDispatchToProps = {
+  updateResultsServiceError: updateResultsValidationServiceError,
+  updateZipValError: updateZipValidationServiceError,
+};
+
 const mapStateToProps = state => ({
+  resultsValidationError: state?.incomeLimits?.resultsValidationServiceError,
+  resultsValidationErrorText: state?.incomeLimits?.resultsValidationErrorText,
   zipValidationError: state?.incomeLimits?.zipValidationServiceError,
 });
 
 IncomeLimitsApp.propTypes = {
+  router: PropTypes.shape({
+    getCurrentLocation: PropTypes.func,
+  }).isRequired,
   children: PropTypes.any,
+  resultsValidationError: PropTypes.bool,
+  resultsValidationErrorText: PropTypes.string,
+  updateResultsServiceError: PropTypes.func,
+  updateZipValError: PropTypes.func,
   zipValidationError: PropTypes.bool,
 };
 
-export default connect(mapStateToProps)(IncomeLimitsApp);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(IncomeLimitsApp);

--- a/src/applications/income-limits/constants/index.js
+++ b/src/applications/income-limits/constants/index.js
@@ -5,6 +5,8 @@ export const IL_EDIT_MODE = 'income-limits/EDIT_MODE';
 export const IL_PAST_MODE = 'income-limits/PAST_MODE';
 export const IL_UPDATE_RESULTS = 'income-limits/UPDATE_RESULTS';
 export const IL_ZIP_VAL_ERROR = 'income-limits/ZIP_VAL_ERROR';
+export const IL_RESULTS_VAL_ERROR = 'income-limits/RESULTS_VAL_ERROR';
+export const IL_RESULTS_VAL_ERROR_TEXT = 'income-limits/RESULTS_VAL_ERROR_TEXT';
 
 export const ROUTES = {
   DEPENDENTS: 'dependents',

--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -25,7 +25,7 @@ const DependentsPage = ({
   const [submitted, setSubmitted] = useState(false);
 
   const dependentsValid = deps => {
-    return deps?.match(/^[0-9]+$/);
+    return deps?.match(/^[0-9]+$/) && deps >= 0 && deps <= 100;
   };
 
   const validDependents = dependents?.length > 0 && dependentsValid(dependents);
@@ -71,6 +71,7 @@ const DependentsPage = ({
   };
 
   const onDependentsInput = event => {
+    setError(false);
     updateDependentsField(event.target.value);
   };
 
@@ -89,7 +90,9 @@ const DependentsPage = ({
         <VaNumberInput
           data-testid="il-dependents"
           error={
-            (submitted && error && 'Please enter a number for dependents') ||
+            (submitted &&
+              error &&
+              'Please enter a number between 0 and 100.') ||
             null
           }
           hint="Dependents hint text"

--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -34,12 +34,14 @@ const HomePage = ({
     [updateDependentsField, updateYearField, updateZipCodeField],
   );
 
-  const goToCurrent = () => {
+  const goToCurrent = event => {
+    event.preventDefault();
     togglePastMode(false);
     router.push(ROUTES.ZIPCODE);
   };
 
-  const goToPast = () => {
+  const goToPast = event => {
+    event.preventDefault();
     togglePastMode(true);
     router.push(ROUTES.YEAR);
   };

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -105,7 +105,7 @@ const YearPage = ({
       <VaSelect
         autocomplete="false"
         data-testid="il-year"
-        error={(submitted && error && 'Please select a year') || null}
+        error={(submitted && error && 'Please select a year.') || null}
         id="year"
         label="Year"
         name="year"

--- a/src/applications/income-limits/reducers/index.js
+++ b/src/applications/income-limits/reducers/index.js
@@ -2,6 +2,8 @@ import {
   IL_EDIT_MODE,
   IL_UPDATE_DEPENDENTS,
   IL_PAST_MODE,
+  IL_RESULTS_VAL_ERROR,
+  IL_RESULTS_VAL_ERROR_TEXT,
   IL_UPDATE_RESULTS,
   IL_UPDATE_YEAR,
   IL_UPDATE_ZIP,
@@ -17,6 +19,7 @@ const initialState = {
   },
   pastMode: null,
   results: null,
+  resultsValidationServiceError: false,
   zipValidationServiceError: false,
 };
 
@@ -65,6 +68,16 @@ const incomeLimits = (state = initialState, action) => {
       return {
         ...state,
         zipValidationServiceError: action.payload,
+      };
+    case IL_RESULTS_VAL_ERROR:
+      return {
+        ...state,
+        resultsValidationServiceError: action.payload,
+      };
+    case IL_RESULTS_VAL_ERROR_TEXT:
+      return {
+        ...state,
+        resultsValidationErrorText: action.payload,
       };
     default:
       return state;

--- a/src/applications/income-limits/tests/helpers.js
+++ b/src/applications/income-limits/tests/helpers.js
@@ -41,7 +41,7 @@ export const clickBack = () =>
   cy
     .findByTestId('il-buttonPair')
     .shadow()
-    .get('button')
+    .get('va-button')
     .first()
     .should('be.visible')
     .click();
@@ -50,7 +50,7 @@ export const clickContinue = () =>
   cy
     .findByTestId('il-buttonPair')
     .shadow()
-    .get('button')
+    .get('va-button')
     .eq(1)
     .should('be.visible')
     .click();
@@ -81,6 +81,7 @@ export const clearInput = selector =>
     .shadow()
     .get('input')
     .first()
+    .focus()
     .clear();
 
 export const selectFromDropdown = (selector, value) =>
@@ -89,7 +90,7 @@ export const selectFromDropdown = (selector, value) =>
     .shadow()
     .get('select')
     .first()
-    .select(value);
+    .select(value, { force: true });
 
 export const checkInputText = (selector, expectedValue) =>
   cy.findByTestId(selector).should('have.value', expectedValue);
@@ -106,12 +107,25 @@ export const checkAccordionValue = (selector, expectedValue, index) =>
 export const verifyElement = selector =>
   cy.findByTestId(selector).should('exist');
 
-export const verifyAlertNotShown = selector =>
+export const verifyFormErrorNotShown = selector =>
   cy
     .findByTestId(selector)
     .shadow()
     .get('span[role="alert"]')
     .should('not.be.visible');
+
+export const verifyAlertNotShown = () =>
+  cy.findByTestId('il-service-error').should('not.exist');
+
+export const verifyLoadingIndicatorShown = () =>
+  cy
+    .findByTestId('il-loading-indicator')
+    .shadow()
+    .get('div[role="progressbar"')
+    .should('be.visible');
+
+export const verifyLoadingIndicatorNotShown = () =>
+  cy.findByTestId('il-loading-indicator').should('not.exist');
 
 export const getEditLink = index => cy.get('.income-limits-edit a').eq(index);
 export const checkListItemText = (selector, expectedValue) =>


### PR DESCRIPTION
## Summary
Finish up error handling for the Income Limits API and form.

Specifics:
- Refactored the API calls to use `try`/`catch` blocks instead of Promises for easy error handling and simplicity
- Broke out alert banner into two separate banners - one for the zip code validation error and the other for the results validation (it has multiple types of messages depending on the failure cause)
- Added requirement for dependents to be between 0 and 100, inclusive
- Prevented the home page links (Current & Past) from navigating with a `#` (i.e. `/zip#`) so that when the browser back button is used, you don't have to navigate first to `/zip` and then `/` (to a veteran, it will appear that the back button didn't work)
- Added error handling to the data call on the review page.
- Added logic to clear alert banners when navigating forward and backward in the app
- Added a timeout of 5 seconds for the API

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13737

## Testing done
Thorough testing information and screenshots here
https://docs.google.com/document/d/1ubN8B0mWys5cnHome0FU7d85Xmg1NXOE1toAPtMDa3A/edit?usp=sharing

## Screenshots

See above

## Acceptance criteria

- [x] The Zip input requires a 5-digit number before I can continue to the next screen
- [x] The dependents input requires a number between 0 and 100 (inclusive) before I can continue to the next screen
- [x] The year input requires a year to be selected before I can continue to the next screen
- [x] If the API fails to return a response within 5 seconds, trigger general alert (in screen shot above) "We've run into a problem..."
- [x] If the API returns a 422 Invalid Zipcode response, display error to User "The zip code you entered doesn't exist in our database."
- [x] If the API returns a 422 Invalid Year response, display error to user "The year you entered doesn't exist in our database."
- [x] If the API returns a 422 Invalid number of dependents response, display error to user "The number of dependents you entered is not between 0 and 100."
- [x] Loading indicator replaces the buttons (continue and back) on the Review Info page after Continue is clicked, until the API response returns, per design
- [x] Loading indicator replaces the buttons (continue and back) on the Zip code page after Continue is clicked, until the API response returns, per design
- [x] Text under spinner is "Reviewing your information..." on both pages
- [x] Aria-label and focus parameters set per a11y recommendation on both pages

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.