### PR TITLE
[SW] Added external link icon to privacy policy link in checkbox label.

### DIFF
--- a/src/applications/financial-status-report/components/shared/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/shared/PreSubmitSignature.jsx
@@ -64,7 +64,7 @@ const PreSubmitSignature = ({
   };
 
   const privacyLabel = (
-    <span>
+    <span className="description">
       I have read and accept the
       <a
         target="_blank"
@@ -73,6 +73,12 @@ const PreSubmitSignature = ({
         href={`${environment.BASE_URL}/privacy-policy`}
       >
         privacy policy
+        <i
+          className="fas fa-arrow-up-right-from-square"
+          aria-hidden="true"
+          role="img"
+        />
+        <span className="sr-only">opens in a new window</span>
       </a>
     </span>
   );
@@ -230,7 +236,6 @@ const PreSubmitSignature = ({
         could affect our decision on this request. Penalties may include a fine,
         imprisonment, or both.
       </p>
-
       <Checkbox
         name="privacy-policy"
         className="vads-u-margin-bottom--3"


### PR DESCRIPTION
## Summary

Added an external link icon indicator to the Privacy policy link next to the checkbox on the final review page to show that the link opens in a new window so that users know they can review the link while staying in the form flow.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63393

## Testing done

- Tested locally in browser

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="653" alt="Screenshot 2023-08-10 at 10 29 32 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/9c6b316d-a89b-47c5-b5ac-341254ea35dd"> | <img width="621" alt="Screenshot 2023-08-10 at 10 40 14 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/afd0b88b-8f61-482c-9ee6-37b60750ab55"> |

## What areas of the site does it impact?

Review and Submit page of FSR form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
