### PR TITLE
Feature: Benefit Selection Page Enhancements

### DIFF
--- a/src/applications/my-education-benefits/components/CannotRelinquishLabel.jsx
+++ b/src/applications/my-education-benefits/components/CannotRelinquishLabel.jsx
@@ -16,4 +16,5 @@ CannotRelinquishLabel.prototypes = {
 const mapStateToProps = state => ({
   ...getAppData(state),
 });
+
 export default connect(mapStateToProps)(CannotRelinquishLabel);

--- a/src/applications/my-education-benefits/components/CannotRelinquishLabel.jsx
+++ b/src/applications/my-education-benefits/components/CannotRelinquishLabel.jsx
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { getAppData } from '../selectors/selectors';
+
+const CannotRelinquishLabel = ({ showMebEnhancements09 }) => {
+  return showMebEnhancements09
+    ? "I'm not eligible for Chapter 30 or Chapter 1606 benefits"
+    : "I'm not sure";
+};
+
+CannotRelinquishLabel.prototypes = {
+  showMebEnhancements09: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  ...getAppData(state),
+});
+export default connect(mapStateToProps)(CannotRelinquishLabel);

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -1439,7 +1439,14 @@ const formConfig = {
                     Chapter30: 'Montgomery GI Bill Active Duty (Chapter 30)',
                     Chapter1606:
                       'Montgomery GI Bill Selected Reserve (Chapter 1606)',
-                    CannotRelinquish: "I'm not sure",
+                    CannotRelinquish: state => {
+                      // Access the feature flag from the state here.
+                      const { showMebEnhancements09 } = state.featureToggles;
+
+                      return showMebEnhancements09
+                        ? "I'm not eligible for Chapter 30 or Chapter 1606 benefits"
+                        : "I'm not sure";
+                    },
                   },
                   widgetProps: {
                     Chapter30: { 'data-info': 'Chapter30' },
@@ -1448,9 +1455,7 @@ const formConfig = {
                   },
                   selectedProps: {
                     Chapter30: { 'aria-describedby': 'Chapter30' },
-                    Chapter1606: {
-                      'aria-describedby': 'Chapter1606',
-                    },
+                    Chapter1606: { 'aria-describedby': 'Chapter1606' },
                     CannotRelinquish: {
                       'aria-describedby': 'CannotRelinquish',
                     },
@@ -1462,7 +1467,6 @@ const formConfig = {
                         if (!eligibility || !eligibility.length) {
                           return benefits;
                         }
-
                         return {
                           enum: benefits.filter(
                             benefit =>

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -1405,7 +1405,14 @@ const formConfig = {
           path: 'benefit-selection',
           title: 'Benefit selection',
           subTitle: 'You’re applying for the Post-9/11 GI Bill®',
-          depends: formData => formData.eligibility?.length,
+          depends: formData => {
+            // If the showMebEnhancements09 feature flag is turned on, show the page
+            if (formData.showMebEnhancements09) {
+              return true;
+            }
+            // If the feature flag is not turned on, check the eligibility length
+            return Boolean(formData.eligibility?.length);
+          },
           uiSchema: {
             'view:post911Notice': {
               'ui:description': (

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -30,6 +30,7 @@ import ApplicantIdentityView from '../components/ApplicantIdentityView';
 import ApplicantInformationReviewPage from '../components/ApplicantInformationReviewPage.jsx';
 import BenefitGivenUpReviewField from '../components/BenefitGivenUpReviewField';
 import BenefitRelinquishedLabel from '../components/BenefitRelinquishedLabel';
+import CannotRelinquishLabel from '../components/CannotRelinquishLabel';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import CustomReviewDOBField from '../components/CustomReviewDOBField';
 import CustomEmailField from '../components/CustomEmailField';
@@ -162,12 +163,6 @@ const filterEligibility = (form, state) => {
         eligibility.includes(benefit) || benefit === 'CannotRelinquish',
     ),
   };
-};
-const adjustLabelForFeatureFlag = state => {
-  const { showMebEnhancements09 } = state.featureToggles; // Update path to your feature flag.
-  return showMebEnhancements09
-    ? "I'm not eligible for Chapter 30 or Chapter 1606 benefits"
-    : "I'm not sure";
 };
 
 function isOnlyWhitespace(str) {
@@ -1458,9 +1453,7 @@ const formConfig = {
                     Chapter30: 'Montgomery GI Bill Active Duty (Chapter 30)',
                     Chapter1606:
                       'Montgomery GI Bill Selected Reserve (Chapter 1606)',
-                    CannotRelinquish: (() => {
-                      return state => adjustLabelForFeatureFlag(state);
-                    })(),
+                    CannotRelinquish: <CannotRelinquishLabel />,
                   },
                   widgetProps: {
                     Chapter30: { 'data-info': 'Chapter30' },

--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -39,6 +39,7 @@ export const App = ({
   showMebEnhancements,
   showMebEnhancements06,
   showMebEnhancements08,
+  showMebEnhancements09,
   email,
   duplicateEmail,
   duplicatePhone,
@@ -70,6 +71,7 @@ export const App = ({
     [
       claimantInfo,
       featureTogglesLoaded,
+      fetchedContactInfo,
       fetchedPersonalInfo,
       formData,
       getPersonalInfo,
@@ -214,6 +216,13 @@ export const App = ({
         });
       }
 
+      if (showMebEnhancements09 !== formData.showMebEnhancements09) {
+        setFormData({
+          ...formData,
+          showMebEnhancements09,
+        });
+      }
+
       if (isLOA3 !== formData.isLOA3) {
         setFormData({
           ...formData,
@@ -231,7 +240,10 @@ export const App = ({
       showMebEnhancements,
       showMebEnhancements06,
       showMebEnhancements08,
+      showMebEnhancements09,
       getDuplicateContactInfo,
+      duplicateEmail,
+      duplicatePhone,
     ],
   );
 
@@ -247,7 +259,7 @@ export const App = ({
         });
       }
     },
-    [email],
+    [email, formData, setFormData],
   );
 
   // Commenting out until Direct Deposit component is updated
@@ -280,7 +292,10 @@ export const App = ({
 App.propTypes = {
   children: PropTypes.object,
   claimantInfo: PropTypes.object,
+  duplicateEmail: PropTypes.array,
+  duplicatePhone: PropTypes.array,
   eligibility: PropTypes.arrayOf(PropTypes.string),
+  email: PropTypes.string,
   featureTogglesLoaded: PropTypes.bool,
   firstName: PropTypes.string,
   formData: PropTypes.object,
@@ -290,16 +305,14 @@ App.propTypes = {
   isLOA3: PropTypes.bool,
   isLoggedIn: PropTypes.bool,
   location: PropTypes.object,
-  setFormData: PropTypes.func,
-  showMebDgi40Features: PropTypes.bool,
-  showMebCh33SelfForm: PropTypes.bool,
-  email: PropTypes.string,
   mobilePhone: PropTypes.string,
+  setFormData: PropTypes.func,
+  showMebCh33SelfForm: PropTypes.bool,
+  showMebDgi40Features: PropTypes.bool,
   showMebEnhancements: PropTypes.bool,
   showMebEnhancements06: PropTypes.bool,
   showMebEnhancements08: PropTypes.bool,
-  duplicateEmail: PropTypes.array,
-  duplicatePhone: PropTypes.array,
+  showMebEnhancements09: PropTypes.bool,
 };
 
 const mapStateToProps = state => {

--- a/src/applications/my-education-benefits/selectors/selectors.js
+++ b/src/applications/my-education-benefits/selectors/selectors.js
@@ -42,5 +42,8 @@ export const getAppData = state => ({
   showMebEnhancements08: !!toggleValues(state)[
     FEATURE_FLAG_NAMES.showMebEnhancements08
   ],
+  showMebEnhancements09: !!toggleValues(state)[
+    FEATURE_FLAG_NAMES.showMebEnhancements09
+  ],
   user: state.user || {},
 });


### PR DESCRIPTION
## Summary

- using show_meb_enhancements_09 flipper
- Conditionally changes the cannot relinquish radio button label
- Conditionally renders the benefit selection page to default to always render when the 09 feature flag is on
- custom redux component for the cannot relinquish label with integrated feature flag
- some use effect and prop type clean ups in App.jsx container

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
My Education Benefits 1990EZ form

## Acceptance criteria

- When Eligibility call fails with feature flag on the user still will see the benefit selection page
- Updated label for cannotRelinquish enum

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
