### PR TITLE
Streamlined waiver submission objects for BE

### DIFF
--- a/src/applications/financial-status-report/config/chapters/_buildChapters.js
+++ b/src/applications/financial-status-report/config/chapters/_buildChapters.js
@@ -9,6 +9,28 @@ import {
   enhancedFSRFeatureToggle,
 } from '../../utils/helpers';
 
+export const formFlows = {
+  'Below GMT': [
+    veteranInformationChapter,
+    householdIncomeChapter,
+    householdAssetsChapter,
+  ],
+  'Above GMT,   Below 150% of GMT': [
+    veteranInformationChapter,
+    householdIncomeChapter,
+    householdAssetsChapter,
+    householdExpensesChapter,
+  ],
+  'Above 150% of GMT': [
+    veteranInformationChapter,
+    householdIncomeChapter,
+    householdAssetsChapter,
+    householdExpensesChapter,
+    resolutionOptionsChapter,
+    bankruptcyAttestationChapter,
+  ],
+};
+
 export const buildForm = () => {
   let chaptersConfig = {};
   if (streamlinedWaiverFeatureToggle) {
@@ -16,7 +38,6 @@ export const buildForm = () => {
       ...veteranInformationChapter,
       ...householdIncomeChapter,
       ...householdAssetsChapter,
-      ...householdExpensesChapter,
     };
   } else if (enhancedFSRFeatureToggle) {
     chaptersConfig = {

--- a/src/applications/financial-status-report/config/chapters/_buildChapters.js
+++ b/src/applications/financial-status-report/config/chapters/_buildChapters.js
@@ -1,0 +1,36 @@
+import veteranInformationChapter from './veteranInformationChapter';
+import householdIncomeChapter from './householdIncomeChapter';
+import householdAssetsChapter from './householdAssetsChapter';
+import householdExpensesChapter from './householdExpensesChapter';
+import resolutionOptionsChapter from './resolutionOptionsChapter';
+import bankruptcyAttestationChapter from './bankruptcyAttestationChapter';
+import {
+  streamlinedWaiverFeatureToggle,
+  enhancedFSRFeatureToggle,
+} from '../../utils/helpers';
+
+export const buildForm = () => {
+  let chaptersConfig = {};
+  if (streamlinedWaiverFeatureToggle) {
+    chaptersConfig = {
+      ...veteranInformationChapter,
+      ...householdIncomeChapter,
+      ...householdAssetsChapter,
+      ...householdExpensesChapter,
+    };
+  } else if (enhancedFSRFeatureToggle) {
+    chaptersConfig = {
+      ...veteranInformationChapter,
+      ...householdIncomeChapter,
+      ...householdAssetsChapter,
+      ...householdExpensesChapter,
+      ...resolutionOptionsChapter,
+      ...bankruptcyAttestationChapter,
+    };
+  } else {
+    // return an empty object instead of null
+    chaptersConfig = {};
+  }
+
+  return chaptersConfig;
+};

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -10,12 +10,9 @@ import { transform } from '../utils/transform';
 import { SubmissionAlert } from '../components/Alerts';
 import { WIZARD_STATUS } from '../wizard/constants';
 import submitForm from './submitForm';
-import veteranInformationChapter from './chapters/veteranInformationChapter';
-import householdIncomeChapter from './chapters/householdIncomeChapter';
-import householdAssetsChapter from './chapters/householdAssetsChapter';
-import householdExpensesChapter from './chapters/householdExpensesChapter';
-import resolutionOptionsChapter from './chapters/resolutionOptionsChapter';
-import bankruptcyAttestationChapter from './chapters/bankruptcyAttestationChapter';
+import { buildForm } from './chapters/_buildChapters';
+
+const chaptersConfig = buildForm();
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -58,17 +55,8 @@ const formConfig = {
     reviewPageTitle: 'Review your request',
     submitButtonText: 'Submit your request',
   },
-  // when true, initial focus on page to H3s by default, and enable page
-  // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
-  chapters: {
-    ...veteranInformationChapter,
-    ...householdIncomeChapter,
-    ...householdAssetsChapter,
-    ...householdExpensesChapter,
-    ...resolutionOptionsChapter,
-    ...bankruptcyAttestationChapter,
-  },
+  chapters: chaptersConfig, // from _buildForm.js
 };
 
 export default formConfig;

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/belowGMT.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/belowGMT.json
@@ -1,0 +1,159 @@
+{
+  "personalIdentification": {
+    "ssn": "4437",
+    "fileNumber": "4437",
+    "fsrReason": ""
+  },
+  "personalData": {
+    "veteranFullName": {
+      "first": "Mark",
+      "middle": "",
+      "last": "Webb"
+    },
+    "address": {
+      "addresslineOne": "1200 Park Ave",
+      "addresslineTwo": "c/o Pixar",
+      "addresslineThree": "",
+      "city": "Emeryville",
+      "stateOrProvince": "CA",
+      "zipOrPostalCode": "94608",
+      "countryName": "US"
+    },
+    "telephoneNumber": "(510) 922-4444",
+    "dateOfBirth": "10/04/1950",
+    "married": false,
+    "spouseFullName": {
+      "first": "",
+      "middle": "",
+      "last": ""
+    },
+    "agesOfOtherDependents": [
+      "2",
+      "2"
+    ],
+    "employmentHistory": []
+  },
+  "income": [
+    {
+      "veteranOrSpouse": "VETERAN",
+      "monthlyGrossSalary": "0.00",
+      "deductions": {
+        "taxes": "0.00",
+        "retirement": "0.00",
+        "socialSecurity": "0.00",
+        "otherDeductions": {
+          "name": "",
+          "amount": "0.00"
+        }
+      },
+      "totalDeductions": "0.00",
+      "netTakeHomePay": "0.00",
+      "otherIncome": {
+        "name": "",
+        "amount": "0.00"
+      },
+      "totalMonthlyNetIncome": "0.00"
+    },
+    {
+      "veteranOrSpouse": "SPOUSE",
+      "monthlyGrossSalary": "0.00",
+      "deductions": {
+        "taxes": "0.00",
+        "retirement": "0.00",
+        "socialSecurity": "0.00",
+        "otherDeductions": {
+          "name": "",
+          "amount": "0.00"
+        }
+      },
+      "totalDeductions": "0.00",
+      "netTakeHomePay": "0.00",
+      "otherIncome": {
+        "name": "",
+        "amount": "0.00"
+      },
+      "totalMonthlyNetIncome": "0.00"
+    }
+  ],
+  "expenses": {
+    "rentOrMortgage": "2.00",
+    "food": "0.00",
+    "utilities": "4.00",
+    "otherLivingExpenses": {
+      "name": "Renter's or home insurance",
+      "amount": "2.00"
+    },
+    "expensesInstallmentContractsAndOtherDebts": "0.00",
+    "totalMonthlyExpenses": "8.00"
+  },
+  "discretionaryIncome": {
+    "netMonthlyIncomeLessExpenses": "-8.00",
+    "amountCanBePaidTowardDebt": "0.00"
+  },
+  "assets": {
+    "cashInBank": "0.00",
+    "cashOnHand": "0.00",
+    "usSavingsBonds": "0.00",
+    "stocksAndOtherBonds": "0.00",
+    "realEstateOwned": "0.00",
+    "otherAssets": [
+      {
+        "name": "Antiques",
+        "amount": "2"
+      }
+    ],
+    "totalAssets": "2.00"
+  },
+  "installmentContractsAndOtherDebts": [],
+  "totalOfInstallmentContractsAndOtherDebts": {
+    "originalAmount": "0.00",
+    "unpaidBalance": "0.00",
+    "amountDueMonthly": "0.00",
+    "amountPastDue": "0.00"
+  },
+  "additionalData": {
+    "bankruptcy": {
+      "courtLocation": "",
+      "docketNumber": ""
+    },
+    "additionalComments": "\nIndividual expense amount: Renter's or home insurance ($2.00)"
+  },
+  "applicantCertifications": {
+    "veteranSignature": "Mark  Webb",
+    "veteranDateSigned": "07/20/2023"
+  },
+  "selectedDebtsAndCopays": [
+    {
+      "fileNumber": "796121200",
+      "payeeNumber": "00",
+      "personEntitled": "AJHONS",
+      "deductionCode": "30",
+      "benefitType": "Comp & Pen",
+      "diaryCode": "080",
+      "diaryCodeDescription": "Referred to the Department of the Treasury",
+      "amountOverpaid": "0.00",
+      "amountWithheld": "0.00",
+      "originalAr": "136.24",
+      "currentAr": "100.00",
+      "debtHistory": [
+        {
+          "date": "02/25/2009",
+          "letterCode": "914",
+          "description": "Paid In Full - Account balance cleared via offset, not including TOP."
+        },
+        {
+          "date": "02/07/2009",
+          "letterCode": "905",
+          "description": "Administrative Write Off"
+        },
+        {
+          "date": "12/03/2008",
+          "letterCode": "487",
+          "description": "Death Case Pending Action"
+        }
+      ],
+      "id": "0.00",
+      "debtType": "DEBT"
+    }
+  ]
+}

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -25,6 +25,12 @@ export const enhancedFSRFeatureToggle = state => {
   ];
 };
 
+export const streamlinedWaiverFeatureToggle = state => {
+  return toggleValues(state)[
+    FEATURE_FLAG_NAMES.financialStatusReportStreamlinedWaiver
+  ];
+};
+
 export const fsrConfirmationEmailToggle = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.fsrConfirmationEmail];
 

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -390,14 +390,18 @@ export const transform = (formConfig, form) => {
       ),
     },
     additionalData: {
+      // bankruptcy  - additionalData?.bankruptcy?.dateDischarged || '',
       bankruptcy: {
-        hasBeenAdjudicatedBankrupt: questions.hasBeenAdjudicatedBankrupt,
-        dateDischarged: dateFormatter(additionalData.bankruptcy.dateDischarged),
-        courtLocation: additionalData.bankruptcy.courtLocation,
-        docketNumber: additionalData.bankruptcy.docketNumber,
+        hasBeenAdjudicatedBankrupt: questions?.hasBeenAdjudicatedBankrupt,
+        dateDischarged: dateFormatter(
+          additionalData?.bankruptcy?.dateDischarged || '',
+        ),
+        courtLocation: additionalData?.bankruptcy?.courtLocation || '',
+        docketNumber: additionalData?.bankruptcy?.docketNumber || '',
       },
       additionalComments: mergeAdditionalComments(
-        additionalData.additionalComments,
+        //  additionalData?.additionalComments || '',
+        additionalData?.additionalComments || '',
         enhancedFSRActive ? filteredExpenses : otherExpenses,
       ),
     },
@@ -413,6 +417,5 @@ export const transform = (formConfig, form) => {
   const convertIntegerToString = (key, value) => {
     return typeof value === 'number' ? value.toFixed(2).toString() : value;
   };
-
   return JSON.stringify(submissionObj, convertIntegerToString);
 };


### PR DESCRIPTION
STUB

Since streamlined is cutting off some of the form, we need to create examples of submission objects for the different routes so BE can adjust the required fields.

Tasks

- [x]  Create example submission objects for each FSR path for streamlined waiver
- [ ]  maximal object
- [x]  minimal object

Acceptance Criteria

- [ ]  BE has submission examples for new SW flow.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61843

Will not be merged or moved to a normal pull request