### PR TITLE
Pull Veteran name from view field on HCA confirmation page

### DIFF
--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -13,7 +13,7 @@ const ConfirmationPage = ({ form, profile, isLoggedIn }) => {
   // if authenticated, get veteran's name from profile, else, from form data
   const nameToDisplay = isLoggedIn
     ? profile.userFullName
-    : data.veteranFullName;
+    : data['view:veteranInformation'].veteranFullName;
   const veteranName = normalizeFullName(nameToDisplay, true);
 
   return (

--- a/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.js
+++ b/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.js
@@ -11,10 +11,12 @@ describe('hca ConfirmationPage', () => {
     form: {
       submission: false,
       data: {
-        veteranFullName: {
-          first: 'Jack',
-          middle: 'William',
-          last: 'Smith',
+        'view:veteranInformation': {
+          veteranFullName: {
+            first: 'Jack',
+            middle: 'William',
+            last: 'Smith',
+          },
         },
       },
     },


### PR DESCRIPTION
## Description
This PR updates where the Veteran name comes from in the form data for the confirmation page of the Health Care Application.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#61746

## Acceptance criteria
- Veteran name is pulled from valid form data key