### PR TITLE
Check in/63315/new travel logic

### DIFF
--- a/src/applications/check-in/actions/day-of/index.js
+++ b/src/applications/check-in/actions/day-of/index.js
@@ -48,11 +48,15 @@ export const updateFormAction = ({
   patientDemographicsStatus,
   isTravelReimbursementEnabled,
   appointments,
+  isTravelLogicEnabled,
+  travelPaySent,
 }) => {
   const pages = updateForm(
     patientDemographicsStatus,
     isTravelReimbursementEnabled,
     appointments,
+    isTravelLogicEnabled,
+    travelPaySent,
   );
   return {
     type: UPDATE_DAY_OF_CHECK_IN_FORM,

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -61,13 +61,27 @@ const CheckInConfirmation = props => {
   const {
     setShouldSendTravelPayClaim,
     getShouldSendTravelPayClaim,
+    setTravelPaySent,
+    getTravelPaySent,
   } = useSessionStorage(false);
 
   useEffect(
     () => {
-      if (travelPayClaimSent) setShouldSendTravelPayClaim(window, false);
+      if (travelPayClaimSent) {
+        const facility = selectedAppointment.facilityId;
+        const travelPaySent = getTravelPaySent(window);
+        travelPaySent[facility] = new Date();
+        setShouldSendTravelPayClaim(window, false);
+        setTravelPaySent(window, travelPaySent);
+      }
     },
-    [travelPayClaimSent, setShouldSendTravelPayClaim],
+    [
+      travelPayClaimSent,
+      setShouldSendTravelPayClaim,
+      setTravelPaySent,
+      getTravelPaySent,
+      selectedAppointment,
+    ],
   );
 
   const doTravelPay = isTravelReimbursementEnabled && travelPayClaimRequested;

--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -43,9 +43,12 @@ const useGetCheckInData = ({
   const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
   const { token } = useSelector(selectCurrentContext);
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const { isTravelReimbursementEnabled } = useSelector(selectFeatureToggles);
+  const { isTravelReimbursementEnabled, isTravelLogicEnabled } = useSelector(
+    selectFeatureToggles,
+  );
   const { jumpToPage } = useFormRouting(router);
   const { setPreCheckinComplete } = useSessionStorage();
+  const { getTravelPaySent } = useSessionStorage(false);
 
   const dispatch = useDispatch();
 
@@ -67,12 +70,15 @@ const useGetCheckInData = ({
         dispatch(receivedMultipleAppointmentDetails(appointments, token));
 
         if (!appointmentsOnly) {
+          const travelPaySent = getTravelPaySent(window);
           dispatch(receivedDemographicsData(demographics));
           dispatch(
             updateDayOfForm({
               patientDemographicsStatus,
               isTravelReimbursementEnabled,
               appointments,
+              isTravelLogicEnabled,
+              travelPaySent,
             }),
           );
         }

--- a/src/applications/check-in/hooks/useSessionStorage.jsx
+++ b/src/applications/check-in/hooks/useSessionStorage.jsx
@@ -148,6 +148,21 @@ const useSessionStorage = (isPreCheckIn = true) => {
     [SESSION_STORAGE_KEYS],
   );
 
+  const setTravelPaySent = useCallback(
+    (window, value) => {
+      setSessionKey(window, SESSION_STORAGE_KEYS.TRAVELPAY_SENT, value);
+    },
+    [SESSION_STORAGE_KEYS],
+  );
+
+  const getTravelPaySent = useCallback(
+    window => {
+      const value = getSessionKey(window, SESSION_STORAGE_KEYS.TRAVELPAY_SENT);
+      return value || {};
+    },
+    [SESSION_STORAGE_KEYS],
+  );
+
   return {
     clearCurrentSession,
     setCurrentToken,
@@ -164,6 +179,8 @@ const useSessionStorage = (isPreCheckIn = true) => {
     getProgressState,
     setPermissions,
     getPermissions,
+    setTravelPaySent,
+    getTravelPaySent,
   };
 };
 

--- a/src/applications/check-in/utils/navigation/day-of/index.js
+++ b/src/applications/check-in/utils/navigation/day-of/index.js
@@ -68,6 +68,8 @@ const updateForm = (
   patientDemographicsStatus,
   isTravelReimbursementEnabled,
   appointments,
+  isTravelLogicEnabled,
+  travelPaySent,
 ) => {
   const pages = CHECK_IN_FORM_PAGES.map(page => page.url);
 
@@ -77,6 +79,8 @@ const updateForm = (
     URLS,
     isTravelReimbursementEnabled,
     appointments,
+    isTravelLogicEnabled,
+    travelPaySent,
   );
 };
 

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -1,4 +1,4 @@
-import { differenceInCalendarDays } from 'date-fns';
+import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { isInAllowList } from '../appConstants';
 
 const isWithInDays = (days, pageLastUpdated) => {
@@ -12,6 +12,8 @@ const updateFormPages = (
   URLS,
   isTravelReimbursementEnabled = false,
   appointments = [],
+  isTravelLogicEnabled = false,
+  travelPaySent = {},
 ) => {
   const skippedPages = [];
   const {
@@ -62,9 +64,21 @@ const updateFormPages = (
 
   // Skip travel pay if not enabled, if veteran has more than one appointment for the day, or station if not in the allow list.
   // The allowlist currently only looks at the first appointment in the array, if we support multiple appointments later, this will need to get updated to a loop.
+  let skipLogic = appointments.length > 1;
+
+  if (isTravelLogicEnabled) {
+    const { facilityId } = appointments[0];
+    skipLogic =
+      facilityId in travelPaySent &&
+      !differenceInCalendarDays(
+        Date.now(),
+        parseISO(travelPaySent[facilityId]),
+      );
+  }
+
   if (
     !isTravelReimbursementEnabled ||
-    appointments.length > 1 ||
+    skipLogic ||
     !isInAllowList(appointments[0])
   ) {
     skippedPages.push(...travelPayPages);

--- a/src/applications/check-in/utils/navigation/navigation.unit.spec.js
+++ b/src/applications/check-in/utils/navigation/navigation.unit.spec.js
@@ -323,6 +323,34 @@ describe('Global check in', () => {
         expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.exist;
         expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.exist;
       });
+      it('should not skip travel pages if different facility is in local storage within the last day', () => {
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: true,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: true,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: true,
+          emergencyContactConfirmedAt: '2021-12-01T00:00:00.000-05:00',
+        };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [
+          { stationNo: '0001', clinicIen: '0001', facilityId: 'testId' },
+        ];
+        expect(appointments).to.have.lengthOf(1);
+        const form = updateFormPages(
+          patientDemographicsStatus,
+          testPages,
+          URLS,
+          isTravelReimbursementEnabled,
+          appointments,
+          true,
+          { testId2: new Date().toISOString() },
+        );
+        expect(form.find(page => page === URLS.TRAVEL_QUESTION)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.exist;
+      });
     });
   });
 });

--- a/src/applications/check-in/utils/navigation/navigation.unit.spec.js
+++ b/src/applications/check-in/utils/navigation/navigation.unit.spec.js
@@ -238,6 +238,91 @@ describe('Global check in', () => {
         expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.be.undefined;
         expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.be.undefined;
       });
+      it('should skip travel pages if facility is in local storage within the last day', () => {
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: true,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: true,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: true,
+          emergencyContactConfirmedAt: '2021-12-01T00:00:00.000-05:00',
+        };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [
+          { stationNo: '0001', clinicIen: '0001', facilityId: 'testId' },
+        ];
+        expect(appointments).to.have.lengthOf(1);
+        const form = updateFormPages(
+          patientDemographicsStatus,
+          testPages,
+          URLS,
+          isTravelReimbursementEnabled,
+          appointments,
+          true,
+          { testId: new Date().toISOString() },
+        );
+        expect(form.find(page => page === URLS.TRAVEL_PAY)).to.be.undefined;
+        expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.be.undefined;
+        expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.be.undefined;
+        expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.be.undefined;
+      });
+      it('should not skip travel pages if facility is in local storage but not in the last day', () => {
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: true,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: true,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: true,
+          emergencyContactConfirmedAt: '2021-12-01T00:00:00.000-05:00',
+        };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [
+          { stationNo: '0001', clinicIen: '0001', facilityId: 'testId' },
+        ];
+        expect(appointments).to.have.lengthOf(1);
+        const form = updateFormPages(
+          patientDemographicsStatus,
+          testPages,
+          URLS,
+          isTravelReimbursementEnabled,
+          appointments,
+          true,
+          { testId: new Date('2023-01-01T03:24:00').toISOString() },
+        );
+        expect(form.find(page => page === URLS.TRAVEL_QUESTION)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.exist;
+      });
+      it('should not skip travel pages if facility is not in local storage and there are multiple appointments', () => {
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: true,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: true,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: true,
+          emergencyContactConfirmedAt: '2021-12-01T00:00:00.000-05:00',
+        };
+        const isTravelReimbursementEnabled = true;
+        const appointments = [
+          { stationNo: '0001', clinicIen: '0001', facilityId: 'testId' },
+          { stationNo: '0001', clinicIen: '0001', facilityId: 'testId' },
+        ];
+        expect(appointments).to.have.lengthOf(2);
+        const form = updateFormPages(
+          patientDemographicsStatus,
+          testPages,
+          URLS,
+          isTravelReimbursementEnabled,
+          appointments,
+          true,
+          {},
+        );
+        expect(form.find(page => page === URLS.TRAVEL_QUESTION)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_ADDRESS)).to.exist;
+        expect(form.find(page => page === URLS.TRAVEL_MILEAGE)).to.exist;
+      });
     });
   });
 });

--- a/src/applications/check-in/utils/session-storage/index.js
+++ b/src/applications/check-in/utils/session-storage/index.js
@@ -13,6 +13,7 @@ const createSessionStorageKeys = ({ isPreCheckIn = true }) => {
   if (!isPreCheckIn) {
     sessionStorageKeys.SHOULD_SEND_TRAVEL_PAY_CLAIM = `${namespace}.should.send.travel.pay.claim`;
     sessionStorageKeys.TRAVEL_CLAIM_DATA = `${namespace}.travel.claim.data`;
+    sessionStorageKeys.TRAVELPAY_SENT = `${namespace}.travel.pay.sent`;
   }
   return sessionStorageKeys;
 };

--- a/src/applications/check-in/utils/session-storage/sessions.storage.unit.spec.js
+++ b/src/applications/check-in/utils/session-storage/sessions.storage.unit.spec.js
@@ -29,6 +29,7 @@ describe('check in', () => {
           PERMISSIONS: 'health.care.check-in.permissions',
           PROGRESS_STATE: 'health.care.check-in.progress',
           TRAVEL_CLAIM_DATA: 'health.care.check-in.travel.claim.data',
+          TRAVELPAY_SENT: 'health.care.check-in.travel.pay.sent',
         });
       });
     });


### PR DESCRIPTION
## Summary

This PR adds a new method for skipping travel pages based on local storage. It allows one facility per day to submit a travel claim. It is behind the travel logic feature flag.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63315

## Testing done

Adds/updates unit tests

## What areas of the site does it impact?

Day of check-in

## Acceptance criteria

 - [ ] With the feature on: stores a history of facilityId with time stamp of submitted travel claims. Filters out travel pages if that facility has already been submitted for the day. Allows new facilities to submit travel on the same day.
 - [ ] With the feature off: limits travel only to appointment payloads that have no more than one appointment.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

