### PR TITLE
File upload | Fix button labels & focus

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -108,10 +108,14 @@ const FileField = props => {
   const content = {
     upload: uiOptions.buttonText || 'Upload',
     uploadAnother: uiOptions.addAnotherLabel || 'Upload another',
+    passwordLabel: fileName => `Add a password for ${fileName}`,
     tryAgain: 'Try again',
+    tryAgainLabel: fileName => `Try uploading ${fileName} again`,
     newFile: 'Upload a new file',
     cancel: 'Cancel',
+    cancelLabel: fileName => `Cancel upload of ${fileName}`,
     delete: 'Delete file',
+    deleteLabel: fileName => `Delete ${fileName}`,
     modalTitle:
       uiOptions.modalTitle || 'Are you sure you want to remove this issue?',
     modalContent: fileName =>
@@ -384,7 +388,7 @@ const FileField = props => {
 
   const deleteThenAddFile = index => {
     removeFile(index, false);
-    fileButtonRef.current.click();
+    fileInputRef.current.click();
   };
 
   const getRetryFunction = (allowRetry, index, file) => {
@@ -455,7 +459,8 @@ const FileField = props => {
               setTimeout(() => {
                 scrollToFirstError();
                 if (enableShortWorkflow) {
-                  focusElement(`[name="retry_upload_${index}"]`);
+                  const retryButton = $(`[name="retry_upload_${index}"]`);
+                  focusElement('button', {}, retryButton?.shadowRoot);
                 } else if (showPasswordInput) {
                   focusElement(`#${fileListId} .usa-input-error-message`);
                 } else {
@@ -504,8 +509,7 @@ const FileField = props => {
                       onClick={() => {
                         cancelUpload(index);
                       }}
-                      aria-describedby={fileNameId}
-                      label="Cancel Upload"
+                      label={content.cancelLabel(file.name)}
                       text={content.cancel}
                     />
                   </div>
@@ -572,7 +576,7 @@ const FileField = props => {
                     file={file.file}
                     index={index}
                     onSubmitPassword={onSubmitPassword}
-                    ariaDescribedby={fileNameId}
+                    passwordLabel={content.passwordLabel(file.name)}
                   />
                 )}
                 {!formContext.reviewMode &&
@@ -588,7 +592,11 @@ const FileField = props => {
                               index,
                               file.file,
                             )}
-                            aria-describedby={fileNameId}
+                            label={
+                              allowRetry
+                                ? content.tryAgainLabel(file.name)
+                                : content.newFile
+                            }
                             text={retryButtonText}
                           />
                         )}
@@ -598,7 +606,7 @@ const FileField = props => {
                         onClick={() => {
                           openRemoveModal(index);
                         }}
-                        aria-describedby={fileNameId}
+                        label={content.deleteLabel(file.name)}
                         text={deleteButtonText}
                       />
                     </div>

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
 import { focusElement } from '../ui';
 
 const ShowPdfPassword = ({
   file,
   index,
   onSubmitPassword,
-  ariaDescribedby = null,
+  passwordLabel = null,
   testVal = '', // for testing
 }) => {
   const [value, setValue] = useState(testVal);
@@ -35,7 +37,7 @@ const ShowPdfPassword = ({
 
   return (
     <div className="vads-u-margin-bottom--2">
-      <va-text-input
+      <VaTextInput
         ref={inputRef}
         label="PDF password"
         error={(dirty && !value && errorMessage) || null}
@@ -44,7 +46,7 @@ const ShowPdfPassword = ({
         value={value}
         onInput={({ target }) => setValue(target.value || '')}
         onBlur={() => setDirty(true)}
-        aria-describedby={ariaDescribedby}
+        messageAriaDescribedby={passwordLabel}
       />
       <va-button
         className="vads-u-width--auto"
@@ -58,16 +60,16 @@ const ShowPdfPassword = ({
             setFocus();
           }
         }}
-        aria-describedby={ariaDescribedby}
+        label={passwordLabel}
       />
     </div>
   );
 };
 
 ShowPdfPassword.propTypes = {
-  ariaDescribedby: PropTypes.string,
   file: PropTypes.shape({}),
   index: PropTypes.number,
+  passwordLabel: PropTypes.string,
   testVal: PropTypes.string,
   onSubmitPassword: PropTypes.func,
 };

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -74,7 +74,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
       },
     ];
     const registry = {
@@ -95,7 +95,7 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect($('li', container).textContent).to.contain('Test file name');
+    expect($('li', container).textContent).to.contain('Test file name.pdf');
   });
 
   it('should remove files with empty file object when initializing', async () => {
@@ -114,21 +114,21 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test1',
+        name: 'Test1.png',
       },
       {
         file: {},
-        name: 'Test2',
+        name: 'Test2.pdf',
       },
       {
         file: {
           name: 'fake', // should never happen
         },
-        name: 'Test3',
+        name: 'Test3.txt',
       },
       {
-        file: new File([1, 2, 3], 'Test3'),
-        name: 'Test4',
+        file: new File([1, 2, 3], 'Test4.jpg'),
+        name: 'Test4.jpg',
       },
     ];
     const registry = {
@@ -154,7 +154,7 @@ describe('Schemaform <FileField>', () => {
       expect(onChange.calledOnce).to.be.true;
       expect(onChange.firstCall.args[0].length).to.equal(3);
       // empty file object was removed;
-      expect(onChange.firstCall.args[0][1].name).to.equal('Test3');
+      expect(onChange.firstCall.args[0][1].name).to.equal('Test3.txt');
     });
   });
 
@@ -174,7 +174,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
       },
     ];
     const registry = {
@@ -227,6 +227,7 @@ describe('Schemaform <FileField>', () => {
     const uiSchema = fileUploadUI('Files');
     const formData = [
       {
+        name: 'Test.pdf',
         uploading: true,
       },
     ];
@@ -252,7 +253,7 @@ describe('Schemaform <FileField>', () => {
     const button = $('.cancel-upload', container);
     expect(button).to.exist;
     expect(button.getAttribute('text')).to.eq('Cancel');
-    expect(button.getAttribute('aria-describedby')).to.eq('field_file_name_0');
+    expect(button.getAttribute('label')).to.eq('Cancel upload of Test.pdf');
   });
 
   it('should show progress', () => {
@@ -365,7 +366,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
       },
     ];
     const registry = {
@@ -405,7 +406,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
       },
     ];
     const registry = {
@@ -446,7 +447,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
         size: 12345678,
       },
     ];
@@ -472,7 +473,7 @@ describe('Schemaform <FileField>', () => {
     expect($('.delete-upload', container)).to.exist;
 
     const text = $('li', container).textContent;
-    expect(text).to.include('Test file name');
+    expect(text).to.include('Test file name.pdf');
     expect(text).to.include('12MB');
   });
 
@@ -832,7 +833,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
         size: 987654,
       },
     ];
@@ -858,12 +859,12 @@ describe('Schemaform <FileField>', () => {
     );
 
     const text = $('li').textContent;
-    expect(text).to.contain('Test file name');
+    expect(text).to.contain('Test file name.pdf');
     expect(text).to.contain('965KB');
 
     const deleteButton = $('.delete-upload', container);
-    expect(deleteButton?.getAttribute('aria-describedby')).to.eq(
-      'field_file_name_0',
+    expect(deleteButton?.getAttribute('label')).to.eq(
+      'Delete Test file name.pdf',
     );
 
     // check ids & index passed into SchemaField
@@ -915,6 +916,7 @@ describe('Schemaform <FileField>', () => {
     });
     const formData = [
       {
+        name: 'Test file name.pdf',
         attachmentId: '1234',
       },
     ];
@@ -939,9 +941,9 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect(
-      $('.delete-upload', container).getAttribute('aria-describedby'),
-    ).to.eq('field_file_name_0');
+    expect($('.delete-upload', container).getAttribute('label')).to.eq(
+      'Delete Test file name.pdf',
+    );
 
     // check ids & index passed into SchemaField
     const { widgetProps } = testProps.uiSchema['ui:options'];
@@ -987,7 +989,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
       },
     ];
     const registry = {
@@ -1044,7 +1046,7 @@ describe('Schemaform <FileField>', () => {
     const formData = [
       {
         confirmationCode: 'abcdef',
-        name: 'Test file name',
+        name: 'Test file name.pdf',
       },
     ];
     const registry = {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Pointers to the file name were set using `aria-describedby` on the `va-button` which did not work as expected. This fix adds a custom `label` to the `va-button` which in turn applies the content to the internal button's `aria-label`.
  > - Fix focus of the `enableShortWorkflow` (which isn't used anywhere?) retry button to focus on the internal `button` & make the `onClick` trigger the actual input instead of the (hidden) button inside the label (bug fix)
  > - Updated unit tests
- _(If bug, how to reproduce)_
  > Test file upload delete & cancel while using a screen reader
- _(What is the solution, why is this the solution)_
  > An `aria-label` was added to every file form button
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#58596](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58596)
- [Design docs comment #1770](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1770#issuecomment-1631209057)

## Testing done

- _Describe what the old behavior was prior to the change_
  > "Delete file" was read out by the screen reader - these buttons were not distinguishable from each other
- _Describe the steps required to verify your changes are working as expected_
  > Add `aria-label` text which includes the file name
- _Describe the tests completed and the results_
  > Updated unit test to check these changes
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All apps that use platform's `FileField`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
