### PR TITLE
Update text for comp and pen details page

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -54,9 +54,9 @@ export default function DetailsVA({ appointment, facilityData }) {
                 {typeOfCare}
               </h2>
               <p className="vads-l-col--12 vads-u-margin-top--0 medium-screen:vads-l-col--8">
-                This appointment is for rating purposes only and will not
-                include treatment. If you have any medical evidence to claim,
-                please bring copies to your exam.
+                This appointment is for disability rating purposes only. It
+                doesn’t include treatment. If you have medical evidence to
+                support your claim, bring copies to this appointment.
               </p>
             </>
           ) : (

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.util.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.util.jsx
@@ -19,7 +19,7 @@ export function formatHeader(appointment) {
     (isPastAppointment && isCompAndPenAppointment) ||
     (isCompAndPenAppointment && cancelled)
   ) {
-    return 'Compensation and pension exam';
+    return 'Claim exam';
   }
   return 'VA appointment';
 }

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/DetailsVA.util.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/DetailsVA.util.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { formatHeader } from '../DetailsVA.util';
 
-describe('appointment-list / components / ConfirmedAppointmenDetailsPage / DetailsVA.util', () => {
+describe('appointment-list / components / ConfirmedAppointmentDetailsPage / DetailsVA.util', () => {
   it('should return appointment type header as COVID-19 vaccine', () => {
     const appointment = {
       vaos: {
@@ -20,7 +20,7 @@ describe('appointment-list / components / ConfirmedAppointmenDetailsPage / Detai
     const header = formatHeader(appointment);
     expect(header).to.equal('VA appointment over the phone');
   });
-  it('should return appointment type header as Compensation and pension exam for past c&p appoinment', () => {
+  it('should return appointment type header as Claim exam for past c&p appointment', () => {
     const appointment = {
       status: 'booked',
       vaos: {
@@ -29,9 +29,9 @@ describe('appointment-list / components / ConfirmedAppointmenDetailsPage / Detai
       },
     };
     const header = formatHeader(appointment);
-    expect(header).to.equal('Compensation and pension exam');
+    expect(header).to.equal('Claim exam');
   });
-  it('should return appointment type header as Compensation and pension exam for cancelled c&p appoinment', () => {
+  it('should return appointment type header as Claim exam for cancelled c&p appointment', () => {
     const appointment = {
       status: 'cancelled',
       vaos: {
@@ -40,7 +40,7 @@ describe('appointment-list / components / ConfirmedAppointmenDetailsPage / Detai
       },
     };
     const header = formatHeader(appointment);
-    expect(header).to.equal('Compensation and pension exam');
+    expect(header).to.equal('Claim exam');
   });
   it('should return appointment type header as VA appointment', () => {
     const appointment = {

--- a/src/applications/vaos/appointment-list/redux/tests/selectors.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/redux/tests/selectors.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('appointment-list / redux / selectors', () => {
       },
     };
     const typeOfCareName = selectTypeOfCareName(appointment);
-    expect(typeOfCareName).to.equal('Compensation and pension exam');
+    expect(typeOfCareName).to.equal('Claim exam');
   });
   it('should return Audiology and speech as type of care', () => {
     const appointment = {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -465,6 +465,6 @@ export const ERROR_CODES = [
 export const SERVICE_CATEGORY = [
   {
     id: COMP_AND_PEN,
-    displayName: 'Compensation and pension exam',
+    displayName: 'Claim exam',
   },
 ];


### PR DESCRIPTION
## Summary
Mobile team has made some content changes for the C&P appointment. Update the content changes on web based on [copy doc](https://github.com/department-of-veterans-affairs/va.gov-team/pull/61096/files).

## Acceptance criteria

- [ ] Change the service category name from "Compensation and pension exam" to "Claim exam"
- [ ] Change the description text to read "This appointment is for disability rating purposes only. It doesn't include treatment. If you have medical evidence to support your claim, bring copies to this appointment."


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61091


## Testing done

unit test

## Screenshots

Upcoming

![Screenshot 2023-07-07 at 10 39 35 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/9f464f1a-6a7d-4dc5-a250-d794b80e5398)

Past

![Screenshot 2023-07-07 at 10 40 49 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/37439c77-1929-4068-af84-822089ad88e3)

Canceled

![Screenshot 2023-07-07 at 10 41 40 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/dcebaf8c-4ec2-4101-97a6-e30ce72ca307)

Appointment list page

![Screenshot 2023-07-07 at 12 11 48 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/07b7ee8c-b606-4ed4-80d7-3773f1d4f447)

## What areas of the site does it impact?

C&P details page and appointment list page







