### PR TITLE
Fix typo in function name for e2e test

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
@@ -43,7 +43,7 @@ describe('Secure Messaging Manage Folder AXE check', () => {
     cy.intercept('DELETE', `/my_health/v1/messaging/folders/${folderId}`, {
       statusCode: 204,
     }).as('deleteFolder');
-    folderPage.clickAndLoadCustumFolder(
+    folderPage.clickAndLoadCustomFolder(
       folderName,
       folderId,
       MockCustomFolderResponse,


### PR DESCRIPTION
## Summary

- Update e2e test in secure-messaging-manage-folder.cypress.spec.js to fix typo `folderPage.clickAndLoadCustumFolder` to `folderPage.clickAndLoadCustomFolder`

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/63972

## What areas of the site does it impact?

fixes unit test for MHV secure messaging

### Quality Assurance & Testing

- [x ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


