### PR TITLE
21 10210 - Update Confirmation-page content

### DIFF
--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -37,9 +37,9 @@ import transformForSubmit from './submit-transformer';
 // import the appropriate file [flow?.json] for the flow you're working on, or
 // noStmtInfo.json for all flows [manually select claimOwnership, claimantType,
 // & witnessRelationshipWithClaimant via UI]
-import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
+// import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
 
-const mockData = testData.data;
+// const mockData = testData.data;
 
 const pageFocus = () => {
   return () => {
@@ -157,8 +157,8 @@ const formConfig = {
           scrollAndFocusTarget: pageFocus(),
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
-          initialData:
-            !!mockData && environment.isLocalhost() ? mockData : undefined,
+          // initialData:
+          // !!mockData && environment.isLocalhost() ? mockData : undefined,
           uiSchema: claimOwnershipPg.uiSchema,
           schema: claimOwnershipPg.schema,
         },

--- a/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
@@ -25,7 +25,7 @@ const getPreparerFullName = formData => {
 const content = {
   headlineText: 'You’ve submitted your lay witness request.',
   nextStepsText:
-    'Once we’ve reviewed your submission, a coordinator will contact you to discuss next steps.',
+    'Once we’ve reviewed your submission, we’ll contact you to discuss next steps.',
 };
 
 export const ConfirmationPage = () => {


### PR DESCRIPTION
## Summary

- Update content on Lay/Witness Statement (21-10210) Confirmation page\*
- Team: VA Product Forms
- Flipper currently set at 25% in Production

\*Also, make form-config local-dev initialData disabled by default; leaving this enabled slows down the Cypress E2E-spec.

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#424

## Testing done

- N/A - Change is content-only.
