### PR TITLE
feat: add GA source for rating info endpoint action

### DIFF
--- a/src/applications/personalization/rated-disabilities/actions/index.js
+++ b/src/applications/personalization/rated-disabilities/actions/index.js
@@ -71,6 +71,9 @@ export function fetchTotalDisabilityRating(recordAnalyticsEvent = recordEvent) {
       type: FETCH_TOTAL_RATING_STARTED,
     });
     const response = await getData('/disability_compensation_form/rating_info');
+    const source = response?.source;
+    const sourceString = source ? ` - ${source}` : '';
+    const apiName = `GET disability rating${sourceString}`;
 
     const error = getResponseError(response);
     if (error) {
@@ -79,14 +82,14 @@ export function fetchTotalDisabilityRating(recordAnalyticsEvent = recordEvent) {
         recordAnalyticsEvent({
           event: `api_call`,
           'error-key': `${errorCode} internal error`,
-          'api-name': 'GET disability rating',
+          'api-name': apiName,
           'api-status': 'failed',
         });
       } else if (isClientError(errorCode)) {
         recordAnalyticsEvent({
           event: `api_call`,
           'error-key': `${errorCode} no combined rating found`,
-          'api-name': 'GET disability rating',
+          'api-name': apiName,
           'api-status': 'failed',
         });
       }
@@ -95,12 +98,9 @@ export function fetchTotalDisabilityRating(recordAnalyticsEvent = recordEvent) {
         error,
       });
     } else {
-      const source = response?.source;
-      const sourceString = source ? ` - ${source}` : '';
-
       recordAnalyticsEvent({
         event: `api_call`,
-        'api-name': `GET disability rating${sourceString}`,
+        'api-name': apiName,
         'api-status': 'successful',
       });
       dispatch({

--- a/src/applications/personalization/rated-disabilities/actions/index.js
+++ b/src/applications/personalization/rated-disabilities/actions/index.js
@@ -65,7 +65,7 @@ function getResponseError(response) {
   return null;
 }
 
-export function fetchTotalDisabilityRating() {
+export function fetchTotalDisabilityRating(recordAnalyticsEvent = recordEvent) {
   return async dispatch => {
     dispatch({
       type: FETCH_TOTAL_RATING_STARTED,
@@ -76,14 +76,14 @@ export function fetchTotalDisabilityRating() {
     if (error) {
       const errorCode = error.code;
       if (isServerError(errorCode)) {
-        recordEvent({
+        recordAnalyticsEvent({
           event: `api_call`,
           'error-key': `${errorCode} internal error`,
           'api-name': 'GET disability rating',
           'api-status': 'failed',
         });
       } else if (isClientError(errorCode)) {
-        recordEvent({
+        recordAnalyticsEvent({
           event: `api_call`,
           'error-key': `${errorCode} no combined rating found`,
           'api-name': 'GET disability rating',
@@ -95,9 +95,12 @@ export function fetchTotalDisabilityRating() {
         error,
       });
     } else {
-      recordEvent({
+      const source = response?.source;
+      const sourceString = source ? ` - ${source}` : '';
+
+      recordAnalyticsEvent({
         event: `api_call`,
-        'api-name': 'GET disability rating',
+        'api-name': `GET disability rating${sourceString}`,
         'api-status': 'successful',
       });
       dispatch({

--- a/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
@@ -70,11 +70,11 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
   });
 });
 
-describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
+describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
   beforeEach(() => mockFetch());
 
   it('should fetch the total rating', () => {
-    const total = { userPercentOfDisability: 80 };
+    const total = { data: { attributes: { userPercentOfDisability: 80 } } };
 
     setFetchJSONResponse(global.fetch.onCall(0), total);
 
@@ -88,6 +88,94 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
         );
       }
     };
+    thunk(dispatch);
+  });
+
+  it('should attach the appropriate source to the analytics event when EVSS is source', () => {
+    const total = {
+      data: { attributes: { userPercentOfDisability: 80, source: 'EVSS' } },
+    };
+    setFetchJSONResponse(global.fetch.onCall(0), total);
+
+    const analyticsSpy = sinon.spy();
+
+    const thunk = fetchTotalDisabilityRating(analyticsSpy);
+
+    const dispatchSpy = sinon.spy();
+
+    const dispatch = action => {
+      dispatchSpy(action);
+
+      if (dispatchSpy.callCount === 2) {
+        expect(analyticsSpy.calledOnce).to.be.true;
+
+        expect(analyticsSpy.firstCall.args[0]['api-name'].includes('EVSS')).to
+          .be.true;
+      }
+    };
+
+    thunk(dispatch);
+  });
+
+  it('should attach the appropriate source to the analytics event when Lighthouse is source', () => {
+    const total = {
+      data: {
+        attributes: { userPercentOfDisability: 80, source: 'Lighthouse' },
+      },
+    };
+    setFetchJSONResponse(global.fetch.onCall(0), total);
+
+    const analyticsSpy = sinon.spy();
+
+    const thunk = fetchTotalDisabilityRating(analyticsSpy);
+
+    const dispatchSpy = sinon.spy();
+
+    const dispatch = action => {
+      dispatchSpy(action);
+
+      if (dispatchSpy.callCount === 2) {
+        expect(analyticsSpy.calledOnce).to.be.true;
+
+        expect(
+          analyticsSpy.firstCall.args[0]['api-name'].includes('Lighthouse'),
+        ).to.be.true;
+      }
+    };
+
+    thunk(dispatch);
+  });
+
+  it('should fourmat analytics string without source if it is not present in response, but still succeed', () => {
+    const total = {
+      data: {
+        attributes: { userPercentOfDisability: 80 },
+      },
+    };
+    setFetchJSONResponse(global.fetch.onCall(0), total);
+
+    const analyticsSpy = sinon.spy();
+
+    const thunk = fetchTotalDisabilityRating(analyticsSpy);
+
+    const dispatchSpy = sinon.spy();
+
+    const dispatch = action => {
+      dispatchSpy(action);
+
+      if (dispatchSpy.callCount === 2) {
+        expect(analyticsSpy.calledOnce).to.be.true;
+
+        expect(analyticsSpy.firstCall.args[0]['api-name']).to.equal(
+          'GET disability rating',
+        );
+
+        expect(dispatchSpy.secondCall.args[0].type).to.equal(
+          FETCH_TOTAL_RATING_SUCCEEDED,
+        );
+      }
+    };
+
     thunk(dispatch);
   });
 

--- a/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
@@ -4,7 +4,7 @@ import {
   mockFetch,
   setFetchJSONFailure,
   setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+} from '~/platform/testing/unit/helpers';
 
 import {
   FETCH_RATED_DISABILITIES_SUCCESS,
@@ -75,9 +75,7 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
 
   it('should fetch the total rating', () => {
     const total = { data: { attributes: { userPercentOfDisability: 80 } } };
-
     setFetchJSONResponse(global.fetch.onCall(0), total);
-
     const thunk = fetchTotalDisabilityRating();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -96,19 +94,14 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
       data: { attributes: { userPercentOfDisability: 80, source: 'EVSS' } },
     };
     setFetchJSONResponse(global.fetch.onCall(0), total);
-
     const analyticsSpy = sinon.spy();
-
     const thunk = fetchTotalDisabilityRating(analyticsSpy);
-
     const dispatchSpy = sinon.spy();
-
     const dispatch = action => {
       dispatchSpy(action);
 
       if (dispatchSpy.callCount === 2) {
         expect(analyticsSpy.calledOnce).to.be.true;
-
         expect(analyticsSpy.firstCall.args[0]['api-name'].includes('EVSS')).to
           .be.true;
       }
@@ -124,19 +117,14 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
       },
     };
     setFetchJSONResponse(global.fetch.onCall(0), total);
-
     const analyticsSpy = sinon.spy();
-
     const thunk = fetchTotalDisabilityRating(analyticsSpy);
-
     const dispatchSpy = sinon.spy();
-
     const dispatch = action => {
       dispatchSpy(action);
 
       if (dispatchSpy.callCount === 2) {
         expect(analyticsSpy.calledOnce).to.be.true;
-
         expect(
           analyticsSpy.firstCall.args[0]['api-name'].includes('Lighthouse'),
         ).to.be.true;
@@ -153,29 +141,53 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
       },
     };
     setFetchJSONResponse(global.fetch.onCall(0), total);
-
     const analyticsSpy = sinon.spy();
-
     const thunk = fetchTotalDisabilityRating(analyticsSpy);
-
     const dispatchSpy = sinon.spy();
-
     const dispatch = action => {
       dispatchSpy(action);
 
       if (dispatchSpy.callCount === 2) {
         expect(analyticsSpy.calledOnce).to.be.true;
-
         expect(analyticsSpy.firstCall.args[0]['api-name']).to.equal(
           'GET disability rating',
         );
-
         expect(dispatchSpy.secondCall.args[0].type).to.equal(
           FETCH_TOTAL_RATING_SUCCEEDED,
         );
       }
     };
 
+    thunk(dispatch);
+  });
+
+  it('should pass source to error analytics call if present', () => {
+    const response = {
+      data: {
+        attributes: { source: 'EVSS' },
+      },
+      errors: [
+        {
+          code: '500',
+          status: 'some status',
+        },
+      ],
+    };
+    setFetchJSONResponse(global.fetch.onCall(0), response);
+    const analyticsSpy = sinon.spy();
+    const thunk = fetchTotalDisabilityRating(analyticsSpy);
+    const dispatchSpy = sinon.spy();
+    const dispatch = action => {
+      dispatchSpy(action);
+      if (dispatchSpy.callCount === 2) {
+        expect(dispatchSpy.secondCall.args[0].type).to.equal(
+          FETCH_TOTAL_RATING_FAILED,
+        );
+        expect(analyticsSpy.calledOnce).to.be.true;
+        expect(analyticsSpy.firstCall.args[0]['api-name'].includes('EVSS')).to
+          .be.true;
+      }
+    };
     thunk(dispatch);
   });
 

--- a/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
@@ -134,7 +134,7 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
     thunk(dispatch);
   });
 
-  it('should fourmat analytics string without source if it is not present in response, but still succeed', () => {
+  it('should succeed and format the analytics string if source is missing in the response', () => {
     const total = {
       data: {
         attributes: { userPercentOfDisability: 80 },


### PR DESCRIPTION
## Summary

The `rating_info` endpoint will now return a source in it's response with EVSS or Lighthouse depending on a feature toggle. You can read the related [BE work in this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/13012)

To track this in GA, we have added that source to the end of the api-name property for the recordEvent call.=

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61095

## Testing done

- tested locally
- unit tests added for action to verify that source is added when present and that event still fires successfully even if not found, and that request failures also include source

## Screenshots

No UI changes, just analytics data changes

## What areas of the site does it impact?

Profile and Dashboard applications

## Acceptance criteria

- [x] GA event includes source when present in request response

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution