### PR TITLE
MHV-42360: Date format fixed for microbio

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -8,15 +8,13 @@ import PrintHeader from '../shared/PrintHeader';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import PrintDownload from '../shared/PrintDownload';
-import { dateFormat, nameFormat, sendErrorToSentry } from '../../util/helpers';
+import { nameFormat, sendErrorToSentry } from '../../util/helpers';
 
 const MicroDetails = props => {
   const { record, fullState } = props;
   const user = useSelector(state => state.user.profile);
   const name = nameFormat(user.userFullName);
-  const dob = dateFormat(user.dob, 'LL');
-
-  const formattedDate = formatDateLong(record?.date);
+  const dob = formatDateLong(user.dob, 'LL');
 
   const generateMicrobiologyPdf = async () => {
     const pdfData = {
@@ -32,9 +30,7 @@ const MicroDetails = props => {
         'LL',
       )}`,
       footerRight: 'Page %PAGE_NUMBER% of %TOTAL_PAGES%',
-      title: `Lab and test results: Microbiology on ${formatDateLong(
-        record.date,
-      )}`,
+      title: `Lab and test results: Microbiology on ${record.date}`,
       subject: 'VA Medical Record',
       preface:
         'If you have any questions about these results, send a secure message to your care team.',
@@ -76,7 +72,7 @@ const MicroDetails = props => {
               },
               {
                 title: 'Date completed',
-                value: formatDateLong(record.date),
+                value: record.date,
                 inline: true,
               },
             ],
@@ -113,7 +109,7 @@ const MicroDetails = props => {
               <h2 className="vads-u-font-size--base vads-u-font-family--sans">
                 Date:{' '}
               </h2>
-              <p>{formattedDate}</p>
+              <p>{record.date}</p>
             </div>
             <div className="no-print">
               <PrintDownload list download={generateMicrobiologyPdf} />
@@ -161,7 +157,7 @@ const MicroDetails = props => {
               <h3 className="vads-u-font-size--base vads-u-font-family--sans">
                 Date completed
               </h3>
-              <p>{formattedDate}</p>
+              <p>{record.date}</p>
             </div>
 
             <div className="test-results-container">

--- a/src/applications/mhv/medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv/medical-records/reducers/labsAndTests.js
@@ -1,3 +1,4 @@
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { Actions } from '../util/actionTypes';
 import {
   concatCategoryCodeText,
@@ -77,7 +78,7 @@ const convertMicrobiologyRecord = record => {
     category: '',
     orderedBy: 'Beth M. Smith',
     requestedBy: 'John J. Lydon',
-    date: record.effectiveDateTime || emptyField,
+    date: formatDateLong(record.effectiveDateTime) || emptyField,
     sampleFrom: record.type?.text || emptyField,
     sampleTested: record.specimen?.text || emptyField,
     orderingLocation:


### PR DESCRIPTION
## Summary
The date in the header of the pdf generated for labs and tests - microbiology has been fixed so that the date conversion happens in the reducer.  

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-42360

## Testing done
No additional tests needed

## Screenshots
No UI changes. 

## What areas of the site does it impact?
MHV medical records - labs and tests - microbiology pdf generation

## Acceptance criteria
AC1 Download Microbiology has been added (TBD)
AC2 No significant formatting is needed until designs are final
AC3 Product a PDF with placeholder data
AC4 Formatting of PDF will occur in future story when format is finalized

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
