### PR TITLE
61179 - added runtimeChunk property to optimizationzation object in w…

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -23,7 +23,7 @@ const ENVIRONMENTS = require('../src/site/constants/environments');
 const scaffoldRegistry = require('../src/applications/registry.scaffold.json');
 const facilitySidebar = require('../src/platform/landing-pages/facility-sidebar.json');
 
-const { VAGOVSTAGING, VAGOVPROD, LOCALHOST } = ENVIRONMENTS;
+const { VAGOVSTAGING, VAGOVPROD, LOCALHOST, VAGOVDEV } = ENVIRONMENTS;
 
 const {
   getAppManifests,
@@ -260,15 +260,16 @@ module.exports = async (env = {}) => {
     destination: buildtype,
     ...env,
   };
-
   const apps = getEntryPoints(buildOptions.entry);
   const entryFiles = { ...apps, ...globalEntryFiles };
   const isOptimizedBuild = [VAGOVSTAGING, VAGOVPROD].includes(buildtype);
+  const isNotLocalHost = [VAGOVDEV, VAGOVPROD, VAGOVSTAGING].includes(
+    buildtype,
+  );
   const scaffoldAssets = await getScaffoldAssets();
   const appRegistry = JSON.parse(scaffoldAssets['registry.json']);
   const envBucketUrl = BUCKETS[buildtype];
   const sourceMapSlug = envBucketUrl || '';
-
   const buildPath = path.resolve(
     __dirname,
     '../',
@@ -436,6 +437,7 @@ module.exports = async (env = {}) => {
           },
         },
       },
+      runtimeChunk: false,
     },
     plugins: [
       new webpack.DefinePlugin({
@@ -520,6 +522,11 @@ module.exports = async (env = {}) => {
       }),
     );
   }
-
+  console.log(`\n\nThe isNotLocalHost is:\t${isNotLocalHost}`);
+  console.log(
+    `\n\nThe baseConfig.optimization.runtimeChunk is:\t${
+      baseConfig.optimization.runtimeChunk
+    }`,
+  );
   return baseConfig;
 };


### PR DESCRIPTION
# Summary

    - Added ternary statement to explicitly set the runtimeChunk property of the webpack configuration object to false in staging and production and 'single' if not staging or production(this defaults to false if runtimeChunk is not explicitly set). 
    - (If bug, how to reproduce)
        N/A
    - (What is the solution, why is this the solution)
        - Request was made to investigate and provide any optimizations to decrease the build time for local webpack builds. By default the runtimeChunk value is false. After researching recommended 
        webpack optimizations we have determined that setting this value to 'single' during local development will decrease the build time from 20+ seconds to approximately 2 seconds. The solution we are implementing has no benefit to production build times. We made the decision to gate out changes behind the isOptimization variable so that there would be no changes in staging or production.
    - (Which team do you work for, does your team own the maintenance of this component?)
        Benefits and Non Disability Claims
    - (If using a flipper, what is the end date of the flipper being required/success criteria being targeted)
        N/A

# Related issue(s)

    - Zenhub ticket for this change https://app.zenhub.com/workspaces/benefits-non-disability-645913c7d909c20011380ae8/issues/gh/department-of-veterans-affairs/va.gov-team/61179

# Testing done

    - Describe what the old behavior was prior to the change:
        The old behavior prior to this change was the runtime chunks for the same pieces of functionality were being built and rebuilt on save for each entry point in the application (94 entry points)
        Rebuilding the application locally (saving after making a change) was taking around 20+/- seconds each save
    - Describe the steps required to verify your changes are working as expected:
        To ensure changes are working run the build locally using the `yarn watch` or `npm run watch` commands. Make any change to a file that would cause webpack to rebuild and save. You should notice a rebuild time somewhere around the 2 second mark. Navigate to the home page and log in. You should see all existing functionality that was already there with no changes. Open up your dev tools. Look inside of Main Thread/Webpack/webpack/runtime/ directory . There should be no duplicate files for runtime chunks in this directory.
    Describe the tests completed and the results
        Tests have been completed on local machine. Once changes are in staging QAT will be conducted before launching to prod.
    Optionally, provide a link to your test plan and test execution records N/A

# Screenshots

Note: This field is mandatory for UI changes (non-component work should NOT have screenshots).

BEFORE (There are multiple runtime chunks for runtime deficiencies for each application, and a build time of 20+ seconds on change)

Image of source files without runtimeChunk set
![webpack_1](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/cb544271-ed16-4849-b598-57669c5f1121)
Image of source files without runtimeChunk set
![webpack_2](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/40d48d5b-b516-49d3-8f6a-d5dc315aef42)
Image of source files without runtimeChunk set
![webpack_3](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/99a2ac71-3521-421a-89d4-4c71a2420d99)
Image of build time  without runtimeChunk set
![speed_1](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/70ca0fe7-3277-47e3-aa40-b7c71a45f2a3)


AFTER (There is a single runtime chunk for each runtime dependency, and a build time of around 2 seconds on change)

Image of source files with runtimeChunk set to 'single'
![webpack_4](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/29c757be-08b3-4008-8d32-9184730cac20)
Image of build time  with runtimeChunk set to 'single'
![speed_2](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/3439e3b9-3a88-4187-af6a-5de6778df5a4)

# What areas of the site does it impact?
(Describe what parts of the site are impacted if code touched other areas)
All parts of the vets-website are effected when running locally. No changes to site when running in staging or production.

# Acceptance Criteria

## Quality Assurance & Testing

    - No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
        N/A
    - Linting warnings have been addressed
        Yes
    - Documentation has been updated (link to documentation *if necessary)
        N/A
    - Screenshot of the developed feature is added
        Yes
    - Accessibility testing has been performed
        N/A
    - I fixed|updated|added unit tests and integration tests for each feature (if applicable).
        No additional unit tests added.
        Confirmed existing unit tests still pass.

# Error Handling
    - Browser console contains no warnings or errors.
    - Events are being sent to the appropriate logging solution
    - No updates to event logging
# Authentication

    - Did you login to a local build and verify all authenticated routes work as expected with a test user
        Yes

⚠️ Team Sites (only applies to modifications made to the VA.gov header) ⚠️
    N/A
The vets-website header does not contain any web-components
    N/A

Requested Feedback

(OPTIONAL) What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?
I am feeling good about this pr. It does not effect production or staging build. Changes will only effect the local build. If there are any questions or concerns please reach out. I appreciate any concerns or feedback.