### PR TITLE
My VA: Update GA api-name for benefits claims

### DIFF
--- a/src/applications/personalization/dashboard/actions/claims.jsx
+++ b/src/applications/personalization/dashboard/actions/claims.jsx
@@ -128,7 +128,7 @@ const recordClaimsAPIEvent = ({
   startTime,
   success,
   error,
-  apiName = 'GET claims',
+  apiName = 'GET EVSS claims /v0/evss_claims_async',
 }) => {
   const event = {
     event: 'api_call',
@@ -158,7 +158,7 @@ const recordLighthouseClaimsAPIEvent = ({ startTime, success, error }) => {
     startTime,
     success,
     error,
-    apiName: 'GET /benefits_claims',
+    apiName: 'GET Lighthouse claims /v0/benefits_claims',
   });
 };
 


### PR DESCRIPTION
Updates the Google Analytics (GA) api-name when fetching benefits claims in My VA.

Makes it easier for Product team to differentiate EVSS calls from Lighthouse calls in GA.

## Summary

- Use `GET EVSS claims /v0/evss_claims_async` for EVSS
- Use `GET Lighthouse claims /v0/benefits_claims` for Lighthouse

## Related issue(s)

- [63410](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63410)

## Testing done

- Tested locally through JavaScript console that the proper api names fire on success and failure

## What areas of the site does it impact?
My VA

## Acceptance criteria
- [ ] `GET EVSS claims /v0/evss_claims_async` is sent to GA for EVSS
- [ ] `GET Lighthouse claims /v0/benefits_claims`  is sent to GA for Lighthouse

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
