### PR TITLE
NOD | Fix contestable issue validation

### DIFF
--- a/src/applications/appeals/10182/pages/contestableIssues.js
+++ b/src/applications/appeals/10182/pages/contestableIssues.js
@@ -3,7 +3,6 @@ import ContestableIssuesWidget from '../components/ContestableIssuesWidget';
 import { ContestableIssuesAdditionalInfo } from '../content/contestableIssues';
 
 import { selectionRequired, maxIssues } from '../validations/issues';
-// import { hasSomeSelected } from '../utils/helpers';
 import { SELECTED } from '../constants';
 
 /**
@@ -20,7 +19,7 @@ const contestableIssues = {
       'ui:title': ' ',
       'ui:field': 'StringField',
       'ui:widget': ContestableIssuesWidget,
-      // 'ui:required': formData => !hasSomeSelected(formData),
+      'ui:required': () => true,
       'ui:options': {
         forceDivWrapper: true,
         keepInPageOnReview: true,

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -44,6 +44,17 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(testData => {
+            cy.findByText('Continue', { selector: 'button' }).click();
+            // prevent continuing without any issues selected
+            cy.location('pathname').should(
+              'eq',
+              `${BASE_URL}/${CONTESTABLE_ISSUES_PATH}`,
+            );
+            cy.get('va-alert[status="error"] h3').should(
+              'contain',
+              'You’ll need to select an issue',
+            );
+
             testData.additionalIssues?.forEach(additionalIssue => {
               if (additionalIssue.issue && additionalIssue[SELECTED]) {
                 cy.get('.add-new-issue').click();

--- a/src/applications/appeals/995/pages/contestableIssues.js
+++ b/src/applications/appeals/995/pages/contestableIssues.js
@@ -19,6 +19,7 @@ const contestableIssues = {
       'ui:title': ' ',
       'ui:field': 'StringField',
       'ui:widget': ContestableIssuesWidget,
+      'ui:required': () => true,
       'ui:options': {
         forceDivWrapper: true,
         keepInPageOnReview: true,

--- a/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
@@ -11,6 +11,7 @@ import {
   mockContestableIssuesWithLegacyAppeals,
   getPastItf,
   fetchItf,
+  getRandomDate,
 } from './995.cypress.helpers';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockPrefill from './fixtures/mocks/prefill.json';
@@ -22,6 +23,7 @@ import {
   CONTESTABLE_ISSUES_API,
   EVIDENCE_UPLOAD_API,
   PRIMARY_PHONE,
+  SELECTED,
   BASE_URL,
   CONTESTABLE_ISSUES_PATH,
   EVIDENCE_VA_PATH,
@@ -68,21 +70,41 @@ const testConfig = createTestConfig(
         });
       },
       [CONTESTABLE_ISSUES_PATH]: ({ afterHook }) => {
-        cy.fillPage();
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(testData => {
-            testData.additionalIssues?.forEach(({ issue, decisionDate }) => {
-              if (issue) {
+            cy.findByText('Continue', { selector: 'button' }).click();
+            // prevent continuing without any issues selected
+            cy.location('pathname').should(
+              'eq',
+              `${BASE_URL}/${CONTESTABLE_ISSUES_PATH}`,
+            );
+            cy.get('va-alert[status="error"] h3').should(
+              'contain',
+              'You’ll need to select an issue',
+            );
+
+            testData.additionalIssues?.forEach(additionalIssue => {
+              if (additionalIssue.issue && additionalIssue[SELECTED]) {
                 cy.get('.add-new-issue').click();
                 cy.url().should('include', `${BASE_URL}/add-issue?index=`);
                 cy.axeCheck();
                 cy.get('#issue-name')
                   .shadow()
                   .find('input')
-                  .type(issue);
-                cy.fillDate('decision-date', decisionDate);
+                  .type(additionalIssue.issue);
+                cy.fillDate('decision-date', getRandomDate());
                 cy.get('#submit').click();
+              }
+            });
+            testData.contestedIssues.forEach(issue => {
+              if (issue[SELECTED]) {
+                cy.get(
+                  `h4:contains("${issue.attributes.ratingIssueSubjectText}")`,
+                )
+                  .closest('li')
+                  .find('input[type="checkbox"]')
+                  .click();
               }
             });
             cy.findByText('Continue', { selector: 'button' }).click();

--- a/src/applications/appeals/995/tests/fixtures/data/no-evidence-test.json
+++ b/src/applications/appeals/995/tests/fixtures/data/no-evidence-test.json
@@ -12,9 +12,9 @@
         "ratingIssueReferenceId": "142894",
         "ratingIssueProfileDate": "2022-03-12",
         "ratingIssueDiagnosticCode": "5260",
-        "ratingIssueSubjectText": "Ankylosis of knee",
+        "ratingIssueSubjectText": "Headaches",
+        "description": "Acute chronic head pain",
         "ratingIssuePercentNumber": "10",
-        "description": "Service connection for Ankylosis of knee is granted with an evaluation of 10 percent effective December 2, 2020.",
         "isRating": true,
         "latestIssuesInChain": [{
           "id": null,

--- a/src/applications/appeals/995/tests/fixtures/data/transformed-no-evidence-test.json
+++ b/src/applications/appeals/995/tests/fixtures/data/transformed-no-evidence-test.json
@@ -33,7 +33,7 @@
   "included": [{
     "type": "contestableIssue",
     "attributes": {
-      "issue": "Ankylosis of knee - 10% - Service connection for Ankylosis of knee is granted with an evaluation of 10 percent effective December 2, 2020.",
+      "issue": "Headaches - 10% - Acute chronic head pain",
       "decisionDate": "2022-03-12",
       "ratingIssueReferenceId": "142894"
     }

--- a/src/applications/appeals/996/pages/contestableIssues.js
+++ b/src/applications/appeals/996/pages/contestableIssues.js
@@ -19,6 +19,7 @@ const contestableIssues = {
       'ui:title': ' ',
       'ui:field': 'StringField',
       'ui:widget': ContestableIssuesWidget,
+      'ui:required': () => true,
       'ui:options': {
         forceDivWrapper: true,
         keepInPageOnReview: true,

--- a/src/applications/appeals/996/tests/hlr.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr.cypress.spec.js
@@ -55,6 +55,17 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(testData => {
+            cy.findByText('Continue', { selector: 'button' }).click();
+            // prevent continuing without any issues selected
+            cy.location('pathname').should(
+              'eq',
+              `${BASE_URL}/${CONTESTABLE_ISSUES_PATH}`,
+            );
+            cy.get('va-alert[status="error"] h3').should(
+              'contain',
+              'You’ll need to select an issue',
+            );
+
             testData.additionalIssues?.forEach(additionalIssue => {
               if (additionalIssue.issue && additionalIssue[SELECTED]) {
                 cy.get('.add-new-issue').click();


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Prior to this fix, the contestable issues page of the Notice of Disagreement form (Board Appeals) would allow the user to continue past the page without having any issues selected. This would cause the NOD to be immediately rejected upon submission - we haven't seen this happening in our logs.
- _(If bug, how to reproduce)_
  > Start NOD in staging, log into any user, continue past the contestable issues page
- _(What is the solution, why is this the solution)_
  > The `ui:required` setting was missing in all 3 appeals forms, but only NOD was allowing users to navigate past the issues page; either way, this PR adds the required setting to all 3 forms.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#60775](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60775)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Validation functions were skipped. Adding the `ui:required` setting ensured that the `ui:validations` functions were executed 
- _Describe the steps required to verify your changes are working as expected_
  > Attempt to reproduce the issues - continue past the contestable issue page without any issues selected
- _Describe the tests completed and the results_
  > Updated e2e test to check that the alert shows when no issues are selected
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |        | <img width="616" alt="Screenshot 2023-07-17 at 1 59 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/57690f21-55b0-4ae6-aca1-b04e3b67f7ee"> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
