### PR TITLE
Use React router Links on mock simple forms patterns introduction page

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/containers/IntroductionPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
@@ -27,22 +28,16 @@ const childContent = (
     <h3>Pages</h3>
     <ul>
       <li>
-        <a href="/mock-form-patterns/personal-information-1">
-          Personal information
-        </a>
+        <Link to="/personal-information-1">Personal information</Link>
       </li>
       <li>
-        <a href="/mock-form-patterns/personal-information-2">
-          Identification information
-        </a>
+        <Link to="/personal-information-2">Identification information</Link>
       </li>
       <li>
-        <a href="/mock-form-patterns/mailing-address">Mailing address</a>
+        <Link to="/mailing-address">Mailing address</Link>
       </li>
       <li>
-        <a href="/mock-form-patterns/contact-information">
-          Contact information
-        </a>
+        <Link to="/contact-information">Contact information</Link>
       </li>
     </ul>
   </>

--- a/src/applications/simple-forms/mock-simple-forms-patterns/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/containers/IntroductionPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
@@ -28,59 +29,45 @@ class IntroductionPage extends React.Component {
           <h3>Pages</h3>
           <ul>
             <li>
-              <a href="/mock-simple-forms-patterns/text-input">Text input</a>
+              <Link to="/text-input">Text input</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/text-input-widgets1">
-                Text input widgets 1
-              </a>
+              <Link to="/text-input-widgets1">Text input widgets 1</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/text-input-full-name">
-                Text input full name
-              </a>
+              <Link to="/text-input-full-name">Text input full name</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/text-input-address">
-                Text input address
-              </a>
+              <Link to="/text-input-address">Text input address</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/ssn-pattern">Ssn pattern</a>
+              <Link to="/ssn-pattern">Ssn pattern</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/checkbox-and-text-input">
-                Checkbox and text input
-              </a>
+              <Link to="/checkbox-and-text-input">Checkbox and text input</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/checkbox-group">
-                Checkbox group
-              </a>
+              <Link to="/checkbox-group">Checkbox group</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/select">Select</a>
+              <Link to="/select">Select</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/radio">Radio</a>
+              <Link to="/radio">Radio</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/radio-relationship-to-veteran">
+              <Link to="/radio-relationship-to-veteran">
                 Radio relationship to veteran
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/date">Date</a>
+              <Link to="/date">Date</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/array-single-page">
-                Array in a single page
-              </a>
+              <Link to="/array-single-page">Array in a single page</Link>
             </li>
             <li>
-              <a href="/mock-simple-forms-patterns/array-multiple-page">
-                Array with multiple pages
-              </a>
+              <Link to="/array-multiple-page">Array with multiple pages</Link>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
This updates the regular link tags on the introduction page of the mock simple forms patterns form to be React router links. This will allow navigation from the introduction page when using the form in staging. No visual difference.

## Related issue(s)

department-of-veterans-affairs/va.gov-team-forms#465
