### PR TITLE
DHP-917 add google site verification meta tag to dhp page

### DIFF
--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -19,6 +19,10 @@ export default function App() {
     <div className="usa-grid-full margin landing-page">
       <MetaTags>
         <meta name="robots" content="noindex" />
+        <meta
+          name="google-site-verification"
+          content="scLJgpqcnJ33AfSYWbB9cdebuyOuHWWWoW_zdeyYNc4"
+        />
       </MetaTags>
       <div className="usa-width-three-fourths">
         <article className="usa-content">


### PR DESCRIPTION
## Summary

We want Google to not show results for the VA DHP page. To do this we need to add a `meta` tag to verify we own the page.

## Testing done
-  manual testing was done.

## Acceptance criteria
- Google can verify the site
- 
### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
