### PR TITLE
create minimal submission objects DAN Path

### DIFF
--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -13,9 +13,9 @@ import submitForm from './submitForm';
 import veteranInformationChapter from './chapters/veteranInformationChapter';
 import householdIncomeChapter from './chapters/householdIncomeChapter';
 import householdAssetsChapter from './chapters/householdAssetsChapter';
-import householdExpensesChapter from './chapters/householdExpensesChapter';
-import resolutionOptionsChapter from './chapters/resolutionOptionsChapter';
-import bankruptcyAttestationChapter from './chapters/bankruptcyAttestationChapter';
+// import householdExpensesChapter from './chapters/householdExpensesChapter';
+// import resolutionOptionsChapter from './chapters/resolutionOptionsChapter';
+// import bankruptcyAttestationChapter from './chapters/bankruptcyAttestationChapter';
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -65,9 +65,9 @@ const formConfig = {
     ...veteranInformationChapter,
     ...householdIncomeChapter,
     ...householdAssetsChapter,
-    ...householdExpensesChapter,
-    ...resolutionOptionsChapter,
-    ...bankruptcyAttestationChapter,
+    // ...householdExpensesChapter,
+    // ...resolutionOptionsChapter,
+    // ...bankruptcyAttestationChapter,
   },
 };
 

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -13,7 +13,7 @@ import submitForm from './submitForm';
 import veteranInformationChapter from './chapters/veteranInformationChapter';
 import householdIncomeChapter from './chapters/householdIncomeChapter';
 import householdAssetsChapter from './chapters/householdAssetsChapter';
-// import householdExpensesChapter from './chapters/householdExpensesChapter';
+import householdExpensesChapter from './chapters/householdExpensesChapter';
 // import resolutionOptionsChapter from './chapters/resolutionOptionsChapter';
 // import bankruptcyAttestationChapter from './chapters/bankruptcyAttestationChapter';
 
@@ -28,7 +28,6 @@ const formConfig = {
   wizardStorageKey: WIZARD_STATUS,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
-  VA_FORM_IDS: VA_FORM_IDS.FORM_5655,
   preSubmitInfo: PreSubmitSignature,
   formId: VA_FORM_IDS.FORM_5655,
   version: 0,
@@ -62,14 +61,32 @@ const formConfig = {
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
+
+  // config dan path (Veternan Info, Income, Assets)
+  // chapters: {
+  //   ...veteranInformationChapter,
+  //   ...householdIncomeChapter,
+  //   ...householdAssetsChapter,
+  // },
+
+  // config zoey path (Veternan Info, Income, Assets, Expenses)
+
   chapters: {
     ...veteranInformationChapter,
     ...householdIncomeChapter,
     ...householdAssetsChapter,
-    // ...householdExpensesChapter,
-    // ...resolutionOptionsChapter,
-    // ...bankruptcyAttestationChapter,
+    ...householdExpensesChapter,
   },
+
+  // config default path (Veternan Info, Income, Assets, Expenses, Resolution Options, Bankruptcy Attestation)
+  // chapters: {
+  //   ...veteranInformationChapter,
+  //   ...householdIncomeChapter,
+  //   ...householdAssetsChapter,
+  //   ...householdExpensesChapter,
+  //   ...resolutionOptionsChapter,
+  //   ...bankruptcyAttestationChapter,
+  // },
 };
 
 export default formConfig;

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -28,6 +28,7 @@ const formConfig = {
   wizardStorageKey: WIZARD_STATUS,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  VA_FORM_IDS: VA_FORM_IDS.FORM_5655,
   preSubmitInfo: PreSubmitSignature,
   formId: VA_FORM_IDS.FORM_5655,
   version: 0,

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-minimal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-minimal.json
@@ -3,9 +3,9 @@
     "hasRecreationalVehicle": false,
     "hasVehicle": false,
     "hasRealEstate": false,
-    "hasDependents": "0",
+    "hasDependents": "1",
     "isMarried": false,
-    "vetIsEmployed": false
+    "vetIsEmployed": true
   },
   "view:components": {
     "view:realEstateAdditionalInfo": {},
@@ -86,10 +86,45 @@
       }
     },
     "employmentHistory": {
-      "veteran": {},
-      "spouse": {}
+      "veteran": {
+        "employmentRecords": [
+          {
+            "type": "Full time",
+            "from": "2020-03-XX",
+            "to": "",
+            "isCurrent": true,
+            "employerName": "Dan's Wizard Hole",
+            "grossMonthlyIncome": "3313",
+            "deductions": [
+              {
+                "name": "Federal tax",
+                "amount": "426.75"
+              },
+              {
+                "name": "State tax",
+                "amount": "426.75"
+              }
+            ]
+          }
+        ]
+      },
+      "spouse": {},
+      "newRecord": {
+        "type": "",
+        "from": "",
+        "to": "",
+        "isCurrent": false,
+        "employerName": "",
+        "grossMonthlyIncome": "",
+        "deductions": []
+      }
     },
-    "spouseFullName": {}
+    "spouseFullName": {},
+    "dependents": [
+      {
+        "dependentAge": "12"
+      }
+    ]
   },
   "personalIdentification": {
     "ssn": "4437",
@@ -215,12 +250,25 @@
   "benefits": {
     "spouseBenefits": {}
   },
-  "assets": {},
+  "assets": {
+    "monetaryAssets": [
+      {
+        "name": "Savings accounts",
+        "amount": "500"
+      }
+    ]
+  },
   "view:combinedFinancialStatusReport": true,
   "view:enhancedFinancialStatusReport": true,
   "income": [
     {
       "veteranOrSpouse": "VETERAN"
     }
-  ]
+  ],
+  "agreed": false,
+  "AGREED": false,
+  "streamlined": {
+    "value": true,
+    "type": "short"
+  }
 }

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-minimal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-minimal.json
@@ -1,0 +1,226 @@
+{
+  "questions": {
+    "hasRecreationalVehicle": false,
+    "hasVehicle": false,
+    "hasRealEstate": false,
+    "hasDependents": "0",
+    "isMarried": false,
+    "vetIsEmployed": false
+  },
+  "view:components": {
+    "view:realEstateAdditionalInfo": {},
+    "view:maritalStatus": {},
+    "view:veteranInfo": {},
+    "view:vaBenefitsOnFile": {},
+    "view:vehicleInfo": {},
+    "view:recVehicleInfo": {},
+    "view:assetInfo": {}
+  },
+  "personalData": {
+    "veteranFullName": {
+      "first": "Mark",
+      "last": "Webb",
+      "middle": "",
+      "suffix": "Jr."
+    },
+    "dateOfBirth": "1950-10-04",
+    "address": {
+      "livesOnMilitaryBaseInfo": {},
+      "country": "USA",
+      "street": "123 Faker Street",
+      "city": "Bogusville",
+      "state": "GA",
+      "postalCode": "30058"
+    },
+    "telephoneNumber": "4445551212",
+    "emailAddress": "test2@test1.net",
+    "veteranContactInformation": {
+      "email": "test@user.com",
+      "mobilePhone": {
+        "areaCode": "510",
+        "countryCode": "1",
+        "createdAt": "2020-06-12T16:56:37.000+00:00",
+        "extension": "",
+        "effectiveEndDate": null,
+        "effectiveStartDate": "2020-07-14T19:07:45.000+00:00",
+        "id": 146766,
+        "isInternational": false,
+        "isTextable": null,
+        "isTextPermitted": null,
+        "isTty": null,
+        "isVoicemailable": null,
+        "phoneNumber": "9224444",
+        "phoneType": "HOME",
+        "sourceDate": "2020-07-14T19:07:45.000+00:00",
+        "sourceSystemUser": null,
+        "transactionId": "92c49d39-22b2-4bd6-92b4-0b7e7c63c6a9",
+        "updatedAt": "2020-07-14T19:07:46.000+00:00",
+        "vet360Id": "1273780"
+      },
+      "address": {
+        "addressLine1": "1200 Park Ave",
+        "addressLine2": "c/o Pixar",
+        "addressPou": "CORRESPONDENCE",
+        "addressType": "DOMESTIC",
+        "city": "Emeryville",
+        "countryName": "United States",
+        "countryCodeIso2": "US",
+        "countryCodeIso3": "USA",
+        "countryCodeFips": null,
+        "countyCode": null,
+        "countyName": null,
+        "createdAt": "2020-05-30T03:57:20.000+00:00",
+        "effectiveEndDate": null,
+        "effectiveStartDate": "2020-07-10T20:10:45.000+00:00",
+        "id": 173917,
+        "province": null,
+        "sourceDate": "2020-07-10T20:10:45.000+00:00",
+        "sourceSystemUser": null,
+        "stateCode": "CA",
+        "transactionId": "7139aa82-fd06-45ea-a217-9654869924bd",
+        "updatedAt": "2020-07-10T20:10:46.000+00:00",
+        "validationKey": null,
+        "vet360Id": "1273780",
+        "zipCode": "94608",
+        "zipCodeSuffix": null
+      }
+    },
+    "employmentHistory": {
+      "veteran": {},
+      "spouse": {}
+    },
+    "spouseFullName": {}
+  },
+  "personalIdentification": {
+    "ssn": "4437",
+    "fileNumber": "4437"
+  },
+  "selectedDebts": [],
+  "selectedDebtsAndCopays": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "pSSeqNum": 1,
+      "pSTotSeqNum": 1,
+      "pSFacilityNum": "757",
+      "pSFacPhoneNum": null,
+      "pSTotStatement": 3,
+      "pSStatementVal": "0000037953E",
+      "pSStatementDate": "05242023",
+      "pSStatementDateOutput": "05/24/2023",
+      "pSProcessDate": "12102020",
+      "pSProcessDateOutput": "12/10/2020",
+      "pHPatientLstNme": "HHUFHYULSEHU",
+      "pHPatientFstNme": "CDAA",
+      "pHPatientMidNme": "A",
+      "pHAddress1": "7780 RED MAPLE CT",
+      "pHAddress2": null,
+      "pHAddress3": null,
+      "pHCity": "HUBER HEIGHTS",
+      "pHState": "OH",
+      "pHZipCde": "45424",
+      "pHZipCdeOutput": "45424",
+      "pHCtryNme": null,
+      "pHAmtDue": 105.24,
+      "pHAmtDueOutput": "105.24&nbsp;&nbsp;",
+      "pHPrevBal": 103.21,
+      "pHPrevBalOutput": "103.21&nbsp;&nbsp;",
+      "pHTotCharges": 2.03,
+      "pHTotChargesOutput": "2.03&nbsp;&nbsp;",
+      "pHTotCredits": 0,
+      "pHTotCreditsOutput": ".00&nbsp;&nbsp;",
+      "pHNewBalance": 105.24,
+      "pHNewBalanceOutput": "105.24&nbsp;&nbsp;",
+      "pHSpecialNotes": null,
+      "pHroParaCdes": "0125304050556065708085",
+      "pHNumOfLines": 2,
+      "pHDfnNumber": 197750,
+      "pHCernerStatementNumber": 0,
+      "pHCernerPatientId": "                ",
+      "pHCernerAccountNumber": "                ",
+      "pHIcnNumber": "                 ",
+      "pHAccountNumber": 7570000000197750,
+      "pHLargeFontIndcator": 0,
+      "details": [
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+          "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+          "pDTransAmt": 2.03,
+          "pDTransAmtOutput": "2.03&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "Please refer to previous statement of rights.",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;Please refer to previous statement of rights.",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        }
+      ],
+      "station": {
+        "facilitYNum": "757",
+        "visNNum": "10",
+        "facilitYDesc": "CHALMERS P WYLIE VA ACC (757)",
+        "cyclENum": "004",
+        "remiTToFlag": "L",
+        "maiLInsertFlag": "0",
+        "staTAddress1": "420 N JAMES RD",
+        "staTAddress2": null,
+        "staTAddress3": null,
+        "city": "Columbus",
+        "state": "OH",
+        "ziPCde": "432191834",
+        "ziPCdeOutput": "43219-1834",
+        "baRCde": "*432191834203*",
+        "teLNumFlag": "S",
+        "teLNum": "1-866-812-0318",
+        "teLNum2": null,
+        "contacTInfo": null,
+        "dM2TelNum": null,
+        "contacTInfo2": null,
+        "toPTelNum": null,
+        "lbXFedexAddress1": null,
+        "lbXFedexAddress2": null,
+        "lbXFedexAddress3": null,
+        "lbXFedexCity": null,
+        "lbXFedexState": null,
+        "lbXFedexZipCde": null,
+        "lbXFedexBarCde": null,
+        "lbXFedexContact": null,
+        "lbXFedexContactTelNum": null,
+        "facilityName": "Chalmers P. Wylie Veterans Outpatient Clinic"
+      },
+      "debtType": "COPAY"
+    }
+  ],
+  "debt": {
+    "currentAr": 0,
+    "debtHistory": [
+      {
+        "date": ""
+      }
+    ],
+    "deductionCode": "",
+    "originalAr": 0
+  },
+  "socialSecurity": {
+    "spouse": {}
+  },
+  "additionalIncome": {
+    "spouse": {}
+  },
+  "benefits": {
+    "spouseBenefits": {}
+  },
+  "assets": {},
+  "view:combinedFinancialStatusReport": true,
+  "view:enhancedFinancialStatusReport": true,
+  "income": [
+    {
+      "veteranOrSpouse": "VETERAN"
+    }
+  ]
+}

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-submissionObject.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-submissionObject.json
@@ -1,0 +1,212 @@
+{
+  "personalIdentification": {
+      "ssn": "4437",
+      "fileNumber": "4437",
+      "fsrReason": ""
+  },
+  "personalData": {
+      "veteranFullName": {
+          "first": "Mark",
+          "middle": "",
+          "last": "Webb"
+      },
+      "address": {
+          "addresslineOne": "1200 Park Ave",
+          "addresslineTwo": "c/o Pixar",
+          "addresslineThree": "",
+          "city": "Emeryville",
+          "stateOrProvince": "CA",
+          "zipOrPostalCode": "94608",
+          "countryName": "US"
+      },
+      "telephoneNumber": "(510) 922-4444",
+      "dateOfBirth": "10/04/1950",
+      "married": false,
+      "spouseFullName": {
+          "first": "",
+          "middle": "",
+          "last": ""
+      },
+      "agesOfOtherDependents": [],
+      "employmentHistory": []
+  },
+  "income": [
+      {
+          "veteranOrSpouse": "VETERAN",
+          "monthlyGrossSalary": "0.00",
+          "deductions": {
+              "taxes": "0.00",
+              "retirement": "0.00",
+              "socialSecurity": "0.00",
+              "otherDeductions": {
+                  "name": "",
+                  "amount": "0.00"
+              }
+          },
+          "totalDeductions": "0.00",
+          "netTakeHomePay": "0.00",
+          "otherIncome": {
+              "name": "",
+              "amount": "0.00"
+          },
+          "totalMonthlyNetIncome": "0.00"
+      },
+      {
+          "veteranOrSpouse": "SPOUSE",
+          "monthlyGrossSalary": "0.00",
+          "deductions": {
+              "taxes": "0.00",
+              "retirement": "0.00",
+              "socialSecurity": "0.00",
+              "otherDeductions": {
+                  "name": "",
+                  "amount": "0.00"
+              }
+          },
+          "totalDeductions": "0.00",
+          "netTakeHomePay": "0.00",
+          "otherIncome": {
+              "name": "",
+              "amount": "0.00"
+          },
+          "totalMonthlyNetIncome": "0.00"
+      }
+  ],
+  "expenses": {
+      "rentOrMortgage": "0.00",
+      "food": "0.00",
+      "utilities": "0.00",
+      "otherLivingExpenses": {
+          "name": "",
+          "amount": "0.00"
+      },
+      "expensesInstallmentContractsAndOtherDebts": "0.00",
+      "totalMonthlyExpenses": "0.00"
+  },
+  "discretionaryIncome": {
+      "netMonthlyIncomeLessExpenses": "0.00",
+      "amountCanBePaidTowardDebt": "0.00"
+  },
+  "assets": {
+      "cashInBank": "0.00",
+      "cashOnHand": "0.00",
+      "usSavingsBonds": "0.00",
+      "stocksAndOtherBonds": "0.00",
+      "realEstateOwned": "0.00",
+      "totalAssets": "0.00"
+  },
+  "installmentContractsAndOtherDebts": [],
+  "totalOfInstallmentContractsAndOtherDebts": {
+      "originalAmount": "0.00",
+      "unpaidBalance": "0.00",
+      "amountDueMonthly": "0.00",
+      "amountPastDue": "0.00"
+  },
+  "additionalData": {
+      "bankruptcy": {}
+  },
+  "applicantCertifications": {
+      "veteranSignature": "Mark  Webb",
+      "veteranDateSigned": "07/24/2023"
+  },
+  "selectedDebtsAndCopays": [
+      {
+          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "pSSeqNum": "1.00",
+          "pSTotSeqNum": "1.00",
+          "pSFacilityNum": "757",
+          "pSFacPhoneNum": null,
+          "pSTotStatement": "3.00",
+          "pSStatementVal": "0000037953E",
+          "pSStatementDate": "05242023",
+          "pSStatementDateOutput": "05/24/2023",
+          "pSProcessDate": "12102020",
+          "pSProcessDateOutput": "12/10/2020",
+          "pHPatientLstNme": "HHUFHYULSEHU",
+          "pHPatientFstNme": "CDAA",
+          "pHPatientMidNme": "A",
+          "pHAddress1": "7780 RED MAPLE CT",
+          "pHAddress2": null,
+          "pHAddress3": null,
+          "pHCity": "HUBER HEIGHTS",
+          "pHState": "OH",
+          "pHZipCde": "45424",
+          "pHZipCdeOutput": "45424",
+          "pHCtryNme": null,
+          "pHAmtDue": "105.24",
+          "pHAmtDueOutput": "105.24&nbsp;&nbsp;",
+          "pHPrevBal": "103.21",
+          "pHPrevBalOutput": "103.21&nbsp;&nbsp;",
+          "pHTotCharges": "2.03",
+          "pHTotChargesOutput": "2.03&nbsp;&nbsp;",
+          "pHTotCredits": "0.00",
+          "pHTotCreditsOutput": ".00&nbsp;&nbsp;",
+          "pHNewBalance": "105.24",
+          "pHNewBalanceOutput": "105.24&nbsp;&nbsp;",
+          "pHSpecialNotes": null,
+          "pHroParaCdes": "0125304050556065708085",
+          "pHNumOfLines": "2.00",
+          "pHDfnNumber": "197750.00",
+          "pHCernerStatementNumber": "0.00",
+          "pHCernerPatientId": "                ",
+          "pHCernerAccountNumber": "                ",
+          "pHIcnNumber": "                 ",
+          "pHAccountNumber": "7570000000197750.00",
+          "pHLargeFontIndcator": "0.00",
+          "details": [
+              {
+                  "pDDatePosted": null,
+                  "pDDatePostedOutput": "",
+                  "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+                  "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+                  "pDTransAmt": "2.03",
+                  "pDTransAmtOutput": "2.03&nbsp;&nbsp;",
+                  "pDRefNo": null
+              },
+              {
+                  "pDDatePosted": null,
+                  "pDDatePostedOutput": "",
+                  "pDTransDesc": "Please refer to previous statement of rights.",
+                  "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;Please refer to previous statement of rights.",
+                  "pDTransAmt": "0.00",
+                  "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+                  "pDRefNo": null
+              }
+          ],
+          "station": {
+              "facilitYNum": "757",
+              "visNNum": "10",
+              "facilitYDesc": "CHALMERS P WYLIE VA ACC (757)",
+              "cyclENum": "004",
+              "remiTToFlag": "L",
+              "maiLInsertFlag": "0",
+              "staTAddress1": "420 N JAMES RD",
+              "staTAddress2": null,
+              "staTAddress3": null,
+              "city": "Columbus",
+              "state": "OH",
+              "ziPCde": "432191834",
+              "ziPCdeOutput": "43219-1834",
+              "baRCde": "*432191834203*",
+              "teLNumFlag": "S",
+              "teLNum": "1-866-812-0318",
+              "teLNum2": null,
+              "contacTInfo": null,
+              "dM2TelNum": null,
+              "contacTInfo2": null,
+              "toPTelNum": null,
+              "lbXFedexAddress1": null,
+              "lbXFedexAddress2": null,
+              "lbXFedexAddress3": null,
+              "lbXFedexCity": null,
+              "lbXFedexState": null,
+              "lbXFedexZipCde": null,
+              "lbXFedexBarCde": null,
+              "lbXFedexContact": null,
+              "lbXFedexContactTelNum": null,
+              "facilityName": "Chalmers P. Wylie Veterans Outpatient Clinic"
+          },
+          "debtType": "COPAY"
+      }
+  ]
+}

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-submissionObject.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/dan-submissionObject.json
@@ -1,212 +1,236 @@
 {
-  "personalIdentification": {
+    "personalIdentification": {
       "ssn": "4437",
       "fileNumber": "4437",
       "fsrReason": ""
-  },
-  "personalData": {
+    },
+    "personalData": {
       "veteranFullName": {
-          "first": "Mark",
-          "middle": "",
-          "last": "Webb"
+        "first": "Mark",
+        "middle": "",
+        "last": "Webb"
       },
       "address": {
-          "addresslineOne": "1200 Park Ave",
-          "addresslineTwo": "c/o Pixar",
-          "addresslineThree": "",
-          "city": "Emeryville",
-          "stateOrProvince": "CA",
-          "zipOrPostalCode": "94608",
-          "countryName": "US"
+        "addresslineOne": "1200 Park Ave",
+        "addresslineTwo": "c/o Pixar",
+        "addresslineThree": "",
+        "city": "Emeryville",
+        "stateOrProvince": "CA",
+        "zipOrPostalCode": "94608",
+        "countryName": "US"
       },
       "telephoneNumber": "(510) 922-4444",
       "dateOfBirth": "10/04/1950",
       "married": false,
       "spouseFullName": {
-          "first": "",
-          "middle": "",
-          "last": ""
+        "first": "",
+        "middle": "",
+        "last": ""
       },
-      "agesOfOtherDependents": [],
-      "employmentHistory": []
-  },
-  "income": [
-      {
+      "agesOfOtherDependents": [
+        "12"
+      ],
+      "employmentHistory": [
+        {
           "veteranOrSpouse": "VETERAN",
-          "monthlyGrossSalary": "0.00",
-          "deductions": {
-              "taxes": "0.00",
-              "retirement": "0.00",
-              "socialSecurity": "0.00",
-              "otherDeductions": {
-                  "name": "",
-                  "amount": "0.00"
-              }
-          },
-          "totalDeductions": "0.00",
-          "netTakeHomePay": "0.00",
-          "otherIncome": {
-              "name": "",
-              "amount": "0.00"
-          },
-          "totalMonthlyNetIncome": "0.00"
+          "occupationName": "Full time",
+          "from": "03/2020",
+          "to": "",
+          "present": true,
+          "employerName": "Dan's Wizard Hole",
+          "employerAddress": {
+            "addresslineOne": "",
+            "addresslineTwo": "",
+            "addresslineThree": "",
+            "city": "",
+            "stateOrProvince": "",
+            "zipOrPostalCode": "",
+            "countryName": ""
+          }
+        }
+      ]
+    },
+    "income": [
+      {
+        "veteranOrSpouse": "VETERAN",
+        "monthlyGrossSalary": "3313.00",
+        "deductions": {
+          "taxes": "853.50",
+          "retirement": "0.00",
+          "socialSecurity": "0.00",
+          "otherDeductions": {
+            "name": "",
+            "amount": "0.00"
+          }
+        },
+        "totalDeductions": "853.50",
+        "netTakeHomePay": "2459.50",
+        "otherIncome": {
+          "name": "",
+          "amount": "0.00"
+        },
+        "totalMonthlyNetIncome": "2459.50"
       },
       {
-          "veteranOrSpouse": "SPOUSE",
-          "monthlyGrossSalary": "0.00",
-          "deductions": {
-              "taxes": "0.00",
-              "retirement": "0.00",
-              "socialSecurity": "0.00",
-              "otherDeductions": {
-                  "name": "",
-                  "amount": "0.00"
-              }
-          },
-          "totalDeductions": "0.00",
-          "netTakeHomePay": "0.00",
-          "otherIncome": {
-              "name": "",
-              "amount": "0.00"
-          },
-          "totalMonthlyNetIncome": "0.00"
+        "veteranOrSpouse": "SPOUSE",
+        "monthlyGrossSalary": "0.00",
+        "deductions": {
+          "taxes": "0.00",
+          "retirement": "0.00",
+          "socialSecurity": "0.00",
+          "otherDeductions": {
+            "name": "",
+            "amount": "0.00"
+          }
+        },
+        "totalDeductions": "0.00",
+        "netTakeHomePay": "0.00",
+        "otherIncome": {
+          "name": "",
+          "amount": "0.00"
+        },
+        "totalMonthlyNetIncome": "0.00"
       }
-  ],
-  "expenses": {
+    ],
+    "expenses": {
       "rentOrMortgage": "0.00",
       "food": "0.00",
       "utilities": "0.00",
       "otherLivingExpenses": {
-          "name": "",
-          "amount": "0.00"
+        "name": "",
+        "amount": "0.00"
       },
       "expensesInstallmentContractsAndOtherDebts": "0.00",
       "totalMonthlyExpenses": "0.00"
-  },
-  "discretionaryIncome": {
-      "netMonthlyIncomeLessExpenses": "0.00",
+    },
+    "discretionaryIncome": {
+      "netMonthlyIncomeLessExpenses": "2459.50",
       "amountCanBePaidTowardDebt": "0.00"
-  },
-  "assets": {
-      "cashInBank": "0.00",
+    },
+    "assets": {
+      "cashInBank": "500.00",
       "cashOnHand": "0.00",
       "usSavingsBonds": "0.00",
       "stocksAndOtherBonds": "0.00",
       "realEstateOwned": "0.00",
-      "totalAssets": "0.00"
-  },
-  "installmentContractsAndOtherDebts": [],
-  "totalOfInstallmentContractsAndOtherDebts": {
+      "totalAssets": "500.00"
+    },
+    "installmentContractsAndOtherDebts": [],
+    "totalOfInstallmentContractsAndOtherDebts": {
       "originalAmount": "0.00",
       "unpaidBalance": "0.00",
       "amountDueMonthly": "0.00",
       "amountPastDue": "0.00"
-  },
-  "additionalData": {
+    },
+    "additionalData": {
       "bankruptcy": {}
-  },
-  "applicantCertifications": {
+    },
+    "applicantCertifications": {
       "veteranSignature": "Mark  Webb",
-      "veteranDateSigned": "07/24/2023"
-  },
-  "selectedDebtsAndCopays": [
+      "veteranDateSigned": "07/25/2023"
+    },
+    "selectedDebtsAndCopays": [
       {
-          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-          "pSSeqNum": "1.00",
-          "pSTotSeqNum": "1.00",
-          "pSFacilityNum": "757",
-          "pSFacPhoneNum": null,
-          "pSTotStatement": "3.00",
-          "pSStatementVal": "0000037953E",
-          "pSStatementDate": "05242023",
-          "pSStatementDateOutput": "05/24/2023",
-          "pSProcessDate": "12102020",
-          "pSProcessDateOutput": "12/10/2020",
-          "pHPatientLstNme": "HHUFHYULSEHU",
-          "pHPatientFstNme": "CDAA",
-          "pHPatientMidNme": "A",
-          "pHAddress1": "7780 RED MAPLE CT",
-          "pHAddress2": null,
-          "pHAddress3": null,
-          "pHCity": "HUBER HEIGHTS",
-          "pHState": "OH",
-          "pHZipCde": "45424",
-          "pHZipCdeOutput": "45424",
-          "pHCtryNme": null,
-          "pHAmtDue": "105.24",
-          "pHAmtDueOutput": "105.24&nbsp;&nbsp;",
-          "pHPrevBal": "103.21",
-          "pHPrevBalOutput": "103.21&nbsp;&nbsp;",
-          "pHTotCharges": "2.03",
-          "pHTotChargesOutput": "2.03&nbsp;&nbsp;",
-          "pHTotCredits": "0.00",
-          "pHTotCreditsOutput": ".00&nbsp;&nbsp;",
-          "pHNewBalance": "105.24",
-          "pHNewBalanceOutput": "105.24&nbsp;&nbsp;",
-          "pHSpecialNotes": null,
-          "pHroParaCdes": "0125304050556065708085",
-          "pHNumOfLines": "2.00",
-          "pHDfnNumber": "197750.00",
-          "pHCernerStatementNumber": "0.00",
-          "pHCernerPatientId": "                ",
-          "pHCernerAccountNumber": "                ",
-          "pHIcnNumber": "                 ",
-          "pHAccountNumber": "7570000000197750.00",
-          "pHLargeFontIndcator": "0.00",
-          "details": [
-              {
-                  "pDDatePosted": null,
-                  "pDDatePostedOutput": "",
-                  "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
-                  "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
-                  "pDTransAmt": "2.03",
-                  "pDTransAmtOutput": "2.03&nbsp;&nbsp;",
-                  "pDRefNo": null
-              },
-              {
-                  "pDDatePosted": null,
-                  "pDDatePostedOutput": "",
-                  "pDTransDesc": "Please refer to previous statement of rights.",
-                  "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;Please refer to previous statement of rights.",
-                  "pDTransAmt": "0.00",
-                  "pDTransAmtOutput": ".00&nbsp;&nbsp;",
-                  "pDRefNo": null
-              }
-          ],
-          "station": {
-              "facilitYNum": "757",
-              "visNNum": "10",
-              "facilitYDesc": "CHALMERS P WYLIE VA ACC (757)",
-              "cyclENum": "004",
-              "remiTToFlag": "L",
-              "maiLInsertFlag": "0",
-              "staTAddress1": "420 N JAMES RD",
-              "staTAddress2": null,
-              "staTAddress3": null,
-              "city": "Columbus",
-              "state": "OH",
-              "ziPCde": "432191834",
-              "ziPCdeOutput": "43219-1834",
-              "baRCde": "*432191834203*",
-              "teLNumFlag": "S",
-              "teLNum": "1-866-812-0318",
-              "teLNum2": null,
-              "contacTInfo": null,
-              "dM2TelNum": null,
-              "contacTInfo2": null,
-              "toPTelNum": null,
-              "lbXFedexAddress1": null,
-              "lbXFedexAddress2": null,
-              "lbXFedexAddress3": null,
-              "lbXFedexCity": null,
-              "lbXFedexState": null,
-              "lbXFedexZipCde": null,
-              "lbXFedexBarCde": null,
-              "lbXFedexContact": null,
-              "lbXFedexContactTelNum": null,
-              "facilityName": "Chalmers P. Wylie Veterans Outpatient Clinic"
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "pSSeqNum": "1.00",
+        "pSTotSeqNum": "1.00",
+        "pSFacilityNum": "757",
+        "pSFacPhoneNum": null,
+        "pSTotStatement": "3.00",
+        "pSStatementVal": "0000037953E",
+        "pSStatementDate": "05242023",
+        "pSStatementDateOutput": "05/24/2023",
+        "pSProcessDate": "12102020",
+        "pSProcessDateOutput": "12/10/2020",
+        "pHPatientLstNme": "HHUFHYULSEHU",
+        "pHPatientFstNme": "CDAA",
+        "pHPatientMidNme": "A",
+        "pHAddress1": "7780 RED MAPLE CT",
+        "pHAddress2": null,
+        "pHAddress3": null,
+        "pHCity": "HUBER HEIGHTS",
+        "pHState": "OH",
+        "pHZipCde": "45424",
+        "pHZipCdeOutput": "45424",
+        "pHCtryNme": null,
+        "pHAmtDue": "105.24",
+        "pHAmtDueOutput": "105.24&nbsp;&nbsp;",
+        "pHPrevBal": "103.21",
+        "pHPrevBalOutput": "103.21&nbsp;&nbsp;",
+        "pHTotCharges": "2.03",
+        "pHTotChargesOutput": "2.03&nbsp;&nbsp;",
+        "pHTotCredits": "0.00",
+        "pHTotCreditsOutput": ".00&nbsp;&nbsp;",
+        "pHNewBalance": "105.24",
+        "pHNewBalanceOutput": "105.24&nbsp;&nbsp;",
+        "pHSpecialNotes": null,
+        "pHroParaCdes": "0125304050556065708085",
+        "pHNumOfLines": "2.00",
+        "pHDfnNumber": "197750.00",
+        "pHCernerStatementNumber": "0.00",
+        "pHCernerPatientId": "                ",
+        "pHCernerAccountNumber": "                ",
+        "pHIcnNumber": "                 ",
+        "pHAccountNumber": "7570000000197750.00",
+        "pHLargeFontIndcator": "0.00",
+        "details": [
+          {
+            "pDDatePosted": null,
+            "pDDatePostedOutput": "",
+            "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+            "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+            "pDTransAmt": "2.03",
+            "pDTransAmtOutput": "2.03&nbsp;&nbsp;",
+            "pDRefNo": null
           },
-          "debtType": "COPAY"
+          {
+            "pDDatePosted": null,
+            "pDDatePostedOutput": "",
+            "pDTransDesc": "Please refer to previous statement of rights.",
+            "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;Please refer to previous statement of rights.",
+            "pDTransAmt": "0.00",
+            "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+            "pDRefNo": null
+          }
+        ],
+        "station": {
+          "facilitYNum": "757",
+          "visNNum": "10",
+          "facilitYDesc": "CHALMERS P WYLIE VA ACC (757)",
+          "cyclENum": "004",
+          "remiTToFlag": "L",
+          "maiLInsertFlag": "0",
+          "staTAddress1": "420 N JAMES RD",
+          "staTAddress2": null,
+          "staTAddress3": null,
+          "city": "Columbus",
+          "state": "OH",
+          "ziPCde": "432191834",
+          "ziPCdeOutput": "43219-1834",
+          "baRCde": "*432191834203*",
+          "teLNumFlag": "S",
+          "teLNum": "1-866-812-0318",
+          "teLNum2": null,
+          "contacTInfo": null,
+          "dM2TelNum": null,
+          "contacTInfo2": null,
+          "toPTelNum": null,
+          "lbXFedexAddress1": null,
+          "lbXFedexAddress2": null,
+          "lbXFedexAddress3": null,
+          "lbXFedexCity": null,
+          "lbXFedexState": null,
+          "lbXFedexZipCde": null,
+          "lbXFedexBarCde": null,
+          "lbXFedexContact": null,
+          "lbXFedexContactTelNum": null,
+          "facilityName": "Chalmers P. Wylie Veterans Outpatient Clinic"
+        },
+        "debtType": "COPAY"
       }
-  ]
-}
+    ],
+    "streamlined": {
+      "value": true,
+      "type": "short"
+    }
+  }

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/zoey-minimal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/zoey-minimal.json
@@ -1,0 +1,321 @@
+{
+  "questions": {
+    "hasRepayments": true,
+    "hasCreditCardBills": true,
+    "hasRecreationalVehicle": false,
+    "hasVehicle": false,
+    "hasRealEstate": false,
+    "hasDependents": "2",
+    "spouseHasBenefits": false,
+    "isMarried": true,
+    "vetIsEmployed": true,
+    "spouseIsEmployed": false
+  },
+  "view:components": {
+    "view:realEstateAdditionalInfo": {},
+    "view:maritalStatus": {},
+    "view:veteranInfo": {},
+    "view:vaBenefitsOnFile": {},
+    "view:vehicleInfo": {},
+    "view:recVehicleInfo": {},
+    "view:assetInfo": {}
+  },
+  "personalData": {
+    "spouseFullName": {
+      "first": "Guy",
+      "last": "Husband"
+    },
+    "veteranFullName": {
+      "first": "Mark",
+      "last": "Webb",
+      "middle": "",
+      "suffix": "Jr."
+    },
+    "dateOfBirth": "1950-10-04",
+    "address": {
+      "livesOnMilitaryBaseInfo": {},
+      "country": "USA",
+      "street": "123 Faker Street",
+      "city": "Bogusville",
+      "state": "GA",
+      "postalCode": "30058"
+    },
+    "telephoneNumber": "4445551212",
+    "emailAddress": "test2@test1.net",
+    "veteranContactInformation": {
+      "email": "test@user.com",
+      "mobilePhone": {
+        "areaCode": "510",
+        "countryCode": "1",
+        "createdAt": "2020-06-12T16:56:37.000+00:00",
+        "extension": "",
+        "effectiveEndDate": null,
+        "effectiveStartDate": "2020-07-14T19:07:45.000+00:00",
+        "id": 146766,
+        "isInternational": false,
+        "isTextable": null,
+        "isTextPermitted": null,
+        "isTty": null,
+        "isVoicemailable": null,
+        "phoneNumber": "9224444",
+        "phoneType": "HOME",
+        "sourceDate": "2020-07-14T19:07:45.000+00:00",
+        "sourceSystemUser": null,
+        "transactionId": "92c49d39-22b2-4bd6-92b4-0b7e7c63c6a9",
+        "updatedAt": "2020-07-14T19:07:46.000+00:00",
+        "vet360Id": "1273780"
+      },
+      "address": {
+        "addressLine1": "1200 Park Ave",
+        "addressLine2": "c/o Pixar",
+        "addressPou": "CORRESPONDENCE",
+        "addressType": "DOMESTIC",
+        "city": "Emeryville",
+        "countryName": "United States",
+        "countryCodeIso2": "US",
+        "countryCodeIso3": "USA",
+        "countryCodeFips": null,
+        "countyCode": null,
+        "countyName": null,
+        "createdAt": "2020-05-30T03:57:20.000+00:00",
+        "effectiveEndDate": null,
+        "effectiveStartDate": "2020-07-10T20:10:45.000+00:00",
+        "id": 173917,
+        "province": null,
+        "sourceDate": "2020-07-10T20:10:45.000+00:00",
+        "sourceSystemUser": null,
+        "stateCode": "CA",
+        "transactionId": "7139aa82-fd06-45ea-a217-9654869924bd",
+        "updatedAt": "2020-07-10T20:10:46.000+00:00",
+        "validationKey": null,
+        "vet360Id": "1273780",
+        "zipCode": "94608",
+        "zipCodeSuffix": null
+      }
+    },
+    "employmentHistory": {
+      "veteran": {
+        "employmentRecords": [
+          {
+            "type": "Full time",
+            "from": "2020-03-XX",
+            "to": "",
+            "isCurrent": true,
+            "employerName": "Zoe publishing company",
+            "grossMonthlyIncome": "6667",
+            "deductions": []
+          }
+        ]
+      },
+      "spouse": {},
+      "newRecord": {
+        "type": "",
+        "from": "",
+        "to": "",
+        "isCurrent": false,
+        "employerName": "",
+        "grossMonthlyIncome": "",
+        "deductions": []
+      }
+    },
+    "dependents": [
+      {
+        "dependentAge": "12"
+      },
+      {
+        "dependentAge": "17"
+      }
+    ]
+  },
+  "personalIdentification": {
+    "ssn": "4437",
+    "fileNumber": "4437"
+  },
+  "selectedDebts": [],
+  "selectedDebtsAndCopays": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "pSSeqNum": 1,
+      "pSTotSeqNum": 1,
+      "pSFacilityNum": "757",
+      "pSFacPhoneNum": null,
+      "pSTotStatement": 3,
+      "pSStatementVal": "0000037953E",
+      "pSStatementDate": "05242023",
+      "pSStatementDateOutput": "05/24/2023",
+      "pSProcessDate": "12102020",
+      "pSProcessDateOutput": "12/10/2020",
+      "pHPatientLstNme": "HHUFHYULSEHU",
+      "pHPatientFstNme": "CDAA",
+      "pHPatientMidNme": "A",
+      "pHAddress1": "7780 RED MAPLE CT",
+      "pHAddress2": null,
+      "pHAddress3": null,
+      "pHCity": "HUBER HEIGHTS",
+      "pHState": "OH",
+      "pHZipCde": "45424",
+      "pHZipCdeOutput": "45424",
+      "pHCtryNme": null,
+      "pHAmtDue": 105.24,
+      "pHAmtDueOutput": "105.24&nbsp;&nbsp;",
+      "pHPrevBal": 103.21,
+      "pHPrevBalOutput": "103.21&nbsp;&nbsp;",
+      "pHTotCharges": 2.03,
+      "pHTotChargesOutput": "2.03&nbsp;&nbsp;",
+      "pHTotCredits": 0,
+      "pHTotCreditsOutput": ".00&nbsp;&nbsp;",
+      "pHNewBalance": 105.24,
+      "pHNewBalanceOutput": "105.24&nbsp;&nbsp;",
+      "pHSpecialNotes": null,
+      "pHroParaCdes": "0125304050556065708085",
+      "pHNumOfLines": 2,
+      "pHDfnNumber": 197750,
+      "pHCernerStatementNumber": 0,
+      "pHCernerPatientId": "                ",
+      "pHCernerAccountNumber": "                ",
+      "pHIcnNumber": "                 ",
+      "pHAccountNumber": 7570000000197750,
+      "pHLargeFontIndcator": 0,
+      "details": [
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+          "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+          "pDTransAmt": 2.03,
+          "pDTransAmtOutput": "2.03&nbsp;&nbsp;",
+          "pDRefNo": null
+        },
+        {
+          "pDDatePosted": null,
+          "pDDatePostedOutput": "",
+          "pDTransDesc": "Please refer to previous statement of rights.",
+          "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;Please refer to previous statement of rights.",
+          "pDTransAmt": 0,
+          "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+          "pDRefNo": null
+        }
+      ],
+      "station": {
+        "facilitYNum": "757",
+        "visNNum": "10",
+        "facilitYDesc": "CHALMERS P WYLIE VA ACC (757)",
+        "cyclENum": "004",
+        "remiTToFlag": "L",
+        "maiLInsertFlag": "0",
+        "staTAddress1": "420 N JAMES RD",
+        "staTAddress2": null,
+        "staTAddress3": null,
+        "city": "Columbus",
+        "state": "OH",
+        "ziPCde": "432191834",
+        "ziPCdeOutput": "43219-1834",
+        "baRCde": "*432191834203*",
+        "teLNumFlag": "S",
+        "teLNum": "1-866-812-0318",
+        "teLNum2": null,
+        "contacTInfo": null,
+        "dM2TelNum": null,
+        "contacTInfo2": null,
+        "toPTelNum": null,
+        "lbXFedexAddress1": null,
+        "lbXFedexAddress2": null,
+        "lbXFedexAddress3": null,
+        "lbXFedexCity": null,
+        "lbXFedexState": null,
+        "lbXFedexZipCde": null,
+        "lbXFedexBarCde": null,
+        "lbXFedexContact": null,
+        "lbXFedexContactTelNum": null,
+        "facilityName": "Chalmers P. Wylie Veterans Outpatient Clinic"
+      },
+      "debtType": "COPAY"
+    }
+  ],
+  "debt": {
+    "currentAr": 0,
+    "debtHistory": [
+      {
+        "date": ""
+      }
+    ],
+    "deductionCode": "",
+    "originalAr": 0
+  },
+  "socialSecurity": {
+    "spouse": {}
+  },
+  "additionalIncome": {
+    "spouse": {}
+  },
+  "benefits": {
+    "spouseBenefits": {}
+  },
+  "assets": {
+    "monetaryAssets": [
+      {
+        "name": "Savings accounts",
+        "amount": "300"
+      }
+    ]
+  },
+  "expenses": {
+    "expenseRecords": [
+      {
+        "name": "Rent",
+        "amount": "2222.33"
+      }
+    ],
+    "creditCardBills": [
+      {
+        "purpose": "Credit card payment",
+        "creditorName": "",
+        "originalAmount": "",
+        "unpaidBalance": "111.375",
+        "amountDueMonthly": "111.375",
+        "dateStarted": "",
+        "amountPastDue": "0"
+      }
+    ]
+  },
+  "utilityRecords": [
+    {
+      "name": "Electricity",
+      "amount": "277.75"
+    },
+    {
+      "name": "Gas",
+      "amount": "277.75"
+    },
+    {
+      "name": "Water",
+      "amount": "1680.40"
+    },
+    {
+      "name": "Sewer",
+      "amount": "1680.40"
+    }
+  ],
+  "installmentContracts": [
+    {
+      "purpose": "Bank of america",
+      "creditorName": "The bank",
+      "originalAmount": 0,
+      "unpaidBalance": 0,
+      "amountDueMonthly": "50",
+      "dateStarted": "2023-07-XX",
+      "amountPastDue": "0"
+    }
+  ],
+  "view:combinedFinancialStatusReport": true,
+  "view:enhancedFinancialStatusReport": true,
+  "income": [
+    {
+      "veteranOrSpouse": "VETERAN"
+    }
+  ],
+  "streamlined": {
+    "value": true,
+    "type": "long"
+  }
+}

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/zoey-submissionObject.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/zoey-submissionObject.json
@@ -1,0 +1,273 @@
+{
+  "personalIdentification": {
+      "ssn": "4437",
+      "fileNumber": "4437",
+      "fsrReason": ""
+  },
+  "personalData": {
+      "veteranFullName": {
+          "first": "Mark",
+          "middle": "",
+          "last": "Webb"
+      },
+      "address": {
+          "addresslineOne": "1200 Park Ave",
+          "addresslineTwo": "c/o Pixar",
+          "addresslineThree": "",
+          "city": "Emeryville",
+          "stateOrProvince": "CA",
+          "zipOrPostalCode": "94608",
+          "countryName": "US"
+      },
+      "telephoneNumber": "(510) 922-4444",
+      "dateOfBirth": "10/04/1950",
+      "married": true,
+      "spouseFullName": {
+          "first": "Guy",
+          "middle": "",
+          "last": "Husband"
+      },
+      "agesOfOtherDependents": [
+          "12",
+          "17"
+      ],
+      "employmentHistory": [
+          {
+              "veteranOrSpouse": "VETERAN",
+              "occupationName": "Full time",
+              "from": "03/2020",
+              "to": "",
+              "present": true,
+              "employerName": "Zoe publishing company",
+              "employerAddress": {
+                  "addresslineOne": "",
+                  "addresslineTwo": "",
+                  "addresslineThree": "",
+                  "city": "",
+                  "stateOrProvince": "",
+                  "zipOrPostalCode": "",
+                  "countryName": ""
+              }
+          }
+      ]
+  },
+  "income": [
+      {
+          "veteranOrSpouse": "VETERAN",
+          "monthlyGrossSalary": "6667.00",
+          "deductions": {
+              "taxes": "0.00",
+              "retirement": "0.00",
+              "socialSecurity": "0.00",
+              "otherDeductions": {
+                  "name": "",
+                  "amount": "0.00"
+              }
+          },
+          "totalDeductions": "0.00",
+          "netTakeHomePay": "6667.00",
+          "otherIncome": {
+              "name": "",
+              "amount": "0.00"
+          },
+          "totalMonthlyNetIncome": "6667.00"
+      },
+      {
+          "veteranOrSpouse": "SPOUSE",
+          "monthlyGrossSalary": "0.00",
+          "deductions": {
+              "taxes": "0.00",
+              "retirement": "0.00",
+              "socialSecurity": "0.00",
+              "otherDeductions": {
+                  "name": "",
+                  "amount": "0.00"
+              }
+          },
+          "totalDeductions": "0.00",
+          "netTakeHomePay": "0.00",
+          "otherIncome": {
+              "name": "",
+              "amount": "0.00"
+          },
+          "totalMonthlyNetIncome": "0.00"
+      }
+  ],
+  "expenses": {
+      "rentOrMortgage": "2222.33",
+      "food": "0.00",
+      "utilities": "3916.30",
+      "otherLivingExpenses": {
+          "name": "",
+          "amount": "0.00"
+      },
+      "expensesInstallmentContractsAndOtherDebts": "161.38",
+      "totalMonthlyExpenses": "6300.01"
+  },
+  "discretionaryIncome": {
+      "netMonthlyIncomeLessExpenses": "366.99",
+      "amountCanBePaidTowardDebt": "0.00"
+  },
+  "assets": {
+      "cashInBank": "300.00",
+      "cashOnHand": "0.00",
+      "usSavingsBonds": "0.00",
+      "stocksAndOtherBonds": "0.00",
+      "realEstateOwned": "0.00",
+      "totalAssets": "300.00"
+  },
+  "installmentContractsAndOtherDebts": [
+      {
+          "purpose": "Bank of america",
+          "creditorName": "The bank",
+          "originalAmount": "0.00",
+          "unpaidBalance": "0.00",
+          "amountDueMonthly": "50",
+          "dateStarted": "07/2023",
+          "amountPastDue": "0",
+          "creditorAddress": {
+              "addresslineOne": "",
+              "addresslineTwo": "",
+              "addresslineThree": "",
+              "city": "",
+              "stateOrProvince": "",
+              "zipOrPostalCode": "",
+              "countryName": ""
+          }
+      },
+      {
+          "purpose": "Credit card payment",
+          "creditorName": "",
+          "originalAmount": "",
+          "unpaidBalance": "111.375",
+          "amountDueMonthly": "111.375",
+          "amountPastDue": "0",
+          "creditorAddress": {
+              "addresslineOne": "",
+              "addresslineTwo": "",
+              "addresslineThree": "",
+              "city": "",
+              "stateOrProvince": "",
+              "zipOrPostalCode": "",
+              "countryName": ""
+          }
+      }
+  ],
+  "totalOfInstallmentContractsAndOtherDebts": {
+      "originalAmount": "0.00",
+      "unpaidBalance": "111.38",
+      "amountDueMonthly": "161.38",
+      "amountPastDue": "0.00"
+  },
+  "additionalData": {
+      "bankruptcy": {}
+  },
+  "applicantCertifications": {
+      "veteranSignature": "Mark  Webb",
+      "veteranDateSigned": "07/26/2023"
+  },
+  "selectedDebtsAndCopays": [
+      {
+          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "pSSeqNum": "1.00",
+          "pSTotSeqNum": "1.00",
+          "pSFacilityNum": "757",
+          "pSFacPhoneNum": null,
+          "pSTotStatement": "3.00",
+          "pSStatementVal": "0000037953E",
+          "pSStatementDate": "05242023",
+          "pSStatementDateOutput": "05/24/2023",
+          "pSProcessDate": "12102020",
+          "pSProcessDateOutput": "12/10/2020",
+          "pHPatientLstNme": "HHUFHYULSEHU",
+          "pHPatientFstNme": "CDAA",
+          "pHPatientMidNme": "A",
+          "pHAddress1": "7780 RED MAPLE CT",
+          "pHAddress2": null,
+          "pHAddress3": null,
+          "pHCity": "HUBER HEIGHTS",
+          "pHState": "OH",
+          "pHZipCde": "45424",
+          "pHZipCdeOutput": "45424",
+          "pHCtryNme": null,
+          "pHAmtDue": "105.24",
+          "pHAmtDueOutput": "105.24&nbsp;&nbsp;",
+          "pHPrevBal": "103.21",
+          "pHPrevBalOutput": "103.21&nbsp;&nbsp;",
+          "pHTotCharges": "2.03",
+          "pHTotChargesOutput": "2.03&nbsp;&nbsp;",
+          "pHTotCredits": "0.00",
+          "pHTotCreditsOutput": ".00&nbsp;&nbsp;",
+          "pHNewBalance": "105.24",
+          "pHNewBalanceOutput": "105.24&nbsp;&nbsp;",
+          "pHSpecialNotes": null,
+          "pHroParaCdes": "0125304050556065708085",
+          "pHNumOfLines": "2.00",
+          "pHDfnNumber": "197750.00",
+          "pHCernerStatementNumber": "0.00",
+          "pHCernerPatientId": "                ",
+          "pHCernerAccountNumber": "                ",
+          "pHIcnNumber": "                 ",
+          "pHAccountNumber": "7570000000197750.00",
+          "pHLargeFontIndcator": "0.00",
+          "details": [
+              {
+                  "pDDatePosted": null,
+                  "pDDatePostedOutput": "",
+                  "pDTransDesc": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+                  "pDTransDescOutput": "INTEREST/ADM. CHARGE (Int:0.10 Adm:1.93 Other:0.00",
+                  "pDTransAmt": "2.03",
+                  "pDTransAmtOutput": "2.03&nbsp;&nbsp;",
+                  "pDRefNo": null
+              },
+              {
+                  "pDDatePosted": null,
+                  "pDDatePostedOutput": "",
+                  "pDTransDesc": "Please refer to previous statement of rights.",
+                  "pDTransDescOutput": "&nbsp;&nbsp;&nbsp;Please refer to previous statement of rights.",
+                  "pDTransAmt": "0.00",
+                  "pDTransAmtOutput": ".00&nbsp;&nbsp;",
+                  "pDRefNo": null
+              }
+          ],
+          "station": {
+              "facilitYNum": "757",
+              "visNNum": "10",
+              "facilitYDesc": "CHALMERS P WYLIE VA ACC (757)",
+              "cyclENum": "004",
+              "remiTToFlag": "L",
+              "maiLInsertFlag": "0",
+              "staTAddress1": "420 N JAMES RD",
+              "staTAddress2": null,
+              "staTAddress3": null,
+              "city": "Columbus",
+              "state": "OH",
+              "ziPCde": "432191834",
+              "ziPCdeOutput": "43219-1834",
+              "baRCde": "*432191834203*",
+              "teLNumFlag": "S",
+              "teLNum": "1-866-812-0318",
+              "teLNum2": null,
+              "contacTInfo": null,
+              "dM2TelNum": null,
+              "contacTInfo2": null,
+              "toPTelNum": null,
+              "lbXFedexAddress1": null,
+              "lbXFedexAddress2": null,
+              "lbXFedexAddress3": null,
+              "lbXFedexCity": null,
+              "lbXFedexState": null,
+              "lbXFedexZipCde": null,
+              "lbXFedexBarCde": null,
+              "lbXFedexContact": null,
+              "lbXFedexContactTelNum": null,
+              "facilityName": "Chalmers P. Wylie Veterans Outpatient Clinic"
+          },
+          "debtType": "COPAY"
+      }
+  ],
+  "streamlined": {
+    "value": true,
+    "type": "long"
+  }
+}

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -276,8 +276,10 @@ export const getMonthlyExpenses = ({
     : sumValues(utilityRecords, 'monthlyUtilityAmount');
   const installments = sumValues(installmentContracts, 'amountDueMonthly');
   const otherExp = sumValues(otherExpenses, 'amount');
+
+  // TODO: Cannot read properties of undefined (reading 'creditCardBills') - add check for creditCardBills
   const creditCardBills = sumValues(
-    expenses.creditCardBills,
+    expenses?.creditCardBills,
     'amountDueMonthly',
   );
 

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -49,12 +49,14 @@ export const transform = (formConfig, form) => {
       },
       veteranContactInformation: { address = {}, mobilePhone = {} } = {},
     },
+    // TODO: Cannot read properties of undefined (reading 'creditCardBills') - Dan Path
     expenses: {
       creditCardBills = [],
       expenseRecords = [],
       food = 0,
       rentOrMortgage = 0,
-    },
+      // adding a default value for expenses resolves this error
+    } = {},
     otherExpenses = [],
     utilityRecords,
     assets,
@@ -65,10 +67,7 @@ export const transform = (formConfig, form) => {
     realEstateRecords,
     currEmployment,
     spCurrEmployment,
-    additionalIncome: {
-      addlIncRecords,
-      spouse: { spAddlIncome },
-    },
+    additionalIncome: { addlIncRecords, spouse: { spAddlIncome } } = {},
     income,
     socialSecurity,
     benefits,
@@ -389,15 +388,19 @@ export const transform = (formConfig, form) => {
         'amountPastDue',
       ),
     },
+
+    // TODO: Cannot read properties of undefined (reading 'bankruptcy') - additionalData?.bankruptcy?.dateDischarged,
     additionalData: {
       bankruptcy: {
-        hasBeenAdjudicatedBankrupt: questions.hasBeenAdjudicatedBankrupt,
-        dateDischarged: dateFormatter(additionalData.bankruptcy.dateDischarged),
-        courtLocation: additionalData.bankruptcy.courtLocation,
-        docketNumber: additionalData.bankruptcy.docketNumber,
+        hasBeenAdjudicatedBankrupt: questions?.hasBeenAdjudicatedBankrupt,
+        dateDischarged: dateFormatter(
+          additionalData?.bankruptcy?.dateDischarged,
+        ),
+        courtLocation: additionalData?.bankruptcy?.courtLocation,
+        docketNumber: additionalData?.bankruptcy?.docketNumber,
       },
       additionalComments: mergeAdditionalComments(
-        additionalData.additionalComments,
+        additionalData?.additionalComments,
         enhancedFSRActive ? filteredExpenses : otherExpenses,
       ),
     },


### PR DESCRIPTION
STUB

Since streamlined is cutting off some of the form, we need to create examples of submission objects for the different routes so BE can adjust the required fields.

Tasks

- [x]  Create example submission objects for each FSR path for streamlined waiver
- [x]  maximal object
- [x]  minimal object

Acceptance Criteria

- [x]  BE has submission examples for new SW flow.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61843

Will not be merged or moved to a normal pull request