### PR TITLE
21-10210 - Refactor custom-scroll-n-focus

### DIFF
--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -1,10 +1,6 @@
 import environment from 'platform/utilities/environment';
 import footerContent from 'platform/forms/components/FormFooter';
-import {
-  getScrollOptions,
-  waitForRenderThenFocus,
-} from 'platform/utilities/ui';
-import scrollTo from 'platform/utilities/ui/scrollTo';
+import { scrollAndFocus } from 'platform/utilities/ui';
 
 import manifest from '../manifest.json';
 import getHelp from '../../shared/components/GetFormHelp';
@@ -42,14 +38,15 @@ import transformForSubmit from './submit-transformer';
 
 // const mockData = testData.data;
 
-const pageFocus = () => {
+const pageScrollAndFocus = () => {
   return () => {
     const { pathname } = document.location;
     let focusSelector = '';
 
-    if (pathname.includes('claim-ownership')) {
-      focusSelector = '#main h1[data-testid="form-title"]';
-    } else if (pathname.includes('claimant-type')) {
+    if (
+      pathname.includes('claim-ownership') ||
+      pathname.includes('claimant-type')
+    ) {
       focusSelector = '#main .schemaform-first-field legend';
     } else {
       // since form-level useCustomScrollAndFocus is true,
@@ -59,11 +56,7 @@ const pageFocus = () => {
     }
 
     if (!window.Cypress) {
-      waitForRenderThenFocus(focusSelector);
-      // need to scroll up to focus-element after waitForRenderThenFocus
-      setTimeout(() => {
-        scrollTo(focusSelector, getScrollOptions({ offset: 100 }));
-      }, 100);
+      scrollAndFocus(document.querySelector(focusSelector));
     }
   };
 };
@@ -161,7 +154,7 @@ const formConfig = {
           // chapter's hideFormNavProgress interferes with scrollAndFocusTarget
           // so using a function here to ensure correct focusSelector is used
           // regardless of which page FormNav thinks current page is.
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
           // initialData:
@@ -175,7 +168,7 @@ const formConfig = {
           path: 'claimant-type',
           title: 'Who is submitting this statement?',
           // see comment for scrollAndFocusTarget in claimOwnershipPage above
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: claimantType.uiSchema,
           schema: claimantType.schema,
         },
@@ -193,7 +186,7 @@ const formConfig = {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
             claimantType: CLAIMANT_TYPES.VETERAN,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: witnessPersInfo.uiSchemaA,
           schema: witnessPersInfo.schema,
         },
@@ -205,7 +198,7 @@ const formConfig = {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: witnessPersInfo.uiSchemaB,
           schema: witnessPersInfo.schema,
         },
@@ -213,7 +206,7 @@ const formConfig = {
           path: 'witness-other-relationship',
           title: 'Your other relationship',
           depends: witnessHasOtherRelationship,
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: witnessOtherRelationship.uiSchema,
           schema: witnessOtherRelationship.schema,
         },
@@ -229,7 +222,7 @@ const formConfig = {
           depends: {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: witnessContInfo.uiSchema,
           schema: witnessContInfo.schema,
         },
@@ -248,7 +241,7 @@ const formConfig = {
           path: 'statement-a',
           title:
             'Tell us about the claimed issue that you’re addressing on behalf of the Veteran',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: statement.uiSchema,
           schema: statement.schema,
         },
@@ -266,7 +259,7 @@ const formConfig = {
           },
           path: 'statement-b',
           title: 'Please indicate the claimed issue that you are addressing',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: statement.uiSchema,
           schema: statement.schema,
         },
@@ -285,7 +278,7 @@ const formConfig = {
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: claimantPersInfo.uiSchema,
           schema: claimantPersInfo.schema,
         },
@@ -304,7 +297,7 @@ const formConfig = {
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: claimantIdInfo.uiSchema,
           schema: claimantIdInfo.schema,
         },
@@ -323,7 +316,7 @@ const formConfig = {
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: claimantAddrInfo.uiSchema,
           schema: claimantAddrInfo.schema,
         },
@@ -342,7 +335,7 @@ const formConfig = {
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: claimantContInfo.uiSchema,
           schema: claimantContInfo.schema,
         },
@@ -360,7 +353,7 @@ const formConfig = {
           },
           path: 'statement-c',
           title: 'Tell us about the claimed issue that you’re addressing',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: statement.uiSchema,
           schema: statement.schema,
         },
@@ -377,7 +370,7 @@ const formConfig = {
         vetPersInfoPage: {
           path: 'veteran-personal-information',
           title: 'Veteran personal information',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetPersInfo.uiSchema,
           schema: vetPersInfo.schema,
         },
@@ -394,7 +387,7 @@ const formConfig = {
         veteranIdentificationInfo1: {
           path: 'veteran-identification-information',
           title: 'Veteran identification information',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetIdInfo.uiSchema,
           schema: vetIdInfo.schema,
         },
@@ -411,7 +404,7 @@ const formConfig = {
         veteranMailingAddressInfo1: {
           path: 'veteran-mailing-address',
           title: 'Veteran mailing address',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetAddrInfo.uiSchema,
           schema: vetAddrInfo.schema,
         },
@@ -428,7 +421,7 @@ const formConfig = {
         veteranContactInfo1: {
           path: 'veteran-contact-information',
           title: 'Veteran contact information',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetContInfo.uiSchema,
           schema: vetContInfo.schema,
         },
@@ -446,7 +439,7 @@ const formConfig = {
           },
           path: 'statement-d',
           title: 'Provide your supporting statement',
-          scrollAndFocusTarget: pageFocus(),
+          scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: statement.uiSchema,
           schema: statement.schema,
         },


### PR DESCRIPTION
## Summary

- Change Lay/Witness Statement (21-10210) custom-scroll-and-focus for more consistent behavior:
  - Make both claim-ownership & claimant-type pages focus on same element
  - Refactor/simplify scroll-n-focus code
- Team: Platform VA Product Forms

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#492 [see [this review-comment](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/492#issuecomment-1684440997)]

## Testing done

- Local manual-UI, unit-, and E2E-tests were all successful

## What areas of the site does it impact?

This form ONLY
