### PR TITLE
56297 omb component migration

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -275,9 +274,11 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro buttonOnly {...sipProps} />
         {itfNotice}
-        <div className="omb-info--container">
-          <OMBInfo resBurden={25} ombNumber="2900-0747" expDate="03/31/2021" />
-        </div>
+        <va-omb-info
+          res-burden={25}
+          omb-number="2900-0747"
+          exp-date="03/31/2021"
+        />
       </div>
     );
   }

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -20,6 +20,7 @@ import {
   PAGE_TITLE_SUFFIX,
   DOCUMENT_TITLE_SUFFIX,
   DBQ_URL,
+  OMB_CONTROL,
 } from '../constants';
 
 class IntroductionPage extends React.Component {
@@ -276,7 +277,7 @@ class IntroductionPage extends React.Component {
         {itfNotice}
         <va-omb-info
           res-burden={25}
-          omb-number="2900-0747"
+          omb-number={OMB_CONTROL}
           exp-date="03/31/2021"
         />
       </div>

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -337,3 +337,5 @@ export const CHAR_LIMITS = [
 
 // migration max string length
 export const MAX_HOUSING_STRING_LENGTH = 500;
+
+export const OMB_CONTROL = '2900-0747';

--- a/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
@@ -6,6 +6,7 @@ import {
   SAVED_SEPARATION_DATE,
   FORM_STATUS_BDD,
   WIZARD_STATUS,
+  OMB_CONTROL,
 } from '../constants';
 
 // Date saved to sessionStorage includes leading zeros
@@ -153,6 +154,10 @@ describe('526 wizard', () => {
       'eq',
       `${DISABILITY_526_V2_ROOT_URL}/introduction`,
     );
+
+    // omb info
+    cy.get('va-omb-info').contains(OMB_CONTROL);
+
     cy.injectAxe();
     cy.axeCheck();
   });

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import moment from 'moment';
-import { render } from '@testing-library/react';
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
-import { Provider } from 'react-redux';
 import { IntroductionPage } from '../../components/IntroductionPage';
 import formConfig from '../../config/form';
 import {
@@ -139,80 +136,10 @@ describe('<IntroductionPage/>', () => {
     wrapper.unmount();
   });
 
-  it('should render OMB component - enzyme test', () => {
+  it('should render OMB info', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
 
     expect(wrapper.find('va-omb-info').length).to.equal(1);
     wrapper.unmount();
-  });
-
-  const getData = ({
-    loggedIn = true,
-    isVerified = true,
-    data = {},
-    contestableIssues = {},
-  } = {}) => ({
-    props: {
-      formId: formConfig.formId,
-      loggedIn,
-      location: {
-        basename: '/base-url',
-      },
-      route: {
-        formConfig,
-        pageList: [
-          { path: '/introduction' },
-          { path: '/first-page', formConfig },
-        ],
-      },
-    },
-    mockStore: {
-      getState: () => ({
-        user: {
-          login: {
-            currentlyLoggedIn: loggedIn,
-          },
-          profile: {
-            savedForms: [],
-            prefillsAvailable: [],
-            verified: isVerified,
-            userFullName: {
-              first: 'Peter',
-              middle: 'B',
-              last: 'Parker',
-            },
-          },
-        },
-        form: {
-          formId: formConfig.formId,
-          loadedStatus: 'success',
-          savedStatus: '',
-          loadedData: {
-            metadata: {},
-          },
-          data,
-          contestableIssues,
-        },
-        scheduledDowntime: {
-          globalDowntime: null,
-          isReady: true,
-          isPending: false,
-          serviceMap: { get() {} },
-          dismissedDowntimeWarnings: [],
-        },
-      }),
-      subscribe: () => {},
-      dispatch: () => {},
-    },
-  });
-
-  it('should render OMB component - rtl test', () => {
-    const { props, mockStore } = getData({ loggedIn: true });
-    const { container } = render(
-      <Provider store={mockStore}>
-        <IntroductionPage {...props} />
-      </Provider>,
-    );
-    expect($('va-omb-info', container)).to.exist;
   });
 });


### PR DESCRIPTION
## Summary

- Move from deprecated react component to web components version for OMB Info
- This component is displayed near the bottom of the Introduction page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#56297](https://github.com/department-of-veterans-affairs/va.gov-team/issues/56297)

## Testing done
- _Describe what the old behavior was prior to the change_
The page was previously using the react version of the OMB info component which is now deprecated
- _Describe the steps required to verify your changes are working as expected_
Visit the intro page and perform all the usual front end tests. Also click on the privacy link to make sure the modal is working as expected
- _Describe the tests completed and the results_
Unit, e2e and manual tests were successful

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/4f96d02a-aefe-4a2c-95a7-a0b76e16bb55)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/eb4977c7-0bdf-4306-9aa5-76be413ebc4d)


## What areas of the site does it impact?
form 526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

