### PR TITLE
Account for prod-like envs when fetching assets

### DIFF
--- a/src/platform/pdf/registerFonts.js
+++ b/src/platform/pdf/registerFonts.js
@@ -1,4 +1,4 @@
-import { environment } from '@department-of-veterans-affairs/platform-utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import * as BUCKETS from 'site/constants/buckets';
 import fs from 'fs';
 

--- a/src/platform/pdf/registerFonts.js
+++ b/src/platform/pdf/registerFonts.js
@@ -1,3 +1,5 @@
+import { environment } from '@department-of-veterans-affairs/platform-utilities/environment';
+import * as BUCKETS from 'site/constants/buckets';
 import fs from 'fs';
 
 const knownFonts = {
@@ -21,7 +23,10 @@ const registerLocalFont = (doc, font) => {
 };
 
 const downloadAndRegisterFont = async (doc, font) => {
-  const request = await fetch(`/generated/${knownFonts[font]}`);
+  const bucket = environment.isLocalhost()
+    ? ''
+    : BUCKETS[environment.BUILDTYPE];
+  const request = await fetch(`${bucket}/generated/${knownFonts[font]}`);
   const binaryFont = await request.arrayBuffer();
   const encodedFont = Buffer.from(binaryFont).toString('base64');
   fs.writeFileSync(knownFonts[font], encodedFont);


### PR DESCRIPTION
## Summary

This PR fixes the asset paths when fetching fonts to render PDFs on non local/review environments.

## Testing done

Unfortunately this can only be tested on dev/staging. This work is not yet in use in production, so there is no risk of regression for end users.

## Screenshots

No UI changes.

## What areas of the site does it impact?

Platform PDF generation.

## Acceptance criteria

- [ ] fonts are fetched on dev/staging/prod