### PR TITLE
Update breadcrumb on confirmation page

### DIFF
--- a/src/applications/vaos/components/BackLink.jsx
+++ b/src/applications/vaos/components/BackLink.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { selectFeatureBreadcrumbUrlUpdate } from '../redux/selectors';
 
 export default function BackLink({ appointment }) {
   const {
@@ -8,9 +10,14 @@ export default function BackLink({ appointment }) {
     isPendingAppointment,
     isUpcomingAppointment,
   } = appointment.vaos;
+  const featureBreadcrumbUrlUpdate = useSelector(state =>
+    selectFeatureBreadcrumbUrlUpdate(state),
+  );
   const handleBackLinkText = () => {
     let linkText;
-    if (isPendingAppointment) {
+    if (isPendingAppointment && featureBreadcrumbUrlUpdate) {
+      linkText = 'Back to requests';
+    } else if (isPendingAppointment) {
       linkText = 'Back to pending appointments';
     } else if (isUpcomingAppointment) {
       linkText = 'Back to appointments';

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -217,11 +217,14 @@ const responses = {
       practitioners = [{ identifier: [{ system: null, value: null }] }],
     } = req.body;
     const providerNpi = practitioners[0]?.identifier[0].value;
+    const selectedTime = appointmentSlotsV2.data
+      .filter(slot => slot.id === req.body.slot.id)
+      .map(slot => slot.attributes.start);
     const submittedAppt = {
       id: `mock${currentMockId}`,
       attributes: {
         ...req.body,
-        start: req.body.slot ? req.body.slot.start : null,
+        start: req.body.slot.id ? selectedTime[0] : null,
         preferredProviderName: providerNpi ? providerMock[providerNpi] : null,
       },
     };

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -216,7 +216,7 @@ const responses = {
     const {
       practitioners = [{ identifier: [{ system: null, value: null }] }],
     } = req.body;
-    const providerNpi = practitioners[0].identifier[0].value;
+    const providerNpi = practitioners[0]?.identifier[0].value;
     const submittedAppt = {
       id: `mock${currentMockId}`,
       attributes: {
@@ -640,7 +640,7 @@ const responses = {
         { name: 'vaOnlineSchedulingUseDsot', value: true },
         { name: 'vaOnlineSchedulingRequestFlowUpdate', value: true },
         { name: 'vaOnlineSchedulingConvertUtcToLocal', value: false },
-        { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: false },
+        { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: true },
         { name: 'vaOnlineSchedulingPrintList', value: true },
         { name: 'va_online_scheduling_descriptive_back_link', value: true },
         { name: 'vaOnlineSchedulingStaticLandingPage', value: true },


### PR DESCRIPTION
## Summary
The PR updates the breadcrumb back link text on the confirmation details page when `va_online_scheduling_breadcrumb_url_update` toggle is on

## Acceptance Criteria

When the va_online_scheduling_breadcrumb_url_update toggle is on


- [x] Given the user is on Upcoming VA appointments landing page,

And the user clicks on Start Scheduling button and books an appointment
Then confirmation page breadcrumbs will be updated to < Back to appointments


- [x] Given the user is on Upcoming VA appointments landing page,

And the user clicks on Start Scheduling button and submits a pending VA appointment
Then confirmation page breadcrumbs will be updated to < Back to requests


- [x] Given the user is on Upcoming VA appointments landing page,

And the user clicks on Start Scheduling button and submits a pending Community Care appointment
Then confirmation page breadcrumbs will be updated to < Back to requests
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61015


## Testing done

n/a
## Screenshots

VA Request
![Screenshot 2023-07-27 at 2 23 04 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/81ea5508-9102-47d9-89c7-97bebb6c7bc4)

Community Care request
![Screenshot 2023-07-27 at 2 25 03 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/74287ee4-1678-4331-bf0f-646d9e7d7fcf)

VA Appointment
![Screenshot 2023-07-27 at 8 39 13 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/6f5c2301-a5eb-4688-a520-123c9bf190f6)

## What areas of the site does it impact?

VAOS confirmation details page


