### PR TITLE
Add character limit to 21P-0847's last question

### DIFF
--- a/src/applications/simple-forms/21P-0847/pages/additionalInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/additionalInformation.js
@@ -7,6 +7,9 @@ export default {
       'ui:title':
         'Do you have more information to support your request? You can tell us about your relationship to the deceased claimant, the claim they were working on, or any other relevant information.',
       'ui:webComponentField': VaTextareaField,
+      'ui:errorMessages': {
+        maxLength: 'Please limit your answer to no more than 300 characters',
+      },
     },
   },
   schema: {
@@ -14,6 +17,7 @@ export default {
     properties: {
       additionalInformation: {
         type: 'string',
+        maxLength: 300,
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR adds a character limit of 300 to the final question on form 21P-0847. We need this character limit because without it data could be lost from the printed PDF.

## Related issue(s)

https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/312#issuecomment-1678947545

## Screenshots

<img width="621" alt="Screenshot 2023-08-18 at 10 04 00 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/50491f70-dc1f-4007-b47b-715dd0036cf6">


## What areas of the site does it impact?

Form 21P-0847