### PR TITLE
MHV-46057, 46067 SM to VA.gov - Modals defects

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
+++ b/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
@@ -63,15 +63,6 @@ const ManageFolderButtons = () => {
     [nameWarning],
   );
 
-  useEffect(
-    () => {
-      if (isEmptyWarning) {
-        focusElement(emptyFolderConfirmBtn.current);
-      }
-    },
-    [isEmptyWarning],
-  );
-
   const openDelModal = () => {
     dispatch(closeAlert());
     if (messages?.length > 0) {

--- a/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
+++ b/src/applications/mhv/secure-messaging/components/ManageFolderButtons.jsx
@@ -65,15 +65,6 @@ const ManageFolderButtons = () => {
 
   useEffect(
     () => {
-      if (deleteModal) {
-        focusElement(removeButton.current);
-      }
-    },
-    [deleteModal],
-  );
-
-  useEffect(
-    () => {
       if (isEmptyWarning) {
         focusElement(emptyFolderConfirmBtn.current);
       }

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
@@ -69,7 +69,7 @@ const PrintBtn = props => {
           data-testid="print-modal-popup"
           visible={isModalVisible}
         >
-          <div className="modal-body">
+          <div>
             <VaRadio
               className="form-radio-buttons"
               enable-analytics
@@ -86,9 +86,7 @@ const PrintBtn = props => {
               <VaRadioOption
                 data-testid="radio-print-all-messages"
                 style={{ display: 'flex' }}
-                aria-label={`Print all messages in this conversation (${
-                  messageThreadCount.current
-                } messages)`}
+                aria-label={`Print all messages in this conversation (${messageThreadCount} messages)`}
                 label="Print all messages in this conversation"
                 value={PrintMessageOptions.PRINT_THREAD}
                 name="all-messages"

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -43,6 +43,10 @@ va-alert button {
   width: auto;
 }
 
+va-modal va-radio {
+  margin-left: 12px;
+}
+
 .message-box {
   background-color: $color-gray-lightest;
   border-radius: 4px;
@@ -252,13 +256,13 @@ va-alert button {
     width: 14px;
     height: 3.5px;
     background-color: $color-red-dark;
-}
-.remove-attachment-icon:before {
-  transform: translate(-50%, -50%) rotate(45deg);
-}
-.remove-attachment-icon:after {
-  transform: translate(-50%, -50%) rotate(-45deg);
-}
+  }
+  .remove-attachment-icon:before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+  .remove-attachment-icon:after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
   .remove-attachment-button {
     color: $color-red-dark;
     background-color: $color-white;


### PR DESCRIPTION
## Summary

- When removing a folder, the "Are you sure?" confirmation modal behaves slightly differently than all of the other modals. Rather than default keyboard focus being set to the close "X" button, default focus is set to the primary "Remove" button. Resolving by handling focus in a default way on "X" close modal button as recommended
- Form fields such as radio buttons have a left margin. For the error state this displays a left red border. The error state in the modals does not have that left margin and therefore displays off the modal. Tweaking styling to remediate the problem above


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/59498
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/59483
- https://jira.devops.va.gov/browse/MHV-46057
- https://jira.devops.va.gov/browse/MHV-46067

## Testing done

- SQA Testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/c0619fee-64af-4906-9db9-bd381126b598)![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/77aa1f71-4093-4364-8dc1-86f33ed2b13a)|![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/433853d4-80af-4cd5-9a4b-42db3b9e3df5)![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/22f7c3f7-43b0-4eb3-b005-ec259cd579d5)|

## What areas of the site does it impact?

My Health - Secure Messages

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
