### PR TITLE
update penalty notice

### DIFF
--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -116,7 +116,7 @@ export function PreSubmitSection(props) {
             <strong>Note:</strong> According to federal law, there are criminal
             penalties, including a fine and/or imprisonment for up to 5 years,
             for withholding information or for providing incorrect information
-            (See 18 U.S.C. 1001).
+            (Reference: 18 U.S.C. 1001).
           </p>
           <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--3 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--3">
             <h3>{statementOfTruth.heading || 'Statement of truth'}</h3>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
This PR replaces `see` with `reference` in one of the form component.

## Related issue(s)
department-of-veterans-affairs/vets-design-system-documentation#1960

## Testing done
Yes

## Screenshots
N/A

## What areas of the site does it impact?
N/A