### PR TITLE
VACMS-14571: Add redirect for education rates page

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1307,5 +1307,10 @@
     "domain": "www.benefits.va.gov",
     "src": "/GIBILL/comparison_chart.asp",
     "dest": "/resources/compare-va-education-benefits/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/resources/benefits_resources/rate_tables.asp",
+    "dest": "/education/benefit-rates/"
   }
 ]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Add redirect for the education rates page to modernized page on va.gov

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-cms/issues/14571

