### PR TITLE
MHV-42360: micriobio pdf date fix in header

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -32,9 +32,8 @@ const MicroDetails = props => {
         'LL',
       )}`,
       footerRight: 'Page %PAGE_NUMBER% of %TOTAL_PAGES%',
-      title: `Lab and test results: Microbiology on ${dateFormat(
+      title: `Lab and test results: Microbiology on ${formatDateLong(
         record.date,
-        'LLL',
       )}`,
       subject: 'VA Medical Record',
       preface:


### PR DESCRIPTION
## Summary
The date in the header of the pdf generated for labs and tests - microbiology has been fixed to be formatted correctly. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-42360

## Testing done
No additional tests needed

## Screenshots
<img width="836" alt="Screenshot 2023-08-01 at 10 17 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/21a718fa-5f5f-4413-b7a0-14a5cd5504ae">

## What areas of the site does it impact?
MHV medical records - labs and tests - microbiology pdf generation

## Acceptance criteria
AC1 Download Microbiology has been added (TBD)
AC2 No significant formatting is needed until designs are final
AC3 Product a PDF with placeholder data
AC4 Formatting of PDF will occur in future story when format is finalized

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
