### PR TITLE
Supplemental Claim | Update date validation

### DIFF
--- a/src/applications/appeals/995/components/IssueCard.jsx
+++ b/src/applications/appeals/995/components/IssueCard.jsx
@@ -3,8 +3,14 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Link } from 'react-router';
 
-import { SELECTED, FORMAT_YMD, FORMAT_READABLE } from '../constants';
+import {
+  SELECTED,
+  FORMAT_YMD,
+  FORMAT_READABLE,
+  errorMessages,
+} from '../constants';
 import { replaceDescriptionContent } from '../utils/replace';
+import { isValidDate } from '../validations/date';
 
 /** Modified from HLR v2 card */
 /**
@@ -28,6 +34,13 @@ export const IssueCardContent = ({
   // A valid rated disability *can* have a rating percentage of 0%
   const showPercentNumber = (ratingIssuePercentNumber || '') !== '';
   const date = approxDecisionDate || decisionDate;
+  const dateMessage = isValidDate(date) ? (
+    moment(date, FORMAT_YMD).format(FORMAT_READABLE)
+  ) : (
+    <span className="usa-input-error-message vads-u-display--inline">
+      {errorMessages.cardInvalidDate}
+    </span>
+  );
 
   return (
     <div id={id} className="widget-content-wrap">
@@ -43,8 +56,7 @@ export const IssueCardContent = ({
       )}
       {date && (
         <p>
-          Decision date:{' '}
-          <strong>{moment(date, FORMAT_YMD).format(FORMAT_READABLE)}</strong>
+          Decision date: <strong>{dateMessage}</strong>
         </p>
       )}
     </div>

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -89,6 +89,7 @@ export const errorMessages = {
   // startDateInPast: 'The start date must be in the future',
   // endDateInPast: 'The end date must be in the future',
   endDateBeforeStart: 'The end date must be after the start date',
+  cardInvalidDate: 'Invalid decision date',
 
   decisions: {
     missingDate: 'You must enter a decision date',

--- a/src/applications/appeals/995/pages/contestableIssues.js
+++ b/src/applications/appeals/995/pages/contestableIssues.js
@@ -2,7 +2,11 @@ import ContestableIssuesWidget from '../components/ContestableIssuesWidget';
 
 import { ContestableIssuesAdditionalInfo } from '../content/contestableIssues';
 
-import { selectionRequired, maxIssues } from '../validations/issues';
+import {
+  checkIssues,
+  selectionRequired,
+  maxIssues,
+} from '../validations/issues';
 import { hasSomeSelected } from '../utils/helpers';
 import { SELECTED } from '../constants';
 
@@ -26,7 +30,7 @@ const contestableIssues = {
         keepInPageOnReview: true,
         customTitle: 'Issues', // override DL wrapper
       },
-      'ui:validations': [selectionRequired, maxIssues],
+      'ui:validations': [checkIssues, selectionRequired, maxIssues],
     },
     'view:issueNotListed': {
       'ui:description': ContestableIssuesAdditionalInfo,

--- a/src/applications/appeals/995/tests/components/IssueCard.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/IssueCard.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { IssueCardContent, IssueCard } from '../../components/IssueCard';
-import { SELECTED } from '../../constants';
+import { SELECTED, errorMessages } from '../../constants';
 
 const getContestableIssue = (id, selected) => ({
   ratingIssueSubjectText: `issue-${id}`,
@@ -118,6 +118,27 @@ describe('<IssueCardContent>', () => {
     const { container } = render(<IssueCardContent {...issue} />);
     expect($('.widget-content-wrap', container).textContent).to.contain(
       'Decision date: February 21, 2021',
+    );
+  });
+  it('should render API loaded issue with invalid date message', () => {
+    const issue = {
+      ...getContestableIssue('20'),
+      approxDecisionDate: '2020-?-?',
+    };
+    const { container } = render(<IssueCardContent {...issue} />);
+
+    expect($('.widget-content-wrap', container).textContent).to.contain(
+      `Decision date: ${errorMessages.cardInvalidDate}`,
+    );
+  });
+  it('should render AdditionalIssue invalid date message', () => {
+    const issue = {
+      ...getAdditionalIssue('21'),
+      decisionDate: '2021-?-?',
+    };
+    const { container } = render(<IssueCardContent {...issue} />);
+    expect($('.widget-content-wrap', container).textContent).to.contain(
+      `Decision date: ${errorMessages.cardInvalidDate}`,
     );
   });
 });

--- a/src/applications/appeals/995/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/date.unit.spec.js
@@ -37,6 +37,24 @@ describe('validateDate & isValidDate', () => {
     expect(errorMessage[1]).to.contain('other');
     expect(isValidDate('200')).to.be.false;
   });
+  it('should throw a missing date error when month is a symbol', () => {
+    validateDate(errors, '2023-?-05'); // "?" for month
+    expect(errorMessage[0]).to.eq(errorMessages.decisions.missingDate);
+    expect(errorMessage[1]).to.not.contain('month');
+    expect(errorMessage[1]).to.not.contain('day');
+    expect(errorMessage[1]).to.not.contain('year');
+    expect(errorMessage[1]).to.contain('other');
+    expect(isValidDate('2023-?-05')).to.be.false;
+  });
+  it('should throw a missing date error when day is a symbol', () => {
+    validateDate(errors, '2023-02-?'); // "?" for day
+    expect(errorMessage[0]).to.eq(errorMessages.decisions.missingDate);
+    expect(errorMessage[1]).to.not.contain('month');
+    expect(errorMessage[1]).to.not.contain('day');
+    expect(errorMessage[1]).to.not.contain('year');
+    expect(errorMessage[1]).to.contain('other');
+    expect(isValidDate('2023-02-?')).to.be.false;
+  });
   it('should throw a invalid date error', () => {
     validateDate(errors, '2023-02-29'); // max 28 days
     expect(errorMessage[0]).to.eq(errorMessages.invalidDate);

--- a/src/applications/appeals/995/tests/validations/issues.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/issues.unit.spec.js
@@ -5,12 +5,126 @@ import { getDate } from '../../utils/dates';
 import { SELECTED, MAX_LENGTH } from '../../constants';
 
 import {
+  checkIssues,
   uniqueIssue,
   maxIssues,
   selectionRequired,
   missingIssueName,
   maxNameLength,
 } from '../../validations/issues';
+
+describe('checkIssues', () => {
+  const _ = null;
+  const getData = ({
+    ciSelect = true,
+    ciName = 'Test',
+    ciDate = '2021-01-01',
+    aiSelect = true,
+    aiName = 'Test 2',
+    aiDate = '2021-01-01',
+  } = {}) => ({
+    contestedIssues: [
+      {
+        attributes: {
+          ratingIssueSubjectText: ciName,
+          approxDecisionDate: ciDate,
+        },
+        [SELECTED]: ciSelect,
+      },
+    ],
+    additionalIssues: [
+      {
+        issue: aiName,
+        decisionDate: aiDate,
+        [SELECTED]: aiSelect,
+      },
+    ],
+  });
+
+  it('should not show an error when there are no issues', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(errors, _, _, _, _, _, {});
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should not show an error when there are valid selected issues', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(errors, _, _, _, _, _, getData());
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should not show an error with missing unselected contestable issue name', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(
+      errors,
+      _,
+      _,
+      _,
+      _,
+      _,
+      getData({ ciSelect: false, ciName: '' }),
+    );
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should show an error with missing selected contestable issues name', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(errors, _, _, _, _, _, getData({ ciName: '' }));
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should not show an error with invalid unselected contestable issue date', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(
+      errors,
+      _,
+      _,
+      _,
+      _,
+      _,
+      getData({ ciSelect: false, ciDate: '2021-?-?' }),
+    );
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should show an error with invalid selected contestable issues date', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(errors, _, _, _, _, _, getData({ ciDate: '2021-?-?' }));
+    expect(errors.addError.called).to.be.true;
+  });
+
+  it('should not show an error with missing unselected additional issue name', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(
+      errors,
+      _,
+      _,
+      _,
+      _,
+      _,
+      getData({ aiSelect: false, aiName: '' }),
+    );
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should show an error with missing selected additional issues name', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(errors, _, _, _, _, _, getData({ aiName: '' }));
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should not show an error with invalid unselected additional issue date', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(
+      errors,
+      _,
+      _,
+      _,
+      _,
+      _,
+      getData({ aiSelect: false, aiDate: '2021-?-?' }),
+    );
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should show an error with invalid selected additional issues date', () => {
+    const errors = { addError: sinon.spy() };
+    checkIssues(errors, _, _, _, _, _, getData({ aiDate: '2021-?-?' }));
+    expect(errors.addError.called).to.be.true;
+  });
+});
 
 describe('uniqueIssue', () => {
   const _ = null;

--- a/src/applications/appeals/995/validations/date.js
+++ b/src/applications/appeals/995/validations/date.js
@@ -30,9 +30,12 @@ export const validateDate = (errors, rawString = '', fullData) => {
   if (
     !year ||
     !day ||
+    isNaN(day) ||
     day === '0' ||
     !month ||
+    isNaN(month) ||
     month === '0' ||
+    isNaN(year) ||
     dateString?.length < FORMAT_YMD.length
   ) {
     // The va-memorable-date component currently overrides the error message

--- a/src/applications/appeals/995/validations/issues.js
+++ b/src/applications/appeals/995/validations/issues.js
@@ -1,9 +1,16 @@
-import { getSelected, hasSomeSelected, hasDuplicates } from '../utils/helpers';
+import {
+  getSelected,
+  hasSomeSelected,
+  hasDuplicates,
+  getIssueName,
+  getIssueDate,
+} from '../utils/helpers';
 import {
   noneSelected,
   maxSelectedErrorMessage,
 } from '../content/contestableIssues';
 import { errorMessages, MAX_LENGTH } from '../constants';
+import { validateDate } from './date';
 
 export const selectionRequired = (
   errors,
@@ -38,20 +45,37 @@ export const uniqueIssue = (
   }
 };
 
-export const maxIssues = (error, data) => {
+export const maxIssues = (errors, data) => {
   if (getSelected(data).length > MAX_LENGTH.SELECTIONS) {
-    error.addError(maxSelectedErrorMessage);
+    errors.addError(maxSelectedErrorMessage);
   }
 };
 
-export const missingIssueName = (error, data) => {
+export const missingIssueName = (errors, data) => {
   if (!data) {
-    error.addError(errorMessages.missingIssue);
+    errors.addError(errorMessages.missingIssue);
   }
 };
 
-export const maxNameLength = (error, data) => {
+export const maxNameLength = (errors, data) => {
   if (data.length > MAX_LENGTH.ISSUE_NAME) {
-    error.addError(errorMessages.maxLength);
+    errors.addError(errorMessages.maxLength);
   }
+};
+
+export const checkIssues = (
+  errors,
+  _fieldData,
+  formData,
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData,
+) => {
+  const data = Object.keys(appStateData || {}).length ? appStateData : formData;
+  // Only use selected in case an API loaded issues includes an invalid date
+  getSelected(data).forEach(issue => {
+    missingIssueName(errors, getIssueName(issue));
+    validateDate(errors, getIssueDate(issue));
+  });
 };


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In one Supplemental Claim submission failure, we noticed the decision date was in this format `2000-01-?` which was successfully validated, but rejected on submission. A fix to the validation was made to prevent non-digits from defaulting to `01` (which is displayed, but `?` is submitted).
  > - Add validation error message to issue card - existing issues will show up on the review & submit page
  > - Add contestable issue validation on the main issue page
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#62838](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62838)

## Testing done

- _Describe what the old behavior was prior to the change_
  > a month or day of `?` or any non-digit characters would default to `01` (January or the 1st of the month) because moment.js would ignore the characters.
- _Describe the steps required to verify your changes are working as expected_
  > After using platform's `parseISODate` function, the month & day are now checked for `NaN` (which is a string); so we're using `isNaN` (uses `==` internally) instead of `Number.isNaN` (uses `===`)
- _Describe the tests completed and the results_
  > Added unit tests for all changes; all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Page |  |
| ------- | ------ |
| Contestable issue page  | <img width="579" alt="decision date error in issue card" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c090d72c-31ff-4f4d-9415-390f619a5056"> | 
| Review & submit | <img width="636" alt="decision date error in review & submit" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c5bd1a92-bbd5-4d2f-8f5c-021a32b4e5e6"> |

## What areas of the site does it impact?

Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
