### PR TITLE
simple forms: 21-4142 Add character limit to fit pdf size

### DIFF
--- a/src/applications/simple-forms/21-4142/pages/recordsRequested.js
+++ b/src/applications/simple-forms/21-4142/pages/recordsRequested.js
@@ -83,6 +83,13 @@ export default {
           'ui:required': () => true,
           'ui:errorMessages': {
             required: 'Please list at least one condition',
+            maxLength: 'Please limit your answer to no more than 75 characters',
+          },
+          'ui:options': {
+            updateSchema: () => ({
+              type: 'string',
+              maxLength: 75,
+            }),
           },
         },
         [providerFacilityFields.treatmentDateRange]: {


### PR DESCRIPTION
Set character limit to 75 for text area field where PDF cannot accomodate more than that

## Related issue(s)

- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/396

## Testing done

- Viewed locally

## Screenshots
![Screenshot 2023-07-14 at 3 19 40 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/57802560/3d52e488-5677-4954-b9d2-74ed6e086480)


## What areas of the site does it impact?
Form 21-4142
