### PR TITLE
Added breadcrumb in playground

### DIFF
--- a/src/applications/ds-playground/pages/V1V3Page.jsx
+++ b/src/applications/ds-playground/pages/V1V3Page.jsx
@@ -23,6 +23,7 @@ import {
   VaAdditionalInfo,
   VaAccordion,
   VaAccordionItem,
+  VaBreadcrumbs,
 } from '@department-of-veterans-affairs/web-components/react-bindings';
 
 export default function V1V3Page() {
@@ -824,6 +825,41 @@ export default function V1V3Page() {
                   </p>
                 </VaAccordionItem>
               </VaAccordion>
+            </div>
+          </div>
+        </div>
+
+        {/* Breadcrumb */}
+        <div className="vads-l-row">
+          <h3>Breadcrumbs</h3>
+          <div className="vads-l-col--12 vads-u-align-items--center vads-u-border-bottom--1px vads-u-border-color--primary medium-screen:vads-u-display--flex">
+            <div className="vads-l-col--12 small-screen:vads-l-col--6 vads-u-margin--1">
+              <VaBreadcrumbs label="Breadcrumb">
+                <a href="#home">Home</a>
+                <a href="#one">Level one</a>
+                <a href="#two">Level two</a>
+              </VaBreadcrumbs>
+            </div>
+
+            <div className="vads-l-col--12 small-screen:vads-l-col--6 vads-u-margin--1">
+              <VaBreadcrumbs
+                breadcrumbList={[
+                  {
+                    href: '#one',
+                    label: 'Level one',
+                  },
+                  {
+                    href: '#two',
+                    label: 'Level two',
+                  },
+                  {
+                    href: '#three',
+                    label: 'Level three',
+                  },
+                ]}
+                label="Breadcrumb"
+                uswds
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

Added the breadcrumb to the ds playground.

## Related issue(s)

department-of-veterans-affairs/vets-design-system-documentation#1812

## Testing done
Yes.
In chrome/Edge.

## Screenshots
<img width="1001" alt="Screenshot 2023-08-21 at 1 00 47 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/22892911/7cad9889-1e27-4b9f-aa7c-ecb39a77858b">
