### PR TITLE
Fix right margin alignment

### DIFF
--- a/src/applications/vaos/appointment-list/components/PageLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/PageLayout.jsx
@@ -10,7 +10,6 @@ export default function PageLayout({
   children,
   showBreadcrumbs,
   showNeedHelp,
-  style,
 }) {
   const featureAppointmentList = useSelector(state =>
     selectFeatureAppointmentList(state),
@@ -21,8 +20,7 @@ export default function PageLayout({
       {showBreadcrumbs && <Breadcrumbs />}
       <div className="vads-l-row">
         <div
-          style={{ ...style }}
-          className={classNames('vads-l-col--12', 'vads-u-margin--2', {
+          className={classNames('vads-l-col--12', 'vads-u-margin-y--2', {
             'medium-screen:vads-l-col--8': !featureAppointmentList,
           })}
         >

--- a/src/applications/vaos/components/BackLink.jsx
+++ b/src/applications/vaos/components/BackLink.jsx
@@ -35,14 +35,16 @@ export default function BackLink({ appointment }) {
       className="backLinkContainer"
       aria-describedby="vaos-hide-for-print backLink"
     >
-      <div aria-hidden style={{ color: '#0753A3', marginRight: '0.5rem' }}>
+      <div
+        aria-hidden
+        className="vads-u-color--link-default vads-u-margin-right--1"
+      >
         ‹
       </div>
       <NavLink
-        style={{ color: '#0753A3' }}
         aria-label={handleBackLinkText()}
         to={handleBackLink()}
-        className="vaos-hide-for-print backLink"
+        className="vaos-hide-for-print vads-u-color--link-default"
       >
         {handleBackLinkText()}
       </NavLink>

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -641,7 +641,7 @@ const responses = {
         { name: 'vaOnlineSchedulingRequestFlowUpdate', value: true },
         { name: 'vaOnlineSchedulingConvertUtcToLocal', value: false },
         { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: false },
-        { name: 'vaOnlineSchedulingPrintList', value: false },
+        { name: 'vaOnlineSchedulingPrintList', value: true },
         { name: 'va_online_scheduling_descriptive_back_link', value: true },
         { name: 'selectFeaturePocTypeOfCare', value: true },
         { name: 'edu_section_103', value: true },


### PR DESCRIPTION
## Summary
The right margin of the appointment list is too close to the right edge in all the screen views

## Acceptance criteria

- [ ] adjust the right margin to have the same gutter (spacing) as that of the left margin

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61727


## Testing done

n/a

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |     ![Screenshot 2023-07-10 at 2 57 59 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/b89584b6-9b2e-4182-ae7b-9e28b67e0401)   |    ![Screenshot 2023-07-11 at 4 49 34 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/11dd2141-b72b-4b9d-8fe4-d6b746e91777)   |
| Desktop |   ![Screenshot 2023-07-10 at 3 03 35 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/484c9127-ad88-4dcf-a1a4-52aee86aee4f)   |   ![Screenshot 2023-07-11 at 4 51 00 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/806c61b7-0c98-4028-8f72-1f15645119f5)    |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

