### PR TITLE
NOD: Fix older decision date message

### DIFF
--- a/src/applications/appeals/10182/content/addIssue.jsx
+++ b/src/applications/appeals/10182/content/addIssue.jsx
@@ -13,7 +13,10 @@ export const issueErrorMessages = {
   missingDecisionDate: 'Enter a decision date',
   invalidDateRange: (min, max) => `Enter a year between ${min} and ${max}`,
   pastDate: 'Add a past decision date',
+  // date must be < 1 year old
   newerDate: 'Add an issue with a decision date less than a year old',
+  // date must be more recent (set to 100 years max)
+  recentDate: 'You must add a more recent decision date',
 };
 
 export const content = {

--- a/src/applications/appeals/10182/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/date.unit.spec.js
@@ -117,4 +117,14 @@ describe('validateDate & isValidDate', () => {
     validateDate(errors, date, { [SHOW_PART3]: true });
     expect(errorMessage[0]).to.be.undefined;
   });
+  it('should throw an error for dates in the distant past when feature toggle is set to support the new form', () => {
+    const date = getDate({ offset: { years: -110 } });
+    validateDate(errors, date, { [SHOW_PART3]: true });
+    expect(errorMessage[0]).to.eq(issueErrorMessages.recentDate);
+    expect(errorMessage[1]).to.not.contain('month');
+    expect(errorMessage[1]).to.not.contain('day');
+    expect(errorMessage[1]).to.contain('year');
+    expect(errorMessage[1]).to.not.contain('other');
+    expect(isValidDate(date)).to.be.false;
+  });
 });

--- a/src/applications/appeals/10182/validations/date.js
+++ b/src/applications/appeals/10182/validations/date.js
@@ -65,12 +65,12 @@ export const validateDate = (
     // Lighthouse won't accept same day (as submission) decision date
     errors.addError(issueErrorMessages.pastDate);
     errorParts.year = true; // only the year is invalid at this point
-  } else if (
-    (!data[SHOW_PART3] && date.isBefore(minDate1)) ||
-    date.isBefore(minDate100)
-  ) {
-    // max 1 year for old form or 100 years for newer form
+  } else if (!data[SHOW_PART3] && date.isBefore(minDate1)) {
     errors.addError(issueErrorMessages.newerDate);
+    errorParts.year = true;
+  } else if (date.isBefore(minDate100)) {
+    // max 1 year for old form or 100 years for newer form
+    errors.addError(issueErrorMessages.recentDate);
     errorParts.year = true; // only the year is invalid at this point
   }
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In the NOD form update, decision dates more than a year in the past can be entered; but the error message continues to inform the Veteran to enter a date less than a year old. This PR adds a new message (copied from Supplemental Claims) of "You must add a more recent decision date" 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#62961](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62961)

## Testing done

- _Describe what the old behavior was prior to the change_
  > When the feature toggle is enabled and a date older than 1 year is entered, a message of "Add an issue with a decision date less than a year old" is displayed, but the 1 year limitation is no longer needed.
- _Describe the steps required to verify your changes are working as expected_
  > Test this PR in a review instance, or locally 
- _Describe the tests completed and the results_
  > Updated unit tests; all passing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Error message | <img width="566" alt="Screenshot 2023-08-02 at 2 51 46 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2e3c9544-7667-43dc-9483-d9673c87a772"> | <img width="543" alt="Screenshot 2023-08-02 at 2 52 16 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/a2a07c4a-d4ec-4c9f-98bc-0352c06e1e8c"> |

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
