### PR TITLE
[MHV-46068] SM to VA.gov - print modal radio label

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
@@ -87,14 +87,11 @@ const PrintBtn = props => {
                 data-testid="radio-print-all-messages"
                 style={{ display: 'flex' }}
                 aria-label={`Print all messages in this conversation (${messageThreadCount} messages)`}
-                label="Print all messages in this conversation"
+                label={`Print all messages in this conversation (${messageThreadCount} messages)`}
                 value={PrintMessageOptions.PRINT_THREAD}
                 name="all-messages"
               />
             </VaRadio>
-            <p>
-              <strong>{`(${messageThreadCount} messages)`}</strong>
-            </p>
           </div>
         </VaModal>
       </div>

--- a/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageActionButtons/PrintBtn.jsx
@@ -87,7 +87,8 @@ const PrintBtn = props => {
                 data-testid="radio-print-all-messages"
                 style={{ display: 'flex' }}
                 aria-label={`Print all messages in this conversation (${messageThreadCount} messages)`}
-                label={`Print all messages in this conversation (${messageThreadCount} messages)`}
+                label="Print all messages in this conversation"
+                description={`(${messageThreadCount} messages)`}
                 value={PrintMessageOptions.PRINT_THREAD}
                 name="all-messages"
               />

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -44,7 +44,8 @@ va-alert button {
 }
 
 va-modal va-radio {
-  margin-left: 12px;
+  margin-left: 0px;
+  margin-bottom: 24px;
 }
 
 .message-box {

--- a/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/PrintBtn.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/PrintBtn.unit.spec.jsx
@@ -52,7 +52,8 @@ describe('Print button', () => {
     const printAllMessages = screen.getByTestId('radio-print-all-messages');
     expect(printAllMessages).to.have.attribute(
       'label',
-      'Print all messages in this conversation (2 messages)',
+      'Print all messages in this conversation',
     );
+    expect(printAllMessages).to.have.attribute('description', '(2 messages)');
   });
 });

--- a/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/PrintBtn.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/MessageActionButtons/PrintBtn.unit.spec.jsx
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/dom';
 import { expect } from 'chai';
 import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import PrintBtn from '../../../components/MessageActionButtons/PrintBtn';
-import messageResponse from '../../fixtures/message-response.json';
+import messageDetails from '../../fixtures/threads/message-thread-reducer.json';
 import reducers from '~/applications/mhv/secure-messaging/reducers';
 
 describe('Print button', () => {
@@ -11,15 +11,9 @@ describe('Print button', () => {
   beforeEach(() => {
     const id = 7155731;
     const handlePrint = () => {};
-    // const initialState = {
-    //   message: { message: { messageResponse }, messages: null },
-    // };
     const initialState = {
       sm: {
-        messageDetails: {
-          message: messageResponse,
-          messageHistory: null,
-        },
+        ...messageDetails,
       },
     };
 
@@ -40,9 +34,25 @@ describe('Print button', () => {
   });
   it('opens modal when print button is clicked and displays both options', () => {
     fireEvent.click(screen.getByTestId('print-button'));
-    // expect(screen.getByLabelText('Only print this message')).to.exist;
-    expect(screen.getByTestId('radio-print-one-message')).to.exist;
 
-    expect(screen.getByTestId('radio-print-all-messages')).to.exist;
+    const modal = screen.getByTestId('print-modal-popup');
+    expect(modal).to.exist;
+    expect(modal).to.have.attribute('modaltitle', 'What do you want to print?');
+    expect(modal).to.have.attribute('visible', 'true');
+    expect(modal).to.have.attribute('large', 'true');
+    expect(modal).to.have.attribute('primary-button-text', 'Print');
+    expect(modal).to.have.attribute('secondary-button-text', 'Cancel');
+
+    const printOneMessage = screen.getByTestId('radio-print-one-message');
+    expect(printOneMessage).to.have.attribute(
+      'label',
+      'Print only this message',
+    );
+
+    const printAllMessages = screen.getByTestId('radio-print-all-messages');
+    expect(printAllMessages).to.have.attribute(
+      'label',
+      'Print all messages in this conversation (2 messages)',
+    );
   });
 });


### PR DESCRIPTION
## Summary

When printing a message modal, the second radio button, "Print all messages in this conversation," is followed by a line of text indicating how many messages are in that conversation --- important context for a user deciding how much they want to print. That line of text isn't programmatically associated with the radio button, so it's not announced by a screen reader when a user moves focus to the radio button. Since it's just a p paragraph of text that doesn't receive focus, a screen reader user who's tabbing through the interactive elements in the modal is likely to skip right over that text entirely without ever hearing it.

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-46068
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/59482

## Testing done

- SQA Testing 
- Unit Testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="200px" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/7df41c9c-3676-4541-b066-747585156e71">|<img width="200px" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/f322ea7c-182e-4718-a328-d09adc6a5857">|
| Desktop |<img width="200px" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/f8dfd84b-8a0c-4b32-9918-a5c83e46863b">|<img width="200px" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/7cbe4a78-11ca-4b49-83ee-310bdb45611e">|

## What areas of the site does it impact?

M Health - Secure Messages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
