### PR TITLE
updated word "certify" to "confirm"

### DIFF
--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -8,7 +8,7 @@
   "answer-pre-check-in-questions": "Answer pre-check-in questions",
   "answer-questions": "Answer questions",
   "complete-pre-check-in": "Complete pre-check-in",
-  "answer-yes-if-you-traveled-from-the-address": "Answer “Yes” if you traveled from the address listed here and you certify that it’s not a Post Office box.",
+  "answer-yes-if-you-traveled-from-the-address": "Answer “Yes” if you traveled from the address listed here and you confirm that it’s not a Post Office box.",
   "are-you-claiming-only-mileage-and-no-other": "Are you claiming only mileage and no other expenses today?",
   "ask-a-staff-member": "Ask a staff member.",
   "back-to-last-screen": "Back to last screen",


### PR DESCRIPTION
## Summary

Updates text to be "Answer “Yes” if you traveled from the address listed here and you confirm that it’s not a Post Office box." from "Answer “Yes” if you traveled from the address listed here and you certify that it’s not a Post Office box.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#62840

## Testing done

Visual testing

## Screenshots
![localhost_3001_health-care_appointment-check-in_travel-address](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/2d963152-9b48-4aaa-8aa1-9f95e694fa0e)

## What areas of the site does it impact?
Patient check-in, travel claim.

## Acceptance criteria
Sentence uses the word `confirm` rather than `certify`.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

