### PR TITLE
VACMS-13750 Income Limits: add real content

### DIFF
--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
+import { getPreviousYear } from '../utilities/utils';
 import { ROUTES } from '../constants';
 import { updateDependents, updateEditMode } from '../actions';
 
@@ -72,7 +73,7 @@ const DependentsPage = ({
 
   const onDependentsInput = event => {
     setError(false);
-    updateDependentsField(event.target.value);
+    updateDependentsField(parseInt(event.target.value, 10).toString());
   };
 
   const onBackClick = () => {
@@ -85,9 +86,14 @@ const DependentsPage = ({
 
   return (
     <>
-      <h1>Donec nec venenatis neque etiam ac nisi orci?</h1>
+      {pastMode && year ? (
+        <h1>How many dependents did you have in {year - 1}?</h1>
+      ) : (
+        <h1>How many dependents did you have last year?</h1>
+      )}
       <form>
         <VaNumberInput
+          className="vads-u-margin-bottom--1"
           data-testid="il-dependents"
           error={
             (submitted &&
@@ -95,7 +101,10 @@ const DependentsPage = ({
               'Please enter a number between 0 and 100.') ||
             null
           }
-          hint="Dependents hint text"
+          hint={`Enter the total number of dependents for ${getPreviousYear(
+            pastMode,
+            year,
+          )}, including your spouse, unmarried children under 18 years old, and other dependents.`}
           id="numberOfDependents"
           inputmode="numeric"
           label="Number of dependents"
@@ -107,7 +116,22 @@ const DependentsPage = ({
           required
           value={dependents || ''}
         />
+        <va-additional-info trigger="Who qualifies as a dependent">
+          <div>
+            <p className="vads-u-margin-top--0">
+              Here&#8217;s who we consider dependents for health care
+              eligibility purposes:
+            </p>
+            <ul>
+              <li>Your spouse</li>
+              <li>Unmarried children who are under 18 years old</li>
+              <li>Adult children who were disabled before age 18</li>
+              <li>Children ages 18 to 23 who attend school full time</li>
+            </ul>
+          </div>
+        </va-additional-info>
         <VaButtonPair
+          className="vads-u-margin-top--3"
           data-testid="il-buttonPair"
           onPrimaryClick={onContinueClick}
           onSecondaryClick={onBackClick}

--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -48,24 +48,58 @@ const HomePage = ({
 
   return (
     <>
-      <h1>Home Page</h1>
+      <h1>Income limits and your VA health care</h1>
+      <p>
+        Answer 2 questions to find out how your income may affect your VA health
+        care eligibility and costs.
+      </p>
+      <h2>What to know before you start:</h2>
+      <ul className="vads-u-margin-left--1">
+        <li>
+          Some Veterans are eligible for VA health care no matter their income.
+          You may be eligible based on your VA disability rating, service
+          history, or other factors. If you think you may be eligible, we
+          encourage you to apply anytime.{' '}
+          <va-link
+            href="https://www.va.gov/health-care/eligibility/"
+            text="Review health care eligibility factors"
+          />
+        </li>
+        <li>
+          If you’re not eligible for VA health care based on other factors, you
+          may still be eligible based on your income.
+        </li>
+        <li>
+          If your income changes after you&#8217;re enrolled in VA health care,
+          you can report the update to us. We&#8217;ll review your current
+          income and may adjust your copay costs.
+        </li>
+        <li>
+          You&#8217;ll need information about your{' '}
+          {new Date().getFullYear() - 1} household income and deductions to
+          check income limits. Limits vary by where you live and change each
+          year.
+        </li>
+      </ul>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a
         data-testid="income-limits-current"
         href="#"
-        className="vads-u-display--block vads-u-margin-bottom--1"
+        className="vads-u-display--block vads-u-margin-bottom--1 vads-u-margin-top--3 vads-c-action-link--green"
         onClick={goToCurrent}
       >
-        Current income limits
+        Check current income limits
       </a>
+      <h2>Past income limits</h2>
+      <p>You can also use this tool to review income limits for past years.</p>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a
         data-testid="income-limits-past"
         href="#"
-        className="vads-u-display--block"
+        className="vads-u-display--block vads-u-margin-top--4 vads-c-action-link--blue"
         onClick={goToPast}
       >
-        Past income limits
+        Check income limits for a previous year
       </a>
     </>
   );

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -2,8 +2,10 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
+import { ROUTES } from '../constants';
 import {
   getFirstAccordionHeader,
   getSecondAccordionHeader,
@@ -11,7 +13,7 @@ import {
   getFourthAccordionHeader,
   getFifthAccordionHeader,
 } from '../utilities/results-accordions';
-import { redirectIfFormIncomplete } from '../utilities/utils';
+import { getPreviousYear, redirectIfFormIncomplete } from '../utilities/utils';
 
 /**
  * There are two pathways to displaying income ranges on this page
@@ -19,28 +21,18 @@ import { redirectIfFormIncomplete } from '../utilities/utils';
  * 1) Standard: GMT > NMT
  * 2) Non-standard: GMT < NMT  In some rural areas, the Geographic Means Test is lower than the National Means Test
  */
-const Results = ({
-  dependentsInput,
-  pastMode,
-  results,
-  router,
-  yearInput,
-  zipCodeInput,
-}) => {
+const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
+  const APPLY_URL =
+    'https://www.va.gov/health-care/apply/application/introduction';
+
   useEffect(
     () => {
-      redirectIfFormIncomplete(
-        dependentsInput,
-        pastMode,
-        router,
-        yearInput,
-        zipCodeInput,
-      );
+      redirectIfFormIncomplete(dependents, pastMode, router, year, zipCode);
 
       waitForRenderThenFocus('h1');
       scrollToTop();
     },
-    [dependentsInput, pastMode, router, yearInput, zipCodeInput],
+    [dependents, pastMode, router, year, zipCode],
   );
 
   if (results) {
@@ -51,74 +43,251 @@ const Results = ({
     } = results;
 
     const isStandard = gmt > national;
+    const previousYear = getPreviousYear(pastMode, year);
     const currentYear = new Date().getFullYear();
+
+    const currentFlowCopy = (
+      <>
+        <p>
+          We use your last year&#8217;s household income, minus certain
+          deductions, to determine your VA health care eligibility and costs.
+          Select your income range to find out how your income may affect your
+          eligibility and costs. But remember, the only way to know for sure is
+          to apply.
+        </p>
+        <p>How to estimate your household income range:</p>
+        <ul>
+          <li>
+            Add up all the money your household earned in {previousYear} from
+            jobs and other sources. Your household includes you and your spouse
+            and dependents if you have them.
+          </li>
+          <li>
+            Then subtract any deductions you had in {previousYear}. You can
+            deduct some health care costs you didn&#8217;t get paid back for,
+            expenses for your own college or vocational training, and any
+            funeral or burial expenses for a spouse or dependent child.
+          </li>
+        </ul>
+      </>
+    );
+
+    const pastFlowCopy = (
+      <>
+        <p>
+          We used your previous year&#8217;s household income, minus certain
+          deductions, to determine your VA health care eligibility and costs for{' '}
+          {year}. Select your income range to find out how your income may have
+          affected your eligibility and costs for the year.
+        </p>
+        <p>How to estimate your household income range:</p>
+        <ul>
+          <li>
+            Add up all the money your household earned in {previousYear} from
+            jobs and other sources. Your household includes you and your spouse
+            and dependents if you have them.
+          </li>
+          <li>
+            Then subtract any deductions you had in {previousYear}. You can
+            deduct some health care costs you didn&#8217;t get paid back for,
+            expenses for your own college or vocational training, and any
+            funeral or burial expenses for a spouse or dependent child.
+          </li>
+        </ul>
+      </>
+    );
+
+    const currentFlowEligibility = `Here's what you may be eligible for:`;
+    const pastFlowEligibility = `Here's what you may have been eligible for:`;
+
+    const currentFlowDisclaimer = (
+      <p>
+        You may not be eligible for VA health care based on your income. But you
+        may still be eligible based on factors like your VA disability rating or
+        service history.
+      </p>
+    );
+
+    const pastFlowDisclaimer = (
+      <p>
+        You may not have been eligible for VA health care based on your income.
+        But you may still have been eligible based on factors like your VA
+        disability rating or service history.
+      </p>
+    );
+
+    const applyUrl = (
+      <a
+        href={APPLY_URL}
+        className="vads-u-display--block vads-u-margin-top--3 vads-u-margin-bottom--1 vads-c-action-link--green"
+      >
+        Apply for VA health care
+      </a>
+    );
 
     return (
       <>
-        <h1>Your income limits for {yearInput || currentYear}</h1>
-        <p>
-          In posuere, sem in ornare mattis, urna libero vulputate quam, a dictum
-          justo nisl non tortor. Nulla at mauris non dolor dignissim pharetra.
-          Nam ac laoreet leo, nec fringilla libero. Maecenas ac felis non augue
-          malesuada iaculis id sit amet tellus. Etiam molestie auctor neque, eu
-          pharetra lacus rhoncus at.
-        </p>
-        <p>
-          Morbi placerat nibh augue, sit amet aliquam ipsum mattis sed. Morbi
-          pellentesque fermentum tortor, ac vestibulum ligula suscipit sit amet.
-          Donec scelerisque lectus a eros pellentesque rutrum. Sed sit amet
-          varius ipsum, ut rutrum lacus. Aliquam ut pulvinar sapien, eu gravida
-          nisi.
-        </p>
-        <h2>Fusce risus lacus efficitur ac magna vitae</h2>
+        <h1>Your income limits for {year || currentYear}</h1>
+        {pastMode && pastFlowCopy}
+        {!pastMode && currentFlowCopy}
+        <va-link
+          href="https://www.va.gov/resources/va-health-care-income-limits"
+          text="Learn more about income limits and deductions"
+        />
+        <h2>Select your {previousYear} household income range</h2>
         <va-accordion bordered data-testid="il-results" open-single>
           <va-accordion-item
             data-testid="il-results-1"
             header={getFirstAccordionHeader(pension)}
           >
-            In posuere, sem in ornare mattis, urna libero vulputate quam, a
-            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
-            pharetra. Nam ac laoreet leo, nec fringilla libero.
+            <p>{pastMode ? pastFlowEligibility : currentFlowEligibility}</p>
+            <ul>
+              <li>
+                Free VA health care for most types of care (like outpatient
+                primary care, outpatient specialty care, and inpatient hospital
+                care)
+              </li>
+              <li>Free prescription medicines</li>
+              <li>
+                Travel reimbursement (meaning we&#8217;ll pay you back for the
+                cost of travel to and from health care appointments)
+              </li>
+            </ul>
+            {!pastMode && applyUrl}
           </va-accordion-item>
           <va-accordion-item
             data-testid="il-results-2"
             header={getSecondAccordionHeader(pension, national)}
           >
-            In posuere, sem in ornare mattis, urna libero vulputate quam, a
-            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
-            pharetra. Nam ac laoreet leo, nec fringilla libero.
+            <p>{pastMode ? pastFlowEligibility : currentFlowEligibility}</p>
+            <ul>
+              <li>
+                Free VA health care for most types of care (like primary care,
+                outpatient specialty care, and inpatient hospital care)
+              </li>
+              <li>Prescription medicines with copays</li>
+            </ul>
+            {!pastMode && applyUrl}
           </va-accordion-item>
-          <va-accordion-item
-            data-testid="il-results-3"
-            header={getThirdAccordionHeader(national, gmt, isStandard)}
-          >
-            In posuere, sem in ornare mattis, urna libero vulputate quam, a
-            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
-            pharetra. Nam ac laoreet leo, nec fringilla libero.
-          </va-accordion-item>
+          {isStandard && (
+            <va-accordion-item
+              data-testid="il-results-3"
+              header={getThirdAccordionHeader(national, gmt)}
+            >
+              <p>{pastMode ? pastFlowEligibility : currentFlowEligibility}</p>
+              <ul>
+                <li>
+                  VA health care with copays for most types of care (like
+                  primary and outpatient specialty care) and reduced copays for
+                  inpatient hospital care
+                </li>
+                <li>Prescription medicines with copays</li>
+              </ul>
+              {!pastMode && applyUrl}
+            </va-accordion-item>
+          )}
           <va-accordion-item
             data-testid="il-results-4"
             header={getFourthAccordionHeader(national, gmt, isStandard)}
           >
-            In posuere, sem in ornare mattis, urna libero vulputate quam, a
-            dictum justo nisl non tortor. Nulla at mauris non dolor dignissim
-            pharetra. Nam ac laoreet leo, nec fringilla libero.
+            <p>{pastMode ? pastFlowEligibility : currentFlowEligibility}</p>
+            <ul>
+              <li>
+                VA health care with copays for most types of care (like primary
+                care, outpatient specialty care, and inpatient hospital care)
+              </li>
+              <li>Prescription medicines with copays</li>
+            </ul>
+            {!pastMode && applyUrl}
           </va-accordion-item>
-          {isStandard && (
-            <va-accordion-item
-              data-testid="il-results-5"
-              header={getFifthAccordionHeader(gmt)}
-            >
-              In posuere, sem in ornare mattis, urna libero vulputate quam, a
-              justo nisl non tortor. Nulla at mauris non dolor dignissim
-              pharetra. Nam ac laoreet leo, nec fringilla libero.
-            </va-accordion-item>
-          )}
+          <va-accordion-item
+            data-testid="il-results-5"
+            header={getFifthAccordionHeader(national, gmt, isStandard)}
+          >
+            {pastMode ? pastFlowDisclaimer : currentFlowDisclaimer}
+            {!pastMode && (
+              <>
+                <va-link
+                  href="https://www.va.gov/health-care/eligibility/"
+                  text="Find out if you may be eligible for VA health care"
+                />
+                <p>
+                  We can connect you with mental health care&#8212;no matter
+                  your discharge status, service history, or eligibility for VA
+                  health care.
+                </p>
+                <va-link
+                  href="https://www.va.gov/health-care/health-needs-conditions/mental-health/"
+                  text="Find out how to get mental health care"
+                />
+                <p>You can also explore non-VA health insurance options.</p>
+                <va-link
+                  href="https://www.healthcare.gov/"
+                  text="Explore health insurance options on the HealthCare.gov website"
+                />
+              </>
+            )}
+          </va-accordion-item>
         </va-accordion>
-        <h2>Aliquam ut pulvinar sapien, eu gravida nisi</h2>
+        <va-button
+          back
+          class="vads-u-margin-top--3"
+          data-testid="il-results-back"
+          onClick={() => router.push(ROUTES.REVIEW)}
+        />
+        <h2>More helpful information</h2>
+        <ul className="il-results-more-info">
+          <li>
+            <va-link
+              href="https://www.va.gov/health-care/eligibility/"
+              text="Eligibility for VA health care"
+            />
+          </li>
+          <li>
+            <va-link
+              href="https://www.va.gov/health-care/copay-rates/"
+              text="Current VA health care copay rates"
+            />
+          </li>
+          <li>
+            <va-link
+              href="https://www.va.gov/health-care/update-health-information/"
+              text="Update your VA health benefits information"
+            />
+          </li>
+          <li>
+            <va-link
+              href="https://www.va.gov/health-care/get-reimbursed-for-travel-pay/"
+              text="VA travel pay reimbursement"
+            />
+          </li>
+          <li>
+            <va-link
+              href="https://www.va.gov/health-care/health-needs-conditions/mental-health/"
+              text="VA mental health services"
+            />
+          </li>
+          <li>
+            <va-link
+              href="https://www.va.gov/health-care/about-va-health-benefits/"
+              text="About VA health benefits"
+            />
+          </li>
+        </ul>
+        <h2>What to do if you have more questions</h2>
         <p>
-          Aenean tortor lorem, commodo quis est at, interdum mollis ipsum.
-          Suspendisse et nulla nisi.
+          Call us at{' '}
+          <va-telephone
+            className="il-results-links"
+            contact={CONTACTS['222_VETS']}
+          />{' '}
+          (
+          <va-telephone
+            className="il-results-links"
+            contact={CONTACTS[711]}
+            tty
+          />
+          ). We&#8217;re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </p>
       </>
     );
@@ -128,15 +297,15 @@ const Results = ({
 };
 
 const mapStateToProps = state => ({
-  dependentsInput: state?.incomeLimits?.form?.dependents,
+  dependents: state?.incomeLimits?.form?.dependents,
   pastMode: state?.incomeLimits?.pastMode,
   results: state?.incomeLimits?.results,
-  yearInput: state?.incomeLimits?.form?.year,
-  zipCodeInput: state?.incomeLimits?.form?.zipCode,
+  year: state?.incomeLimits?.form?.year,
+  zipCode: state?.incomeLimits?.form?.zipCode,
 });
 
 Results.propTypes = {
-  dependentsInput: PropTypes.string.isRequired,
+  dependents: PropTypes.string.isRequired,
   pastMode: PropTypes.bool.isRequired,
   results: PropTypes.shape({
     // eslint-disable-next-line camelcase
@@ -149,8 +318,8 @@ Results.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
-  zipCodeInput: PropTypes.string.isRequired,
-  yearInput: PropTypes.string,
+  zipCode: PropTypes.string.isRequired,
+  year: PropTypes.string,
 };
 
 export default connect(mapStateToProps)(Results);

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -108,15 +108,16 @@ const ReviewPage = ({
 
   return (
     <>
-      <h1>Aenean tristique mollis</h1>
+      <h1>Review your information</h1>
       <p className="il-review">
-        Fusce risus lacus, efficitur ac magna vitae, cursus lobortis dui.
+        Make any edits that you may need to. Then select{' '}
+        <strong>Continue</strong>.
       </p>
       <ul data-testid="il-review">
         {pastMode && (
           <li>
             <span data-testid="review-year">
-              <strong>Vitae:</strong>
+              <strong>Year:</strong>
               <br /> {yearInput}
             </span>
             <span className="income-limits-edit">
@@ -134,7 +135,7 @@ const ReviewPage = ({
         )}
         <li>
           <span data-testid="review-zip">
-            <strong>Nisci orci:</strong>
+            <strong>Zip code:</strong>
             <br /> {zipCodeInput}
           </span>
           <span className="income-limits-edit">
@@ -151,7 +152,7 @@ const ReviewPage = ({
         </li>
         <li>
           <span data-testid="review-dependents">
-            <strong>Malesuada felis ultrices:</strong>
+            <strong>Number of dependents:</strong>
             <br /> {dependentsInput}
           </span>
           <span className="income-limits-edit">

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -88,19 +88,16 @@ const YearPage = ({
 
   return (
     <>
-      <h1>Ipsum quia dolor sit amet consectetur adipisci velit</h1>
+      <h1>Income limits from past years going back to 2001</h1>
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non
-        tortor massa. Fusce eros mi, porttitor eu neque nec, mattis vehicula
-        urna. Integer consectetur urna ex, ac tempor urna feugiat ut.
-      </p>{' '}
+        Select the year you&#8217;d like to check income limits for. Then answer
+        2 questions to find out how your income may have affected your VA health
+        care eligibility and costs for that year.
+      </p>
       <p>
-        Curabitur euismod fermentum ante, non maximus ex feugiat quis. Fusce
-        dignissim commodo mauris. Duis posuere congue elit. Aenean ut fermentum
-        quam. Morbi faucibus lacus eu tristique tempor. Fusce at leo ipsum.
-        Maecenas at augue arcu. Duis eu lacinia ligula, quis sodales felis.
-        Praesent aliquet dictum nisl, vel rhoncus eros luctus vulputate. Nullam
-        a massa ut tellus consectetur porttitor.
+        You&#8217;ll need information about your previous year&#8217;s household
+        income and deductions to check income limits. Limits vary by where you
+        live and change each year.
       </p>
       <VaSelect
         autocomplete="false"

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { scrollToTop } from '../utilities/scroll-to-top';
+import { getPreviousYear } from '../utilities/utils';
 import { ROUTES } from '../constants';
 import {
   updateEditMode,
@@ -124,7 +125,11 @@ const ZipCodePage = ({
 
   return (
     <>
-      <h1>Donec id elit vitae sapien finibus sagittis?</h1>
+      {pastMode && year ? (
+        <h1>What was your zip code in {year - 1}?</h1>
+      ) : (
+        <h1>What was your zip code last year?</h1>
+      )}
       <form>
         <VaNumberInput
           className="input-size-3"
@@ -132,7 +137,10 @@ const ZipCodePage = ({
           error={
             (formError && 'Please enter a valid 5 digit zip code.') || null
           }
-          hint="Zip code hint text"
+          hint={`Enter the zip code for where you lived for all or most of ${getPreviousYear(
+            pastMode,
+            year,
+          )}.`}
           id="zipCode"
           inputmode="numeric"
           label="Zip code"

--- a/src/applications/income-limits/sass/income-limits.scss
+++ b/src/applications/income-limits/sass/income-limits.scss
@@ -24,4 +24,13 @@
   h1:focus {
     outline: none;
   }
+
+  .il-results-more-info {
+    padding-left: 0;
+    list-style: none;
+
+    li {
+      margin-bottom: 16px;
+    }
+  }
 }

--- a/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
@@ -75,11 +75,11 @@ describe('Review Page', () => {
     );
 
     expect(screen.getByTestId('review-zip').textContent).to.equal(
-      'Nisci orci: 10108',
+      'Zip code: 10108',
     );
 
     expect(screen.getByTestId('review-dependents').textContent).to.equal(
-      'Malesuada felis ultrices: 2',
+      'Number of dependents: 2',
     );
   });
 
@@ -91,15 +91,15 @@ describe('Review Page', () => {
     );
 
     expect(screen.getByTestId('review-year').textContent).to.equal(
-      'Vitae: 2016',
+      'Year: 2016',
     );
 
     expect(screen.getByTestId('review-zip').textContent).to.equal(
-      'Nisci orci: 60507',
+      'Zip code: 60507',
     );
 
     expect(screen.getByTestId('review-dependents').textContent).to.equal(
-      'Malesuada felis ultrices: 3',
+      'Number of dependents: 3',
     );
   });
 

--- a/src/applications/income-limits/tests/income-limits.cypress.spec.js
+++ b/src/applications/income-limits/tests/income-limits.cypress.spec.js
@@ -5,7 +5,7 @@ import nonStandardLimits from './fixtures/non-standard-fixture.json';
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
 
-// Temporarily disabling these tests because there is a flaky hector that fails 4 out of 20 times
+// Temporarily disabling these tests because there is a flaky selector that fails 4 out of 20 times
 // An upgrade to the latest Cypress fixes this problem and Platform is actively working on it
 // https://dsva.slack.com/archives/CBU0KDSB1/p1687455543337769
 xdescribe('Income Limits', () => {
@@ -315,8 +315,8 @@ xdescribe('Income Limits', () => {
       h.verifyElement(h.RESULTSPAGE);
       h.checkAccordionValue(h.RESULTS_1, '$16,037 or less', 0);
       h.checkAccordionValue(h.RESULTS_2, '$16,038 - $39,849', 1);
-      h.checkAccordionValue(h.RESULTS_3, '$39,850 - $43,834', 2);
-      h.checkAccordionValue(h.RESULTS_4, '$43,835 or more', 3);
+      h.checkAccordionValue(h.RESULTS_4, '$39,850 - $43,834', 2);
+      h.checkAccordionValue(h.RESULTS_5, '$43,835 or more', 3);
     });
   });
 

--- a/src/applications/income-limits/tests/results-accordions.unit.spec.js
+++ b/src/applications/income-limits/tests/results-accordions.unit.spec.js
@@ -52,16 +52,6 @@ describe('getSecondAccordionHeader', () => {
 });
 
 describe('getThirdAccordionHeader', () => {
-  it('should return the correct output for the non-standard case', () => {
-    expect(
-      getThirdAccordionHeader(
-        nonStandardLimits.national_threshold,
-        nonStandardLimits.gmt_threshold,
-        false,
-      ),
-    ).to.equal('$44,445 - $48,889');
-  });
-
   it('should return the correct output for the standard case', () => {
     expect(
       getThirdAccordionHeader(
@@ -70,17 +60,6 @@ describe('getThirdAccordionHeader', () => {
         true,
       ),
     ).to.equal('$44,445 - $77,777');
-  });
-
-  // Extra formatting is only for the non-standard case on the third accordion header
-  it('should return the correct output for odd numbers for the non-standard case', () => {
-    expect(
-      getThirdAccordionHeader(
-        oddLimitsNonStandard.national_threshold,
-        oddLimitsNonStandard.gmt_threshold,
-        false,
-      ),
-    ).to.equal('$60,930 - $67,022');
   });
 });
 
@@ -92,7 +71,7 @@ describe('getFourthAccordionHeader', () => {
         nonStandardLimits.gmt_threshold,
         false,
       ),
-    ).to.equal('$48,890 or more');
+    ).to.equal('$44,445 - $48,889');
   });
 
   it('should return the correct output for the standard case', () => {
@@ -112,7 +91,7 @@ describe('getFourthAccordionHeader', () => {
         oddLimitsNonStandard.gmt_threshold,
         false,
       ),
-    ).to.equal('$67,023 or more');
+    ).to.equal('$60,930 - $67,022');
   });
 
   it('should return the correct output for odd numbers for the standard case', () => {
@@ -128,13 +107,33 @@ describe('getFourthAccordionHeader', () => {
 
 // Only appears for standard case
 describe('getFifthAccordionHeader', () => {
-  it('should return the correct output for even numbers', () => {
+  it('should return the correct output for the non-standard case', () => {
+    expect(
+      getFifthAccordionHeader(
+        nonStandardLimits.national_threshold,
+        nonStandardLimits.gmt_threshold,
+        false,
+      ),
+    ).to.equal('$48,890 or more');
+  });
+
+  it('should return the correct output for odd numbers for the non-standard case', () => {
+    expect(
+      getFifthAccordionHeader(
+        oddLimitsNonStandard.national_threshold,
+        oddLimitsNonStandard.gmt_threshold,
+        false,
+      ),
+    ).to.equal('$67,023 or more');
+  });
+
+  it('should return the correct output for the standard case', () => {
     expect(getFifthAccordionHeader(limits.gmt_threshold)).to.equal(
       '$85,556 or more',
     );
   });
 
-  it('should return the correct output for odd numbers', () => {
+  it('should return the correct output for odd numbers for the standard case', () => {
     expect(getFifthAccordionHeader(oddLimits.gmt_threshold)).to.equal(
       '$55,674 or more',
     );

--- a/src/applications/income-limits/tests/utils.unit.spec.js
+++ b/src/applications/income-limits/tests/utils.unit.spec.js
@@ -1,0 +1,69 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { getPreviousYear, redirectIfFormIncomplete } from '../utilities/utils';
+
+const pushStub = sinon.stub();
+const router = {
+  push: pushStub,
+};
+
+describe('utilities', () => {
+  afterEach(() => {
+    pushStub.resetHistory();
+  });
+
+  describe('redirectIfFormIncomplete', () => {
+    // No zip or dependents
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('', false, router, '', '');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+
+    // No zip
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('0', false, router, '', '');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+
+    // No dependents
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('', false, router, '', '78258');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+
+    // Past mode - no inputs
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('', true, router, '', '');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+
+    // Past mode - no zip
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('0', true, router, '2019', '');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+
+    // Past mode - no year
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('0', true, router, '', '78258');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+
+    // Past mode - no dependents
+    it('should navigate the user to the homepage only if the criteria are met', () => {
+      redirectIfFormIncomplete('', true, router, '2019', '78258');
+      expect(pushStub.withArgs('introduction').calledOnce).to.be.true;
+    });
+  });
+
+  describe('getPreviousYear', () => {
+    it('should return the correct year if pastMode is true', () => {
+      expect(getPreviousYear(true, '2017')).to.eq(2016);
+    });
+
+    it('should return the correct year if pastMode is false', () => {
+      const previousYear = new Date().getFullYear() - 1;
+      expect(getPreviousYear(false, '')).to.eq(previousYear);
+    });
+  });
+});

--- a/src/applications/income-limits/utilities/results-accordions.js
+++ b/src/applications/income-limits/utilities/results-accordions.js
@@ -22,13 +22,7 @@ export const getSecondAccordionHeader = (pension, national) => {
 // ACCORDION 3
 // Non-standard: national_threshold + $1 through national_threshold + 10%
 // Standard: national_threshold + $1 through gmt_threshold
-export const getThirdAccordionHeader = (national, gmt, isStandard) => {
-  if (!isStandard) {
-    return `${formatter.format(national + 1)} - ${formatter.format(
-      Math.ceil(national * 1.1).toFixed(),
-    )}`;
-  }
-
+export const getThirdAccordionHeader = (national, gmt) => {
   return `${formatter.format(national + 1)} - ${formatter.format(gmt)}`;
 };
 
@@ -37,9 +31,9 @@ export const getThirdAccordionHeader = (national, gmt, isStandard) => {
 // Standard: gmt_threshold + $1 through gmt_threshold + 10%
 export const getFourthAccordionHeader = (national, gmt, isStandard) => {
   if (!isStandard) {
-    return `${formatter.format(
-      Math.ceil((national * 1.1).toFixed(2)) + 1,
-    )} or more`;
+    return `${formatter.format(national + 1)} - ${formatter.format(
+      Math.ceil(national * 1.1).toFixed(),
+    )}`;
   }
 
   return `${formatter.format(gmt + 1)} - ${formatter.format(
@@ -49,6 +43,12 @@ export const getFourthAccordionHeader = (national, gmt, isStandard) => {
 
 // ACCORDION 5 (does not appear for Non-standard case)
 // Geographic threshold + 10% + $1 "or more"
-export const getFifthAccordionHeader = gmt => {
+export const getFifthAccordionHeader = (national, gmt, isStandard) => {
+  if (!isStandard) {
+    return `${formatter.format(
+      Math.ceil((national * 1.1).toFixed(2)) + 1,
+    )} or more`;
+  }
+
   return `${formatter.format(Math.ceil((gmt * 1.1).toFixed(2)) + 1)} or more`;
 };

--- a/src/applications/income-limits/utilities/utils.js
+++ b/src/applications/income-limits/utilities/utils.js
@@ -17,3 +17,10 @@ export const redirectIfFormIncomplete = (
     router.push(ROUTES.HOME);
   }
 };
+
+// Income limits are always based on the previous year's data
+// This gets the previous year from either the current year or from the
+// veteran-selected year
+export const getPreviousYear = (pastMode, year) => {
+  return pastMode && year ? year - 1 : new Date().getFullYear() - 1;
+};


### PR DESCRIPTION
## Summary
Adding real content into the Income Limits app.

Some notes:
- The content is written to drop the 3rd accordion on the Results page for the Jonesboro (non-standard) case. Previously I had re-numbered the accordions (simply 1-4), but it made more sense to track the accordion logic to match the content (non-standard = 1, 2, 4, 5). So there are some changes related to this.
- Added a fix to drop leading zeroes off the Dependents field. Re-tested with `'02'`, `'007'`, `'2'`, etc.
- Content is based on [this Word doc](https://dvagov-my.sharepoint.com/:w:/g/personal/wesley_rowe_va_gov/EVGex-FjRcBDo11XO6EV6zwBbH8yKyLCfPYVmwBhBGex9Q?e=EUNd2O) (CAG required)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13750

## Testing done
All tested locally. Logic for accordions was re-tested as well.

## Screenshots
All screenshots are in a comment in [the ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13750#issuecomment-1642441644).

## Acceptance criteria
- [x] Each screen in both current-year and previous-year flows matches exactly what's in the Word doc linked above.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.