### PR TITLE
NOD | Fix nested fieldsets on evidence page

### DIFF
--- a/src/applications/appeals/10182/content/evidenceIntro.jsx
+++ b/src/applications/appeals/10182/content/evidenceIntro.jsx
@@ -10,7 +10,7 @@ export const evidenceUploadIntroDescription = (
       You can choose to submit more evidence now or within 90 days after we
       receive this request.
     </p>
-    <div className="vads-u-margin-y--2">
+    <div className="vads-u-margin-top--2">
       <va-additional-info trigger="How do I submit evidence later?">
         You can submit more evidence by mailing it to this address:
         <p className="vads-u-padding-y--2">

--- a/src/applications/appeals/10182/pages/evidenceIntro.js
+++ b/src/applications/appeals/10182/pages/evidenceIntro.js
@@ -8,6 +8,11 @@ const contactInfo = {
   uiSchema: {
     'ui:title': evidenceUploadIntroTitle,
     'ui:description': evidenceUploadIntroDescription,
+    'ui:options': {
+      forceDivWrapper: true,
+      showFieldLabel: 'no-wrap', // new option
+      hideDuplicateDescription: true, // new option
+    },
     'view:additionalEvidence': {
       'ui:title': evidenceUploadIntroLabel,
       'ui:widget': 'yesNo',
@@ -16,6 +21,7 @@ const contactInfo = {
           N: 'No, I’ll submit it later.',
         },
         enableAnalytics: true,
+        classNames: 'vads-u-margin-top--0',
       },
     },
   },

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -37,7 +37,10 @@ export default function FieldTemplate(props) {
   const useLabelElement =
     showFieldLabel === 'label' || showFieldLabel === 'no-wrap';
 
-  const description = uiSchema['ui:description'];
+  // The children may also include the description
+  const description = uiOptions?.hideDuplicateDescription
+    ? null
+    : uiSchema['ui:description'];
   const textDescription = typeof description === 'string' ? description : null;
   const DescriptionField = isReactComponent(description) ? description : null;
 

--- a/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
@@ -326,6 +326,35 @@ describe('Schemaform <FieldTemplate>', () => {
     expect(tree.subTree('label').text()).to.equal('Title');
     expect(tree.subTree('fieldset')).to.be.false;
   });
+  it('should not render fieldset or label wrapper if showFieldLabel is set to no-wrap', () => {
+    const schema = {
+      type: 'string',
+    };
+    const uiSchema = {
+      'ui:title': <h3>Title</h3>,
+      'ui:widget': 'radio',
+      'ui:options': {
+        showFieldLabel: 'no-wrap',
+      },
+    };
+    const formContext = {
+      touched: {},
+    };
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+        id="test"
+        schema={schema}
+        uiSchema={uiSchema}
+        formContext={formContext}
+      >
+        <div className="field-child" />
+      </FieldTemplate>,
+    );
+
+    expect(tree.subTree('h3').text()).to.equal('Title');
+    expect(tree.subTree('label')).to.be.false;
+    expect(tree.subTree('fieldset')).to.be.false;
+  });
   it('should not render a label if no title provided', () => {
     const schema = {
       type: 'string',

--- a/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
@@ -217,6 +217,35 @@ describe('Schemaform <FieldTemplate>', () => {
 
     expect(tree.text()).to.contain('Blah');
   });
+  it('should hide the description using ui:option', () => {
+    const schema = {
+      type: 'string',
+    };
+    const uiSchema = {
+      'ui:title': 'Title',
+      'ui:description': <div>Blah</div>,
+      'ui:options': {
+        hideDuplicateDescription: true,
+      },
+    };
+    const formContext = {
+      touched: {},
+    };
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+        id="test"
+        schema={schema}
+        uiSchema={uiSchema}
+        rawErrors={errors}
+        formContext={formContext}
+      >
+        <div className="field-child" />
+      </FieldTemplate>,
+    );
+
+    expect(tree.text()).to.not.contain('Blah');
+  });
   it('should render description component', () => {
     const schema = {
       type: 'string',


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Added new `'no-wrap'` setting for `showFieldLabel` to not include any wrapper (currently a `label` or `fieldset`) around the content (see screenshots for different scenarios) within the `FieldTemplate`
  > - Added new `hideDuplicateDescription` ui option to stop render of the `ui:description` specifically for situations where the description is already being rendered within the `children` of the `FieldTemplate`
  > - Updated our Notice of Disagreement form to use both of these new settings and add a `forceDivWrapper` to prevent rendering the extra `fieldset`
- _(If bug, how to reproduce)_
  > - Go to [NOD in staging](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/evidence-submission)
  > - Log into any user
  > - Navigate to `/evidence-submission` and inspect the page - you'll find 2 sets of `fieldset` & `legend` tags - one nested within the other
- _(What is the solution, why is this the solution)_
  > - Add new `showFieldLabel` `'no-wrap'` setting within `FieldTemplate` to which instead of wrapping the header in a `label` (which _should_ be associated with a form element), it renders the header without a wrapper
  > - Upon setting the `showFieldLabel` option, the `description` is rendered, but it happens to be a duplicate of the content rendered within the `FieldTemplate` children. So, a new `hideDuplicateDescription` option was added to not render the duplicate. The option was added because I had previously solved this using CSS and making this a global change might cause issues with other forms I'm not aware of.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#61391](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61391)
- [#1962](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1962) documentation addition

## Testing done

- _Describe what the old behavior was prior to the change_
  > Nested `fieldset` and `legend` pairs were rendered
- _Describe the steps required to verify your changes are working as expected_
  > Test these changes in a review instance or locally
- _Describe the tests completed and the results_
  > Added `FieldTemplate` unit tests to test these new settings/options
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Page rendered with different settings |  |
| ------- | ------ |
| Current nested fieldsets | <img alt="nested fieldsets" src="https://user-images.githubusercontent.com/14154792/251207854-11c84d0c-6737-4a51-9f1f-a9b5b74a3c16.png" /> |
| `label` setting showing duplicate description | <img alt="show-field-label-label-with-duplicate-description" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/bd5143f0-156b-45fd-a0bb-7d1693bfdf17"> |
| Duplicate description rendered in `ObjectField` | <img alt="description-in-children" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/417069de-135e-4371-8895-fc7a4197333b"> |
| `no-wrap` setting, but still has duplicate description | <img alt="show-field-label-no-wrap-with-duplicate-description" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c285df74-75f9-43eb-9001-e6a370632a83"> |
| `hideDuplicateDescription` enabled | <img alt="show-field-label-no-wrap-and-hide-duplicate-description" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/8a3158b4-9db8-4d45-a26c-a826b59ba66a"> |
| Including `forceDivWrapper` to remove `fieldset` rendered by `ObjectField` | <img alt="show-field-label-no-wrap-hide-duplicate-description-and-force-div-wrapper" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f3f3e140-1ee7-4982-94ad-391e3fa2d29c"> |

## What areas of the site does it impact?

All forms that use the 2 new settings (NOD for now)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
