### PR TITLE
[FSR] Fix - Adding spread for additional income

### DIFF
--- a/src/applications/financial-status-report/components/householdIncome/SpouseAdditionalIncomeCheckList.jsx
+++ b/src/applications/financial-status-report/components/householdIncome/SpouseAdditionalIncomeCheckList.jsx
@@ -40,6 +40,7 @@ const SpouseAdditionalIncomeCheckList = ({
       ? setFormData({
           ...data,
           additionalIncome: {
+            ...additionalIncome,
             spouse: {
               spAddlIncome: spAddlIncome.filter(
                 source => source.name !== value,


### PR DESCRIPTION
## Summary
Recent update didn't inlclude a spread operator when updating the store so some data was getting lost when unchecking spouse additional income fields. 

## Related issue(s)

- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#24937

## Testing done
Manual testing completed

## Acceptance criteria
- [x] Unchecking values in Spouse additional income checklist no longer removes other values

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
