### PR TITLE
Add optional chaining to startsWith method

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -26,7 +26,7 @@ const CalendarCell = ({
   const buttonRef = useRef(null);
   const optionsHeightRef = useRef(null);
   const inSelectedArray = selectedDates?.some(selectedDate =>
-    selectedDate.startsWith(date),
+    selectedDate?.startsWith(date),
   );
 
   useEffect(

--- a/src/applications/vaos/components/calendar/CalendarOptionsSlots.jsx
+++ b/src/applications/vaos/components/calendar/CalendarOptionsSlots.jsx
@@ -50,7 +50,7 @@ export default function CalendarOptionsSlots({
   showWeekends,
 }) {
   const currentSlots = availableSlots.filter(slot =>
-    slot?.start.startsWith(currentlySelectedDate),
+    slot?.start?.startsWith(currentlySelectedDate),
   );
 
   // [0, 1, 2, 3, 4, 5, 6]

--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -10,7 +10,7 @@ function isCellDisabled({ date, availableSlots, minDate, maxDate }) {
   // in the array.
   if (
     (Array.isArray(availableSlots) &&
-      !availableSlots.some(slot => slot?.start.startsWith(date))) ||
+      !availableSlots.some(slot => slot?.start?.startsWith(date))) ||
     moment(date).isBefore(moment().format('YYYY-MM-DD'))
   ) {
     disabled = true;

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/SelectedIndicator.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/SelectedIndicator.jsx
@@ -3,12 +3,13 @@ import moment from 'moment';
 
 export function getSelectedLabel(date, selectedDates) {
   const matchingTimes = selectedDates.filter(selected =>
-    selected.startsWith(date),
+    selected?.startsWith(date),
   );
 
   if (matchingTimes.length === 2) {
     return 'AM and PM selected.';
-  } else if (moment(matchingTimes[0]).hours() >= 12) {
+  }
+  if (moment(matchingTimes[0]).hours() >= 12) {
     return 'PM selected.';
   }
 
@@ -18,7 +19,7 @@ export function getSelectedLabel(date, selectedDates) {
 export default function SelectedIndicator({ date, selectedDates }) {
   const bubbles = selectedDates
     .reduce((selectedFieldValues, currentDate) => {
-      if (currentDate.startsWith(date)) {
+      if (currentDate?.startsWith(date)) {
         selectedFieldValues.push(
           moment(currentDate).hour() >= 12 ? 'PM' : 'AM',
         );

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/SelectedIndicator.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/SelectedIndicator.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 export function getSelectedLabel(date, selectedDates) {
   const matchingTimes = selectedDates.filter(selected =>
-    selected?.startsWith(date),
+    selected.startsWith(date),
   );
 
   if (matchingTimes.length === 2) {
@@ -19,7 +19,7 @@ export function getSelectedLabel(date, selectedDates) {
 export default function SelectedIndicator({ date, selectedDates }) {
   const bubbles = selectedDates
     .reduce((selectedFieldValues, currentDate) => {
-      if (currentDate?.startsWith(date)) {
+      if (currentDate.startsWith(date)) {
         selectedFieldValues.push(
           moment(currentDate).hour() >= 12 ? 'PM' : 'AM',
         );


### PR DESCRIPTION
## Summary
This PR adds optional chaining directly to the startsWith() method inside the components that make up the CalendarWidget



### Background

Google Analytic is recording error from `/health-care/schedule-view-va-appointments/appointments/new-appointment/select-date/`.  The error is listed below and on the screenshot of GA dashboard. 

- Cannot read properties of undefined (reading 'startsWith')
- undefined is not an object (evaluating 'e.start.startsWith')

Previous PRs did not fix the error. This PR adds optional chaining directly to the startsWith() method.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#53873

## Screen Shot of error key captured in GA

![Screenshot 2023-08-01 at 11 43 09 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/a6574b3f-48be-40ee-8345-ad1c19e830d2)

## What areas of the site does it impact?

VAOS google analytic
