### PR TITLE
Updates page title and URLs on appointment detail and list pages

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -11,7 +11,10 @@ import ErrorMessage from '../../../components/ErrorMessage';
 import FullWidthLayout from '../../../components/FullWidthLayout';
 import { fetchConfirmedAppointmentDetails } from '../../redux/actions';
 import { getConfirmedAppointmentDetailsInfo } from '../../redux/selectors';
-import { selectFeatureVaosV2Next } from '../../../redux/selectors';
+import {
+  selectFeatureBreadcrumbUrlUpdate,
+  selectFeatureVaosV2Next,
+} from '../../../redux/selectors';
 import DetailsVA from './DetailsVA';
 import DetailsCC from './DetailsCC';
 import DetailsVideo from './DetailsVideo';
@@ -28,6 +31,9 @@ export default function ConfirmedAppointmentDetailsPage() {
   } = useSelector(
     state => getConfirmedAppointmentDetailsInfo(state, id),
     shallowEqual,
+  );
+  const featureBreadcrumbUrlUpdate = useSelector(state =>
+    selectFeatureBreadcrumbUrlUpdate(state),
   );
   const featureVaosV2Next = useSelector(state =>
     selectFeatureVaosV2Next(state),
@@ -51,10 +57,13 @@ export default function ConfirmedAppointmentDetailsPage() {
   useEffect(
     () => {
       const pageTitle = isCommunityCare ? 'Community care' : 'VA';
+      const pageTitleSuffix = featureBreadcrumbUrlUpdate
+        ? ' | Veterans Affairs'
+        : '';
       if (appointment && appointmentDate) {
         document.title = `${pageTitle} appointment on ${appointmentDate.format(
           'dddd, MMMM D, YYYY',
-        )}`;
+        )}${pageTitleSuffix}`;
         scrollAndFocus();
       }
     },

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -22,6 +22,7 @@ import {
   getVAAppointmentLocationId,
 } from '../../services/appointment';
 import { selectRequestedAppointmentDetails } from '../redux/selectors';
+import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 import ErrorMessage from '../../components/ErrorMessage';
 import PageLayout from './PageLayout';
 import FullWidthLayout from '../../components/FullWidthLayout';
@@ -63,6 +64,9 @@ export default function RequestedAppointmentDetailsPage() {
     state => selectRequestedAppointmentDetails(state, id),
     shallowEqual,
   );
+  const featureBreadcrumbUrlUpdate = useSelector(state =>
+    selectFeatureBreadcrumbUrlUpdate(state),
+  );
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
   const showBackLink = useToggleValue(
     TOGGLE_NAMES.vaOnlineSchedulingDescriptiveBackLink,
@@ -81,9 +85,13 @@ export default function RequestedAppointmentDetailsPage() {
         const typeOfCareText = lowerCase(
           appointment?.type?.coding?.[0]?.display,
         );
-        const title = `${isCanceled ? 'Canceled' : 'Pending'} ${
+        let title = `${isCanceled ? 'Canceled' : 'Pending'} ${
           isCC ? 'Community care' : 'VA'
         } ${typeOfCareText} appointment`;
+
+        if (featureBreadcrumbUrlUpdate) {
+          title = title.concat(` | Veterans Affairs`);
+        }
 
         document.title = title;
       }

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -643,7 +643,7 @@ const responses = {
         { name: 'vaOnlineSchedulingUseDsot', value: true },
         { name: 'vaOnlineSchedulingRequestFlowUpdate', value: true },
         { name: 'vaOnlineSchedulingConvertUtcToLocal', value: false },
-        { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: false },
+        { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: true },
         { name: 'vaOnlineSchedulingPrintList', value: true },
         { name: 'va_online_scheduling_descriptive_back_link', value: true },
         { name: 'vaOnlineSchedulingStaticLandingPage', value: true },

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -643,7 +643,7 @@ const responses = {
         { name: 'vaOnlineSchedulingUseDsot', value: true },
         { name: 'vaOnlineSchedulingRequestFlowUpdate', value: true },
         { name: 'vaOnlineSchedulingConvertUtcToLocal', value: false },
-        { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: true },
+        { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: false },
         { name: 'vaOnlineSchedulingPrintList', value: true },
         { name: 'va_online_scheduling_descriptive_back_link', value: true },
         { name: 'vaOnlineSchedulingStaticLandingPage', value: true },

--- a/src/applications/vaos/services/mocks/v2/requests.json
+++ b/src/applications/vaos/services/mocks/v2/requests.json
@@ -1,6 +1,115 @@
 {
   "data": [
     {
+      "id": "172403",
+      "type": "appointments",
+      "attributes": {
+        "id": "172403",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "14251"
+          }
+        ],
+        "kind": "cc",
+        "status": "proposed",
+        "serviceType": "audiology-routine exam",
+        "serviceTypes": [
+          {
+            "text": "audiology-routine exam"
+          }
+        ],
+        "reasonCode": {
+          "text": "test"
+        },
+        "patientIcn": "1013124304V115761",
+        "locationId": "984",
+        "created": "2023-05-12T17:45:00Z",
+        "requestedPeriods": [
+          {
+            "start": "2023-05-17T04:00:00Z",
+            "localStartTime": "2023-05-17T00:00:00.000-04:00"
+          }
+        ],
+        "contact": {
+          "telecom": [
+            {
+              "type": "phone",
+              "value": "7036753607"
+            },
+            {
+              "type": "email",
+              "value": "marcy.nadedau@va.gov"
+            }
+          ]
+        },
+        "preferredTimesForPhoneCall": [
+          "Morning"
+        ],
+        "preferredLocation": {
+          "city": "Dayton",
+          "state": "OH"
+        },
+        "preferredLanguage": "English",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "ccRequestedCancellation": false,
+          "hsrmTaskId": "14251"
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "25956",
       "type": "appointments",
       "attributes": {

--- a/src/applications/vaos/tests/appointment-list/components/UrlAndPageTitleChange.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UrlAndPageTitleChange.unit.spec.jsx
@@ -228,10 +228,12 @@ describe('VAOS <AppointmentsPageV2>', () => {
       );
     });
 
+    // WIP
     it('should display updated title on pending appointment detail page', async () => {
       return true;
     });
 
+    // WIP
     it('should display updated title on past appointment detail page', async () => {
       return true;
     });

--- a/src/applications/vaos/tests/appointment-list/components/UrlAndPageTitleChange.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UrlAndPageTitleChange.unit.spec.jsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import MockDate from 'mockdate';
+import { expect } from 'chai';
+import moment from 'moment';
+import { waitFor, within } from '@testing-library/dom';
+import { mockFetch } from 'platform/testing/unit/helpers';
+import userEvent from '@testing-library/user-event';
+import { renderWithStoreAndRouter, getTestDate } from '../../mocks/setup';
+import AppointmentsPageV2 from '../../../appointment-list/components/AppointmentsPageV2';
+import {
+  mockAppointmentInfo,
+  mockPastAppointmentInfo,
+} from '../../mocks/helpers';
+import { createMockAppointmentByVersion } from '../../mocks/data';
+import { mockVAOSAppointmentsFetch } from '../../mocks/helpers.v2';
+import { getVAOSRequestMock } from '../../mocks/v2';
+
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingCancel: true,
+    vaOnlineSchedulingRequests: true,
+    vaOnlineSchedulingPast: true,
+    vaOnlineSchedulingStatusImprovement: false,
+    // eslint-disable-next-line camelcase
+    show_new_schedule_view_appointments_page: true,
+  },
+};
+
+describe('VAOS <AppointmentsPageV2>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTestDate());
+    mockAppointmentInfo({});
+  });
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  const userState = {
+    profile: {
+      facilities: [{ facilityId: '983', isCerner: false }],
+    },
+  };
+
+  describe('when scheduling breadcrumb url update flag is on', () => {
+    const defaultState = {
+      featureToggles: {
+        ...initialState.featureToggles,
+        vaOnlineSchedulingDirect: true,
+        vaOnlineSchedulingCommunityCare: false,
+        vaOnlineSchedulingStatusImprovement: true,
+        vaOnlineSchedulingBreadcrumbUrlUpdate: true,
+      },
+      user: userState,
+    };
+
+    it('should display updated title on upcoming appointments page', async () => {
+      // Given the veteran lands on the VAOS homepage
+      mockPastAppointmentInfo({});
+
+      // When the page displays
+      const screen = renderWithStoreAndRouter(<AppointmentsPageV2 />, {
+        initialState: defaultState,
+      });
+
+      // Then it should display the upcoming appointments
+      expect(
+        await screen.findByRole('heading', {
+          level: 1,
+          name: 'Appointments',
+        }),
+      );
+      await waitFor(() => {
+        expect(global.document.title).to.equal(
+          `Appointments | Veterans Affairs`,
+        );
+      });
+
+      // and breadcrumbs should be updated
+      const navigation = screen.getByRole('navigation', {
+        name: 'Breadcrumbs',
+      });
+      expect(navigation).to.be.ok;
+      expect(within(navigation).queryByRole('link', { name: 'Pending' })).not.to
+        .exist;
+      expect(within(navigation).queryByRole('link', { name: 'Past' })).not.to
+        .exist;
+
+      // and scheduling button should be displayed
+      expect(
+        screen.getByRole('button', { name: 'Start scheduling an appointment' }),
+      ).to.be.ok;
+
+      // and appointment list navigation should be displayed
+      expect(
+        screen.getByRole('navigation', { name: 'Appointment list navigation' }),
+      ).to.be.ok;
+      expect(screen.getByRole('link', { name: 'Upcoming' })).to.be.ok;
+      expect(screen.getByRole('link', { name: /Pending \(\d\)/ })).to.be.ok;
+      expect(screen.getByRole('link', { name: 'Past' })).to.be.ok;
+
+      // and status dropdown should not be displayed
+      expect(screen.queryByLabelText('Show by status')).not.to.exists;
+    });
+
+    it('should display updated title appointment request page', async () => {
+      // Given the veteran lands on the VAOS homepage
+      const appointment = getVAOSRequestMock();
+      appointment.id = '1';
+      appointment.attributes = {
+        id: '1',
+        kind: 'clinic',
+        locationId: '983',
+        requestedPeriods: [{}],
+        serviceType: 'primaryCare',
+        status: 'proposed',
+      };
+
+      mockVAOSAppointmentsFetch({
+        start: moment()
+          .subtract(1, 'month')
+          .format('YYYY-MM-DD'),
+        end: moment()
+          .add(395, 'days')
+          .format('YYYY-MM-DD'),
+        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+        requests: [appointment],
+      });
+      mockVAOSAppointmentsFetch({
+        start: moment()
+          .subtract(120, 'days')
+          .format('YYYY-MM-DD'),
+        end: moment().format('YYYY-MM-DD'),
+        statuses: ['proposed', 'cancelled'],
+        requests: [appointment],
+      });
+
+      // When the page displays
+      const screen = renderWithStoreAndRouter(<AppointmentsPageV2 />, {
+        initialState: defaultState,
+      });
+
+      // Then it should display upcoming appointments
+      await screen.findByRole('heading', { name: 'Appointments' });
+
+      // When the veteran clicks the Pending button
+      const navigation = await screen.findByRole('link', {
+        name: /^Pending \(1\)/,
+      });
+      userEvent.click(navigation);
+      await waitFor(() => {
+        expect(screen.history.push.lastCall.args[0].pathname).to.equal(
+          '/pending',
+        );
+      });
+
+      // Then it should display the requested appointments
+      await waitFor(() => {
+        expect(
+          screen.findByRole('heading', {
+            level: 1,
+            name: 'Pending appointments',
+          }),
+        );
+      });
+      await waitFor(() => {
+        expect(global.document.title).to.equal(
+          `Pending appointments | Veterans Affairs`,
+        );
+      });
+
+      expect(
+        global.window.dataLayer.some(
+          e => e === `vaos-status-pending-link-clicked`,
+        ),
+      );
+    });
+
+    it('should display updated past appointment page', async () => {
+      // Given the veteran lands on the VAOS homepage
+      const pastDate = moment().subtract(3, 'months');
+      const data = {
+        id: '1234',
+        kind: 'clinic',
+        clinic: 'fake',
+        start: pastDate.format(),
+        locationId: '983GC',
+        status: 'booked',
+      };
+      const appointment = createMockAppointmentByVersion({
+        version: 0,
+        ...data,
+      });
+      mockPastAppointmentInfo({ va: [appointment] });
+
+      // When the page displays
+      const screen = renderWithStoreAndRouter(<AppointmentsPageV2 />, {
+        initialState: defaultState,
+      });
+
+      // Then it should display the upcoming appointments
+      await screen.findByRole('heading', { name: 'Appointments' });
+
+      // When the veteran clicks the Past button
+      const navigation = screen.getByRole('link', { name: 'Past' });
+      userEvent.click(navigation);
+      await waitFor(() =>
+        expect(screen.history.push.lastCall.args[0].pathname).to.equal('/past'),
+      );
+
+      // Then it should display the past appointments
+      expect(
+        await screen.findByRole('heading', {
+          level: 1,
+          name: 'Past appointments',
+        }),
+      ).to.be.ok;
+      await waitFor(() => {
+        expect(global.document.title).to.equal(
+          `Past appointments | Veterans Affairs`,
+        );
+      });
+
+      expect(
+        global.window.dataLayer.some(
+          e => e === `vaos-status-past-link-clicked`,
+        ),
+      );
+    });
+
+    it('should display updated title on pending appointment detail page', async () => {
+      return true;
+    });
+
+    it('should display updated title on past appointment detail page', async () => {
+      return true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR changes the page title for the requested appointments confirmation page (both VA and CC).

The URL change is taken care of in this PR: https://github.com/department-of-veterans-affairs/vets-website/pull/24994

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61085
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/60754
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/60752

## Testing done

- Local testing
- e2e testing
- Unit testing
