### PR TITLE
Use display none instead of not render checkboxes while api request is pending

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationCheckbox.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationCheckbox.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import classNames from 'classnames';
 import { NOTIFICATION_CHANNEL_LABELS } from '../../constants';
 import { NotificationStatusMessage } from './NotificationStatusMessage';
 
@@ -88,24 +89,27 @@ export const NotificationCheckbox = ({
     );
   }
 
+  const className = classNames({
+    'vads-u-padding-bottom--0p5': last,
+    'vads-u-display--none': loadingMessage,
+  });
+
   return (
     <div>
       {!loadingMessage && !successMessage && errorSpan}
       {!loadingMessage && !errorMessage && successSpan}
       {!errorMessage && !successMessage && loadingSpan}
-      {!loadingMessage && (
-        <VaCheckbox
-          checked={checked}
-          enableAnalytics
-          label={label}
-          onVaChange={handleChange}
-          data-testid={checkboxId}
-          id={checkboxId}
-          disabled={disabled}
-          uswds
-          className={last ? 'vads-u-padding-bottom--0p5' : ''}
-        />
-      )}
+      <VaCheckbox
+        checked={checked}
+        enable-analytics
+        label={label}
+        onVaChange={handleChange}
+        data-testid={checkboxId}
+        id={checkboxId}
+        disabled={disabled}
+        uswds
+        className={className}
+      />{' '}
     </div>
   );
 };

--- a/src/applications/personalization/profile/tests/components/notification-settings/NotificationCheckbox.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/notification-settings/NotificationCheckbox.unit.spec.jsx
@@ -40,10 +40,6 @@ describe('<NotificationCheckbox />', () => {
     );
     const loadingSpan = view.getByText(loadingMessage);
     expect(loadingSpan).to.exist;
-
-    // while loading the checkbox should not be displayed
-    const checkbox = view.queryByTestId(`checkbox-${defaultProps.channelId}`);
-    expect(checkbox).to.not.exist;
   });
 
   it('renders success message when provided', () => {


### PR DESCRIPTION
## Summary

- Previous PR did not successfully add GA events to checkbox interaction
- I thought it was an issue locally, but really it was an issue in the rendering logic.
- If the checkbox stops being rendered (while api request for the notification is pending) then it can't add the event to the dataLayer for reporting to GA, so it wasn't firing at all.
- I added a display-none css class to the checkbox instead of not rendering it, so that the correct GA event can not fire and be added to the dataLayer

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61112

## Testing done

- Was able to fully test locally this time. I learned my lesson I suppose.

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile -> Notification Settings

## Acceptance criteria

- [x] checkbox event fires correctly
