### PR TITLE
File upload | Add delete upload confirmation modal

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -1,16 +1,22 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import { displayFileSize } from 'platform/utilities/ui';
-import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from 'platform/forms-system/src/js/constants';
+
+import { toggleValues } from '../../../../site-wide/feature-toggles/selectors';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
 import unset from '../../../../utilities/data/unset';
+import {
+  displayFileSize,
+  scrollTo,
+  focusElement,
+  scrollToFirstError,
+} from '../../../../utilities/ui';
 
-import { focusElement } from '../utilities/ui';
+import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from '../constants';
+import { $ } from '../utilities/ui';
 import {
   ShowPdfPassword,
   PasswordLabel,
@@ -20,59 +26,135 @@ import {
   checkIsEncryptedPdf,
   FILE_TYPE_MISMATCH_ERROR,
 } from '../utilities/file';
+import { usePreviousValue } from '../helpers';
 
-class FileField extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      progress: 0,
-    };
-    this.uploadRequest = null;
-  }
+/**
+ * FormData of supported files
+ * @typeof Files
+ * @type {object}
+ * @property {string} name - file name
+ * @property {boolean} uploading - flag indicating that an upload is in
+ *  progress
+ * @property {string} confirmationCode - uuid of uploaded file
+ * @property {string} attachmentId - form ID set by user
+ * @property {string} errorMessage - error message string returned from API
+ * @property {boolean} isEncrypted - (Encrypted PDF only; pre-upload only)
+ *  encrypted state of the file
+ * @property {DOMFileObject} file - (Encrypted PDF only) File object, used
+ *  when user submits password
+ */
+const FileField = props => {
+  const {
+    enableShortWorkflow,
+    errorSchema,
+    formContext,
+    formData = [],
+    idSchema,
+    onBlur,
+    onChange,
+    registry,
+    schema,
+    uiSchema,
+  } = props;
 
-  fileInputRef = React.createRef();
+  const files = formData || [];
+  const [progress, setProgress] = useState(0);
+  const [uploadRequest, setUploadRequest] = useState(null);
+  const [isUploading, setIsUploading] = useState(
+    files.some(file => file.uploading),
+  );
 
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillReceiveProps(newProps) {
-    const newFiles = newProps.formData || [];
-    const files = this.props.formData || [];
-    if (newFiles.length !== files.length) {
-      this.focusAddAnotherButton();
-    }
+  const previousValue = usePreviousValue(formData);
+  const fileInputRef = useRef(null);
+  const fileButtonRef = useRef(null);
 
-    const isUploading = newFiles.some(file => file.uploading);
-    const wasUploading = files.some(file => file.uploading);
-    if (isUploading && !wasUploading) {
-      this.setState({ progress: 0 });
-    }
-  }
+  const uiOptions = uiSchema?.['ui:options'];
 
-  componentDidMount() {
+  const maxItems = schema.maxItems || Infinity;
+  const { SchemaField } = registry.fields;
+  const attachmentIdRequired = schema.additionalItems.required
+    ? schema.additionalItems.required.includes('attachmentId')
+    : false;
+
+  const buttonText = {
+    upload: uiOptions.buttonText || 'Upload',
+    uploadAnother: uiOptions.addAnotherLabel || 'Upload another',
+    tryAgain: 'Try again',
+    newFile: 'Upload a new file',
+    cancel: 'Cancel',
+    delete: 'Delete file',
+  };
+
+  const Tag = formContext.onReviewPage && formContext.reviewMode ? 'dl' : 'div';
+
+  // hide upload & delete buttons on review & submit page when reviewing
+  const showButtons = !formContext.reviewMode && !isUploading;
+
+  const titleString =
+    typeof uiSchema['ui:title'] === 'string'
+      ? uiSchema['ui:title']
+      : schema.title;
+
+  // This is always true if enableShortWorkflow is not enabled
+  // If enabled, do not allow upload if any error exist
+  const checkUploadVisibility = () =>
+    !enableShortWorkflow ||
+    (enableShortWorkflow &&
+      !files.some((file, index) => {
+        const errors =
+          errorSchema?.[index]?.__errors ||
+          [file.errorMessage].filter(error => error);
+
+        return errors.length > 0;
+      }));
+
+  const focusAddAnotherButton = () => {
+    // focus on upload button, not the label
+    focusElement('button', {}, $(`#upload-button`)?.shadowRoot);
+  };
+
+  const updateProgress = percent => {
+    setProgress(percent);
+  };
+
+  useEffect(
+    () => {
+      const prevFiles = previousValue || [];
+      fileButtonRef?.current?.classList?.toggle(
+        'vads-u-display--none',
+        !checkUploadVisibility(),
+      );
+      if (files.length !== prevFiles.length) {
+        focusAddAnotherButton();
+      }
+
+      const hasUploading = files.some(file => file.uploading);
+      const wasUploading = prevFiles.some(file => file.uploading);
+      setIsUploading(hasUploading);
+      if (hasUploading && !wasUploading) {
+        setProgress(0);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [formData],
+  );
+
+  useEffect(() => {
     // The File object is not preserved in the save-in-progress data
     // We need to remove these entries; an empty `file` is included in the
     // entry, but if API File Object still exists (within the same session), we
     // can't use Object.keys() on it because it returns an empty array
-    const formData = (this.props.formData || []).filter(
+    const newData = files.filter(
       // keep - file may not exist (already uploaded)
       // keep - file may contain File object; ensure name isn't empty
       // remove - file may be an empty object
       data => !data.file || (data.file?.name || '') !== '',
     );
-    if (formData.length !== (this.props.formData || []).length) {
-      this.props.onChange(formData);
-    }
-  }
 
-  focusAddAnotherButton = () => {
-    // focus on span pseudo-button, not the label
-    focusElement(`#${this.props.idSchema.$id}_add_label span`);
-  };
-
-  onSubmitPassword = (file, index, password) => {
-    if (file && password) {
-      this.onAddFile({ target: { files: [file] } }, index, password);
+    if (newData.length !== files.length) {
+      onChange(newData);
     }
-  };
+  });
 
   /**
    * Add file to list and upload
@@ -82,23 +164,17 @@ class FileField extends React.Component {
    *   `onSubmitPassword` function
    * @listens
    */
-  onAddFile = async (event, index = null, password) => {
-    if (event.target.files && event.target.files.length) {
+  const onAddFile = async (event, index = null, password) => {
+    if (event.target?.files?.length) {
       const currentFile = event.target.files[0];
-      const files = this.props.formData || [];
-      const {
-        onChange,
-        formContext,
-        uiSchema,
-        enableShortWorkflow,
-      } = this.props;
-      const uiOptions = uiSchema['ui:options'];
+      const allFiles = props.formData || [];
+      const addUiOptions = props.uiSchema['ui:options'];
       // needed for FileField unit tests
       const { mockReadAndCheckFile } = uiOptions;
 
       let idx = index;
       if (idx === null) {
-        idx = files.length === 0 ? 0 : files.length;
+        idx = allFiles.length === 0 ? 0 : allFiles.length;
       }
 
       let checkResults;
@@ -119,12 +195,12 @@ class FileField extends React.Component {
       }
 
       if (!checkResults.checkTypeAndExtensionMatches) {
-        files[idx] = {
+        allFiles[idx] = {
           file: currentFile,
           name: currentFile.name,
           errorMessage: FILE_TYPE_MISMATCH_ERROR,
         };
-        onChange(files);
+        props.onChange(allFiles);
         return;
       }
 
@@ -134,421 +210,357 @@ class FileField extends React.Component {
         !password &&
         checkResults.checkIsEncryptedPdf
       ) {
-        files[idx] = {
+        allFiles[idx] = {
           file: currentFile,
           name: currentFile.name,
           isEncrypted: true,
         };
 
-        onChange(files);
+        props.onChange(allFiles);
         // wait for user to enter a password before uploading
         return;
       }
 
-      this.uploadRequest = formContext.uploadFile(
-        currentFile,
-        uiOptions,
-        this.updateProgress,
-        file => {
-          // formData is undefined initially
-          const { formData = [] } = this.props;
-          formData[idx] = { ...file, isEncrypted: !!password };
-          onChange(formData);
-          // Focus on the 'Cancel' button when a file is being uploaded
-          if (file.uploading) {
-            document
-              .querySelector('.schemaform-file-uploading')
-              ?.querySelector('button')
-              ?.focus();
-          }
-          // Focus on the file name input after the file has finished uploading
-          if (!file.uploading) {
-            document.querySelector(`input[value="${file.name}"]`)?.focus();
-          }
-          this.uploadRequest = null;
-        },
-        () => {
-          this.uploadRequest = null;
-        },
-        formContext.trackingPrefix,
-        password,
-        enableShortWorkflow,
+      setUploadRequest(
+        props.formContext.uploadFile(
+          currentFile,
+          addUiOptions,
+          updateProgress,
+          file => {
+            // formData is undefined initially
+            const newData = props.formData || [];
+            newData[idx] = { ...file, isEncrypted: !!password };
+            onChange(newData);
+            // Focus on the 'Cancel' button when a file is being uploaded
+            if (file.uploading) {
+              $('.schemaform-file-uploading button')?.focus();
+            }
+            // Focus on the file name input after the file has finished uploading
+            if (!file.uploading) {
+              $(`input[value="${file.name}"]`)?.focus();
+            }
+            setUploadRequest(null);
+          },
+          () => {
+            setUploadRequest(null);
+          },
+          formContext.trackingPrefix,
+          password,
+          props.enableShortWorkflow,
+        ),
       );
     }
   };
 
-  onAttachmentIdChange = (index, value) => {
+  const onSubmitPassword = (file, index, password) => {
+    if (file && password) {
+      onAddFile({ target: { files: [file] } }, index, password);
+    }
+  };
+
+  const onAttachmentIdChange = (index, value) => {
     if (!value) {
-      this.props.onChange(unset([index, 'attachmentId'], this.props.formData));
+      props.onChange(unset([index, 'attachmentId'], props.formData));
     } else {
-      this.props.onChange(
-        set([index, 'attachmentId'], value, this.props.formData),
-      );
+      props.onChange(set([index, 'attachmentId'], value, props.formData));
     }
   };
 
-  onAttachmentNameChange = (index, value) => {
+  const onAttachmentNameChange = (index, value) => {
     if (!value) {
-      this.props.onChange(unset([index, 'name'], this.props.formData));
+      props.onChange(unset([index, 'name'], props.formData));
     } else {
-      this.props.onChange(set([index, 'name'], value, this.props.formData));
+      props.onChange(set([index, 'name'], value, props.formData));
     }
   };
 
-  updateProgress = progress => {
-    this.setState({ progress });
-  };
-
-  cancelUpload = index => {
-    if (this.uploadRequest) {
-      this.uploadRequest.abort();
-    }
-    this.removeFile(index);
-  };
-
-  removeFile = (index, focusAddButton = true) => {
-    const newFileList = this.props.formData.filter((__, idx) => index !== idx);
+  const removeFile = (index, focusAddButton = true) => {
+    const newFileList = props.formData.filter((__, idx) => index !== idx);
     if (!newFileList.length) {
-      this.props.onChange();
+      props.onChange();
     } else {
-      this.props.onChange(newFileList);
+      props.onChange(newFileList);
     }
 
     // clear file input value; without this, the user won't be able to open the
     // upload file window
-    if (this.fileInputRef.current) {
-      this.fileInputRef.current.value = '';
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
     }
 
     // When other actions follow removeFile, we do not want to apply this focus
     if (focusAddButton) {
       // Add a timeout to allow for the upload button to reappear in the DOM before trying to focus on it
       setTimeout(() => {
-        this.focusAddAnotherButton();
+        focusAddAnotherButton();
       }, 0);
     }
   };
 
-  retryLastUpload = (index, file) => {
-    this.onAddFile({ target: { files: [file] } }, index);
+  const cancelUpload = index => {
+    if (uploadRequest) {
+      uploadRequest.abort();
+    }
+    removeFile(index);
   };
 
-  deleteThenAddFile = index => {
-    this.removeFile(index, false);
-    this.fileInputRef.current.click();
+  const retryLastUpload = (index, file) => {
+    onAddFile({ target: { files: [file] } }, index);
   };
 
-  getRetryFunction = (allowRetry, index, file) =>
-    allowRetry
-      ? () => this.retryLastUpload(index, file)
-      : () => this.deleteThenAddFile(index);
+  const deleteThenAddFile = index => {
+    removeFile(index, false);
+    fileButtonRef.current.click();
+  };
 
-  /**
-   * FormData of supported files
-   * @typeof Files
-   * @type {object}
-   * @property {string} name - file name
-   * @property {boolean} uploading - flag indicating that an upload is in
-   *  progress
-   * @property {string} confirmationCode - uuid of uploaded file
-   * @property {string} attachmentId - form ID set by user
-   * @property {string} errorMessage - error message string returned from API
-   * @property {boolean} isEncrypted - (Encrypted PDF only; pre-upload only)
-   *  encrypted state of the file
-   * @property {DOMFileObject} file - (Encrypted PDF only) File object, used
-   *  when user submits password
-   */
-  render() {
-    const {
-      uiSchema,
-      errorSchema,
-      idSchema,
-      formData,
-      schema,
-      formContext,
-      onBlur,
-      registry,
-      enableShortWorkflow,
-    } = this.props;
-    const uiOptions = uiSchema?.['ui:options'];
-    const files = formData || [];
-    const maxItems = schema.maxItems || Infinity;
-    const { SchemaField } = registry.fields;
-    const attachmentIdRequired = schema.additionalItems.required
-      ? schema.additionalItems.required.includes('attachmentId')
-      : false;
+  const getRetryFunction = (allowRetry, index, file) => {
+    return allowRetry
+      ? () => retryLastUpload(index, file)
+      : () => deleteThenAddFile(index);
+  };
 
-    const isUploading = files.some(file => file.uploading);
-    // hide upload & delete buttons on review & submit page when reviewing
-    const showButtons = !formContext.reviewMode && !isUploading;
+  const uploadText = buttonText[files.length > 0 ? 'uploadAnother' : 'upload'];
 
-    let { buttonText = 'Upload' } = uiOptions;
-    if (files.length > 0) buttonText = uiOptions.addAnotherLabel;
+  return (
+    <div
+      className={
+        formContext.reviewMode ? 'schemaform-file-upload-review' : undefined
+      }
+    >
+      {files.length > 0 && (
+        <ul className="schemaform-file-list">
+          {files.map((file, index) => {
+            const errors =
+              errorSchema?.[index]?.__errors ||
+              [file.errorMessage].filter(error => error);
+            const hasErrors = errors.length > 0;
+            const itemClasses = classNames('va-growable-background', {
+              'schemaform-file-error usa-input-error':
+                hasErrors && !file.uploading,
+            });
+            const itemSchema = schema.items[index];
+            const attachmentIdSchema = {
+              $id: `${idSchema.$id}_${index}_attachmentId`,
+            };
+            const attachmentNameSchema = {
+              $id: `${idSchema.$id}_${index}_attachmentName`,
+            };
+            const attachmentIdErrors = get(
+              [index, 'attachmentId'],
+              errorSchema,
+            );
+            const attachmentNameErrors = get([index, 'name'], errorSchema);
+            const showPasswordInput =
+              file.isEncrypted && !file.confirmationCode;
+            const showPasswordSuccess =
+              file.isEncrypted && file.confirmationCode;
+            const description =
+              (!file.uploading && uiOptions.itemDescription) || '';
 
-    const Tag =
-      formContext.onReviewPage && formContext.reviewMode ? 'dl' : 'div';
-
-    const titleString =
-      typeof uiSchema['ui:title'] === 'string'
-        ? uiSchema['ui:title']
-        : schema.title;
-
-    // This is always true if enableShortWorkflow is not enabled
-    // If enabled, do not allow upload if any error exist
-    const allowUpload =
-      !enableShortWorkflow ||
-      (enableShortWorkflow &&
-        !files.some((file, index) => {
-          const errors =
-            errorSchema?.[index]?.__errors ||
-            [file.errorMessage].filter(error => error);
-
-          return errors.length > 0;
-        }));
-
-    return (
-      <div
-        className={
-          formContext.reviewMode ? 'schemaform-file-upload-review' : undefined
-        }
-      >
-        {files.length > 0 && (
-          <ul className="schemaform-file-list">
-            {files.map((file, index) => {
-              const errors =
-                errorSchema?.[index]?.__errors ||
-                [file.errorMessage].filter(error => error);
-              const hasErrors = errors.length > 0;
-              const itemClasses = classNames('va-growable-background', {
-                'schemaform-file-error usa-input-error':
-                  hasErrors && !file.uploading,
-              });
-              const itemSchema = schema.items[index];
-              const attachmentIdSchema = {
-                $id: `${idSchema.$id}_${index}_attachmentId`,
-              };
-              const attachmentNameSchema = {
-                $id: `${idSchema.$id}_${index}_attachmentName`,
-              };
-              const attachmentIdErrors = get(
-                [index, 'attachmentId'],
-                errorSchema,
-              );
-              const attachmentNameErrors = get([index, 'name'], errorSchema);
-              const showPasswordInput =
-                file.isEncrypted && !file.confirmationCode;
-              const showPasswordSuccess =
-                file.isEncrypted && file.confirmationCode;
-              const description =
-                (!file.uploading && uiOptions.itemDescription) || '';
-
-              if (showPasswordInput) {
-                setTimeout(() => {
-                  focusElement(`[name="get_password_${index}"]`);
-                }, 100);
-              } else if (hasErrors && enableShortWorkflow) {
-                setTimeout(() => {
+            if (hasErrors) {
+              setTimeout(() => {
+                scrollToFirstError();
+                if (enableShortWorkflow) {
                   focusElement(`[name="retry_upload_${index}"]`);
-                }, 100);
-              }
+                } else if (showPasswordInput) {
+                  focusElement(
+                    `#root_additionalDocuments_file_${index} .usa-input-error-message`,
+                  );
+                } else {
+                  focusElement('.usa-input-error, .input-error-date, [error]');
+                }
+              }, 100);
+            } else if (showPasswordInput) {
+              setTimeout(() => {
+                const passwordInput = $(`[name="get_password_${index}"]`);
+                focusElement('input', null, passwordInput.shadowRoot);
+                scrollTo(`get_password_${index}"]`);
+              }, 100);
+            }
 
-              const allowRetry =
-                errors[0] === FILE_UPLOAD_NETWORK_ERROR_MESSAGE;
+            const allowRetry = errors[0] === FILE_UPLOAD_NETWORK_ERROR_MESSAGE;
 
-              const retryButtonText = allowRetry
-                ? 'Try again'
-                : 'Upload a new file';
+            const retryButtonText =
+              buttonText[allowRetry ? 'tryAgain' : 'newFile'];
+            const deleteButtonText =
+              buttonText[
+                enableShortWorkflow && hasErrors ? 'cancel' : 'delete'
+              ];
 
-              const deleteButtonText =
-                enableShortWorkflow && hasErrors ? 'Cancel' : 'Delete file';
+            const fileId = `${idSchema.$id}_file_name_${index}`;
 
-              const fileId = `${idSchema.$id}_file_name_${index}`;
+            const getUiSchema = innerUiSchema =>
+              typeof innerUiSchema === 'function'
+                ? innerUiSchema({ fileId, index })
+                : innerUiSchema;
 
-              const getUiSchema = innerUiSchema =>
-                typeof innerUiSchema === 'function'
-                  ? innerUiSchema({ fileId, index })
-                  : innerUiSchema;
+            // make index available to widgets in attachment ui schema
+            const indexedRegistry = {
+              ...registry,
+              formContext: {
+                ...registry.formContext,
+                pagePerItemIndex: index,
+              },
+            };
 
-              // make index available to widgets in attachment ui schema
-              const indexedRegistry = {
-                ...registry,
-                formContext: {
-                  ...registry.formContext,
-                  pagePerItemIndex: index,
-                },
-              };
-
-              return (
-                <li
-                  key={index}
-                  id={`${idSchema.$id}_file_${index}`}
-                  className={itemClasses}
-                >
-                  {file.uploading && (
-                    <div className="schemaform-file-uploading">
-                      <strong id={fileId}>{file.name}</strong>
-                      <br />
-                      <va-progress-bar percent={this.state.progress} />
-                      <button
-                        type="button"
-                        className="usa-button-secondary vads-u-width--auto"
-                        onClick={() => {
-                          this.cancelUpload(index);
-                        }}
-                        aria-label="Cancel Upload"
-                        aria-describedby={fileId}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  )}
-                  {description && <p>{description}</p>}
-                  {!file.uploading && (
-                    <>
-                      <strong id={fileId}>{file.name}</strong>
-                      {file?.size && <div> {displayFileSize(file.size)}</div>}
-                    </>
-                  )}
-                  {(showPasswordInput || showPasswordSuccess) && (
-                    <PasswordLabel />
-                  )}
-                  {showPasswordSuccess && <PasswordSuccess />}
-                  {!hasErrors &&
-                    !showPasswordInput &&
-                    get('properties.attachmentId', itemSchema) && (
-                      <Tag className="schemaform-file-attachment review">
-                        <SchemaField
-                          name="attachmentId"
-                          required={attachmentIdRequired}
-                          schema={itemSchema.properties.attachmentId}
-                          uiSchema={getUiSchema(uiOptions.attachmentSchema)}
-                          errorSchema={attachmentIdErrors}
-                          idSchema={attachmentIdSchema}
-                          formData={formData[index].attachmentId}
-                          onChange={value =>
-                            this.onAttachmentIdChange(index, value)
-                          }
-                          onBlur={onBlur}
-                          registry={indexedRegistry}
-                          disabled={this.props.disabled}
-                          readonly={this.props.readonly}
-                        />
-                      </Tag>
-                    )}
-                  {!hasErrors &&
-                    !showPasswordInput &&
-                    uiOptions.attachmentName && (
-                      <Tag className="schemaform-file-attachment review">
-                        <SchemaField
-                          name="attachmentName"
-                          required
-                          schema={itemSchema.properties.name}
-                          uiSchema={getUiSchema(uiOptions.attachmentName)}
-                          errorSchema={attachmentNameErrors}
-                          idSchema={attachmentNameSchema}
-                          formData={formData[index].name}
-                          onChange={value =>
-                            this.onAttachmentNameChange(index, value)
-                          }
-                          onBlur={onBlur}
-                          registry={indexedRegistry}
-                          disabled={this.props.disabled}
-                          readonly={this.props.readonly}
-                        />
-                      </Tag>
-                    )}
-                  {!file.uploading &&
-                    hasErrors && (
-                      <span className="usa-input-error-message" role="alert">
-                        <span className="sr-only">Error</span> {errors[0]}
-                      </span>
-                    )}
-                  {showPasswordInput && (
-                    <ShowPdfPassword
-                      file={file.file}
-                      index={index}
-                      onSubmitPassword={this.onSubmitPassword}
-                      ariaDescribedby={fileId}
+            return (
+              <li
+                key={index}
+                id={`${idSchema.$id}_file_${index}`}
+                className={itemClasses}
+              >
+                {file.uploading && (
+                  <div className="schemaform-file-uploading">
+                    <strong id={fileId}>{file.name}</strong>
+                    <br />
+                    <va-progress-bar percent={progress} />
+                    <va-button
+                      secondary
+                      class="cancel-upload vads-u-width--auto"
+                      onClick={() => {
+                        cancelUpload(index);
+                      }}
+                      aria-describedby={fileId}
+                      label="Cancel Upload"
+                      text={buttonText.cancel}
                     />
+                  </div>
+                )}
+                {description && <p>{description}</p>}
+                {!file.uploading && (
+                  <>
+                    <strong id={fileId}>{file.name}</strong>
+                    {file?.size && <div> {displayFileSize(file.size)}</div>}
+                  </>
+                )}
+                {(showPasswordInput || showPasswordSuccess) && (
+                  <PasswordLabel />
+                )}
+                {showPasswordSuccess && <PasswordSuccess />}
+                {!hasErrors &&
+                  !showPasswordInput &&
+                  get('properties.attachmentId', itemSchema) && (
+                    <Tag className="schemaform-file-attachment review">
+                      <SchemaField
+                        name="attachmentId"
+                        required={attachmentIdRequired}
+                        schema={itemSchema.properties.attachmentId}
+                        uiSchema={getUiSchema(uiOptions.attachmentSchema)}
+                        errorSchema={attachmentIdErrors}
+                        idSchema={attachmentIdSchema}
+                        formData={formData[index].attachmentId}
+                        onChange={value => onAttachmentIdChange(index, value)}
+                        onBlur={onBlur}
+                        registry={indexedRegistry}
+                        disabled={props.disabled}
+                        readonly={props.readonly}
+                      />
+                    </Tag>
                   )}
-                  {showButtons && (
+                {!hasErrors &&
+                  !showPasswordInput &&
+                  uiOptions.attachmentName && (
+                    <Tag className="schemaform-file-attachment review">
+                      <SchemaField
+                        name="attachmentName"
+                        required
+                        schema={itemSchema.properties.name}
+                        uiSchema={getUiSchema(uiOptions.attachmentName)}
+                        errorSchema={attachmentNameErrors}
+                        idSchema={attachmentNameSchema}
+                        formData={formData[index].name}
+                        onChange={value => onAttachmentNameChange(index, value)}
+                        onBlur={onBlur}
+                        registry={indexedRegistry}
+                        disabled={props.disabled}
+                        readonly={props.readonly}
+                      />
+                    </Tag>
+                  )}
+                {!file.uploading &&
+                  hasErrors && (
+                    <span className="usa-input-error-message" role="alert">
+                      <span className="sr-only">Error</span> {errors[0]}
+                    </span>
+                  )}
+                {showPasswordInput && (
+                  <ShowPdfPassword
+                    file={file.file}
+                    index={index}
+                    onSubmitPassword={onSubmitPassword}
+                    ariaDescribedby={fileId}
+                  />
+                )}
+                {!formContext.reviewMode &&
+                  !isUploading && (
                     <div className="vads-u-margin-top--2">
                       {hasErrors &&
                         enableShortWorkflow && (
-                          <button
+                          <va-button
                             name={`retry_upload_${index}`}
-                            type="button"
-                            className="usa-button-primary vads-u-width--auto vads-u-margin-right--2"
-                            onClick={this.getRetryFunction(
+                            class="retry-upload vads-u-width--auto vads-u-margin-right--2"
+                            onClick={getRetryFunction(
                               allowRetry,
                               index,
                               file.file,
                             )}
                             aria-describedby={fileId}
-                          >
-                            {retryButtonText}
-                          </button>
+                            text={retryButtonText}
+                          />
                         )}
-                      <button
-                        type="button"
-                        className="usa-button-secondary vads-u-width--auto"
+                      <va-button
+                        secondary
+                        class="delete-upload vads-u-width--auto"
                         onClick={() => {
-                          this.removeFile(index);
+                          removeFile(index);
                         }}
                         aria-describedby={fileId}
-                      >
-                        {deleteButtonText}
-                      </button>
+                        text={deleteButtonText}
+                      />
                     </div>
                   )}
-                </li>
-              );
-            })}
-          </ul>
-        )}
-        {// Don't render an upload button on review & submit page while in
-        // review mode
-        showButtons && (
-          <>
-            {(maxItems === null || files.length < maxItems) &&
-              // Prevent additional upload if any upload has error state
-              allowUpload && (
-                <label
-                  id={`${idSchema.$id}_add_label`}
-                  htmlFor={idSchema.$id}
-                  className="vads-u-display--inline-block"
-                >
-                  <span
-                    role="button"
-                    className="usa-button usa-button-secondary vads-u-padding-x--2 vads-u-padding-y--1"
-                    onKeyPress={e => {
-                      e.preventDefault();
-                      if (['Enter', ' ', 'Spacebar'].indexOf(e.key) !== -1) {
-                        this.fileInputRef.current.click();
-                      }
-                    }}
-                    tabIndex="0"
-                    aria-label={`${buttonText} ${titleString}`}
-                  >
-                    {buttonText}
-                  </span>
-                </label>
-              )}
-            <input
-              type="file"
-              ref={this.fileInputRef}
-              accept={uiOptions.fileTypes.map(item => `.${item}`).join(',')}
-              style={{ display: 'none' }}
-              id={idSchema.$id}
-              name={idSchema.$id}
-              onChange={this.onAddFile}
-            />
-          </>
-        )}
-      </div>
-    );
-  }
-}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {// Don't render an upload button on review & submit page while in
+      // review mode
+      showButtons && (
+        <>
+          {(maxItems === null || files.length < maxItems) &&
+            // Prevent additional upload if any upload has error state
+            checkUploadVisibility() && (
+              <label
+                id={`${idSchema.$id}_add_label`}
+                htmlFor={idSchema.$id}
+                className="upload-button-label vads-u-display--inline-block"
+              >
+                <va-button
+                  id="upload-button"
+                  ref={fileButtonRef}
+                  secondary
+                  class="vads-u-padding-x--2 vads-u-padding-y--1"
+                  onClick={() => fileInputRef?.current?.click()}
+                  label={`${uploadText} ${titleString || ''}`}
+                  text={uploadText}
+                />
+              </label>
+            )}
+          <input
+            type="file"
+            ref={fileInputRef}
+            accept={uiOptions.fileTypes.map(item => `.${item}`).join(',')}
+            style={{ display: 'none' }}
+            id={idSchema.$id}
+            name={idSchema.$id}
+            onChange={onAddFile}
+          />
+        </>
+      )}
+    </div>
+  );
+};
 
 FileField.propTypes = {
   schema: PropTypes.object.isRequired,

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import moment from 'moment';
 import { intersection, matches, merge, uniq } from 'lodash';
 import shouldUpdate from 'recompose/shouldUpdate';
@@ -721,4 +722,18 @@ export function showReviewField(
     !hiddenOnSchema &&
     !collapsedOnSchema
   );
+}
+
+/**
+ * Custom hook to track previous values inside a useEffect
+ * See https://blog.logrocket.com/accessing-previous-props-state-react-hooks/
+ * @param {*} value - previous value to track
+ * @returns previous value
+ */
+export function usePreviousValue(value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
 }

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { focusElement } from '../ui';
 
 const ShowPdfPassword = ({
   file,
@@ -10,15 +11,34 @@ const ShowPdfPassword = ({
 }) => {
   const [value, setValue] = useState(testVal);
   const [dirty, setDirty] = useState(false);
+  const inputRef = useRef(null);
 
-  const errorMessage =
-    dirty && !value ? 'Please provide a password to decrypt this file' : null;
+  const errorMessage = 'Please provide a password to decrypt this file';
+
+  const setFocus = () => {
+    if (inputRef?.current) {
+      focusElement('input', {}, inputRef.current.shadowRoot);
+    } else {
+      focusElement(`#root_additionalDocuments_file_${index}`);
+    }
+  };
+
+  useEffect(
+    () => {
+      if (dirty && !value && inputRef?.current) {
+        setFocus();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dirty, value, inputRef],
+  );
 
   return (
     <div className="vads-u-margin-bottom--2">
       <va-text-input
+        ref={inputRef}
         label="PDF password"
-        error={errorMessage}
+        error={(dirty && !value && errorMessage) || null}
         name={`get_password_${index}`}
         required
         value={value}
@@ -35,6 +55,7 @@ const ShowPdfPassword = ({
           } else {
             setValue('');
             setDirty(true);
+            setFocus();
           }
         }}
         aria-describedby={ariaDescribedby}

--- a/src/platform/forms-system/test/js/definitions/file.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/file.unit.spec.jsx
@@ -16,7 +16,7 @@ describe('Schemaform definition file', () => {
       </Provider>,
     );
 
-    expect(container.querySelector('input[type="file"]')).not.to.be.null;
-    expect(container.querySelector('label>span[role="button"]')).not.to.be.null;
+    expect(container.querySelector('input[type="file"]')).to.exist;
+    expect(container.querySelector('label>va-button#upload-button')).to.exist;
   });
 });

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -341,7 +341,7 @@ fieldset.schemaform-field-template {
   list-style: none;
   padding-left: 0;
   overflow-wrap: break-word;
-  word-break: break-all;
+  word-break: break-word;
   > li {
     list-style: none;
   }


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Prior to release of our team's Supplemental Claims form, the collaboration cycle mentioned that this [confirmation of a destructive action](https://github.com/department-of-veterans-affairs/va.gov-team/issues/56082) was missing in several pages of our form. One of which was the removing of uploaded files.
  > Note: these changes _do not_ include upload code within individual apps, e.g. claim status tool, COE, etc...
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > A `va-modal` appears after activating the delete upload button.
  > - Choosing yes, will remove the uploaded file and shift focus to the upload button
  > - Choosing no, will abort the removal and return focus to the delete button
  > This solution mimics what we've done with our Supplemental Claims form: confirmations for removing issues, VA evidence, private evidence and evidence on the summary page
- _(Which team do you work for, does your team own the maintenance of this component?)_
 > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#58596](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58596)
- [Design System ticket #1770](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1770)

## Testing done

- _Describe what the old behavior was prior to the change_
  > - After activating the delete upload button, the file was immediately removed; focus was shifted to the upload button
  > - After attempting to add an empty password, focus would remain on the "add password" button instead of returning to the password input
- _Describe the steps required to verify your changes are working as expected_
  > - Test in review instance in 526, NOD or Supplemental Claims forms
- _Describe the tests completed and the results_
  > Updated unit tests to use RTL and added tests specific to the modal, including focus management
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="649" alt="delete uploaded file confirmation modal appearance with yes remove this and no keep this buttons" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/0fab37b4-298d-4d68-b56f-5515198689d1">

![delete  upload confirmation modal appears after clicking on the delete button. Choosing no closes the modal and move focus back to the delete button. Choose yes closes the modal and moves focus to the add another upload button. Uploading a password protected PDF shows the password input, and clicking on the add password button with an empty input returns focus to the password input](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/9677053a-b462-42fa-ab3d-d59c3e285ecf)

## What areas of the site does it impact?

All apps that use the platform `FileField` component to upload files

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) (PENDING)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
