### PR TITLE
remove edit from review and submit

### DIFF
--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -234,7 +234,6 @@
   }
 }
 
-
 .field-disabled {
   pointer-events: none;
   input,
@@ -331,7 +330,8 @@
   background-color: transparent;
   width: auto !important;
   font-weight: bold;
-  &:hover, &:active {
+  &:hover,
+  &:active {
     color: $color-secondary-darkest;
     background-color: $color-secondary-lightest;
   }
@@ -339,7 +339,17 @@
 
 /* Hide mobile phone extension entry, per design */
 #edit-mobilePhone {
-  form[name="Contact Info Form"] .schemaform-field-template:not(.schemaform-first-field) {
+  form[name="Contact Info Form"]
+    .schemaform-field-template:not(.schemaform-first-field) {
     display: none;
   }
 }
+
+@mixin hide-button($selector) {
+  .form-review-panel #{$selector} {
+    display: none;
+  }
+}
+
+@include hide-button("button.edit-page");
+@include hide-button(".edit-btn.primary-outline");


### PR DESCRIPTION
Issue Description
We're aiming to render the 'review and submit' page as read-only. To accomplish this, we need to eliminate the option to edit each individual section, thereby aligning these sections with our updated read-only design.

## Front-end Tasks

[x] Utilize CSS to target and hide the edit buttons on the 'review and submit' page.
## Acceptance Criteria

[x] Edit buttons are no longer visible on the 'review and submit' page.
[x] Users can still submit forms.
[x] All tests are successful.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61546


## Testing done

- Edit buttons where visible prior to css update


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
|------ | ----- |

| Desktop |  ![Before_review-and-submit](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/da9df35b-a826-4dcb-a12b-58177bd9aa26)
      |   ![After_review-and-submit](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/2b369594-3720-4e6a-a8ef-2022987a6971)    |


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
