### PR TITLE
Update error message keys for Forms Library emailUI definition

### DIFF
--- a/src/platform/forms-system/src/js/definitions/email.js
+++ b/src/platform/forms-system/src/js/definitions/email.js
@@ -7,7 +7,7 @@ export default function uiSchema(title = 'Email address') {
   return {
     'ui:title': title,
     'ui:errorMessages': {
-      format:
+      pattern:
         'Enter a valid email address using the format email@domain.com. Your email address can only have letters, numbers, the @ symbol and a period, with no spaces.',
       required: 'Please enter an email address',
     },

--- a/src/platform/forms-system/test/js/definitions/email.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/email.unit.spec.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import definitions from 'vets-json-schema/dist/definitions.json';
+import uiSchema from '../../../src/js/definitions/email';
+
+describe('Schemaform definition email', () => {
+  it('should render email', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester schema={definitions.email} uiSchema={uiSchema()} />,
+    );
+    const formDOM = findDOMNode(form);
+    const input = formDOM.querySelector('input');
+    expect(input).to.have.attr('type', 'email');
+    expect(input).have.attr('maxLength', `${definitions.email.maxLength}`);
+  });
+
+  it('should render invalid email error', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester schema={definitions.date} uiSchema={uiSchema()} />,
+    );
+    const formDOM = findDOMNode(form);
+    const input = formDOM.querySelector('input');
+
+    expect(
+      formDOM.querySelectorAll('.usa-input-error-message'),
+    ).to.have.lengthOf(0);
+
+    ReactTestUtils.Simulate.change(input, {
+      target: {
+        value: 'as@d.c',
+      },
+    });
+    ReactTestUtils.Simulate.blur(input);
+
+    expect(
+      formDOM.querySelector('.usa-input-error-message').textContent,
+    ).to.equal(`Error ${uiSchema()['ui:errorMessages'].pattern}`);
+  });
+
+  it('should render email title', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        schema={definitions.email}
+        uiSchema={uiSchema('My email')}
+      />,
+    );
+    const formDOM = findDOMNode(form);
+    expect(formDOM.querySelector('label').textContent).to.equal('My email');
+  });
+
+  it('should render email for review', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        reviewMode
+        schema={definitions.ssn}
+        uiSchema={uiSchema()}
+        data="email@domain.com"
+      />,
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelector('dd').textContent).to.equal(
+      'email@domain.com',
+    );
+  });
+});


### PR DESCRIPTION
## Description
This PR updates an incorrect error message key for the emailUI definition in the forms library. With the key being incorrect, instead of users seeing a helpful error message, they see that the declared pattern is invalid. As there was no previous unit tests on this definition, unit tests were also added as part of this PR.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#61888

## Testing done
- [x] Unit tests

## Screenshots
**Before:**
![Screenshot 2023-08-02 at 2 53 42 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/25fd2c75-3120-45d7-a21b-0ab32217b268)

**After:**
![Screenshot 2023-08-02 at 2 51 50 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/e8e29719-825c-4358-8d4a-b28d9d9a3722)

## Acceptance criteria
- Form input displayed helpful validation message that matches what has been declared in the function
