### PR TITLE
Re-enable and update simple-forms cypress tests 

### DIFF
--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -126,7 +126,9 @@ const formConfig = {
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
           initialData:
-            !!mockData && environment.isLocalhost() ? mockData : undefined,
+            !!mockData && environment.isLocalhost() && !window.Cypress
+              ? mockData
+              : undefined,
           uiSchema: preparerPersonalInformation.uiSchema,
           schema: preparerPersonalInformation.schema,
         },

--- a/src/applications/simple-forms/21-0972/tests/e2e/21-0972-alternate-signer.cypress.spec.js
+++ b/src/applications/simple-forms/21-0972/tests/e2e/21-0972-alternate-signer.cypress.spec.js
@@ -247,8 +247,6 @@ const testConfig = createTestConfig(
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
       cy.intercept('POST', testFormConfig.submitUrl, mockSubmit);
     },
-
-    skip: Cypress.env('CI'),
   },
   manifest,
   testFormConfig,

--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -37,9 +37,9 @@ import transformForSubmit from './submit-transformer';
 // import the appropriate file [flow?.json] for the flow you're working on, or
 // noStmtInfo.json for all flows [manually select claimOwnership, claimantType,
 // & witnessRelationshipWithClaimant via UI]
-// import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
+import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
 
-// const mockData = testData.data;
+const mockData = testData.data;
 
 const pageFocus = () => {
   return () => {
@@ -157,8 +157,10 @@ const formConfig = {
           scrollAndFocusTarget: pageFocus(),
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
-          // initialData:
-          // !!mockData && environment.isLocalhost() ? mockData : undefined,
+          initialData:
+            !!mockData && environment.isLocalhost() && !window.Cypress
+              ? mockData
+              : undefined,
           uiSchema: claimOwnershipPg.uiSchema,
           schema: claimOwnershipPg.schema,
         },

--- a/src/applications/simple-forms/21-10210/tests/e2e/10210-lay-witness-statement.cypress.spec.js
+++ b/src/applications/simple-forms/21-10210/tests/e2e/10210-lay-witness-statement.cypress.spec.js
@@ -77,7 +77,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(data => {
             const signerName = getSignerFullName(data);
-            reviewAndSubmitPageFlow(signerName);
+            reviewAndSubmitPageFlow(signerName, 'Submit statement');
           });
         });
       },
@@ -87,8 +87,6 @@ const testConfig = createTestConfig(
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
     },
-
-    skip: Cypress.env('CI'),
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/shared/tests/e2e/helpers.js
+++ b/src/applications/simple-forms/shared/tests/e2e/helpers.js
@@ -170,20 +170,27 @@ export const introductionPageFlow = () => {
     .click({ force: true });
 };
 
-export const reviewAndSubmitPageFlow = signerName => {
+export const reviewAndSubmitPageFlow = (
+  signerName,
+  submitButtonText = 'Submit application',
+) => {
+  let veteranSignature = signerName;
+
+  if (typeof veteranSignature === 'object') {
+    veteranSignature = signerName.middle
+      ? `${signerName.first} ${signerName.middle} ${signerName.last}`
+      : `${signerName.first} ${signerName.last}`;
+  }
+
   cy.get('#veteran-signature')
     .shadow()
     .get('#inputField')
-    .type(
-      signerName.middle
-        ? `${signerName.first} ${signerName.middle} ${signerName.last}`
-        : `${signerName.first} ${signerName.last}`,
-    );
+    .type(veteranSignature);
   cy.get(`va-checkbox[name="veteran-certify"]`)
     .shadow()
     .find('input')
     .check();
-  cy.findAllByText(/Submit application/i, {
+  cy.findByText(submitButtonText, {
     selector: 'button',
   }).click();
 };


### PR DESCRIPTION
## Summary
We had to disable a couple e2e tests that were behaving wonky locally due to how we were using `initialData`. The data now has an additional check to see if cypress is running and **not** prefill any data if that is the case. In addition to this, additional params are now supported on the shared review page cypress test function to allow for different submit button texts and signer name formats.

Currently creating this PR as a draft due to a weird accessibility error I was getting.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#394