### PR TITLE
NOD & HLR: Fix disagreement title & a11y

### DIFF
--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -7,7 +7,8 @@ import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 export const missingAreaOfDisagreementErrorMessage =
   'Choose or enter a reason for disagreement';
 
-const titlePrefix = 'Decision for';
+const titlePrefix = 'Disagreement with';
+const titleConnector = ' decision on ';
 
 /**
  * Title for review & submit page, text string returned
@@ -20,7 +21,7 @@ export const getIssueTitle = data => {
     <>
       {titlePrefix}{' '}
       <span className="dd-privacy-hidden">{getIssueName(data)}</span>
-      {' dated '}
+      {titleConnector}
       <span className="dd-privacy-hidden">{date}</span>
     </>
   );
@@ -36,7 +37,7 @@ export const issueName = ({ formData, formContext } = {}) => {
       className="schemaform-block-title schemaform-title-underline"
       aria-describedby={`area-of-disagreement-label-${index}`}
     >
-      <Header className="vads-u-margin-top--0">
+      <Header id="disagreement-title" className="vads-u-margin-top--0">
         {getIssueTitle(formData)}
       </Header>
     </legend>
@@ -73,17 +74,13 @@ export const issusDescription = ({ formContext }) => {
   );
 };
 
-const titles = {
+export const titles = {
   serviceConnection: 'The service connection',
   effectiveDate: 'The effective date of award',
   evaluation: 'Your evaluation of my condition',
   otherEntry: 'Something else:',
 };
 
-export const { serviceConnection } = titles;
-export const { effectiveDate } = titles;
-export const { evaluation } = titles;
-export const otherLabel = 'Something else:';
 // Includes _{index} which is appended by the TextWidget
 export const otherDescription = ({ index }) => (
   <div

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -1,11 +1,8 @@
 import {
   issueName,
   issusDescription,
-  serviceConnection,
-  effectiveDate,
-  evaluation,
   AreaOfDisagreementReviewField,
-  otherLabel,
+  titles,
   otherDescription,
   missingAreaOfDisagreementErrorMessage,
 } from '../content/areaOfDisagreement';
@@ -18,6 +15,11 @@ import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
 // add 1 for last comma
 const allDisagreementsLength =
   Object.values(SUBMITTED_DISAGREEMENTS).join(',').length + 1;
+
+const widgetProps = {
+  true: { 'aria-describedby': 'disagreement-title' },
+  false: { 'aria-describedby': 'disagreement-title' },
+};
 
 export default {
   uiSchema: {
@@ -40,20 +42,23 @@ export default {
         },
         disagreementOptions: {
           serviceConnection: {
-            'ui:title': serviceConnection,
+            'ui:title': titles.serviceConnection,
             'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': { widgetProps },
           },
           effectiveDate: {
-            'ui:title': effectiveDate,
+            'ui:title': titles.effectiveDate,
             'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': { widgetProps },
           },
           evaluation: {
-            'ui:title': evaluation,
+            'ui:title': titles.evaluation,
             'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': { widgetProps },
           },
         },
         otherEntry: {
-          'ui:title': otherLabel,
+          'ui:title': titles.otherEntry,
           'ui:reviewField': AreaOfDisagreementReviewField,
           'ui:description': otherDescription,
           'ui:options': {
@@ -64,7 +69,7 @@ export default {
               ),
             }),
             // index is appended to this ID in the TextWidget
-            ariaDescribedby: 'other_hint_text',
+            ariaDescribedby: 'disagreement-title other_hint_text',
             hideEmptyValueInReview: true,
           },
         },

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import sinon from 'sinon';
 
-import {
-  DefinitionTester,
-  selectCheckbox,
-  fillData,
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 import { AreaOfDisagreementReviewField } from '../../content/areaOfDisagreement';
@@ -31,7 +28,7 @@ describe('area of disagreement page', () => {
   };
 
   it('should render', () => {
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         arrayPath={arrayPath}
@@ -42,16 +39,24 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    expect(form.find('input[type="checkbox"]').length).to.equal(3);
-    expect(form.find('input[type="text"]').length).to.equal(1);
-    expect(form.find('h3').text()).to.contain('Tinnitus dated January 1, 2021');
-    expect(form.find('h3 .dd-privacy-hidden').length).to.equal(2);
-    form.unmount();
+    expect($$('input[type="checkbox"]', container).length).to.equal(3);
+    expect($$('input[type="text"]', container).length).to.equal(1);
+    expect(
+      $$('input[aria-describedby="disagreement-title"]', container).length,
+    ).to.equal(3);
+    expect(
+      $('#root_otherEntry', container).getAttribute('aria-describedby'),
+    ).to.equal('disagreement-title other_hint_text_0');
+    const header = $('h3', container);
+    expect(header.id).to.equal('disagreement-title');
+    expect(header.textContent).to.contain('Tinnitus');
+    expect(header.textContent).to.contain('January 1, 2021');
+    expect($('h3 .dd-privacy-hidden', container)).to.exist;
   });
 
-  it('should not allow submit when nothing is checked', () => {
+  it('should not allow submit when nothing is checked and the input is blank', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         arrayPath={arrayPath}
@@ -63,13 +68,14 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit($('form', container));
+    expect($('.usa-input-error-message', container)).to.exist;
     expect(onSubmit.called).to.be.false;
-    form.unmount();
   });
-  it('should allow submit when a checkbox is checked', () => {
+
+  it('should allow submit when an area is checked', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container, getByLabelText } = render(
       <DefinitionTester
         definitions={{}}
         arrayPath={arrayPath}
@@ -81,14 +87,14 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    selectCheckbox(form, 'root_disagreementOptions_serviceConnection', true);
-    form.find('form').simulate('submit');
+    fireEvent.click(getByLabelText('The service connection'));
+    fireEvent.submit($('form', container));
     expect(onSubmit.called).to.be.true;
-    form.unmount();
   });
-  it('should allow submit when additional text is included', () => {
+
+  it('should allow submit with additional text', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         definitions={{}}
         arrayPath={arrayPath}
@@ -100,15 +106,16 @@ describe('area of disagreement page', () => {
       />,
     );
 
-    fillData(form, '[name="root_otherEntry"]', 'foo');
-    form.find('form').simulate('submit');
+    fireEvent.change($('[name="root_otherEntry"]', container), {
+      target: { value: 'foo' },
+    });
+    fireEvent.submit($('form', container));
     expect(onSubmit.called).to.be.true;
-    form.unmount();
   });
 
   it('should render AreaOfDisagreementReviewField', () => {
     const title = 'Your evaluation of my condition';
-    const form = mount(
+    const { container } = render(
       <AreaOfDisagreementReviewField>
         {React.createElement(
           'div',
@@ -121,14 +128,13 @@ describe('area of disagreement page', () => {
         )}
       </AreaOfDisagreementReviewField>,
     );
-    expect(form.find('dt').text()).to.equal(title);
-    expect(form.find('dd').text()).to.equal('Bar');
-    expect(form.find('dd.dd-privacy-hidden').length).to.equal(0);
-    form.unmount();
+    expect($('dt', container).textContent).to.equal(title);
+    expect($('dd', container).textContent).to.equal('Bar');
+    expect($$('dd.dd-privacy-hidden', container).length).to.equal(0);
   });
   it('should render AreaOfDisagreementReviewField with hidden Datadog class', () => {
     const title = 'Something else:';
-    const form = mount(
+    const { container } = render(
       <AreaOfDisagreementReviewField>
         {React.createElement(
           'div',
@@ -141,8 +147,7 @@ describe('area of disagreement page', () => {
         )}
       </AreaOfDisagreementReviewField>,
     );
-    expect(form.find('dt').text()).to.equal(title);
-    expect(form.find('dd.dd-privacy-hidden').text()).to.equal('Bar');
-    form.unmount();
+    expect($('dt', container).textContent).to.equal(title);
+    expect($('dd.dd-privacy-hidden', container).textContent).to.equal('Bar');
   });
 });

--- a/src/applications/appeals/996/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/996/content/areaOfDisagreement.jsx
@@ -7,7 +7,8 @@ import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 export const missingAreaOfDisagreementErrorMessage =
   'Please choose or enter a reason for disagreement';
 
-const titlePrefix = 'Decision for';
+const titlePrefix = 'Disagreement with';
+const titleConnector = ' decision on ';
 
 /**
  * Title for review & submit page, text string returned
@@ -20,8 +21,8 @@ export const getIssueTitle = data => {
     <>
       {titlePrefix}{' '}
       <span className="dd-privacy-hidden">{getIssueName(data)}</span>
-      {' dated'}
-      {date}
+      {titleConnector}
+      <span className="dd-privacy-hidden">{date}</span>
     </>
   );
 };
@@ -36,7 +37,7 @@ export const issueName = ({ formData, formContext } = {}) => {
       className="schemaform-block-title schemaform-title-underline"
       aria-describedby={`area-of-disagreement-label-${index}`}
     >
-      <Header className="vads-u-margin-top--0">
+      <Header id="disagreement-title" className="vads-u-margin-top--0">
         {getIssueTitle(formData)}
       </Header>
     </legend>
@@ -78,16 +79,13 @@ export const issusDescription = ({ formContext }) => {
   );
 };
 
-const titles = {
+export const titles = {
   serviceConnection: 'The service connection',
   effectiveDate: 'The effective date of award',
   evaluation: 'Your evaluation of my condition',
+  otherEntry: 'Something else:',
 };
 
-export const { serviceConnection } = titles;
-export const { effectiveDate } = titles;
-export const { evaluation } = titles;
-export const otherLabel = 'Something else:';
 // Includes _{index} which is appended by the TextWidget
 export const otherDescription = ({ index }) => (
   <div
@@ -99,10 +97,14 @@ export const otherDescription = ({ index }) => (
 );
 
 // Only show set values (ignore false & undefined)
-export const AreaOfDisagreementReviewField = ({ children }) =>
-  children?.props.formData ? (
+export const AreaOfDisagreementReviewField = ({ children }) => {
+  const { formData, name } = children?.props || {};
+  return formData ? (
     <div className="review-row">
-      <dt>{titles[children.props.name]}</dt>
-      <dd>{children}</dd>
+      <dt>{titles[name]}</dt>
+      <dd className={name === 'otherEntry' ? 'dd-privacy-hidden' : ''}>
+        {children}
+      </dd>
     </div>
   ) : null;
+};

--- a/src/applications/appeals/996/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/996/pages/areaOfDisagreement.js
@@ -1,11 +1,8 @@
 import {
   issueName,
   issusDescription,
-  serviceConnection,
-  effectiveDate,
-  evaluation,
+  titles,
   AreaOfDisagreementReviewField,
-  otherLabel,
   otherDescription,
   missingAreaOfDisagreementErrorMessage,
 } from '../content/areaOfDisagreement';
@@ -18,6 +15,11 @@ import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
 // add 1 for last comma
 const allDisagreementsLength =
   Object.values(SUBMITTED_DISAGREEMENTS).join(',').length + 1;
+
+const widgetProps = {
+  true: { 'aria-describedby': 'disagreement-title' },
+  false: { 'aria-describedby': 'disagreement-title' },
+};
 
 export default {
   uiSchema: {
@@ -40,20 +42,24 @@ export default {
         },
         disagreementOptions: {
           serviceConnection: {
-            'ui:title': serviceConnection,
+            'ui:title': titles.serviceConnection,
             'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': { widgetProps },
           },
           effectiveDate: {
-            'ui:title': effectiveDate,
+            'ui:title': titles.effectiveDate,
             'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': { widgetProps },
           },
           evaluation: {
-            'ui:title': evaluation,
+            'ui:title': titles.evaluation,
             'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': { widgetProps },
           },
         },
         otherEntry: {
-          'ui:title': otherLabel,
+          'ui:title': titles.otherEntry,
+          'ui:reviewField': AreaOfDisagreementReviewField,
           'ui:description': otherDescription,
           'ui:options': {
             updateSchema: (formData, _schema, uiSchema, index) => ({
@@ -63,8 +69,9 @@ export default {
               ),
             }),
             // index is appended to this ID in the TextWidget
-            ariaDescribedby: 'other_hint_text',
+            ariaDescribedby: 'disagreement-title other_hint_text',
             hideEmptyValueInReview: true,
+            widgetProps,
           },
         },
       },


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Make Higher-Level Review & Notice of Disagreement area of disagreement page more accessible:
  > - Updated the header to be more descriptive
  > - Added `aria-describedby` to the checkboxes and text input pointing to the descriptive header
  > - Added unit tests
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Recommendations from a11y expert
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#61370](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61370)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Page title was not descriptive & checkbox descriptions did not include issue description
- _Describe the steps required to verify your changes are working as expected_
  > Test in review instance using screenreader
- _Describe the tests completed and the results_
  > Added unit tests to check `aria-describedby`
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Area of Disagreement | <img width="579" alt="Screenshot 2023-08-02 at 1 02 53 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/1c5fd3b1-7817-4a4f-8e0c-9ef1b232504e"> | <img width="584" alt="disagreement-title" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/183bafd6-3052-40c4-a1fa-8f4e8faaa56d"> |
| Review area of disagreement | <img width="617" alt="Screenshot 2023-08-02 at 1 04 39 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/5f161826-a65d-4d26-a1a5-76151d2fdd04"> | <img width="628" alt="review-disagreement-titles" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/07fb5a4b-f10a-4e90-b52a-16895b39ae87"> |

| Accessibility view from screenreader |  |
| ----- | ----- |
| Tabbing to checkbox | <img width="909" alt="checkbox-description" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/54f87c59-0b21-4832-a2a3-853acff0afe9"> |
| Tabbing to input | <img width="922" alt="input-tabbing" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e2defafc-9485-48f7-8eed-652da7821acd"> |
| Input more content | <img width="1250" alt="input-tabbing-more-content-available" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/daacd424-bf1e-402a-bd68-c1a807424b55"> |
| Clicking on input | <img width="927" alt="input readout including page title, but not hint text?" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f0e7051c-55f4-4a2e-a211-7eb2d4a62394"> |

## What areas of the site does it impact?

Higher-Level Review & Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
