### PR TITLE
Removes useV2 logic from redux in VAOS

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -11,7 +11,6 @@ import { recordItemsRetrieved } from '../../utils/events';
 import {
   selectSystemIds,
   selectFeatureVAOSServiceRequests,
-  selectFeatureVAOSServiceCCAppointments,
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureAcheronService,
 } from '../../redux/selectors';
@@ -185,7 +184,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             endDate: moment()
               .add(featureVAOSServiceRequests ? 1 : 0, 'days')
               .format('YYYY-MM-DD'),
-            useV2: featureVAOSServiceRequests,
             useAcheron: featureAcheronVAOSServiceRequests,
           })
             .then(requests => {
@@ -500,16 +498,11 @@ export function fetchConfirmedAppointmentDetails(id, type) {
       const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
         state,
       );
-      const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
-        state,
-      );
+
       const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
         state,
       );
-      const useV2 =
-        type === 'cc'
-          ? featureVAOSServiceCCAppointments
-          : featureVAOSServiceVAAppointments;
+
       let appointment = selectAppointmentById(state, id, [
         type === 'cc'
           ? APPOINTMENT_TYPES.ccAppointment
@@ -527,7 +520,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         appointment = await fetchBookedAppointment({
           id,
           type,
-          useV2,
+
           useAcheron: featureAcheronVAOSServiceRequests,
         });
       }

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -27,8 +27,6 @@ import {
 import {
   selectFeatureRequests,
   selectFeatureCancel,
-  selectFeatureVAOSServiceVAAppointments,
-  selectFeatureVAOSServiceCCAppointments,
   selectFeatureAppointmentList,
 } from '../../redux/selectors';
 import { TYPE_OF_CARE_ID as VACCINE_TYPE_OF_CARE_ID } from '../../covid-19-vaccine/utils';
@@ -221,9 +219,7 @@ export function selectCanUseVaccineFlow(state) {
 
 export function selectRequestedAppointmentDetails(state, id) {
   const { appointmentDetailsStatus, facilityData } = state.appointments;
-  const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
-    state,
-  );
+
   return {
     appointment: selectAppointmentById(state, id, [
       APPOINTMENT_TYPES.request,
@@ -232,7 +228,6 @@ export function selectRequestedAppointmentDetails(state, id) {
     appointmentDetailsStatus,
     facilityData,
     cancelInfo: getCancelInfo(state),
-    useV2: featureVAOSServiceCCAppointments,
   };
 }
 
@@ -268,16 +263,12 @@ export function getUpcomingAppointmentListInfo(state) {
 
 export function getConfirmedAppointmentDetailsInfo(state, id) {
   const { appointmentDetailsStatus, facilityData } = state.appointments;
-  const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
-    state,
-  );
   return {
     appointment: selectAppointmentById(state, id),
     appointmentDetailsStatus,
     cancelInfo: getCancelInfo(state),
     facilityData,
     showCancelButton: selectFeatureCancel(state),
-    useV2: featureVAOSServiceVAAppointments,
   };
 }
 
@@ -297,16 +288,13 @@ export function getPastAppointmentListInfo(state) {
 
 export function selectCommunityCareDetailsInfo(state, id) {
   const { appointmentDetailsStatus, facilityData } = state.appointments;
-  const featureVAOSServiceCCAppointments = selectFeatureVAOSServiceCCAppointments(
-    state,
-  );
+
   return {
     appointment: selectAppointmentById(state, id, [
       APPOINTMENT_TYPES.ccAppointment,
     ]),
     appointmentDetailsStatus,
     facilityData,
-    useV2: featureVAOSServiceCCAppointments,
   };
 }
 export function selectBackendServiceFailuresInfo(state) {

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -8,7 +8,6 @@ import moment from 'moment';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 
 import {
-  selectFeatureFacilitiesServiceV2,
   selectSystemIds,
   selectFeatureAcheronService,
 } from '../../redux/selectors';
@@ -153,9 +152,6 @@ export function openFacilityPage() {
     try {
       const initialState = getState();
       const newBooking = selectCovid19VaccineNewBooking(initialState);
-      const featureFacilitiesServiceV2 = selectFeatureFacilitiesServiceV2(
-        initialState,
-      );
       const siteIds = selectSystemIds(initialState);
       let { facilities } = newBooking;
       let facilityId = newBooking.data.vaFacility;
@@ -168,7 +164,6 @@ export function openFacilityPage() {
       if (!facilities) {
         facilities = await getLocationsByTypeOfCareAndSiteIds({
           siteIds,
-          useV2: featureFacilitiesServiceV2,
         });
       }
 
@@ -496,9 +491,7 @@ export function openContactFacilitiesPage() {
     try {
       const initialState = getState();
       const newBooking = selectCovid19VaccineNewBooking(initialState);
-      const featureFacilitiesServiceV2 = selectFeatureFacilitiesServiceV2(
-        initialState,
-      );
+
       const siteIds = selectSystemIds(initialState);
       let { facilities } = newBooking;
 
@@ -510,7 +503,6 @@ export function openContactFacilitiesPage() {
       if (!facilities) {
         facilities = await getLocationsByTypeOfCareAndSiteIds({
           siteIds,
-          useV2: featureFacilitiesServiceV2,
         });
       }
 

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -246,9 +246,6 @@ export function checkEligibility({ location, showModal }) {
     const state = getState();
     const directSchedulingEnabled = selectFeatureDirectScheduling(state);
     const typeOfCare = getTypeOfCare(getState().newAppointment.data);
-    const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
-      state,
-    );
     const featureClinicFilter = selectFeatureClinicFilter(state);
 
     dispatch({
@@ -266,7 +263,6 @@ export function checkEligibility({ location, showModal }) {
         location,
         typeOfCare,
         directSchedulingEnabled,
-        useV2: featureVAOSServiceVAAppointments,
         featureClinicFilter,
       });
 
@@ -303,9 +299,6 @@ export function openFacilityPageV2(page, uiSchema, schema) {
   return async (dispatch, getState) => {
     try {
       const initialState = getState();
-      const featureFacilitiesServiceV2 = selectFeatureFacilitiesServiceV2(
-        initialState,
-      );
       const { newAppointment } = initialState;
       const typeOfCare = getTypeOfCare(newAppointment.data);
       const typeOfCareId = typeOfCare?.id;
@@ -324,7 +317,6 @@ export function openFacilityPageV2(page, uiSchema, schema) {
         if (!typeOfCareFacilities) {
           typeOfCareFacilities = await getLocationsByTypeOfCareAndSiteIds({
             siteIds,
-            useV2: featureFacilitiesServiceV2,
           });
         }
 
@@ -506,7 +498,6 @@ export function openReasonForAppointment(
   page,
   uiSchema,
   schema,
-  useV2 = false,
   useAcheron = false,
 ) {
   return {
@@ -514,7 +505,6 @@ export function openReasonForAppointment(
     page,
     uiSchema,
     schema,
-    useV2,
     useAcheron,
   };
 }
@@ -523,7 +513,6 @@ export function updateReasonForAppointmentData(
   page,
   uiSchema,
   data,
-  useV2 = false,
   useAcheron = false,
 ) {
   return {
@@ -531,7 +520,6 @@ export function updateReasonForAppointmentData(
     page,
     uiSchema,
     data,
-    useV2,
     useAcheron,
   };
 }

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -22,7 +22,6 @@ import {
   selectFeatureCommunityCare,
   selectFeatureDirectScheduling,
   selectRegisteredCernerFacilityIds,
-  selectFeatureVAOSServiceVAAppointments,
   selectFeatureAcheronService,
 } from '../../redux/selectors';
 import { removeDuplicateId } from '../../utils/data';
@@ -385,9 +384,6 @@ export function selectReviewPage(state) {
 export function selectTypeOfCarePage(state) {
   const newAppointment = getNewAppointment(state);
   const address = selectVAPResidentialAddress(state);
-  const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
-    state,
-  );
   const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(state);
 
   return {
@@ -399,7 +395,7 @@ export function selectTypeOfCarePage(state) {
     showDirectScheduling: selectFeatureDirectScheduling(state),
     showPodiatryApptUnavailableModal:
       newAppointment.showPodiatryAppointmentUnavailableModal,
-    useV2: featureVAOSServiceVAAppointments,
+
     useAcheron: featureAcheronVAOSServiceRequests,
   };
 }

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -76,8 +76,6 @@ function apptRequestSort(a, b) {
  * @async
  * @param {String} startDate Date in YYYY-MM-DD format
  * @param {String} endDate Date in YYYY-MM-DD format
- * @param {Boolean} useV2VA Toggle fetching VA appointments via VAOS api services version 2
- * @param {Boolean} useV2CC Toggle fetching CC appointments via VAOS api services version 2
  * @returns {Appointment[]} A FHIR searchset of booked Appointment resources
  */
 export async function fetchAppointments({
@@ -185,7 +183,6 @@ export async function fetchRequestById({ id, useAcheron }) {
  * @export
  * @async
  * @param {string} id MAS or community care booked appointment id
- * @param {Boolean} useV2 Toggle fetching VA or CC appointment via VAOS api services version 2
  * @returns {Appointment} A transformed appointment with the given id
  */
 export async function fetchBookedAppointment({ id, useAcheron = false }) {
@@ -828,8 +825,6 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
         const p1 = await fetchAppointments({
           startDate: curr.start,
           endDate: curr.end,
-          useV2VA: true,
-          useV2CC: true,
         });
         batch.push(p1);
         return Promise.resolve([...batch].flat());

--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -35,7 +35,6 @@ import { getRealFacilityId } from '../../utils/appointment';
  * @async
  * @param {Object} locationParams Parameters needed for fetching locations
  * @param {Array<string>} locationParams.facilityIds A list of va facility ids to fetch
- * @param {boolean} params.useV2 Use the VAOS v2 endpoints to get locations
  * @returns {Array<Location>} A FHIR searchset of Location resources
  */
 export async function getLocations({ facilityIds, children = false }) {
@@ -59,7 +58,6 @@ export async function getLocations({ facilityIds, children = false }) {
  * @async
  * @param {Object} locationParams Parameters needed for fetching locations
  * @param {Array<string>} locationParams.facilityId An id for the facility to fetch info for
- * @param {boolean} locationParams.useV2 Use the VAOS v2 endpoints to get locations
  * @returns {Location} A FHIR Location resource
  */
 export async function getLocation({ facilityId }) {
@@ -294,8 +292,6 @@ export async function fetchParentLocations({ siteIds }) {
  * @export
  * @param {Object} params
  * @param {Array<Location>} params.locations The locations to find CC support at
- * @param {boolean} params.useV2 Use the V2 scheduling configurations endpoint
- *   to get the CC supported locations
  * @returns {Array<Location>} A list of locations that support CC requests
  */
 export async function fetchCommunityCareSupportedSites({ locations }) {

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -78,7 +78,6 @@ const VAOS_SERVICE_REQUEST_LIMIT = 'facility-request-limit-exceeded';
  * @param {'direct'|'request'|null} [params.type=null] The type to check eligibility for. By default,
  *   will check both
  * }
- * @param {boolean} [params.useV2=false] Use the v2 apis when making eligibility calls
  * @returns {PatientEligibility} Patient eligibility data
  */
 export async function fetchPatientEligibility({
@@ -267,7 +266,6 @@ function logEligibilityExplanation(
  * @param {TypeOfCare} params.typeOfCare Type of care object for the currently chosen type of care
  * @param {Location} params.location The current location to check eligibility against
  * @param {boolean} params.directSchedulingEnabled If direct scheduling is currently enabled
- * @param {boolean} [params.useV2=false] Use the v2 apis when making eligibility calls
  * @param {boolean} [params.featureClinicFilter=false] feature flag to filter clinics based on VATS
  * @returns {FlowEligibilityReturnData} Eligibility results, plus clinics and past appointments
  *   so that they can be cache and reused later
@@ -276,7 +274,6 @@ export async function fetchFlowEligibilityAndClinics({
   typeOfCare,
   location,
   directSchedulingEnabled,
-  useV2 = false,
   featureClinicFilter = false,
   useAcheron = false,
 }) {
@@ -358,7 +355,7 @@ export async function fetchFlowEligibilityAndClinics({
 
   // Similar to above, but for direct scheduling
   // v2 needs to filter clinics
-  if (useV2 && featureClinicFilter) {
+  if (featureClinicFilter) {
     results.clinics = results?.clinics?.filter(
       clinic => clinic.patientDirectScheduling === true,
     );
@@ -392,12 +389,10 @@ export async function fetchFlowEligibilityAndClinics({
     }
 
     if (featureClinicFilter) {
-      // v2 uses boolean while v0 uses Yes/No string for patientHistoryRequired
-      const enable = useV2 ? true : 'Yes';
       if (
         typeOfCare.id !== PRIMARY_CARE &&
         typeOfCare.id !== MENTAL_HEALTH &&
-        directTypeOfCareSettings.patientHistoryRequired === enable &&
+        directTypeOfCareSettings.patientHistoryRequired === true &&
         !hasMatchingClinics(
           results.clinics,
           results.pastAppointments,

--- a/src/applications/vaos/services/slot/index.js
+++ b/src/applications/vaos/services/slot/index.js
@@ -28,7 +28,6 @@ import { transformV2Slots } from './transformers.v2';
  * @param {string} slotsRequest.clinicId clinic id
  * @param {string} slotsRequest.startDate start date to search for appointments lots formatted as YYYY-MM-DD
  * @param {string} slotsRequest.endDate end date to search for appointments lots formatted as YYYY-MM-DD
- * @param {Boolean} useV2 Toggle fetching appointments via VAOS api services version 2
  * @returns {Array<Slot>} A list of Slot resources
  */
 export async function getSlots({ siteId, clinicId, startDate, endDate }) {


### PR DESCRIPTION
## Summary

This removes `useV2` logic from the VAOS redux store. 

## Testing done

- Unit testing
- e2e testing

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
