### PR TITLE
Add support for the v3 segmented progress bar to the forms library

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
@@ -45,6 +45,7 @@ const formConfig = {
   trackingPrefix: 'mock-simple-forms-patterns-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  v3SegmentedProgressBar: true,
   formId: 'FORM_MOCK_SF_PATTERNS',
   saveInProgress: {},
   version: 0,

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -139,6 +139,7 @@ export default function FormNav(props) {
     ],
   );
 
+  const v3SegmentedProgressBar = formConfig?.v3SegmentedProgressBar;
   // show progress-bar and stepText only if hideFormNavProgress is falsy.
   return (
     <div>
@@ -146,30 +147,32 @@ export default function FormNav(props) {
         <va-segmented-progress-bar
           total={chaptersLengthDisplay}
           current={currentChapterDisplay}
+          uswds={v3SegmentedProgressBar}
+          heading-text={chapterName ?? ''} // functionality only available for v3
         />
       )}
-      <div className="schemaform-chapter-progress">
-        <div className="nav-header nav-header-schemaform">
-          {showHeader &&
-            !hideFormNavProgress && (
-              <h2
-                id="nav-form-header"
-                data-testid="navFormHeader"
-                className="vads-u-font-size--h4"
-              >
-                {stepText}
-                {inProgressMessage}
-              </h2>
-            )}
-          {!showHeader &&
-            !hideFormNavProgress && (
-              <div data-testid="navFormDiv" className="vads-u-font-size--h4">
-                {stepText}
-                {inProgressMessage}
-              </div>
-            )}
-        </div>
-      </div>
+      {!v3SegmentedProgressBar &&
+        !hideFormNavProgress && (
+          <div className="schemaform-chapter-progress">
+            <div className="nav-header nav-header-schemaform">
+              {showHeader ? (
+                <h2
+                  id="nav-form-header"
+                  data-testid="navFormHeader"
+                  className="vads-u-font-size--h4"
+                >
+                  {stepText}
+                  {inProgressMessage}
+                </h2>
+              ) : (
+                <div data-testid="navFormDiv" className="vads-u-font-size--h4">
+                  {stepText}
+                  {inProgressMessage}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
     </div>
   );
 }

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -54,6 +54,7 @@
  * @property {(form: any, formConfig: any) => any} [transformForSubmit]
  * @property {string} [urlPrefix]
  * @property {boolean} [useCustomScrollAndFocus]
+ * @property {boolean} [v3SegmentedProgressBar] - if true, the V3 segmented progress bar web component is used in place of the v2
  * @property {boolean} [verifyRequiredPrefill]
  * @property {number} [version]
  * @property {string} [wizardStorageKey]

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -73,6 +73,7 @@ const formConfigKeys = [
   'showReviewErrors',
   'reviewErrors',
   'useCustomScrollAndFocus',
+  'v3SegmentedProgressBar',
 ];
 
 const validProperty = (


### PR DESCRIPTION
## Summary
This adds support for the new v3 version of the [segmented progress bar](https://design.va.gov/components/form/progress-bar-segmented) to the forms library. It is currently only enabled on a form by form basis. It requires setting the `v3SegmentedProgressBar` property to `true` in the `formConfig` object. Currently, it is enabled in our mock-simple-forms-patterns form.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#431

## Screenshots
<img width="491" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/9a9bf938-619b-4a8a-8774-d535415d31de">
