### PR TITLE
NOD | Update to v1 submission endpoint

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -1,4 +1,3 @@
-import environment from 'platform/utilities/environment';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices as services } from 'platform/monitoring/DowntimeNotification';
 
@@ -58,7 +57,7 @@ import hearingType from '../pages/hearingType';
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/v0/notice_of_disagreements`,
+  submitUrl: '/notice_of_disagreements',
   trackingPrefix: '10182-board-appeal-',
 
   downtime: {

--- a/src/applications/appeals/10182/config/submitForm.js
+++ b/src/applications/appeals/10182/config/submitForm.js
@@ -9,10 +9,9 @@ export const buildEventData = () => {};
 
 const submitForm = (form, formConfig) => {
   const { trackingPrefix } = formConfig;
-  // update once v2 (add part III data) is available
-  const submitUrl = form.data[SHOW_PART3]
-    ? `${environment.API_URL}/v0/notice_of_disagreements`
-    : formConfig.submitUrl;
+  // v1 (add part III data)
+  const apiVer = form.data[SHOW_PART3] ? 'v1' : 'v0';
+  const submitUrl = `${environment.API_URL}/${apiVer}/${formConfig.submitUrl}`;
   const body = formConfig.transformForSubmit
     ? formConfig.transformForSubmit(formConfig, form)
     : transformForSubmit(formConfig, form);

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -25,7 +25,7 @@ const testConfig = createTestConfig(
     dataPrefix: 'data',
 
     // Rename and modify the test data as needed.
-    dataSets: ['maximal-test'], // ['no-api-issues', 'minimal-test', 'maximal-test'],
+    dataSets: ['no-api-issues', 'minimal-test', 'maximal-test'],
 
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),
@@ -120,7 +120,8 @@ const testConfig = createTestConfig(
       cy.intercept('GET', '/v0/profile/status', mockStatus);
       cy.intercept('GET', '/v0/maintenance_windows', []);
       cy.intercept('POST', 'v0/decision_review_evidence', mockUpload);
-      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+      cy.intercept('POST', `v0/${formConfig.submitUrl}`, mockSubmit);
+      cy.intercept('POST', `v1/${formConfig.submitUrl}`, mockSubmit);
 
       cy.get('@testData').then(data => {
         cy.intercept('GET', '/v0/in_progress_forms/10182', mockPrefill);


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Our Notice of Disagreement form is being updated to include a new form section (part III, box 11). We're updating the submission URL to use the correct backend submission API endpoint
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > New questions only visibly behind a feature toggle, the submission to the v1 endpoint will only occur based on the feature toggle.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  > Once we're ramped up to 100% and verify that there are no issues with the new endpoint & submissions, we'll remove the feature toggle

## Related issue(s)

[#62311](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62311)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Failed submissions because the data doesn't match the schema
- _Describe the steps required to verify your changes are working as expected_
  > After merging this PR, we'll test submissions in staging
- _Describe the tests completed and the results_
  > Manual testing on FE & BE
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
