### PR TITLE
Enable Isolated Application Builds for MHV on VA.gov

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -57,6 +57,10 @@
       "slackGroup": "<@U0329KDCJ0Y> <@U031KTDNYEP>"
     },
     {
+      "rootFolder": "mhv",
+      "slackGroup": "@mhv-on-va-gov-group"
+    },
+    {
       "rootFolder": "mhv-inherited-proofing",
       "slackGroup": "@vsp-identity-group"
     },


### PR DESCRIPTION
## Summary

See title.

Following the instructions from "FE Docs > Isolated App Builds > [How to add your application to the allow-list](https://depo-platform-documentation.scrollhelp.site/developer-docs/how-to-add-your-application-to-the-allow-list)"

## Related issue(s)

department-of-veterans-affairs/va.gov-team#61867

