### PR TITLE
Change tertiary print button text to uppercase

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/PrintButton.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/PrintButton.jsx
@@ -12,9 +12,19 @@ const handleClick = () => {
 export default function PrintButton() {
   return (
     <div className="vaos-hide-for-print">
-      <button className="tertiary-button" onClick={handleClick()} type="button">
-        <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
-        Print
+      <button
+        className="tertiary-button"
+        onClick={handleClick()}
+        type="button"
+        aria-label="print list"
+        id="print-list"
+      >
+        <i
+          aria-hidden="true"
+          className="fas fa-print"
+          style={{ paddingRight: '6px' }}
+        />
+        PRINT
       </button>
     </div>
   );

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -641,7 +641,7 @@ const responses = {
         { name: 'vaOnlineSchedulingRequestFlowUpdate', value: true },
         { name: 'vaOnlineSchedulingConvertUtcToLocal', value: false },
         { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: false },
-        { name: 'vaOnlineSchedulingPrintList', value: false },
+        { name: 'vaOnlineSchedulingPrintList', value: true },
         { name: 'va_online_scheduling_descriptive_back_link', value: true },
         { name: 'selectFeaturePocTypeOfCare', value: true },
         { name: 'edu_section_103', value: true },

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
@@ -421,4 +421,30 @@ describe('VAOS <AppointmentsPageV2>', () => {
       );
     });
   });
+
+  describe('when print list flag is on', () => {
+    const defaultState = {
+      featureToggles: {
+        ...initialState.featureToggles,
+        vaOnlineSchedulingDirect: true,
+        vaOnlineSchedulingCommunityCare: false,
+        vaOnlineSchedulingStatusImprovement: true,
+        vaOnlineSchedulingPrintList: true,
+      },
+      user: userState,
+    };
+
+    it('should show tertiary print button', async () => {
+      // Given the veteran lands on the VAOS homepage
+      mockPastAppointmentInfo({});
+
+      // When the page displays
+      const screen = renderWithStoreAndRouter(<AppointmentsPageV2 />, {
+        initialState: defaultState,
+      });
+
+      // Then it should display the tertiary print button
+      expect(screen.getByRole('button', { name: 'print list' })).to.be.ok;
+    });
+  });
 });


### PR DESCRIPTION
## Summary
The print button needs to be in all caps to match the VA.gov design system. We also need to match the spacing between the icon and the text.

## Acceptance criteria
- [x]  Print is in all caps.
- [x]  6px between icon and text


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61769


## Testing done

unit test

## Screenshots

![Screenshot 2023-07-12 at 12 46 25 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/57b386b3-a26c-4449-8c35-fc691400c6cd)


## What areas of the site does it impact?

vaos tertiary print button



