### PR TITLE
Update Forms Library legends to meet Design System standards

### DIFF
--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -24,7 +24,7 @@
 }
 
 legend {
-  color: $color-primary-darkest;
+  color: $color-gray-dark;
   font-size: 1.35em;
   font-weight: 700;
   line-height: 1.5;


### PR DESCRIPTION
## Description
Per feedback from a recent staging review, it was discovered that the legend color for fieldsets is incorrect. This PR updates the color from the darkest primary color to the dark gray.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#61939

## Screenshots
**Before:**
![Screenshot 2023-07-24 at 11 41 03 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/ce35ca62-87b9-4acf-8091-2fbbad77b955)

**After:**
![Screenshot 2023-07-24 at 11 41 59 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/0ab0cb33-b306-4009-8612-646354ad4003)

## Acceptance criteria
- Legend color meets correct Design System standards
