### PR TITLE
Add `:index` support to Cypress pageHooks

### DIFF
--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -116,6 +116,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.fillPage(); // temporary until page is updated with web components
+          // console.log('testing :index pageHooks', index);
           cy.findByText('Continue', { selector: 'button' }).click();
         });
       },

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -112,6 +112,14 @@ const testConfig = createTestConfig(
         areaOfDisagreementPageHook({ afterHook, index: 2 });
       },
 
+      'area-of-disagreement/:index': ({ afterHook /* , index */ }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.fillPage(); // temporary until page is updated with web components
+          cy.findByText('Continue', { selector: 'button' }).click();
+        });
+      },
+
       'evidence-submission/upload': () => {
         cy.get('input[type="file"]')
           .upload(

--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -1,5 +1,5 @@
 ----
-# We're moving our docs! 
+# We're moving our docs!
 ### Find [the latest version of this page](https://depo-platform-documentation.scrollhelp.site/developer-docs/Cypress-Form-Tester.1870331957.html) on the Platform website.
 ### Still can't find what you're looking for? Reach out to [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) on Slack.
 
@@ -254,6 +254,9 @@ pageHooks: {
   // http://localhost:3001/some-form-app-url/some/path
   'some/path': () => { ... },
 
+  // http://localhost:3001/some-form-app-url/array/1
+  'array/:index': () => { ... },
+
   // http://localhost:3001/some-form-app-url/path
   '/some-form-app-url/path': () => { ... },
 
@@ -262,11 +265,13 @@ pageHooks: {
 },
 ```
 
-The functions **all have access to a context object as a first argument**, which currently provides two things:
+The functions **all have access to a context object as a first argument**, which currently provides three things:
 
 1. `pathname`: a convenient reference to the full pathname that got matched for this page hook.
 
-2. `afterHook`: a helper function that takes a function and uses it to **override the usual end-of-page behavior**.
+2. `index`: index of the page from the array data. This value is obtained from the pathname, e.g. `array-page/1` would set the index to `1`.
+
+3. `afterHook`: a helper function that takes a function and uses it to **override the usual end-of-page behavior**.
 
    Typically, the standard flow for processing a page follows these steps:
 
@@ -298,7 +303,7 @@ The functions **all have access to a context object as a first argument**, which
       });
     },
 
-    'some-other-page': ({ afterHook, pathname }) => {
+    'some-other-page': ({ afterHook, pathname, index }) => {
       // Do whatever you need to in the "main body" of the hook,
       // which replaces the default autofilling behavior.
       cy.log(`Look, I'm on ${pathname}!`);

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -243,7 +243,7 @@ Cypress.Commands.add('execHook', pathname => {
               .replace(REGEXP_REMOVE_END_SLASH, '') // remove trailing `/`
           : pathname;
 
-        const hook = pageHooks?.[pathnameKey];
+        const hook = pageHooks?.[pathname] || pageHooks?.[pathnameKey];
         let hookExecuted = false;
         let postHook = defaultPostHook(pathname);
 

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -81,7 +81,11 @@ const getArrayItemPath = pathname => {
         return match;
       }) || {};
 
-    return arrayPath ? `${arrayPath}[${parseInt(index, 10)}]` : '';
+    const indexNumber = parseInt(index, 10);
+    return {
+      arrayItemPath: arrayPath ? `${arrayPath}[${indexNumber}]` : '',
+      index: indexNumber,
+    };
   });
 };
 
@@ -217,45 +221,62 @@ const defaultPostHook = pathname => {
   };
 };
 
+// Look for "/#" or "/#/" in the path
+const REGEXP_PATH_INDEX = /\/\d+\/?/;
+const REGEXP_REMOVE_END_SLASH = /\/$/;
+
 /**
  * Runs the page hook if there is one for the current page.
  * @param {string} pathname - The pathname for the current URL.
  * @returns {boolean} Resolves true if a hook ran and false otherwise.
  */
 Cypress.Commands.add('execHook', pathname => {
-  cy.get('@pageHooks', NO_LOG_OPTION).then(pageHooks => {
-    const hook = pageHooks?.[pathname];
-    let hookExecuted = false;
-    let postHook = defaultPostHook(pathname);
+  cy.get('@pageHooks', NO_LOG_OPTION).then(pageHooks =>
+    cy
+      .location('pathname', NO_LOG_OPTION)
+      .then(getArrayItemPath)
+      .then(({ index }) => {
+        const pathnameKey = REGEXP_PATH_INDEX.test(pathname)
+          ? pathname
+              .split(REGEXP_PATH_INDEX)
+              .join('/:index/')
+              .replace(REGEXP_REMOVE_END_SLASH, '') // remove trailing `/`
+          : pathname;
 
-    if (!hook) return cy.wrap({ hookExecuted, postHook }, NO_LOG_OPTION);
+        const hook = pageHooks?.[pathnameKey];
+        let hookExecuted = false;
+        let postHook = defaultPostHook(pathname);
 
-    if (typeof hook !== 'function') {
-      throw new Error(`Page hook for ${pathname} is not a function`);
-    }
+        if (!hook) return cy.wrap({ hookExecuted, postHook }, NO_LOG_OPTION);
 
-    // Give the page hook the option to set a custom post hook.
-    const overridePostHook = fn => {
-      if (typeof fn !== 'function') {
-        throw new Error(`Post hook for ${pathname} is not a function`);
-      }
-      postHook = fn;
-    };
+        if (typeof hook !== 'function') {
+          throw new Error(`Page hook for ${pathnameKey} is not a function`);
+        }
 
-    // Context object that's available all page hooks as the first argument.
-    const context = {
-      afterHook: overridePostHook,
-      pathname,
-    };
+        // Give the page hook the option to set a custom post hook.
+        const overridePostHook = fn => {
+          if (typeof fn !== 'function') {
+            throw new Error(`Post hook for ${pathnameKey} is not a function`);
+          }
+          postHook = fn;
+        };
 
-    const hookPromise = new Promise(resolve => {
-      hook(context);
-      hookExecuted = true;
-      resolve({ hookExecuted, postHook });
-    });
+        // Context object that's available all page hooks as the first argument.
+        const context = {
+          afterHook: overridePostHook,
+          pathname: pathnameKey,
+          index,
+        };
 
-    return cy.wrap(hookPromise, NO_LOG_OPTION);
-  });
+        const hookPromise = new Promise(resolve => {
+          hook(context);
+          hookExecuted = true;
+          resolve({ hookExecuted, postHook });
+        });
+
+        return cy.wrap(hookPromise, NO_LOG_OPTION);
+      }),
+  );
 });
 
 /**
@@ -391,7 +412,7 @@ Cypress.Commands.add('enterData', field => {
 Cypress.Commands.add('fillPage', () => {
   cy.location('pathname', NO_LOG_OPTION)
     .then(getArrayItemPath)
-    .then(arrayItemPath => {
+    .then(({ arrayItemPath }) => {
       const touchedFields = new Set();
       const snapshot = {};
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Our form will be switching to use web components on an array indexed page, but Cypress `pageHooks` does not currently support a key which includes an `:index` in the path name. This PR adds support, updates the main read me and enables a page hook test in our Notice of Disagreement form (10182)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > I could have used `pathname/0`, `pathname/1`, etc; but each would be set to use the same function. This update allows adding `pathname/:index` instead.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#61370](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61370)

## Testing done

- _Describe what the old behavior was prior to the change_
  > No support of `:index`
- _Describe the steps required to verify your changes are working as expected_
  > - Pull in PR branch locally
  > - Open `src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js` in editor
  > - Go to the `'area-of-disagreement/:index'` page hook entry (line 104)
  > - Un-comment out the `index` parameter and the console log within the `afterHook`
  > - Run this e2e test with console in dev tools open
- _Describe the tests completed and the results_
  > Manual testing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement e2e test

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
