### PR TITLE
Simple forms: 21-0972 Confirmation page remove Philippine Claims accordion

### DIFF
--- a/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
@@ -182,25 +182,6 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Philippine claims" id="eleventh">
-        <ul>
-          <li>
-            <a href="/find-forms/about-form-21p-0784">
-              Supplemental Income Questionnaire (VA Form 21-0784)
-            </a>
-          </li>
-          <li>
-            {/* 
-              TODO: Determine if we need this, 
-              cannot find form in va.gov/find-forms
-            */}
-            <a href="/find-forms">
-              Supplement to VA Forms 21-526EZ, 21P-534EZ, and 21P-535 (For
-              Philippine Claims) (VA Form 21-4169)
-            </a>
-          </li>
-        </ul>
-      </va-accordion-item>
       <va-accordion-item header="Post-tramatic stress disorder" id="twelfth">
         <ul>
           <li>


### PR DESCRIPTION
## Summary

- Remove accordion we don't have links for

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/362

## Testing done

- Verified locally

## Screenshots

Before
![Screenshot 2023-07-12 at 2 23 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/f4f5f203-a211-4b29-8e4a-26daf31760b4)

After
![Screenshot 2023-07-12 at 2 24 06 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/5d6ed07c-1eb0-4abd-93dc-a01e43c4b52c)


## What areas of the site does it impact?
21-0972 (non prod)
