### PR TITLE
DR | Set up shared area of disagreement code

### DIFF
--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  VaCheckboxGroup,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import cloneDeep from 'platform/utilities/data/cloneDeep';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
+
+import { DISAGREEMENT_TYPES, MAX_LENGTH } from '../constants';
+import {
+  getIssueTitle,
+  issueTitle,
+  content,
+  errorMessages,
+} from '../content/areaOfDisagreement';
+import { calculateOtherMaxLength } from '../utils/areaOfDisagreement';
+
+import { hasAreaOfDisagreementChoice } from '../validations/areaOfDisagreement';
+
+const AreaOfDisagreement = ({
+  data = {},
+  pagePerItemIndex,
+  goBack,
+  goForward,
+  setFormData,
+  contentBeforeButtons,
+  contentAfterButtons,
+  onReviewPage,
+  updatePage,
+}) => {
+  const [checkboxErrorMessage, setCheckboxErrorMessage] = useState(null);
+  const [inputErrorMessage, setInputErrorMessage] = useState(null);
+  const [maxLength, setMaxLength] = useState(MAX_LENGTH.DISAGREEMENT_REASON);
+
+  useEffect(
+    () => {
+      // clear error state between pages
+      setCheckboxErrorMessage(null);
+      setInputErrorMessage(null);
+      if (onReviewPage) {
+        waitForRenderThenFocus(`#disagreement-title-${pagePerItemIndex}`);
+      }
+    },
+    [pagePerItemIndex, onReviewPage],
+  );
+
+  const setMaxError = (disagreement = {}) => {
+    const max = calculateOtherMaxLength(disagreement);
+    const hasError = (disagreement.otherEntry?.length || 0) > max;
+    setMaxLength(max);
+    setInputErrorMessage(hasError ? errorMessages.maxOtherEntry(max) : null);
+    return hasError;
+  };
+
+  const setCheckboxError = (disagreement = {}) => {
+    const hasError = !hasAreaOfDisagreementChoice(disagreement);
+    setCheckboxErrorMessage(
+      hasError ? errorMessages.maxOtherEntry.missingDisagreement : null,
+    );
+    return hasError;
+  };
+
+  const handlers = {
+    onGroupChange: event => {
+      // event.target.name doesn't work on va-checkbox
+      const name = event.target.getAttribute('name');
+      const { checked } = event.detail;
+      if (name && pagePerItemIndex) {
+        const areaOfDisagreement = cloneDeep(data.areaOfDisagreement);
+        const disagreement = areaOfDisagreement[pagePerItemIndex];
+        disagreement.disagreementOptions = {
+          ...(disagreement.disagreementOptions || {}),
+          [name]: checked,
+        };
+
+        setFormData({ ...data, areaOfDisagreement });
+        setMaxError(disagreement);
+        setCheckboxError(disagreement);
+      }
+    },
+    onInput: event => {
+      const { value } = event.target;
+      const areaOfDisagreement = cloneDeep(data.areaOfDisagreement);
+      const disagreement = areaOfDisagreement[pagePerItemIndex];
+      disagreement.otherEntry = value;
+      setFormData({ ...data, areaOfDisagreement });
+      setMaxError(disagreement);
+      setCheckboxError(disagreement);
+    },
+    onSubmit: () => {
+      const disagreement = data.areaOfDisagreement?.[pagePerItemIndex];
+      if (setMaxError(disagreement)) {
+        // clear no reason error
+        setCheckboxErrorMessage(null);
+      } else if (!setCheckboxError(disagreement)) {
+        return goForward(data);
+      }
+      return false;
+    },
+    updatePage: () => {
+      waitForRenderThenFocus(
+        `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form .edit-btn`,
+      );
+      updatePage();
+    },
+  };
+
+  const disagreements = data.areaOfDisagreement?.[pagePerItemIndex] || {};
+  const options = disagreements?.disagreementOptions || {};
+  const titlePlainText = getIssueTitle(disagreements, { plainText: true });
+
+  return (
+    <form onSubmit={handlers.onSubmit}>
+      {issueTitle({ data: disagreements, onReviewPage })}
+
+      <VaCheckboxGroup
+        label={content.disagreementLegend}
+        hint={content.disagreementHint}
+        onVaChange={handlers.onGroupChange}
+        error={checkboxErrorMessage}
+        required
+      >
+        {Object.entries(DISAGREEMENT_TYPES).map(
+          ([key, label]) =>
+            key === 'otherEntry' ? null : (
+              <va-checkbox
+                key={key}
+                name={key}
+                label={label}
+                checked={options[key]}
+                message-aria-describedby={titlePlainText}
+              />
+            ),
+        )}
+        <VaTextInput
+          label={DISAGREEMENT_TYPES.otherEntry}
+          hint={content.otherEntryHint}
+          name="otherEntry"
+          error={inputErrorMessage}
+          onInput={handlers.onInput}
+          value={disagreements.otherEntry}
+          maxlength={maxLength}
+        />
+      </VaCheckboxGroup>
+
+      {onReviewPage ? (
+        <va-button text={content.update} onClick={handlers.updatePage} />
+      ) : (
+        <div className="vads-u-margin-top--4">
+          {contentBeforeButtons}
+          <FormNavButtons goBack={goBack} goForward={handlers.onSubmit} />
+          {contentAfterButtons}
+        </div>
+      )}
+    </form>
+  );
+};
+
+AreaOfDisagreement.propTypes = {
+  contentAfterButtons: PropTypes.element,
+  contentBeforeButtons: PropTypes.element,
+  data: PropTypes.shape({
+    limitedConsent: PropTypes.string,
+    providerFacility: PropTypes.array,
+  }),
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  goToPath: PropTypes.func,
+  pagePerItemIndex: PropTypes.number,
+  setFormData: PropTypes.func,
+  updatePage: PropTypes.func,
+  onReviewPage: PropTypes.bool,
+};
+
+export default AreaOfDisagreement;

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -1,0 +1,107 @@
+/**
+ **** KEYS ****
+ */
+// key for contestableIssues to indicate that the user selected the issue
+export const SELECTED = 'view:selected';
+
+/**
+ **** INTERNAL FORM URL PATHS ****
+ */
+export const CONTACT_INFO = '/contact-information';
+
+/**
+ **** URL PATHS ****
+ */
+export const DR_URL = '/decision-reviews';
+export const CONTESTED_CLAIMS_URL = `${DR_URL}/contested-claims`;
+export const GET_HELP_REVIEW_REQUEST_URL = `${DR_URL}/get-help-with-review-request`;
+
+export const SC_INFO_URL = `${DR_URL}/supplemental-claim`;
+export const SC_BASE_URL = `${SC_INFO_URL}/file-supplemental-claim-form-20-0995`;
+export const SC_OTHER_WAYS_URL = `${SC_INFO_URL}#file-by-mail-in-person-or-with`;
+export const SC_FORM_URL =
+  'https://www.vba.va.gov/pubs/forms/VBA-20-0995-ARE.pdf';
+
+export const HLR_INFO_URL = `${DR_URL}/higher-level-review`;
+export const HLR_BASE_URL = `${HLR_INFO_URL}/request-higher-level-review-form-20-0996`;
+// 8622 is the ID of the <va-accordion-item> with a header of the "Find
+// addresses for other benefit types"
+export const HLR_OTHER_WAYS_URL = `${HLR_INFO_URL}#find-addresses-for-other-benef-8622`;
+export const HLR_FORM_URL =
+  'https://www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf';
+
+export const NOD_INFO_URL = `${DR_URL}/board-appeal`;
+export const NOD_BASE_URL = `${NOD_INFO_URL}/request-board-appeal-form-10182`;
+export const NOD_OTHER_WAYS_URL = `${NOD_INFO_URL}#you-can-also-request-a-board-a`;
+export const NOD_FORM_URL = 'https://www.va.gov/vaforms/va/pdf/VA10182.pdf';
+
+export const CLAIM_STATUS_TOOL_URL = '/claim-or-appeal-status';
+
+export const COVID_FAQ_URL =
+  'https://www.va.gov/coronavirus-veteran-frequently-asked-questions/#more-benefit-and-claim-questio';
+
+export const FACILITY_LOCATOR_URL = '/find-locations';
+export const PROFILE_URL = '/profile';
+
+export const REVIEW_AND_SUBMIT = '/review-and-submit';
+
+/**
+ **** DATES ****
+ */
+// contested issue dates
+export const FORMAT_YMD = 'YYYY-MM-DD';
+export const FORMAT_READABLE = 'LL';
+export const FORMAT_COMPACT = 'MMM DD, YYYY';
+
+// Limit past decision dates to 100 years until told otherwise
+export const MAX_YEARS_PAST = 100;
+
+export const AMA_DATE = '2019-02-19'; // Appeals Modernization Act in effect
+
+/**
+ **** UPLOADS ****
+ */
+export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
+
+export const MAX_FILE_SIZE_MB = 100;
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
+
+/**
+ **** MAX LENGTH ****
+ */
+
+// Values from Lighthouse maintained schema v1
+// see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v1/10182.json
+export const MAX_LENGTH = {
+  SELECTIONS: 100, // submitted issues
+  DISAGREEMENT_REASON: 90,
+};
+
+/**
+ **** REGULAR EXPRESSIONS ****
+ */
+export const REGEXP = {
+  WHITESPACE: /\s/g,
+  APOSTROPHE: /\u2019/g,
+  PERCENT: /(\s|\b)percent(\s|\b)/gi,
+};
+
+/**
+ **** AREA OF DISAGREEMENTS ****
+ */
+export const DISAGREEMENT_TYPES = {
+  serviceConnection: 'The service connection',
+  effectiveDate: 'The effective date of award',
+  evaluation: 'Your evaluation of my condition',
+  otherEntry: 'Something else:',
+};
+
+// Using MAX_LENGTH.DISAGREEMENT_REASON (90) and with all checkboxes selected,
+// this string is submitted - the numbers constitute the "something else" typed
+// in value
+// "service connection,effective date,disability evaluation,1234567890123456789012345678901234"
+export const SUBMITTED_DISAGREEMENTS = {
+  serviceConnection: 'service connection',
+  effectiveDate: 'effective date',
+  evaluation: 'disability evaluation',
+};

--- a/src/applications/appeals/shared/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/content/areaOfDisagreement.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import moment from 'moment';
+
+import { getIssueName, getIssueDate } from '../utils/issues';
+import { FORMAT_YMD, FORMAT_READABLE, DISAGREEMENT_TYPES } from '../constants';
+
+export const errorMessages = {
+  maxOtherEntry: max => `This field should be less than ${max} characters`,
+  missingDisagreement: 'Choose or enter a reason for disagreement',
+};
+
+export const content = {
+  disagreementLegend:
+    'Tell us what you disagree with. You can choose more than one.',
+  disagreementHint: 'I disagree with this:',
+  otherEntryHint: 'Explain in a few words',
+  edit: 'Edit',
+  update: 'Update page',
+};
+
+/**
+ * Title for review & submit page, text string returned
+ * @param {*} data - item data (contestable issue or added issue)
+ * @param {object} formContext - overloaded formContext
+ * @returns {String} - ObjectField error if not a string
+ */
+export const getIssueTitle = (data = {}, { plainText } = {}) => {
+  const prefix = 'Disagreement with ';
+  const joiner = ' decision on ';
+  const name = getIssueName(data);
+  const date = moment(getIssueDate(data) || undefined, FORMAT_YMD);
+  const formattedDate = date.isValid() ? date.format(FORMAT_READABLE) : '';
+
+  return plainText === true ? (
+    [prefix, name, joiner, formattedDate].join('')
+  ) : (
+    <>
+      {prefix}
+      <span className="dd-privacy-hidden">{name}</span>
+      {joiner}
+      <span className="dd-privacy-hidden">{formattedDate}</span>
+    </>
+  );
+};
+
+// This is used in the `ui:title`, but doesn't get called because we're using a
+// CustomPage
+export const issueTitle = (props = {}) => {
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/27096
+  const Header = props.onReviewPage ? 'h4' : 'h3';
+  const index = props.data?.index || '0';
+  return (
+    <Header
+      id={`disagreement-title-${index}`}
+      className="vads-u-margin-top--0 schemaform-title-underline"
+    >
+      {getIssueTitle(props.data)}
+    </Header>
+  );
+};
+
+// Only show set values (ignore false & undefined)
+export const AreaOfDisagreementReviewField = ({ children }) => {
+  const { formData, name } = children?.props || {};
+  return formData ? (
+    <div className="review-row">
+      <dt>{DISAGREEMENT_TYPES[name]}</dt>
+      <dd className={name === 'otherEntry' ? 'dd-privacy-hidden' : ''}>
+        {children}
+      </dd>
+    </div>
+  ) : null;
+};

--- a/src/applications/appeals/shared/content/contactInfo.js
+++ b/src/applications/appeals/shared/content/contactInfo.js
@@ -1,0 +1,6 @@
+export const errorMessages = {
+  missingEmail: 'Add an email address to your profile',
+  missingHomePhone: 'Add a home phone number to your profile',
+  missingMobilePhone: 'Add a mobile phone number to your profile',
+  missingMailingAddress: 'Add a mailing address to your profile',
+};

--- a/src/applications/appeals/shared/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/shared/pages/areaOfDisagreement.js
@@ -1,0 +1,97 @@
+import {
+  issueTitle,
+  content,
+  errorMessages,
+  AreaOfDisagreementReviewField,
+} from '../content/areaOfDisagreement';
+import { areaOfDisagreementRequired } from '../validations/areaOfDisagreement';
+import { calculateOtherMaxLength } from '../utils/areaOfDisagreement';
+import {
+  MAX_LENGTH,
+  DISAGREEMENT_TYPES,
+  SUBMITTED_DISAGREEMENTS,
+} from '../constants';
+
+// add 1 for last comma
+const allDisagreementsLength =
+  Object.values(SUBMITTED_DISAGREEMENTS).join(',').length + 1;
+
+export default {
+  uiSchema: {
+    areaOfDisagreement: {
+      items: {
+        'ui:title': issueTitle,
+        'ui:required': () => true,
+        'ui:validations': [areaOfDisagreementRequired],
+        'ui:errorMessages': {
+          required: errorMessages.missingDisagreement,
+        },
+        // Not used by CustomPage, kept here for review & submit page render
+        disagreementOptions: {
+          'ui:title': content.disagreementLegend,
+          'ui:description': content.disagreementHint,
+          serviceConnection: {
+            'ui:title': DISAGREEMENT_TYPES.serviceConnection,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+          effectiveDate: {
+            'ui:title': DISAGREEMENT_TYPES.effectiveDate,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+          evaluation: {
+            'ui:title': DISAGREEMENT_TYPES.evaluation,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+        },
+        otherEntry: {
+          'ui:title': DISAGREEMENT_TYPES.otherEntry,
+          'ui:reviewField': AreaOfDisagreementReviewField,
+          'ui:description': content.otherEntryHint,
+          'ui:options': {
+            updateSchema: (formData, _schema, _uiSchema, index) => ({
+              type: 'string',
+              maxLength: calculateOtherMaxLength(
+                formData.areaOfDisagreement[index],
+              ),
+            }),
+          },
+        },
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {
+      areaOfDisagreement: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            disagreementOptions: {
+              type: 'object',
+              properties: {
+                serviceConnection: {
+                  type: 'boolean',
+                },
+                effectiveDate: {
+                  type: 'boolean',
+                },
+                evaluation: {
+                  type: 'boolean',
+                },
+              },
+            },
+            otherEntry: {
+              type: 'string',
+              // disagreementArea limited to 90 chars max
+              maxLength:
+                MAX_LENGTH.DISAGREEMENT_REASON - allDisagreementsLength,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/appeals/shared/sass/appeals.scss
+++ b/src/applications/appeals/shared/sass/appeals.scss
@@ -1,0 +1,5 @@
+
+/* area of disagreement input error removes top margin */
+va-checkbox-group va-text-input[error]::part(label) {
+  margin-top: 3rem;
+}

--- a/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import AreaOfDisagreement from '../../components/AreaOfDisagreement';
+import { SELECTED, DISAGREEMENT_TYPES } from '../../constants';
+
+describe('<AreaOfDisagreement>', () => {
+  const aod1 = {
+    issue: 'right arm',
+    decisionDate: '2021-6-7',
+    [SELECTED]: true,
+    disagreementOptions: {},
+    otherEntry: '',
+  };
+  const aod2 = {
+    issue: 'left arm',
+    decisionDate: '2022-7-8',
+    [SELECTED]: true,
+    disagreementOptions: {},
+    otherEntry: '',
+  };
+  const getData = ({
+    data = [aod1, aod2],
+    pagePerItemIndex = 0,
+    goBack = () => {},
+    goForward = () => {},
+    setFormData = () => {},
+    contentBeforeButtons = <div>before</div>,
+    contentAfterButtons = <div>after</div>,
+    onReviewPage = false,
+    updatePage = () => {},
+  } = {}) => ({
+    data: { areaOfDisagreement: data },
+    pagePerItemIndex,
+    goBack,
+    goForward,
+    setFormData,
+    contentBeforeButtons,
+    contentAfterButtons,
+    onReviewPage,
+    updatePage,
+  });
+
+  it('should render', () => {
+    const data = getData();
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    expect($('h3', container).textContent).to.contain(
+      'Disagreement with right arm decision on June 7, 2021',
+    );
+    expect($('va-checkbox-group', container)).to.exist;
+
+    // RTL doesn't handle shadow dom
+    const html = container.innerHTML;
+    Object.keys(DISAGREEMENT_TYPES).forEach(type => {
+      if (type === 'otherEntry') {
+        expect(html).to.contain('va-text-input');
+      } else {
+        expect(html).to.contain(`va-checkbox name="${type}"`);
+      }
+    });
+  });
+
+  it('should submit with only checkboxes set', () => {
+    const goSpy = sinon.spy();
+    const aod = {
+      ...aod1,
+      disagreementOptions: {
+        serviceConnection: true,
+      },
+    };
+    const data = getData({ goForward: goSpy, data: [aod] });
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    fireEvent.click($('button.usa-button-primary', container));
+    expect(goSpy.called).to.be.true;
+  });
+
+  it('should submit with only text input set', () => {
+    const goSpy = sinon.spy();
+    const aod = {
+      ...aod2,
+      otherEntry: 'something',
+    };
+    const data = getData({ goForward: goSpy, data: [aod] });
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    fireEvent.click($('button.usa-button-primary', container));
+    expect(goSpy.called).to.be.true;
+  });
+
+  it('should submit with both checkboxes and text input set', () => {
+    const goSpy = sinon.spy();
+    const aod = {
+      ...aod2,
+      disagreementOptions: {
+        serviceConnection: true,
+        effectiveDate: true,
+        evaluation: true,
+      },
+      otherEntry: 'something',
+    };
+    const data = getData({ goForward: goSpy, data: [aod] });
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    fireEvent.click($('button.usa-button-primary', container));
+    expect(goSpy.called).to.be.true;
+  });
+
+  it('should not submit page when nothing is checked or input is empty', () => {
+    const goSpy = sinon.spy();
+    const data = getData({ goForward: goSpy });
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    fireEvent.click($('button.usa-button-primary', container));
+    expect(goSpy.called).to.be.false;
+  });
+
+  it('should not submit page when text input is too long', () => {
+    const goSpy = sinon.spy();
+    const aod = {
+      ...aod1,
+      disagreementOptions: {
+        serviceConnection: true,
+        effectiveDate: true,
+        evaluation: true,
+      },
+      otherEntry: 'something'.repeat(10),
+    };
+    const data = getData({ goForward: goSpy, data: [aod] });
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    fireEvent.click($('button.usa-button-primary', container));
+    expect(goSpy.called).to.be.false;
+  });
+});

--- a/src/applications/appeals/shared/tests/components/NeedsTpVerify.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/NeedsTpVerify.unit.spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import NeedsToVerify from '../../components/NeedsToVerify';
+
+describe('<NeedsToVerify>', () => {
+  const heading =
+    'You’ll need to verify your identity to access more VA.gov tools and features';
+  const setup = ({ pathname = '/introduction' } = {}) => {
+    return (
+      <div>
+        <NeedsToVerify pathname={pathname} />
+      </div>
+    );
+  };
+  it('should render', () => {
+    const { container } = render(setup());
+    expect($('va-alert', container)).to.exist;
+    expect($('h2', container).textContent).to.eq(heading);
+  });
+
+  it('should capture google analytics', async () => {
+    global.window.dataLayer = [];
+    render(setup());
+
+    await waitFor(() => {
+      const event = global.window.dataLayer.slice(-1)[0];
+      expect(event).to.deep.equal({
+        event: 'visible-alert-box',
+        'alert-box-type': 'continue',
+        'alert-box-heading': heading,
+        'error-key': 'not_verified',
+        'alert-box-full-width': false,
+        'alert-box-background-only': false,
+        'alert-box-closeable': false,
+        'reason-for-alert': `Not verified`,
+      });
+    });
+  });
+});

--- a/src/applications/appeals/shared/tests/content/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/content/areaOfDisagreement.unit.spec.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+
+import {
+  getIssueTitle,
+  issueTitle,
+  AreaOfDisagreementReviewField,
+} from '../../content/areaOfDisagreement';
+
+describe('getIssueTitle', () => {
+  const data = { issue: 'left arm', decisionDate: '2022-02-02' };
+  it('should return title content', () => {
+    const { container } = render(<div>{getIssueTitle(data)}</div>);
+
+    expect($('div', container).textContent).to.eq(
+      'Disagreement with left arm decision on February 2, 2022',
+    );
+    expect($$('.dd-privacy-hidden', container).length).to.eq(2);
+  });
+  it('should return a plain string', () => {
+    const result = getIssueTitle(data, { plainText: true });
+    expect(result).to.eq(
+      'Disagreement with left arm decision on February 2, 2022',
+    );
+  });
+  it('should not render a date if it is invalid', () => {
+    const { container } = render(
+      <div>{getIssueTitle({ issue: 'foo', decisionDate: 'abcd' })}</div>,
+    );
+
+    expect($('div', container).textContent).to.eq(
+      'Disagreement with foo decision on ',
+    );
+  });
+  it('should not throw an error if no data is passed in', () => {
+    const { container } = render(<div>{getIssueTitle()}</div>);
+
+    expect($('div', container)).to.exist;
+  });
+});
+
+describe('issueTitle', () => {
+  it('should return title wrapped in an h3', () => {
+    const data = {
+      data: {
+        issue: 'right arm',
+        decisionDate: '2023-03-03',
+        index: 1,
+      },
+      onReviewPage: false,
+    };
+    const { container } = render(<div>{issueTitle(data)}</div>);
+
+    const header = $('h3', container);
+    expect(header.id).to.eq('disagreement-title-1');
+    expect(header.textContent).to.eq(
+      'Disagreement with right arm decision on March 3, 2023',
+    );
+  });
+  it('should return title wrapped in an h4', () => {
+    const data = {
+      data: {
+        issue: 'right arm',
+        decisionDate: '2023-04-04',
+        index: 2,
+      },
+      onReviewPage: true,
+    };
+    const { container } = render(<div>{issueTitle(data)}</div>);
+
+    const header = $('h4', container);
+    expect(header.id).to.eq('disagreement-title-2');
+    expect(header.textContent).to.eq(
+      'Disagreement with right arm decision on April 4, 2023',
+    );
+  });
+});
+
+describe('AreaOfDisagreementReviewField', () => {
+  it('should render AreaOfDisagreementReviewField', () => {
+    const title = 'Your evaluation of my condition';
+    const { container } = render(
+      <AreaOfDisagreementReviewField>
+        {React.createElement(
+          'div',
+          {
+            id: 'foo',
+            name: 'evaluation',
+            formData: {},
+          },
+          'Bar',
+        )}
+      </AreaOfDisagreementReviewField>,
+    );
+    expect($('dt', container).textContent).to.equal(title);
+    expect($('dd', container).textContent).to.equal('Bar');
+    expect($$('dd.dd-privacy-hidden', container).length).to.equal(0);
+  });
+
+  it('should render AreaOfDisagreementReviewField with hidden Datadog class', () => {
+    const title = 'Something else:';
+    const { container } = render(
+      <AreaOfDisagreementReviewField>
+        {React.createElement(
+          'div',
+          {
+            id: 'foo',
+            name: 'otherEntry',
+            formData: {},
+          },
+          'Bar',
+        )}
+      </AreaOfDisagreementReviewField>,
+    );
+    expect($('dt', container).textContent).to.equal(title);
+    expect($('dd.dd-privacy-hidden', container).textContent).to.equal('Bar');
+  });
+});

--- a/src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+
+import formConfig from '../../../10182/config/form';
+
+describe('area of disagreement page', () => {
+  const {
+    schema,
+    uiSchema,
+    arrayPath,
+  } = formConfig.chapters.conditions.pages.areaOfDisagreementFollowUp;
+
+  it('should render', () => {
+    const { container } = render(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          areaOfDisagreement: [
+            {
+              issue: 'blah',
+              decisionDate: '2022-02-02',
+            },
+            {
+              attributes: {
+                ratingIssueSubjectText: 'Tinnitus',
+                approxDecisionDate: '2021-01-01',
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    // This is rendering the uiSchema, so no CustomPage components
+    const header = $('h3', container);
+    expect(header.id).to.contain('disagreement-title-');
+    // issueTitle isn't called with form data, so we check the static text
+    expect(header.textContent).to.contain('Disagreement with');
+    expect(header.textContent).to.contain('decision on');
+    expect($('h3 .dd-privacy-hidden', container)).to.exist;
+  });
+});

--- a/src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -41,7 +41,7 @@ describe('area of disagreement page', () => {
 
     // This is rendering the uiSchema, so no CustomPage components
     const header = $('h3', container);
-    expect(header.id).to.contain('disagreement-title-');
+    expect(header.id).to.contain('disagreement-title');
     // issueTitle isn't called with form data, so we check the static text
     expect(header.textContent).to.contain('Disagreement with');
     expect(header.textContent).to.contain('decision on');

--- a/src/applications/appeals/shared/tests/utils/areaOfDisagreement.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/areaOfDisagreement.unit.spec.js
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+
+import {
+  copyAreaOfDisagreementOptions,
+  calculateOtherMaxLength,
+} from '../../utils/areaOfDisagreement';
+import { SUBMITTED_DISAGREEMENTS, MAX_LENGTH } from '../../constants';
+
+describe('copyAreaOfDisagreementOptions', () => {
+  it('should return original issues only', () => {
+    const result = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(copyAreaOfDisagreementOptions(result, [])).to.deep.equal(result);
+  });
+  it('should return additional issue with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      { issue: 'test', disagreementOptions: { test: true } },
+    ];
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: '' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal(result);
+  });
+  it('should return eligible issues with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      {
+        attributes: { ratingIssueSubjectText: 'test2' },
+        disagreementOptions: { test: true },
+        otherEntry: 'ok',
+      },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal([newIssues[0], existingIssues[0]]);
+  });
+
+  it('should return disagreement options & other entry', () => {
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: 'ok' },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions([{ issue: 'test' }], result),
+    ).to.deep.equal(result);
+  });
+});
+
+describe('calculateOtherMaxLength', () => {
+  const keys = Object.keys(SUBMITTED_DISAGREEMENTS);
+  const values = Object.values(SUBMITTED_DISAGREEMENTS);
+  const getData = settings => {
+    const disagreementOptions = keys.reduce((finalOptions, key, index) => {
+      if (settings[index]) {
+        return { ...finalOptions, [key]: true };
+      }
+      return finalOptions;
+    }, {});
+    return { disagreementOptions };
+  };
+  const calcLength = settings => {
+    const string = values.filter((value, index) => settings[index]).join(',');
+    // add 1 to string length for the final comma
+    return MAX_LENGTH.DISAGREEMENT_REASON - (string.length + 1);
+  };
+  it('should return max length when nothing is selected', () => {
+    expect(calculateOtherMaxLength(getData([]))).to.eq(
+      MAX_LENGTH.DISAGREEMENT_REASON,
+    );
+  });
+  it('should return appropriate length with 1 selection', () => {
+    const data = [true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 2 selections', () => {
+    const data = [true, false, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 2 different selections', () => {
+    const data = [false, true, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 3 selections', () => {
+    const data = [true, true, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+});

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import { FORMAT_YMD, FORMAT_READABLE } from '../../constants';
+import { getDate } from '../../utils/dates';
+
+describe('getDate', () => {
+  const dateString = '2021-02-10 00:00:00';
+  const date = new Date(dateString);
+
+  it('should return a date string from date object', () => {
+    expect(getDate()).to.equal(moment().format(FORMAT_YMD));
+  });
+  it('should return a date string from date string & offset', () => {
+    expect(getDate({ date, offset: { days: 3 } })).to.contain('2021-02-13');
+  });
+  it('should return a date string pattern based on date & offset', () => {
+    expect(getDate({ date, offset: { years: -1 } })).to.contain('2020-02-10');
+    expect(
+      getDate({
+        date,
+        offset: { years: -1 },
+        pattern: FORMAT_READABLE,
+      }),
+    ).to.contain('February 10, 2020');
+    expect(
+      getDate({ date: '2021-02-10 00:00:00', pattern: FORMAT_READABLE }),
+    ).to.contain('February 10, 2021');
+  });
+});

--- a/src/applications/appeals/shared/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/helpers.unit.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+
+import { isEmptyObject, getItemSchema } from '../../utils/helpers';
+
+describe('isEmptyObject', () => {
+  it('should return true for an empty object', () => {
+    expect(isEmptyObject({})).to.be.true;
+  });
+  it('should return true for non objects or filled objects', () => {
+    expect(isEmptyObject()).to.be.false;
+    expect(isEmptyObject('')).to.be.false;
+    expect(isEmptyObject([])).to.be.false;
+    expect(isEmptyObject('test')).to.be.false;
+    expect(isEmptyObject(null)).to.be.false;
+    expect(isEmptyObject(true)).to.be.false;
+    expect(isEmptyObject(() => {})).to.be.false;
+    expect(isEmptyObject({ test: '' })).to.be.false;
+  });
+});
+
+describe('getItemSchema', () => {
+  const schema = {
+    items: [{ a: 1 }, { a: 2 }, { a: 3 }],
+    additionalItems: { b: 1 },
+  };
+  it('should return indexed iItems', () => {
+    expect(getItemSchema(schema, 0)).to.deep.equal({ a: 1 });
+    expect(getItemSchema(schema, 1)).to.deep.equal({ a: 2 });
+    expect(getItemSchema(schema, 2)).to.deep.equal({ a: 3 });
+  });
+  it('should return additionalItems', () => {
+    expect(getItemSchema(schema, 3)).to.deep.equal({ b: 1 });
+  });
+});

--- a/src/applications/appeals/shared/tests/utils/issues.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/issues.unit.spec.js
@@ -1,0 +1,294 @@
+import { expect } from 'chai';
+
+import { SELECTED } from '../../constants';
+import {
+  getIssueName,
+  getIssueDate,
+  getIssueNameAndDate,
+  someSelected,
+  hasSomeSelected,
+  getSelected,
+  getSelectedCount,
+  hasDuplicates,
+  processContestableIssues,
+  calculateIndexOffset,
+  issuesNeedUpdating,
+  appStateSelector,
+} from '../../utils/issues';
+
+describe('getIssueName', () => {
+  it('should return undefined', () => {
+    expect(getIssueName()).to.be.undefined;
+  });
+  it('should return a contestable issue name', () => {
+    expect(
+      getIssueName({ attributes: { ratingIssueSubjectText: 'test' } }),
+    ).to.eq('test');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('getIssueDate', () => {
+  it('should return undefined', () => {
+    expect(getIssueDate()).to.eq('');
+  });
+  it('should return a contestable issue date', () => {
+    expect(
+      getIssueDate({ attributes: { approxDecisionDate: '2021-01-01' } }),
+    ).to.eq('2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueDate({ decisionDate: '2021-02-01' })).to.eq('2021-02-01');
+  });
+});
+
+describe('getIssueNameAndDate', () => {
+  it('should return empty string', () => {
+    expect(getIssueNameAndDate()).to.equal('');
+  });
+  it('should return a contestable issue name', () => {
+    expect(
+      getIssueNameAndDate({
+        attributes: {
+          ratingIssueSubjectText: 'test',
+          approxDecisionDate: '2021-01-01',
+        },
+      }),
+    ).to.eq('test2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(
+      getIssueNameAndDate({ issue: 'test2', decisionDate: '2021-02-02' }),
+    ).to.eq('test22021-02-02');
+  });
+});
+
+describe('someSelected', () => {
+  it('should return true for issues that have some selected values', () => {
+    expect(someSelected([{ [SELECTED]: true }, {}])).to.be.true;
+    expect(someSelected([{}, { [SELECTED]: true }, {}])).to.be.true;
+    expect(someSelected([{}, {}, {}, { [SELECTED]: true }])).to.be.true;
+  });
+  it('should return false for issues with no selected values', () => {
+    expect(someSelected()).to.be.false;
+    expect(someSelected([])).to.be.false;
+    expect(someSelected([{}, {}])).to.be.false;
+    expect(someSelected([{}, { [SELECTED]: false }, {}])).to.be.false;
+    expect(someSelected([{}, {}, {}, { [SELECTED]: false }])).to.be.false;
+  });
+});
+
+describe('hasSomeSelected', () => {
+  const testIssues = (contestedIssues, additionalIssues) =>
+    hasSomeSelected({ contestedIssues, additionalIssues });
+  it('should return true for issues that have some selected values', () => {
+    expect(testIssues([{ [SELECTED]: true }], [{}])).to.be.true;
+    expect(testIssues([{}], [{ [SELECTED]: true }, {}])).to.be.true;
+    expect(testIssues([{}], [{}, {}, { [SELECTED]: true }])).to.be.true;
+    expect(
+      testIssues([{}, { [SELECTED]: true }], [{}, {}, { [SELECTED]: true }]),
+    ).to.be.true;
+  });
+  it('should return false for no selected issues', () => {
+    expect(testIssues()).to.be.false;
+    expect(testIssues([], [])).to.be.false;
+    expect(testIssues([{}], [{}])).to.be.false;
+    expect(testIssues([{ [SELECTED]: false }], [{}])).to.be.false;
+    expect(testIssues([{}], [{ [SELECTED]: false }, {}])).to.be.false;
+    expect(testIssues([{}], [{}, {}, { [SELECTED]: false }])).to.be.false;
+    expect(
+      testIssues([{}, { [SELECTED]: false }], [{}, {}, { [SELECTED]: false }]),
+    ).to.be.false;
+  });
+});
+
+describe('getSelected & getSelectedCount', () => {
+  it('should return selected contestable issues', () => {
+    const data = {
+      contestedIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
+  });
+  it('should return selected additional issues', () => {
+    const data = {
+      additionalIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
+  });
+  it('should return all selected issues', () => {
+    const data = {
+      contestedIssues: [
+        { type: 'no1', [SELECTED]: false },
+        { type: 'ok1', [SELECTED]: true },
+      ],
+      additionalIssues: [
+        { type: 'no2', [SELECTED]: false },
+        { type: 'ok2', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok1', [SELECTED]: true, index: 0 },
+      { type: 'ok2', [SELECTED]: true, index: 1 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(2);
+  });
+});
+
+describe('hasDuplicates', () => {
+  const contestedIssues = [
+    {
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: '2021-01-01',
+      },
+    },
+  ];
+
+  it('should be false with no duplicate additional issues', () => {
+    const result = hasDuplicates();
+    expect(result).to.be.false;
+  });
+  it('should be false when there are duplicate contestable issues', () => {
+    const result = hasDuplicates({
+      contestedIssues: [contestedIssues[0], contestedIssues[0]],
+    });
+    expect(result).to.be.false;
+  });
+  it('should be false when there are no duplicate issues (only date differs)', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-02' }],
+    });
+    expect(result).to.be.false;
+  });
+  it('should be true when there is a duplicate additional issue', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-01' }],
+    });
+    expect(result).to.be.true;
+  });
+  it('should be true when there is are multiple duplicate additional issues', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [
+        { issue: 'test2', decisionDate: '2021-02-01' },
+        { issue: 'test2', decisionDate: '2021-02-01' },
+      ],
+    });
+    expect(result).to.be.true;
+  });
+});
+
+describe('processContestableIssues', () => {
+  const getIssues = dates =>
+    dates.map(date => ({
+      attributes: { ratingIssueSubjectText: 'a', approxDecisionDate: date },
+    }));
+  const getDates = dates =>
+    dates.map(date => date.attributes.approxDecisionDate);
+
+  it('should return an empty array with undefined issues', () => {
+    expect(getDates(processContestableIssues())).to.deep.equal([]);
+  });
+  it('should filter out issues missing a title', () => {
+    const issues = getIssues(['2020-02-01', '2020-03-01', '2020-01-01']);
+    issues[0].attributes.ratingIssueSubjectText = '';
+    const result = processContestableIssues(issues);
+    expect(getDates(result)).to.deep.equal(['2020-03-01', '2020-01-01']);
+  });
+  it('should sort issues spanning months with newest date first', () => {
+    const dates = ['2020-02-01', '2020-03-01', '2020-01-01'];
+    const result = processContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2020-03-01',
+      '2020-02-01',
+      '2020-01-01',
+    ]);
+  });
+  it('should sort issues spanning a year & months with newest date first', () => {
+    const dates = ['2021-01-31', '2020-12-01', '2021-02-02', '2021-02-01'];
+    const result = processContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2021-02-02',
+      '2021-02-01',
+      '2021-01-31',
+      '2020-12-01',
+    ]);
+  });
+});
+
+describe('calculateIndexOffset', () => {
+  it('should return an offset value', () => {
+    expect(calculateIndexOffset(2, 2)).to.eq(0);
+    expect(calculateIndexOffset(4, 2)).to.eq(2);
+    expect(calculateIndexOffset(5, 4)).to.eq(1);
+  });
+});
+
+describe('issuesNeedUpdating', () => {
+  const createEntry = (ratingIssueSubjectText, approxDecisionDate) => ({
+    attributes: {
+      ratingIssueSubjectText,
+      approxDecisionDate,
+    },
+  });
+  it('should return true if array lengths are different', () => {
+    expect(issuesNeedUpdating([], [''])).to.be.true;
+    expect(issuesNeedUpdating([''], ['', ''])).to.be.true;
+  });
+  it('should return true if content is different', () => {
+    expect(
+      issuesNeedUpdating(
+        [createEntry('test', '123'), createEntry('test2', '345')],
+        [createEntry('test', '123'), createEntry('test2', '346')],
+      ),
+    ).to.be.true;
+    expect(
+      issuesNeedUpdating(
+        [createEntry('test', '123'), createEntry('test3', '345')],
+        [createEntry('test', '123'), createEntry('test', '345')],
+      ),
+    ).to.be.true;
+  });
+  it('should return true if arrays are the same', () => {
+    expect(
+      issuesNeedUpdating(
+        [createEntry('test', '123'), createEntry('test2', '345')],
+        [createEntry('test', '123'), createEntry('test2', '345')],
+      ),
+    ).to.be.false;
+  });
+});
+
+describe('appStateSelector', () => {
+  const getIssues = (contestedIssues, additionalIssues) => ({
+    state: { form: { data: { contestedIssues, additionalIssues } } },
+    result: { contestedIssues, additionalIssues },
+  });
+  it('should return empty array if data is undefined', () => {
+    expect(appStateSelector({})).to.deep.equal(getIssues([], []).result);
+  });
+  it('should pull issues from state', () => {
+    const data1 = getIssues([], [1, 2, 3]);
+    expect(appStateSelector(data1.state)).to.deep.equal(data1.result);
+    const data2 = getIssues([1, 2, 3], []);
+    expect(appStateSelector(data2.state)).to.deep.equal(data2.result);
+    const data3 = getIssues([1, 2], [3, 4, 5]);
+    expect(appStateSelector(data3.state)).to.deep.equal(data3.result);
+  });
+});

--- a/src/applications/appeals/shared/tests/utils/replace.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/replace.unit.spec.js
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+
+import {
+  replaceDescriptionContent,
+  replaceSubmittedData,
+  fixDateFormat,
+} from '../../../10182/utils/replace';
+
+describe('replaceDescriptionContent', () => {
+  it('should return an empty string', () => {
+    expect(replaceDescriptionContent()).to.eq('');
+    expect(replaceDescriptionContent(null)).to.eq('');
+    expect(replaceDescriptionContent('')).to.eq('');
+  });
+  it('should not alter an these strings', () => {
+    expect(replaceDescriptionContent('   ')).to.eq('   ');
+    expect(replaceDescriptionContent('abc 123')).to.eq('abc 123');
+  });
+  it('should replace percent with a % symbol', () => {
+    expect(replaceDescriptionContent('10 percent')).to.eq('10%');
+    expect(replaceDescriptionContent('10 percent.')).to.eq('10%.');
+    expect(replaceDescriptionContent('Percent effective')).to.eq('% effective');
+    expect(replaceDescriptionContent('Equal to 30 percent income')).to.eq(
+      'Equal to 30% income',
+    );
+  });
+  it('should not replace percent within words', () => {
+    expect(replaceDescriptionContent('Percentage due')).to.eq('Percentage due');
+    expect(replaceDescriptionContent('20 percentile')).to.eq('20 percentile');
+    expect(replaceDescriptionContent('percentpercent')).to.eq('percentpercent');
+  });
+});
+
+describe('replaceSubmittedData', () => {
+  it('should return an empty string', () => {
+    expect(replaceSubmittedData()).to.eq('');
+    expect(replaceSubmittedData(null)).to.eq('');
+    expect(replaceSubmittedData('')).to.eq('');
+  });
+  it('should not alter an these strings', () => {
+    expect(replaceSubmittedData('   ')).to.eq('   ');
+    expect(replaceSubmittedData('abc 123')).to.eq('abc 123');
+  });
+  it('should replace typographical apostrophes with a single quote', () => {
+    expect(replaceSubmittedData('don’t won’t can’t you’ll')).to.eq(
+      "don't won't can't you'll",
+    );
+    expect(replaceSubmittedData('’100’ times')).to.eq("'100' times");
+  });
+});
+
+describe('fixDateFormat', () => {
+  it('should return invalid dates strings', () => {
+    expect(fixDateFormat()).to.eq('-00-00');
+    expect(fixDateFormat('200')).to.eq('200-00-00');
+  });
+  it('should return already properly formatted date string', () => {
+    expect(fixDateFormat('2020-01-02')).to.eq('2020-01-02');
+    expect(fixDateFormat('2023-12-31')).to.eq('2023-12-31');
+    expect(fixDateFormat('2000-06-30')).to.eq('2000-06-30');
+  });
+  it('should return properly formatted date string when passed dates with no leading zero', () => {
+    expect(fixDateFormat('2020-1-2')).to.eq('2020-01-02');
+    expect(fixDateFormat('2023-10-1')).to.eq('2023-10-01');
+    expect(fixDateFormat('2000-6-30')).to.eq('2000-06-30');
+  });
+  it('should return properly formatted date string when passed dates with weird spacing', () => {
+    expect(fixDateFormat('2020--')).to.eq('2020-00-00');
+    expect(fixDateFormat('2020-1-')).to.eq('2020-01-00');
+    expect(fixDateFormat('2020- 1 - 2 ')).to.eq('2020-01-02');
+    expect(fixDateFormat('2023 - 10 - 1')).to.eq('2023-10-01');
+    expect(fixDateFormat('2000-6 - 30')).to.eq('2000-06-30');
+  });
+});

--- a/src/applications/appeals/shared/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/submit.unit.spec.js
@@ -1,0 +1,124 @@
+import { expect } from 'chai';
+import { getDate } from '../../utils/dates';
+
+import { addAreaOfDisagreement } from '../../utils/submit';
+
+const validDate1 = getDate({ offset: { months: -2 } });
+const issue1 = {
+  raw: {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'tinnitus',
+      description: 'both ears',
+      approxDecisionDate: validDate1,
+      decisionIssueId: 1,
+      ratingIssueReferenceId: '2',
+      ratingDecisionReferenceId: '3',
+      ratingIssuePercentNumber: '10',
+    },
+  },
+  result: {
+    type: 'contestableIssue',
+    attributes: {
+      issue: 'tinnitus - 10% - both ears',
+      decisionDate: validDate1,
+      decisionIssueId: 1,
+      ratingIssueReferenceId: '2',
+      ratingDecisionReferenceId: '3',
+    },
+  },
+};
+
+const validDate2 = getDate({ offset: { months: -4 } });
+const issue2 = {
+  raw: {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'left knee',
+      approxDecisionDate: validDate2,
+      decisionIssueId: 4,
+      ratingIssueReferenceId: '5',
+    },
+  },
+  result: {
+    type: 'contestableIssue',
+    attributes: {
+      issue: 'left knee - 0%',
+      decisionDate: validDate2,
+      decisionIssueId: 4,
+      ratingIssueReferenceId: '5',
+    },
+  },
+};
+
+describe('addAreaOfDisagreement', () => {
+  it('should process a single choice', () => {
+    const formData = {
+      areaOfDisagreement: [
+        {
+          disagreementOptions: {
+            serviceConnection: true,
+            effectiveDate: false,
+          },
+        },
+        {
+          disagreementOptions: {
+            effectiveDate: true,
+          },
+          otherEntry: '',
+        },
+      ],
+    };
+    const result = addAreaOfDisagreement(
+      [issue1.result, issue2.result],
+      formData,
+    );
+    expect(result[0].attributes.disagreementArea).to.equal(
+      'service connection',
+    );
+    expect(result[1].attributes.disagreementArea).to.equal('effective date');
+  });
+  it('should process multiple choices', () => {
+    const formData = {
+      areaOfDisagreement: [
+        {
+          disagreementOptions: {
+            serviceConnection: true,
+            effectiveDate: true,
+            evaluation: true,
+          },
+          otherEntry: '',
+        },
+      ],
+    };
+    const result = addAreaOfDisagreement([issue1.result], formData);
+    expect(result[0].attributes.disagreementArea).to.equal(
+      'service connection,effective date,disability evaluation',
+    );
+  });
+  it('should process other choice', () => {
+    const formData = {
+      areaOfDisagreement: [
+        {
+          disagreementOptions: {
+            serviceConnection: true,
+            effectiveDate: true,
+            evaluation: true,
+          },
+          otherEntry: 'this is an other entry',
+        },
+      ],
+    };
+    const result = addAreaOfDisagreement([issue1.result], formData);
+    expect(result[0].attributes.disagreementArea).to.equal(
+      'service connection,effective date,disability evaluation,this is an other entry',
+    );
+  });
+  it('should not throw a JS error with no disagreement options', () => {
+    const formData = {
+      areaOfDisagreement: [],
+    };
+    const result = addAreaOfDisagreement([issue1.result], formData);
+    expect(result[0].attributes.disagreementArea).to.equal('');
+  });
+});

--- a/src/applications/appeals/shared/tests/utils/ui.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/ui.unit.spec.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+
+import { readableList } from '../../utils/ui';
+
+describe('readableList', () => {
+  it('should return an empty string', () => {
+    expect(readableList([])).to.eq('');
+    expect(readableList(['', null, 0])).to.eq('');
+  });
+  it('should return a combined list with commas with "and" for the last item', () => {
+    expect(readableList(['one'])).to.eq('one');
+    expect(readableList(['', 'one', null])).to.eq('one');
+    expect(readableList(['one', 'two'])).to.eq('one and two');
+    expect(readableList([1, 2, 'three'])).to.eq('1, 2 and three');
+    expect(readableList(['v', null, 'w', 'x', '', 'y', 'z'])).to.eq(
+      'v, w, x, y and z',
+    );
+  });
+});

--- a/src/applications/appeals/shared/tests/validatiions/areaOfDisagreements.unit.spec.js
+++ b/src/applications/appeals/shared/tests/validatiions/areaOfDisagreements.unit.spec.js
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { MAX_LENGTH } from '../../constants';
+
+import {
+  hasAreaOfDisagreementChoice,
+  areaOfDisagreementRequired,
+  areaOfDisagreementMaxLength,
+} from '../../validations/areaOfDisagreement';
+
+describe('hasAreaOfDisagreementChoice && areaOfDisagreementRequired', () => {
+  it('should show an error with no selections', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors);
+    expect(errors.addError.called).to.be.true;
+    expect(hasAreaOfDisagreementChoice()).to.be.false;
+  });
+  it('should show an error with no selections, and no entry text', () => {
+    const errors = { addError: sinon.spy() };
+    const data = { disagreementOptions: {}, otherEntry: '' };
+    areaOfDisagreementRequired(errors, data);
+    expect(errors.addError.called).to.be.true;
+    expect(hasAreaOfDisagreementChoice(data)).to.be.false;
+  });
+  it('should not show an error with a single selection', () => {
+    const errors = { addError: sinon.spy() };
+    const data = { disagreementOptions: { foo: true } };
+    areaOfDisagreementRequired(errors, data);
+    expect(errors.addError.called).to.be.false;
+    expect(hasAreaOfDisagreementChoice(data)).to.be.true;
+  });
+  it('should not show an error with entry text', () => {
+    const errors = { addError: sinon.spy() };
+    const data = { disagreementOptions: {}, otherEntry: 'foo' };
+    areaOfDisagreementRequired(errors, data);
+    expect(errors.addError.called).to.be.false;
+    expect(hasAreaOfDisagreementChoice(data)).to.be.true;
+  });
+  it('should not show an error with a selection and entry text', () => {
+    const errors = { addError: sinon.spy() };
+    const data = { disagreementOptions: { foo: true }, otherEntry: 'bar' };
+    areaOfDisagreementRequired(errors, data);
+    expect(errors.addError.called).to.be.false;
+    expect(hasAreaOfDisagreementChoice(data)).to.be.true;
+  });
+});
+
+describe.skip('areaOfDisagreementMaxLength', () => {
+  it('should show an error when a name is too long', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementMaxLength(
+      errors,
+      'ab '.repeat(MAX_LENGTH.ISSUE_NAME / 2),
+    );
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error when a name is not too long', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementMaxLength(errors, 'test');
+    expect(errors.addError.called).to.be.false;
+  });
+});

--- a/src/applications/appeals/shared/tests/validatiions/contactInfo.unit.spec.js
+++ b/src/applications/appeals/shared/tests/validatiions/contactInfo.unit.spec.js
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { contactInfoValidation } from '../../validations/contactInfo';
+
+describe('contactInfoValidation', () => {
+  const getData = ({
+    email = true,
+    phone = true,
+    address = true,
+    homeless = false,
+  } = {}) => ({
+    veteran: {
+      email: email ? 'placeholder' : '',
+      phone: phone ? { phoneNumber: 'placeholder' } : {},
+      address: address ? { addressLine1: 'placeholder' } : {},
+    },
+    homeless,
+  });
+  it('should not show an error when data is available', () => {
+    const addError = sinon.spy();
+    contactInfoValidation({ addError }, null, getData());
+    expect(addError.notCalled).to.be.true;
+  });
+  it('should have an error when email is missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation({ addError }, null, getData({ email: false }));
+    expect(addError.called).to.be.true;
+    expect(addError.args[0][0]).to.contain('Add an email');
+  });
+  it('should have multiple errors when email & phone are missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ email: false, phone: false }),
+    );
+    expect(addError.called).to.be.true;
+    expect(addError.firstCall.args[0]).to.contain('Add an email');
+    expect(addError.secondCall.args[0]).to.contain('Add a mobile phone');
+  });
+  it('should have multiple errors when everything is missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ email: false, phone: false, address: false }),
+    );
+    expect(addError.called).to.be.true;
+    expect(addError.firstCall.args[0]).to.contain('Add an email');
+    expect(addError.secondCall.args[0]).to.contain('Add a mobile phone');
+    expect(addError.thirdCall.args[0]).to.contain('Add a mailing address');
+  });
+  it('should not include address when homeless is true', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ address: false, homeless: true }),
+    );
+    expect(addError.called).to.be.false;
+  });
+  it('should not throw an error when addError function is missing', () => {
+    try {
+      contactInfoValidation();
+      expect(true).to.be.true;
+    } catch (error) {
+      expect(error).to.be.null;
+    }
+  });
+});

--- a/src/applications/appeals/shared/utils/areaOfDisagreement.js
+++ b/src/applications/appeals/shared/utils/areaOfDisagreement.js
@@ -1,0 +1,66 @@
+import { MAX_LENGTH, SUBMITTED_DISAGREEMENTS } from '../constants';
+import { getIssueName } from './issues';
+
+/**
+ * @typedef AreaOfDisagreement~Options
+ * @type {object}
+ * @property {boolean} serviceConnection
+ * @property {boolean} effectiveDate
+ * @property {boolean} evaluation
+ */
+/**
+ * @typedef AreaOfDisagreement~Page
+ * @type {object}
+ * @property {object} attributes - Attributes of issue
+ * @property {AreaOfDisagreement~Options} disagreementOptions
+ * @property {string} otherEntry - Free text input
+ */
+/**
+ * @typedef FormData~AreaOfDisagreement
+ * @type {AreaOfDisagreement~Page[]}
+ */
+
+/**
+ * Compare currently selected issues with previously selected issues and copy
+ * over the area of disagreement selections if the issue persists
+ * @param {array} newIssues - currently selected issues
+ * @param {array} existingIssues - previously selected issues
+ * @returns {FormData~AreaOfDisagreement}
+ */
+export const copyAreaOfDisagreementOptions = (newIssues, existingIssues) => {
+  return newIssues.map(issue => {
+    const foundIssue = (existingIssues || []).find(
+      entry => getIssueName(entry) === getIssueName(issue),
+    );
+    if (foundIssue) {
+      const { disagreementOptions = {}, otherEntry = '' } = foundIssue;
+      return {
+        ...issue,
+        disagreementOptions,
+        otherEntry,
+      };
+    }
+    return issue;
+  });
+};
+
+/**
+ * Calculate schema max length of area of disagreement "other" free text input
+ * for a specific page
+ * @param {AreaOfDisagreement~Page} areaOfDisagreement
+ * @returns {number}
+ */
+export const calculateOtherMaxLength = areaOfDisagreement => {
+  // Schema has a max length of 90 characters for the areaOfDisagreement value
+  // We include fixed text for each selected option with the left over for the
+  // free-text "other reason" input to use up the remaining characters
+  const options = areaOfDisagreement?.disagreementOptions || {};
+  const stringLength = Object.keys(options).reduce((totalLength, key) => {
+    if (key !== 'otherEntry' && options[key]) {
+      // add one for the comma
+      return totalLength + SUBMITTED_DISAGREEMENTS[key].length + 1;
+    }
+    return totalLength;
+  }, 0);
+  return MAX_LENGTH.DISAGREEMENT_REASON - stringLength;
+};

--- a/src/applications/appeals/shared/utils/dates.js
+++ b/src/applications/appeals/shared/utils/dates.js
@@ -1,0 +1,28 @@
+import moment from 'moment';
+
+import { FORMAT_YMD } from '../constants';
+/**
+ * @typedef DateFns~offset
+ * @property {Number} years - positive or negative number
+ * @property {Number} months - positive or negative number
+ * @property {Number} weeks - positive or negative number
+ * @property {Number} days - positive or negative number
+ * @property {Number} hours - positive or negative number
+ * @property {Number} minutes - positive or negative number
+ * @property {Number} seconds - positive or negative number
+ */
+/**
+ * Get dynamic date value based on starting date and an offset
+ * @param {DateFns~offset} [offset={}] - date offset
+ * @param {Date} [date=new Date()] - starting date of offset
+ * @param {String} [pattern=FORMAT_YMD]
+ * @returns {String} - formatted as 'YYYY-MM-DD'
+ */
+export const getDate = ({
+  offset = {},
+  date = new Date(),
+  pattern = FORMAT_YMD,
+} = {}) => {
+  const dateObj = moment(date);
+  return dateObj.isValid() ? dateObj.add(offset).format(pattern) : date;
+};

--- a/src/applications/appeals/shared/utils/helpers.js
+++ b/src/applications/appeals/shared/utils/helpers.js
@@ -1,0 +1,13 @@
+// Simple one level deep check
+export const isEmptyObject = obj =>
+  obj && typeof obj === 'object' && !Array.isArray(obj)
+    ? Object.keys(obj)?.length === 0 || false
+    : false;
+
+export const getItemSchema = (schema, index) => {
+  const itemSchema = schema;
+  if (itemSchema.items.length > index) {
+    return itemSchema.items[index];
+  }
+  return itemSchema.additionalItems;
+};

--- a/src/applications/appeals/shared/utils/issues.js
+++ b/src/applications/appeals/shared/utils/issues.js
@@ -1,0 +1,120 @@
+// import the toggleValues helper
+import { SELECTED } from '../constants';
+
+/**
+ * Get issue name/title from either a manually added issue or issue loaded from
+ * the API
+ * @param {AdditionalIssueItem|ContestableIssueItem}
+ */
+export const getIssueName = (entry = {}) =>
+  entry.issue || entry.attributes?.ratingIssueSubjectText;
+
+export const getIssueDate = (entry = {}) =>
+  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
+
+// used for string comparison
+export const getIssueNameAndDate = (entry = {}) =>
+  `${(getIssueName(entry) || '').toLowerCase()}${getIssueDate(entry)}`;
+
+/*
+ * Selected issues helpers
+ */
+export const someSelected = issues =>
+  (issues || []).some(issue => issue[SELECTED]);
+
+export const hasSomeSelected = ({ contestedIssues, additionalIssues } = {}) =>
+  someSelected(contestedIssues) || someSelected(additionalIssues);
+
+export const getSelected = formData => {
+  const contestedIssues = (formData?.contestedIssues || []).filter(
+    issue => issue[SELECTED],
+  );
+  const additionalIssues = (formData?.additionalIssues || []).filter(
+    issue => issue[SELECTED],
+  );
+  // include index to help with error messaging
+  return contestedIssues.concat(additionalIssues).map((issue, index) => ({
+    ...issue,
+    index,
+  }));
+};
+
+// additionalIssues (items) are separate because we're checking the count before
+// the formData is updated
+export const getSelectedCount = (formData, items) =>
+  getSelected({ ...formData, additionalIssues: items }).length;
+
+/*
+ * Look for duplicates
+ */
+const processIssues = (array = []) =>
+  array.filter(Boolean).map(entry => getIssueNameAndDate(entry));
+
+export const hasDuplicates = (data = {}) => {
+  const contestedIssues = processIssues(data.contestedIssues);
+  const additionalIssues = processIssues(data.additionalIssues);
+  // ignore duplicate contestable issues (if any)
+  const fullList = [...new Set(contestedIssues)].concat(additionalIssues);
+
+  return fullList.length !== new Set(fullList).size;
+};
+
+// getEligibleContestableIssues will remove deferred issues and issues > 1 year
+// past their decision date. This function removes issues with no title & sorts
+// the list by descending (newest first) decision date
+export const processContestableIssues = contestedIssues => {
+  const regexDash = /-/g;
+  const getDate = entry =>
+    (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
+
+  // remove issues with no title & sort by date - see
+  // https://dsva.slack.com/archives/CSKKUL36K/p1623956682119300
+  return (contestedIssues || [])
+    .filter(issue => getIssueName(issue))
+    .sort((a, b) => {
+      const dateA = getDate(a);
+      const dateB = getDate(b);
+      if (dateA === dateB) {
+        // If the dates are the same, sort by title
+        return getIssueName(a) > getIssueName(b) ? 1 : -1;
+      }
+      // YYYYMMDD string comparisons will work in place of using moment
+      return dateA > dateB ? -1 : 1;
+    });
+};
+
+/**
+ * Calculate the index offset for the additional issue
+ * @param {Number} index - index of data in combined array of contestable issues
+ *   and additional issues
+ * @param {Number} contestableIssuesLength - contestable issues array length
+ * @returns {Number}
+ */
+export const calculateIndexOffset = (index, contestableIssuesLength) =>
+  index - contestableIssuesLength;
+
+export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
+  if (loadedIssues.length !== existingIssues.length) {
+    return true;
+  }
+  // sort both arrays so we don't end up in an endless loop
+  const issues = processContestableIssues(existingIssues);
+
+  return !processContestableIssues(loadedIssues).every(
+    ({ attributes }, index) => {
+      const existing = issues[index]?.attributes || {};
+      return (
+        attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
+        attributes.approxDecisionDate === existing.approxDecisionDate
+      );
+    },
+  );
+};
+
+export const appStateSelector = state => ({
+  // Validation functions are provided the pageData and not the
+  // formData on the review & submit page. For more details
+  // see https://dsva.slack.com/archives/CBU0KDSB1/p1614182869206900
+  contestedIssues: state.form?.data?.contestedIssues || [],
+  additionalIssues: state.form?.data?.additionalIssues || [],
+});

--- a/src/applications/appeals/shared/utils/replace.js
+++ b/src/applications/appeals/shared/utils/replace.js
@@ -1,0 +1,68 @@
+import { parseISODate } from 'platform/forms-system/src/js/helpers';
+
+import { REGEXP } from '../constants';
+
+/** Replace "percent" with "%" - see va.gov-team/issues/34810
+ * Include spacing in regexp so:
+ *  "10 percent " => "10% "
+ *  "20 percent." => "20%."
+ */
+const replacePercent = text => text.replace(REGEXP.PERCENT, '%$2');
+
+const transformers = [
+  // add more here
+  replacePercent,
+];
+
+/**
+ * Replace specific content within the issue description
+ * @param {String} text - text to modify
+ * @returns {String}
+ */
+export const replaceDescriptionContent = text =>
+  transformers.reduce(
+    (resultingText, transformer) => transformer(resultingText),
+    text || '',
+  );
+
+/**
+ * Replace typographical quote with single quote
+ * Lighthouse needs ASCII (Windows-1252) characters to build the PDF, but there
+ * is no conversion in place (yet)
+ */
+const replaceApostrophe = text => text.replace(REGEXP.APOSTROPHE, "'");
+
+const submitTransformers = [
+  // add more here
+  replaceApostrophe,
+];
+
+/**
+ * Replace problematic characters preventing submission to Lighthouse
+ * @param {String} text - text to modify
+ * @returns {String}
+ */
+export const replaceSubmittedData = text =>
+  submitTransformers.reduce(
+    (resultingText, transformer) => transformer(resultingText),
+    text || '',
+  );
+
+// Add leading zero to date month or day; but use slice since we have some
+// Veterans using older Safari versions that don't support padStart
+const addLeadingZero = part => `00${part || ''}`.slice(-2);
+
+/**
+ * Change a date string with no leading zeros (e.g. 2020-1-2) into a date with
+ * leading zeros (e.g. 2020-01-02) as expected in the schema
+ * @param {String} dateString YYYY-M-D or YYYY-MM-DD date string
+ * @returns {String} YYYY-MM-DD date string
+ */
+export const fixDateFormat = date => {
+  const dateString = (date || '').replace(REGEXP.WHITESPACE, '');
+  if (dateString.length === 10) {
+    return dateString;
+  }
+  const { day, month, year } = parseISODate(dateString);
+  return `${year}-${addLeadingZero(month)}-${addLeadingZero(day)}`;
+};

--- a/src/applications/appeals/shared/utils/submit.js
+++ b/src/applications/appeals/shared/utils/submit.js
@@ -1,0 +1,34 @@
+import { SUBMITTED_DISAGREEMENTS, MAX_LENGTH } from '../constants';
+import { replaceSubmittedData } from './replace';
+
+/**
+ * Add area of disagreement
+ * @param {ContestableIssue~Submittable} issues - selected & processed issues
+ * @param {FormData} formData
+ * @return {ContestableIssues~Submittable} issues with "disagreementArea" added
+ */
+export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
+  const keywords = {
+    serviceConnection: () => SUBMITTED_DISAGREEMENTS.serviceConnection,
+    effectiveDate: () => SUBMITTED_DISAGREEMENTS.effectiveDate,
+    evaluation: () => SUBMITTED_DISAGREEMENTS.evaluation,
+  };
+  return issues.map((issue, index) => {
+    const entry = areaOfDisagreement[index];
+    const reasons = Object.entries(entry?.disagreementOptions || {})
+      .map(([key, value]) => value && keywords[key](entry))
+      .concat((entry?.otherEntry || '').trim())
+      .filter(Boolean);
+    const disagreementArea = replaceSubmittedData(
+      // max length in schema
+      reasons.join(',').substring(0, MAX_LENGTH.DISAGREEMENT_REASON),
+    );
+    return {
+      ...issue,
+      attributes: {
+        ...issue.attributes,
+        disagreementArea,
+      },
+    };
+  });
+};

--- a/src/applications/appeals/shared/utils/ui.js
+++ b/src/applications/appeals/shared/utils/ui.js
@@ -1,0 +1,14 @@
+/**
+ * Convert an array into a readable list of items
+ * @param {String[]} list - Array of items. Empty entries are stripped out
+ * @returns {String}
+ * @example
+ * readableList(['1', '2', '3', '4', 'five'])
+ * // => '1, 2, 3, 4 and five'
+ */
+export const readableList = list => {
+  const cleanedList = list.filter(Boolean);
+  return [cleanedList.slice(0, -1).join(', '), cleanedList.slice(-1)[0]].join(
+    cleanedList.length < 2 ? '' : ' and ',
+  );
+};

--- a/src/applications/appeals/shared/validations/areaOfDisagreement.js
+++ b/src/applications/appeals/shared/validations/areaOfDisagreement.js
@@ -1,0 +1,25 @@
+import { errorMessages } from '../content/areaOfDisagreement';
+import { calculateOtherMaxLength } from '../utils/areaOfDisagreement';
+
+export const hasAreaOfDisagreementChoice = disagreements => {
+  const { disagreementOptions = {}, otherEntry = '' } = disagreements || {};
+  const keys = Object.keys(disagreementOptions);
+  return keys.some(key => disagreementOptions[key]) || !!otherEntry;
+};
+
+export const areaOfDisagreementRequired = (errors, fieldData) => {
+  if (!hasAreaOfDisagreementChoice(fieldData)) {
+    errors.addError?.(errorMessages.missingDisagreement);
+  }
+};
+
+export const areaOfDisagreementMaxLength = (
+  errors,
+  // added index to get around arrayIndex being null
+  disagreement,
+) => {
+  const max = calculateOtherMaxLength(disagreement);
+  if (disagreement.otherEntry?.length > max) {
+    errors.addError?.(errorMessages.maxOtherEntry(max));
+  }
+};

--- a/src/applications/appeals/shared/validations/contactInfo.js
+++ b/src/applications/appeals/shared/validations/contactInfo.js
@@ -1,0 +1,14 @@
+import { errorMessages } from '../content/contactInfo';
+
+export const contactInfoValidation = (errors = {}, _fieldData, formData) => {
+  const { veteran = {}, homeless } = formData || {};
+  if (!veteran.email) {
+    errors.addError?.(errorMessages.missingEmail);
+  }
+  if (!veteran.phone?.phoneNumber) {
+    errors.addError?.(errorMessages.missingMobilePhone);
+  }
+  if (!homeless && !veteran.address?.addressLine1) {
+    errors.addError?.(errorMessages.missingMailingAddress);
+  }
+};


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While fixing the a11y of the Notice of Disagreement (NOD) area of disagreement page, it was determined that a `CustomPage` was needed to set up the needed semantic HTML. And since the Higher-Level Review (HLR) form also includes an area of disagreement page, it would be better to add this new code to the shared folder. The actual changes to both NOD & HLR will be done in a separate PR.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > The form system doesn't _easily_ support rendering a header above a fieldset/legend wrapper on an array page. Many attempts were made to stay within the bounds of the form system uiSchema, but none were satisfactory. The original page itself includes a work-around to show the proper error highlight (left border) to combine the grouped checkbox and the text input.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#61370](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61370)

## Testing done

- _Describe what the old behavior was prior to the change_
  > N/A
- _Describe the steps required to verify your changes are working as expected_
  > Unit tests passing
- _Describe the tests completed and the results_
  > Added unit tests for all code; a11y review of new component within a code sandbox
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Area of disagreement | <img width="587" alt="before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2a8d511c-4657-40e2-b27b-b7f25b58272c"> | <img width="586" alt="after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d5db0687-8ae8-49f3-98bb-67df356d6c39"> |
| Review & submit (no diff) | <img width="617" alt="review-aoe-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4e618504-65f3-4443-8109-18c1bc760e96"> | <img width="626" alt="review-aoe-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/74bf9c00-39db-4390-93b8-ff9406b28967"> |

Minor differences in the new component:
- The spacing between checkboxes is reduced
- The "I disagree with this:" is now hint text and a lighter gray color

## What areas of the site does it impact?

Currently none, but will impact both NOD & HLR apps

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
