### PR TITLE
FileField: Prevent JS error

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -388,7 +388,7 @@ const FileField = props => {
 
   const deleteThenAddFile = index => {
     removeFile(index, false);
-    fileInputRef.current.click();
+    fileInputRef.current?.click();
   };
 
   const getRetryFunction = (allowRetry, index, file) => {
@@ -460,7 +460,9 @@ const FileField = props => {
                 scrollToFirstError();
                 if (enableShortWorkflow) {
                   const retryButton = $(`[name="retry_upload_${index}"]`);
-                  focusElement('button', {}, retryButton?.shadowRoot);
+                  if (retryButton) {
+                    focusElement('button', {}, retryButton?.shadowRoot);
+                  }
                 } else if (showPasswordInput) {
                   focusElement(`#${fileListId} .usa-input-error-message`);
                 } else {
@@ -470,8 +472,10 @@ const FileField = props => {
             } else if (showPasswordInput) {
               setTimeout(() => {
                 const passwordInput = $(`[name="get_password_${index}"]`);
-                focusElement('input', null, passwordInput.shadowRoot);
-                scrollTo(`get_password_${index}"]`);
+                if (passwordInput) {
+                  focusElement('input', {}, passwordInput?.shadowRoot);
+                  scrollTo(`get_password_${index}"]`);
+                }
               }, 100);
             }
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In Sentry logs two new errors showed up last week
  > - [`Cannot read properties of null (reading 'click')`](http://sentry.vfs.va.gov/organizations/vsp/discover/results/?field=message&name=Supplemental+Claims&project=4&query=url%3Ahttps%3A%2F%2Fwww.va.gov%2Fdecision-reviews%2Fsupplemental-claim%2Ffile-supplemental-claim-form-20-0995%2F%2A+level%3Aerror+message%3A%22Cannot+read+properties+of+null+%28reading+%27shadowRoot%27%29+TypeError+%2Fgenerated%2F995-supplemental-claim.entry.js+%3F%28generated%2F995-supplemental-claim.entry%29%22&sort=-message&statsPeriod=7d&widths=-1)
  > - [`null is not an object (evaluating 'cg('[name=get_password_'.concat(i,']').shadowRoot') TypeError`](http://sentry.vfs.va.gov/organizations/vsp/discover/results/?field=message&name=Supplemental+Claims&project=4&query=url%3Ahttps%3A%2F%2Fwww.va.gov%2Fdecision-reviews%2Fsupplemental-claim%2Ffile-supplemental-claim-form-20-0995%2F%2A+level%3Aerror+message%3A%22cg%28...%29+is+null+TypeError+%2Fgenerated%2F995-supplemental-claim.entry.js+_z%2F%3C%2F%3C+_z%2F%3C%2F%3C%28generated%2F995-supplemental-claim.entry%29%22&sort=-message&statsPeriod=7d&widths=-1)
  > Both of which appear to be caused by not optional chaining a `shadowRoot` check on a web component
- _(If bug, how to reproduce)_
  > Unknown
- _(What is the solution, why is this the solution)_
  > Add optional chaining, and a secondary check to ensure the DOM element exists
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#58596](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58596)

## Testing done

- _Describe what the old behavior was prior to the change_
  > - Because `enableShortWorkflow` is enabled in production, a failed upload would show an "Upload a new file" button. Which when activated would delete the associated file and `click` the file upload button, but the React `ref` may not have been properly registered to the `current` value causing an error. 
  > - Password input selector would return `null` and immediately attempt to get the `shadowRoot`.
- _Describe the steps required to verify your changes are working as expected_
  > Not able to reproduce, but added optional chaining & a truthy check to prevent JS errors from being thrown
- _Describe the tests completed and the results_
  > No change to unit tests, all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All apps that use platform's `FileField` component

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
