### PR TITLE
Vet relationship custom label suggestion

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockRadioRelationshipToVeteran.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockRadioRelationshipToVeteran.js
@@ -5,17 +5,28 @@ import {
   relationshipToVeteranSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+const customLabels = {
+  spouse: 'I am the spouse',
+  child: 'I am the child',
+  other: 'Other option',
+};
+
 /** @type {PageSchema} */
 export default {
   uiSchema: {
     wcTitle: titleUI('Web component'),
-    wcv3RelationshipToVeteran: relationshipToVeteranUI(),
+    wcv3RelationshipToVeteran: relationshipToVeteranUI(
+      'what is your relationship to this person?',
+      'type something else here',
+      customLabels,
+      'other',
+    ),
   },
   schema: {
     type: 'object',
     properties: {
       wcTitle: titleSchema,
-      wcv3RelationshipToVeteran: relationshipToVeteranSchema,
+      wcv3RelationshipToVeteran: relationshipToVeteranSchema(customLabels),
     },
   },
 };

--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -1,6 +1,14 @@
 import { radioUI, radioSchema } from './radioPattern';
 import VaTextInputField from '../web-component-fields/VaTextInputField';
 
+const defaultLabels = {
+  spouse: 'Spouse',
+  child: 'Child',
+  parent: 'Parent',
+  executor: 'Executor/Administrator of Estate',
+  other: 'A relationship not listed here',
+};
+
 export const relationshipToVeteranUI = (
   relationshipToVeteranTitle,
   otherRelationshipToVeteranTitle,
@@ -12,7 +20,7 @@ export const relationshipToVeteranUI = (
       title:
         relationshipToVeteranTitle ??
         'What’s your relationship to the veteran?',
-      labels: customLabels,
+      labels: customLabels ?? defaultLabels,
     }),
     otherRelationshipToVeteran: {
       'ui:title':
@@ -21,7 +29,7 @@ export const relationshipToVeteranUI = (
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'relationshipToVeteran',
-        expandUnderCondition: otherRelationshipKey,
+        expandUnderCondition: otherRelationshipKey ?? 'other',
       },
     },
     'ui:options': {
@@ -41,10 +49,13 @@ export const relationshipToVeteranUI = (
 };
 
 export const relationshipToVeteranSchema = customLabels => {
+  const labelKeys = customLabels
+    ? Object.keys(customLabels)
+    : Object.keys(defaultLabels);
   return {
     type: 'object',
     properties: {
-      relationshipToVeteran: radioSchema(Object.keys(customLabels)),
+      relationshipToVeteran: radioSchema(labelKeys),
       otherRelationshipToVeteran: {
         type: 'string',
       },

--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -4,19 +4,15 @@ import VaTextInputField from '../web-component-fields/VaTextInputField';
 export const relationshipToVeteranUI = (
   relationshipToVeteranTitle,
   otherRelationshipToVeteranTitle,
+  customLabels,
+  otherRelationshipKey,
 ) => {
   return {
     relationshipToVeteran: radioUI({
       title:
         relationshipToVeteranTitle ??
         'What’s your relationship to the veteran?',
-      labels: {
-        spouse: 'Spouse',
-        child: 'Child',
-        parent: 'Parent',
-        executor: 'Executor/Administrator of Estate',
-        other: 'A relationship not listed here',
-      },
+      labels: customLabels,
     }),
     otherRelationshipToVeteran: {
       'ui:title':
@@ -25,7 +21,7 @@ export const relationshipToVeteranUI = (
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'relationshipToVeteran',
-        expandUnderCondition: 'other',
+        expandUnderCondition: otherRelationshipKey,
       },
     },
     'ui:options': {
@@ -44,19 +40,15 @@ export const relationshipToVeteranUI = (
   };
 };
 
-export const relationshipToVeteranSchema = {
-  type: 'object',
-  properties: {
-    relationshipToVeteran: radioSchema([
-      'spouse',
-      'child',
-      'parent',
-      'executor',
-      'other',
-    ]),
-    otherRelationshipToVeteran: {
-      type: 'string',
+export const relationshipToVeteranSchema = customLabels => {
+  return {
+    type: 'object',
+    properties: {
+      relationshipToVeteran: radioSchema(Object.keys(customLabels)),
+      otherRelationshipToVeteran: {
+        type: 'string',
+      },
     },
-  },
-  required: ['relationshipToVeteran'],
+    required: ['relationshipToVeteran'],
+  };
 };


### PR DESCRIPTION
building on https://github.com/department-of-veterans-affairs/vets-website/pull/24854

### Summary
- Add two parameters to relationshipToVeteranUI for customLabels and other relationship key
  - we _might_ be able to rely on it always being the last key, but just safer this way, and can rename
- Add one parameter to relationshipToVeteranSchema for customLabels
- Add default label object to pattern, use when no custom labels provided
