### PR TITLE
Feature/61015 revert back breadcrumb text for pending appointments

### DIFF
--- a/src/applications/vaos/components/BackLink.jsx
+++ b/src/applications/vaos/components/BackLink.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
-import { selectFeatureBreadcrumbUrlUpdate } from '../redux/selectors';
 
 export default function BackLink({ appointment }) {
   const {
@@ -10,14 +8,10 @@ export default function BackLink({ appointment }) {
     isPendingAppointment,
     isUpcomingAppointment,
   } = appointment.vaos;
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+
   const handleBackLinkText = () => {
     let linkText;
-    if (isPendingAppointment && featureBreadcrumbUrlUpdate) {
-      linkText = 'Back to requests';
-    } else if (isPendingAppointment) {
+    if (isPendingAppointment) {
       linkText = 'Back to pending appointments';
     } else if (isUpcomingAppointment) {
       linkText = 'Back to appointments';

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -218,13 +218,13 @@ const responses = {
     } = req.body;
     const providerNpi = practitioners[0]?.identifier[0].value;
     const selectedTime = appointmentSlotsV2.data
-      .filter(slot => slot.id === req.body.slot.id)
+      .filter(slot => slot.id === req.body.slot?.id)
       .map(slot => slot.attributes.start);
     const submittedAppt = {
       id: `mock${currentMockId}`,
       attributes: {
         ...req.body,
-        start: req.body.slot.id ? selectedTime[0] : null,
+        start: req.body.slot?.id ? selectedTime[0] : null,
         preferredProviderName: providerNpi ? providerMock[providerNpi] : null,
       },
     };


### PR DESCRIPTION
## Summary
This PR change the pending appointment breadcrumb back text to "Back to pending appointments" without the reliance of va_online_scheduling_breadcrumb_url_update toggle flag. 

This PR also fixes the mock request POST call when slot.id is does not exists for pending appointments.

### Background
The former AC for request confirmation page uses the breadcrumb toggle flag to change the breadcrumb back text to "Back to request".  This is no longer the case. We are reverting it back to the original text, "Back to pending appointments".

## Acceptance Criteria

- [ ] Given the user clicks on Start Scheduling button and submits a request appointment
Then confirmation page breadcrumbs will be updated to < Back to pending appointments

- [ ] Given the user is on the Upcoming VA appointments landing page,
When the user clicks on Pending link and Details link for a pending appointment, 
then breadcrumbs will be updated to < Back to pending appointments

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61015


## Testing done
n/a

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

VA request confirmation page

![Screenshot 2023-08-03 at 12 00 26 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/fbd81c74-ead6-4210-beb3-0d0a516fd72f)


CC request confirmation page

![Screenshot 2023-08-03 at 12 01 59 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/2d0d7181-d5a7-4da9-addd-d6a87bbd84ef)

## What areas of the site does it impact?

VAOS breadcrumb


