### PR TITLE
Tweak the eligibility check for Direct Deposit for use in Lighthouse API work

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
@@ -14,7 +14,7 @@ import {
 } from '@@profile/actions/paymentInformation';
 import {
   cnpDirectDepositAccountInformation,
-  cnpDirectDepositAddressIsSetUp,
+  cnpDirectDepositIsEligible,
   cnpDirectDepositInformation,
   cnpDirectDepositIsSetUp,
   cnpDirectDepositLoadError,
@@ -458,6 +458,9 @@ BankInfo.propTypes = {
 
 export const mapStateToProps = (state, ownProps) => {
   const typeIsCNP = ownProps.type === benefitTypes.CNP;
+  const useLighthouseDirectDepositEndpoint = profileUseLighthouseDirectDepositEndpoint(
+    state,
+  );
   return {
     typeIsCNP,
     isLOA3: isLOA3Selector(state),
@@ -474,14 +477,12 @@ export const mapStateToProps = (state, ownProps) => {
       ? !!cnpDirectDepositLoadError(state)
       : !!eduDirectDepositLoadError(state),
     isEligibleToSetUpDirectDeposit: typeIsCNP
-      ? cnpDirectDepositAddressIsSetUp(state)
+      ? cnpDirectDepositIsEligible(state, useLighthouseDirectDepositEndpoint)
       : false,
     directDepositUiState: typeIsCNP
       ? cnpDirectDepositUiStateSelector(state)
       : eduDirectDepositUiStateSelector(state),
-    useLighthouseDirectDepositEndpoint: profileUseLighthouseDirectDepositEndpoint(
-      state,
-    ),
+    useLighthouseDirectDepositEndpoint,
   };
 };
 

--- a/src/applications/personalization/profile/mocks/endpoints/disability-compensations/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/disability-compensations/index.js
@@ -59,7 +59,7 @@ const isDeceased = _.set(
 );
 setInstitutionName(isDeceased, 'TEST DECEASED FLAG - DISABILITY COMPENSATIONS');
 
-const notEnrolled = _.set(_.cloneDeep(base), 'data.attributes.paymentAccount', {
+const isEligible = _.set(_.cloneDeep(base), 'data.attributes.paymentAccount', {
   name: null,
   accountType: null,
   accountNumber: null,
@@ -138,7 +138,7 @@ module.exports = {
   isDeceased,
   isFiduciary,
   isNotCompetent,
-  notEnrolled,
+  isEligible,
   updates: {
     success: _.set(_.cloneDeep(base), 'data.attributes.paymentAccount', {
       name: 'TEST UPDATE SUCCESS - DISABILITY COMPENSATIONS',

--- a/src/applications/personalization/profile/mocks/endpoints/payment-information/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/payment-information/index.js
@@ -87,6 +87,21 @@ const notEligible = _.set(
   },
 );
 
+const isEligible = _.set(
+  _.cloneDeep(notEligible),
+  'data.attributes.responses[0].paymentAddress',
+  {
+    type: 'DOMESTIC',
+    addressEffectiveDate: '2019-01-01T00:00:00.000+00:00',
+    addressOne: '1234 Test St',
+    addressTwo: null,
+    addressThree: null,
+    city: 'Test City',
+    stateCode: 'TN',
+    zipCode: '12345',
+  },
+);
+
 const errorResponse = {
   data: {
     errors: [{}],
@@ -99,6 +114,7 @@ module.exports = {
   isFiduciary,
   isNotCompetent,
   notEligible,
+  isEligible,
   errorResponse,
   updates: {
     success: _.set(

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -87,7 +87,7 @@ const responses = {
     // This is a 'normal' payment history / control case data
     // paymentInformation.base
 
-    return res.status(200).json(paymentInformation.base);
+    return res.status(200).json(paymentInformation.notEligible);
   },
   'PUT /v0/ppiu/payment_information': (_req, res) => {
     // substitute the various errors arrays to test various update error responses

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -57,7 +57,14 @@ export const eduDirectDepositLoadError = state => {
 export const cnpDirectDepositAddressInformation = state =>
   cnpDirectDepositInformation(state)?.paymentAddress;
 
-export const cnpDirectDepositAddressIsSetUp = state => {
+export const cnpDirectDepositIsEligible = (
+  state,
+  useLighthouseFormat = false,
+) => {
+  if (useLighthouseFormat) {
+    return !!cnpDirectDepositInformation(state)?.controlInformation
+      ?.canUpdateDirectDeposit;
+  }
   return isEligibleForCNPDirectDeposit(cnpDirectDepositInformation(state));
 };
 

--- a/src/applications/personalization/profile/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile/tests/selectors.unit.spec.js
@@ -100,7 +100,7 @@ describe('profile selectors', () => {
     });
   });
 
-  describe('cnpDirectDepositAddressIsSetUp selector', () => {
+  describe('cnpDirectDepositIsEligible selector', () => {
     let state;
     beforeEach(() => {
       state = {
@@ -116,19 +116,19 @@ describe('profile selectors', () => {
       };
     });
     it('returns `true` if there is a street, city, and state set on the payment info payment address', () => {
-      expect(selectors.cnpDirectDepositAddressIsSetUp(state)).to.be.true;
+      expect(selectors.cnpDirectDepositIsEligible(state)).to.be.true;
     });
     it('returns `false` if the street address is missing', () => {
       state.vaProfile.cnpPaymentInformation.paymentAddress.addressOne = '';
-      expect(selectors.cnpDirectDepositAddressIsSetUp(state)).to.be.false;
+      expect(selectors.cnpDirectDepositIsEligible(state)).to.be.false;
     });
     it('returns `false` if the city is missing', () => {
       state.vaProfile.cnpPaymentInformation.paymentAddress.city = '';
-      expect(selectors.cnpDirectDepositAddressIsSetUp(state)).to.be.false;
+      expect(selectors.cnpDirectDepositIsEligible(state)).to.be.false;
     });
     it('returns `false` if the state is missing', () => {
       state.vaProfile.cnpPaymentInformation.paymentAddress.stateCode = '';
-      expect(selectors.cnpDirectDepositAddressIsSetUp(state)).to.be.false;
+      expect(selectors.cnpDirectDepositIsEligible(state)).to.be.false;
     });
 
     it('returns `false` when the payment info endpoint failed to get data', () => {
@@ -139,7 +139,7 @@ describe('profile selectors', () => {
           },
         },
       };
-      expect(selectors.cnpDirectDepositAddressIsSetUp(state)).to.be.false;
+      expect(selectors.cnpDirectDepositIsEligible(state)).to.be.false;
     });
   });
 

--- a/src/applications/personalization/profile/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile/tests/selectors.unit.spec.js
@@ -141,6 +141,29 @@ describe('profile selectors', () => {
       };
       expect(selectors.cnpDirectDepositIsEligible(state)).to.be.false;
     });
+
+    describe('when useLighthouseFormat is true', () => {
+      beforeEach(() => {
+        state = {
+          vaProfile: {
+            cnpPaymentInformation: {
+              controlInformation: {
+                canUpdateDirectDeposit: true,
+              },
+            },
+          },
+        };
+      });
+
+      it('returns `true` if control info canUpdateDirectDeposit is true', () => {
+        expect(selectors.cnpDirectDepositIsEligible(state, true)).to.be.true;
+      });
+
+      it('returns `false` if control info canUpdateDirectDeposit is false', () => {
+        state.vaProfile.cnpPaymentInformation.controlInformation.canUpdateDirectDeposit = false;
+        expect(selectors.cnpDirectDepositIsEligible(state, true)).to.be.false;
+      });
+    });
   });
 
   describe('cnpDirectDepositIsBlocked', () => {


### PR DESCRIPTION
## Summary

- The eligibility of the user to enroll in the direct deposit for CNP is based on the user having an address on file. With the old endpoint we would get the address itself, and in the new Lighthouse based endpoint we can now use some expanded control information to check for eligibility.
- Updates the selector `cnpDirectDepositIsEligible` and passes in the toggle value for use in the logic

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61252


## Testing done

- Updated mock server responses for sample responses, and used those responses to check this locally.
- Added unit tests around the selector

Once this is merged, the fix can be confirmed on staging using the test user 82

## Screenshots

Non-UI work, just updating logic for state selector

## What areas of the site does it impact?

Profile -> Direct Deposit -> Staging (with toggle `profile_lighthouse_direct_deposit` turned on)

## Acceptance criteria

- [x] Logic for eligibility selector updated

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.