### PR TITLE
Decision Reviews | Show no loaded issues alert initially-only

### DIFF
--- a/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
@@ -180,7 +180,7 @@ const ContestableIssuesWidget = props => {
   return (
     <>
       <div name="eligibleScrollElement" />
-      {showNoIssues && <NoIssuesLoadedAlert submitted={submitted} />}
+      {showNoIssues && <NoIssuesLoadedAlert />}
       {!showNoIssues &&
         submitted &&
         !hasSelected && (

--- a/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
@@ -86,6 +86,8 @@ const ContestableIssuesWidget = props => {
     .concat((additionalIssues || []).filter(Boolean));
 
   const hasSelected = someSelected(items);
+  // Only show alert initially when no issues loaded
+  const [showNoLoadedIssues] = useState(items.length === 0);
 
   if (onReviewPage && inReviewMode && items.length && !hasSelected) {
     return <NoneSelectedAlert count={items.length} headerLevel={5} />;
@@ -173,7 +175,7 @@ const ContestableIssuesWidget = props => {
   });
 
   const showNoIssues =
-    items.length === 0 && (!onReviewPage || (onReviewPage && inReviewMode));
+    showNoLoadedIssues && (!onReviewPage || (onReviewPage && inReviewMode));
 
   return (
     <>

--- a/src/applications/appeals/10182/content/contestableIssues.jsx
+++ b/src/applications/appeals/10182/content/contestableIssues.jsx
@@ -68,7 +68,7 @@ MaxSelectionsAlert.propTypes = {
   closeModal: PropTypes.func,
 };
 
-export const NoIssuesLoadedAlert = ({ submitted }) => {
+export const NoIssuesLoadedAlert = () => {
   const wrapAlert = useRef(null);
 
   useEffect(
@@ -77,7 +77,7 @@ export const NoIssuesLoadedAlert = ({ submitted }) => {
         scrollAndFocus(wrapAlert.current);
       }
     },
-    [wrapAlert, submitted],
+    [wrapAlert],
   );
 
   recordEvent({
@@ -102,10 +102,6 @@ export const NoIssuesLoadedAlert = ({ submitted }) => {
       </va-alert>
     </div>
   );
-};
-
-NoIssuesLoadedAlert.propTypes = {
-  submitted: PropTypes.bool,
 };
 
 export const noneSelected =

--- a/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -141,4 +141,30 @@ describe('<ContestableIssuesWidget>', () => {
       expect(setFormDataSpy.called).to.be.false;
     });
   });
+
+  it('should not show no loaded issues alert after remove all additional items', async () => {
+    const props = getProps();
+    const { container } = render(
+      <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
+    );
+
+    expect($$('va-alert', container).length).to.equal(1);
+    expect($('va-alert', container).innerHTML).to.contain(
+      'Sorry, we couldn’t find any eligible issues',
+    );
+  });
+
+  it('should not show no loaded issues alert after remove all additional items', async () => {
+    const props = getProps();
+    const { container, rerender } = render(
+      <ContestableIssuesWidget {...props} value={[]} />,
+    );
+
+    rerender(
+      <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
+    );
+    await waitFor(() => {
+      expect($$('va-alert', container).length).to.equal(0);
+    });
+  });
 });

--- a/src/applications/appeals/995/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/995/components/ContestableIssuesWidget.jsx
@@ -102,6 +102,8 @@ const ContestableIssuesWidget = props => {
     .concat(additionalIssues);
 
   const hasSelected = someSelected(items);
+  // Only show alert initially when no issues loaded
+  const [showNoLoadedIssues] = useState(items.length === 0);
 
   if (onReviewPage && inReviewMode && items.length && !hasSelected) {
     return <NoneSelectedAlert count={items.length} headerLevel={5} />;
@@ -188,12 +190,12 @@ const ContestableIssuesWidget = props => {
   });
 
   const showNoIssues =
-    items.length === 0 && (!onReviewPage || (onReviewPage && inReviewMode));
+    showNoLoadedIssues && (!onReviewPage || (onReviewPage && inReviewMode));
 
   return (
     <>
       <div name="eligibleScrollElement" />
-      {showNoIssues && <NoIssuesLoadedAlert submitted={submitted} />}
+      {showNoIssues && <NoIssuesLoadedAlert />}
       {!showNoIssues &&
         submitted &&
         !hasSelected && (

--- a/src/applications/appeals/995/content/contestableIssues.jsx
+++ b/src/applications/appeals/995/content/contestableIssues.jsx
@@ -68,7 +68,7 @@ MaxSelectionsAlert.propTypes = {
   closeModal: PropTypes.func,
 };
 
-export const NoIssuesLoadedAlert = ({ submitted }) => {
+export const NoIssuesLoadedAlert = () => {
   const wrapAlert = useRef(null);
 
   useEffect(
@@ -77,7 +77,7 @@ export const NoIssuesLoadedAlert = ({ submitted }) => {
         scrollAndFocus(wrapAlert.current);
       }
     },
-    [wrapAlert, submitted],
+    [wrapAlert],
   );
 
   recordEvent({
@@ -102,10 +102,6 @@ export const NoIssuesLoadedAlert = ({ submitted }) => {
       </va-alert>
     </div>
   );
-};
-
-NoIssuesLoadedAlert.propTypes = {
-  submitted: PropTypes.bool,
 };
 
 export const noneSelected =

--- a/src/applications/appeals/995/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -141,4 +141,30 @@ describe('<ContestableIssuesWidget>', () => {
       expect(setFormDataSpy.called).to.be.false;
     });
   });
+
+  it('should not show no loaded issues alert after remove all additional items', async () => {
+    const props = getProps();
+    const { container } = render(
+      <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
+    );
+
+    expect($$('va-alert', container).length).to.equal(1);
+    expect($('va-alert', container).innerHTML).to.contain(
+      'Sorry, we couldn’t find any eligible issues',
+    );
+  });
+
+  it('should not show no loaded issues alert after remove all additional items', async () => {
+    const props = getProps();
+    const { container, rerender } = render(
+      <ContestableIssuesWidget {...props} value={[]} />,
+    );
+
+    rerender(
+      <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
+    );
+    await waitFor(() => {
+      expect($$('va-alert', container).length).to.equal(0);
+    });
+  });
 });

--- a/src/applications/appeals/996/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/996/components/ContestableIssuesWidget.jsx
@@ -86,6 +86,8 @@ const ContestableIssuesWidget = props => {
     .concat((additionalIssues || []).filter(Boolean));
 
   const hasSelected = someSelected(items);
+  // Only show alert initially when no issues loaded
+  const [showNoLoadedIssues] = useState(items.length === 0);
 
   if (onReviewPage && inReviewMode && items.length && !hasSelected) {
     return <NoneSelectedAlert count={items.length} headerLevel={5} />;
@@ -171,12 +173,12 @@ const ContestableIssuesWidget = props => {
   });
 
   const showNoIssues =
-    items.length === 0 && (!onReviewPage || (onReviewPage && inReviewMode));
+    showNoLoadedIssues && (!onReviewPage || (onReviewPage && inReviewMode));
 
   return (
     <>
       <div name="eligibleScrollElement" />
-      {showNoIssues && <NoIssuesLoadedAlert submitted={submitted} />}
+      {showNoIssues && <NoIssuesLoadedAlert />}
       {!showNoIssues &&
         submitted &&
         !hasSelected && (

--- a/src/applications/appeals/996/content/contestableIssues.jsx
+++ b/src/applications/appeals/996/content/contestableIssues.jsx
@@ -182,7 +182,7 @@ MaxSelectionsAlert.propTypes = {
   closeModal: PropTypes.func,
 };
 
-export const NoIssuesLoadedAlert = ({ submitted }) => {
+export const NoIssuesLoadedAlert = () => {
   const wrapAlert = useRef(null);
 
   useEffect(
@@ -191,7 +191,7 @@ export const NoIssuesLoadedAlert = ({ submitted }) => {
         scrollAndFocus(wrapAlert.current);
       }
     },
-    [wrapAlert, submitted],
+    [wrapAlert],
   );
 
   recordEvent({
@@ -216,10 +216,6 @@ export const NoIssuesLoadedAlert = ({ submitted }) => {
       </va-alert>
     </div>
   );
-};
-
-NoIssuesLoadedAlert.propTypes = {
-  submitted: PropTypes.bool,
 };
 
 export const noneSelected =

--- a/src/applications/appeals/996/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -141,4 +141,30 @@ describe('<ContestableIssuesWidget>', () => {
       expect(setFormDataSpy.called).to.be.false;
     });
   });
+
+  it('should not show no loaded issues alert after remove all additional items', async () => {
+    const props = getProps();
+    const { container } = render(
+      <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
+    );
+
+    expect($$('va-alert', container).length).to.equal(1);
+    expect($('va-alert', container).innerHTML).to.contain(
+      'Sorry, we couldn’t find any eligible issues',
+    );
+  });
+
+  it('should not show no loaded issues alert after remove all additional items', async () => {
+    const props = getProps();
+    const { container, rerender } = render(
+      <ContestableIssuesWidget {...props} value={[]} />,
+    );
+
+    rerender(
+      <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
+    );
+    await waitFor(() => {
+      expect($$('va-alert', container).length).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > During an a11y audit, it was pointed out that an alert showing that no issues were loaded is re-displayed _after_ the user removes the last added issue. This alert should only be shown initially.
- _(If bug, how to reproduce)_
  > - Log into a user with no contestable issues (user 0 is one possibility)
  > - Start NOD (or any of the other decision review forms), and get to the issue page
  > - Note the no loaded issues alert at the top of the page
  > - Add an issue manually
  > - Upon returning to the issue page, the alert should not show
  > - Delete the issue
  > - The no loaded issues alert should not show, but the no selected issues alert will show if you attempt to continue without any issues
  > The no loaded issues alert will show up again if you navigate back one page and return to the issue page.
- _(What is the solution, why is this the solution)_
  > Only show the no loaded issues alert initially
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#61365](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61365)

## Testing done

- _Describe what the old behavior was prior to the change_
  > The no loaded issues alert would become visible after removing the last added issues, with no loaded issues. The UX/A11y experience is that an error shouldn't show with no error state.
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<table>
<thead>
<tr><th></th><th>Before</th><th>After</th></tr>
</thead>
<tbody>
<td>Desktop</td>
<td>

https://github.com/department-of-veterans-affairs/va.gov-team/assets/14154792/96691594-44be-4996-89a2-db47e5fd15cb

</td><td>

![no-issues-initial-only](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/ed1ae859-e23e-496f-96c6-1f6b721918c4)
</td></tr>
</tbody>
</table>

## What areas of the site does it impact?

Decision review forms: NOD, HLR & Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
