### PR TITLE
526 | Update ITF content & add back link

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router';
 
 import { focusElement } from 'platform/utilities/ui';
 
@@ -9,6 +10,7 @@ import {
   itfSuccess,
   itfActive,
 } from '../content/itfWrapper';
+import { DISABILITY_526_V2_ROOT_URL } from '../constants';
 
 export default class ITFBanner extends React.Component {
   constructor(props) {
@@ -29,9 +31,9 @@ export default class ITFBanner extends React.Component {
     switch (this.props.status) {
       case 'error':
         message = itfMessage(
-          'We’re sorry. Something went wrong on our end.',
+          'Something went wrong on our end, but we’ve received your intent to file!',
           itfError,
-          'error',
+          'info',
         );
         break;
       case 'itf-found':
@@ -65,6 +67,7 @@ export default class ITFBanner extends React.Component {
         <div className="usa-content">
           <h1>{this.props.title}</h1>
           {message}
+          <Link to={DISABILITY_526_V2_ROOT_URL}>Back</Link>
           {this.props.status !== 'error' && (
             <button
               type="button"

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -55,27 +55,27 @@ export const claimsIntakeAddress = (
 
 export const itfError = (
   <div>
-    <div>
+    <div className="vads-u-margin-bottom--2">
       <p className="vads-u-font-size--base">
         Due to the high volume of submissions we are receiving, you can’t
         continue with this claim form at this time - but we have received your
-        intent to file and saved your effective date for benefits. <br />
-        Here’s what this means for you:
-        <ul>
-          <li>You have 1 year from today to complete your claim.</li>
-          <li>
-            If we determine that you’re eligible for disability compensation,
-            we’ll backdate your benefits to today as your claim effective date.
-          </li>
-          <li>
-            If you’re filing a claim based on the PACT Act, you may still be
-            eligible to receive benefits backdated to August 10, 2022.
-          </li>
-        </ul>
-        <strong>Note:</strong> If you come back to this form in the next few
-        days and continue to get this message, don’t worry. Your intent to file
-        date is set for today.
+        intent to file and saved your effective date for benefits.
       </p>
+      Here’s what this means for you:
+      <ul>
+        <li>You have 1 year from today to complete your claim.</li>
+        <li>
+          If we determine that you’re eligible for disability compensation,
+          we’ll use today to determine the effective date of your benefits.
+        </li>
+        <li>
+          If you’re filing a claim based on the PACT Act, you may still be
+          eligible to receive benefits backdated to August 10, 2022.
+        </li>
+      </ul>
+      <strong>Note:</strong> If you come back to this form in the next few days
+      and continue to get this message, don’t worry. Your intent to file date is
+      set for today.
     </div>
     {expander}
   </div>


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Updating the Intent-to-File content based on the volume of ITF auto-submissions and timeouts. We changed the following:
  > - Changed from error to informational alert
  > - Updated title & content
  > - Added a back link pointing to the introduction page to allow Veterans to back out of the screen 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Content changes from OCTO
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#63451](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63451)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Content did not match new recommendations & the page was a dead-end for users, so we added a back link
- _Describe the steps required to verify your changes are working as expected_
  > Test in review instance; block the ITF api call to see the screen
- _Describe the tests completed and the results_
  > No tests were updated since it's mostly content
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| ITF error | <img width="763" alt="before-itf" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b2c371f9-c87b-4f14-9e9e-dac290830140"> | <img width="778" alt="after-itf" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b98b9223-a3be-4647-a3c1-290c2ffa8bde"> |

## What areas of the site does it impact?

526 only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
