### PR TITLE
Modify submit-transformer for 21-0972 to handle booleans

### DIFF
--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import footerContent from '@department-of-veterans-affairs/platform-forms/components/FormFooter';
+import footerContent from '@department-of-veterans-affairs/platform-forms/FormFooter';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import {

--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -13,7 +13,7 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import getHelp from '../../shared/components/GetFormHelp';
-import transformForSubmit from '../../shared/config/submit-transformer';
+import transformForSubmit from './submit-transformer';
 
 import preparerPersonalInformation from '../pages/preparerPersonalInformation';
 import preparerAddress from '../pages/preparerAddress';

--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import footerContent from 'platform/forms/components/FormFooter';
-import environment from 'platform/utilities/environment';
+import footerContent from '@department-of-veterans-affairs/platform-forms/components/FormFooter';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import {
   claimantAddressTitle,
@@ -81,8 +81,6 @@ const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
-  submit: () =>
-    Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   transformForSubmit,
   trackingPrefix: '21-0972-alternate-signer-',
   dev: {

--- a/src/applications/simple-forms/21-0972/config/submit-transformer.js
+++ b/src/applications/simple-forms/21-0972/config/submit-transformer.js
@@ -1,0 +1,57 @@
+import sharedTransformForSubmit from '../../shared/config/submit-transformer';
+import {
+  preparerQualificationsOptions,
+  preparerSigningReasonOptions,
+} from '../definitions/constants';
+
+export default function transformForSubmit(formConfig, form) {
+  let transformedData = JSON.parse(sharedTransformForSubmit(formConfig, form));
+
+  const preparerQualifications = transformedData?.preparerQualifications;
+  let booleanPreparerQualifications = {};
+  const preparerSigningReason = transformedData?.preparerSigningReason;
+  let booleanPreparerSigningReason = {};
+
+  if (preparerQualifications) {
+    booleanPreparerQualifications = {
+      'court-appointed-rep': preparerQualifications.includes(
+        preparerQualificationsOptions.COURT_APPOINTED_REP,
+      ),
+      attorney: preparerQualifications.includes(
+        preparerQualificationsOptions.ATTORNEY,
+      ),
+      caregiver: preparerQualifications.includes(
+        preparerQualificationsOptions.CAREGIVER,
+      ),
+      manager: preparerQualifications.includes(
+        preparerQualificationsOptions.MANAGER,
+      ),
+    };
+  }
+
+  if (preparerSigningReason) {
+    booleanPreparerSigningReason = {
+      under18: preparerSigningReason.includes(
+        preparerSigningReasonOptions.UNDER18,
+      ),
+      'mentally-incapable': preparerSigningReason.includes(
+        preparerSigningReasonOptions.MENTALLY_INCAPABLE,
+      ),
+      'physically-incapable': preparerSigningReason.includes(
+        preparerSigningReasonOptions.PHYSICALLY_INCAPABLE,
+      ),
+    };
+  }
+
+  transformedData = {
+    ...transformedData,
+    preparerQualifications: {
+      ...booleanPreparerQualifications,
+    },
+    preparerSigningReason: {
+      ...booleanPreparerSigningReason,
+    },
+  };
+
+  return JSON.stringify(transformedData);
+}

--- a/src/applications/simple-forms/21-0972/config/submit-transformer.js
+++ b/src/applications/simple-forms/21-0972/config/submit-transformer.js
@@ -4,16 +4,11 @@ import {
   preparerSigningReasonOptions,
 } from '../definitions/constants';
 
-export default function transformForSubmit(formConfig, form) {
-  let transformedData = JSON.parse(sharedTransformForSubmit(formConfig, form));
-
-  const preparerQualifications = transformedData?.preparerQualifications;
-  let booleanPreparerQualifications = {};
-  const preparerSigningReason = transformedData?.preparerSigningReason;
-  let booleanPreparerSigningReason = {};
+function booleanPreparerQualifications(preparerQualifications) {
+  let booleanPreparerQualificationsOutput = {};
 
   if (preparerQualifications) {
-    booleanPreparerQualifications = {
+    booleanPreparerQualificationsOutput = {
       'court-appointed-rep': preparerQualifications.includes(
         preparerQualificationsOptions.COURT_APPOINTED_REP,
       ),
@@ -29,8 +24,14 @@ export default function transformForSubmit(formConfig, form) {
     };
   }
 
+  return booleanPreparerQualificationsOutput;
+}
+
+function booleanPreparerSigningReason(preparerSigningReason) {
+  let booleanPreparerSigningReasonOutput = {};
+
   if (preparerSigningReason) {
-    booleanPreparerSigningReason = {
+    booleanPreparerSigningReasonOutput = {
       under18: preparerSigningReason.includes(
         preparerSigningReasonOptions.UNDER18,
       ),
@@ -43,13 +44,19 @@ export default function transformForSubmit(formConfig, form) {
     };
   }
 
+  return booleanPreparerSigningReasonOutput;
+}
+
+export default function transformForSubmit(formConfig, form) {
+  let transformedData = JSON.parse(sharedTransformForSubmit(formConfig, form));
+
   transformedData = {
     ...transformedData,
     preparerQualifications: {
-      ...booleanPreparerQualifications,
+      ...booleanPreparerQualifications(transformedData?.preparerQualifications),
     },
     preparerSigningReason: {
-      ...booleanPreparerSigningReason,
+      ...booleanPreparerSigningReason(transformedData?.preparerSigningReason),
     },
   };
 


### PR DESCRIPTION
Modify the submit-transformer for 21-0972 so that we can extract booleans from the string search on the FE rather than having the BE do it.

## Summary

- This is in preparation for [this API PR](https://github.com/department-of-veterans-affairs/vets-api/pull/13299).
- The website returns a long string with all checked checkboxes expressed as substrings. This code makes the submit-transformer seek out those substrings and send the data to the BE in a more easily digestible format.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/390

## Testing done

Tested locally by submitting the form and confirmed that the PDF is filled out correctly (with the necessary BE changes).

## What areas of the site does it impact?

Form 21-0972

## Acceptance criteria

### Quality Assurance & Testing

- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
