### PR TITLE
Allow for resubmission of ID Form in Health Care Application

### DIFF
--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -16,7 +16,10 @@ import { isLoggedIn, isProfileLoading } from 'platform/user/selectors';
 import { ServerErrorAlert } from '../components/FormAlerts';
 import LoginRequiredAlert from '../components/FormAlerts/LoginRequiredAlert';
 
-import { getEnrollmentStatus } from '../utils/actions';
+import {
+  getEnrollmentStatus,
+  resetEnrollmentStatus as resetEnrollmentStatusAction,
+} from '../utils/actions';
 import { didEnrollmentStatusChange } from '../utils/helpers';
 import { HCA_ENROLLMENT_STATUSES } from '../utils/constants';
 import {
@@ -30,6 +33,7 @@ const IDPage = props => {
     isSubmittingIDForm,
     loginRequired,
     noESRRecordFound,
+    resetEnrollmentStatus,
     router,
     shouldRedirect,
     showLoadingIndicator,
@@ -89,6 +93,7 @@ const IDPage = props => {
 
   useEffect(() => {
     if (shouldRedirect) router.push('/');
+    resetEnrollmentStatus();
     focusElement('.va-nav-breadcrumbs-list');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -184,6 +189,7 @@ IDPage.propTypes = {
   location: PropTypes.object,
   loginRequired: PropTypes.bool,
   noESRRecordFound: PropTypes.bool,
+  resetEnrollmentStatus: PropTypes.func,
   route: PropTypes.object,
   router: PropTypes.object,
   setFormData: PropTypes.func,
@@ -195,6 +201,7 @@ IDPage.propTypes = {
 };
 
 const mapDispatchToProps = {
+  resetEnrollmentStatus: resetEnrollmentStatusAction,
   setFormData: setData,
   submitIDForm: getEnrollmentStatus,
   toggleLoginModal: toggleLoginModalAction,

--- a/src/applications/hca/reducers/total-disabilities.js
+++ b/src/applications/hca/reducers/total-disabilities.js
@@ -1,8 +1,4 @@
-import {
-  FETCH_TOTAL_RATING_STARTED,
-  FETCH_TOTAL_RATING_SUCCEEDED,
-  FETCH_TOTAL_RATING_FAILED,
-} from '../utils/actions';
+import { DISABILITY_RATING_ACTIONS } from '../utils/constants';
 
 const initialState = {
   loading: true, // app starts in loading state
@@ -12,27 +8,29 @@ const initialState = {
 };
 
 function totalRating(state = initialState, action) {
-  switch (action.type) {
-    case FETCH_TOTAL_RATING_STARTED:
-      return {
-        ...initialState,
-      };
-    case FETCH_TOTAL_RATING_FAILED:
-      return {
-        ...state,
-        loading: false,
-        error: action.error,
-      };
-    case FETCH_TOTAL_RATING_SUCCEEDED:
-      return {
-        ...state,
-        loading: false,
-        totalDisabilityRating: action.response.userPercentOfDisability,
-        disabilityDecisionTypeName: action.response.disabilityDecisionTypeName,
-      };
-    default:
-      return state;
-  }
+  const { response = {}, error = null, type } = action;
+  const {
+    FETCH_TOTAL_RATING_STARTED,
+    FETCH_TOTAL_RATING_FAILED,
+    FETCH_TOTAL_RATING_SUCCEEDED,
+  } = DISABILITY_RATING_ACTIONS;
+
+  const actionMap = {
+    [FETCH_TOTAL_RATING_STARTED]: { ...initialState },
+    [FETCH_TOTAL_RATING_FAILED]: {
+      ...state,
+      loading: false,
+      error,
+    },
+    [FETCH_TOTAL_RATING_SUCCEEDED]: {
+      ...state,
+      loading: false,
+      totalDisabilityRating: response.userPercentOfDisability,
+      disabilityDecisionTypeName: response.disabilityDecisionTypeName,
+    },
+  };
+
+  return actionMap[type] || state;
 }
 
 export default totalRating;

--- a/src/applications/hca/tests/reducers/enrollment-status.unit.spec.js
+++ b/src/applications/hca/tests/reducers/enrollment-status.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import * as actions from '../../utils/actions';
+import { ENROLLMENT_STATUS_ACTIONS } from '../../utils/constants';
 import reducer from '../../reducers/enrollment-status';
 
 describe('hca EnrollmentStatus reducer', () => {
@@ -12,21 +12,61 @@ describe('hca EnrollmentStatus reducer', () => {
     state = undefined;
   });
 
+  describe('default behavior', () => {
+    it('should return the initial state', () => {
+      action = {};
+      reducedState = reducer(state, action);
+      expect(reducedState.applicationDate).to.be.null;
+      expect(reducedState.enrollmentDate).to.be.null;
+      expect(reducedState.preferredFacility).to.be.null;
+      expect(reducedState.enrollmentStatus).to.be.null;
+      expect(reducedState.enrollmentStatusEffectiveDate).to.be.null;
+      expect(reducedState.isUserInMVI).to.be.false;
+      expect(reducedState.loginRequired).to.be.false;
+      expect(reducedState.noESRRecordFound).to.be.false;
+      expect(reducedState.showReapplyContent).to.be.false;
+      expect(reducedState.hasServerError).to.be.false;
+      expect(reducedState.isLoadingApplicationStatus).to.be.false;
+      expect(reducedState.isLoadingDismissedNotification).to.be.false;
+    });
+  });
+
+  describe('when the action type is not a match', () => {
+    it('should return the initial state', () => {
+      action = { type: '@@INIT' };
+      reducedState = reducer(state, action);
+      expect(reducedState.applicationDate).to.be.null;
+      expect(reducedState.enrollmentDate).to.be.null;
+      expect(reducedState.preferredFacility).to.be.null;
+      expect(reducedState.enrollmentStatus).to.be.null;
+      expect(reducedState.enrollmentStatusEffectiveDate).to.be.null;
+      expect(reducedState.isUserInMVI).to.be.false;
+      expect(reducedState.loginRequired).to.be.false;
+      expect(reducedState.noESRRecordFound).to.be.false;
+      expect(reducedState.showReapplyContent).to.be.false;
+      expect(reducedState.hasServerError).to.be.false;
+      expect(reducedState.isLoadingApplicationStatus).to.be.false;
+      expect(reducedState.isLoadingDismissedNotification).to.be.false;
+    });
+  });
+
   describe('when `FETCH_ENROLLMENT_STATUS_STARTED` executes', () => {
+    const { FETCH_ENROLLMENT_STATUS_STARTED } = ENROLLMENT_STATUS_ACTIONS;
     it('should set `isLoadingApplicationStatus` to `true`', () => {
       action = {
-        type: actions.FETCH_ENROLLMENT_STATUS_STARTED,
+        type: FETCH_ENROLLMENT_STATUS_STARTED,
       };
       reducedState = reducer(state, action);
       expect(reducedState.isLoadingApplicationStatus).to.be.true;
     });
   });
 
-  describe('when FETCH_ENROLLMENT_STATUS_SUCCEEDED executes', () => {
+  describe('when `FETCH_ENROLLMENT_STATUS_SUCCEEDED` executes', () => {
+    const { FETCH_ENROLLMENT_STATUS_SUCCEEDED } = ENROLLMENT_STATUS_ACTIONS;
     describe('when `parsedStatus` contains any value', () => {
       it('should set the state correctly', () => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          type: FETCH_ENROLLMENT_STATUS_SUCCEEDED,
           data: {
             parsedStatus: 'enrolled',
             effectiveDate: '2019-01-02T21:58:55.000-06:00',
@@ -59,7 +99,7 @@ describe('hca EnrollmentStatus reducer', () => {
     describe('when `parsedStatus` is `none_of_the_above`', () => {
       beforeEach(() => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          type: FETCH_ENROLLMENT_STATUS_SUCCEEDED,
           data: {
             parsedStatus: 'none_of_the_above',
           },
@@ -77,7 +117,7 @@ describe('hca EnrollmentStatus reducer', () => {
     describe('when `parsedStatus` is anything other than `none_of_the_above`', () => {
       beforeEach(() => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          type: FETCH_ENROLLMENT_STATUS_SUCCEEDED,
           data: {
             parsedStatus: 'enrolled',
           },
@@ -93,11 +133,12 @@ describe('hca EnrollmentStatus reducer', () => {
     });
   });
 
-  describe('when FETCH_ENROLLMENT_STATUS_FAILED executes', () => {
+  describe('when `FETCH_ENROLLMENT_STATUS_FAILED` executes', () => {
+    const { FETCH_ENROLLMENT_STATUS_FAILED } = ENROLLMENT_STATUS_ACTIONS;
     describe('when the error code is 404', () => {
       it('should set `noESRRecordFound` to `true` and `hasServerError` to `false`', () => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          type: FETCH_ENROLLMENT_STATUS_FAILED,
           errors: [{ code: '404' }],
         };
         reducedState = reducer(state, action);
@@ -111,7 +152,7 @@ describe('hca EnrollmentStatus reducer', () => {
     describe('when the error code is 429', () => {
       it('should set `loginRequired` to `true` and `hasServerError` to `false`', () => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          type: FETCH_ENROLLMENT_STATUS_FAILED,
           errors: [{ code: '429' }],
         };
         reducedState = reducer(state, action);
@@ -125,7 +166,7 @@ describe('hca EnrollmentStatus reducer', () => {
     describe('when the error code is >=500', () => {
       it('should set `hasServerError` to `true`', () => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          type: FETCH_ENROLLMENT_STATUS_FAILED,
           errors: [{ code: '500' }],
         };
         reducedState = reducer(state, action);
@@ -139,7 +180,7 @@ describe('hca EnrollmentStatus reducer', () => {
     describe('when the error code cannot be determined', () => {
       it('should set `hasServerError` to `true`', () => {
         action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          type: FETCH_ENROLLMENT_STATUS_FAILED,
           errors: null,
         };
         reducedState = reducer(state, action);
@@ -149,35 +190,67 @@ describe('hca EnrollmentStatus reducer', () => {
     });
   });
 
-  describe('when SHOW_HCA_REAPPLY_CONTENT executes', () => {
-    it('should set `showReapplyContent` to `true`', () => {
+  describe('when `RESET_ENROLLMENT_STATUS` executes', () => {
+    const { RESET_ENROLLMENT_STATUS } = ENROLLMENT_STATUS_ACTIONS;
+    it('should reset enrollment data', () => {
       action = {
-        type: actions.SHOW_HCA_REAPPLY_CONTENT,
+        type: RESET_ENROLLMENT_STATUS,
       };
       reducedState = reducer(state, action);
-      expect(reducedState.showReapplyContent).to.be.true;
+      expect(reducedState.applicationDate).to.be.null;
+      expect(reducedState.enrollmentDate).to.be.null;
+      expect(reducedState.preferredFacility).to.be.null;
+      expect(reducedState.enrollmentStatus).to.be.null;
+      expect(reducedState.enrollmentStatusEffectiveDate).to.be.null;
+    });
+
+    it('should reset user lookup values', () => {
+      action = {
+        type: RESET_ENROLLMENT_STATUS,
+      };
+      reducedState = reducer(state, action);
+      expect(reducedState.isUserInMVI).to.be.false;
+      expect(reducedState.loginRequired).to.be.false;
+      expect(reducedState.noESRRecordFound).to.be.false;
+      expect(reducedState.showReapplyContent).to.be.false;
+    });
+
+    it('should reset loading and error values', () => {
+      action = {
+        type: RESET_ENROLLMENT_STATUS,
+      };
+      reducedState = reducer(state, action);
+      expect(reducedState.hasServerError).to.be.false;
+      expect(reducedState.isLoadingApplicationStatus).to.be.false;
+      expect(reducedState.isLoadingDismissedNotification).to.be.false;
     });
   });
 
-  describe('when FETCH_DISMISSED_HCA_NOTIFICATION_STARTED executes', () => {
+  describe('when `FETCH_DISMISSED_HCA_NOTIFICATION_STARTED` executes', () => {
+    const {
+      FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
+    } = ENROLLMENT_STATUS_ACTIONS;
     it('should set `isLoadingDismissedNotification` to `true`', () => {
       state = { isLoadingDismissedNotification: false };
       action = {
-        type: actions.FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
+        type: FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
       };
       reducedState = reducer(state, action);
       expect(reducedState.isLoadingDismissedNotification).to.be.true;
     });
   });
 
-  describe('when FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED executes', () => {
+  describe('when `FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED` executes', () => {
+    const {
+      FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
+    } = ENROLLMENT_STATUS_ACTIONS;
     it('should set the state correctly', () => {
       state = {
         isLoadingDismissedNotification: true,
         dismissedNotificationDate: null,
       };
       action = {
-        type: actions.FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
+        type: FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
         response: {
           data: {
             attributes: {
@@ -197,16 +270,30 @@ describe('hca EnrollmentStatus reducer', () => {
     });
   });
 
-  describe('when FETCH_DISMISSED_HCA_NOTIFICATION_FAILED executes', () => {
+  describe('when `FETCH_DISMISSED_HCA_NOTIFICATION_FAILED` executes', () => {
+    const {
+      FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
+    } = ENROLLMENT_STATUS_ACTIONS;
     it('should set `isLoadingDismissedNotification` to `false`', () => {
       state = {
         isLoadingDismissedNotification: true,
       };
       action = {
-        type: actions.FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
+        type: FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
       };
       reducedState = reducer(state, action);
       expect(reducedState.isLoadingDismissedNotification).to.be.false;
+    });
+  });
+
+  describe('when `SHOW_HCA_REAPPLY_CONTENT` executes', () => {
+    const { SHOW_HCA_REAPPLY_CONTENT } = ENROLLMENT_STATUS_ACTIONS;
+    it('should set `showReapplyContent` to `true`', () => {
+      action = {
+        type: SHOW_HCA_REAPPLY_CONTENT,
+      };
+      reducedState = reducer(state, action);
+      expect(reducedState.showReapplyContent).to.be.true;
     });
   });
 });

--- a/src/applications/hca/tests/reducers/total-disabilities.unit.spec.js
+++ b/src/applications/hca/tests/reducers/total-disabilities.unit.spec.js
@@ -1,70 +1,80 @@
 import { expect } from 'chai';
-import {
-  FETCH_TOTAL_RATING_SUCCEEDED,
-  FETCH_TOTAL_RATING_FAILED,
-} from '../../utils/actions';
-import totalRating from '../../reducers/total-disabilities';
+import { DISABILITY_RATING_ACTIONS } from '../../utils/constants';
+import reducer from '../../reducers/total-disabilities';
 
 describe('hca TotalDisabilities reducer', () => {
-  const initialState = {
-    loading: true, // app starts in loading state
-    error: null,
-    totalDisabilityRating: null,
-    disabilityDecisionTypeName: null,
-  };
+  let state;
+  let reducedState;
+  let action;
+
+  beforeEach(() => {
+    state = undefined;
+  });
 
   describe('default behavior', () => {
     it('should return the initial state', () => {
-      const state = totalRating(initialState, {});
-      expect(state.loading).to.equal(true);
-      expect(state.error).to.equal(null);
-      expect(state.totalDisabilityRating).to.equal(null);
+      action = {};
+      reducedState = reducer(state, action);
+      expect(reducedState.loading).to.be.true;
+      expect(reducedState.error).to.be.null;
+      expect(reducedState.totalDisabilityRating).to.be.null;
+      expect(reducedState.disabilityDecisionTypeName).to.be.null;
     });
   });
 
-  describe('when the API returns an error', () => {
-    it('should handle the error from the API call', () => {
-      const state = totalRating(initialState, {
-        type: FETCH_TOTAL_RATING_FAILED,
-        error: {
-          code: 500,
-          detail: 'failed to load',
-        },
-      });
-      const err = { code: 500, detail: 'failed to load' };
-      expect(state.loading).to.equal(false);
-      expect(state.error.code).to.equal(err.code);
-      expect(state.error.detail).to.equal(err.detail);
-      expect(state.totalDisabilityRating).to.equal(null);
+  describe('when the action type is not a match', () => {
+    it('should return the inital state', () => {
+      action = { type: '@@INIT' };
+      reducedState = reducer(state, action);
+      expect(reducedState.loading).to.be.true;
+      expect(reducedState.error).to.be.null;
+      expect(reducedState.totalDisabilityRating).to.be.null;
+      expect(reducedState.disabilityDecisionTypeName).to.be.null;
     });
   });
 
-  describe('when the API returns a success response', () => {
-    it('should handle a successful API call', () => {
-      const state = totalRating(initialState, {
-        type: FETCH_TOTAL_RATING_SUCCEEDED,
-        response: {
-          disabilityDecisionTypeName: 'Service Connected',
-          userPercentOfDisability: 80,
-        },
-      });
-      expect(state.loading).to.equal(false);
-      expect(state.error).to.equal(null);
-      expect(state.totalDisabilityRating).to.equal(80);
-      expect(state.disabilityDecisionTypeName).to.equal('Service Connected');
+  describe('when `FETCH_TOTAL_RATING_STARTED` executes', () => {
+    const { FETCH_TOTAL_RATING_STARTED } = DISABILITY_RATING_ACTIONS;
+    it('should return the inital state', () => {
+      action = { type: FETCH_TOTAL_RATING_STARTED };
+      reducedState = reducer(state, action);
+      expect(reducedState.loading).to.be.true;
+      expect(reducedState.error).to.be.null;
+      expect(reducedState.totalDisabilityRating).to.be.null;
+      expect(reducedState.disabilityDecisionTypeName).to.be.null;
     });
   });
 
-  describe('when the type is not a match', () => {
-    it('should return the state when there is a type mismatch', () => {
-      const state = totalRating(initialState, {
-        type: 'BLERG',
-      });
+  describe('when `FETCH_TOTAL_RATING_FAILED` executes', () => {
+    const { FETCH_TOTAL_RATING_FAILED } = DISABILITY_RATING_ACTIONS;
+    it('should properly handle the error', () => {
+      const error = { code: 500, detail: 'failed to load' };
+      action = { type: FETCH_TOTAL_RATING_FAILED, error };
+      reducedState = reducer(state, action);
+      expect(reducedState.loading).to.be.false;
+      expect(reducedState.error.code).to.equal(error.code);
+      expect(reducedState.error.detail).to.equal(error.detail);
+      expect(reducedState.totalDisabilityRating).to.be.null;
+    });
+  });
 
-      expect(state.loading).to.equal(true);
-      expect(state.error).to.equal(null);
-      expect(state.totalDisabilityRating).to.equal(null);
-      expect(state.disabilityDecisionTypeName).to.equal(null);
+  describe('when `FETCH_TOTAL_RATING_SUCCEEDED` executes', () => {
+    const { FETCH_TOTAL_RATING_SUCCEEDED } = DISABILITY_RATING_ACTIONS;
+    it('should properly handle the response', () => {
+      const response = {
+        disabilityDecisionTypeName: 'Service Connected',
+        userPercentOfDisability: 80,
+      };
+      action = { type: FETCH_TOTAL_RATING_SUCCEEDED, response };
+      reducedState = reducer(state, action);
+      expect(reducedState.loading).to.be.false;
+      expect(reducedState.error).to.be.null;
+      expect(reducedState.totalDisabilityRating).to.equal(
+        response.userPercentOfDisability,
+      );
+      expect(reducedState.disabilityDecisionTypeName).to.equal(
+        response.disabilityDecisionTypeName,
+      );
     });
   });
 });

--- a/src/applications/hca/tests/utils/actions.unit.spec.js
+++ b/src/applications/hca/tests/utils/actions.unit.spec.js
@@ -11,16 +11,21 @@ import {
   getDismissedHCANotification,
   setDismissedHCANotification,
   getEnrollmentStatus,
-  FETCH_ENROLLMENT_STATUS_STARTED,
-  FETCH_ENROLLMENT_STATUS_SUCCEEDED,
-  FETCH_ENROLLMENT_STATUS_FAILED,
-  FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-  FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-  FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-  SET_DISMISSED_HCA_NOTIFICATION,
+  resetEnrollmentStatus,
 } from '../../utils/actions';
+import { ENROLLMENT_STATUS_ACTIONS } from '../../utils/constants';
 
 describe('hca actions', () => {
+  const {
+    FETCH_ENROLLMENT_STATUS_STARTED,
+    FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+    FETCH_ENROLLMENT_STATUS_FAILED,
+    RESET_ENROLLMENT_STATUS,
+    FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
+    FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
+    FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
+    SET_DISMISSED_HCA_NOTIFICATION,
+  } = ENROLLMENT_STATUS_ACTIONS;
   let dispatch;
 
   describe('when `getEnrollmentStatus` executes', () => {
@@ -115,6 +120,17 @@ describe('hca actions', () => {
           );
         });
       });
+    });
+  });
+
+  describe('when `resetEnrollmentStatus` executes', () => {
+    beforeEach(() => {
+      dispatch = sinon.spy();
+    });
+
+    it('should dispatch a reset enrollment status action', () => {
+      resetEnrollmentStatus()(dispatch);
+      expect(dispatch.firstCall.args[0].type).to.equal(RESET_ENROLLMENT_STATUS);
     });
   });
 

--- a/src/applications/hca/utils/constants.js
+++ b/src/applications/hca/utils/constants.js
@@ -13,6 +13,16 @@ export const DEPENDENT_VIEW_FIELDS = {
   skip: 'view:skipDependentInfo',
 };
 
+// declare prefix for use in GA events related to disability rating
+export const DISABILITY_PREFIX = 'disability-ratings';
+
+// declare action statuses for fetching disability rating
+export const DISABILITY_RATING_ACTIONS = {
+  FETCH_TOTAL_RATING_STARTED: 'FETCH_TOTAL_RATING_STARTED',
+  FETCH_TOTAL_RATING_SUCCEEDED: 'FETCH_TOTAL_RATING_SUCCEEDED',
+  FETCH_TOTAL_RATING_FAILED: 'FETCH_TOTAL_RATING_FAILED',
+};
+
 // declare labels for discharge type select box
 export const DISCHARGE_TYPE_LABELS = {
   honorable: 'Honorable',
@@ -21,6 +31,22 @@ export const DISCHARGE_TYPE_LABELS = {
   'bad-conduct': 'Bad Conduct',
   dishonorable: 'Dishonorable',
   undesirable: 'Undesirable',
+};
+
+// declare action statuses for fetching enrollment status
+export const ENROLLMENT_STATUS_ACTIONS = {
+  FETCH_DISMISSED_HCA_NOTIFICATION_STARTED:
+    'FETCH_DISMISSED_HCA_NOTIFICATION_STARTED',
+  FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED:
+    'FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED',
+  FETCH_DISMISSED_HCA_NOTIFICATION_FAILED:
+    'FETCH_DISMISSED_HCA_NOTIFICATION_FAILED',
+  FETCH_ENROLLMENT_STATUS_STARTED: 'FETCH_ENROLLMENT_STATUS_STARTED',
+  FETCH_ENROLLMENT_STATUS_SUCCEEDED: 'FETCH_ENROLLMENT_STATUS_SUCCEEDED',
+  FETCH_ENROLLMENT_STATUS_FAILED: 'FETCH_ENROLLMENT_STATUS_FAILED',
+  RESET_ENROLLMENT_STATUS: 'RESET_ENROLLMENT_STATUS',
+  SET_DISMISSED_HCA_NOTIFICATION: 'SET_DISMISSED_HCA_NOTIFICATION',
+  SHOW_HCA_REAPPLY_CONTENT: 'SHOW_HCA_REAPPLY_CONTENT',
 };
 
 // declare enrollment status strings


### PR DESCRIPTION
## Description
After a guest user successfully completes the enrollment verification form (ID form), they are taken to the first form page in the Health Care Application. If they choose to navigate back to the ID form page, either with the browser or with the back button on the form page, they are not permitted to resubmit the form without a hard refresh of the page. This PR adds an action to reset the enrollment status data to allow for resubmission of the ID form.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#63165

## Testing done
- [x] Unit tests

## Acceptance criteria
- ID form successfully resets the enrollment status on each render
- ID form can be submitted once data reset has completed
