### PR TITLE
VACMS-14593 Fix Income Limits results page accordion header levels

### DIFF
--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -136,6 +136,7 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
         <h2>Select your {previousYear} household income range</h2>
         <va-accordion bordered data-testid="il-results" open-single>
           <va-accordion-item
+            level="3"
             data-testid="il-results-1"
             header={getFirstAccordionHeader(pension)}
           >
@@ -155,6 +156,7 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             {!pastMode && applyUrl}
           </va-accordion-item>
           <va-accordion-item
+            level="3"
             data-testid="il-results-2"
             header={getSecondAccordionHeader(pension, national)}
           >
@@ -170,6 +172,7 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
           </va-accordion-item>
           {isStandard && (
             <va-accordion-item
+              level="3"
               data-testid="il-results-3"
               header={getThirdAccordionHeader(national, gmt)}
             >
@@ -186,6 +189,7 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             </va-accordion-item>
           )}
           <va-accordion-item
+            level="3"
             data-testid="il-results-4"
             header={getFourthAccordionHeader(national, gmt, isStandard)}
           >
@@ -200,6 +204,7 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             {!pastMode && applyUrl}
           </va-accordion-item>
           <va-accordion-item
+            level="3"
             data-testid="il-results-5"
             header={getFifthAccordionHeader(national, gmt, isStandard)}
           >


### PR DESCRIPTION
## Summary
Changes the accordion header levels from `<h2>` to `<h3>`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14593

## Testing Done
Go to `/health-care/income-limits` and proceed through the flow until you reach the Results screen. Verify that each accordion header is an `<h3>`.

## Screenshots

<img width="1800" alt="Screenshot 2023-08-03 at 2 20 45 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/c7f7f51f-21b9-4da4-9cd6-45b6df68693d">

## Acceptance criteria
- [x] Each income level accordion has a heading level of H3
- [x] Accessibility lead review