### PR TITLE
VACMS-14729 PACT Act Wizard: adding Results page 1

### DIFF
--- a/src/applications/pact-act/actions/index.js
+++ b/src/applications/pact-act/actions/index.js
@@ -1,0 +1,8 @@
+import { PAW_VIEWED_RESULTS_PAGE_1 } from '../constants';
+
+export const updateResultsPage1Viewed = value => {
+  return {
+    type: PAW_VIEWED_RESULTS_PAGE_1,
+    payload: value,
+  };
+};

--- a/src/applications/pact-act/components/Breadcrumbs.jsx
+++ b/src/applications/pact-act/components/Breadcrumbs.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Breadcrumbs = () => {
+  return (
+    <va-breadcrumbs class="pact-act-breadcrumbs" label="Breadcrumbs">
+      <a href="/" key="home">
+        Home
+      </a>
+      <a href="/pact-act">PACT Act</a>
+    </va-breadcrumbs>
+  );
+};
+
+export default Breadcrumbs;

--- a/src/applications/pact-act/components/PACTActApp.jsx
+++ b/src/applications/pact-act/components/PACTActApp.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Breadcrumbs from './Breadcrumbs';
+
+const PACTActApp = ({ children }) => {
+  return (
+    <div className="pact-act-app row vads-u-padding-bottom--8">
+      <Breadcrumbs />
+      <div className="usa-width-two-thirds medium-8 columns">{children}</div>
+    </div>
+  );
+};
+
+PACTActApp.propTypes = {
+  children: PropTypes.any,
+};
+
+export default connect()(PACTActApp);

--- a/src/applications/pact-act/constants/index.js
+++ b/src/applications/pact-act/constants/index.js
@@ -1,0 +1,6 @@
+export const PAW_VIEWED_RESULTS_PAGE_1 = 'pact-act/PAW_VIEWED_RESULTS_PAGE_1';
+
+export const ROUTES = {
+  RESULTS_SET_1_PAGE_1: 'results-1-1',
+  RESULTS_SET_1_PAGE_2: 'results-1-2',
+};

--- a/src/applications/pact-act/constants/results-set-1-page-2-accordions.jsx
+++ b/src/applications/pact-act/constants/results-set-1-page-2-accordions.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+export const accordions = {
+  'burn-pit': [
+    {
+      title: 'New PACT Act presumptive conditions for Burn pit exposure',
+      content: (
+        <>
+          <p>
+            We’ve added more than 20 burn pit and other toxic exposure
+            presumptive conditions based on the PACT Act. This change expands
+            benefits for Gulf War era and post-9/11 Veterans.
+          </p>
+          <p>
+            <strong>These cancers are now presumptive:</strong>
+          </p>
+          <ul>
+            <li>Brain cancer</li>
+            <li>Gastrointestinal cancer of any type</li>
+            <li>Glioblastoma</li>
+            <li>Head cancer of any type</li>
+            <li>Kidney cancer</li>
+            <li>Lymphoma of any type</li>
+            <li>Melanoma</li>
+            <li>Neck cancer of any type</li>
+            <li>Pancreatic cancer</li>
+            <li>Reproductive cancer of any type</li>
+            <li>Respiratory (breathing-related) cancer of any type</li>
+          </ul>
+          <va-link
+            class="vads-u-margin-top--3 vads-u-margin-bottom--3 vads-u-display--block"
+            href="/resources/presumptive-cancers-related-to-burn-pit-exposure"
+            text="Learn more about presumptive cancers related to burn pits"
+          />
+          <p>
+            <strong>These illnesses are now presumptive:</strong>
+          </p>
+          <ul>
+            <li>Asthma that was diagnosed after service</li>
+            <li>Chronic bronchitis</li>
+            <li>Chronic obstructive pulmonary disease (COPD)</li>
+            <li>Chronic rhinitis</li>
+            <li>Chronic sinusitis</li>
+            <li>Constrictive bronchiolitis or obliterative bronchiolitis</li>
+            <li>Emphysema</li>
+            <li>Granulomatous disease</li>
+            <li>Interstitial lung disease (ILD)</li>
+            <li>Pleuritis</li>
+            <li>Pulmonary fibrosis</li>
+            <li>Sarcoidosis</li>
+          </ul>
+        </>
+      ),
+    },
+    {
+      title: 'Other Gulf War illnesses presumptive conditions',
+      content: (
+        <>
+          <p>
+            We presume that these conditions are caused by military service in
+            Iraq, Afghanistan, and certain other locations during certain time
+            periods:
+          </p>
+          <ul>
+            <li>
+              Undiagnosed illnesses (like chronic fatigue syndrome,
+              fibromyalgia, and medically unexplained chronic multisymptom
+              illness)
+            </li>
+            <li>
+              Infectious diseases (like brucellosis, malaria, and West Nile
+              virus)
+            </li>
+          </ul>
+          <va-link
+            href="/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan/"
+            text="Learn more about Gulf War illnesses and VA disability compensation"
+          />
+        </>
+      ),
+    },
+  ],
+};

--- a/src/applications/pact-act/containers/results/1/Page1.jsx
+++ b/src/applications/pact-act/containers/results/1/Page1.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router';
+import PropTypes from 'prop-types';
+import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { ROUTES } from '../../../constants';
+import { updateResultsPage1Viewed } from '../../../actions';
+import { customizeTitle } from '../../../utilities/customize-title';
+
+const ResultsSet1Page1 = ({
+  router,
+  updateResults1Viewed,
+  viewedResultsPage1,
+}) => {
+  const H1 = 'You may be eligible for VA benefits';
+
+  useEffect(
+    () => {
+      document.title = customizeTitle(H1);
+
+      if (!viewedResultsPage1) {
+        router.push('/');
+      }
+
+      updateResults1Viewed(true);
+    },
+    [router, updateResults1Viewed, viewedResultsPage1],
+  );
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+    waitForRenderThenFocus('h1');
+  });
+
+  return (
+    <>
+      <h1>{H1}</h1>
+      <p>
+        You may be eligible for benefits, including a monthly disability
+        compensation payment and VA health care.
+      </p>
+      <p>
+        Based on where you told us you served, we think you may have had
+        exposure to a toxic substance. We call this a "presumption of exposure."
+      </p>
+      <h2>Presumptive exposure locations we think may apply to you</h2>
+      <p>
+        Burn pit or other toxic exposures from service in any of these
+        locations, on or after <strong>August 2, 1990</strong>:
+      </p>
+      <ul>
+        <li>Arabian Sea</li>
+        <li>Gulf of Aden</li>
+        <li>Gulf of Oman</li>
+        <li>Neutral zone between Iraq/Saudi Arabia</li>
+        <li>Persian Gulf</li>
+        <li>Red Sea</li>
+      </ul>
+      <p>
+        We’ve added new presumptive conditions for these locations under the
+        PACT Act.
+      </p>
+      <h2>What this means for you</h2>
+      <p>
+        We automatically assume (or “presume”) that these exposures cause
+        certain health conditions. We call these “presumptive conditions.”
+      </p>
+      <p>
+        If you have a presumptive condition, you don’t need to prove that your
+        service caused the condition to get VA disability compensation. You only
+        need to meet the service requirements for presumption.
+      </p>
+      <Link
+        className="vads-c-action-link--green"
+        to={ROUTES.RESULTS_SET_1_PAGE_2}
+      >
+        Learn what to do next
+      </Link>
+    </>
+  );
+};
+
+ResultsSet1Page1.propTypes = {
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+  viewedResultsPage1: PropTypes.bool.isRequired,
+  updateResults1Viewed: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  viewedResultsPage1: state?.pactAct?.viewedResultsPage1,
+});
+
+const mapDispatchToProps = {
+  updateResults1Viewed: updateResultsPage1Viewed,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ResultsSet1Page1);

--- a/src/applications/pact-act/containers/results/1/Page2.jsx
+++ b/src/applications/pact-act/containers/results/1/Page2.jsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { accordions } from '../../../constants/results-set-1-page-2-accordions';
+import { customizeTitle } from '../../../utilities/customize-title';
+import { ROUTES } from '../../../constants';
+
+const ResultsSet1Page2 = ({ viewedResultsPage1, router }) => {
+  const [hasScrolled, setHasScrolled] = useState(false);
+  const H1 = 'Apply for VA benefits now';
+
+  useEffect(() => {
+    document.title = customizeTitle(H1);
+  });
+
+  useEffect(
+    () => {
+      if (!viewedResultsPage1) {
+        router.push(ROUTES.RESULTS_SET_1_PAGE_1);
+      }
+    },
+    [viewedResultsPage1, router],
+  );
+
+  useEffect(
+    () => {
+      if (!hasScrolled) {
+        window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+        waitForRenderThenFocus('h1');
+        setHasScrolled(true);
+      }
+    },
+    [hasScrolled],
+  );
+
+  const renderAccordions = () => {
+    const contents = accordions['burn-pit'].map(accordion => (
+      <va-accordion-item
+        level="3"
+        data-testid="il-results-1"
+        header={accordion?.title}
+        key={accordion?.title}
+      >
+        {accordion?.content}
+      </va-accordion-item>
+    ));
+
+    return (
+      <va-accordion class="vads-u-margin-top--4" open-single>
+        {contents}
+      </va-accordion>
+    );
+  };
+
+  return (
+    <>
+      <h1>{H1}</h1>
+      <p>
+        Here’s how to apply for VA disability compensation and health care
+        online now.
+      </p>
+      <article>
+        <va-on-this-page />
+        <h2 id="file-a-disability-compensation-claim">
+          File a claim for disability compensation
+        </h2>
+        <p>
+          If you think you’re eligible, we encourage you to file a claim for
+          disability compensation now. If you have an illness that we don’t
+          consider presumptive, you can still file a claim. But you’ll need to
+          provide evidence that your service caused your condition.
+        </p>
+        {renderAccordions()}
+        <h3>If you haven’t yet filed a claim for your condition</h3>
+        <p>
+          You can file a claim now. If you already get disability compensation
+          for a different condition, we still encourage you to file a claim for
+          any condition you believe your service caused. You may be able to get
+          additional or other benefits.
+        </p>
+        <a
+          className="vads-c-action-link--blue"
+          href="/disability/file-disability-claim-form-21-526ez/"
+        >
+          File a disability compensation claim
+        </a>
+        <h3>If we denied your claim for this condition in the past</h3>
+        <p>
+          If we now consider your condition presumptive under the PACT Act, you
+          can file a Supplemental Claim. We’ll reconsider your claim.
+        </p>
+        <a
+          className="vads-c-action-link--blue"
+          href="/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/"
+        >
+          File a Supplemental Claim
+        </a>
+        <h2 id="apply-for-va-health-care">Apply for VA health care</h2>
+        <p>You may also be eligible for VA health care.</p>
+        <p>
+          We’re extending and expanding VA health care eligibility based on the
+          PACT Act. We encourage you to apply, no matter your separation date.
+          Your eligibility depends on your service history and other factors.
+        </p>
+        <a
+          className="vads-c-action-link--blue"
+          href="/health-care/apply/application/introduction"
+        >
+          Apply for VA health care
+        </a>
+        <p>
+          <va-link
+            class="vads-u-margin-top--3 vads-u-display--block"
+            href="/health-care/eligibility/"
+            text="Learn more about health care eligibility"
+          />
+        </p>
+      </article>
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  viewedResultsPage1: state?.pactAct?.viewedResultsPage1,
+});
+
+ResultsSet1Page2.propTypes = {
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+  viewedResultsPage1: PropTypes.bool.isRequired,
+};
+
+export default connect(mapStateToProps)(ResultsSet1Page2);

--- a/src/applications/pact-act/manifest.json
+++ b/src/applications/pact-act/manifest.json
@@ -1,0 +1,6 @@
+{
+  "appName": "PACT Act",
+  "entryFile": "./pact-act-entry.jsx",
+  "entryName": "pact-act",
+  "rootUrl": "/test/pact-act"
+}

--- a/src/applications/pact-act/pact-act-entry.jsx
+++ b/src/applications/pact-act/pact-act-entry.jsx
@@ -1,0 +1,14 @@
+import 'platform/polyfills';
+import './sass/pact-act.scss';
+
+import startApp from 'platform/startup';
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  entryName: manifest.entryName,
+  reducer,
+  routes,
+});

--- a/src/applications/pact-act/reducers/index.js
+++ b/src/applications/pact-act/reducers/index.js
@@ -1,0 +1,20 @@
+import { PAW_VIEWED_RESULTS_PAGE_1 } from '../constants';
+
+const initialState = {
+  viewedResultsPage1: false,
+};
+
+const pactAct = (state = initialState, action) => {
+  if (action.type === PAW_VIEWED_RESULTS_PAGE_1) {
+    return {
+      ...state,
+      viewedResultsPage1: action.payload,
+    };
+  }
+
+  return state;
+};
+
+export default {
+  pactAct,
+};

--- a/src/applications/pact-act/routes.jsx
+++ b/src/applications/pact-act/routes.jsx
@@ -1,0 +1,19 @@
+import PACTActApp from './components/PACTActApp';
+import Results1Page1 from './containers/results/1/Page1';
+import Results1Page2 from './containers/results/1/Page2';
+import { ROUTES } from './constants';
+
+const routes = {
+  path: '/',
+  component: PACTActApp,
+  indexRoute: {
+    onEnter: (nextState, replace) => replace(`/${ROUTES.RESULTS_SET_1_PAGE_1}`),
+    component: Results1Page1,
+  },
+  childRoutes: [
+    { path: ROUTES.RESULTS_SET_1_PAGE_1, component: Results1Page1 },
+    { path: ROUTES.RESULTS_SET_1_PAGE_2, component: Results1Page2 },
+  ],
+};
+
+export default routes;

--- a/src/applications/pact-act/sass/pact-act.scss
+++ b/src/applications/pact-act/sass/pact-act.scss
@@ -1,0 +1,21 @@
+.pact-act-app {
+  h1:focus {
+    outline: none;
+  }
+
+  .pact-act-breadcrumbs {
+    &:focus {
+      outline: none;
+    }
+  }
+
+  article {
+    padding: 0;
+  }
+
+  va-on-this-page {
+    @media screen and (min-width: 768px) {
+      margin-left: 8px;
+    }
+  }
+}

--- a/src/applications/pact-act/utilities/customize-title.js
+++ b/src/applications/pact-act/utilities/customize-title.js
@@ -1,0 +1,9 @@
+// Used to customize the <title> element in the head of the document
+// for accessibility
+export const customizeTitle = h1 => {
+  if (h1) {
+    return `${h1} | PACT Act | Veterans Affairs`;
+  }
+
+  return 'PACT Act | Veterans Affairs';
+};


### PR DESCRIPTION
Adding the PACT Act wizard application basics and the first Results page (pages 1-2).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14729

## Testing done
1. Navigate to `/test/pact-act`
2. Validate text against Danielle's copy for results page 1 ([Danielle's copy](https://dvagov-my.sharepoint.com/:w:/g/personal/cynthia_merrill_va_gov/EXcXBeLPnthDhzKkq0tHOgkB1hz4H5z-TpljngwAkGniFw?e=WJhfZI) - Requires CAG) and/or against Jordan's [design](https://www.sketch.com/s/2bf4405b-5cc4-4672-88fb-d215abdf3b0d)
3. Validate `Learn what to do next` link at the bottom of the page links to page 2
4. Validate text against copy or Jordan's design for page 2
5. Ensure that deep-linking redirects appropriately. I.e. from either results page (`/results-1-1` or `/results-1-2`), you get redirected to `/test/pact-act/results-1-1` when reloading the page.

## Screenshots

### Desktop
#### Results set 1, page 1
<img width="1039" alt="Screenshot 2023-08-15 at 11 06 51 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f176e379-f4a7-4b40-adef-4e31130f6f5d">

#### Results set 1, page 2
<img width="1038" alt="Screenshot 2023-08-15 at 11 07 00 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/6c24d813-bd69-4b43-b2d2-da17c9677218">

##### Accordion 1
<img width="1040" alt="Screenshot 2023-08-15 at 11 07 11 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/d67053bb-e03d-46ee-8e82-33421e15b9fb">

##### Accordion 2
<img width="679" alt="Screenshot 2023-08-15 at 11 07 19 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e6c695da-8331-4b6e-9891-6bbb3b2c586b">

### Mobile
#### Results set 1, page 1
<img width="320" alt="Screenshot 2023-08-15 at 11 10 52 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b76f8151-0429-4ab7-96b2-cdf88cbb11b9">
<br/>
<img width="320" alt="Screenshot 2023-08-15 at 11 10 57 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1bfbb87d-3f88-40bf-bc72-97ea3cf513ec">

#### Results set 1, page 2
<img width="320" alt="Screenshot 2023-08-15 at 11 11 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/73f5e033-7409-40bc-8613-a060d2262be6">
<br/>
<img width="320" alt="Screenshot 2023-08-15 at 11 11 19 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/99ca4d33-a50a-4c13-ba09-28c87907c25b">
<br/>
<img width="320" alt="Screenshot 2023-08-15 at 11 11 30 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/99c6d3ef-fe91-4843-b25a-07908f74fc6a">
<br/>
<img width="320" alt="Screenshot 2023-08-15 at 11 11 35 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e7254b6a-8fa3-4e01-a13e-fa32512cbbbd">


## Acceptance criteria

- [x] Both screens of the R1 "results screen flow" are built, and linked by a link at the bottom of the first screen
- [x] The first screen is available at `/test/pact-act`
- [x] Confirmed that the screens conform to the design system (and are "working right") on both mobile and desktop devices