### PR TITLE
NOD: submit email for v1 endpoint

### DIFF
--- a/src/applications/appeals/10182/config/submit-transformer.js
+++ b/src/applications/appeals/10182/config/submit-transformer.js
@@ -21,7 +21,7 @@ export function transform(formConfig, form) {
             homeless: formData.homeless || false,
             address: getAddress(formData),
             phone: getPhone(formData),
-            ...getEmail(formData), // emailAddressText: formData.veteran?.email || '',
+            ...getEmail(formData),
           },
           boardReviewOption: formData.boardReviewOption || '',
           hearingTypePreference: formData.hearingTypePreference || '',

--- a/src/applications/appeals/10182/config/submit-transformer.js
+++ b/src/applications/appeals/10182/config/submit-transformer.js
@@ -4,6 +4,7 @@ import {
   addUploads,
   getAddress,
   getPhone,
+  getEmail,
   getTimeZone,
   getPart3Data,
 } from '../utils/submit';
@@ -20,7 +21,7 @@ export function transform(formConfig, form) {
             homeless: formData.homeless || false,
             address: getAddress(formData),
             phone: getPhone(formData),
-            emailAddressText: formData.veteran?.email || '',
+            ...getEmail(formData), // emailAddressText: formData.veteran?.email || '',
           },
           boardReviewOption: formData.boardReviewOption || '',
           hearingTypePreference: formData.hearingTypePreference || '',

--- a/src/applications/appeals/10182/tests/schema/submit-transformer.unit.spec.js
+++ b/src/applications/appeals/10182/tests/schema/submit-transformer.unit.spec.js
@@ -40,9 +40,15 @@ describe('transform', () => {
     result.data.attributes.veteran.address.countryCodeISO2 = 'US';
     delete result.data.attributes.veteran.address.countryName;
 
+    // add part III, box 11 data
     result.data.attributes.requestingExtension = true;
     result.data.attributes.extensionReason = 'Lorem ipsum';
     result.data.attributes.appealingVhaDenial = false;
+
+    // switch emailAddressText to email for v1
+    result.data.attributes.veteran.email =
+      result.data.attributes.veteran.emailAddressText;
+    delete result.data.attributes.veteran.emailAddressText;
 
     expect(transformedResult).to.deep.equal(result);
   });

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -295,7 +295,8 @@ export const removeEmptyEntries = object =>
  * Veteran~submittable
  * @property {Address~submittable} address
  * @property {Phone~submittable} phone
- * @property {String} emailAddressText
+ * @property {String} emailAddressText (v0)
+ * @property {String} email (v1)
  * @property {Boolean} homeless
  */
 /**
@@ -365,6 +366,18 @@ export const getPhone = ({ veteran = {} } = {}) => {
     phoneNumber: truncate('phoneNumber', MAX_LENGTH.PHONE_NUMBER),
     phoneNumberExt: truncate('phoneNumberExt', MAX_LENGTH.PHONE_NUMBER_EXT),
   });
+};
+
+/**
+ *
+ * @param {*} formData
+ * @returns
+ */
+export const getEmail = (formData = {}) => {
+  // v0 uses emailAddressText
+  // v1 uses email
+  const key = formData[SHOW_PART3] ? 'email' : 'emailAddressText';
+  return { [key]: formData.veteran?.email || '' };
 };
 
 /**

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -369,9 +369,9 @@ export const getPhone = ({ veteran = {} } = {}) => {
 };
 
 /**
- *
- * @param {*} formData
- * @returns
+ * Return v0 or v1 key with email data
+ * @param {Veteran} veteran - Veteran formData object
+ * @returns {Object} submittable email
  */
 export const getEmail = (formData = {}) => {
   // v0 uses emailAddressText


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While testing the newer NOD v1 submission endpoint, we discovered that Lighthouse changed the email key from `emailAddressText` to `email`
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Switch between email keys based on the feature toggle setting
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#62311](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62311)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Submission to v1 failed because `email` was expected
- _Describe the steps required to verify your changes are working as expected_
  > Attempt to submit an NOD in staging (already has feature toggle enabled)
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement (Board Appeal)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
