### PR TITLE
Focus for address edit view and validation alert

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -52,7 +52,7 @@ import manifest from '../manifest.json';
 import hearingType from '../pages/hearingType';
 
 /**
- * add custom focust for the contact info mailing address edit page
+ * add custom focus for the contact info mailing address edit page
  * fixes issue [#61243](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61243)
  */
 const confirmContactInfoEditMailingAddress = {

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -1,4 +1,5 @@
 import environment from 'platform/utilities/environment';
+import { focusElement } from 'platform/utilities/ui';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices as services } from 'platform/monitoring/DowntimeNotification';
 
@@ -49,6 +50,16 @@ import {
 
 import manifest from '../manifest.json';
 import hearingType from '../pages/hearingType';
+
+// add custom focust for the contact info mailing address edit page
+const confirmContactInfoEditMailingAddress = {
+  ...contactInfo.confirmContactInfoEditMailingAddress,
+  scrollAndFocusTarget: () => {
+    // even when not having this focusElement call the h3 still gets focused, sooo not sure if I should include this
+    // or just leave it blank since it's the default behavior if scrollAndFocusTarget is set to an empty function
+    focusElement('#main h3');
+  },
+};
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -112,7 +123,7 @@ const formConfig = {
           uiSchema: homeless.uiSchema,
           schema: homeless.schema,
         },
-        ...contactInfo,
+        ...{ ...contactInfo, confirmContactInfoEditMailingAddress },
       },
     },
     conditions: {

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -51,12 +51,13 @@ import {
 import manifest from '../manifest.json';
 import hearingType from '../pages/hearingType';
 
-// add custom focust for the contact info mailing address edit page
+/**
+ * add custom focust for the contact info mailing address edit page
+ * fixes issue [#61243](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61243)
+ */
 const confirmContactInfoEditMailingAddress = {
   ...contactInfo.confirmContactInfoEditMailingAddress,
   scrollAndFocusTarget: () => {
-    // even when not having this focusElement call the h3 still gets focused, sooo not sure if I should include this
-    // or just leave it blank since it's the default behavior if scrollAndFocusTarget is set to an empty function
     focusElement('#main h3');
   },
 };

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -1,5 +1,4 @@
 import environment from 'platform/utilities/environment';
-import { focusElement } from 'platform/utilities/ui';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices as services } from 'platform/monitoring/DowntimeNotification';
 
@@ -50,17 +49,6 @@ import {
 
 import manifest from '../manifest.json';
 import hearingType from '../pages/hearingType';
-
-/**
- * add custom focus for the contact info mailing address edit page
- * fixes issue [#61243](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61243)
- */
-const confirmContactInfoEditMailingAddress = {
-  ...contactInfo.confirmContactInfoEditMailingAddress,
-  scrollAndFocusTarget: () => {
-    focusElement('#main h3');
-  },
-};
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -124,7 +112,7 @@ const formConfig = {
           uiSchema: homeless.uiSchema,
           schema: homeless.schema,
         },
-        ...{ ...contactInfo, confirmContactInfoEditMailingAddress },
+        ...contactInfo,
       },
     },
     conditions: {

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityTables.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityTables.jsx
@@ -82,7 +82,7 @@ export const AccountSecurityTables = ({
     <>
       {/* legacy toble view for email address table */}
       <ProfileInfoCard
-        title="Sign in information"
+        title="Sign-in information"
         level={2}
         data={
           <EmailAddressNotification signInServiceName={signInServiceName} />

--- a/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
@@ -15,6 +15,7 @@ describe('Personal and contact information', () => {
       addressPage.saveForm();
       addressPage.confirmAddress(formFields, [], true, true);
       addressPage.validateSavedForm(formFields);
+      cy.injectAxeThenAxeCheck();
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -86,11 +86,15 @@ class AddressPage {
     });
     fields.military &&
       cy.findByTestId('mailingAddress').should('contain', 'FPO');
-    saved &&
-      cy
-        .focused()
-        .invoke('text')
-        .should('match', /edit/i);
+    if (saved) {
+      cy.findByTestId('update-success-alert').should('exist');
+      cy.get('#edit-mailing-address').should('exist');
+      cy.focused().then($focused => {
+        expect($focused).to.have.attr('aria-label', 'Edit Mailing address');
+        expect($focused).to.have.text('Edit');
+      });
+    }
+
     altText && cy.findByText(altText).should('exist');
   };
 

--- a/src/platform/forms-system/src/js/components/EditContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/EditContactInfo.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 // import {
 //   ProfileInformationFieldController,
@@ -18,9 +19,13 @@ import { FIELD_NAMES } from 'platform/user/profile/vap-svc/constants';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import { REVIEW_CONTACT, setReturnState } from '../utilities/data/profile';
+import { usePrevious } from '../../../../utilities/react-hooks';
 
 export const BuildPage = ({ title, field, id, goToPath, contactPath }) => {
   const headerRef = useRef(null);
+
+  const modalState = useSelector(state => state?.vapService.modal);
+  const prevModalState = usePrevious(modalState);
 
   useEffect(
     () => {
@@ -29,6 +34,22 @@ export const BuildPage = ({ title, field, id, goToPath, contactPath }) => {
       }
     },
     [headerRef],
+  );
+
+  useEffect(
+    () => {
+      const shouldFocusOnHeaderRef =
+        prevModalState === 'addressValidation' &&
+        modalState === 'mailingAddress';
+
+      // we do this to make sure focus is set when cancelling out of address validation UI
+      if (shouldFocusOnHeaderRef) {
+        setTimeout(() => {
+          focusElement(headerRef?.current);
+        }, 250);
+      }
+    },
+    [modalState, prevModalState],
   );
 
   const onReviewPage = window.sessionStorage.getItem(REVIEW_CONTACT) === 'true';

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -127,7 +127,8 @@ class ProfileInformationFieldController extends React.Component {
         if (forceEditView && typeof successCallback === 'function') {
           successCallback();
         }
-      } else {
+      } else if (!forceEditView) {
+        // forcesEditView will result in now standard edit button being rendered, so we don't want to focus on it
         // focusElement did not work here on iphone or safari, so using waitForRenderThenFocus
         waitForRenderThenFocus(`#${getEditButtonId(fieldName)}`, document, 50);
       }

--- a/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
+++ b/src/platform/user/profile/vap-svc/components/ProfileInformationFieldController.jsx
@@ -123,7 +123,6 @@ class ProfileInformationFieldController extends React.Component {
       if (this.props.transaction) {
         focusElement(`div#${fieldName}-transaction-status`);
       } else if (showUpdateSuccessAlert) {
-        focusElement('[data-testid=update-success-alert]');
         // Success check after confirming suggested address
         if (forceEditView && typeof successCallback === 'function') {
           successCallback();

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -12,8 +12,7 @@ import { hasBadAddress } from 'applications/personalization/profile/selectors';
 import { formatAddress } from 'platform/forms/address/helpers';
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import recordEvent from 'platform/monitoring/record-event';
-import { focusElement, scrollAndFocus } from 'platform/utilities/ui';
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { focusElement, waitForRenderThenFocus } from 'platform/utilities/ui';
 import * as VAP_SERVICE from '../constants';
 import {
   openModal,
@@ -29,7 +28,7 @@ import { ADDRESS_VALIDATION_MESSAGES } from '../constants/addressValidationMessa
 class AddressValidationView extends React.Component {
   componentDidMount() {
     // scroll on the alert since the web component doesn't have a focus/suto-scroll method built in like the React component
-    scrollAndFocus($('va-alert'));
+    waitForRenderThenFocus('#address-validation-alert-heading');
   }
 
   componentDidUpdate(prevProps) {
@@ -261,7 +260,9 @@ class AddressValidationView extends React.Component {
             status="warning"
             visible
           >
-            <h4 slot="headline">{addressValidationMessage.headline}</h4>
+            <h4 id="address-validation-alert-heading" slot="headline">
+              {addressValidationMessage.headline}
+            </h4>
             <addressValidationMessage.ModalText
               editFunction={this.onEditClick}
             />


### PR DESCRIPTION
## Summary

- Fixes focus for 10182 form during address validation flow
- Inside EditContactInfo component, we are checking the state of the modal/editing UI, and if the previous state was 'addressValidation' and the new state is 'mailingAddress' we are triggering the focus onto the correct H3.
  - this prevents unneeded calls to focus for other contact info like mobile phone or email as well 
- Also fixes the focus being lost when the address validation alert shows up by using `waitForRenderThenFocus` within the `AddressValidationView`
- Removes one unneeded focus call where the alert would be focused after succesful update, and then immediately focus on the edit button. The alert is read by a screen reader when it is shown, so the first focus call was not needed, and it also introduced flakiness to the e2e tests

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/61243

## Testing done

- Tested locally
- Updating E2E tests for address validation

## Screenshots

No visible changes made, just focus adjustment

## What areas of the site does it impact?

10182 contact info focus, Profile application -> Contact Information

## Acceptance criteria

- [x] Focus is set correctly

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.