### PR TITLE
VACMS-14347 Remove flaky Income Limits unit tests and replace in Cypress

### DIFF
--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -21,8 +21,6 @@ const HomePage = ({
 }) => {
   useEffect(
     () => {
-      router.push(ROUTES.HOME);
-
       const clearForm = () => {
         updateDependentsField('');
         updateYearField('');

--- a/src/applications/income-limits/routes.jsx
+++ b/src/applications/income-limits/routes.jsx
@@ -10,7 +10,10 @@ import { ROUTES } from './constants';
 const routes = {
   path: '/',
   component: IncomeLimitsApp,
-  indexRoute: { component: HomePage },
+  indexRoute: {
+    onEnter: (nextState, replace) => replace('/introduction'),
+    component: HomePage,
+  },
   childRoutes: [
     { path: ROUTES.HOME, component: HomePage },
     { path: ROUTES.DEPENDENTS, component: DependentsPage },

--- a/src/applications/income-limits/tests/DependentsPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/DependentsPage.unit.spec.jsx
@@ -2,12 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import DependentsPage from '../containers/DependentsPage';
-
-const pushSpyZipIsEmpty = sinon.spy();
-const pushSpyYearIsEmpty = sinon.spy();
 
 const mockStoreStandard = {
   getState: () => ({
@@ -38,66 +34,8 @@ const propsStandard = {
   zipCode: '10108',
 };
 
-const mockStoreZipIsEmpty = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      form: {
-        dependents: '',
-        year: '',
-        zipCode: '',
-      },
-      pastMode: false,
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsZipIsEmpty = {
-  editMode: false,
-  pastMode: false,
-  router: {
-    push: pushSpyZipIsEmpty,
-  },
-  updateZipCodeField: () => {},
-  toggleEditMode: () => {},
-  dependents: '',
-  year: '',
-  zipCode: '',
-};
-
-const mockStoreZipYearAreEmpty = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      form: {
-        dependents: '',
-        year: '',
-        zipCode: '',
-      },
-      pastMode: true,
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsZipYearAreEmpty = {
-  editMode: false,
-  pastMode: true,
-  router: {
-    push: pushSpyYearIsEmpty,
-  },
-  updateZipCodeField: () => {},
-  toggleEditMode: () => {},
-  dependents: '',
-  year: '',
-  zipCode: '',
-};
-
 describe('Dependents Page', () => {
-  it.skip('should correctly load the dependents page in the standard flow', () => {
+  it('should correctly load the dependents page in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
         <DependentsPage {...propsStandard} />
@@ -105,25 +43,5 @@ describe('Dependents Page', () => {
     );
 
     expect(screen.getByTestId('il-dependents')).to.exist;
-  });
-
-  it.skip('should not allow deep linking to this page if zip is empty', () => {
-    render(
-      <Provider store={mockStoreZipIsEmpty}>
-        <DependentsPage {...propsZipIsEmpty} />
-      </Provider>,
-    );
-
-    expect(pushSpyZipIsEmpty.withArgs('introduction').calledOnce).to.be.true;
-  });
-
-  it.skip('should not allow deep linking to this page if the year field and zip field are empty and pastMode is true', () => {
-    render(
-      <Provider store={mockStoreZipYearAreEmpty}>
-        <DependentsPage {...propsZipYearAreEmpty} />
-      </Provider>,
-    );
-
-    expect(pushSpyYearIsEmpty.withArgs('introduction').calledOnce).to.be.true;
   });
 });

--- a/src/applications/income-limits/tests/ResultsPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ResultsPage.unit.spec.jsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import ResultsPage from '../containers/ResultsPage';
-
-const pushSpyFormIncomplete = sinon.spy();
 
 const mockStoreStandard = {
   getState: () => ({
@@ -49,36 +46,8 @@ const propsStandard = {
   yearInput: '2015',
 };
 
-const mockStoreFormIncomplete = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      pastMode: false,
-      form: {
-        dependents: '',
-        year: '',
-        zipCode: '',
-      },
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsFormIncomplete = {
-  dependentsInput: '',
-  editMode: false,
-  pastMode: false,
-  router: {
-    push: pushSpyFormIncomplete,
-  },
-  toggleEditMode: () => {},
-  yearInput: '',
-  zipCodeInput: '',
-};
-
 describe('Results Page', () => {
-  it.skip('should correctly load the results page in the standard flow', () => {
+  it('should correctly load the results page in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
         <ResultsPage {...propsStandard} />
@@ -86,16 +55,5 @@ describe('Results Page', () => {
     );
 
     expect(screen.getByTestId('il-results')).to.exist;
-  });
-
-  it.skip('should not allow deep linking to this page if the form is not complete', () => {
-    render(
-      <Provider store={mockStoreFormIncomplete}>
-        <ResultsPage {...propsFormIncomplete} />
-      </Provider>,
-    );
-
-    expect(pushSpyFormIncomplete.withArgs('introduction').calledOnce).to.be
-      .true;
   });
 });

--- a/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ReviewPage.unit.spec.jsx
@@ -9,7 +9,6 @@ import ReviewPage from '../containers/ReviewPage';
 
 const pushSpyStandard = sinon.spy();
 const pushSpyPast = sinon.spy();
-const pushSpyFormIncomplete = sinon.spy();
 
 const mockStoreStandard = {
   getState: () => ({
@@ -67,36 +66,8 @@ const propsPast = {
   zipCodeInput: '60507',
 };
 
-const mockStoreFormIncomplete = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      pastMode: false,
-      form: {
-        dependents: '',
-        year: '',
-        zipCode: '',
-      },
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsFormIncomplete = {
-  dependentsInput: '',
-  editMode: false,
-  pastMode: false,
-  router: {
-    push: pushSpyFormIncomplete,
-  },
-  toggleEditMode: () => {},
-  yearInput: '',
-  zipCodeInput: '',
-};
-
 describe('Review Page', () => {
-  it.skip('should correctly load the review page in the standard flow', () => {
+  it('should correctly load the review page in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
         <ReviewPage {...propsStandard} />
@@ -112,7 +83,7 @@ describe('Review Page', () => {
     );
   });
 
-  it.skip('should correctly load the review page in the past flow', () => {
+  it('should correctly load the review page in the past flow', () => {
     const screen = render(
       <Provider store={mockStorePast}>
         <ReviewPage {...propsPast} />
@@ -132,7 +103,7 @@ describe('Review Page', () => {
     );
   });
 
-  it.skip('should call the correct function when the Edit link is used in the standard flow', () => {
+  it('should call the correct function when the Edit link is used in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
         <ReviewPage {...propsStandard} />
@@ -143,7 +114,7 @@ describe('Review Page', () => {
     expect(pushSpyStandard.withArgs('dependents').calledOnce).to.be.true;
   });
 
-  it.skip('should call the correct function when the Edit link is used in the past flow', () => {
+  it('should call the correct function when the Edit link is used in the past flow', () => {
     const screen = render(
       <Provider store={mockStorePast}>
         <ReviewPage {...propsPast} />
@@ -152,16 +123,5 @@ describe('Review Page', () => {
 
     userEvent.click(screen.getAllByText('Edit')[0]);
     expect(pushSpyPast.withArgs('year').calledOnce).to.be.true;
-  });
-
-  it.skip('should not allow deep linking to this page if the form is not complete', () => {
-    render(
-      <Provider store={mockStoreFormIncomplete}>
-        <ReviewPage {...propsFormIncomplete} />
-      </Provider>,
-    );
-
-    expect(pushSpyFormIncomplete.withArgs('introduction').calledOnce).to.be
-      .true;
   });
 });

--- a/src/applications/income-limits/tests/YearPage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/YearPage.unit.spec.jsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import YearPage from '../containers/YearPage';
-
-const pushSpyPastIsNull = sinon.spy();
 
 const mockStoreStandard = {
   getState: () => ({
@@ -33,31 +30,6 @@ const propsStandard = {
   yearInput: '2015',
 };
 
-const mockStorePastIsNull = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      form: {
-        year: '2015',
-      },
-      pastMode: null,
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsPastIsNull = {
-  editMode: false,
-  pastMode: null,
-  router: {
-    push: pushSpyPastIsNull,
-  },
-  updateYearField: () => {},
-  toggleEditMode: () => {},
-  yearInput: '2015',
-};
-
 describe('Year Page', () => {
   it('should correctly load the year page in the standard flow', () => {
     const screen = render(
@@ -67,15 +39,5 @@ describe('Year Page', () => {
     );
 
     expect(screen.getByTestId('il-year')).to.exist;
-  });
-
-  it('should not allow deep linking to this page if pastMode is null', () => {
-    render(
-      <Provider store={mockStorePastIsNull}>
-        <YearPage {...propsPastIsNull} />
-      </Provider>,
-    );
-
-    expect(pushSpyPastIsNull.withArgs('introduction').calledOnce).to.be.true;
   });
 });

--- a/src/applications/income-limits/tests/ZipCodePage.unit.spec.jsx
+++ b/src/applications/income-limits/tests/ZipCodePage.unit.spec.jsx
@@ -2,12 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import ZipCodePage from '../containers/ZipCodePage';
-
-const pushSpyPastIsNull = sinon.spy();
-const pushSpyYearIsEmpty = sinon.spy();
 
 const mockStoreStandard = {
   getState: () => ({
@@ -36,64 +32,8 @@ const propsStandard = {
   zipCode: '',
 };
 
-const mockStorePastIsNull = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      form: {
-        year: '',
-        zipCode: '',
-      },
-      pastMode: null,
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsPastIsNull = {
-  editMode: false,
-  pastMode: null,
-  router: {
-    push: pushSpyPastIsNull,
-  },
-  updateZipCodeField: () => {},
-  updateZipValError: () => {},
-  toggleEditMode: () => {},
-  year: '',
-  zipCode: '',
-};
-
-const mockStoreYearIsEmpty = {
-  getState: () => ({
-    incomeLimits: {
-      editMode: false,
-      form: {
-        year: '',
-        zipCode: '',
-      },
-      pastMode: true,
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const propsYearIsEmpty = {
-  editMode: false,
-  pastMode: true,
-  router: {
-    push: pushSpyYearIsEmpty,
-  },
-  updateZipCodeField: () => {},
-  updateZipValError: () => {},
-  toggleEditMode: () => {},
-  year: '',
-  zipCode: '',
-};
-
 describe('Zip Code Page', () => {
-  it.skip('should correctly load the zip code page in the standard flow', () => {
+  it('should correctly load the zip code page in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
         <ZipCodePage {...propsStandard} />
@@ -101,25 +41,5 @@ describe('Zip Code Page', () => {
     );
 
     expect(screen.getByTestId('il-zipCode')).to.exist;
-  });
-
-  it.skip('should not allow deep linking to this page if pastMode is null', () => {
-    render(
-      <Provider store={mockStorePastIsNull}>
-        <ZipCodePage {...propsPastIsNull} />
-      </Provider>,
-    );
-
-    expect(pushSpyPastIsNull.withArgs('introduction').calledOnce).to.be.true;
-  });
-
-  it.skip('should not allow deep linking to this page if the year field is empty and pastMode is true', () => {
-    render(
-      <Provider store={mockStoreYearIsEmpty}>
-        <ZipCodePage {...propsYearIsEmpty} />
-      </Provider>,
-    );
-
-    expect(pushSpyYearIsEmpty.withArgs('introduction').calledOnce).to.be.true;
   });
 });

--- a/src/applications/income-limits/tests/income-limits.cypress.spec.js
+++ b/src/applications/income-limits/tests/income-limits.cypress.spec.js
@@ -474,7 +474,7 @@ xdescribe('Income Limits', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We’ve run into a problemThe zip code you entered doesn't exist in our database.`,
+        `We’ve run into a problemYour information couldn’t go through. Please enter a valid 5 digit zip code.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });
@@ -516,7 +516,7 @@ xdescribe('Income Limits', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We’ve run into a problemThe year you entered doesn't exist in our database.`,
+        `We’ve run into a problemYour information couldn’t go through. Please select a year again.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });
@@ -558,7 +558,7 @@ xdescribe('Income Limits', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We’ve run into a problemThe number of dependents you entered is not between 0 and 100`,
+        `We’ve run into a problemYour information couldn’t go through. Please enter a number of dependents between 0 and 100.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });
@@ -604,6 +604,36 @@ xdescribe('Income Limits', () => {
         `We’ve run into a problemWe’re sorry. Something went wrong on our end. Please try again.`,
       );
       h.verifyLoadingIndicatorNotShown();
+    });
+  });
+
+  describe('preventing deep linking', () => {
+    it('should redirect to home if an URL is navigated to without the correct data', () => {
+      cy.visit('/health-care/income-limits');
+
+      // Home
+      h.verifyElement(h.CURRENT_LINK);
+      cy.injectAxeThenAxeCheck();
+
+      cy.visit('/health-care/income-limits/zip');
+      // Home
+      h.verifyElement(h.CURRENT_LINK);
+
+      cy.visit('/health-care/income-limits/dependents');
+      // Home
+      h.verifyElement(h.CURRENT_LINK);
+
+      cy.visit('/health-care/income-limits/year');
+      // Home
+      h.verifyElement(h.CURRENT_LINK);
+
+      cy.visit('/health-care/income-limits/results');
+      // Home
+      h.verifyElement(h.CURRENT_LINK);
+
+      cy.visit('/health-care/income-limits/review');
+      // Home
+      h.verifyElement(h.CURRENT_LINK);
     });
   });
 });


### PR DESCRIPTION
## Summary
A Platform ticket was added last week - someone on another team was running into flaky Income Limits unit tests when running the full suite of vets-website unit tests. The tests passed every time when running in isolation (an individual file, or the Income Limits suite as a whole). They even passed when run in the CI (with the full suite of other tests) reliably. The only problem was when they were running locally all together. Weird. But this fixes that - I removed all the offending tests from unit tests and we're testing the same functionality exclusively in Cypress now.

Also includes a quick fix for this reported issue: https://dsva.slack.com/archives/C52CL1PKQ/p1689623797281879 regarding clicking `My VA` while in the Income Limits flow. Previously, the home page had an automatic redirect to `/introduction` when you land on that page. It helped rename the original `/` route to the expected route. The problem was that the `My VA` link's href is `{income limits URL}/{path to pop up the login modal`. So it was going to the original income limits URL and then redirecting to `/introduction` without bringing up the login modal.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14347

## Testing done
- Ran `yarn test:unit` to verify that all the unit tests are passing as-is with the offending tests removed.
- Ran `yarn cy:open` to verify all Income Limits tests are passing (they are still skipped in CI because of a weird flaky selector problem that happens below version 12 of Cypress. Platform is working on the v12 upgrade now.

## Acceptance criteria
- [x] All Income Limits tests pass when running yarn test:unit