### PR TITLE
VFEP-709  ageWarning and Highschool question trigger update

### DIFF
--- a/src/applications/edu-benefits/5490/components/applicantInformationUpdate.jsx
+++ b/src/applications/edu-benefits/5490/components/applicantInformationUpdate.jsx
@@ -19,7 +19,6 @@ const defaults = prefix => ({
     'view:noSSN',
     `${prefix}SocialSecurityNumber`,
     `${prefix}DateOfBirth`,
-    'view:ageWarningNotification',
     'minorHighSchoolQuestions',
     'gender',
     'relationshipAndChildType',
@@ -51,10 +50,6 @@ export default function applicantInformationUpdate(schema, options) {
     ...schema.properties,
     'view:noSSN': {
       type: 'boolean',
-    },
-    'view:ageWarningNotification': {
-      type: 'object',
-      properties: {},
     },
     minorHighSchoolQuestions: {
       type: 'object',
@@ -90,17 +85,10 @@ export default function applicantInformationUpdate(schema, options) {
           futureDate: 'Please provide a valid date',
         },
       },
-      'view:ageWarningNotification': {
+      minorHighSchoolQuestions: {
         'ui:description': ageWarning,
         'ui:options': {
-          hideIf: formData => {
-            return eighteenOrOver(formData.relativeDateOfBirth);
-          },
-        },
-      },
-      minorHighSchoolQuestions: {
-        'ui:options': {
-          expandUnder: 'view:ageWarningNotification',
+          expandUnder: [`${prefix}DateOfBirth`],
           hideIf: formData => eighteenOrOver(formData.relativeDateOfBirth),
         },
         minorHighSchoolQuestion: {


### PR DESCRIPTION
## Summary

- - Changes made to how the high school questions appear. Visually there is no change, the change is in the code base. Previously when an applicant entered their birth date and is 17 years old, this would cause a trigger to show additional questions for the applicant to answer. These questions ask about High school completion dates. The way the questions would appear on the screen was to expand under the notification warning called ageWarning. 

This caused an issue if the applicant made it to the presubmit section of the code and tried to change their date of birth before submitting the form. In the presubmit section, if the user entered a birth date that made them 17 the age warning would not appear causing the high school questions to not show (since high school questions were programmed to expand under ageWarning)

To fix this issue, the age warning was deleted as it's own entity and combined with the high school questions, and have the high school questions expand under the date field. Now when the user edits the date field in the presubmit section and is 17 years old, the high school questions appear as they should.

- _(If bug, how to reproduce)_ N/A
- _(What is the solution, why is this the solution)_
-  - The ageWarning was conditionally rendered meaning it would only appear if the criteria for it was met. This caused an issue in the presubmit section were the ageWarning (even when the condition was met) would not render, thus, making the high school questions not render. By expanding the high school questions under the date field (date field always shows) we are able to get the desired trigger to work in the presubmit section.
- _(Which team do you work for, does your team own the maintenance of this component?)_
-  - I work for GOVCIO, we are the code owners for this.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- - No flipper but I am using an environmental variable to keep changes in staging until testing is completed.

## Related issue(s)

Jira Ticket - https://jira.devops.va.gov/browse/VFEP-709

## Testing done

- _Describe what the old behavior was prior to the change_
- - In the presubmit section of the form, the user would not be able to fill anything out when editing if the user changed their birth date that made them 17 years old. What would happen is that conditionally hidden fields that are also conditionally required would not show as they should. However, the condition that makes them required would trigger meaning you now had fields that were required and could not be filled out since they were not being displayed to the screen. This caused the form to lock up until the birth date was changed to an ager older than 17.
- _Describe the steps required to verify your changes are working as expected_
- - Work through the form, once you make it to the presubmit section, edit the applicant information section. Change the applicants date of birth to make the applicant older than 17. Then change the applicants date of birth to make them 17. If the ageWarning appears and the high school questions appear, the change is working.
- _Describe the tests completed and the results_
- - Test conducted on local machine. Further testing will be completed in staging.
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_ NA

## Screenshots NA / no Visual change made, all code related


## What areas of the site does it impact?
- - This impacts the form 22-5490

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- - User can change date of birth that makes them 17 in the presubmit section of form 22-5490 and see the new ageWarning and high school questions appear

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
