### PR TITLE
My VA: remove show_myva_dashboard_2_0 feature toggle

### DIFF
--- a/src/applications/personalization/common/mocks/feature-toggles/index.js
+++ b/src/applications/personalization/common/mocks/feature-toggles/index.js
@@ -1,7 +1,6 @@
 const generateFeatureToggles = (toggles = {}) => {
   const {
     myVaUseExperimental = true,
-    showMyVADashboardV2 = true,
     myVaUseLighthouseClaims = true,
     myVaUpdateErrorsWarnings = true,
   } = toggles;
@@ -13,10 +12,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'my_va_experimental',
           value: myVaUseExperimental,
-        },
-        {
-          name: 'show_myva_dashboard_2_0',
-          value: showMyVADashboardV2,
         },
         {
           name: 'my_va_lighthouse_claims',

--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -94,7 +94,6 @@ const Dashboard = ({
   getPayments,
   isLOA3,
   payments,
-  shouldShowV2Dashboard,
   showLoader,
   showMPIConnectionError,
   showNameTag,
@@ -170,7 +169,7 @@ const Dashboard = ({
     <RequiredLoginView
       serviceRequired={[backendServices.USER_PROFILE]}
       user={props.user}
-      showProfileErrorMessage={shouldShowV2Dashboard}
+      showProfileErrorMessage
     >
       <DowntimeNotification
         appTitle="user dashboard"
@@ -221,7 +220,7 @@ const Dashboard = ({
                 </div>
               ) : null}
 
-              {props.showClaimsAndAppeals && shouldShowV2Dashboard ? (
+              {props.showClaimsAndAppeals && (
                 <DowntimeNotification
                   dependencies={[
                     externalServices.mhv,
@@ -233,30 +232,21 @@ const Dashboard = ({
                     useLighthouseClaims={useLighthouseClaims}
                   />
                 </DowntimeNotification>
-              ) : null}
-
-              {isLOA3 && shouldShowV2Dashboard ? (
-                <HealthCareV2 isVAPatient={isVAPatient} />
-              ) : null}
-
-              {isLOA3 &&
-                shouldShowV2Dashboard && (
-                  <>
-                    <DebtsV2 />
-                    <BenefitPaymentsV2
-                      payments={payments}
-                      showNotifications={showNotifications}
-                    />
-                  </>
-                )}
-              {isLOA3 && shouldShowV2Dashboard ? (
-                <EducationAndTraining />
-              ) : null}
-              {isLOA3 && shouldShowV2Dashboard ? (
-                <SavedApplications />
-              ) : (
-                <ApplyForBenefits />
               )}
+
+              {isLOA3 && <HealthCareV2 isVAPatient={isVAPatient} />}
+
+              {isLOA3 && (
+                <>
+                  <DebtsV2 />
+                  <BenefitPaymentsV2
+                    payments={payments}
+                    showNotifications={showNotifications}
+                  />
+                </>
+              )}
+              {isLOA3 && <EducationAndTraining />}
+              {isLOA3 ? <SavedApplications /> : <ApplyForBenefits />}
             </div>
           </div>
         )}
@@ -329,10 +319,6 @@ const mapStateToProps = state => {
     isLOA3 &&
     isVAPatient;
 
-  const shouldShowV2Dashboard = toggleValues(state)[
-    FEATURE_FLAG_NAMES.showMyVADashboardV2
-  ];
-
   const useLighthouseClaims = toggleValues(state)[
     FEATURE_FLAG_NAMES.myVaUseLighthouseClaims
   ];
@@ -356,7 +342,6 @@ const mapStateToProps = state => {
     totalDisabilityRatingServerError: hasTotalDisabilityServerError(state),
     useLighthouseClaims,
     user: state.user,
-    shouldShowV2Dashboard,
     showMPIConnectionError,
     showNotInMPIError,
     showNotifications,
@@ -386,7 +371,6 @@ Dashboard.propTypes = {
       accountNumber: PropTypes.string.isRequired,
     }),
   ),
-  shouldShowV2Dashboard: PropTypes.bool,
   showClaimsAndAppeals: PropTypes.bool,
   showHealthCare: PropTypes.bool,
   showLoader: PropTypes.bool,

--- a/src/applications/personalization/dashboard/components/debts-v2/DebtsV2.jsx
+++ b/src/applications/personalization/dashboard/components/debts-v2/DebtsV2.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import DashboardWidgetWrapper from '../DashboardWidgetWrapper';
 import IconCTALink from '../IconCTALink';
@@ -77,7 +75,6 @@ const BenefitPaymentsAndDebtV2 = ({
   getDebts,
   getCopays,
   shouldShowLoadingIndicator,
-  shouldShowV2Dashboard,
 }) => {
   useEffect(
     () => {
@@ -110,63 +107,40 @@ const BenefitPaymentsAndDebtV2 = ({
       data-testid="dashboard-section-debts-v2"
     >
       <h2>Outstanding debts</h2>
-      {shouldShowV2Dashboard && (
-        <>
-          <div className="vads-l-row">
-            {(hasCopayError || hasDebtError) && (
-              <>
-                <DashboardWidgetWrapper>
-                  <OutstandingDebtsError />
-                </DashboardWidgetWrapper>
-                <DashboardWidgetWrapper>
-                  {hasDebtError &&
-                    copaysCount > 0 && <PopularActionsForDebts />}
-                </DashboardWidgetWrapper>
-              </>
-            )}
-            {hasNoOutstandingDebts() && (
-              <>
-                <DashboardWidgetWrapper>
-                  <NoOutstandingDebtsText />
-                </DashboardWidgetWrapper>
-              </>
-            )}
-            {debtsCount > 0 && (
-              <DashboardWidgetWrapper>
-                <DebtsCardV2 debts={debts} />
-              </DashboardWidgetWrapper>
-            )}
-            {copaysCount > 0 && (
-              <>
-                <DashboardWidgetWrapper>
-                  <CopaysCardV2 copays={copays} />
-                </DashboardWidgetWrapper>
-                <DashboardWidgetWrapper>
-                  {!debtsCount && !hasDebtError && <PopularActionsForDebts />}
-                </DashboardWidgetWrapper>
-              </>
-            )}
-          </div>
-        </>
-      )}
-      {!shouldShowV2Dashboard && (
-        <>
+      <div className="vads-l-row">
+        {(hasCopayError || hasDebtError) && (
+          <>
+            <DashboardWidgetWrapper>
+              <OutstandingDebtsError />
+            </DashboardWidgetWrapper>
+            <DashboardWidgetWrapper>
+              {hasDebtError && copaysCount > 0 && <PopularActionsForDebts />}
+            </DashboardWidgetWrapper>
+          </>
+        )}
+        {hasNoOutstandingDebts() && (
+          <>
+            <DashboardWidgetWrapper>
+              <NoOutstandingDebtsText />
+            </DashboardWidgetWrapper>
+          </>
+        )}
+        {debtsCount > 0 && (
           <DashboardWidgetWrapper>
-            {(hasDebtError || hasCopayError) && (
-              <>
-                <OutstandingDebtsError />
-              </>
-            )}
-            {!hasDebtError &&
-              !hasCopayError &&
-              debtsCount < 1 &&
-              copaysCount < 1 && <NoOutstandingDebtsText />}
-            {debtsCount > 0 && <DebtsCardV2 debts={debts} />}
-            {copaysCount > 0 && <CopaysCardV2 copays={copays} />}
-            {copaysCount > 0 && hasDebtError && <PopularActionsForDebts />}
+            <DebtsCardV2 debts={debts} />
           </DashboardWidgetWrapper>
-        </>
-      )}
+        )}
+        {copaysCount > 0 && (
+          <>
+            <DashboardWidgetWrapper>
+              <CopaysCardV2 copays={copays} />
+            </DashboardWidgetWrapper>
+            <DashboardWidgetWrapper>
+              {!debtsCount && !hasDebtError && <PopularActionsForDebts />}
+            </DashboardWidgetWrapper>
+          </>
+        )}
+      </div>
       {((debtsCount === 0 && copaysCount === 0) ||
         (hasCopayError && debtsCount === 0) ||
         (hasDebtError && copaysCount === 0)) && (
@@ -208,23 +182,18 @@ BenefitPaymentsAndDebtV2.propTypes = {
   hasCopayError: PropTypes.bool,
   hasDebtError: PropTypes.bool,
   shouldShowLoadingIndicator: PropTypes.bool,
-  shouldShowV2Dashboard: PropTypes.bool,
 };
 
 const mapStateToProps = state => {
   const debtsIsLoading = state.allDebts.isLoading;
   const debts = state.allDebts.debts || [];
   const copays = state.allDebts.copays || [];
-  const shouldShowV2Dashboard = toggleValues(state)[
-    FEATURE_FLAG_NAMES.showMyVADashboardV2
-  ];
   return {
     debts,
     copays,
     hasDebtError: state.allDebts.debtsErrors.length > 0,
     hasCopayError: state.allDebts.copaysErrors.length > 0,
     shouldShowLoadingIndicator: debtsIsLoading,
-    shouldShowV2Dashboard,
   };
 };
 

--- a/src/applications/personalization/dashboard/mocks/server.js
+++ b/src/applications/personalization/dashboard/mocks/server.js
@@ -21,7 +21,6 @@ const hasDebts = false;
 const responses = {
   'GET /v0/feature_toggles': generateFeatureToggles({
     myVaUseExperimental: true,
-    showMyVADashboardV2: true,
     myVaUseLighthouseClaims: true,
     myVaUpdateErrorsWarnings: true,
   }),

--- a/src/applications/personalization/dashboard/tests/e2e/appointments-v2-errors.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/appointments-v2-errors.cypress.spec.js
@@ -6,7 +6,6 @@ import disabilityRating from '@@profile/tests/fixtures/disability-rating-success
 import ERROR_500 from '@@profile/tests/fixtures/500.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
-import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 import vamcErc from '../fixtures/vamc-ehr.json';
 import ERROR_400 from '~/applications/personalization/dashboard/utils/mocks/ERROR_400';
 import MOCK_FACILITIES from '../../utils/mocks/appointments/MOCK_FACILITIES.json';
@@ -30,17 +29,6 @@ describe('MyVA Dashboard - Appointments v2 Error States', () => {
     );
     cy.intercept('/v1/facilities/va?ids=*', MOCK_FACILITIES);
     cy.intercept('GET', '/data/cms/vamc-ehr.json', vamcErc);
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
   });
 
   describe('when the user has VA Healthcare', () => {

--- a/src/applications/personalization/dashboard/tests/e2e/appointments-v2-rx-messaging.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/appointments-v2-rx-messaging.cypress.spec.js
@@ -2,7 +2,6 @@ import enrollmentStatusEnrolled from '@@profile/tests/fixtures/enrollment-system
 
 import { v2 } from '../../mocks/appointments';
 import { mockFolderResponse } from '../../utils/mocks/messaging/folder';
-import { generateFeatureToggles } from '../../../common/mocks/feature-toggles';
 
 import {
   makeUserObject,
@@ -28,12 +27,6 @@ const userWithoutRxMessaging = makeUserObject({
 describe('MyVA Dashboard - Rx Messaging - v2', () => {
   beforeEach(() => {
     mockLocalStorage();
-    cy.intercept(
-      '/v0/feature_toggles*',
-      generateFeatureToggles({
-        showMyVADashboardV2: true,
-      }),
-    );
     cy.intercept('GET', '/vaos/v2/appointments*', req => {
       const rv = v2.createAppointmentSuccess({ startsInDays: [] });
       req.reply(rv);

--- a/src/applications/personalization/dashboard/tests/e2e/appointments-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/appointments-v2.cypress.spec.js
@@ -1,5 +1,4 @@
 import { v2 } from '../../mocks/appointments';
-import { generateFeatureToggles } from '../../../common/mocks/feature-toggles';
 
 import {
   makeUserObject,
@@ -17,12 +16,6 @@ const mockUser = makeUserObject({
 describe('MyVA Dashboard - Appointments - v2', () => {
   beforeEach(() => {
     mockLocalStorage();
-    cy.intercept(
-      '/v0/feature_toggles*',
-      generateFeatureToggles({
-        showMyVADashboardV2: true,
-      }),
-    );
   });
 
   it('has an appointment in the next 30 days', () => {

--- a/src/applications/personalization/dashboard/tests/e2e/benefit-payments-v2-error-states.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefit-payments-v2-error-states.cypress.spec.js
@@ -11,7 +11,6 @@ import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { paymentsError } from '../fixtures/test-payments-response';
 import appointmentsEmpty from '../fixtures/appointments-empty';
 import MOCK_FACILITIES from '../../utils/mocks/appointments/MOCK_FACILITIES.json';
@@ -24,17 +23,6 @@ describe('My VA - Benefit payments - error-states', () => {
   Cypress.config({ defaultCommandTimeout: 12000, requestTimeout: 20000 });
   beforeEach(() => {
     mockLocalStorage();
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
     cy.intercept('/v0/evss_claims_async', claimsSuccess());

--- a/src/applications/personalization/dashboard/tests/e2e/benefit-payments-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefit-payments-v2.cypress.spec.js
@@ -11,7 +11,6 @@ import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import {
   paymentsSuccess,
   paymentsSuccessEmpty,
@@ -30,17 +29,6 @@ describe('The My VA Dashboard - Benefit Payments', () => {
   beforeEach(() => {
     mockLocalStorage();
     cy.login(mockUser);
-    cy.intercept('/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
     cy.intercept('/v0/evss_claims_async', claimsSuccess());
@@ -185,17 +173,6 @@ describe('when the payment history claims does not exist', () => {
       },
     });
     cy.login(mockUser1);
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
     cy.intercept('/v0/evss_claims_async', claimsSuccess());
@@ -254,17 +231,6 @@ describe('when the payment history claims is false', () => {
       },
     });
     cy.login(mockUser2);
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
     cy.intercept('/v0/evss_claims_async', claimsSuccess());

--- a/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
@@ -9,7 +9,6 @@ import { makeMockUser } from '@@profile/tests/fixtures/users/user';
 import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
 import notInESR from '@@profile/tests/fixtures/enrollment-system/not-in-esr.json';
 import loa1User from '@@profile/tests/fixtures/users/user-loa1.json';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import manifest from '~/applications/personalization/dashboard/manifest.json';
 
 import {
@@ -50,17 +49,6 @@ describe('The My VA Dashboard', () => {
       const user = makeMockUser();
       cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
       cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
-      cy.intercept('GET', '/v0/feature_toggles*', {
-        data: {
-          type: 'feature_toggles',
-          features: [
-            {
-              name: featureFlagNames.showMyVADashboardV2,
-              value: true,
-            },
-          ],
-        },
-      }).as('featuresB');
       cy.login(user);
       cy.visit(manifest.rootUrl);
     });

--- a/src/applications/personalization/dashboard/tests/e2e/cerner-messaging/header-is-still-showing.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/cerner-messaging/header-is-still-showing.cypress.spec.js
@@ -1,4 +1,3 @@
-import { generateFeatureToggles } from '../../../../common/mocks/feature-toggles';
 import { cernerUser } from '../../../../common/mocks/users';
 import vamcErc from '../../fixtures/vamc-ehr.json';
 
@@ -13,10 +12,6 @@ describe('MyVA Dashboard - Appointments - v2', () => {
   });
 
   it('Header still exists when cerner message exists on V2', () => {
-    cy.intercept(
-      '/v0/feature_toggles*',
-      generateFeatureToggles({ showMyVADashboardV2: true }),
-    );
     cy.visit('my-va/');
     cy.injectAxeThenAxeCheck();
     cy.get('[data-testid="cerner-widget"] > .hydrated').should('exist');

--- a/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals-v2-lighthouse.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals-v2-lighthouse.cypress.spec.js
@@ -28,10 +28,6 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
           type: 'feature_toggles',
           features: [
             {
-              name: featureFlagNames.showMyVADashboardV2,
-              value: true,
-            },
-            {
               name: featureFlagNames.myVaUseLighthouseClaims,
               value: true,
             },

--- a/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals-v2.cypress.spec.js
@@ -28,10 +28,6 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
           type: 'feature_toggles',
           features: [
             {
-              name: featureFlagNames.showMyVADashboardV2,
-              value: true,
-            },
-            {
               name: featureFlagNames.myVaUseLighthouseClaims,
               value: false,
             },

--- a/src/applications/personalization/dashboard/tests/e2e/downtime.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/downtime.cypress.spec.js
@@ -4,7 +4,6 @@ import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 
 import manifest from 'applications/personalization/dashboard/manifest.json';
 
@@ -26,17 +25,6 @@ describe('The My VA Dashboard', () => {
       '/v0/disability_compensation_form/rating_info',
       disabilityRating,
     );
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
   });
 
   it('should show a dismissible modal if a dependent service has downtime approaching in the next hour', () => {

--- a/src/applications/personalization/dashboard/tests/e2e/health-care-cerner.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/health-care-cerner.cypress.spec.js
@@ -1,6 +1,5 @@
 import enrollmentStatusEnrolled from '@@profile/tests/fixtures/enrollment-system/enrolled.json';
 import vamcErc from '../fixtures/vamc-ehr.json';
-import { generateFeatureToggles } from '../../../common/mocks/feature-toggles';
 
 import {
   makeUserObject,
@@ -54,10 +53,6 @@ describe('MyVA Dashboard - Cerner Widget', () => {
         'GET',
         '/v0/health_care_applications/enrollment_status',
         enrollmentStatusEnrolled,
-      );
-      cy.intercept(
-        '/v0/feature_toggles*',
-        generateFeatureToggles({ showMyVADashboardV2: true }),
       );
       cy.intercept('GET', '/data/cms/vamc-ehr.json', vamcErc);
     });

--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -2,7 +2,6 @@ import { mockUser } from '@@profile/tests/fixtures/users/user';
 import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import manifest from 'applications/personalization/dashboard/manifest.json';
 
 describe('The My VA Dashboard', () => {
@@ -16,17 +15,6 @@ describe('The My VA Dashboard', () => {
       '/v0/disability_compensation_form/rating_info',
       disabilityRating,
     );
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    }).as('featuresB');
   });
   describe('when there are in-progress forms', () => {
     beforeEach(() => {

--- a/src/applications/personalization/dashboard/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/messaging-error.cypress.spec.js
@@ -1,17 +1,12 @@
 import { mockUser } from '@@profile/tests/fixtures/users/user';
 
 import ERROR_400 from '~/applications/personalization/dashboard/utils/mocks/ERROR_400';
-import { generateFeatureToggles } from '../../../common/mocks/feature-toggles';
 import vamcErc from '../fixtures/vamc-ehr.json';
 
 describe('MyVA Dashboard - Messaging', () => {
   describe('when there is an error fetching the inbox data', () => {
     beforeEach(() => {
       cy.login(mockUser);
-      cy.intercept(
-        '/v0/feature_toggles*',
-        generateFeatureToggles({ showMyVADashboardV2: true }),
-      );
       cy.intercept('GET', '/v0/messaging/health/folders/0', {
         statusCode: 400,
         body: ERROR_400,

--- a/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2-error-states.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2-error-states.cypress.spec.js
@@ -11,7 +11,6 @@ import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { paymentsSuccessEmpty } from '../fixtures/test-payments-response';
 import {
   debtsError,
@@ -31,17 +30,6 @@ describe('My VA - Outstanding debts error-states', () => {
   Cypress.config({ defaultCommandTimeout: 12000, requestTimeout: 20000 });
   beforeEach(() => {
     mockLocalStorage();
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
     cy.intercept('/v0/evss_claims_async', claimsSuccess());

--- a/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/outstanding-debts-v2.cypress.spec.js
@@ -11,7 +11,6 @@ import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import featureFlagNames from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { paymentsSuccessEmpty } from '../fixtures/test-payments-response';
 import {
   debtsSuccess,
@@ -30,17 +29,6 @@ describe('The My VA Dashboard - Outstanding Debts', () => {
   beforeEach(() => {
     mockLocalStorage();
     cy.login(mockUser);
-    cy.intercept('/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: featureFlagNames.showMyVADashboardV2,
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
     cy.intercept('/v0/evss_claims_async', claimsSuccess());

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -118,7 +118,6 @@ export default Object.freeze({
   showPaymentAndDebtSection: 'show_payment_and_debt_section',
   showContactChatbot: 'show_contact_chatbot',
   showDashboardNotifications: 'show_dashboard_notifications',
-  showMyVADashboardV2: 'show_myva_dashboard_2_0',
   showDigitalForm1095b: 'show_digital_form_1095b',
   showEduBenefits0994Wizard: 'show_edu_benefits_0994_wizard',
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',


### PR DESCRIPTION
Removes the `show_myva_dashboard_2_0` feature flag and related code since we are 100% enabled for all users.

## Summary

- Remove `show_myva_dashboard_2_0` feature flag
- Remove conditionals using this flag
- Update specs

## Related issue(s)

- [60360](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60360)

## What areas of the site does it impact?
My VA Dashboard

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
