### PR TITLE
File upload | Prevent focus on init

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -91,6 +91,7 @@ const FileField = props => {
   );
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [removeIndex, setRemoveIndex] = useState(null);
+  const [initialized, setInitialized] = useState(false);
 
   const previousValue = usePreviousValue(formData);
   const fileInputRef = useRef(null);
@@ -175,7 +176,7 @@ const FileField = props => {
         'vads-u-display--none',
         !checkUploadVisibility(),
       );
-      if (files.length !== prevFiles.length) {
+      if (initialized && files.length !== prevFiles.length) {
         focusAddAnotherButton();
       }
 
@@ -184,6 +185,9 @@ const FileField = props => {
       setIsUploading(hasUploading);
       if (hasUploading && !wasUploading) {
         setProgress(0);
+      }
+      if (!initialized) {
+        setInitialized(true);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -186,30 +186,30 @@ const FileField = props => {
       if (hasUploading && !wasUploading) {
         setProgress(0);
       }
-      if (!initialized) {
-        setInitialized(true);
-      }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [formData],
   );
 
-  useEffect(() => {
-    // The File object is not preserved in the save-in-progress data
-    // We need to remove these entries; an empty `file` is included in the
-    // entry, but if API File Object still exists (within the same session), we
-    // can't use Object.keys() on it because it returns an empty array
-    const newData = files.filter(
-      // keep - file may not exist (already uploaded)
-      // keep - file may contain File object; ensure name isn't empty
-      // remove - file may be an empty object
-      data => !data.file || (data.file?.name || '') !== '',
-    );
-
-    if (newData.length !== files.length) {
-      onChange(newData);
-    }
-  });
+  useEffect(
+    () => {
+      // The File object is not preserved in the save-in-progress data
+      // We need to remove these entries; an empty `file` is included in the
+      // entry, but if API File Object still exists (within the same session), we
+      // can't use Object.keys() on it because it returns an empty array
+      const newData = files.filter(
+        // keep - file may not exist (already uploaded)
+        // keep - file may contain File object; ensure name isn't empty
+        // remove - file may be an empty object
+        data => !data.file || (data.file?.name || '') !== '',
+      );
+      if (newData.length !== files.length) {
+        onChange(newData);
+      }
+      setInitialized(true);
+    },
+    [files, onChange],
+  );
 
   /**
    * Add file to list and upload
@@ -461,7 +461,7 @@ const FileField = props => {
                 } else {
                   focusElement('.usa-input-error, .input-error-date, [error]');
                 }
-              }, 100);
+              }, 250);
             } else if (showPasswordInput) {
               setTimeout(() => {
                 const passwordInput = $(`[name="get_password_${index}"]`);


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > After the work from #24787 was merged, and testing was performed on staging. Our team noticed that the initial focus was _always_ sent to the add (another) upload button. In our form initial focus is moved to the page `H3` after a delay causing the page to jump, and returning to the page from our summary page via editing moved focus to the add button instead of focusing on the intended target.
  >
  > This PR adds an init flag to prevent initial focus on the add (another) upload button
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Prevent auto-focus on init
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#58596](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58596)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Focus initially sent to the upload button
- _Describe the steps required to verify your changes are working as expected_
  > Test in instance review
- _Describe the tests completed and the results_
  > No new tests added - all test remain passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All apps that use the platform file upload

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
