### PR TITLE
VFEP-738 Only try to fetch entitlements for loggedIn users.

### DIFF
--- a/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
@@ -10,8 +10,10 @@ import { getRemainingEntitlement } from '../actions/post-911-gib-status';
 
 export class IntroductionPage extends React.Component {
   componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-    this.props.getRemainingEntitlement();
+    if (this.props.isLoggedIn) {
+      focusElement('.va-nav-breadcrumbs-list');
+      this.props.getRemainingEntitlement();
+    }
   }
 
   moreThanSixMonths = remaining => {


### PR DESCRIPTION
## Problem

1. When a user visit the Apply for the Rogers STEM Scholarship
2. They get the following error if they are not logged in: Failed to load resource: the server responded with a status of 404 (Not Found)"
3. You'll need to look at the console in order to see the error: [Apply for the Rogers STEM Scholarship](http://localhost:3001/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction)


## Summary
- VFEP-738 I added an if statement to only try to fetch entitlements for loggedIn users.


## Jira
- [VFEP-738](https://vajira.max.gov/browse/VFEP-738)

## Testing done
- I verified the changes on my local machine.

## Screenshots

![401 unauthorized](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/a17849e1-ae03-4d23-8845-55a0de639ee2)
