### PR TITLE
#61855: Add feature toggle for the static landing widget (Public Websites)

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -89,3 +89,6 @@ export const selectFeaturePrintList = state =>
 
 export const selectFeatureDescriptiveBackLink = state =>
   toggleValues(state).vaOnlineSchedulingDescriptiveBackLink;
+
+export const selectFeatureStaticLandingPage = state =>
+  toggleValues(state).vaOnlineSchedulingStaticLandingPage;

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -643,6 +643,7 @@ const responses = {
         { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: false },
         { name: 'vaOnlineSchedulingPrintList', value: true },
         { name: 'va_online_scheduling_descriptive_back_link', value: true },
+        { name: 'vaOnlineSchedulingStaticLandingPage', value: true },
         { name: 'selectFeaturePocTypeOfCare', value: true },
         { name: 'edu_section_103', value: true },
         { name: 'vaViewDependentsAccess', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -181,6 +181,7 @@ export default Object.freeze({
   vaOnlineSchedulingBreadcrumbUrlUpdate: 'va_online_scheduling_breadcrumb_url_update',
   vaOnlineSchedulingPrintList: 'va_online_scheduling_print_list',
   vaOnlineSchedulingDescriptiveBackLink: 'va_online_scheduling_descriptive_back_link',
+  vaOnlineSchedulingStaticLandingPage: 'va_online_scheduling_static_landing_page',
   vaViewDependentsAccess: 'va_view_dependents_access',
   virtualAgentShowFloatingChatbot: 'virtual_agent_show_floating_chatbot',
   virtualAgentVoice: 'virtual_agent_voice',


### PR DESCRIPTION
## Summary
Added a feature toggle, `va_online_scheduling_static_landing_page`, to update the static landing widget on the Public Websites page.
 vets-api PR:  https://github.com/department-of-veterans-affairs/vets-api/pull/13246
## Related issue(s)
department-of-veterans-affairs/va.gov-team#61855
