### PR TITLE
Fix save in progress intro content issues

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -248,9 +248,13 @@ class SaveInProgressIntro extends React.Component {
                 </>
               )}
               <p>
-                <strong>Note:</strong> You can sign in after you start your{' '}
-                {appType}. But you&rsquo;ll lose any information you already
-                filled in.
+                {!this.props.hideUnauthedStartLink && (
+                  <>
+                    <strong>Note:</strong> You can sign in after you start your{' '}
+                    {appType}. But you&rsquo;ll lose any information you already
+                    filled in.
+                  </>
+                )}
               </p>
               {unauthStartButton}
               {!this.props.hideUnauthedStartLink && (

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -249,6 +249,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     expect(tree.find('.schemaform-start-button').html()).to.contain(
       'Start your application without signing in',
     );
+    expect(tree.text()).to.include('lose any information you already');
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.false;
     tree.unmount();
   });
@@ -619,6 +620,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     );
 
     expect(tree.find('.schemaform-start-button').exists()).to.be.false;
+    expect(tree.text()).to.not.include('lose any information you already');
 
     tree.unmount();
   });
@@ -654,6 +656,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     );
 
     expect(tree.find('.schemaform-start-button').exists()).to.be.false;
+    expect(tree.text()).to.not.include('lose any information you already');
 
     tree.unmount();
   });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
> When using the `SaveInProgressIntro` on a form's introduction page, it can be set up to:
>  - Sign in prior to starting the app (Sign in button; [Request a Board Appeal example](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182))
>  - Start the app without signing in (start app link; [mock form example](https://staging.va.gov/mock-form))
>
> || Sign in optional | Sign in required |
> |-|------------------|------------------|
> | Main (above process list) | <img width="698" alt="sign in optional. Has a start your application without signing in link" src="https://user-images.githubusercontent.com/136959/234391777-57230585-3c86-4ec0-a1ae-f38a5071445b.png"> |  <img width="695" alt="sign in required. Has sign in button" src="https://user-images.githubusercontent.com/136959/234391784-94febf3f-f357-4e86-be8e-d56f78a6b593.png"> |
> | Button only (below process list) | <img width="331" alt="Screenshot 2023-04-25 at 3 23 48 PM" src="https://user-images.githubusercontent.com/136959/234395201-9f4c2ca9-007f-44da-821a-29b1290f68a1.png"> | <img width="293" alt="Screenshot 2023-04-25 at 3 22 59 PM" src="https://user-images.githubusercontent.com/136959/234395204-1c87480b-0043-4900-b8d0-142e529068ac.png"> |

- _(If bug, how to reproduce)_
  > See summary
- _(What is the solution, why is this the solution)_
  > Only show the note about losing information when the "Start your application without signing in" link
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#1710](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1710)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Note about losing information is _always_ visible
- _Describe the steps required to verify your changes are working as expected_
  > Test in the review instance or locally - no need to log in
- _Describe the tests completed and the results_
  > Added unit test checks for note visibility
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mock form | <img width="698" alt="sign in optional. Has a start your application without signing in link" src="https://user-images.githubusercontent.com/136959/234391777-57230585-3c86-4ec0-a1ae-f38a5071445b.png"> | <img width="691" alt="Screenshot 2023-07-13 at 4 21 33 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/0524c77c-ff01-4589-89f0-22707ffb0de4"> |
| NOD | <img width="695" alt="sign in required. Has sign in button" src="https://user-images.githubusercontent.com/136959/234391784-94febf3f-f357-4e86-be8e-d56f78a6b593.png"> | <img width="695" alt="Screenshot 2023-07-13 at 4 21 18 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2c14c008-0925-4d29-8af6-0f8341e30892"> |

## What areas of the site does it impact?

All apps using the `SaveInProgressIntro` component

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
