### PR TITLE
NOD | Rename data to `appealingVHADenial`

### DIFF
--- a/src/applications/appeals/10182/pages/appealingVhaDenial.js
+++ b/src/applications/appeals/10182/pages/appealingVhaDenial.js
@@ -3,7 +3,7 @@ import { content } from '../content/appealingVhaDenial';
 const appealingVhaDenial = {
   uiSchema: {
     'ui:title': content.title,
-    appealingVhaDenial: {
+    appealingVHADenial: {
       'ui:title': content.label,
       'ui:widget': 'yesNo',
       'ui:options': {
@@ -15,7 +15,7 @@ const appealingVhaDenial = {
   schema: {
     type: 'object',
     properties: {
-      appealingVhaDenial: {
+      appealingVHADenial: {
         type: 'boolean',
       },
     },

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -28,7 +28,7 @@
     "view:additionalEvidence": true,
     "requestingExtension": true,
     "extensionReason": "Lorem ipsum",
-    "appealingVhaDenial": false,
+    "appealingVHADenial": false,
 
     "contestableIssues": [
       {

--- a/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
@@ -27,7 +27,7 @@
     "socOptIn": false,
     "view:additionalEvidence": false,
     "requestingExtension": false,
-    "appealingVhaDenial": false,
+    "appealingVHADenial": false,
 
     "contestableIssues": [
       {

--- a/src/applications/appeals/10182/tests/pages/appealingVhaDenial.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/appealingVhaDenial.unit.spec.jsx
@@ -53,7 +53,7 @@ describe('extension request page', () => {
         definitions={{}}
         schema={schema}
         uiSchema={uiSchema}
-        data={{ appealingVhaDenial: true }}
+        data={{ appealingVHADenial: true }}
         formData={{}}
         onSubmit={onSubmit}
       />,

--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -398,7 +398,7 @@ describe('getTimeZone', () => {
 describe('getPart3Data', () => {
   const getResult = ({ ext = false, denial = false } = {}) => ({
     requestingExtension: ext,
-    appealingVhaDenial: denial,
+    appealingVhaDenial: denial, // Vha not VHA is submitted
   });
   it('should return an empty object', () => {
     expect(getPart3Data({})).to.deep.equal({});
@@ -407,7 +407,7 @@ describe('getPart3Data', () => {
     expect(getPart3Data({ [SHOW_PART3]: true })).to.deep.equal(getResult());
   });
   it('should return appealing VHA denial as true', () => {
-    const data = { [SHOW_PART3]: true, appealingVhaDenial: true };
+    const data = { [SHOW_PART3]: true, appealingVHADenial: true };
     const result = getResult({ denial: true });
     expect(getPart3Data(data)).to.deep.equal(result);
   });

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -26,7 +26,7 @@ import { replaceSubmittedData, fixDateFormat } from './replace';
  *   requesting an extension
  * @property {String} extensionReason - Text of why the Veteran is requesting an
  *   extension
- * @property {Boolean} appealingVhaDenial - yes/no indicating the Veteran is
+ * @property {Boolean} appealingVHADenial - yes/no indicating the Veteran is
  *   appealing a VHA denial
  * @property {Boolean} view:additionalEvidence - Veteran choice to upload more
  *   evidence
@@ -396,7 +396,7 @@ export const getTimeZone = () =>
  *   requesting an extension
  * @param {String} extensionReason - Text of why the Veteran is requesting an
  *   extension
- * @param {Boolean} appealingVhaDenial - yes/no indicating the Veteran is
+ * @param {Boolean} appealingVHADenial - yes/no indicating the Veteran is
  *   appealing a VHA denial
  * @returns {Object} data from part III, box 11 of form expiring on 3/31/2025
  */
@@ -407,9 +407,15 @@ export const getPart3Data = formData => {
   const {
     requestingExtension = false,
     extensionReason = '',
-    appealingVhaDenial = false,
+    appealingVHADenial = false,
   } = formData;
-  const result = { requestingExtension, appealingVhaDenial };
+  const result = {
+    requestingExtension,
+    /* - Lighthouse is expecting `appealingVhaDenial`
+     * - Save-in-progress renames `appealingVhaDenial` to `appealingVHADenial`
+     *   so we just kept the all-cap VHA within the form data */
+    appealingVhaDenial: appealingVHADenial,
+  };
   if (requestingExtension) {
     result.extensionReason = extensionReason;
   }


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When adding the Notice of Disagreement part III, box 11 update, we included a form data variable named `appealingVhaDenial` which matches the value name that Lighthouse expects. But during testing, the save-in-progress response includes `appealingVHADenial` in the form data; the variable was renamed to make `VHA` all caps. We planned to investigate the backend to determine if this was intentional, but we haven't had time to look into it. So, on the frontend, we're just going to rename the value to use all caps `VHA` and move the backend investigation to the back log. 
- _(If bug, how to reproduce)_
  > - Log in and start a Notice of Disagreement form in staging.
  > - Get to the "Denial of VA health care benefits" page
  > - Choose "Yes"
  > - Activate the "Finish this request later" link
  > - Open network tab in the dev console
  > - Reload the app and activate the "Continue your request" button
  > - Check the save-in-progress (`10182`) API call and note that the form data now includes a `appealingVHADenial` and the radio buttons on the "Denial of VA health care benefits" page contain no selection
- _(What is the solution, why is this the solution)_
  > Trivial change to rename the variable and then submit the camel-cased value to Lighthouse
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  > `nod_part3_update` - currently set to 0% production - to be removed once this update is ramped up to 100% and we verify that there are no issues

## Related issue(s)

[#63322](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63322)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Radio would not include a setting after returning to the form
- _Describe the steps required to verify your changes are working as expected_
  > Test in staging based on summary reproducing bug steps
- _Describe the tests completed and the results_
  > Updated unit tests; all passing - verified the camel-cased value is submitted
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
