### PR TITLE
Add direct import of i18n-setup

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -6,6 +6,7 @@ import Select from '@department-of-veterans-affairs/component-library/Select';
 import environment from 'platform/utilities/environment';
 import { getActivePages } from 'platform/forms-system/src/js/helpers';
 import localStorage from 'platform/utilities/storage/localStorage';
+import '@department-of-veterans-affairs/component-library/i18n-setup';
 
 const docsPage =
   'https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/forms/save-in-progress-menu';

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+// eslint-disable-next-line deprecate/import
 import Select from '@department-of-veterans-affairs/component-library/Select';
 
 import environment from 'platform/utilities/environment';

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM /* , { act } */ from 'react-dom';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
-import '@department-of-veterans-affairs/component-library/i18n-setup';
+
 import { getFormDOM } from 'platform/testing/unit/schemaform-utils.jsx';
 import cloneDeep from '../../../utilities/data/cloneDeep';
 import SipsDevModal from '../../save-in-progress/SaveInProgressDevModal';

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM /* , { act } */ from 'react-dom';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
-
+import '@department-of-veterans-affairs/component-library/i18n-setup';
 import { getFormDOM } from 'platform/testing/unit/schemaform-utils.jsx';
 import cloneDeep from '../../../utilities/data/cloneDeep';
 import SipsDevModal from '../../save-in-progress/SaveInProgressDevModal';


### PR DESCRIPTION
## Summary

Adds import of i18n-setup to vets-website. This is currently implicitly being imported with the component library's react components, but as those are being deprecated, tests are breaking without this import.

## Related issue(s)

- Closes [investigate i18n-setup file 1839](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1839)

## Testing done

- This change will unblock deprecating the [select react component](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1735)
- Ran tests locally and checked website locally

## Screenshots

![Day-of-check-in--Appointment-detail-checked-in](https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/50d620fb-8aff-4f3a-9423-ec23821e8023)
![Day-of-check-in--Appointment-detail-checked-in-spanish](https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/66886ce3-1b03-4fb1-ab86-4f7c0aaa27e9)

Here are screenshots of the components after replacing the react component with web ones.
Replaced Select
![Screenshot 2023-07-18 at 5 50 50 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/a8f3f91f-dd18-4a2a-9aa7-8bb0fe4ae353)

Replaced TextInput
![Screenshot 2023-07-18 at 5 50 39 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/0af85741-886c-4d66-99b8-abe44564f08a)

## What areas of the site does it impact?

*Only affects tests

## Requested Feedback

As this only affects tests, I added this import to a test that breaks when the react component is removed. If there is somewhere better for this to be added I'm happy to move it.
