### PR TITLE
add class names at form app level

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -79,8 +79,13 @@ class FormApp extends React.Component {
       );
     }
 
+    let formAppClassNames = 'form-app-container';
+    if (formConfig.formAppClassNames) {
+      formAppClassNames += ` ${formConfig.formAppClassNames}`;
+    }
+
     return (
-      <div>
+      <div className={formAppClassNames}>
         <div className="row">
           <div className="usa-width-two-thirds medium-8 columns">
             <Element name="topScrollElement" />

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -30,6 +30,11 @@
  * @property {Downtime} [downtime]
  * @property {(props: any) => JSX.Element} [errorText]
  * @property {(props: any) => JSX.Element} [footerContent]
+ * @property {string} [formAppClassNames] A css class that is applied to the outer html of the form app.
+ *   - Applied to every page including Introduction and Confirmation pages.
+ *   - Includes navigation (top) and form content.
+ *
+ *   Recommendation: `"form-app-<unique-text-or-id>"`
  * @property {string} [formId]
  * @property {(props: any) => JSX.Element} [formSavedPage]
  * @property {() => JSX.Element} [getHelp]


### PR DESCRIPTION
## Summary

- Add default className `'form-app-container'` to outer div HTML form for all forms (no CSS)
- Specifying `formConfig.formAppClassNames` will also add a css class to the outer HTML form

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61989

## Testing done

- Browser/unit/cypress

## Screenshots

No UI change
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/86eeb3ad-4b93-43b4-b208-5214992db269)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/2080cbbf-f549-49f5-a2a0-73ab0970ebf2)


## What areas of the site does it impact?

- Every form will now have class 'form-app-container' applied at the form app level. 
- No CSS is associated with this class.
- Forms can opt in to use this styling to ensure styles are restricted to their form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
