### PR TITLE
Update design system component library to latest version v17.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^17.0.0",
+    "@department-of-veterans-affairs/component-library": "^17.0.1",
     "@department-of-veterans-affairs/formation": "^7.0.8",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/src/applications/mhv/secure-messaging/containers/App.jsx
+++ b/src/applications/mhv/secure-messaging/containers/App.jsx
@@ -51,7 +51,7 @@ const App = () => {
       user={user}
       serviceRequired={[backendServices.MESSAGING]}
     >
-      <div className="vads-l-grid-container">
+      <div className="secure-messaging-page-container vads-l-grid-container">
         <SmBreadcrumbs />
         <div className="secure-messaging-container vads-u-display--flex">
           <Navigation />
@@ -60,9 +60,7 @@ const App = () => {
             <AuthorizedRoutes />
           </Switch>
         </div>
-      </div>
-      <div className="vads-u-padding-right--1">
-        <va-back-to-top aria-label="Back to top" />
+        <va-back-to-top />
       </div>
     </RequiredLoginView>
   );

--- a/src/applications/mhv/secure-messaging/containers/App.jsx
+++ b/src/applications/mhv/secure-messaging/containers/App.jsx
@@ -51,7 +51,7 @@ const App = () => {
       user={user}
       serviceRequired={[backendServices.MESSAGING]}
     >
-      <div className="secure-messaging-page-container vads-l-grid-container">
+      <div className="vads-l-grid-container">
         <SmBreadcrumbs />
         <div className="secure-messaging-container vads-u-display--flex">
           <Navigation />
@@ -60,7 +60,9 @@ const App = () => {
             <AuthorizedRoutes />
           </Switch>
         </div>
-        <va-back-to-top />
+        <div className="bottom-container">
+          <va-back-to-top />
+        </div>
       </div>
     </RequiredLoginView>
   );

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.secure-messaging-page-container {
+.bottom-container {
   background-color: $color-white;
 }
 

--- a/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv/secure-messaging/sass/secure-messaging.scss
@@ -21,6 +21,10 @@
   }
 }
 
+.secure-messaging-page-container {
+  background-color: $color-white;
+}
+
 .breadcrumb-angle .desktop-view-crumb {
   color: unset;
   pointer-events: auto;

--- a/src/applications/mhv/secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-links-buttons-landing-page.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-links-buttons-landing-page.cypress.spec.js
@@ -15,9 +15,7 @@ describe('Secure Messaging Verify Links and Buttons Keyboard Nav', () => {
     cy.tabToElement('.welcome-message > :nth-child(4) > a').should(
       'have.focus',
     );
-    cy.tabToElement('.vads-u-padding-right--1 > .hydrated').should(
-      'have.focus',
-    );
+    cy.tabToElement('va-back-to-top').should('have.focus');
     cy.injectAxe();
     cy.axeCheck('main', {
       rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2558,13 +2558,13 @@
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.0.tgz#8c7e8028a5fc22ad102fa542b0a446c956830455"
   integrity sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==
 
-"@department-of-veterans-affairs/component-library@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-17.0.0.tgz#c1ec5be04bc88cbe0d3f46f78d46db3c01d17ca7"
-  integrity sha512-sYimN9RHUkvS/21nRuKIe2qTQu9tJBhWagWlkIcLqZ3Srcj6qoFdbbh+BsuH+f204Ec/rSMnpQbZOey7tFgTGw==
+"@department-of-veterans-affairs/component-library@^17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-17.0.1.tgz#a6d9713b384c2c8b5b97cc365f4cb26793f9ee9f"
+  integrity sha512-ugmuFMEs/mKsMDzPOo3lIxnX6u+3lbfIhL8K/JGOt2oo9g+YPCST254+05kHf/FXWCYAn1UF0oK8UqrqDD1aFg==
   dependencies:
     "@department-of-veterans-affairs/react-components" "12.0.0"
-    "@department-of-veterans-affairs/web-components" "4.42.1"
+    "@department-of-veterans-affairs/web-components" "4.42.7"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2637,10 +2637,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@4.42.1":
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.42.1.tgz#f2394ca91c5de87bffb6e8d80349ee67dd707466"
-  integrity sha512-MpKKK1ivEnBlsMMWdDw8PDLKplicdmrMN5bSdKU4WrR0G5w6uIa4+wHVwh7eIB/NPwB/N1pe1dUZKay5HRWKkA==
+"@department-of-veterans-affairs/web-components@4.42.7":
+  version "4.42.7"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.42.7.tgz#e6e05e02cb8637b3f4bf3ce1ad49b7113fbc9b3f"
+  integrity sha512-ZMFQpCjsAup46gkMgKUMvwdP8ckM4hv+e8ZtmMKW872LaD8vhlgZQVdLn+kVZvvd90+W9/qqsa0bJn02NIIgBg==
   dependencies:
     "@stencil/core" "^2.19.2"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
Component library release notes: https://github.com/department-of-veterans-affairs/component-library/releases/tag/v17.0.1

## Summary

This PR updates the component library to the latest release.

In doing so, I was getting an Axe a11y test failure for the va-back-to-top component in the secure messaging app. I was able to resolve it by adding a white background to its wrapping div. I tried to use `vads-u-background-color--white` but for some reason that wasn't resolving the error so I needed to update the app's stylesheet.

This update also adjusts the placement of the back to top because it was sitting far to the right of the content. Now it will display below its parent container. The design system guidance for the [back to top component placement](https://design.va.gov/components/back-to-top#placement) says:

> The Back to top component is anchored to the **lower right edge of its parent container (the main content area)** on desktop, and the lower right edge of the viewport on smaller screens.

## Related issue(s)
No related ticket

## Testing done

Locally e2e tests

## Screenshots

![Screenshot 2023-07-19 at 2 43 47 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/872479/48c015a0-3808-49ab-b7a8-f9f00037ca56)


**Before**

![Screenshot 2023-07-19 at 2 40 00 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/872479/e37db068-298a-4bed-980b-551fe8877989)


**After**

![Screenshot 2023-07-19 at 3 50 03 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/872479/272ac73e-4143-4f56-98e9-da5669cae145)



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
