### PR TITLE
NOD | Add masks and hide PII for Datadog RUM recordings

### DIFF
--- a/src/applications/appeals/10182/components/IssueCard.jsx
+++ b/src/applications/appeals/10182/components/IssueCard.jsx
@@ -119,6 +119,7 @@ export const IssueCard = ({
 
   const titleClass = [
     'widget-title',
+    'dd-privacy-hidden',
     'vads-u-font-size--h4',
     'vads-u-margin--0',
     'capitalize',

--- a/src/applications/appeals/10182/components/ShowIssuesList.jsx
+++ b/src/applications/appeals/10182/components/ShowIssuesList.jsx
@@ -8,7 +8,7 @@ const ShowIssuesList = ({ issues }) => (
   <ul>
     {issues.map((issue, index) => (
       <li key={index}>
-        <strong className="capitalize">
+        <strong className="capitalize dd-privacy-hidden">
           {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
         </strong>
         <div>

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -8,14 +8,15 @@ import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
-import { FORMAT_READABLE } from '../constants';
+import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 
 const VeteranInformation = ({ profile = {}, veteran = {} }) => {
   const { ssnLastFour, vaFileLastFour } = veteran;
   const { dob, gender, userFullName = {} } = profile;
   const { first, middle, last, suffix } = userFullName;
 
-  const dateOfBirth = dob ? moment(dob).format(FORMAT_READABLE) : '';
+  // moment called with undefined = today's date
+  const momentDob = moment(dob || null, FORMAT_YMD);
 
   // separate each number so the screenreader reads "number ending with 1 2 3 4"
   // instead of "number ending with 1,234"
@@ -38,22 +39,33 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
           {suffix && `, ${suffix}`}
         </strong>
         {ssnLastFour && (
-          <p className="ssn">Social Security number: {mask(ssnLastFour)}</p>
+          <p className="ssn">
+            Social Security number:{' '}
+            <span className="dd-privacy-mask">{mask(ssnLastFour)}</span>
+          </p>
         )}
         {vaFileLastFour && (
-          <p className="vafn">VA file number: {mask(vaFileLastFour)}</p>
+          <p className="vafn">
+            VA file number:{' '}
+            <span className="dd-privacy-mask">{mask(vaFileLastFour)}</span>
+          </p>
         )}
         <p>
-          Date of birth: <span className="dob">{dateOfBirth}</span>
+          Date of birth:{' '}
+          {momentDob.isValid() ? (
+            <span className="dob dd-privacy-mask">
+              {momentDob.format(FORMAT_READABLE)}
+            </span>
+          ) : null}
         </p>
         <p>
           Gender:{' '}
-          <span className="gender">
+          <span className="gender dd-privacy-mask">
             {(gender && genderLabels[gender]) || ''}
           </span>
         </p>
       </div>
-      <br />
+      <br role="presentation" />
       <p>
         <strong>Note:</strong> If you need to update your personal information,
         call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />. We’re here

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -34,7 +34,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name dd-privacy-mask">
+        <strong className="name dd-privacy-hidden">
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix && `, ${suffix}`}
         </strong>
@@ -60,7 +60,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         </p>
         <p>
           Gender:{' '}
-          <span className="gender dd-privacy-mask">
+          <span className="gender dd-privacy-hidden">
             {(gender && genderLabels[gender]) || ''}
           </span>
         </p>

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -34,7 +34,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name">
+        <strong className="name dd-privacy-mask">
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix && `, ${suffix}`}
         </strong>

--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -21,7 +21,7 @@ export class ConfirmationPage extends React.Component {
     const { submission, formId, data } = form;
     const issues = getSelected(data || []).map((issue, index) => (
       <li key={index} className="vads-u-margin-bottom--0">
-        {getIssueName(issue)}
+        <span className="dd-privacy-hidden">{getIssueName(issue)}</span>
       </li>
     ));
     const fullName = `${name.first} ${name.middle || ''} ${name.last}`;
@@ -50,12 +50,14 @@ export class ConfirmationPage extends React.Component {
             Request a Board Appeal{' '}
             <span className="additional">(Form {formId})</span>
           </h3>
-          for {fullName}
-          {name.suffix && `, ${name.suffix}`}
+          for <span className="dd-privacy-hidden">{fullName}</span>
+          {name.suffix && (
+            <span className="dd-privacy-hidden">{`, ${name.suffix}`}</span>
+          )}
           {submitDate.isValid() && (
             <p>
               <strong>Date submitted</strong>
-              <br />
+              <br role="presentation" />
               <span>{submitDate.format(FORMAT_READABLE)}</span>
             </p>
           )}
@@ -94,7 +96,7 @@ export class ConfirmationPage extends React.Component {
           don’t request another appeal. Call us at{' '}
           <va-telephone contact={CONTACTS.VA_BENEFITS} />.
         </p>
-        <br />
+        <br role="presentation" />
         <a
           href="/claim-or-appeal-status/"
           className="usa-button usa-button-primary"

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -16,7 +16,14 @@ const titlePrefix = 'Decision for';
  */
 export const getIssueTitle = data => {
   const date = moment(getIssueDate(data), FORMAT_YMD).format(FORMAT_READABLE);
-  return `${titlePrefix} ${getIssueName(data)} dated ${date}`;
+  return (
+    <>
+      {titlePrefix}{' '}
+      <span className="dd-privacy-hidden">{getIssueName(data)}</span>
+      {' dated '}
+      {date}
+    </>
+  );
 };
 
 // formContext.pagePerItemIndex is undefined here? Use index added to data :(

--- a/src/applications/appeals/10182/content/evidenceIntro.jsx
+++ b/src/applications/appeals/10182/content/evidenceIntro.jsx
@@ -15,9 +15,9 @@ export const evidenceUploadIntroDescription = (
         You can submit more evidence by mailing it to this address:
         <p className="vads-u-padding-y--2">
           Board of Veterans’ Appeals
-          <br />
+          <br role="presentation" />
           PO Box 27063
-          <br />
+          <br role="presentation" />
           Washington, D.C. 20038
         </p>
         You can also fax it to{' '}

--- a/src/applications/appeals/10182/tests/components/IssueCard.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/IssueCard.unit.spec.jsx
@@ -41,6 +41,7 @@ describe('<IssueCard>', () => {
     const { container } = render(<IssueCard {...props} item={issue} />);
     expect($$('input[type="checkbox"]', container).length).to.equal(1);
     expect($('.widget-title', container).textContent).to.eq('issue-10');
+    expect($('.widget-title.dd-privacy-hidden', container)).to.exist;
     expect($('.widget-content', container).textContent).to.contain('blah');
     expect($('.widget-content', container).textContent).to.contain(
       'Current rating: 10%',

--- a/src/applications/appeals/10182/tests/components/ShowIssuesList.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ShowIssuesList.unit.spec.jsx
@@ -43,6 +43,7 @@ describe('ShowIssuesList', () => {
     expect(list.first().text()).to.contain('Decision date: January 1, 2021');
     expect(list.last().text()).to.contain('Issue 4');
     expect(list.last().text()).to.contain('Decision date: February 2, 2021');
+    expect(wrapper.find('strong.dd-privacy-hidden').length).to.eq(4);
     wrapper.unmount();
   });
 });

--- a/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
@@ -40,6 +40,7 @@ describe('<VeteranInformation>', () => {
 
     expect(text).to.contain('Date of birth: January 5, 2000');
     expect(text).to.contain('Gender: Female');
+    expect(wrapper.find('.dd-privacy-mask').length).to.eq(4);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('<VeteranInformation>', () => {
 
     expect(text).to.contain('Date of birth: January 5, 2000');
     expect(text).to.contain('Gender: Female');
-    expect(wrapper.find('.dd-privacy-mask').length).to.eq(4);
+    expect(wrapper.find('.dd-privacy-mask').length).to.eq(5);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
@@ -40,7 +40,8 @@ describe('<VeteranInformation>', () => {
 
     expect(text).to.contain('Date of birth: January 5, 2000');
     expect(text).to.contain('Gender: Female');
-    expect(wrapper.find('.dd-privacy-mask').length).to.eq(5);
+    expect(wrapper.find('.dd-privacy-mask').length).to.eq(3);
+    expect(wrapper.find('.dd-privacy-hidden').length).to.eq(2);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -16,6 +16,7 @@ const data = {
         first: 'Foo',
         middle: 'Man',
         last: 'Choo',
+        suffix: 'Esq.',
       },
     },
   },
@@ -59,7 +60,7 @@ describe('Confirmation page', () => {
   });
   it('should render the user name', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
-    expect(tree.text()).to.contain('Foo Man Choo');
+    expect(tree.text()).to.contain('Foo Man Choo, Esq.');
     tree.unmount();
   });
   it('should render the submit date', () => {
@@ -75,8 +76,10 @@ describe('Confirmation page', () => {
     expect(list).not.to.contain('test 987');
     tree.unmount();
   });
-  it('should reset the wizard sessionStorage', () => {
+  it('should have Datadog class names to hide PII', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
+    expect(tree.find('span.dd-privacy-hidden').length).to.eq(3);
+    expect(tree.find('li .dd-privacy-hidden').length).to.eq(1);
     tree.unmount();
   });
 });

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -44,6 +44,7 @@ describe('area of disagreement page', () => {
     expect(form.find('input[type="checkbox"]').length).to.equal(3);
     expect(form.find('input[type="text"]').length).to.equal(1);
     expect(form.find('h3').text()).to.contain('Tinnitus dated January 1, 2021');
+    expect(form.find('h3 .dd-privacy-hidden')).to.exist;
     form.unmount();
   });
 

--- a/src/applications/appeals/995/components/ContactInfo.jsx
+++ b/src/applications/appeals/995/components/ContactInfo.jsx
@@ -141,7 +141,7 @@ const ContactInfo = ({
         Home phone number
       </Headers>
       {showSuccessAlert('home-phone', 'Home phone number')}
-      <span>{getFormattedPhone(homePhone)}</span>
+      <span className="dd-privacy-hidden">{getFormattedPhone(homePhone)}</span>
       <p className="vads-u-margin-top--0p5">
         <Link
           id="edit-home-phone"
@@ -154,7 +154,9 @@ const ContactInfo = ({
 
       <Headers className={headerClassNames}>Mobile phone number</Headers>
       {showSuccessAlert('mobile-phone', 'Mobile phone number')}
-      <span>{getFormattedPhone(mobilePhone)}</span>
+      <span className="dd-privacy-hidden">
+        {getFormattedPhone(mobilePhone)}
+      </span>
       <p className="vads-u-margin-top--0p5">
         <Link
           id="edit-mobile-phone"
@@ -167,7 +169,7 @@ const ContactInfo = ({
 
       <Headers className={headerClassNames}>Email address</Headers>
       {showSuccessAlert('email', 'Email address')}
-      <span>{email || ''}</span>
+      <span className="dd-privacy-hidden">{email || ''}</span>
       <p className="vads-u-margin-top--0p5">
         <Link
           id="edit-email"
@@ -180,9 +182,7 @@ const ContactInfo = ({
 
       <Headers className={headerClassNames}>Mailing address</Headers>
       {showSuccessAlert('address', 'Mailing address')}
-      <div className="vads-u-display--flex">
-        <AddressView data={address} />
-      </div>
+      <AddressView data={address} />
       <p className="vads-u-margin-top--0p5">
         <Link
           id="edit-address"

--- a/src/applications/appeals/995/components/IssueCard.jsx
+++ b/src/applications/appeals/995/components/IssueCard.jsx
@@ -119,6 +119,7 @@ export const IssueCard = ({
 
   const titleClass = [
     'widget-title',
+    'dd-privacy-hidden',
     'vads-u-font-size--h4',
     'vads-u-margin--0',
     'capitalize',

--- a/src/applications/appeals/995/components/VeteranInformation.jsx
+++ b/src/applications/appeals/995/components/VeteranInformation.jsx
@@ -34,7 +34,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name">
+        <strong className="name dd-privacy-mask">
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix ? `, ${suffix}` : null}
         </strong>

--- a/src/applications/appeals/995/components/VeteranInformation.jsx
+++ b/src/applications/appeals/995/components/VeteranInformation.jsx
@@ -9,7 +9,7 @@ import { selectProfile } from 'platform/user/selectors';
 
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
-import { FORMAT_YMD } from '../constants';
+import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 
 // separate each number so the screenreader reads "number ending with 1 2 3 4"
 // instead of "number ending with 1,234"
@@ -39,19 +39,30 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
           {suffix ? `, ${suffix}` : null}
         </strong>
         {ssnLastFour ? (
-          <p className="ssn">Social Security number: {mask(ssnLastFour)}</p>
+          <p className="ssn">
+            Social Security number:{' '}
+            <span className="dd-privacy-mask">{mask(ssnLastFour)}</span>
+          </p>
         ) : null}
         {vaFileLastFour ? (
-          <p className="vafn">VA file number: {mask(vaFileLastFour)}</p>
+          <p className="vafn">
+            VA file number:{' '}
+            <span className="dd-privacy-mask">{mask(vaFileLastFour)}</span>
+          </p>
         ) : null}
         <p>
           Date of birth:{' '}
           {momentDob.isValid() ? (
-            <span className="dob">{momentDob.format('LL')}</span>
+            <span className="dob dd-privacy-mask">
+              {momentDob.format(FORMAT_READABLE)}
+            </span>
           ) : null}
         </p>
         <p>
-          Gender: <span className="gender">{genderLabels?.[gender] || ''}</span>
+          Gender:{' '}
+          <span className="gender dd-privacy-mask">
+            {genderLabels?.[gender] || ''}
+          </span>
         </p>
       </div>
 

--- a/src/applications/appeals/995/components/VeteranInformation.jsx
+++ b/src/applications/appeals/995/components/VeteranInformation.jsx
@@ -34,7 +34,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name dd-privacy-mask">
+        <strong className="name dd-privacy-hidden">
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix ? `, ${suffix}` : null}
         </strong>
@@ -60,7 +60,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         </p>
         <p>
           Gender:{' '}
-          <span className="gender dd-privacy-mask">
+          <span className="gender dd-privacy-hidden">
             {genderLabels?.[gender] || ''}
           </span>
         </p>

--- a/src/applications/appeals/995/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/containers/ConfirmationPage.jsx
@@ -32,7 +32,7 @@ export const ConfirmationPage = () => {
   const { submission, data } = form;
   const issues = getSelected(data || []).map((issue, index) => (
     <li key={index} className="vads-u-margin-bottom--0">
-      {getIssueName(issue)}
+      <span className="dd-privacy-hidden">{getIssueName(issue)}</span>
     </li>
   ));
   const fullName = `${name.first} ${name.middle || ''} ${name.last}`;
@@ -62,7 +62,7 @@ export const ConfirmationPage = () => {
         </h3>
         <h4>Your name</h4>
         {fullName ? (
-          <div>
+          <div className="dd-privacy-hidden">
             {name.first} {name.middle} {name.last}
             {name.suffix ? `, ${name.suffix}` : null}
           </div>

--- a/src/applications/appeals/995/content/IssueSummary.jsx
+++ b/src/applications/appeals/995/content/IssueSummary.jsx
@@ -32,7 +32,7 @@ const IssueSummary = ({ formData }) => {
         {issues.length ? (
           issues.map((issue, index) => (
             <li key={index} className={listClassNames}>
-              <h4 className="capitalize vads-u-margin-top--0 vads-u-padding-right--2">
+              <h4 className="capitalize vads-u-margin-top--0 vads-u-padding-right--2 dd-privacy-hidden">
                 {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
               </h4>
               <div>

--- a/src/applications/appeals/995/tests/components/ContactInfo.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ContactInfo.unit.spec.jsx
@@ -47,6 +47,8 @@ describe('<ContactInfo>', () => {
     expect($$('h3', container).length).to.equal(1);
     expect($$('h4', container).length).to.equal(4);
     expect($$('h5', container).length).to.equal(0);
+    // mobile phone, home phone, email, mailing address x2
+    expect($$('.dd-privacy-hidden', container).length).to.equal(5);
   });
 
   describe('Successful edit', () => {

--- a/src/applications/appeals/995/tests/components/IssueCard.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/IssueCard.unit.spec.jsx
@@ -42,6 +42,7 @@ describe('<IssueCard>', () => {
     expect($('h4', container)).to.exist;
     expect($('input[type="checkbox"]', container)).to.exist;
     expect($('.widget-title', container).textContent).to.eq('issue-10');
+    expect($('.widget-title.dd-privacy-hidden', container)).to.exist;
     expect($('.widget-content', container).textContent).to.contain('blah');
     expect($('.widget-content', container).textContent).to.contain(
       'Current rating: 10%',

--- a/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
@@ -35,6 +35,7 @@ describe('<VeteranInformation>', () => {
     expect($('.vafn', container).textContent).to.contain('8765');
     expect($('.dob', container).textContent).to.contain('January 5, 2000');
     expect($('.gender', container).textContent).to.contain('Female');
-    expect($$('.dd-privacy-mask', container).length).to.eq(5);
+    expect($$('.dd-privacy-mask', container).length).to.eq(3);
+    expect($$('.dd-privacy-hidden', container).length).to.eq(2);
   });
 });

--- a/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
-import { $ } from '../../utils/ui';
+import { $, $$ } from '../../utils/ui';
 import { VeteranInformation } from '../../components/VeteranInformation';
 
 describe('<VeteranInformation>', () => {
@@ -35,5 +35,6 @@ describe('<VeteranInformation>', () => {
     expect($('.vafn', container).textContent).to.contain('8765');
     expect($('.dob', container).textContent).to.contain('January 5, 2000');
     expect($('.gender', container).textContent).to.contain('Female');
+    expect($$('.dd-privacy-mask', container).length).to.eq(4);
   });
 });

--- a/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/VeteranInformation.unit.spec.jsx
@@ -35,6 +35,6 @@ describe('<VeteranInformation>', () => {
     expect($('.vafn', container).textContent).to.contain('8765');
     expect($('.dob', container).textContent).to.contain('January 5, 2000');
     expect($('.gender', container).textContent).to.contain('Female');
-    expect($$('.dd-privacy-mask', container).length).to.eq(4);
+    expect($$('.dd-privacy-mask', container).length).to.eq(5);
   });
 });

--- a/src/applications/appeals/995/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import moment from 'moment';
 
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 
@@ -20,6 +20,7 @@ const getData = () => ({
         first: 'Foo',
         middle: 'Man',
         last: 'Choo',
+        suffix: 'Esq.',
       },
     },
   },
@@ -65,7 +66,9 @@ describe('Confirmation page', () => {
         <ConfirmationPage />
       </Provider>,
     );
-    expect($('.inset', container).textContent).to.contain('Foo Man Choo');
+    expect($('.dd-privacy-hidden', container).textContent).to.contain(
+      'Foo Man Choo, Esq.',
+    );
   });
   it('should render the submit date', () => {
     const data = getData();
@@ -86,6 +89,7 @@ describe('Confirmation page', () => {
     const list = $('ul', container);
     expect(list.textContent).to.contain('test 543');
     expect(list.textContent).not.to.contain('test 987');
+    expect($$('span.dd-privacy-hidden', container).length).to.eq(1);
   });
   it('should focus on H2 inside va-alert', async () => {
     const { container } = render(

--- a/src/applications/appeals/995/tests/content/IssueSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/content/IssueSummary.unit.spec.jsx
@@ -71,5 +71,6 @@ describe('IssueSummary', () => {
     expect(list[2].textContent).to.contain('Decision date: February 1, 2021');
     expect(list[3].textContent).to.contain('Issue 4');
     expect(list[3].textContent).to.contain('Decision date: February 2, 2021');
+    expect($$('.dd-privacy-hidden', container).length).to.eq(4);
   });
 });

--- a/src/applications/appeals/996/components/IssueCard.jsx
+++ b/src/applications/appeals/996/components/IssueCard.jsx
@@ -120,6 +120,7 @@ export const IssueCard = ({
 
   const titleClass = [
     'widget-title',
+    'dd-privacy-hidden',
     'vads-u-font-size--h4',
     'vads-u-margin--0',
     'capitalize',

--- a/src/applications/appeals/996/components/ShowIssuesList.jsx
+++ b/src/applications/appeals/996/components/ShowIssuesList.jsx
@@ -6,7 +6,7 @@ export const ShowIssuesList = ({ issues }) => (
   <ul>
     {issues.map((issue, index) => (
       <li key={index}>
-        <strong className="capitalize">
+        <strong className="capitalize dd-privacy-hidden">
           {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
         </strong>
         <div>

--- a/src/applications/appeals/996/components/VeteranInformation.jsx
+++ b/src/applications/appeals/996/components/VeteranInformation.jsx
@@ -34,7 +34,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name">
+        <strong className="name dd-privacy-mask">
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix ? `, ${suffix}` : null}
         </strong>

--- a/src/applications/appeals/996/components/VeteranInformation.jsx
+++ b/src/applications/appeals/996/components/VeteranInformation.jsx
@@ -6,25 +6,27 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';
-
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
-// separate each number so the screenreader reads "number ending with 1 2 3 4"
-// instead of "number ending with 1,234"
-const mask = value => {
-  const number = (value || '').toString().slice(-4);
-  return srSubstitute(
-    `●●●–●●–${number}`,
-    `ending with ${number.split('').join(' ')}`,
-  );
-};
+import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 
 const VeteranInformation = ({ profile = {}, veteran = {} }) => {
   const { ssnLastFour, vaFileLastFour } = veteran;
   const { dob, gender, userFullName = {} } = profile;
-
   const { first, middle, last, suffix } = userFullName;
-  const momentDob = moment(dob || null); // called with undefined = today's date
+
+  // called with undefined = today's date
+  const momentDob = moment(dob || null, FORMAT_YMD);
+
+  // separate each number so the screenreader reads "number ending with 1 2 3 4"
+  // instead of "number ending with 1,234"
+  const mask = value => {
+    const number = (value || '').toString().slice(-4);
+    return srSubstitute(
+      `●●●–●●–${number}`,
+      `ending with ${number.split('').join(' ')}`,
+    );
+  };
 
   return (
     <>
@@ -37,22 +39,33 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
           {suffix ? `, ${suffix}` : null}
         </strong>
         {ssnLastFour ? (
-          <p className="ssn">Social Security number: {mask(ssnLastFour)}</p>
+          <p className="ssn">
+            Social Security number:{' '}
+            <span className="dd-privacy-mask">{mask(ssnLastFour)}</span>
+          </p>
         ) : null}
         {vaFileLastFour ? (
-          <p className="vafn">VA file number: {mask(vaFileLastFour)}</p>
+          <p className="vafn">
+            VA file number:{' '}
+            <span className="dd-privacy-mask">{mask(vaFileLastFour)}</span>
+          </p>
         ) : null}
         <p>
           Date of birth:{' '}
           {momentDob.isValid() ? (
-            <span className="dob">{momentDob.format('LL')}</span>
+            <span className="dob dd-privacy-mask">
+              {momentDob.format(FORMAT_READABLE)}
+            </span>
           ) : null}
         </p>
         <p>
-          Gender: <span className="gender">{genderLabels?.[gender] || ''}</span>
+          Gender:{' '}
+          <span className="gender dd-privacy-mask">
+            {genderLabels?.[gender] || ''}
+          </span>
         </p>
       </div>
-      <br />
+      <br role="presentation" />
       <p>
         <strong>Note:</strong> If you need to update your personal information,
         please call Veterans Benefits Assistance toll free at{' '}

--- a/src/applications/appeals/996/components/VeteranInformation.jsx
+++ b/src/applications/appeals/996/components/VeteranInformation.jsx
@@ -34,7 +34,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name dd-privacy-mask">
+        <strong className="name dd-privacy-hidden">
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix ? `, ${suffix}` : null}
         </strong>
@@ -60,7 +60,7 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         </p>
         <p>
           Gender:{' '}
-          <span className="gender dd-privacy-mask">
+          <span className="gender dd-privacy-hidden">
             {genderLabels?.[gender] || ''}
           </span>
         </p>

--- a/src/applications/appeals/996/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/996/containers/ConfirmationPage.jsx
@@ -27,7 +27,7 @@ export class ConfirmationPage extends React.Component {
     const { response } = submission;
     const issues = getSelected(data || []).map((issue, index) => (
       <li key={index} className="vads-u-margin-bottom--0">
-        {getIssueName(issue)}
+        <span className="dd-privacy-hidden">{getIssueName(issue)}</span>
       </li>
     ));
     const fullName = `${name.first} ${name.middle || ''} ${name.last}`;
@@ -56,14 +56,16 @@ export class ConfirmationPage extends React.Component {
             Higher-Level Review{' '}
             <span className="additional">(Form {formId})</span>
           </h3>
-          for {fullName}
-          {name.suffix && `, ${name.suffix}`}
+          for <span className="dd-privacy-hidden">{fullName}</span>
+          {name.suffix && (
+            <span className="dd-privacy-hidden">{`, ${name.suffix}`}</span>
+          )}
           {response && (
             <>
               {submitDate.isValid() && (
                 <p>
                   <strong>Date submitted</strong>
-                  <br />
+                  <br role="presentation" />
                   <span>{submitDate.format(FORMAT_READABLE)}</span>
                 </p>
               )}
@@ -104,7 +106,7 @@ export class ConfirmationPage extends React.Component {
           please don’t request another review. Call VA at{' '}
           <va-telephone contact={CONTACTS.VA_BENEFITS} />.
         </p>
-        <br />
+        <br role="presentation" />
         <a
           href="/claim-or-appeal-status/"
           className="usa-button usa-button-primary"

--- a/src/applications/appeals/996/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/996/content/areaOfDisagreement.jsx
@@ -16,7 +16,14 @@ const titlePrefix = 'Decision for';
  */
 export const getIssueTitle = data => {
   const date = moment(getIssueDate(data), FORMAT_YMD).format(FORMAT_READABLE);
-  return `${titlePrefix} ${getIssueName(data)} dated ${date}`;
+  return (
+    <>
+      {titlePrefix}{' '}
+      <span className="dd-privacy-hidden">{getIssueName(data)}</span>
+      {' dated'}
+      {date}
+    </>
+  );
 };
 
 // formContext.pagePerItemIndex is undefined here? Use index added to data :(

--- a/src/applications/appeals/996/tests/components/IssueCardV2.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/IssueCardV2.unit.spec.jsx
@@ -39,6 +39,7 @@ describe('<IssueCard>', () => {
     const wrapper = mount(<IssueCard {...props} item={issue} />);
     expect(wrapper.find('input[type="checkbox"]').length).to.equal(1);
     expect(wrapper.find('.widget-title').text()).to.eq('issue-10');
+    expect(wrapper.find('.widget-title.dd-privacy-hidden')).to.exist;
     expect(wrapper.find('.widget-content').text()).to.contain('blah');
     expect(wrapper.find('.widget-content').text()).to.contain(
       'Current rating: 10%',

--- a/src/applications/appeals/996/tests/components/ShowIssuesList.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/ShowIssuesList.unit.spec.jsx
@@ -43,6 +43,7 @@ describe('ShowIssuesList', () => {
     expect(list.first().text()).to.contain('Decision date: January 1, 2021');
     expect(list.last().text()).to.contain('Issue 4');
     expect(list.last().text()).to.contain('Decision date: February 2, 2021');
+    expect(wrapper.find('strong.dd-privacy-hidden').length).to.eq(4);
     wrapper.unmount();
   });
 });

--- a/src/applications/appeals/996/tests/components/veteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/veteranInformation.unit.spec.jsx
@@ -39,7 +39,7 @@ describe('<VeteranInformation>', () => {
     expect(wrapper.find('.vafn').text()).to.contain('8765');
     expect(wrapper.find('.dob').text()).to.contain('January 5, 2000');
     expect(wrapper.find('.gender').text()).to.contain('Female');
-    expect(wrapper.find('.dd-privacy-mask').length).to.eq(4);
+    expect(wrapper.find('.dd-privacy-mask').length).to.eq(5);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/996/tests/components/veteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/veteranInformation.unit.spec.jsx
@@ -39,7 +39,8 @@ describe('<VeteranInformation>', () => {
     expect(wrapper.find('.vafn').text()).to.contain('8765');
     expect(wrapper.find('.dob').text()).to.contain('January 5, 2000');
     expect(wrapper.find('.gender').text()).to.contain('Female');
-    expect(wrapper.find('.dd-privacy-mask').length).to.eq(5);
+    expect(wrapper.find('.dd-privacy-mask').length).to.eq(3);
+    expect(wrapper.find('.dd-privacy-hidden').length).to.eq(2);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/996/tests/components/veteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/veteranInformation.unit.spec.jsx
@@ -39,6 +39,7 @@ describe('<VeteranInformation>', () => {
     expect(wrapper.find('.vafn').text()).to.contain('8765');
     expect(wrapper.find('.dob').text()).to.contain('January 5, 2000');
     expect(wrapper.find('.gender').text()).to.contain('Female');
+    expect(wrapper.find('.dd-privacy-mask').length).to.eq(4);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/996/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -16,6 +16,7 @@ const data = {
         first: 'Foo',
         middle: 'Man',
         last: 'Choo',
+        suffix: 'Esq.',
       },
     },
   },
@@ -58,7 +59,7 @@ describe('Confirmation page', () => {
   });
   it('should render the user name', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
-    expect(tree.text()).to.contain('Foo Man Choo');
+    expect(tree.text()).to.contain('Foo Man Choo, Esq.');
     tree.unmount();
   });
   it('should render the submit date', () => {
@@ -80,6 +81,12 @@ describe('Confirmation page', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
     expect(sessionStorage.getItem(WIZARD_STATUS)).to.be.null;
     expect(sessionStorage.getItem(SAVED_CLAIM_TYPE)).to.be.null;
+    tree.unmount();
+  });
+  it('should have Datadog class names to hide PII', () => {
+    const tree = mount(<ConfirmationPage store={fakeStore} />);
+    expect(tree.find('span.dd-privacy-hidden').length).to.eq(3);
+    expect(tree.find('li .dd-privacy-hidden').length).to.eq(1);
     tree.unmount();
   });
 });

--- a/src/applications/appeals/996/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -45,6 +45,7 @@ describe('area of disagreement page', () => {
     expect(form.find('input[type="text"]').length).to.equal(1);
     expect(form.find('h3').text()).to.contain('Tinnitus');
     expect(form.find('h3').text()).to.contain('January 1, 2021');
+    expect(form.find('h3 .dd-privacy-hidden')).to.exist;
     form.unmount();
   });
 

--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -223,7 +223,9 @@ const ContactInfo = ({
           {content.homePhone}
         </Headers>
         {showSuccessAlert('home-phone', content.homePhone)}
-        <va-telephone contact={homePhoneString} not-clickable />
+        <span className="dd-privacy-hidden">
+          <va-telephone contact={homePhoneString} not-clickable />
+        </span>
         {loggedIn && (
           <p className="vads-u-margin-top--0p5">
             <Link
@@ -242,7 +244,9 @@ const ContactInfo = ({
       <React.Fragment key="mobile">
         <Headers className={headerClassNames}>{content.mobilePhone}</Headers>
         {showSuccessAlert('mobile-phone', content.mobilePhone)}
-        <va-telephone contact={mobilePhoneString} not-clickable />
+        <span className="dd-privacy-hidden">
+          <va-telephone contact={mobilePhoneString} not-clickable />
+        </span>
         {loggedIn && (
           <p className="vads-u-margin-top--0p5">
             <Link
@@ -261,7 +265,7 @@ const ContactInfo = ({
       <React.Fragment key="email">
         <Headers className={headerClassNames}>{content.email}</Headers>
         {showSuccessAlert('email', content.email)}
-        <span>{dataWrap[keys.email] || ''}</span>
+        <span className="dd-privacy-hidden">{dataWrap[keys.email] || ''}</span>
         {loggedIn && (
           <p className="vads-u-margin-top--0p5">
             <Link
@@ -280,9 +284,7 @@ const ContactInfo = ({
       <React.Fragment key="mailing">
         <Headers className={headerClassNames}>{content.mailingAddress}</Headers>
         {showSuccessAlert('address', content.mailingAddress)}
-        <div className="vads-u-display--flex">
-          <AddressView data={dataWrap[keys.address]} />
-        </div>
+        <AddressView data={dataWrap[keys.address]} />
         {loggedIn && (
           <p className="vads-u-margin-top--0p5">
             <Link

--- a/src/platform/forms-system/src/js/components/ContactInfoReview.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfoReview.jsx
@@ -87,7 +87,7 @@ const ContactInfoReview = ({ data, editPage, content, keys }) => {
       return value ? (
         <div key={label + index} className="review-row">
           <dt>{label}</dt>
-          <dd>{value}</dd>
+          <dd className="dd-privacy-hidden">{value}</dd>
         </div>
       ) : null;
     })

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -504,7 +504,7 @@ const FileField = props => {
               <li key={index} id={fileListId} className={itemClasses}>
                 {file.uploading && (
                   <div className="schemaform-file-uploading">
-                    <strong id={fileNameId} className="dd-privacy-mask">
+                    <strong id={fileNameId} className="dd-privacy-hidden">
                       {file.name}
                     </strong>
                     <br />
@@ -523,7 +523,7 @@ const FileField = props => {
                 {description && <p>{description}</p>}
                 {!file.uploading && (
                   <>
-                    <strong id={fileNameId} className="dd-privacy-mask">
+                    <strong id={fileNameId} className="dd-privacy-hidden">
                       {file.name}
                     </strong>
                     {file?.size && <div> {displayFileSize(file.size)}</div>}

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -504,7 +504,9 @@ const FileField = props => {
               <li key={index} id={fileListId} className={itemClasses}>
                 {file.uploading && (
                   <div className="schemaform-file-uploading">
-                    <strong id={fileNameId}>{file.name}</strong>
+                    <strong id={fileNameId} className="dd-privacy-mask">
+                      {file.name}
+                    </strong>
                     <br />
                     <va-progress-bar percent={progress} />
                     <va-button
@@ -521,7 +523,9 @@ const FileField = props => {
                 {description && <p>{description}</p>}
                 {!file.uploading && (
                   <>
-                    <strong id={fileNameId}>{file.name}</strong>
+                    <strong id={fileNameId} className="dd-privacy-mask">
+                      {file.name}
+                    </strong>
                     {file?.size && <div> {displayFileSize(file.size)}</div>}
                   </>
                 )}

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { flow, groupBy } from 'lodash';
-import get from '../../../../utilities/data/get';
-import set from '../../../../utilities/data/set';
 
 import {
   getDefaultFormState,
@@ -12,7 +10,9 @@ import {
 } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 
 import { showReviewField } from '../helpers';
-import { isReactComponent } from 'platform/utilities/ui';
+import { isReactComponent } from '../../../../utilities/ui';
+import get from '../../../../utilities/data/get';
+import set from '../../../../utilities/data/set';
 
 /*
  * This is largely copied from the react-jsonschema-form library,
@@ -20,16 +20,6 @@ import { isReactComponent } from 'platform/utilities/ui';
  */
 
 class ObjectField extends React.Component {
-  static defaultProps = {
-    uiSchema: {},
-    errorSchema: {},
-    idSchema: {},
-    registry: getDefaultRegistry(),
-    required: false,
-    disabled: false,
-    readonly: false,
-  };
-
   constructor() {
     super();
     this.isRequired = this.isRequired.bind(this);
@@ -76,13 +66,13 @@ class ObjectField extends React.Component {
     };
   }
 
-  getStateFromProps(props) {
-    const { schema, formData, registry } = props;
+  getStateFromProps() {
+    const { schema, formData, registry } = this.props;
     return getDefaultFormState(schema, formData, registry.definitions) || {};
   }
 
   isRequired(name) {
-    const schema = this.props.schema;
+    const { schema } = this.props;
     return (
       Array.isArray(schema.required) && schema.required.indexOf(name) !== -1
     );
@@ -90,7 +80,7 @@ class ObjectField extends React.Component {
 
   render() {
     const { uiSchema, errorSchema, idSchema, schema, formContext } = this.props;
-    const SchemaField = this.props.registry.fields.SchemaField;
+    const { SchemaField } = this.props.registry.fields || {};
 
     const properties = Object.keys(schema.properties);
     const isRoot = idSchema.$id === 'root';
@@ -193,11 +183,12 @@ class ObjectField extends React.Component {
       );
     }
 
+    const titleString = typeof title === 'string';
     return isRoot ? (
       <>
         {!formContext?.hideHeaderRow && (
           <div className="form-review-panel-page-header-row">
-            {title?.trim() &&
+            {((titleString && title.trim()) || !titleString) &&
               !formContext?.hideTitle && (
                 <h4 className="form-review-panel-page-header vads-u-font-size--h5">
                   {title}
@@ -214,23 +205,41 @@ class ObjectField extends React.Component {
   }
 }
 
+ObjectField.defaultProps = {
+  uiSchema: {},
+  errorSchema: {},
+  idSchema: {},
+  registry: getDefaultRegistry(),
+  required: false,
+  disabled: false,
+  readonly: false,
+};
+
 ObjectField.propTypes = {
   schema: PropTypes.object.isRequired,
-  uiSchema: PropTypes.object,
-  errorSchema: PropTypes.object,
-  idSchema: PropTypes.object,
-  formData: PropTypes.object,
-  required: PropTypes.bool,
   disabled: PropTypes.bool,
+  errorSchema: PropTypes.object,
+  formContext: PropTypes.shape({
+    hideHeaderRow: PropTypes.bool,
+    hideTitle: PropTypes.bool,
+    onEdit: PropTypes.func,
+    pageTitle: PropTypes.string,
+    reviewMode: PropTypes.bool,
+  }),
+  formData: PropTypes.object,
+  idSchema: PropTypes.object,
   readonly: PropTypes.bool,
   registry: PropTypes.shape({
+    definitions: PropTypes.object.isRequired,
+    fields: PropTypes.objectOf(PropTypes.func).isRequired,
+    formContext: PropTypes.shape({}).isRequired,
     widgets: PropTypes.objectOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     ).isRequired,
-    fields: PropTypes.objectOf(PropTypes.func).isRequired,
-    definitions: PropTypes.object.isRequired,
-    formContext: PropTypes.object.isRequired,
   }),
+  required: PropTypes.bool,
+  uiSchema: PropTypes.object,
+  onChange: PropTypes.func,
 };
 
 export default ObjectField;

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -83,7 +83,7 @@ const PasswordLabel = () => (
 
 const PasswordSuccess = () => (
   <>
-    <p>PDF password</p>
+    <p className="vads-u-margin-top--2">PDF password</p>
     <strong>The PDF password has been added.</strong>
   </>
 );

--- a/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
@@ -90,6 +90,8 @@ describe('<ContactInfo>', () => {
     expect($$('h3', container).length).to.equal(1);
     expect($$('h4', container).length).to.equal(4);
     expect($$('h5', container).length).to.equal(0);
+    // mobile phone, home phone, email, mailing address x2
+    expect($$('.dd-privacy-hidden', container).length).to.equal(5);
   });
 
   it('should render contact data w/no success messages', () => {

--- a/src/platform/forms-system/test/js/components/ContactInfoReview.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfoReview.unit.spec.jsx
@@ -47,7 +47,6 @@ describe('<ContactInfoReview>', () => {
     expect($('button.edit-page', container)).to.exist;
     expect($('h4', container).textContent).to.eq(content.title);
     expect($$('dt', container).length).to.eq(9);
-    expect($$('dd', container).length).to.eq(9);
     expect($$('dd.dd-privacy-hidden', container).length).to.eq(9);
     expect(container.innerHTML).to.contain('Home phone');
   });

--- a/src/platform/forms-system/test/js/components/ContactInfoReview.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfoReview.unit.spec.jsx
@@ -47,6 +47,8 @@ describe('<ContactInfoReview>', () => {
     expect($('button.edit-page', container)).to.exist;
     expect($('h4', container).textContent).to.eq(content.title);
     expect($$('dt', container).length).to.eq(9);
+    expect($$('dd', container).length).to.eq(9);
+    expect($$('dd.dd-privacy-hidden', container).length).to.eq(9);
     expect(container.innerHTML).to.contain('Home phone');
   });
   it('should render all contact data, except home phone on review page', () => {

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -96,7 +96,7 @@ describe('Schemaform <FileField>', () => {
     );
 
     expect($('li', container).textContent).to.contain('Test file name.pdf');
-    expect($('strong.dd-privacy-mask', container)).to.exist;
+    expect($('strong.dd-privacy-hidden', container)).to.exist;
   });
 
   it('should remove files with empty file object when initializing', async () => {

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -96,6 +96,7 @@ describe('Schemaform <FileField>', () => {
     );
 
     expect($('li', container).textContent).to.contain('Test file name.pdf');
+    expect($('strong.dd-privacy-mask', container)).to.exist;
   });
 
   it('should remove files with empty file object when initializing', async () => {

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -184,6 +184,32 @@ describe('Schemaform review: ObjectField', () => {
     expect(tree.getByRole('heading')).to.contain.text('A function title');
   });
 
+  it('should render title JSX without throwing an error', () => {
+    const schema = {
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+
+    const tree = render(
+      <ObjectField
+        uiSchema={{}}
+        schema={schema}
+        formContext={{ pageTitle: () => <span>A title</span> }}
+        requiredSchema={{}}
+        idSchema={{ $id: 'root' }}
+        formData={{}}
+        onChange={f => f}
+        onBlur={f => f}
+      />,
+    );
+
+    expect(tree.getByRole('textbox')).to.exist;
+    expect(tree.getByRole('heading')).to.contain.text('A title');
+  });
+
   it('should hide title', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressView.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressView.jsx
@@ -5,11 +5,13 @@ import { formatAddress } from 'platform/forms/address/helpers';
 export default function AddressView({ data: address }) {
   const { street, cityStateZip, country } = formatAddress(address);
 
+  // Not hiding the country in Datadog RUM in case we encounter an issue with an
+  // international address
   return (
     <>
       <div className="dd-privacy-hidden">{street}</div>
       <div className="dd-privacy-hidden">{cityStateZip}</div>
-      {country && <div className="dd-privacy-hidden">{country}</div>}
+      {country && <div>{country}</div>}
     </>
   );
 }

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressView.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressView.jsx
@@ -6,17 +6,10 @@ export default function AddressView({ data: address }) {
   const { street, cityStateZip, country } = formatAddress(address);
 
   return (
-    <div>
-      {street}
-      <br />
-      {cityStateZip}
-
-      {country && (
-        <>
-          <br />
-          {country}
-        </>
-      )}
-    </div>
+    <>
+      <div className="dd-privacy-hidden">{street}</div>
+      <div className="dd-privacy-hidden">{cityStateZip}</div>
+      {country && <div className="dd-privacy-hidden">{country}</div>}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Our team recently enabled Datadog Real User Monitoring (RUM) for our Notice of Disagreement form. It's released behind a feature flag to enable testing and removal of PII. This PR is an attempt to hide or mask PII. The screenshots highlight this content. Note that Datadog is set up to automatically mask inputs & other fields.
  > Also, fixed an issue in the review `ObjectField` when a `pageTitle` function returns JSX instead of a string, the string `.trim()` would throw a JS error - found after updating the area of disagreement page title from a string to returning JSX
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Using [Datadog instructions to mask sensitive content](https://docs.datadoghq.com/real_user_monitoring/session_replay/privacy_options/#mask-mode)
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  > `nod_browser_monitoring_enabled` - currently only enabled in staging

## Related issue(s)

[#61817](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61817)

## Testing done

- _Describe what the old behavior was prior to the change_
  > PII was not masked/hidden
- _Describe the steps required to verify your changes are working as expected_
  > Step through the NOD form in staging, then check the Datadog RUM recording (set to 100% of users)
- _Describe the tests completed and the results_
  > Added unit test to check for Datadog mask/hidden class names in:
  > - Appeals forms: NOD, HLR & SC
  > - Platform `FileField`
  > Fix test for review `ObjectField` pageTitle to prevent throwing a JS error when JSX is returned
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Note that the color highlighting (plus `{MASKED}` or `{HIDDEN}`) is used to indicate that the text will be obfuscated in Datadog RUM recordings - **_this will only be indicated in these screenshots, NOT visible in the actual form flow_**
* Purple = Masked text
* Orange = Hidden text

| Page | After |
| ------- | ----- |
| Veteran info | <img width="584" alt="veteran-info-masked" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f6910c6f-c7b5-478d-aa44-231581689e05"> |
| Contact info | <img width="582" alt="contact-info-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/1b35763e-0886-4b68-aab5-6d79105cc0f6"> |
| Issues | <img width="599" alt="issues-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/a9f58cdd-3c09-474e-93e1-319a2be07d42"> |
| Area of disagreement | <img width="587" alt="area-of-disagreement-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/641e105e-1f7b-4bf3-99a8-e5e56ca68758"> |
| Issue summary | <img width="528" alt="issue-summary-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/bc6bd0a2-8694-49a4-9020-9c7811423676"> |
| Upload file names | <img width="569" alt="upload-evidence-file-names-masked" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/60d1479c-e68f-4d1c-bd56-c5eb462fc72b"> |
| Review contact info | <img width="635" alt="review-contacts-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d33c08e8-9a51-47e7-a711-98e20909045c"> |
| Review issues | <img width="622" alt="review-issues-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/753abb20-311d-4ca5-840f-93b14ebf4e0d"> |
| Review uploads  | <img width="623" alt="review-uploads-masked" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e5555bb6-0e41-452a-a8aa-5b07fccf7858"> |
| Confirmation | <img width="685" alt="confirmation-hidden" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c77e96ab-e6a9-440f-8224-29f31ed737cf"> |

## What areas of the site does it impact?

- Notice of Disagreement
- Higher-Level Review (only common pages)
- Supplemental Claim (only common pages)
- All apps that use the [platform's contact info list loop definition](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-how-to-create-the-contact-info-ar)
- All apps that use the platform's `fileUploadUI` definition or `FileField` to upload files.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
