### PR TITLE
fix: loading indicator logic, add test

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -100,6 +100,23 @@ const NotificationSettings = ({
 
   const availableGroups = useAvailableGroups();
 
+  const shouldShowNotificationGroups = useMemo(
+    () => {
+      return (
+        !shouldShowAPIError &&
+        !showMissingContactInfoAlert &&
+        !shouldShowLoadingIndicator &&
+        availableGroups.length > 0
+      );
+    },
+    [
+      shouldShowAPIError,
+      showMissingContactInfoAlert,
+      shouldShowLoadingIndicator,
+      availableGroups,
+    ],
+  );
+
   return (
     <>
       <Headline>{PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS}</Headline>
@@ -119,41 +136,40 @@ const NotificationSettings = ({
           }
         />
       )}
-      {!showMissingContactInfoAlert &&
-        availableGroups.length > 0 && (
-          <>
-            <FieldHasBeenUpdatedAlert />
-            <ContactInfoOnFile
-              emailAddress={emailAddress}
-              mobilePhoneNumber={mobilePhoneNumber}
-              showEmailNotificationSettings={
-                notificationToggles.showEmailNotificationSettings
-              }
-            />
-            <MissingContactInfoExpandable
-              showEmailNotificationSettings={
-                notificationToggles.showEmailNotificationSettings
-              }
-            />
-            <hr aria-hidden="true" />
-            {availableGroups.map(({ id }) => {
-              // we handle the health care group a little differently
-              if (id === NOTIFICATION_GROUPS.YOUR_HEALTH_CARE) {
-                return (
-                  <NotificationGroup groupId={id} key={id}>
-                    <HealthCareGroupSupportingText />
-                  </NotificationGroup>
-                );
-              }
+      {shouldShowNotificationGroups && (
+        <>
+          <FieldHasBeenUpdatedAlert />
+          <ContactInfoOnFile
+            emailAddress={emailAddress}
+            mobilePhoneNumber={mobilePhoneNumber}
+            showEmailNotificationSettings={
+              notificationToggles.showEmailNotificationSettings
+            }
+          />
+          <MissingContactInfoExpandable
+            showEmailNotificationSettings={
+              notificationToggles.showEmailNotificationSettings
+            }
+          />
+          <hr aria-hidden="true" />
+          {availableGroups.map(({ id }) => {
+            // we handle the health care group a little differently
+            if (id === NOTIFICATION_GROUPS.YOUR_HEALTH_CARE) {
+              return (
+                <NotificationGroup groupId={id} key={id}>
+                  <HealthCareGroupSupportingText />
+                </NotificationGroup>
+              );
+            }
 
-              return <NotificationGroup groupId={id} key={id} />;
-            })}
-            <p className="vads-u-margin-bottom--0">
-              <strong>Note:</strong> We have limited notification options at
-              this time. Check back for more options in the future.
-            </p>
-          </>
-        )}
+            return <NotificationGroup groupId={id} key={id} />;
+          })}
+          <p className="vads-u-margin-bottom--0">
+            <strong>Note:</strong> We have limited notification options at this
+            time. Check back for more options in the future.
+          </p>
+        </>
+      )}
     </>
   );
 };

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -28,6 +28,10 @@ const {
   baseUserTransitionAvailabilities,
 } = require('./endpoints/user-transition-availabilities');
 
+const error500 = require('../tests/fixtures/500.json');
+const error401 = require('../tests/fixtures/401.json');
+const error403 = require('../tests/fixtures/403.json');
+
 const maintenanceWindows = require('./endpoints/maintenance-windows');
 
 // seed data for VAMC drupal source of truth json file
@@ -38,6 +42,13 @@ const { debug, delaySingleResponse } = require('./script/utils');
 
 // uncomment if using status retries
 // let retries = 0;
+
+// use one of these to provide a generic error for any endpoint
+const genericErrors = {
+  error500,
+  error401,
+  error403,
+};
 
 /* eslint-disable camelcase */
 const responses = {
@@ -202,8 +213,11 @@ const responses = {
       _.set(status.success, 'data.attributes.transactionId', req.params.id),
     );
   },
-  'GET /v0/profile/communication_preferences': (_req, res) => {
-    return res.json(maximalSetOfPreferences);
+  'GET /v0/profile/communication_preferences': (req, res) => {
+    if (req?.query?.error === 'true') {
+      return res.status(500).json(genericErrors.error500);
+    }
+    return delaySingleResponse(() => res.json(maximalSetOfPreferences), 1);
   },
   'PATCH /v0/profile/communication_preferences/:pref': (req, res) => {
     const {

--- a/src/applications/personalization/profile/tests/components/notification-settings/NotificationSettings.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/notification-settings/NotificationSettings.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import { maximalSetOfPreferences } from '@@profile/mocks/endpoints/communication-preferences';
 
+import { waitForElementToBeRemoved } from '@testing-library/dom';
 import NotificationSettings from '../../../components/notification-settings/NotificationSettings';
 import { renderWithProfileReducersAndRouter } from '../../unit-test-helpers';
 
@@ -66,6 +67,64 @@ describe('<NotificationSettings />', () => {
       .exist;
 
     expect(await view.findByText('QuickSubmit')).to.exist;
+  });
+
+  it('renders loading indicator and hides main section of content', async () => {
+    const view = renderWithProfileReducersAndRouter(<NotificationSettings />, {
+      initialState: {
+        featureToggles: {
+          loading: false,
+          [featureFlagNames.profileShowPaymentsNotificationSetting]: true,
+          [featureFlagNames.profileUseNotificationSettingsCheckboxes]: true,
+          [featureFlagNames.profileShowMhvNotificationSettings]: true,
+          [featureFlagNames.profileShowEmailNotificationSettings]: true,
+          [featureFlagNames.profileShowQuickSubmitNotificationSetting]: true,
+        },
+        user: {
+          profile: {
+            vapContactInfo: {
+              mobilePhone: {
+                areaCode: '123',
+                number: '5555555',
+              },
+              email: {
+                emailAddress: 'test@test.com',
+              },
+            },
+            facilities: [
+              {
+                facilityId: '983',
+              },
+            ],
+          },
+        },
+        communicationPreferences: {
+          loadingStatus: 'pending',
+          loadingErrors: null,
+          groups: {
+            ids: [],
+            entities: {},
+          },
+          items: {
+            ids: [],
+            entities: {},
+          },
+          channels: {
+            ids: [],
+            entities: {},
+          },
+        },
+      },
+      path: '/profile/notifications',
+    });
+
+    expect(view.getByTestId('loading-indicator')).to.exist;
+
+    expect(view.queryByText('Your health care')).to.not.exist;
+
+    await waitForElementToBeRemoved(view.getByTestId('loading-indicator'));
+
+    expect(view.queryByText('Your health care')).to.exist;
   });
 
   it('show alert to add mobile phone info', async () => {


### PR DESCRIPTION
## Summary

- A minor bugfix for the loading indicator on the notification settings page. When the page loads _fresh_ from a full reload or initial visit the loading indicator and subsequent display works fine, but upon leaving the notification page for another profile page like contact information and then returning, the loading indicator for the page would display along with the potentially stale content.
- Also memoized the boolean for showing content so as to not have so many conditionals inline in the returned jsx

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61013

## Testing done

- Tested fix locally.
- Added unit test for fix

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
|  | ![Screenshot 2023-07-20 at 9 21 02 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/9fe6d80e-cf8e-4da9-937a-ec35885f7869) | ![Screenshot 2023-07-20 at 9 18 43 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/5f62f6c0-a4c3-4337-a913-b486f31dba70) |

## What areas of the site does it impact?

Profile -> notification settings

## Acceptance criteria

- [x] Loading indicator appears by itself

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added