### PR TITLE
Replace select react component with web component

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-// eslint-disable-next-line deprecate/import
-import Select from '@department-of-veterans-affairs/component-library/Select';
+import {
+  VaModal,
+  VaSelect,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import environment from 'platform/utilities/environment';
 import { getActivePages } from 'platform/forms-system/src/js/helpers';
@@ -118,15 +119,19 @@ const SipsDevModal = props => {
               value={textData}
               onInput={e => handlers.onChange(e.target.value)}
             />
-            <Select
-              label="Return url"
+            <VaSelect
               name="sips_url"
-              options={availablePaths}
-              value={{ value: sipsUrl }}
-              includeBlankOption={false}
-              onValueChange={value => setSipsUrl(value.value)}
-              additionalClass="additional-class"
-            />
+              label="Return url"
+              value={sipsUrl}
+              onVaSelect={event => setSipsUrl(event.target.value)}
+            >
+              {availablePaths &&
+                availablePaths.map(path => (
+                  <option key={path.value} value={path.value}>
+                    {path.label}
+                  </option>
+                ))}
+            </VaSelect>
             <p />
             <a href={docsPage}>
               <i aria-hidden="true" className="fas fa-info-circle" role="img" />{' '}

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -11,7 +11,7 @@ import localStorage from 'platform/utilities/storage/localStorage';
 import '@department-of-veterans-affairs/component-library/i18n-setup';
 
 const docsPage =
-  'https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/forms/save-in-progress-menu';
+  'https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-use-the-save-in-progress-m';
 
 const checkHash = () => {
   const hash = (window?.location?.hash || '').toLowerCase();
@@ -127,8 +127,8 @@ const SipsDevModal = props => {
             >
               {availablePaths &&
                 availablePaths.map(path => (
-                  <option key={path.value} value={path.value}>
-                    {path.label}
+                  <option key={path} value={path}>
+                    {path}
                   </option>
                 ))}
             </VaSelect>

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -102,7 +102,8 @@ describe('Schemaform <SipsDevModal>', () => {
     // open the sips modal
     dom.click('.va-button-link');
     dom.fillData('va-textarea', JSON.stringify(newData));
-    dom.fillData('select', '/page-2');
+    const vaSelect = dom.querySelector('va-select');
+    vaSelect.__events.vaSelect({ target: { value: '/page-2' } });
     dom.click('.usa-button-primary'); // replace button
     expect(result).to.deep.equal({
       formId: 'test',
@@ -135,7 +136,8 @@ describe('Schemaform <SipsDevModal>', () => {
     // open the sips modal
     dom.click('.va-button-link');
     dom.fillData('va-textarea', JSON.stringify(newData));
-    dom.fillData('select', '/page-2');
+    const vaSelect = dom.querySelector('va-select');
+    vaSelect.__events.vaSelect({ target: { value: '/page-2' } });
     // replace button
     dom.click('.usa-button-primary');
     expect(result).to.deep.equal({
@@ -170,7 +172,8 @@ describe('Schemaform <SipsDevModal>', () => {
     // open the sips modal
     dom.click('.va-button-link');
     dom.fillData('va-textarea', JSON.stringify(newData));
-    dom.fillData('select', '/page-1');
+    const vaSelect = dom.querySelector('va-select');
+    vaSelect.__events.vaSelect({ target: { value: '/page-1' } });
     // merge button
     dom.click('.usa-button-secondary');
     expect(result).to.deep.equal({
@@ -205,7 +208,8 @@ describe('Schemaform <SipsDevModal>', () => {
     // open the sips modal
     dom.click('.va-button-link');
     dom.fillData('va-textarea', JSON.stringify(newData));
-    dom.fillData('select', '/page-1');
+    const vaSelect = dom.querySelector('va-select');
+    vaSelect.__events.vaSelect({ target: { value: '/page-1' } });
     // merge button
     dom.click('.usa-button-secondary');
     expect(result).to.deep.equal({


### PR DESCRIPTION
## Summary

- Update react select component to web component
- Update tests
- Fixed issue with last PR not populating list properly
- Updated `docsPage` link with correct link

## Related issue(s)

- Closes [Replace select component](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1735)

## Testing done

- Unit tests updated
- Checked component in chrome

## Screenshots
<img width="451" alt="Screenshot 2023-07-21 at 11 16 33 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/7ab125d9-1a19-4f5e-95ad-add1986814e4">

## What areas of the site does it impact?

Only modal used in dev mode impacted

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
