### PR TITLE
fix: change source to sourceSystem

### DIFF
--- a/src/applications/personalization/rated-disabilities/actions/index.js
+++ b/src/applications/personalization/rated-disabilities/actions/index.js
@@ -71,7 +71,7 @@ export function fetchTotalDisabilityRating(recordAnalyticsEvent = recordEvent) {
       type: FETCH_TOTAL_RATING_STARTED,
     });
     const response = await getData('/disability_compensation_form/rating_info');
-    const source = response?.source;
+    const source = response?.sourceSystem;
     const sourceString = source ? ` - ${source}` : '';
     const apiName = `GET disability rating${sourceString}`;
 

--- a/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
@@ -91,7 +91,9 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
 
   it('should attach the appropriate source to the analytics event when EVSS is source', () => {
     const total = {
-      data: { attributes: { userPercentOfDisability: 80, source: 'EVSS' } },
+      data: {
+        attributes: { userPercentOfDisability: 80, sourceSystem: 'EVSS' },
+      },
     };
     setFetchJSONResponse(global.fetch.onCall(0), total);
     const analyticsSpy = sinon.spy();
@@ -113,7 +115,7 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
   it('should attach the appropriate source to the analytics event when Lighthouse is source', () => {
     const total = {
       data: {
-        attributes: { userPercentOfDisability: 80, source: 'Lighthouse' },
+        attributes: { userPercentOfDisability: 80, sourceSystem: 'Lighthouse' },
       },
     };
     setFetchJSONResponse(global.fetch.onCall(0), total);
@@ -164,7 +166,7 @@ describe('Rated Disabilities actions: fetchTotalDisabilityRating', () => {
   it('should pass source to error analytics call if present', () => {
     const response = {
       data: {
-        attributes: { source: 'EVSS' },
+        attributes: { sourceSystem: 'EVSS' },
       },
       errors: [
         {


### PR DESCRIPTION
## Summary

- I misread the response data, and had the code looking for `source` instead of `sourceSystem` for the rating calls. This fixes the issue. Luckily there were no errors or problems created as I was looking for the optional chaining of `source` being present, so it just didn't add any additional info to the GA calls.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61095

## Testing done

- updated unit tests for action file.

## Screenshots

No UI changes

## What areas of the site does it impact?

GA calls for personalization applications

## Acceptance criteria

- [x] GA call updated to look at `sourceSystem` instead of `source`

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
