### PR TITLE
Add optional chaining

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarOptionsSlots.jsx
+++ b/src/applications/vaos/components/calendar/CalendarOptionsSlots.jsx
@@ -50,7 +50,7 @@ export default function CalendarOptionsSlots({
   showWeekends,
 }) {
   const currentSlots = availableSlots.filter(slot =>
-    slot.start.startsWith(currentlySelectedDate),
+    slot?.start.startsWith(currentlySelectedDate),
   );
 
   // [0, 1, 2, 3, 4, 5, 6]

--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -10,7 +10,7 @@ function isCellDisabled({ date, availableSlots, minDate, maxDate }) {
   // in the array.
   if (
     (Array.isArray(availableSlots) &&
-      !availableSlots.some(slot => slot.start.startsWith(date))) ||
+      !availableSlots.some(slot => slot?.start.startsWith(date))) ||
     moment(date).isBefore(moment().format('YYYY-MM-DD'))
   ) {
     disabled = true;


### PR DESCRIPTION
## Summary

This PR adds optional chaining to the `startsWith()` method inside the components that make up the `CalendarWidget`

### Background
Since converting over to the new VAOS V2 Service on December 14, 2022 we have been logging two new event errors in google analytics. Two new event errors are being triggered daily since the cutover to V2:
  - Cannot read properties of undefined (reading 'startsWith')
  - undefined is not an object (evaluating 'e.start.startsWith')

According to Jeff, these errors are coming from the page
`/health-care/schedule-view-va-appointments/appointments/new-appointment/select-date/`



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#53873


## Testing done

n/a

## Screenshots

n/a

## What areas of the site does it impact?
VAOS


