### PR TITLE
Add event tracker to descriptive back link

### DIFF
--- a/src/applications/vaos/components/BackLink.jsx
+++ b/src/applications/vaos/components/BackLink.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
+import { useLocation, NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import recordEvent from 'platform/monitoring/record-event';
+import { GA_PREFIX } from '../utils/constants';
 
 export default function BackLink({ appointment }) {
   const {
@@ -8,6 +10,31 @@ export default function BackLink({ appointment }) {
     isPendingAppointment,
     isUpcomingAppointment,
   } = appointment.vaos;
+
+  const location = useLocation();
+
+  const handleClickGATracker = () => {
+    let status;
+    if (isPendingAppointment) {
+      status = 'pending';
+    } else if (isUpcomingAppointment) {
+      status = 'upcoming';
+    } else if (isPastAppointment) {
+      status = 'past';
+    }
+
+    const progress =
+      location.search === '?confirmMsg=true' ? 'confirmation' : 'appointment';
+
+    if (progress === 'confirmation' && status === 'upcoming') {
+      status = 'direct';
+    }
+    return () => {
+      recordEvent({
+        event: `${GA_PREFIX}-${status}-${progress}-details-descriptive-back-link`,
+      });
+    };
+  };
 
   const handleBackLinkText = () => {
     let linkText;
@@ -46,6 +73,7 @@ export default function BackLink({ appointment }) {
         aria-label={handleBackLinkText()}
         to={handleBackLink()}
         className="vaos-hide-for-print vads-u-color--link-default"
+        onClick={handleClickGATracker()}
       >
         {handleBackLinkText()}
       </NavLink>


### PR DESCRIPTION
## Summary
This PR  adds tracking event on the descriptive back link for Universal Analytics (UA) tool.

## Acceptance Criteria

- [ ] Given when the user is authenticated to the Appointments application and clicks on `Details` for their upcoming VA appointment
When the user clicks on the descriptive back link
Then it will trigger an event `vaos-upcoming-appointment-details-descriptive-back-link` in UA

- [ ] Given when the user is authenticated to the Appointments application and clicks on `Details` for their pending VA appointment or pending Community Care appointment
When the user clicks on the descriptive back link
Then it will trigger an event `vaos-pending-appointment-details-descriptive-back-link` in UA

- [ ] Given when the user is authenticated to the Appointments application and clicks on `Details` for their past VA appointment
When the user clicks on the descriptive back link
Then it will trigger an event `vaos-past-appointment-details-descriptive-back-link` in UA

- [ ] Given when the user is authenticated to the Appointments application
When the user completes a direct scheduling workflow for a VA booked appointment and clicks on the descriptive back link on the confirmation details page
Then it will trigger an event `vaos-direct-confirmation-details-descriptive-back-link` in UA

- [ ] Given when the user is authenticated to the Appointments application
When the user submits a pending VA appointment or a pending Community Care appointment and clicks on the descriptive back link on the confirmation details page
Then it will trigger an event `vaos-pending-confirmation-details-descriptive-back-link` in UA

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63331


## Testing done

n/a

## Screenshots

{
    "event": "vaos-past-appointment-details-descriptive-back-link"
}
{
    "event": "vaos-pending-appointment-details-descriptive-back-link"
}
{
    "event": "vaos-upcoming-appointment-details-descriptive-back-link"
}
{
    "event": "vaos-pending-confirmation-details-descriptive-back-link"
}
{
    "event": "vaos-direct-confirmation-details-descriptive-back-link"
}


## What areas of the site does it impact?

GA

