### PR TITLE
fix: only add margin in section headings

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInfoCard.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoCard.jsx
@@ -74,22 +74,10 @@ export const classes = {
   rowValue,
 };
 
-export const HeadingLevel = ({
-  namedAnchor,
-  children,
-  level,
-  className,
-  hasRowDescription = false,
-}) => {
+export const HeadingLevel = ({ namedAnchor, children, level, className }) => {
   const Header = `h${level}`;
-  const computedClassNames = classNames(
-    {
-      'vads-u-margin-bottom--1': !hasRowDescription,
-    },
-    className,
-  );
   return children ? (
-    <Header className={computedClassNames} id={namedAnchor}>
+    <Header className={className} id={namedAnchor}>
       {children}
     </Header>
   ) : null;
@@ -98,7 +86,6 @@ export const HeadingLevel = ({
 HeadingLevel.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  hasRowDescription: PropTypes.bool,
   level: numberBetween(1, 6),
   namedAnchor: PropTypes.string,
 };
@@ -153,33 +140,38 @@ List.propTypes = {
 const Sections = ({ data, level }) => {
   return (
     <>
-      {data.map((rowData, index) => (
-        <div
-          key={index}
-          className={index === 0 ? classes.firstRow : classes.secondaryRow}
-          id={rowData.id}
-        >
-          {rowData.title && (
-            <>
-              <HeadingLevel
-                className={classes.rowTitle}
-                level={level}
-                hasRowDescription={!!rowData?.description}
-              >
-                {rowData.title}
-                {rowData.alertMessage && <>{rowData.alertMessage}</>}
-              </HeadingLevel>
-              {rowData.description && (
-                <RowDescription description={rowData.description} />
-              )}
-            </>
-          )}
+      {data.map((rowData, index) => {
+        // heading should only have bottom margin when there is no description
+        const rowHeadingClasses = classNames([
+          classes.rowTitle,
+          {
+            'vads-u-margin-bottom--1': !rowData?.description,
+          },
+        ]);
+        return (
+          <div
+            key={index}
+            className={index === 0 ? classes.firstRow : classes.secondaryRow}
+            id={rowData.id}
+          >
+            {rowData.title && (
+              <>
+                <HeadingLevel className={rowHeadingClasses} level={level}>
+                  {rowData.title}
+                  {rowData.alertMessage && <>{rowData.alertMessage}</>}
+                </HeadingLevel>
+                {rowData.description && (
+                  <RowDescription description={rowData.description} />
+                )}
+              </>
+            )}
 
-          {rowData?.value && (
-            <div className={classes.rowValue}>{rowData.value}</div>
-          )}
-        </div>
-      ))}
+            {rowData?.value && (
+              <div className={classes.rowValue}>{rowData.value}</div>
+            )}
+          </div>
+        );
+      })}
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Minor styling issue popped up when updating gender identity description around heading bottom margins on the main heading of a ProfileInfoCard
- Moved conditional logic for adding bottom margin to the card section render loop.
- Part of Authenticated Experience and Profile team will be responsible for maintenance

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/52130

## Testing done

- Tested locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| | ![Screenshot 2023-08-09 at 9 42 55 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/c1e92e92-1491-4add-a8c9-4a8ae0c3046a) | ![Screenshot 2023-08-09 at 9 42 37 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/2c3d8e90-5dce-40de-8ca5-64af78dfa688) |

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Margin removed from card title

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
