### PR TITLE
Increase screenreader support for HCA fieldset titles & descriptions

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -69,18 +69,26 @@ export const DemographicInfoDescription = (
 );
 
 export const HomeAddressDescription = (
-  <p className="vads-u-line-height--6 vads-u-margin-bottom--4">
-    Any updates you make here to your address will apply only to this
-    application.
-  </p>
+  <>
+    Home address
+    <span className="sr-only">.</span>
+    <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-top--2 vads-u-margin-bottom--4">
+      Any updates you make here to your address will apply only to this
+      application.
+    </div>
+  </>
 );
 
 export const MailingAddressDescription = (
-  <p className="vads-u-line-height--6 vads-u-margin-bottom--4">
-    We’ll send any important information about your application to this address.
-    Any updates you make here to your address will apply only to this
-    application.
-  </p>
+  <>
+    Mailing address
+    <span className="sr-only">.</span>
+    <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-top--2 vads-u-margin-bottom--4">
+      We’ll send any important information about your application to this
+      address. Any updates you make here to your address will apply only to this
+      application.
+    </div>
+  </>
 );
 
 export const SIGIGenderDescription = (
@@ -118,9 +126,10 @@ export const SIGIGenderDescription = (
 export const ServiceHistoryTitle = (
   <>
     Service history
-    <span className="vads-u-display--block vads-u-margin-y--2 vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-color--base">
+    <span className="sr-only">.</span>
+    <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-top--2 vads-u-margin-bottom--4">
       Check all that apply to you.
-    </span>
+    </div>
   </>
 );
 
@@ -226,6 +235,21 @@ export const DeductibleExpensesDescription = (
     </va-additional-info>
   </>
 );
+
+// NOTE: for household v2 only -- rename when v2 is fully-adopted
+export const DeductibleExpensesV2Description = () => {
+  const date = new Date();
+  return (
+    <>
+      Deductible expenses from ${date.getFullYear - 1}
+      <span className="sr-only">.</span>
+      <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-top--2 vads-u-margin-bottom--4">
+        These deductible expenses will lower the amount of money we count as
+        your income.
+      </div>
+    </>
+  );
+};
 
 export const DependentDescription = () => {
   const date = new Date();
@@ -537,27 +561,42 @@ export const OtherIncomeDescription = (
   </>
 );
 
-export const SpouseAdditionalInformation = () => {
+export const SpouseBasicInformationDescription = (
+  <>
+    Spouse’s basic information
+    <span className="sr-only">.</span>
+    <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-y--2">
+      Fill this out to the best of your knowledge. The more accurate your
+      responses, the faster we can process your application.
+    </div>
+  </>
+);
+
+export const SpouseAdditionalInformationTitle = (
+  <>
+    Spouse’s additional information
+    <span className="sr-only">.</span>
+    <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-top--2">
+      Fill this out to the best of your knowledge. The more accurate your
+      responses, the faster we can process your application.
+    </div>
+  </>
+);
+
+export const SpouseAdditionalInformationDescription = () => {
   const date = new Date();
   return (
-    <>
-      <p>
-        Fill this out to the best of your knowledge. The more accurate your
-        responses, the faster we can process your application.
-      </p>
-
-      <va-additional-info
-        trigger="Why we ask for this information"
-        class="vads-u-margin-top--2 vads-u-margin-bottom--4"
-      >
-        <div>
-          <p className="vads-u-margin-top--0">
-            This information helps us determine if your spouse was your
-            dependent in {date.getFullYear() - 1}.
-          </p>
-        </div>
-      </va-additional-info>
-    </>
+    <va-additional-info
+      trigger="Why we ask for this information"
+      class="vads-u-margin-top--1 vads-u-margin-bottom--4"
+    >
+      <div>
+        <p className="vads-u-margin-top--0">
+          This information helps us determine if your spouse was your dependent
+          in {date.getFullYear() - 1}.
+        </p>
+      </div>
+    </va-additional-info>
   );
 };
 

--- a/src/applications/hca/config/chapters/householdInformationV2/deductibleExpenses.js
+++ b/src/applications/hca/config/chapters/householdInformationV2/deductibleExpenses.js
@@ -3,6 +3,7 @@ import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 
 import { validateCurrency } from '../../../utils/validation';
 import {
+  DeductibleExpensesV2Description,
   EducationalExpensesDescription,
   FuneralExpensesDescription,
   MedicalExpensesDescription,
@@ -19,9 +20,7 @@ const lastYear = date.getFullYear() - 1;
 
 export default {
   uiSchema: {
-    'ui:title': `Deductible expenses from ${lastYear}`,
-    'ui:description':
-      'These deductible expenses will lower the amount of money we count as your income.',
+    'ui:title': DeductibleExpensesV2Description,
     'view:deductibleMedicalExpenses': {
       'ui:title': 'Non-reimbursable medical expenses',
       'ui:description': MedicalExpensesDescription,

--- a/src/applications/hca/config/chapters/householdInformationV2/spouseAdditionalInformation.js
+++ b/src/applications/hca/config/chapters/householdInformationV2/spouseAdditionalInformation.js
@@ -1,13 +1,16 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
-import { SpouseAdditionalInformation } from '../../../components/FormDescriptions';
+import {
+  SpouseAdditionalInformationDescription,
+  SpouseAdditionalInformationTitle,
+} from '../../../components/FormDescriptions';
 
 const { cohabitedLastYear, sameAddress } = fullSchemaHca.properties;
 const date = new Date();
 
 export default {
   uiSchema: {
-    'ui:title': 'Spouse\u2019s additional information',
-    'ui:description': SpouseAdditionalInformation,
+    'ui:title': SpouseAdditionalInformationTitle,
+    'ui:description': SpouseAdditionalInformationDescription,
     cohabitedLastYear: {
       'ui:title': `Did you live with your spouse for all or part of ${date.getFullYear() -
         1}?`,

--- a/src/applications/hca/config/chapters/householdInformationV2/spouseBasicInformation.js
+++ b/src/applications/hca/config/chapters/householdInformationV2/spouseBasicInformation.js
@@ -2,6 +2,7 @@ import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import fullNameUI from 'platform/forms/definitions/fullName';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
+import { SpouseBasicInformationDescription } from '../../../components/FormDescriptions';
 
 const {
   dateOfMarriage,
@@ -12,9 +13,7 @@ const {
 
 export default {
   uiSchema: {
-    'ui:title': 'Spouse\u2019s information',
-    'ui:description':
-      'Fill this out to the best of your knowledge. The more accurate your responses, the faster we can process your application.',
+    'ui:title': SpouseBasicInformationDescription,
     spouseFullName: {
       ...fullNameUI,
       first: {

--- a/src/applications/hca/config/chapters/veteranInformation/veteranAddress.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranAddress.js
@@ -25,8 +25,8 @@ export default {
         hideIf: formData => !formData['view:isLoggedIn'],
       },
     },
-    veteranAddress: merge({}, addressUI('Mailing address', true), {
-      'ui:description': MailingAddressDescription,
+    veteranAddress: merge({}, addressUI(null, true), {
+      'ui:title': MailingAddressDescription,
       street: {
         'ui:title': 'Street address',
         'ui:errorMessages': {

--- a/src/applications/hca/config/chapters/veteranInformation/veteranHomeAddress.js
+++ b/src/applications/hca/config/chapters/veteranInformation/veteranHomeAddress.js
@@ -25,8 +25,8 @@ export default {
         hideIf: formData => !formData['view:isLoggedIn'],
       },
     },
-    veteranHomeAddress: merge({}, addressUI('Home address', true), {
-      'ui:description': HomeAddressDescription,
+    veteranHomeAddress: merge({}, addressUI(null, true), {
+      'ui:title': HomeAddressDescription,
       street: {
         'ui:title': 'Street address',
         'ui:errorMessages': {


### PR DESCRIPTION
## Description
Based on staging review feedback, several spots were identified where a fieldset description should be merged into the legend title to provide better screenreader support. This PR moves those descriptions into the fieldset legend.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#61940

## Acceptance criteria
- Screenreader support is increased with the descriptions being read alongside the title