### PR TITLE
Update dependents verification modal headers

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationHeader.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationHeader.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 const DependencyVerificationHeader = () => {
   return (
     <>
-      <h3 className="vads-u-padding-top--3 small-screen:vads-u-padding-top--0">
+      <h1 className="vads-u-padding-top--3 small-screen:vads-u-padding-top--0">
         Please make sure your dependents are correct
-      </h3>
+      </h1>
       <p>
         We have the dependents below on your VA benefits. We need to make sure
         our records are right so your benefits pay is correct. If you skip this

--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationList.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationList.jsx
@@ -9,9 +9,9 @@ const DependencyVerificationList = ({ dependents }) => {
             key={index}
             className="vads-l-row vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding--2"
           >
-            <h3 className="vads-u-margin--0 vads-u-font-size--h5">
+            <h2 className="vads-u-margin--0 vads-u-font-size--h5">
               {dependent.fullName}
-            </h3>
+            </h2>
             <p className="vads-l-col--12 vads-u-margin-bottom--0">
               {dependent.dependencyStatusTypeDescription}
             </p>


### PR DESCRIPTION
## Summary

- Fixing header elements used in a dependents modal to be consistent with best practices for accessibility.
- All headers in the modal were h3. The new configuration has an h1 at the top and uses h2s for the rest.

## Related issue(s)

- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/30026](https://github.com/department-of-veterans-affairs/va.gov-team/issues/30026)

## Testing done

- Testing was done manually using HeadingsMap browser plugin to confirm the correct headers after the change.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="1783" alt="before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/2c5c8a37-c6b7-49c5-a502-3724f2024d55">|![dependents-headers](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/8723794a-c128-4c39-a941-bb108284a721)|

## What areas of the site does it impact?

- Code strictly touches the pictured modal
 
## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) n/a
