### PR TITLE
21-10210 Fix witness-relationship field error-message

### DIFF
--- a/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
@@ -34,6 +34,9 @@ export default {
         ...commonUiSchema.witnessRelationshipToClaimant['ui:options'],
         labels: RELATIONSHIP_TO_VETERAN_OPTIONS,
       },
+      'ui:errorMessages': {
+        required: 'Please select at least one relationship',
+      },
     },
   },
   uiSchemaB: {
@@ -46,6 +49,9 @@ export default {
       'ui:options': {
         ...commonUiSchema.witnessRelationshipToClaimant['ui:options'],
         labels: RELATIONSHIP_TO_CLAIMANT_OPTIONS,
+      },
+      'ui:errorMessages': {
+        required: 'Please select at least one relationship',
       },
     },
   },


### PR DESCRIPTION
## Summary

- Fix Lay/Witness Statement (21-10210) witness-personal-information page witness-relationship error-message.
- Team: Platform VA Product Forms

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#495

## Testing done

- Local manual-UI, unit-, and E2E-tests were all successful.

