### PR TITLE
Added aria-describedby to description

### DIFF
--- a/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/form/config/chapters/loans/loanHistory.js
@@ -157,9 +157,12 @@ export const uiSchema = {
       },
       vaLoanNumber: {
         'ui:title': text.loanNumber.title,
-        'ui:description': <div>{text.loanNumber.description}</div>,
+        'ui:description': (
+          <div id="va-loan-number">{text.loanNumber.description}</div>
+        ),
         'ui:options': {
           widgetClassNames: 'coe-loan-input',
+          ariaDescribedby: 'va-loan-number',
         },
         'ui:errorMessages': {
           pattern: text.loanNumber.pattern,


### PR DESCRIPTION
## Summary

- A small fix for accessibility: Step 4 of 6 (/housing-assistance/home-loans/request-coe-form-26-1880/loan-history). Added aria-describedby to VA loan number field per A11y recommendations.
- Solution was to add `ariaDescribedby` to UI options in the UI Schema and give it an ID. Then add that ID to the div in the description.

## Related issue(s)

- [[Other - Accessibility] Helper text not programmatically associated with input. (00.00.1)#48249](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48249)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |  
![Screenshot from 2023-07-26 15-25-16](https://github.com/department-of-veterans-affairs/vets-website/assets/57480791/90fa0c3f-d2f9-4e7e-8414-3fbf1e73d777)
   |     ![Screenshot from 2023-07-26 15-17-44](https://github.com/department-of-veterans-affairs/vets-website/assets/57480791/07bf207a-c15b-42d0-a3c3-1e6a78890231)  |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

/housing-assistance/home-loans/request-coe-form-26-1880/loan-history

## Acceptance criteria
- [x] The helper or description text for this field should have its own unique ID (<div id="some-unique-id">This number has 12 digits</div>), and the input element should reference that ID using aria-describedby, eg. <input ... aria-describedby="some-unique-id">. 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built
 into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
