### PR TITLE
DHP-917 remove google site verification for dhp page

### DIFF
--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -19,10 +19,6 @@ export default function App() {
     <div className="usa-grid-full margin landing-page">
       <MetaTags>
         <meta name="robots" content="noindex" />
-        <meta
-          name="google-site-verification"
-          content="scLJgpqcnJ33AfSYWbB9cdebuyOuHWWWoW_zdeyYNc4"
-        />
       </MetaTags>
       <div className="usa-width-three-fourths">
         <article className="usa-content">


### PR DESCRIPTION
## Summary
We're removing the google site verification meta tag for the dhp connected devices page. Instead of trying to get Google to recrawl our page, we'll raise a support ticket with vfs-platform-support to see if they can recrawl our page.

## Testing done
Manual testing that the meta tag is removed.

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
The `google-site-verification` meta tag is removed for the dhp connected devices page

### Error Handling

- [x] Browser console contains no warnings or errors.
