### PR TITLE
Fix error messages in simple form 21P-0847

### DIFF
--- a/src/applications/simple-forms/21P-0847/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21P-0847/containers/ConfirmationPage.jsx
@@ -75,6 +75,8 @@ export const ConfirmationPage = () => {
   return (
     <ConfirmationPageView
       submitterName={fullName}
+      submitterHeader="Who submitted this form"
+      formType="submission"
       submitDate={submitDate}
       confirmationNumber={confirmationNumber}
       content={content}

--- a/src/applications/simple-forms/21P-0847/pages/deceasedClaimantPersonalInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/deceasedClaimantPersonalInformation.js
@@ -1,11 +1,12 @@
 import {
   currentOrPastDateSchema,
-  currentOrPastDateUI,
   fullNameNoSuffixSchema,
   fullNameNoSuffixUI,
   titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaMemorableDateField from 'platform/forms-system/src/js/web-component-fields/VaMemorableDateField';
+import { validateCurrentOrPastMemorableDate } from 'platform/forms-system/src/js/validation';
 
 /** @type {PageSchema} */
 export default {
@@ -15,7 +16,14 @@ export default {
       'Now, we’ll ask for information about the person whose claim you’re requesting to continue.',
     ),
     deceasedClaimantFullName: fullNameNoSuffixUI(),
-    deceasedClaimantDateOfDeath: currentOrPastDateUI('Date of death'),
+    deceasedClaimantDateOfDeath: {
+      'ui:title': 'Date of death',
+      'ui:webComponentField': VaMemorableDateField,
+      'ui:validations': [validateCurrentOrPastMemorableDate],
+      'ui:errorMessages': {
+        required: 'Please add date of death',
+      },
+    },
   },
   schema: {
     type: 'object',

--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -5,16 +5,21 @@ export const relationshipToVeteranUI = personTitle => {
   const person = personTitle ?? 'veteran';
 
   return {
-    relationshipToVeteran: radioUI({
-      title: `What’s your relationship to the ${person}?`,
-      labels: {
-        spouse: `I’m the ${person}’s spouse`,
-        child: `I’m the ${person}’s child`,
-        parent: `I’m the ${person}’s parent`,
-        executor: `I’m the ${person}’s executor or administrator of estate`,
-        other: 'We don’t have a relationship that’s listed here',
+    relationshipToVeteran: {
+      ...radioUI({
+        title: `What’s your relationship to the ${person}?`,
+        labels: {
+          spouse: `I’m the ${person}’s spouse`,
+          child: `I’m the ${person}’s child`,
+          parent: `I’m the ${person}’s parent`,
+          executor: `I’m the ${person}’s executor or administrator of estate`,
+          other: 'We don’t have a relationship that’s listed here',
+        },
+      }),
+      'ui:errorMessages': {
+        required: `Please enter your relationship to the ${person}`,
       },
-    }),
+    },
     otherRelationshipToVeteran: {
       'ui:title': `Since your relationship with the ${person} was not listed, please describe it here`,
       'ui:webComponentField': VaTextInputField,

--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -17,7 +17,7 @@ export const relationshipToVeteranUI = personTitle => {
         },
       }),
       'ui:errorMessages': {
-        required: `Please enter your relationship to the ${person}`,
+        required: `Please select your relationship to the ${person}`,
       },
     },
     otherRelationshipToVeteran: {

--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -23,6 +23,9 @@ export const relationshipToVeteranUI = personTitle => {
         expandUnderCondition: 'other',
         expandedContentFocus: true,
       },
+      'ui:errorMessages': {
+        required: `Please enter your relationship to the ${person}`,
+      },
     },
     'ui:options': {
       updateSchema: (formData, formSchema) => {


### PR DESCRIPTION
## Summary

This PR makes two changes to error messages in the 21P-0847 form:
1. Update the Date of Death error message
2. Update the Relationship to the Deceased error message

## Related issue(s)

https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/312

## Testing done

Locally tested

## Screenshots

<img width="583" alt="Screenshot 2023-07-24 at 11 14 56 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/902d746f-2816-4de4-a05d-08039a4f6f85">

<img width="636" alt="Screenshot 2023-07-24 at 11 19 14 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/9525deee-ca3d-4db2-b2ee-29c4a559ef22">

## What areas of the site does it impact?

The form and the form system (`relationshipToVeteranPattern.jsx`)

## Acceptance criteria

### Quality Assurance & Testing

- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [X] Screenshot of the developed feature is added

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution

## Requested Feedback

For the relationship to the veteran message, I didn't hew strictly to the request from the ticket. The request was:
`Please enter your relationship to the deceased`
But in this PR it will read as:
`Please enter your relationship to the deceased claimant`
I made this choice because it was easier to write in code since I could rely on the `${person}` variable. If I should flag this with UX, please let me know!
