### PR TITLE
Fix prop types warning messages

### DIFF
--- a/src/applications/vaos/appointment-list/components/cancel/CancelAppointmentFailedModal.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelAppointmentFailedModal.jsx
@@ -34,7 +34,7 @@ export default function CancelAppointmentFailedModal({
           contact your medical center to cancel:
         </p>
       )}
-      <p>
+      <div>
         {facility ? (
           <>
             <strong>{facility.name}</strong>
@@ -49,13 +49,13 @@ export default function CancelAppointmentFailedModal({
             </NewTabAnchor>
           </>
         )}
-      </p>
+      </div>
     </VaModal>
   );
 }
 CancelAppointmentFailedModal.propTypes = {
   onClose: PropTypes.func.isRequired,
-  facility: PropTypes.string,
+  facility: PropTypes.object,
   isBadRequest: PropTypes.bool,
   isConfirmed: PropTypes.bool,
 };

--- a/src/applications/vaos/new-appointment/components/CommunityCareLanguagePage.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareLanguagePage.jsx
@@ -98,6 +98,6 @@ CommunityCareLanguagePage.propTypes = {
   pageChangeInProgress: PropTypes.bool.isRequired,
   routeToNextAppointmentPage: PropTypes.func.isRequired,
   routeToPreviousAppointmentPage: PropTypes.func.isRequired,
-  schema: PropTypes.object.isRequired,
   updateFormData: PropTypes.func.isRequired,
+  schema: PropTypes.object,
 };

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -256,5 +256,5 @@ export default function DateTimeSelectPage() {
 
 ErrorMessage.propTypes = {
   facilityId: PropTypes.string.isRequired,
-  history: PropTypes.objectOf.isRequired,
+  history: PropTypes.object.isRequired,
 };

--- a/src/applications/vaos/new-appointment/components/ReviewPage/PreferredDatesSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/PreferredDatesSection.jsx
@@ -38,5 +38,5 @@ export default function PreferredDatesSection(props) {
 }
 
 PreferredDatesSection.propTypes = {
-  props: PropTypes.object.isRequired,
+  props: PropTypes.object,
 };


### PR DESCRIPTION
## Summary
The google analytic event label `vaos-error`  are recorded on universal analytics (360) but there is not enough information from the GA dashboard to determine what caused the error or where it originates from. 

Despite not able to identify the GA bug, I did identify areas for improvement eliminating prop type warning and UI warning messages. 

### prop types and UI warning messages

When attempting to reproduce failure at cancel an appointment

![Screenshot 2023-07-21 at 1 16 50 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/83e917a8-cb61-487d-ba84-193e99470b22)

![Screenshot 2023-07-21 at 1 17 22 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/a3313305-7779-4670-8c3e-be268ac20ced)

![Screenshot 2023-07-21 at 1 18 06 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/839be056-de6b-4616-af9e-e5b21a9380f4)

When attempting to reproduce failure at fetching appointment slots

![Screenshot 2023-07-21 at 1 22 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/f7bfe7fd-0510-43b6-85f6-7968a1776a8e)

When attempting to reproduce failure at requesting a CC appointment

![Screenshot 2023-07-21 at 1 24 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/91c65595-fb61-461b-b2a8-32a54024e706)

![Screenshot 2023-07-21 at 1 26 15 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/08abd70c-f496-47ff-a2ee-c446026e3efb)



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#53873


## Testing done

n/a

## Screenshots

## What areas of the site does it impact?
vaos

