### PR TITLE
[DHP-916] WIP - Add disclaimer text

### DIFF
--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -46,6 +46,23 @@ export const DevicesToConnectSection = ({
     return (
       <>
         <div>
+          <strong>
+            Data that you share with VA may not be actively monitored by your VA
+            care team.
+          </strong>{' '}
+          If you have a healthcare concern or specific questions about any of
+          your device data that you’ve shared with VA, please reach out to your
+          VA care team directly via{' '}
+          <a
+            href="https://www.myhealth.va.gov"
+            target="_blank"
+            rel="noreferrer"
+          >
+            My HealtheVet
+          </a>
+          .
+        </div>
+        <div>
           Choose a device type below to connect. You will be directed to an
           external website and asked to enter your sign in information for that
           device. When complete, you will return to this page on VA.gov.

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -46,26 +46,30 @@ export const DevicesToConnectSection = ({
     return (
       <>
         <div>
-          <strong>
-            Data that you share with VA may not be actively monitored by your VA
-            care team.
-          </strong>{' '}
-          If you have a healthcare concern or specific questions about any of
-          your device data that you’ve shared with VA, please reach out to your
-          VA care team directly via{' '}
-          <a
-            href="https://www.myhealth.va.gov"
-            target="_blank"
-            rel="noreferrer"
-          >
-            My HealtheVet
-          </a>
-          .
+          <p>
+            <strong>
+              Data that you share with VA may not be actively monitored by your
+              VA care team.
+            </strong>{' '}
+            If you have a healthcare concern or specific questions about any of
+            your device data that you’ve shared with VA, please reach out to
+            your your VA care team directly via{' '}
+            <a
+              href="https://www.myhealth.va.gov"
+              target="_blank"
+              rel="noreferrer"
+            >
+              My HealtheVet
+            </a>
+            .
+          </p>
         </div>
         <div>
-          Choose a device type below to connect. You will be directed to an
-          external website and asked to enter your sign in information for that
-          device. When complete, you will return to this page on VA.gov.
+          <p>
+            Choose a device type below to connect. You will be directed to an
+            external website and asked to enter your sign in information for
+            that device. When complete, you will return to this page on VA.gov.
+          </p>
         </div>
         {areAllDevicesConnected() && (
           <p data-testid="all-devices-connected-alert">

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -78,7 +78,7 @@ export const DevicesToConnectSection = ({
   const devicesToConnect = () => {
     return (
       <>
-        <div>{disclaimerText()}</div>
+        {disclaimerText()}
         {areAllDevicesConnected() && (
           <p data-testid="all-devices-connected-alert">
             There are no devices available to connect.

--- a/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
+++ b/src/applications/dhp-connected-devices/components/DevicesToConnectSection.jsx
@@ -42,7 +42,7 @@ export const DevicesToConnectSection = ({
     );
   };
 
-  const devicesToConnect = () => {
+  const disclaimerText = () => {
     return (
       <>
         <div>
@@ -71,6 +71,14 @@ export const DevicesToConnectSection = ({
             that device. When complete, you will return to this page on VA.gov.
           </p>
         </div>
+      </>
+    );
+  };
+
+  const devicesToConnect = () => {
+    return (
+      <>
+        <div>{disclaimerText()}</div>
         {areAllDevicesConnected() && (
           <p data-testid="all-devices-connected-alert">
             There are no devices available to connect.

--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -15,6 +15,27 @@ export default function App() {
   );
   const content = isLoading ? <va-loading-indicator set-focus /> : pageContent;
 
+  const disclaimerText = () => {
+    return (
+      <p>
+        <strong>
+          This page is meant for Digital Health Pathway pilot participants only.
+        </strong>{' '}
+        If you have not received an invitation to join a DHP pilot program but
+        are interested in sharing your device data with your VA care team,
+        please visit the{' '}
+        <a
+          href="https://mobile.va.gov/app/share-my-health-data"
+          target="_blank"
+          rel="noreferrer"
+        >
+          VA Share My Health Data app
+        </a>
+        .
+      </p>
+    );
+  };
+
   return (
     <div className="usa-grid-full margin landing-page">
       <MetaTags>
@@ -31,23 +52,7 @@ export default function App() {
               will become available to your care team.
             </p>
           </div>
-          <p>
-            <strong>
-              This page is meant for Digital Health Pathway pilot participants
-              only.
-            </strong>{' '}
-            If you have not received an invitation to join a DHP pilot program
-            but are interested in sharing your device data with your VA care
-            team, please visit the{' '}
-            <a
-              href="https://mobile.va.gov/app/share-my-health-data"
-              target="_blank"
-              rel="noreferrer"
-            >
-              VA Share My Health Data app
-            </a>
-            .
-          </p>
+          {disclaimerText()}
           {content}
           <FrequentlyAskedQuestions />
         </article>

--- a/src/applications/dhp-connected-devices/containers/App.jsx
+++ b/src/applications/dhp-connected-devices/containers/App.jsx
@@ -27,14 +27,26 @@ export default function App() {
           </div>
           <div className="va-introtext">
             <p>
-              Connecting a device will share your device health data with VA.
-              This data is automatically shared with your care team.
+              Connecting a device will share your health data with VA. This data
+              will become available to your care team.
             </p>
           </div>
           <p>
-            <strong>Note:</strong> Your shared data will not be monitored by
-            your VA care team. If you have concerns about any specific shared
-            data, you must contact your care team directly.
+            <strong>
+              This page is meant for Digital Health Pathway pilot participants
+              only.
+            </strong>{' '}
+            If you have not received an invitation to join a DHP pilot program
+            but are interested in sharing your device data with your VA care
+            team, please visit the{' '}
+            <a
+              href="https://mobile.va.gov/app/share-my-health-data"
+              target="_blank"
+              rel="noreferrer"
+            >
+              VA Share My Health Data app
+            </a>
+            .
           </p>
           {content}
           <FrequentlyAskedQuestions />


### PR DESCRIPTION
## Summary

Update disclaimer text for DHP pilot participants

## issue in Jira
https://jira.devops.va.gov/browse/DHP-916

## Screenshots

Will post after PR is created

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  ![Screenshot 2023-07-27 at 2 29 30 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/1357047/d77cae6d-9383-4d12-8ea1-535503faf7e3)   |   ![Screenshot 2023-07-27 at 2 27 06 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/1357047/57621e22-f44a-4d79-90a9-4171afae979b)  |
| Desktop |   ![Screenshot 2023-07-27 at 2 28 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/1357047/29d541ff-2eca-4abe-90fa-3966dab6c6bf)     |   ![Screenshot 2023-07-27 at 10 47 28 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/1357047/1943dac5-1645-4e55-9c3a-962800d5fe7f)    |

## What areas of the site does it impact?

only test on the `/health-care/connected-devices` page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [x] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
Having trouble signing in locally. Will try to use the branch deployment to verify logged in scenario
