### PR TITLE
59257 rename document to file

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -9,10 +9,9 @@ export const UploadDescription = ({ uploadTitle }) => (
   <div>
     {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
-      You can upload your document in a .pdf, .jpg, .jpeg, .png, .gif, .bmp, or
-      .txt file format. You’ll first need to scan a copy of your document onto
-      your computer or mobile phone. You can then upload the document from
-      there.
+      You can upload your file in a .pdf, .jpg, .jpeg, .png, .gif, .bmp, or .txt
+      format. You’ll first need to scan a copy of your file onto your computer
+      or mobile phone. You can then upload the file from there.
     </p>
     <p>Guidelines for uploading a file:</p>
     <ul>

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { MAX_FILE_SIZE_MB, MAX_PDF_FILE_SIZE_MB } from '../constants';
 
 /**
@@ -29,3 +30,7 @@ export const UploadDescription = ({ uploadTitle }) => (
     </p>
   </div>
 );
+
+UploadDescription.propTypes = {
+  uploadTitle: PropTypes.string,
+};

--- a/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecordsAttachments.js
+++ b/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecordsAttachments.js
@@ -9,7 +9,8 @@ const fileUploadUi = ancillaryFormUploadUi(
   '',
   {
     attachmentId: '',
-    addAnotherLabel: 'Add another document',
+    addAnotherLabel: 'Add another file',
+    buttonText: 'Upload file',
   },
 );
 

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -260,6 +260,7 @@ export const ancillaryFormUploadUi = (
     widgetType = 'select',
     customClasses = '',
     isDisabled = false,
+    buttonText = '',
     addAnotherLabel = 'Add Another',
   } = {},
 ) => {
@@ -276,6 +277,7 @@ export const ancillaryFormUploadUi = (
     itemDescription,
     hideLabelText: !label,
     fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
+    buttonText,
     addAnotherLabel,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
     // not sure what to do here... we need to differentiate pdf vs everything

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -304,7 +304,7 @@ export const ancillaryFormUploadUi = (
       };
     },
     attachmentSchema: ({ fileId }) => ({
-      'ui:title': 'Document type',
+      'ui:title': 'File type',
       'ui:disabled': isDisabled,
       'ui:widget': widgetType,
       'ui:options': {

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -3,11 +3,11 @@ import { merge, omit } from 'lodash';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import _ from 'platform/utilities/data';
-import environment from 'platform/utilities/environment';
-import ReviewCardField from 'platform/forms-system/src/js/components/ReviewCardField';
-import AddressViewField from 'platform/forms-system/src/js/components/AddressViewField';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import ReviewCardField from '@department-of-veterans-affairs/platform-forms-system/ReviewCardField';
+import AddressViewField from '@department-of-veterans-affairs/platform-forms-system/AddressViewField';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import {
   validateMilitaryCity,

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -121,7 +121,7 @@ const FileField = props => {
     modalContent: fileName =>
       uiOptions.modalContent?.(fileName || 'Unknown') || (
         <span>
-          We’ll remove the uploaded document{' '}
+          We’ll remove the uploaded file{' '}
           <strong>{fileName || 'Unknown'}</strong>
         </span>
       ),


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
Rename 'document' to 'file' to comply with current [content guidelines](https://design.va.gov/patterns/ask-users-for/files#content-considerations)
- _(If bug, how to reproduce)_
n/a 
- _(What is the solution, why is this the solution)_
Small content updates.
- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEx TRex
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
n/a

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#59257
- _Link to previous change of the code/bug (if applicable)_
n/a
- _Link to epic if not included in ticket_
n/a

## Testing done

- _Describe what the old behavior was prior to the change_
Content previously displayed the word 'document'
- _Describe the steps required to verify your changes are working as expected_
1. Start the process to file a new 526, BDD claim on /disability/file-disability-claim-form-21-526ez/introduction. 
2. When you get to the `/supporting-evidence/service-treatment-records` page, select 'Yes' for 'Do you want to upload your service treatment records?'
3. This will take you to the `/supporting-evidence/service-treatment-records-upload` page which has the changes
4. Upload a file, add another, delete file(s) to view the different states
- _Describe the tests completed and the results_
Manual tests (noted above) were successful
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing_
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
<img width="1237" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/377ae9f9-175e-410a-8c14-3370bb1afdc6">
<img width="1231" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/4b5be3e0-f4ee-4a65-bd78-fce33ffd22ee">
<img width="1283" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/865c7ade-cedf-4e04-8c85-a317af7ca628">

<img width="1014" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/badbf3ba-16ca-432c-8d7b-39ee8148ecc9">
<img width="946" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/e60c4745-dc27-4011-a997-fe050b24a917">
<img width="910" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/cd78088d-0ee7-47fa-9a8e-e7e75c91b521">

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
n/a. small content changes are not covered by automation
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
n/a
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
n/a
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
n/a

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
