### PR TITLE
MHV-45445 Flatten side navigation and remove health history link

### DIFF
--- a/src/applications/mhv/medical-records/components/Navigation.jsx
+++ b/src/applications/mhv/medical-records/components/Navigation.jsx
@@ -7,55 +7,48 @@ const Navigation = () => {
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const location = useLocation();
 
-  const healthHistoryPaths = [
-    {
-      path: '/health-history/care-summaries-and-notes',
-      label: 'Care summaries and notes',
-      datatestid: 'care-summaries-and-notes-sidebar',
-    },
-    {
-      path: '/health-history/vaccines',
-      label: 'Vaccines',
-      datatestid: 'vaccines-sidebar',
-    },
-    {
-      path: '/health-history/allergies',
-      label: 'Allergies',
-      datatestid: 'allergies-sidebar',
-    },
-    {
-      path: '/health-history/health-conditions',
-      label: 'Health conditions',
-      datatestid: 'health-conditions-sidebar',
-    },
-    {
-      path: '/health-history/vitals',
-      label: 'Vitals',
-      datatestid: 'vitals-sidebar',
-    },
-  ];
-
   const paths = [
     {
       path: '/',
       label: 'About VA medical records',
       datatestid: 'about-va-medical-records-sidebar',
-    },
-    {
-      path: '/labs-and-tests',
-      label: 'Lab and test results',
-      datatestid: 'labs-and-tests-sidebar',
-    },
-    {
-      path: '/health-history',
-      label: 'Health history',
-      datatestid: 'health-history-sidebar',
-      subpaths: healthHistoryPaths,
-    },
-    {
-      path: '/share-your-medical-record',
-      label: 'Share your medical record',
-      datatestid: 'share-your-medical-record-sidebar',
+      subpaths: [
+        {
+          path: '/labs-and-tests',
+          label: 'Lab and test results',
+          datatestid: 'labs-and-tests-sidebar',
+        },
+        {
+          path: '/health-history/care-summaries-and-notes',
+          label: 'Care summaries and notes',
+          datatestid: 'care-summaries-and-notes-sidebar',
+        },
+        {
+          path: '/health-history/vaccines',
+          label: 'Vaccines',
+          datatestid: 'vaccines-sidebar',
+        },
+        {
+          path: '/health-history/allergies',
+          label: 'Allergies',
+          datatestid: 'allergies-sidebar',
+        },
+        {
+          path: '/health-history/health-conditions',
+          label: 'Health conditions',
+          datatestid: 'health-conditions-sidebar',
+        },
+        {
+          path: '/health-history/vitals',
+          label: 'Vitals',
+          datatestid: 'vitals-sidebar',
+        },
+        {
+          path: '/share-your-medical-record',
+          label: 'Share your medical record',
+          datatestid: 'share-your-medical-record-sidebar',
+        },
+      ],
     },
   ];
 
@@ -114,9 +107,12 @@ const Navigation = () => {
     return '';
   };
 
-  const handleSubpathsOpen = path => {
-    return location.pathname !== '/' && location.pathname.includes(path);
-  };
+  // We no longer have dynamically opening/closing nav, but leaving this the handleSubpathsOpen
+  // function in case we add it again later.
+
+  // const handleSubpathsOpen = path => {
+  //   return location.pathname !== '/' && location.pathname.includes(path);
+  // };
 
   const subMenu = subpaths => {
     return (
@@ -169,7 +165,7 @@ const Navigation = () => {
                   </div>
 
                   {path.subpaths &&
-                    handleSubpathsOpen(path.path) &&
+                    // handleSubpathsOpen(path.path) &&
                     subMenu(path.subpaths)}
                 </li>
               ))}

--- a/src/applications/mhv/medical-records/tests/e2e/medical-records-view-immunization-list.cypress.spec.js
+++ b/src/applications/mhv/medical-records/tests/e2e/medical-records-view-immunization-list.cypress.spec.js
@@ -6,12 +6,6 @@ describe('Medical Records View Immunizations', () => {
     const site = new MedicalRecordsSite();
     cy.visit('my-health/medical-records');
     site.login();
-    // Click on the health history link
-    // data-testid preferred, but git won't allow it for some reason
-    // cy.get('[data-testid="health-history-link"]').click();
-    cy.get('[href="/my-health/medical-records/health-history"]')
-      .first()
-      .click();
 
     // click on the vaccines link
     cy.get('[href="/my-health/medical-records/health-history/vaccines"]')


### PR DESCRIPTION
## Summary

Flattened side navigation and removed health history link.

For now the "Share your medical records" link remains, but it will be removed when we split up that page.

## Related issue(s)
### [MHV-45445](https://jira.devops.va.gov/browse/MHV-45445) - MR to VA.gov: Remove "Health History" page and flatten the navigation ###
Remove term "Health History" page and flatten the navigation.

The Health History landing page will no longer exist. All domains listed on the page will become child pages to Medical Records on the left/side navigation.

Note: Share my Medical records has been divided into two pages: See https://jira.devops.va.gov/browse/MHV-45447
1-Download my medical records
2-Medical record settings

User Story: As a Medical Records User, I don't want to be confused by the terms health history and medical records.

Acceptance Criteria:
AC1 The page for Health History has been taken away
AC2 Navigation for the Health History have become child pages to the main medical records
AC3
AC4
AC5

Links to UCD:
Sketch Link:
User Flow:
Mobile:
Desktop:
Other Design Notes:

Architectural Notes: Always check for the latest designs in Sketch!

## Testing done

- No structural changes. Ensured existing tests work.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<img width="335" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/afeb588b-432b-4c9f-a45a-b61a2e5f18f3">

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
