### PR TITLE
stylelintrc.json - Ignore mochawesome-report compiled-stylesheets

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,7 +2,8 @@
   "plugins": ["stylelint-scss", "stylelint-order"],
   "ignoreFiles": [
     "src/applications/proxy-rewrite/sass/style-consolidated.scss",
-    "src/applications/vaos/docs/styles/*.css"
+    "src/applications/vaos/docs/styles/*.css",
+    "mochawesome-report/**/*.css"
   ],
   "rules": {
     "at-rule-disallowed-list": ["debug", "extend"],


### PR DESCRIPTION
## Summary

- Ignore mochawesome-report compiled-stylesheets in stylelint configuration.
- Replication-steps are in related bug-ticket below
- Team: Platform VA Product Forms
- Flipper not involved; this was not an app-related bug.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63045


## Testing done

- Successfully tested fix on local

## What areas of the site does it impact?

Local builds [any/all apps]; not app-specific.

## Acceptance criteria

### Quality Assurance & Testing

n/a

### Error Handling

n/a

### Authentication

n/a

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

n/a

## Requested Feedback

None.  Just need regular review & approval.  Thanks!
