### PR TITLE
Check in/62100/login updates

### DIFF
--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -77,13 +77,8 @@ export default function ValidateDisplay({
     : '';
 
   return (
-    <Wrapper pageTitle={header || t('check-in-at-va')}>
-      <p>
-        {subtitle ||
-          t(
-            'we-need-some-information-to-verify-your-identity-so-we-can-check-you-in',
-          )}
-      </p>
+    <Wrapper pageTitle={header || t('start-checking-in-for-your-appointment')}>
+      <p>{subtitle || t('we-need-your-last-name-and-birth')}</p>
       {showValidateError ? (
         <div className="validate-error-alert" tabIndex="-1">
           <va-alert

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
@@ -15,10 +15,10 @@ describe('check-in experience', () => {
             <ValidateDisplay />
           </CheckInProvider>,
         );
-        expect(getByText('Check in at VA')).to.exist;
+        expect(getByText('Start checking in for your appointment')).to.exist;
         expect(
           getByText(
-            'We need some information to verify your identity so we can check you in.',
+            'First, we need your last name and date of birth to make sure it’s you.',
           ),
         ).to.exist;
       });

--- a/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/day-of/pages/ValidateVeteran.jsx
@@ -81,10 +81,6 @@ const ValidateVeteran = props => {
   return (
     <>
       <ValidateDisplay
-        header={t('check-in-at-va')}
-        subTitle={t(
-          'we-need-some-information-to-verify-your-identity-so-we-can-check-you-in',
-        )}
         lastNameInput={{
           lastNameError,
           setLastName,

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -226,5 +226,8 @@
   "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>.",
   "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment.",
   "processing-travel-claim": "<0>We’re processing your travel reimbursement claim.</0> We’ll send you a text to let you know the status of your claim.",
-  "check-in": "Check-In"
+  "check-in": "Check-In",
+  "start-checking-in-for-your-appointment": "Start checking in for your appointment",
+  "we-need-your-last-name-and-birth": "First, we need your last name and date of birth to make sure it’s you.",
+  "check-if-your-info-is-up-to-date": "Check if your information is up to date"
 }

--- a/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Validate/index.jsx
@@ -81,10 +81,7 @@ const Index = ({ router }) => {
   return (
     <>
       <ValidateDisplay
-        header={t('start-pre-check-in')}
-        subtitle={t(
-          'we-need-to-verify-your-identity-so-you-can-start-pre-check-in',
-        )}
+        header={t('check-if-your-info-is-up-to-date')}
         lastNameInput={{
           lastNameError,
           setLastName,

--- a/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
+++ b/src/applications/check-in/tests/e2e/pages/ValidateVeteran.js
@@ -3,12 +3,12 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 const messages = {
   title: {
     dayOf: {
-      en: 'Check in at VA',
-      es: 'Regístrese en VA',
-      tl: 'Mag-check in sa VA',
+      en: 'Start checking in for your appointment',
+      es: 'Start checking in for your appointment',
+      tl: 'Start checking in for your appointment',
     },
     preCheckIn: {
-      en: 'Start pre-check-in',
+      en: 'Check if your information is up to date',
     },
   },
 };


### PR DESCRIPTION
## Summary

Updates the log in pages for pre-check-in and day-of to use new H1 and subtext.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#62100
Epic:
department-of-veterans-affairs/va.gov-team#61390

## Testing done

Updates unit and cypress tests.

## Screenshots
![localhost_3001_health-care_appointment-check-in_verify](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/815afa90-de58-4ab9-aa41-82990747f4ca)
![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/0ef8b1a8-15af-4ee3-9985-08bf6a0799a7)


## What areas of the site does it impact?

Validation  page of check-in and pre-check=in

## Acceptance criteria
[ ] - text changes reflect the [sketch files](https://www.sketch.com/s/0e890de3-2530-4ee0-986e-cf0314334aec/p/868762F3-8E8F-4E23-B0DA-34C1783F0A03/canvas)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.

