### PR TITLE
60578 make VA medical center fields optional

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -337,3 +337,5 @@ export const CHAR_LIMITS = [
 
 // migration max string length
 export const MAX_HOUSING_STRING_LENGTH = 500;
+
+export const NO_FACILITY = 'Facility name not provided';

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'platform/utilities/data';
-import { DATA_PATHS } from '../constants';
+import { DATA_PATHS, NO_FACILITY } from '../constants';
 
 export const summaryOfEvidenceDescription = ({ formData }) => {
   const vaEvidence = _.get('vaTreatmentFacilities', formData, []);
@@ -69,7 +69,7 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
 
   if (vaEvidence.length && vaEvidenceSelected) {
     const facilitiesList = vaEvidence.map((facility, index) => (
-      <li key={index}>{facility.treatmentCenterName}</li>
+      <li key={index}>{facility.treatmentCenterName || NO_FACILITY}</li>
     ));
     vaContent = (
       <div>

--- a/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatDate } from '../utils';
+import { NO_FACILITY } from '../constants';
 
 const MONTH_YEAR = 'MMMM YYYY';
 
@@ -9,7 +10,7 @@ const replaceDay = date => date.replace('XX', '01');
 export const treatmentView = ({ formData }) => {
   const { from } = formData.treatmentDateRange;
 
-  const name = formData.treatmentCenterName;
+  const name = formData.treatmentCenterName || NO_FACILITY;
   let treatmentPeriod = '';
   if (from) {
     treatmentPeriod = formatDate(replaceDay(from), MONTH_YEAR);

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -8,9 +8,8 @@ import {
   validateMilitaryTreatmentCity,
   validateMilitaryTreatmentState,
   startedAfterServicePeriod,
-  validateBooleanGroup,
 } from '../validations';
-import { USA } from '../constants';
+import { NO_FACILITY, USA } from '../constants';
 
 const { vaTreatmentFacilities } = fullSchema.properties;
 
@@ -23,7 +22,7 @@ export const uiSchema = {
   vaTreatmentFacilities: {
     'ui:options': {
       itemName: 'Facility',
-      itemAriaLabel: data => data.treatmentCenterName,
+      itemAriaLabel: data => data.treatmentCenterName || NO_FACILITY,
       viewField: treatmentView,
       showSave: true,
       updateSchema: (formData, schema) => ({
@@ -51,11 +50,6 @@ export const uiSchema = {
           updateSchema: makeSchemaForAllDisabilities,
           itemAriaLabel: data => data.treatmentCenterName,
           showFieldLabel: true,
-        },
-        'ui:validations': [validateBooleanGroup],
-        'ui:errorMessages': {
-          atLeastOne: 'Please select at least one condition',
-          required: 'Please select at least one condition',
         },
       },
       treatmentDateRange: {
@@ -103,7 +97,6 @@ export const schema = {
       minItems: 0, // fixes validation issue
       items: {
         type: 'object',
-        required: ['treatmentCenterName', 'treatedDisabilityNames'],
         properties: {
           treatmentCenterName:
             vaTreatmentFacilities.items.properties.treatmentCenterName,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -118,6 +118,14 @@
           "phlebitis": true,
           "kneereplacement": true
         }
+      },
+      {
+        "treatmentCenterName": "No city, no disability names test",
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": ""
+        },
+        "treatedDisabilityNames": {}
       }
     ],
     "view:hasEvidence": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
@@ -56,6 +56,14 @@
           "city": "Ugandan City"
         },
         "treatedDisabilityNames": ["asthma", "phlebitis", "knee replacement"]
+      },
+      {
+        "treatmentCenterName": "No city, no disability names test",
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": ""
+        },
+        "treatedDisabilityNames": []
       }
     ],
     "confinements": [

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -77,7 +77,7 @@ describe('VA Medical Records', () => {
     form.unmount();
   });
 
-  it('should not submit without all required info', () => {
+  it('can submit with empty info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -98,9 +98,8 @@ describe('VA Medical Records', () => {
     );
 
     form.find('form').simulate('submit');
-    // Required fields: Facility name and related disability
-    expect(form.find('.usa-input-error-message').length).to.equal(2);
-    expect(onSubmit.called).to.be.false;
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
     form.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -154,7 +154,7 @@ export const setActionTypes = formData => {
  *                   "Originally-cased" = the case of the name in the disabilities list.
  */
 export function transformRelatedDisabilities(
-  conditionContainer,
+  conditionContainer = {},
   claimedConditions,
 ) {
   const findCondition = (list, name = '') =>


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
Make 3 fields optional on the VA medical center page: treatment center name, disability names, country.  We have learned that while these fields are helpful for processing a claim, they are not required. User should be able to submit 526 claim with no value or unvalidated value for these fields

These changes are dependent on vets-json-schema changes in https://github.com/department-of-veterans-affairs/vets-json-schema/pull/775


- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability Experience Team, yes

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
n/a

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#60578

- _Link to epic if not included in ticket_
n/a, bug

## Testing done

- _Describe what the old behavior was prior to the change_
These fields were previously required. User could not save the form until they had a valid value for each of them.
 
- _Describe the steps required to verify your changes are working as expected_
1. Start filling out an original claim
2. When you get to the supporting-evidence/evidence-types page, select 'VA medical records' for evidence types. 
3. Continue to the next page
4. Verify you can click the Continue button without filling out any fields. The facility name should be auto populated with 'Facility name not provided' when saving the empty form and also on the supporting-evidence/summary page 
5. As a regression, go back and add a new facility with all fields filled out. Verify you can see both items on the summary page
6. Complete the rest of the 526 form and verify you can submit successfully
- _Describe the tests completed and the results_
Unit test has been updated to include saving empty form

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/fead0d4f-dd81-4c89-95ad-007a3e0445e9)

<img width="500" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/d1cb290c-0b60-4736-b0c4-0aeec383a619">

## What areas of the site does it impact?
21-526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/product/526ez%20Product%20Guide))
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user



