### PR TITLE
update form margins for ObjectField and FormNavButton

### DIFF
--- a/src/applications/simple-forms/21-0972/sass/21-0972-alternate-signer.scss
+++ b/src/applications/simple-forms/21-0972/sass/21-0972-alternate-signer.scss
@@ -5,3 +5,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+@import "../../shared/sass/simple-forms-common";

--- a/src/applications/simple-forms/21P-0847/sass/21P-0847-substitute-claimant.scss
+++ b/src/applications/simple-forms/21P-0847/sass/21P-0847-substitute-claimant.scss
@@ -5,3 +5,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+@import "../../shared/sass/simple-forms-common";

--- a/src/applications/simple-forms/mock-simple-forms-patterns/sass/mock-simple-forms-patterns.scss
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/sass/mock-simple-forms-patterns.scss
@@ -5,4 +5,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+@import "../../shared/sass/simple-forms-common";
 @import "./web-component-adapter";

--- a/src/applications/simple-forms/shared/sass/simple-forms-common.scss
+++ b/src/applications/simple-forms/shared/sass/simple-forms-common.scss
@@ -1,0 +1,9 @@
+.rjsf-object-field {
+  margin-bottom: 0 !important;
+
+  & + .form-nav-buttons,
+  & + .form-progress-buttons,
+  & + .schemaform-save-container {
+    margin-top: 40px !important;
+  }
+}

--- a/src/applications/simple-forms/shared/sass/simple-forms-common.scss
+++ b/src/applications/simple-forms/shared/sass/simple-forms-common.scss
@@ -1,6 +1,4 @@
 .rjsf-object-field {
-  margin-bottom: 0 !important;
-
   & + .form-nav-buttons,
   & + .form-progress-buttons,
   & + .schemaform-save-container {

--- a/src/applications/simple-forms/shared/sass/simple-forms-common.scss
+++ b/src/applications/simple-forms/shared/sass/simple-forms-common.scss
@@ -4,6 +4,6 @@
   & + .form-nav-buttons,
   & + .form-progress-buttons,
   & + .schemaform-save-container {
-    margin-top: 40px !important;
+    margin-top: 4rem !important;
   }
 }

--- a/src/platform/forms-system/src/js/components/FormNavButtons.jsx
+++ b/src/platform/forms-system/src/js/components/FormNavButtons.jsx
@@ -12,7 +12,7 @@ import ProgressButton from './ProgressButton';
  * navigate the user to the next page only if validation is successful.
  */
 const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
-  <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--2">
+  <div className="row form-progress-buttons schemaform-buttons vads-u-margin-top--4 vads-u-margin-bottom--2">
     <div className="small-6 medium-5 columns">
       {goBack && (
         <ProgressButton

--- a/src/platform/forms-system/src/js/components/FormNavButtons.jsx
+++ b/src/platform/forms-system/src/js/components/FormNavButtons.jsx
@@ -12,7 +12,7 @@ import ProgressButton from './ProgressButton';
  * navigate the user to the next page only if validation is successful.
  */
 const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
-  <div className="row form-progress-buttons schemaform-buttons vads-u-margin-top--4 vads-u-margin-bottom--2">
+  <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--2">
     <div className="small-6 medium-5 columns">
       {goBack && (
         <ProgressButton

--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -180,7 +180,7 @@ class ObjectField extends React.Component {
     const { showFieldLabel } = uiOptions;
     const fieldsetClassNames = classNames(
       uiOptions.classNames,
-      'vads-u-margin-y--2',
+      'vads-u-margin-top--2',
     );
 
     const forceDivWrapper = !!uiOptions.forceDivWrapper;

--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -180,7 +180,8 @@ class ObjectField extends React.Component {
     const { showFieldLabel } = uiOptions;
     const fieldsetClassNames = classNames(
       uiOptions.classNames,
-      'vads-u-margin-top--2',
+      'vads-u-margin-y--2',
+      'rjsf-object-field',
     );
 
     const forceDivWrapper = !!uiOptions.forceDivWrapper;

--- a/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
@@ -78,6 +78,8 @@ export const descriptionUI = (text, uiOptions = {}) => {
  * ```
  * @param {string | JSX.Element} [title] 'ui:title'
  * @param {string | JSX.Element} [description] 'ui:description'
+ *
+ * @returns {UISchemaOptions}
  */
 export const inlineTitleUI = (title, description) => {
   return {

--- a/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
@@ -82,7 +82,7 @@ export const descriptionUI = (text, uiOptions = {}) => {
 export const inlineTitleUI = (title, description) => {
   return {
     'ui:title': (
-      <h3 className="vads-u-color--gray-dark vads-u-margin-top--4 vads-u-margin-bottom--neg1">
+      <h3 className="vads-u-color--gray-dark vads-u-margin-top--4 vads-u-margin-bottom--neg3">
         {title}
       </h3>
     ),

--- a/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
@@ -82,7 +82,7 @@ export const descriptionUI = (text, uiOptions = {}) => {
 export const inlineTitleUI = (title, description) => {
   return {
     'ui:title': (
-      <h3 className="vads-u-color--gray-dark vads-u-margin-top--4 vads-u-margin-bottom--neg3">
+      <h3 className="vads-u-color--gray-dark vads-u-margin-top--4 vads-u-margin-bottom--neg1">
         {title}
       </h3>
     ),

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -45,7 +45,11 @@ class SaveFormLink extends React.Component {
     const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
     return (
-      <div className={this.props.children ? 'vads-u-display--inline' : ''}>
+      <div
+        className={`schemaform-save-container${
+          this.props.children ? ' vads-u-display--inline' : ''
+        }`}
+      >
         <Element name="saveFormLinkTop" />
         {saveErrors.has(savedStatus) && (
           <div


### PR DESCRIPTION
## Summary

~Change ObjectField (**AFFECTS EVERY FORM**) to only have `margin-top` instead of `margin-y`. Affects every uiSchema/schema.~

**Updated to only introduce new class names, and not affect every form, only select forms, not in production.**

**Updated to only change bottom button margin**

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61989

## Testing done

- Tested mock form
- Tested 527EZ
- Tested form 4555

## What areas of the site does it impact?

Select web component Forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
