### PR TITLE
Remove dividing line under sub-navigation for mobile pending page

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentListNavigation.jsx
@@ -26,11 +26,10 @@ export default function AppointmentListNavigation({ count, callback }) {
     return (
       <div
         className={classNames(
-          `vaos-hide-for-print vads-l-row xsmall-screen:${
-            !isPending ? 'vads-u-border-bottom--0' : 'vads-u-border-bottom--1px'
-          } vads-u-margin-bottom--3 small-screen:${
-            isPast ? 'vads-u-margin-bottom--3' : 'vads-u-margin-bottom--4'
-          } small-screen:vads-u-border-bottom--1px vads-u-color--gray-medium`,
+          `vaos-hide-for-print vads-l-row xsmall-screen:vads-u-border-bottom--0 
+           vads-u-margin-bottom--3 small-screen:${
+             isPast ? 'vads-u-margin-bottom--3' : 'vads-u-margin-bottom--4'
+           } small-screen:vads-u-border-bottom--1px vads-u-color--gray-medium`,
         )}
       >
         <nav


### PR DESCRIPTION
Remove the dividing line under the breadcrumb for mobile pending page

## Summary

Remove the horizontal rule under breadcrumb for mobile pending page but keep the horizontal rule for tablet and desktop screen

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61509


## Testing done

n/a

## Screenshots

mobile pending
![Screenshot 2023-07-06 at 5 48 24 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/8482d7f6-2d63-43b1-878b-10dea0587e0e)

tablet pending
![Screenshot 2023-07-06 at 5 49 27 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/3f8bd6f9-3a53-4762-b86a-0e9a3cf61734)


## What areas of the site does it impact?

vaos pending mobile view

## Acceptance criteria
- [ ] Remove the horizontal rule under sub-navigation breadcrumb for mobile pending page but keep it for tablet and desktop screen

