### PR TITLE
Fixed bug in CareSummariesDetails / Added max width to pages

### DIFF
--- a/src/applications/mhv/medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
+++ b/src/applications/mhv/medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
@@ -26,30 +26,29 @@ const AdmissionAndDischargeDetails = props => {
               {admissionDate} to {dischargeDate}
             </p>
           </div>
-
-          <p className="vads-u-margin-bottom--0">
-            Review a summary of your stay at a hospital or other health facility
-            (called an admission and discharge summary).
-          </p>
-
-          <div className="no-print">
-            <PrintDownload download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-
+          <section className="set-width-486">
+            <p className="vads-u-margin-bottom--0">
+              Review a summary of your stay at a hospital or other health
+              facility (called an admission and discharge summary).
+            </p>
+            <div className="no-print">
+              <PrintDownload download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+          </section>
           <div className="test-details-container max-80">
             <h2>Details</h2>
             <h3 className="vads-u-font-size--base vads-u-font-family--sans">

--- a/src/applications/mhv/medical-records/components/CareSummaries/ProgressNoteDetails.jsx
+++ b/src/applications/mhv/medical-records/components/CareSummaries/ProgressNoteDetails.jsx
@@ -18,55 +18,54 @@ const ProgressNoteDetails = props => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--0">{results.name}</h1>
-          <div className="time-header">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date:{' '}
-            </h2>
-            <p>{dateSigned}</p>
-          </div>
-
-          <div className="no-print">
-            <PrintDownload download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-
-          <div className="test-details-container max-80">
-            <h2>Details</h2>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Location
-            </h3>
-            <p>{results.facility}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Signed by
-            </h3>
-            <p>{results.signedBy}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Last updated
-            </h3>
-            <p>{dateUpdated}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date signed
-            </h3>
-            <p>{dateSigned}</p>
-          </div>
-
-          <div className="test-results-container">
-            <h2>Note</h2>
-            <p>{results.note}</p>
-          </div>
+          <section className="set-width-486">
+            <div className="time-header">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date:{' '}
+              </h2>
+              <p>{dateSigned}</p>
+            </div>
+            <div className="no-print">
+              <PrintDownload download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+            <div className="test-details-container max-80">
+              <h2>Details</h2>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Location
+              </h3>
+              <p>{results.facility}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Signed by
+              </h3>
+              <p>{results.signedBy}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Last updated
+              </h3>
+              <p>{dateUpdated}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date signed
+              </h3>
+              <p>{dateSigned}</p>
+            </div>
+            <div className="test-results-container">
+              <h2>Note</h2>
+              <p>{results.note}</p>
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -21,105 +21,109 @@ const ChemHemDetails = props => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--1">{record.name}</h1>
-          <div className="time-header">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date:{' '}
-            </h2>
-            <p>{formattedDate}</p>
-          </div>
-
-          <div className="no-print">
-            <PrintDownload list download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-          {/*                   TEST DETAILS                          */}
-          <div className="test-details-container max-80">
-            <h2>Details about this test</h2>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Type of test
-            </h3>
-            <p>{record.category}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample tested
-            </h3>
-            <p>{record.sampleTested}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordered by
-            </h3>
-            <p>{record.orderedBy}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordering location
-            </h3>
-            <p>{record.orderingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Collecting location
-            </h3>
-            <p>{record.collectingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Provider notes
-            </h3>
-            <ItemList list={record.comments} />
-          </div>
-          {/*         RESULTS CARDS            */}
-          <div className="test-results-container">
-            <h2>Results</h2>
-            <va-additional-info
-              trigger="Need help understanding your results?"
-              class="no-print"
-            >
-              <p className="vads-u-margin-bottom--1">
-                If your results are outside the standard range, this doesn’t
-                automatically mean you have a health problem. Your provider will
-                review your results and explain what they mean for your health.
-              </p>
-              <p>
-                To ask a question now, send a secure message to your care team.
-              </p>
-              <p>
-                <a
-                  href={mhvUrl(
-                    isAuthenticatedWithSSOe(fullState),
-                    'secure-messaging',
-                  )}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Compose a message.
-                </a>
-              </p>
-            </va-additional-info>
-            <div className="print-only">
-              <p>
-                Your provider will review your results and explain what they
-                mean for your health. To ask a question now, send a secure
-                message to your care team.
-              </p>
-              <h4 className="vads-u-margin--0 vads-u-font-size--base vads-u-font-family--sans">
-                Standard range
-              </h4>
-              <p className="vads-u-margin-top--0">
-                The standard range is one tool your providers use to understand
-                your results. If your results are outside the standard range,
-                this doesn’t automatically mean you have a health problem. Your
-                provider will explain what your results mean for your health.
-              </p>
+          <section className="set-width-486">
+            <div className="time-header">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date:{' '}
+              </h2>
+              <p>{formattedDate}</p>
             </div>
-            <ChemHemResults results={record.results} />
-            <va-back-to-top class="no-print" />
-          </div>
+            <div className="no-print">
+              <PrintDownload list download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+            {/*                   TEST DETAILS                          */}
+            <div className="test-details-container max-80">
+              <h2>Details about this test</h2>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Type of test
+              </h3>
+              <p>{record.category}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Sample tested
+              </h3>
+              <p>{record.sampleTested}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordered by
+              </h3>
+              <p>{record.orderedBy}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordering location
+              </h3>
+              <p>{record.orderingLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Collecting location
+              </h3>
+              <p>{record.collectingLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Provider notes
+              </h3>
+              <ItemList list={record.comments} />
+            </div>
+            {/*         RESULTS CARDS            */}
+            <div className="test-results-container">
+              <h2>Results</h2>
+              <va-additional-info
+                trigger="Need help understanding your results?"
+                class="no-print"
+              >
+                <p className="vads-u-margin-bottom--1">
+                  If your results are outside the standard range, this doesn’t
+                  automatically mean you have a health problem. Your provider
+                  will review your results and explain what they mean for your
+                  health.
+                </p>
+                <p>
+                  To ask a question now, send a secure message to your care
+                  team.
+                </p>
+                <p>
+                  <a
+                    href={mhvUrl(
+                      isAuthenticatedWithSSOe(fullState),
+                      'secure-messaging',
+                    )}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Compose a message.
+                  </a>
+                </p>
+              </va-additional-info>
+              <div className="print-only">
+                <p>
+                  Your provider will review your results and explain what they
+                  mean for your health. To ask a question now, send a secure
+                  message to your care team.
+                </p>
+                <h4 className="vads-u-margin--0 vads-u-font-size--base vads-u-font-family--sans">
+                  Standard range
+                </h4>
+                <p className="vads-u-margin-top--0">
+                  The standard range is one tool your providers use to
+                  understand your results. If your results are outside the
+                  standard range, this doesn’t automatically mean you have a
+                  health problem. Your provider will explain what your results
+                  mean for your health.
+                </p>
+              </div>
+              <ChemHemResults results={record.results} />
+              <va-back-to-top class="no-print" />
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/components/LabsAndTests/EkgDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/EkgDetails.jsx
@@ -17,54 +17,57 @@ const EkgDetails = props => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--0">{record.name}</h1>
-          <div className="time-header">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date:{' '}
-            </h2>
-            <p>{formattedDate}</p>
-          </div>
-          <div className="condition-buttons no-print">
-            <PrintDownload list download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-          <div className="condition-details max-80">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordering location
-            </h2>
-            <p>
-              {record.facility || 'There is no facility reported at this time'}
-            </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Results
-            </h2>
-            <p>
-              Your EKG results aren’t available in this tool. To get your EKG
-              results, you can request a copy of your complete medical record
-              from your VA health facility.
-            </p>
-            <p className="vads-u-margin-top--2 no-print">
-              <a
-                target="_blank"
-                rel="noreferrer"
-                href="https://www.va.gov/resources/how-to-get-your-medical-records-from-your-va-health-facility/"
-              >
-                Learn how to get records from your VA health facility
-              </a>
-            </p>
-          </div>
+          <section className="set-width-486">
+            <div className="time-header">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date:{' '}
+              </h2>
+              <p>{formattedDate}</p>
+            </div>
+            <div className="condition-buttons no-print">
+              <PrintDownload list download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+            <div className="condition-details max-80">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordering location
+              </h2>
+              <p>
+                {record.facility ||
+                  'There is no facility reported at this time'}
+              </p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Results
+              </h2>
+              <p>
+                Your EKG results aren’t available in this tool. To get your EKG
+                results, you can request a copy of your complete medical record
+                from your VA health facility.
+              </p>
+              <p className="vads-u-margin-top--2 no-print">
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://www.va.gov/resources/how-to-get-your-medical-records-from-your-va-health-facility/"
+                >
+                  Learn how to get records from your VA health facility
+                </a>
+              </p>
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -19,91 +19,91 @@ const MicroDetails = props => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--0">{record.name}</h1>
-          <div className="time-header">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date:{' '}
-            </h2>
-            <p>{formattedDate}</p>
-          </div>
+          <section className="set-width-486">
+            <div className="time-header">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date:{' '}
+              </h2>
+              <p>{formattedDate}</p>
+            </div>
+            <div className="no-print">
+              <PrintDownload list download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+            <div className="test-details-container max-80">
+              <h2>Details about this test</h2>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Sample tested
+              </h3>
+              <p>{record.sampleTested}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Sample from
+              </h3>
+              <p>{record.sampleFrom}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordered by
+              </h3>
+              <p>{record.orderedBy}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordering location
+              </h3>
+              <p>{record.orderingLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Collecting location
+              </h3>
+              <p>{record.collectingLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Lab location
+              </h3>
+              <p>{record.labLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date completed
+              </h3>
+              <p>{formattedDate}</p>
+            </div>
 
-          <div className="no-print">
-            <PrintDownload list download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-
-          <div className="test-details-container max-80">
-            <h2>Details about this test</h2>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample tested
-            </h3>
-            <p>{record.sampleTested}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample from
-            </h3>
-            <p>{record.sampleFrom}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordered by
-            </h3>
-            <p>{record.orderedBy}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordering location
-            </h3>
-            <p>{record.orderingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Collecting location
-            </h3>
-            <p>{record.collectingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Lab location
-            </h3>
-            <p>{record.labLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date completed
-            </h3>
-            <p>{formattedDate}</p>
-          </div>
-
-          <div className="test-results-container">
-            <h2>Results</h2>
-            <va-additional-info
-              trigger="Need help understanding your results?"
-              class="no-print"
-            >
-              <p>
-                Your provider will review your results and explain what they
-                mean for your health. To ask a question now, send a secure
-                message to your care team.
-              </p>
-              <p>
-                <a
-                  href={mhvUrl(
-                    isAuthenticatedWithSSOe(fullState),
-                    'secure-messaging',
-                  )}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Start a new message
-                </a>
-              </p>
-            </va-additional-info>
-            <p className="vads-u-font-size--base make-monospace">
-              {record.results}
-            </p>{' '}
-          </div>
+            <div className="test-results-container">
+              <h2>Results</h2>
+              <va-additional-info
+                trigger="Need help understanding your results?"
+                class="no-print"
+              >
+                <p>
+                  Your provider will review your results and explain what they
+                  mean for your health. To ask a question now, send a secure
+                  message to your care team.
+                </p>
+                <p>
+                  <a
+                    href={mhvUrl(
+                      isAuthenticatedWithSSOe(fullState),
+                      'secure-messaging',
+                    )}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Start a new message
+                  </a>
+                </p>
+              </va-additional-info>
+              <p className="vads-u-font-size--base make-monospace">
+                {record.results}
+              </p>{' '}
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -19,73 +19,72 @@ const PathologyDetails = props => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--0">{record.name}</h1>
-          <div className="time-header">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date:{' '}
-            </h2>
-            <p>{formattedDate}</p>
-          </div>
-
-          <div className="no-print">
-            <PrintDownload list download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-
-          <div className="test-details-container max-80">
-            <h2>Details about this test</h2>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample tested
-            </h3>
-            <p>{record.sampleTested}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Lab location
-            </h3>
-            <p>{record.labLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date completed
-            </h3>
-            <p>{formattedDate}</p>
-          </div>
-
-          <div className="test-results-container">
-            <h2>Results</h2>
-            <va-additional-info
-              trigger="Need help understanding your results?"
-              class="no-print"
-            >
-              <p>
-                Your provider will review your results and explain what they
-                mean for your health. To ask a question now, send a secure
-                message to your care team.
-              </p>
-              <p>
-                <a
-                  href={mhvUrl(
-                    isAuthenticatedWithSSOe(fullState),
-                    'secure-messaging',
-                  )}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Start a new message
-                </a>
-              </p>
-            </va-additional-info>
-            <p>{record.results}</p>
-          </div>
+          <section className="set-width-486">
+            <div className="time-header">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date:{' '}
+              </h2>
+              <p>{formattedDate}</p>
+            </div>
+            <div className="no-print">
+              <PrintDownload list download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+            <div className="test-details-container max-80">
+              <h2>Details about this test</h2>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Sample tested
+              </h3>
+              <p>{record.sampleTested}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Lab location
+              </h3>
+              <p>{record.labLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date completed
+              </h3>
+              <p>{formattedDate}</p>
+            </div>
+            <div className="test-results-container">
+              <h2>Results</h2>
+              <va-additional-info
+                trigger="Need help understanding your results?"
+                class="no-print"
+              >
+                <p>
+                  Your provider will review your results and explain what they
+                  mean for your health. To ask a question now, send a secure
+                  message to your care team.
+                </p>
+                <p>
+                  <a
+                    href={mhvUrl(
+                      isAuthenticatedWithSSOe(fullState),
+                      'secure-messaging',
+                    )}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Start a new message
+                  </a>
+                </p>
+              </va-additional-info>
+              <p>{record.results}</p>
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -22,97 +22,97 @@ const RadiologyDetails = props => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--0">{record.name}</h1>
-          <div className="time-header">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date:{' '}
-            </h2>
-            <p>{formattedDate}</p>
-          </div>
-
-          <div className="no-print">
-            <PrintDownload download={download} />
-            <va-additional-info trigger="What to know about downloading records">
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-
-          <div className="test-details-container max-80">
-            <h2>Details about this test</h2>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans no-print">
-              Images
-            </h3>
-            <p className="no-print">
-              <va-link
-                active
-                href={`/my-health/medical-records/labs-and-tests/radiology-images/${
-                  record.id
-                }`}
-                text={`See all ${record.images.length} images`}
-              />
-            </p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Reason for test
-            </h3>
-            <p>{record.reason}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Clinical history
-            </h3>
-            <p>{record.clinicalHistory}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordered by
-            </h3>
-            <p>{record.orderedBy}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordering location
-            </h3>
-            <p>{record.orderingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Imaging location
-            </h3>
-            <p>{record.imagingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Imaging provider
-            </h3>
-            <p>{record.imagingProvider}</p>
-          </div>
-
-          <div className="test-results-container">
-            <h2>Results</h2>
-            <va-additional-info
-              trigger="Need help understanding your results?"
-              class="no-print"
-            >
-              <p>
-                Your provider will review your results and explain what they
-                mean for your health. To ask a question now, send a secure
-                message to your care team.
+          <section className="set-width-486">
+            <div className="time-header">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Date:{' '}
+              </h2>
+              <p>{formattedDate}</p>
+            </div>
+            <div className="no-print">
+              <PrintDownload download={download} />
+              <va-additional-info trigger="What to know about downloading records">
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
+            </div>
+            <div className="test-details-container max-80">
+              <h2>Details about this test</h2>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans no-print">
+                Images
+              </h3>
+              <p className="no-print">
+                <va-link
+                  active
+                  href={`/my-health/medical-records/labs-and-tests/radiology-images/${
+                    record.id
+                  }`}
+                  text={`See all ${record.images.length} images`}
+                />
               </p>
-              <p>
-                <a
-                  href={mhvUrl(
-                    isAuthenticatedWithSSOe(fullState),
-                    'secure-messaging',
-                  )}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Start a new message
-                </a>
-              </p>
-            </va-additional-info>
-            <p>{record.results}</p>
-          </div>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Reason for test
+              </h3>
+              <p>{record.reason}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Clinical history
+              </h3>
+              <p>{record.clinicalHistory}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordered by
+              </h3>
+              <p>{record.orderedBy}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Ordering location
+              </h3>
+              <p>{record.orderingLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Imaging location
+              </h3>
+              <p>{record.imagingLocation}</p>
+              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+                Imaging provider
+              </h3>
+              <p>{record.imagingProvider}</p>
+            </div>
+
+            <div className="test-results-container">
+              <h2>Results</h2>
+              <va-additional-info
+                trigger="Need help understanding your results?"
+                class="no-print"
+              >
+                <p>
+                  Your provider will review your results and explain what they
+                  mean for your health. To ask a question now, send a secure
+                  message to your care team.
+                </p>
+                <p>
+                  <a
+                    href={mhvUrl(
+                      isAuthenticatedWithSSOe(fullState),
+                      'secure-messaging',
+                    )}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Start a new message
+                  </a>
+                </p>
+              </va-additional-info>
+              <p>{record.results}</p>
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -137,69 +137,70 @@ const Allergies = () => {
     <div id="allergies">
       <PrintHeader />
       <h1 className="vads-u-margin--0">Allergies</h1>
-      <p className="vads-u-margin-top--1">
-        Review allergies and reactions in your VA medical records.
-      </p>
-      <va-additional-info
-        trigger="What to know about allergy records"
-        class="no-print"
-      >
-        <ul>
-          <li className="vads-u-margin-bottom--2">
-            <p className="vads-u-margin--0">
-              If you have allergies that are missing from this list, send a
-              secure message to your care team. You can also send a message to
-              ask questions about your allergy records.
-            </p>
-            <a
-              href={mhvUrl(
-                isAuthenticatedWithSSOe(fullState),
-                'secure-messaging',
-              )}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Compose a new message
-            </a>
-          </li>
-          <li>
-            <p className="vads-u-margin--0">
-              This list doesn’t include information you entered yourself. To
-              find information you entered, go back to your records on the My
-              HealtheVet website.
-            </p>
-            <a
-              href={mhvUrl(
-                isAuthenticatedWithSSOe(fullState),
-                'download-my-data',
-              )}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Go back to medical records on the My HealtheVet website
-            </a>
-          </li>
-        </ul>
-      </va-additional-info>
-      <PrintDownload list download={generateAllergiesPdf} />
-      <va-additional-info
-        trigger="What to know about downloading records"
-        class="no-print"
-      >
-        <ul>
-          <li>
-            <strong>If you’re on a public or shared computer,</strong> print
-            your records instead of downloading. Downloading will save a copy of
-            your records to the public computer.
-          </li>
-          <li>
-            <strong>If you use assistive technology,</strong> a Text file (.txt)
-            may work better for technology such as screen reader, screen
-            enlargers, or Braille displays.
-          </li>
-        </ul>
-      </va-additional-info>
-
+      <section className="set-width-486">
+        <p className="vads-u-margin-top--1">
+          Review allergies and reactions in your VA medical records.
+        </p>
+        <va-additional-info
+          trigger="What to know about allergy records"
+          class="no-print"
+        >
+          <ul>
+            <li className="vads-u-margin-bottom--2">
+              <p className="vads-u-margin--0">
+                If you have allergies that are missing from this list, send a
+                secure message to your care team. You can also send a message to
+                ask questions about your allergy records.
+              </p>
+              <a
+                href={mhvUrl(
+                  isAuthenticatedWithSSOe(fullState),
+                  'secure-messaging',
+                )}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Compose a new message
+              </a>
+            </li>
+            <li>
+              <p className="vads-u-margin--0">
+                This list doesn’t include information you entered yourself. To
+                find information you entered, go back to your records on the My
+                HealtheVet website.
+              </p>
+              <a
+                href={mhvUrl(
+                  isAuthenticatedWithSSOe(fullState),
+                  'download-my-data',
+                )}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Go back to medical records on the My HealtheVet website
+              </a>
+            </li>
+          </ul>
+        </va-additional-info>
+        <PrintDownload list download={generateAllergiesPdf} />
+        <va-additional-info
+          trigger="What to know about downloading records"
+          class="no-print"
+        >
+          <ul>
+            <li>
+              <strong>If you’re on a public or shared computer,</strong> print
+              your records instead of downloading. Downloading will save a copy
+              of your records to the public computer.
+            </li>
+            <li>
+              <strong>If you use assistive technology,</strong> a Text file
+              (.txt) may work better for technology such as screen reader,
+              screen enlargers, or Braille displays.
+            </li>
+          </ul>
+        </va-additional-info>
+      </section>
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -130,63 +130,64 @@ const AllergyDetails = () => {
         <>
           <PrintHeader />
           <h1 className="vads-u-margin-bottom--0p5">Allergy: {allergy.name}</h1>
-          <div className="condition-subheader vads-u-margin-bottom--3">
-            <div className="time-header">
-              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-                Date entered:{' '}
-              </h2>
-              <p>{allergy.date}</p>
+          <section className="set-width-486">
+            <div className="condition-subheader vads-u-margin-bottom--3">
+              <div className="time-header">
+                <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                  Date entered:{' '}
+                </h2>
+                <p>{allergy.date}</p>
+              </div>
+              <PrintDownload list download={generateAllergyPdf} />
+              <va-additional-info
+                trigger="What to know about downloading records"
+                class="no-print"
+              >
+                <ul>
+                  <li>
+                    <strong>If you’re on a public or shared computer,</strong>{' '}
+                    print your records instead of downloading. Downloading will
+                    save a copy of your records to the public computer.
+                  </li>
+                  <li>
+                    <strong>If you use assistive technology,</strong> a Text
+                    file (.txt) may work better for technology such as screen
+                    reader, screen enlargers, or Braille displays.
+                  </li>
+                </ul>
+              </va-additional-info>
             </div>
-            <PrintDownload list download={generateAllergyPdf} />
-            <va-additional-info
-              trigger="What to know about downloading records"
-              class="no-print"
-            >
-              <ul>
-                <li>
-                  <strong>If you’re on a public or shared computer,</strong>{' '}
-                  print your records instead of downloading. Downloading will
-                  save a copy of your records to the public computer.
-                </li>
-                <li>
-                  <strong>If you use assistive technology,</strong> a Text file
-                  (.txt) may work better for technology such as screen reader,
-                  screen enlargers, or Braille displays.
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-
-          <div className="condition-details max-80">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Reaction
-            </h2>
-            <ItemList list={allergy.reaction} />
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Type of allergy
-            </h2>
-            <p>{allergy.type || 'None noted'}</p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              VA drug class
-            </h2>
-            <p>{allergy.drugClass || 'None noted'}</p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Location
-            </h2>
-            <p>{allergy.location || 'None noted'}</p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Observed or reported
-            </h2>
-            <p>
-              {allergy.observed
-                ? 'Observed (your provider observed the reaction in person)'
-                : 'Reported (you told your provider about the reaction)'}
-            </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Provider notes
-            </h2>
-            <ItemList list={allergy.notes} />
-          </div>
+            <div className="condition-details max-80">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Reaction
+              </h2>
+              <ItemList list={allergy.reaction} />
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Type of allergy
+              </h2>
+              <p>{allergy.type || 'None noted'}</p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                VA drug class
+              </h2>
+              <p>{allergy.drugClass || 'None noted'}</p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Location
+              </h2>
+              <p>{allergy.location || 'None noted'}</p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Observed or reported
+              </h2>
+              <p>
+                {allergy.observed
+                  ? 'Observed (your provider observed the reaction in person)'
+                  : 'Reported (you told your provider about the reaction)'}
+              </p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Provider notes
+              </h2>
+              <ItemList list={allergy.notes} />
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv/medical-records/containers/CareSummariesAndNotes.jsx
@@ -58,12 +58,14 @@ const CareSummariesAndNotes = () => {
   return (
     <div id="care-summaries-and-notes">
       <h1 className="page-title">Care summaries and notes</h1>
-      <p>Review care summaries and notes in your VA medical records.</p>
-      <va-additional-info trigger="What to know about your care summaries and notes">
-        This is some additional info about your care summaries and notes, though
-        we are waiting on the Content Team to tell us what should be here...
-      </va-additional-info>
-
+      <section className="set-width-486">
+        <p>Review care summaries and notes in your VA medical records.</p>
+        <va-additional-info trigger="What to know about your care summaries and notes">
+          This is some additional info about your care summaries and notes,
+          though we are waiting on the Content Team to tell us what should be
+          here...
+        </va-additional-info>
+      </section>
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/containers/CareSummariesDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/CareSummariesDetails.jsx
@@ -49,7 +49,7 @@ const CareSummariesDetails = () => {
 
   if (careSummary?.name) {
     switch (careSummary?.name.toLowerCase()) {
-      case 'discharge summary':
+      case 'admission and discharge summary':
         return <AdmissionAndDischargeDetails results={careSummary} />;
       case 'primary care progress note':
         return <ProgressNoteDetails results={careSummary} />;

--- a/src/applications/mhv/medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/ConditionDetails.jsx
@@ -131,39 +131,40 @@ const ConditionDetails = () => {
           <h1 className="vads-u-margin-bottom--0">
             {conditionDetails.name.split(' (')[0]}
           </h1>
-          <div className="condition-subheader vads-u-margin-bottom--3">
-            <div className="time-header">
-              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-                Date and time entered:{' '}
-              </h2>
-              <p>{formattedDate}</p>
+          <section className="set-width-486">
+            <div className="condition-subheader vads-u-margin-bottom--3">
+              <div className="time-header">
+                <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                  Date and time entered:{' '}
+                </h2>
+                <p>{formattedDate}</p>
+              </div>
+              <PrintDownload list download={download} />
             </div>
-            <PrintDownload list download={download} />
-          </div>
-
-          <div className="condition-details max-80">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Status of health condition
-            </h2>
-            <p>{conditionDetails.active ? 'Active' : 'Inactive'}</p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Provider
-            </h2>
-            <p>{conditionDetails.provider}</p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Location
-            </h2>
-            <p>
-              {conditionDetails.facility ||
-                'There is no facility reported at this time'}
-            </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              SNOMED Clinical term
-            </h2>
-            <p>{conditionDetails.name}</p>
-            <h2 className="vads-u-margin-bottom--0">Provider comments</h2>
-            <ItemList list={conditionDetails.comments} />
-          </div>
+            <div className="condition-details max-80">
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Status of health condition
+              </h2>
+              <p>{conditionDetails.active ? 'Active' : 'Inactive'}</p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Provider
+              </h2>
+              <p>{conditionDetails.provider}</p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                Location
+              </h2>
+              <p>
+                {conditionDetails.facility ||
+                  'There is no facility reported at this time'}
+              </p>
+              <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                SNOMED Clinical term
+              </h2>
+              <p>{conditionDetails.name}</p>
+              <h2 className="vads-u-margin-bottom--0">Provider comments</h2>
+              <ItemList list={conditionDetails.comments} />
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv/medical-records/containers/HealthConditions.jsx
@@ -148,12 +148,14 @@ const HealthConditions = () => {
   return (
     <div>
       <h1>Health conditions</h1>
-      <p>Review health conditions in your VA medical records</p>
-      <va-additional-info trigger="What to know about health conditions">
-        This is some additional info about health conditions, though we are
-        waiting on the Content Team to tell us what should be here...
-      </va-additional-info>
-      <PrintDownload list download={download} />
+      <section className="set-width-486">
+        <p>Review health conditions in your VA medical records</p>
+        <va-additional-info trigger="What to know about health conditions">
+          This is some additional info about health conditions, though we are
+          waiting on the Content Team to tell us what should be here...
+        </va-additional-info>
+        <PrintDownload list download={download} />
+      </section>
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/containers/HealthHistory.jsx
+++ b/src/applications/mhv/medical-records/containers/HealthHistory.jsx
@@ -23,89 +23,90 @@ const HealthHistory = () => {
   return (
     <div className="health-history vads-u-padding-bottom--5">
       <h1 className="vads-u-margin-bottom--0">Health history</h1>
-      <p className="vads-u-margin-top--0 va-introtext">
-        Review, print, and download your personal health history.
-      </p>
+      <section className="set-width-486">
+        <p className="vads-u-margin-top--0 va-introtext">
+          Review, print, and download your personal health history.
+        </p>
+        <ul className="unstyled-list">
+          <li>
+            <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+              Care summaries and notes
+            </h2>
+            <va-link
+              className="section-link"
+              active
+              href="/my-health/medical-records/health-history/care-summaries-and-notes"
+              text="Review your care summaries and notes"
+              data-testid="section-link"
+            />
+            <p className="vads-u-margin-top--1">
+              VA Notes from January 1, 2013 forward are available thirty-six
+              (36) hours after they have been completed (except C&P Notes) and
+              signed by all required members of your VA health care team.
+            </p>
+          </li>
 
-      <ul className="unstyled-list">
-        <li>
-          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
-            Care summaries and notes
-          </h2>
-          <va-link
-            className="section-link"
-            active
-            href="/my-health/medical-records/health-history/care-summaries-and-notes"
-            text="Review your care summaries and notes"
-            data-testid="section-link"
-          />
-          <p className="vads-u-margin-top--1">
-            VA Notes from January 1, 2013 forward are available thirty-six (36)
-            hours after they have been completed (except C&P Notes) and signed
-            by all required members of your VA health care team.
-          </p>
-        </li>
+          <li>
+            <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+              Vaccines
+            </h2>
+            <va-link
+              className="section-link"
+              active
+              href="/my-health/medical-records/health-history/vaccines"
+              text="Review your vaccines"
+              data-testid="section-link"
+            />
+            <p className="vads-u-margin-top--1">
+              Your VA immunizations/vaccinations list may not be complete. If
+              you have questions about your vaccinations, contact your VA health
+              care team.
+            </p>
+          </li>
 
-        <li>
-          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
-            Vaccines
-          </h2>
-          <va-link
-            className="section-link"
-            active
-            href="/my-health/medical-records/health-history/vaccines"
-            text="Review your vaccines"
-            data-testid="section-link"
-          />
-          <p className="vads-u-margin-top--1">
-            Your VA immunizations/vaccinations list may not be complete. If you
-            have questions about your vaccinations, contact your VA health care
-            team.
-          </p>
-        </li>
+          <li>
+            <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
+              Allergies
+            </h2>
+            <va-link
+              className="section-link"
+              active
+              href="/my-health/medical-records/health-history/allergies"
+              text="Review your allergies"
+              data-testid="section-link"
+            />
+            <p className="vads-u-margin-top--1">[description of section]</p>
+          </li>
 
-        <li>
-          <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
-            Allergies
-          </h2>
-          <va-link
-            className="section-link"
-            active
-            href="/my-health/medical-records/health-history/allergies"
-            text="Review your allergies"
-            data-testid="section-link"
-          />
-          <p className="vads-u-margin-top--1">[description of section]</p>
-        </li>
+          <li>
+            <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+              Health conditions
+            </h2>
+            <va-link
+              className="section-link"
+              active
+              href="/my-health/medical-records/health-history/health-conditions"
+              text="Review your health conditions"
+              data-testid="section-link"
+            />
+            <p className="vads-u-margin-top--1">[description of section]</p>
+          </li>
 
-        <li>
-          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
-            Health conditions
-          </h2>
-          <va-link
-            className="section-link"
-            active
-            href="/my-health/medical-records/health-history/health-conditions"
-            text="Review your health conditions"
-            data-testid="section-link"
-          />
-          <p className="vads-u-margin-top--1">[description of section]</p>
-        </li>
-
-        <li>
-          <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
-            Vitals
-          </h2>
-          <va-link
-            className="section-link"
-            active
-            href="/my-health/medical-records/health-history/vitals"
-            text="Review your vitals"
-            data-testid="section-link"
-          />
-          <p className="vads-u-margin-top--1">[description of section]</p>
-        </li>
-      </ul>
+          <li>
+            <h2 className="vads-u-margin-bottom--1 vads-u-margin-top--4">
+              Vitals
+            </h2>
+            <va-link
+              className="section-link"
+              active
+              href="/my-health/medical-records/health-history/vitals"
+              text="Review your vitals"
+              data-testid="section-link"
+            />
+            <p className="vads-u-margin-top--1">[description of section]</p>
+          </li>
+        </ul>
+      </section>
     </div>
   );
 };

--- a/src/applications/mhv/medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv/medical-records/containers/LabsAndTests.jsx
@@ -57,12 +57,13 @@ const LabsAndTests = () => {
   return (
     <div id="labs-and-tests">
       <h1 className="page-title">Lab and test results</h1>
-      <p>Review lab and test results in your VA medical records.</p>
-      <va-additional-info trigger="What to know about lab and test results">
-        This is some additional info about lab and test results, though we are
-        waiting on the Content Team to tell us what should be here...
-      </va-additional-info>
-
+      <section className="set-width-486">
+        <p>Review lab and test results in your VA medical records.</p>
+        <va-additional-info trigger="What to know about lab and test results">
+          This is some additional info about lab and test results, though we are
+          waiting on the Content Team to tell us what should be here...
+        </va-additional-info>
+      </section>
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/containers/VaccineDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/VaccineDetails.jsx
@@ -110,21 +110,23 @@ const VaccineDetails = () => {
         <>
           <PrintHeader />
           <h1 className="vaccine-header">{vaccineDetails.name}</h1>
-          <PrintDownload list download={generateVaccinePdf} />
-          <div className="detail-block max-80">
-            <h2 className="vads-u-margin-top--0">Date received</h2>
-            <p>{formattedDate}</p>
-            <h2>Manufacturer</h2>
-            <p>{vaccineDetails.manufacturer}</p>
-            <h2>Location</h2>
-            <p>{vaccineDetails.location}</p>
-            <h2 className="vads-u-margin-bottom--0">
-              Reactions recorded by provider
-            </h2>
-            <ItemList list={vaccineDetails.reactions} />
-            <h2 className="vads-u-margin-bottom--0">Provider notes</h2>
-            <ItemList list={vaccineDetails.notes} />
-          </div>
+          <section className="set-width-480">
+            <PrintDownload list download={generateVaccinePdf} />
+            <div className="detail-block max-80">
+              <h2 className="vads-u-margin-top--0">Date received</h2>
+              <p>{formattedDate}</p>
+              <h2>Manufacturer</h2>
+              <p>{vaccineDetails.manufacturer}</p>
+              <h2>Location</h2>
+              <p>{vaccineDetails.location}</p>
+              <h2 className="vads-u-margin-bottom--0">
+                Reactions recorded by provider
+              </h2>
+              <ItemList list={vaccineDetails.reactions} />
+              <h2 className="vads-u-margin-bottom--0">Provider notes</h2>
+              <ItemList list={vaccineDetails.notes} />
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv/medical-records/containers/Vaccines.jsx
@@ -116,16 +116,17 @@ const Vaccines = () => {
     <div id="vaccines">
       <PrintHeader />
       <h1 className="page-title">Vaccines</h1>
-      <p>
-        This is a complete list of vaccines that the VA has on file for you.
-      </p>
-      <p className="print-only vads-u-margin-bottom--0 max-80">
-        Your VA Vaccines list may not be complete. If you have any questions
-        about your information, visit the FAQs or contact your VA Health care
-        team.
-      </p>
-      <PrintDownload list download={generateVaccinesPdf} />
-
+      <section className="set-width-486">
+        <p>
+          This is a complete list of vaccines that the VA has on file for you.
+        </p>
+        <p className="print-only vads-u-margin-bottom--0 max-80">
+          Your VA Vaccines list may not be complete. If you have any questions
+          about your information, visit the FAQs or contact your VA Health care
+          team.
+        </p>
+        <PrintDownload list download={generateVaccinesPdf} />
+      </section>
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/VitalDetails.jsx
@@ -88,73 +88,75 @@ const VitalDetails = () => {
       return (
         <>
           <h1>{filteredVitals[0].name}</h1>
-          <PrintDownload list download={download} />
-          <div className="vads-u-padding-y--1 vads-u-margin-bottom--0 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light no-print">
-            Displaying {displayNums[0]}
-            &#8211;
-            {displayNums[1]} of {filteredVitals.length} vitals
-          </div>
-          <ul className="vital-details no-print">
-            {currentVitals?.length > 0 &&
-              currentVitals?.map((vital, idx) => (
-                <li key={idx}>
-                  <h2>Measurement:</h2>
-                  <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
-                    {vital.measurement}
-                  </p>
-                  <h2>{idx === 0 ? 'Most recent date:' : 'Date:'}</h2>
-                  <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
-                    {formatDateLong(vital.date)}
-                  </p>
-                  <h2>Location:</h2>
-                  <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
-                    {vital.facility}
-                  </p>
-                  <h2>Provider comments:</h2>
-                  {vital?.comments?.length > 0 ? (
-                    <ul className="comment-list">
-                      {vital.comments.map((comment, commentIdx) => (
-                        <li key={commentIdx}>{comment}</li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="vads-u-margin--0">None noted</p>
-                  )}
-                </li>
-              ))}
-          </ul>
-          <ul className="vital-details print-only">
-            {filteredVitals?.length > 0 &&
-              filteredVitals?.map((vital, idx) => (
-                <li key={idx}>
-                  <h2>Measurement:</h2>
-                  <p>{vital.measurement}</p>
-                  <h2>{idx === 0 ? 'Most recent date:' : 'Date:'}</h2>
-                  <p>{formatDateLong(vital.date)}</p>
-                  <h2>Location:</h2>
-                  <p>{vital.facility}</p>
-                  <h2>Provider comments:</h2>
-                  {vital?.comments?.length > 0 ? (
-                    <ul className="comment-list">
-                      {vital.comments.map((comment, commentIdx) => (
-                        <li key={commentIdx}>{comment}</li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <span className="vads-u-margin--0">None noted</span>
-                  )}
-                </li>
-              ))}
-          </ul>
-          <div className="vads-u-margin-bottom--2 no-print">
-            <VaPagination
-              onPageSelect={e => onPageChange(e.detail.page)}
-              page={currentPage}
-              pages={paginatedVitals.current.length}
-              maxPageListLength={MAX_PAGE_LIST_LENGTH}
-              showLastPage
-            />
-          </div>
+          <section className="set-width-486">
+            <PrintDownload list download={download} />
+            <div className="vads-u-padding-y--1 vads-u-margin-bottom--0 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light no-print">
+              Displaying {displayNums[0]}
+              &#8211;
+              {displayNums[1]} of {filteredVitals.length} vitals
+            </div>
+            <ul className="vital-details no-print">
+              {currentVitals?.length > 0 &&
+                currentVitals?.map((vital, idx) => (
+                  <li key={idx}>
+                    <h2>Measurement:</h2>
+                    <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
+                      {vital.measurement}
+                    </p>
+                    <h2>{idx === 0 ? 'Most recent date:' : 'Date:'}</h2>
+                    <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
+                      {formatDateLong(vital.date)}
+                    </p>
+                    <h2>Location:</h2>
+                    <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
+                      {vital.facility}
+                    </p>
+                    <h2>Provider comments:</h2>
+                    {vital?.comments?.length > 0 ? (
+                      <ul className="comment-list">
+                        {vital.comments.map((comment, commentIdx) => (
+                          <li key={commentIdx}>{comment}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="vads-u-margin--0">None noted</p>
+                    )}
+                  </li>
+                ))}
+            </ul>
+            <ul className="vital-details print-only">
+              {filteredVitals?.length > 0 &&
+                filteredVitals?.map((vital, idx) => (
+                  <li key={idx}>
+                    <h2>Measurement:</h2>
+                    <p>{vital.measurement}</p>
+                    <h2>{idx === 0 ? 'Most recent date:' : 'Date:'}</h2>
+                    <p>{formatDateLong(vital.date)}</p>
+                    <h2>Location:</h2>
+                    <p>{vital.facility}</p>
+                    <h2>Provider comments:</h2>
+                    {vital?.comments?.length > 0 ? (
+                      <ul className="comment-list">
+                        {vital.comments.map((comment, commentIdx) => (
+                          <li key={commentIdx}>{comment}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <span className="vads-u-margin--0">None noted</span>
+                    )}
+                  </li>
+                ))}
+            </ul>
+            <div className="vads-u-margin-bottom--2 no-print">
+              <VaPagination
+                onPageSelect={e => onPageChange(e.detail.page)}
+                page={currentPage}
+                pages={paginatedVitals.current.length}
+                maxPageListLength={MAX_PAGE_LIST_LENGTH}
+                showLastPage
+              />
+            </div>
+          </section>
         </>
       );
     }

--- a/src/applications/mhv/medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv/medical-records/containers/Vitals.jsx
@@ -83,11 +83,13 @@ const Vitals = () => {
   return (
     <div className="vaccines" id="vitals">
       <h1>Vitals</h1>
-      <p>Review vitals in your VA medical records</p>
-      <va-additional-info trigger="What to know about vitals">
-        This is some additional info about vitals, though we are waiting on the
-        Content Team to tell us what should be here...
-      </va-additional-info>
+      <section className="set-width-486">
+        <p>Review vitals in your VA medical records</p>
+        <va-additional-info trigger="What to know about vitals">
+          This is some additional info about vitals, though we are waiting on
+          the Content Team to tell us what should be here...
+        </va-additional-info>
+      </section>
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/sass/labs-and-tests.scss
+++ b/src/applications/mhv/medical-records/sass/labs-and-tests.scss
@@ -45,3 +45,7 @@
 .make-monospace{
   font-family: monospace;
 }
+
+.set-width-486{
+  max-width: 486px;
+}


### PR DESCRIPTION
Fixed a bug in CareSummariesDetails that was preventing Admission entries from rendering. Added a max width of 486px for the pages.

## Summary

- I added a max-width to a lot of pages specified in the ticket. Also repaired an incorrect condition that was preventing a page from rendering in CareSummariesDetails.
- Not a bug.
- MHV Medical Records
- Not using flipper

## Related issue(s)

- [_Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000](https://jira.devops.va.gov/browse/MHV-44363)

## Testing done

- Text was spilling over the entries listed for the section.
