### PR TITLE
NOD | update date validation

### DIFF
--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -28,6 +28,10 @@ export const FORMAT_READABLE = 'LL';
 // contestable issue dates
 export const FORMAT_YMD = 'YYYY-MM-DD';
 
+// NOD update (Part III, box 11) allows for past decision dates, but we should
+// limit them. Picking 100 years until told otherwise
+export const MAX_YEARS_PAST = 100;
+
 export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 
 export const MAX_FILE_SIZE_MB = 100;

--- a/src/applications/appeals/10182/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/date.unit.spec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { getDate } from '../../utils/dates';
 import { validateDate, isValidDate } from '../../validations/date';
 import { issueErrorMessages } from '../../content/addIssue';
+import { SHOW_PART3 } from '../../constants';
 
 describe('validateDate & isValidDate', () => {
   let errorMessage = [];
@@ -110,5 +111,10 @@ describe('validateDate & isValidDate', () => {
     expect(errorMessage[1]).to.not.contain('year');
     expect(errorMessage[1]).to.contain('other');
     expect(isValidDate(date)).to.be.false;
+  });
+  it('should not throw an error for older dates when feature toggle is set to support the new form', () => {
+    const date = getDate({ offset: { years: -2 } });
+    validateDate(errors, date, { [SHOW_PART3]: true });
+    expect(errorMessage[0]).to.be.undefined;
   });
 });

--- a/src/applications/appeals/10182/validations/date.js
+++ b/src/applications/appeals/10182/validations/date.js
@@ -3,17 +3,30 @@ import moment from 'moment';
 import { parseISODate } from 'platform/forms-system/src/js/helpers';
 
 import { fixDateFormat } from '../utils/replace';
-import { FORMAT_YMD } from '../constants';
+import { FORMAT_YMD, SHOW_PART3, MAX_YEARS_PAST } from '../constants';
 
 import { issueErrorMessages } from '../content/addIssue';
 
-const minDate = moment()
+const minDate1 = moment()
   .subtract(1, 'year')
+  .startOf('day');
+
+const minDate100 = moment()
+  .subtract(MAX_YEARS_PAST, 'year')
   .startOf('day');
 
 const maxDate = moment().startOf('day');
 
-export const validateDate = (errors, rawString = '') => {
+export const validateDate = (
+  errors,
+  rawString = '',
+  formData = {},
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData,
+) => {
+  const data = Object.keys(appStateData || {}).length ? appStateData : formData;
   const dateString = fixDateFormat(rawString);
   const { day, month, year } = parseISODate(dateString);
   const date = moment(rawString, FORMAT_YMD);
@@ -52,7 +65,11 @@ export const validateDate = (errors, rawString = '') => {
     // Lighthouse won't accept same day (as submission) decision date
     errors.addError(issueErrorMessages.pastDate);
     errorParts.year = true; // only the year is invalid at this point
-  } else if (date.isBefore(minDate)) {
+  } else if (
+    (!data[SHOW_PART3] && date.isBefore(minDate1)) ||
+    date.isBefore(minDate100)
+  ) {
+    // max 1 year for old form or 100 years for newer form
     errors.addError(issueErrorMessages.newerDate);
     errorParts.year = true; // only the year is invalid at this point
   }


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > As part of the NOD update ([#42493](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42493)), we removed the filtering of issues with a decision date older than 1 year; but we didn't update the validation to allow manually adding issues with a decision date > 1 year in the past.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Update validation checks based on feature toggle setting
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#62961](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62961)

## Testing done

- _Describe what the old behavior was prior to the change_
  > API-loaded issues > 1 year old are visible (based on feature toggle), but manually adding issues with a decision date > 1 year old were showing validation errors
- _Describe the steps required to verify your changes are working as expected_
  > Test NOD in review instance or locally
- _Describe the tests completed and the results_
  > Updated unit tests; all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="542" alt="Screenshot 2023-08-01 at 1 37 54 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4b20e768-9180-4bac-9b75-1be136a5f3ef"> | <img width="351" alt="Screenshot 2023-08-01 at 1 33 38 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d9c21b91-5227-477f-a122-ece29bfca847"> |

## What areas of the site does it impact?

Notice of Disagreement (Board Appeals)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
