### PR TITLE
Updating FE to enforce a 99MB limit on PDF uploads

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -105,7 +105,7 @@ export const VA_FORM4192_URL =
 export const MAX_FILE_SIZE_MB = 50;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
-export const MAX_PDF_FILE_SIZE_MB = 150;
+export const MAX_PDF_FILE_SIZE_MB = 99;
 // binary based
 export const MAX_PDF_FILE_SIZE_BYTES = MAX_PDF_FILE_SIZE_MB * 1024 ** 2;
 

--- a/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
+++ b/src/applications/lgy/coe/form/config/chapters/documents/fileUpload.js
@@ -20,7 +20,7 @@ const DocumentUploadDescription = () => (
     <p>Guidelines for uploading a file:</p>
     <ul>
       <li>You can upload a .pdf, .jpg, .jpeg, or .png file.</li>
-      <li>Your PDF file should be no larger than 150MB.</li>
+      <li>Your PDF file should be no larger than 99MB.</li>
       <li>Non-PDF files should be no larger than 50MB.</li>
     </ul>
     <p>
@@ -108,7 +108,7 @@ export const uiSchema = {
       fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
       hideLabelText: true,
       keepInPageOnReview: true,
-      maxPdfSize: 150 * 1024 * 1024,
+      maxPdfSize: 99 * 1024 * 1024,
       maxSize: 50 * 1024 * 1024,
       minSize: 1024,
       parseResponse: fileInfo => ({


### PR DESCRIPTION
## Summary

To support https://github.com/department-of-veterans-affairs/vets-api/pull/13468 We are decreasing the PDF file upload limit from 150MB to 99MB. This affects the 526 and COE forms. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63166

## Testing done
Prior to change, FE would allow PDF files up to 150 MB to be uploaded. Now when you attempt to upload a PDF in 526 form, system rejects if file size is greater than 99 MB.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing
in 526
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/7817263/069462ec-8139-4fd4-a634-f909aaa6bbc1)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/7817263/8175803f-3aa7-4bde-a92c-5e7f648b4906)

In COE
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/7817263/e8bb9c20-b392-496a-a3bb-800ffcd525a7)



- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
