### PR TITLE
VACMS-12042: Add new semantic h2 with h4 visuals for discharge wizard

### DIFF
--- a/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
+++ b/src/applications/discharge-wizard/components/questions/BranchOfService.jsx
@@ -35,6 +35,7 @@ const BranchOfServiceQuestion = ({
   const radioButtonProps = {
     name: key,
     label: 'In which branch of service did you serve?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
+++ b/src/applications/discharge-wizard/components/questions/CourtMartial.jsx
@@ -45,6 +45,7 @@ const CourtMartial = ({
   const radioButtonProps = {
     name: key,
     label: 'Was your discharge the outcome of a general court-martial?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/DischargeType.jsx
+++ b/src/applications/discharge-wizard/components/questions/DischargeType.jsx
@@ -33,6 +33,7 @@ const DischargeType = ({
   const radioButtonProps = {
     name: key,
     label: 'Which of the following categories best describes you?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
+++ b/src/applications/discharge-wizard/components/questions/FailureToExhaust.jsx
@@ -44,6 +44,7 @@ const FailureToExhaust = ({
     name: key,
     label:
       'Was your application denied due to "failure to exhaust other remedies"? Note: "Failure to exhaust other remedies" generally means you applied to the wrong board.',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/Intention.jsx
+++ b/src/applications/discharge-wizard/components/questions/Intention.jsx
@@ -34,6 +34,7 @@ const Intention = ({
     name: key,
     label:
       'Do you want to change your name, discharge date, or anything written in the “other remarks” section of your DD214?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplication.jsx
@@ -34,6 +34,7 @@ const PrevApplication = ({
     name: key,
     label:
       'Have you previously applied for and been denied a discharge upgrade for this period of service?',
+    'label-header-level': 2,
     hint:
       'Note: You can still apply. Your answer to this question simply changes where you send your application.',
     key,

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationType.jsx
@@ -50,6 +50,7 @@ const PrevApplicationType = ({
     name: key,
     label:
       'What type of application did you make to upgrade your discharge previously?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
+++ b/src/applications/discharge-wizard/components/questions/PrevApplicationYear.jsx
@@ -40,6 +40,7 @@ const PrevApplicationYear = ({
   const radioButtonProps = {
     name: key,
     label: 'What year did you apply for a discharge upgrade?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/PriorService.jsx
+++ b/src/applications/discharge-wizard/components/questions/PriorService.jsx
@@ -50,6 +50,7 @@ const PriorService = ({
     name: key,
     label:
       'Did you complete a period of service in which your character of service was Honorable or General Under Honorable Conditions?',
+    'label-header-level': 2,
     key,
     value: formValues[key],
     onVaValueChange: e => {

--- a/src/applications/discharge-wizard/components/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/questions/Reason.jsx
@@ -36,6 +36,7 @@ const Reason = ({ formValues, handleKeyDown, scrollToLast, updateField }) => {
     name: key,
     label:
       'Which of the following best describes why you want to change your discharge paperwork? Choose the one that’s closest to your situation.',
+    'label-header-level': 2,
     hint:
       'Note: If more than one of these fits your situation, choose the one that started the events leading to your discharge. For example, if you experienced sexual assault and have posttraumatic stress disorder (PTSD) resulting from that experience, choose sexual assault.',
     key,

--- a/src/applications/discharge-wizard/sass/discharge-wizard.scss
+++ b/src/applications/discharge-wizard/sass/discharge-wizard.scss
@@ -97,4 +97,13 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
       color: $color-green-darker !important;
     }
   }
+
+  va-radio::part(header) {
+    font-size: 18px;
+  }
+
+  va-select::part(label) {
+    font-size: 18px;
+    font-weight: bold;
+  }
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
With the new implementation of the RadioButton component. The question/label has become less styled. We have added an `<h2>` tag to all questions for accessibility but visually showing an h4 to not overcrowd the page with too much large text. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-cms#12042

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/cf5d7c26-7b47-40dc-9d3c-5ee0f9d655d5) |  ![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/f17cd09c-e596-48cc-8338-3e629f90876c) 
| Desktop |   ![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/b979a486-38f5-401e-9063-1bcf4e8fb143) |   ![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/e0cc9361-0bba-451e-9d97-66867d7c9301)

 |

## What areas of the site does it impact?
Only discharge wizard page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
