### PR TITLE
Feature: SA-44552 review page accordion padding adjustment

### DIFF
--- a/src/applications/toe/sass/toe.scss
+++ b/src/applications/toe/sass/toe.scss
@@ -39,6 +39,9 @@ va-alert ul {
 .toe-definition-list_definition {
 	margin-left: 1em;
 }
+.form-review-panel .usa-accordion-content {
+    padding: 15px;
+}
 
 // Sponsors List
 .toe-sponsors {
@@ -72,6 +75,7 @@ va-alert ul {
 }
 .form-review-panel-page .toe-review-page-only {
 	display: block;
+	padding: 15px !important;
 }
 .review-row .toe-review-page_selected-sponsors {
 	list-style-type: none;

--- a/src/applications/toe/sass/toe.scss
+++ b/src/applications/toe/sass/toe.scss
@@ -75,7 +75,6 @@ va-alert ul {
 }
 .form-review-panel-page .toe-review-page-only {
 	display: block;
-	padding: 15px !important;
 }
 .review-row .toe-review-page_selected-sponsors {
 	list-style-type: none;


### PR DESCRIPTION
## Summary
Overwriting the padding of the accordion items on the review page to be 15px instead of 16px

## Related issue(s)
https://app.zenhub.com/workspaces/collaboration-cycle-reviews-61d89e9e5f4c120011a0ad37/issues/gh/department-of-veterans-affairs/va.gov-team/50943

## Testing done
Logged in as authenticated user on localhost stack and proceeded through the TOE form and used the chrome developer tools to validate the calculated style changes of the component/

## Screenshots

### Before Styling Change
![Before-Styling-Change](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/0efc8622-408c-450b-8627-1f7a9ca71a1e)


### After Styling Change
![After-styling-change](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/08f97d26-04e3-4ee1-81e9-bb75c0391f33)



## What areas of the site does it impact?
TOE application review page accordion padding.


## Acceptance criteria


### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
