### PR TITLE
Add form content for custom header form

### DIFF
--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -40,8 +40,13 @@ const CustomHeader = ({ formData, formConfig, router, currentLocation }) => {
     <div className="vads-u-background-color--primary-alt-lightest vads-u-padding-y--2 vads-u-margin-bottom--2">
       <div className="row">
         <div className="vads-u-margin-x--2p5">
-          <div className="vads-u-font-size--h4 vads-u-font-family--serif vads-u-margin-bottom--2 vads-u-font-weight--bold">
-            {formConfig.title} ({formConfig.formId})
+          <div className="vads-u-font-size--h4 vads-u-font-family--serif vads-u-font-weight--bold">
+            {formConfig.title}
+          </div>
+          <div className="vads-u-margin-bottom--2">
+            {/* (VA Form {formConfig.formId}) */}
+            {/* Hard coded so we don't show MOCK-FORM-NUMBER */}
+            (VA Form 21-0845)
           </div>
           <div className="rjsf-form-custom-header vads-u-display--flex vads-u-justify-content--space-between small-screen:vads-u-justify-content--flex-start">
             <span>

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -16,7 +16,7 @@ const CustomHeader = ({ formData, formConfig, router, currentLocation }) => {
   const { additionalRoutes } = formConfig;
   let nonFormPages = [];
   if (additionalRoutes) {
-    nonFormPages = additionalRoutes.map(route => route.path);
+    nonFormPages = additionalRoutes.map((route) => route.path);
   }
   const lastPathComponent = currentLocation.pathname.split('/').pop();
   const isIntroductionPage = trimmedPathname.endsWith('introduction');

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -16,7 +16,7 @@ const CustomHeader = ({ formData, formConfig, router, currentLocation }) => {
   const { additionalRoutes } = formConfig;
   let nonFormPages = [];
   if (additionalRoutes) {
-    nonFormPages = additionalRoutes.map((route) => route.path);
+    nonFormPages = additionalRoutes.map(route => route.path);
   }
   const lastPathComponent = currentLocation.pathname.split('/').pop();
   const isIntroductionPage = trimmedPathname.endsWith('introduction');

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/customTitlePattern.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/customTitlePattern.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 export const titleH1UI = (title, description) => {
   return {
     'ui:title': (
-      <h1 className="vads-u-color--gray-dark vads-u-font-size--h3 medium-screen:vads-u-font-size--h1 vads-u-margin-y--0">
+      <h1 className="vads-u-color--gray-dark vads-u-font-size--h3 medium-screen:vads-u-font-size--h1 vads-u-margin-y--neg2">
         {title}
       </h1>
     ),

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/config/form.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/config/form.js
@@ -5,11 +5,18 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import getHelp from '../../shared/components/GetFormHelp';
 import CustomHeader from '../components/CustomHeader';
+import authorizerType from '../pages/authorizerType';
+import nameAndDate from '../pages/nameAndDate';
+import identificationInformation from '../pages/identificationInformation';
+import address from '../pages/mailingAddress';
+import phoneAndEmail from '../pages/phoneAndEmail';
+import thirdPartyType from '../pages/thirdPartyType';
+import organizationInfo from '../pages/organizationInfo';
 
-const placeholderSchema = {
-  type: 'object',
-  properties: {},
-};
+/**
+ * This form is used for experimentally testing a custom header.
+ * Check 21-0845 for the actual form
+ */
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -23,14 +30,7 @@ const formConfig = {
   confirmation: ConfirmationPage,
   v3SegmentedProgressBar: true,
   CustomHeader,
-  preSubmitInfo: {
-    statementOfTruth: {
-      body:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      messageAriaDescribedby:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-    },
-  },
+  preSubmitInfo: {},
   formId: 'FORM_MOCK_ALT_HEADER',
   saveInProgress: {
     messages: {
@@ -62,8 +62,8 @@ const formConfig = {
         authTypePage: {
           path: 'authorizer-type',
           title: 'Who’s submitting this authorization?',
-          uiSchema: {},
-          schema: placeholderSchema,
+          uiSchema: authorizerType.uiSchema,
+          schema: authorizerType.schema,
         },
       },
     },
@@ -73,38 +73,44 @@ const formConfig = {
         nameAndDatePage: {
           path: 'name-and-date-of-birth',
           title: 'Your name and dated of birth',
-          uiSchema: {},
-          schema: placeholderSchema,
+          uiSchema: nameAndDate.uiSchema,
+          schema: nameAndDate.schema,
         },
         identificationInfoPage: {
           path: 'identification-information',
           title: 'Your identification information',
-          uiSchema: {},
-          schema: placeholderSchema,
+          uiSchema: identificationInformation.uiSchema,
+          schema: identificationInformation.schema,
         },
         mailingAddressPage: {
           path: 'mailing-address',
           title: 'Your mailing address',
-          uiSchema: {},
-          schema: placeholderSchema,
+          uiSchema: address.uiSchema,
+          schema: address.schema,
         },
         phoneAndEmailPage: {
           path: 'phone-and-email',
           title: 'Your phone and email',
-          uiSchema: {},
-          schema: placeholderSchema,
+          uiSchema: phoneAndEmail.uiSchema,
+          schema: phoneAndEmail.schema,
         },
       },
     },
     disclosureInfoChapter: {
       title: 'Disclosure information',
       pages: {
-        authTypePage: {
-          path: 'authorized-specific-person-or-org',
+        thirdPartyTypePage: {
+          path: 'third-party-type',
           title:
             'Do you authorize us to release your information to a specific person or to an organization?',
-          uiSchema: {},
-          schema: placeholderSchema,
+          uiSchema: thirdPartyType.uiSchema,
+          schema: thirdPartyType.schema,
+        },
+        organizationInfoPage: {
+          path: 'organization-information',
+          title: "Organization's information",
+          uiSchema: organizationInfo.uiSchema,
+          schema: organizationInfo.schema,
         },
       },
     },

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/definitions/constants.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/definitions/constants.js
@@ -1,0 +1,43 @@
+export const AUTHORIZER_TYPES = {
+  VETERAN: 'veteran',
+  NON_VETERAN: 'nonVeteran',
+};
+
+export const AUTHORIZER_TYPE_ITEMS = {
+  VETERAN: 'I’m a Veteran with an existing claim',
+  NON_VETERAN:
+    'I’m the spouse, dependent, survivor, or caregiver of a Veteran, and I have an existing claim',
+};
+
+export const THIRD_PARTY_TYPES = {
+  PERSON: 'person',
+  ORGANIZATION: 'organization',
+};
+
+export const INFORMATION_SCOPES = {
+  LIMITED: 'limited',
+  ANY: 'any',
+};
+
+export const LIMITED_INFORMATION_ITEMS = {
+  CLAIM_STATUS: 'Status of pending claim or appeal',
+  BENEFIT: 'Current benefit and rate',
+  PAYMENT_HISTORY: 'Payment history',
+  MONEY_OWED: 'Amount of money owed to VA',
+  PAYMENT_LETTER: 'Request a benefit payment letter',
+  ADDRESS_CHANGE: 'Change of address or direct deposit',
+};
+
+export const RELEASE_DURATIONS = {
+  ONCE_ONLY: 'Only release my information this 1 time',
+  UNTIL_DATE: 'Release my information until a specific date that I’ll choose',
+  UNTIL_NOTICE: 'Release my information until I send written notice to stop',
+};
+
+export const SECURITY_QUESTIONS = {
+  MOTHER_BIRTHPLACE: 'What’s the city and state your mother was born in?',
+  HIGH_SCHOOL_NAME: 'What’s the name of the high school you attended?',
+  FIRST_PET_NAME: 'What’s the name of your first pet?',
+  FAVORITE_TEACHER_NAME: 'What’s the name of your favorite teacher?',
+  FATHER_MIDDLE_NAME: 'What’s your father’s middle name?',
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/authorizerType.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/authorizerType.js
@@ -1,0 +1,26 @@
+import {
+  radioUI,
+  radioSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    authorizerType: radioUI({
+      title: "Who's submitting this authorization?",
+      labels: {
+        veteran: "I'm a Veteran submitting on my own behalf",
+        nonVeteran:
+          "I'm a non-Veteran beneficiary or claimant submitting on behalf of a Veteran",
+      },
+      labelHeaderLevel: '1',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['authorizerType'],
+    properties: {
+      authorizerType: radioSchema(['veteran', 'nonVeteran']),
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/identificationInformation.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/identificationInformation.js
@@ -1,0 +1,29 @@
+import {
+  ssnUI,
+  ssnSchema,
+  vaFileNumberUI,
+  vaFileNumberSchema,
+  serviceNumberUI,
+  serviceNumberSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'view:title': titleH1UI('Your identification information'),
+    veteranSSN: ssnUI(),
+    veteranVaFileNumber: vaFileNumberUI(),
+    veteranServiceNumber: serviceNumberUI(),
+  },
+  schema: {
+    type: 'object',
+    required: ['veteranSSN'],
+    properties: {
+      'view:title': titleH1Schema,
+      veteranSSN: ssnSchema,
+      veteranVaFileNumber: vaFileNumberSchema,
+      veteranServiceNumber: serviceNumberSchema,
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/mailingAddress.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/mailingAddress.js
@@ -1,0 +1,21 @@
+import {
+  addressNoMilitaryUI,
+  addressNoMilitarySchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'view:title': titleH1UI('Your mailing address'),
+    address: addressNoMilitaryUI(),
+  },
+  schema: {
+    type: 'object',
+    required: ['address'],
+    properties: {
+      'view:title': titleH1Schema,
+      address: addressNoMilitarySchema(),
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/nameAndDate.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/nameAndDate.js
@@ -1,0 +1,27 @@
+import definitions from 'vets-json-schema/dist/definitions.json';
+import {
+  fullNameNoSuffixUI,
+  fullNameNoSuffixSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'view:title': titleH1UI('Your name and date of birth'),
+    veteranFullName: fullNameNoSuffixUI(),
+    veteranDateOfBirth: {
+      'ui:title': 'Date of birth',
+      'ui:widget': 'date',
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['veteranFullName'],
+    properties: {
+      'view:title': titleH1Schema,
+      veteranFullName: fullNameNoSuffixSchema,
+      veteranDateOfBirth: definitions.date,
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/organizationInfo.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/organizationInfo.js
@@ -1,0 +1,29 @@
+import {
+  addressNoMilitaryUI,
+  addressNoMilitarySchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
+import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'view:title': titleH1UI("Organization's information"),
+    organizationName: {
+      'ui:title': 'Name of organization',
+      'ui:webComponentField': VaTextInputField,
+    },
+    organizationAddress: addressNoMilitaryUI(),
+  },
+  schema: {
+    type: 'object',
+    required: ['organizationName', 'organizationAddress'],
+    properties: {
+      'view:title': titleH1Schema,
+      organizationName: {
+        type: 'string',
+      },
+      organizationAddress: addressNoMilitarySchema(),
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/phoneAndEmail.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/phoneAndEmail.js
@@ -1,0 +1,25 @@
+import {
+  phoneUI,
+  emailUI,
+  phoneSchema,
+  emailSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'view:title': titleH1UI('Your phone and email'),
+    phone: phoneUI(),
+    email: emailUI(),
+  },
+  schema: {
+    type: 'object',
+    required: ['phone'],
+    properties: {
+      'view:title': titleH1Schema,
+      phone: phoneSchema,
+      email: emailSchema,
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/thirdPartyType.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/thirdPartyType.js
@@ -1,0 +1,28 @@
+import {
+  radioUI,
+  radioSchema,
+} from 'platform/forms-system/src/js/web-component-patterns/radioPattern';
+
+import { THIRD_PARTY_TYPES } from '../definitions/constants';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    thirdPartyType: radioUI({
+      title:
+        'Do you authorize us to release your information to a specific person or to an organization?',
+      labels: {
+        [THIRD_PARTY_TYPES.PERSON]: 'A specific person',
+        [THIRD_PARTY_TYPES.ORGANIZATION]: 'An organization',
+      },
+      labelHeaderLevel: '1',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['thirdPartyType'],
+    properties: {
+      thirdPartyType: radioSchema(Object.values(THIRD_PARTY_TYPES)),
+    },
+  },
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/utils.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/utils.js
@@ -1,0 +1,57 @@
+export const getFullNameString = fullName => {
+  const { first, middle, last } = fullName;
+  let fullNameString = `${first}`;
+
+  if (middle) {
+    fullNameString += ` ${middle}`;
+  }
+
+  return `${fullNameString} ${last}`;
+};
+
+export const camelCaseToSnakeAllCaps = str => {
+  return str
+    .split(/(?=[A-Z])/)
+    .join('_')
+    .toUpperCase();
+};
+
+export const snakeAllCapsToCamelCase = str => {
+  const camelCaseArr = str.split('_').map((word, index) => {
+    if (index === 0) {
+      return word.toLowerCase();
+    }
+
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  });
+
+  return camelCaseArr.join('');
+};
+
+export const getLabelsFromConstants = (constants = {}) => {
+  // convert a radio-button-labels constants object (with SNAKE_CASE keys) to
+  // an labels object (with camelCase keys)
+  // for uiSchema['ui:options'].labels
+
+  const labels = {};
+
+  Object.keys(constants).forEach(key => {
+    labels[snakeAllCapsToCamelCase(key)] = constants[key];
+  });
+
+  return labels;
+};
+
+export const getEnumsFromConstants = (constants = {}) => {
+  // convert a radio-button-labels constants object (with SNAKE_CASE keys) to
+  // an enums array of camelCase key-strings
+  // for schema.properties.<text-field>.enum [field type should be 'string']
+
+  const enums = [];
+
+  Object.keys(constants).forEach(key => {
+    enums.push(snakeAllCapsToCamelCase(key));
+  });
+
+  return enums;
+};

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -235,6 +235,7 @@
  * @property {boolean} [invalid] - For web components. Whether or not aria-invalid will be set on the inner input. Useful when composing the component into something larger, like a date component.
  * @property {boolean} [keepInPageOnReview] - Used to keep a field on the review page. Often used with arrays or expandUnder fields. When used with arrays, removes the default editor box on the review page and shows view-only data with an edit button instead.
  * @property {Record<string, string>} [labels] - Used to specify radio button or yes/no labels
+ * @property {'1' | '2' | '3' | '4' | '5'} [labelHeaderLevel] - The header level for the label. For web components such as radio buttons or checkboxes.
  * @property {string} [messageAriaDescribedby] - For web components. An optional message that will be read by screen readers when the input is focused.
  * @property {boolean} [monthSelect] - For VaMemorableDate web component. If true, will use a select dropdown for the month instead of an input.
  * @property {(formData: any, schema: SchemaOptions, uiSchema: UISchemaOptions, index, path: string[]) => SchemaOptions} [replaceSchema]

--- a/src/platform/forms-system/src/js/web-component-fields/vaRadioFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaRadioFieldMapping.jsx
@@ -19,6 +19,7 @@ export default function vaRadioFieldMapping(props) {
       typeof childrenProps.formData === 'undefined'
         ? false
         : childrenProps.formData,
+    labelHeaderLevel: uiOptions?.labelHeaderLevel,
     onBlur: () => childrenProps.onBlur(childrenProps.idSchema.$id),
     children: (
       <div slot="description">

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -477,3 +477,15 @@ export const addressSchema = options => {
 
   return schema;
 };
+
+export const addressNoMilitaryUI = options =>
+  addressUI({
+    omit: ['isMilitary'],
+    ...options,
+  });
+
+export const addressNoMilitarySchema = options =>
+  addressSchema({
+    omit: ['isMilitary'],
+    ...options,
+  });

--- a/src/platform/forms-system/src/js/web-component-patterns/radioPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/radioPattern.jsx
@@ -13,23 +13,20 @@ import VaRadioField from '../web-component-fields/VaRadioField';
  *  }
  * })
  * ```
- * @param {{
+ * @param {UIOptions & {
  *  title?: UISchemaOptions['ui:title'],
  *  description?: UISchemaOptions['ui:description'],
- *  labels: Record<PropertyKey, string>,
- *  tile?: boolean,
  * }} options
  * @returns {UISchemaOptions}
  */
-export const radioUI = ({ title, description, labels, tile }) => {
+export const radioUI = ({ title, description, ...uiOptions }) => {
   return {
     'ui:title': title,
     'ui:description': description,
     'ui:webComponentField': VaRadioField,
     'ui:widget': 'radio', // This is required for the review page to render the field properly
     'ui:options': {
-      tile,
-      labels,
+      ...uiOptions,
     },
   };
 };


### PR DESCRIPTION
## Summary

- Add the form content for the custom form which is testing the experimental new header design.
- Form uses H1 for the form page title (styled as H3 when in mobile)
- Some code copied from 21-0845

### Form content **does not necessarily match 21-0845**. This is mock content based on the [UX](https://www.sketch.com/s/9f215f8f-ba86-4b99-813f-d0ca3c03ca18/p/9A1F9E24-080F-4B22-83F8-20498B6079E5/canvas)

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#458
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/435

## Testing done

- Browser testing

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/9e379da2-899f-4f8b-9a16-7245d27233ef)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/c6fca568-dcf7-4792-b520-4c7aa34ab907)

## What areas of the site does it impact?

- The mock form related to 0845
- Make the radio pattern more flexible for web components

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
