### PR TITLE
simple forms: remove flipper blocking page from 26-4555

### DIFF
--- a/src/applications/simple-forms/26-4555/containers/App.jsx
+++ b/src/applications/simple-forms/26-4555/containers/App.jsx
@@ -1,34 +1,12 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import environment from 'platform/utilities/environment';
-
 import formConfig from '../config/form';
-import { workInProgressContent } from '../definitions/constants';
 
-import { WIP } from '../../shared/components/WIP';
-
-export function App({ location, children, show264555 }) {
-  if (!show264555 && !environment.isLocalhost()) {
-    return <WIP content={workInProgressContent} />;
-  }
+export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
 }
-
-App.propTypes = {
-  show264555: PropTypes.bool,
-};
-
-const mapStateToProps = state => ({
-  show264555: toggleValues(state)[FEATURE_FLAG_NAMES.form264555] || false,
-});
-
-export default connect(mapStateToProps)(App);

--- a/src/applications/simple-forms/shared/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/simple-forms/shared/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,11 +1,6 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [
-      {
-        "name": "form264555",
-        "value": true
-      }
-    ]
+    "features": []
   }
 }


### PR DESCRIPTION
Remove this wip card that blocks the form when the flipper is disabled

## Summary

- Remove extra flipper logic from `App`
- Remove mocked flipper logic from tests
