### PR TITLE
add feature flag for debts-api module

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -66,6 +66,7 @@ export default Object.freeze({
     'facility_locator_show_operational_hours_special_instructions',
   findFormsShowPdfModal: 'find_forms_show_pdf_modal',
   fileUploadShortWorkflowEnabled: 'file_upload_short_workflow_enabled',
+  financialStatusReportDebtsApiModule: 'financial_status_report_debts_api_module',
   financialStatusReportStreamlinedWaiver: 'financial_status_report_streamlined_waiver',
   form10182Nod: 'form10182_nod',
   form2110210: 'form2110210',


### PR DESCRIPTION
## Summary

This PR creates a new feature flag called financial_status_report_debts_api_module which determines if the frontend will hit either the `/v0/financial_status_reports` or the `/debts_api/v0/financial_status_reports` endpoint 

[PR](https://github.com/department-of-veterans-affairs/vets-api/pull/13416) for feature flag work on Vets API

## Related issue(s)
[59919](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/59919)

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/8467971/e05f1ea2-a2df-4179-a2ef-6007c6bc0c14)


## What areas of the site does it impact?
The Financial Status Report
