### PR TITLE
1966 - Add VaProcessList and VaProcessListItem to ds-playground pages

### DIFF
--- a/src/applications/ds-playground/pages/V1V3Page.jsx
+++ b/src/applications/ds-playground/pages/V1V3Page.jsx
@@ -24,6 +24,8 @@ import {
   VaAccordion,
   VaAccordionItem,
   VaBreadcrumbs,
+  VaProcessList,
+  VaProcessListItem,
 } from '@department-of-veterans-affairs/web-components/react-bindings';
 
 export default function V1V3Page() {
@@ -860,6 +862,104 @@ export default function V1V3Page() {
                 label="Breadcrumb"
                 uswds
               />
+            </div>
+          </div>
+        </div>
+
+        {/* Process List Comparison */}
+        <div className="vads-l-row">
+          <h3>Process List</h3>
+          <div className="vads-l-col--12 vads-u-align-items--center vads-u-border-bottom--1px vads-u-border-color--primary medium-screen:vads-u-display--flex">
+            <div className="vads-l-col--12 small-screen:vads-l-col--6 vads-u-margin--1">
+              <VaProcessList>
+                <li>
+                  <h3>Check to be sure you can request a Board Appeal</h3>
+                  <p>
+                    You can request a Board Appeal up to 1 year from the date on
+                    your decision notice. (Exception: if you have a contested
+                    claim, you have only 60 days from the date on your decision
+                    notice to request a Board Appeal.)
+                  </p>
+                  <p>
+                    You can request a Board Appeal for these claim decisions:
+                  </p>
+                  <ul>
+                    <li>An initial claim</li>
+                    <li>A Supplemental Claim</li>
+                    <li>A Higher-Level Review</li>
+                  </ul>
+                  <p>
+                    <strong>Note: </strong>
+                    You can’t request a Board Appeal if you’ve already requested
+                    one for this same claim.
+                  </p>
+                </li>
+                <li>
+                  <h3>Gather your information</h3>
+                  <p>Here’s what you’ll need to apply:</p>
+                  <ul>
+                    <li>Your mailing address</li>
+                    <li>
+                      The VA decision date for each issue you’d like us to
+                      review (this is the date on the decision notice you got in
+                      the mail)
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <h3>Start your request</h3>
+                  <p>
+                    We’ll take you through each step of the process. It should
+                    take about 30 minutes.
+                  </p>
+                </li>
+              </VaProcessList>
+            </div>
+
+            <div className="vads-l-col--12 small-screen:vads-l-col--6 vads-u-margin--1">
+              <VaProcessList uswds>
+                <VaProcessListItem>
+                  <h3>Check to be sure you can request a Board Appeal</h3>
+                  <p>
+                    You can request a Board Appeal up to 1 year from the date on
+                    your decision notice. (Exception: if you have a contested
+                    claim, you have only 60 days from the date on your decision
+                    notice to request a Board Appeal.)
+                  </p>
+                  <p>
+                    You can request a Board Appeal for these claim decisions:
+                  </p>
+                  <ul>
+                    <li>An initial claim</li>
+                    <li>A Supplemental Claim</li>
+                    <li>A Higher-Level Review</li>
+                  </ul>
+                  <p>
+                    <strong>Note: </strong>
+                    You can’t request a Board Appeal if you’ve already requested
+                    one for this same claim.
+                  </p>
+                </VaProcessListItem>
+                <VaProcessListItem>
+                  <h3>Gather your information</h3>
+                  <p>Here’s what you’ll need to apply:</p>
+                  <ul>
+                    <li>Your mailing address</li>
+                    <li>
+                      The VA decision date for each issue you’d like us to
+                      review (this is the date on the decision notice you got in
+                      the mail)
+                    </li>
+                  </ul>
+                </VaProcessListItem>
+                <VaProcessListItem>
+                  <h3>Start your request</h3>
+                  <p>
+                    We’ll take you through each step of the process. It should
+                    take about 30 minutes.
+                  </p>
+                </VaProcessListItem>
+              </VaProcessList>
             </div>
           </div>
         </div>

--- a/src/applications/ds-v3-playground/pages/V3BasePage.jsx
+++ b/src/applications/ds-v3-playground/pages/V3BasePage.jsx
@@ -21,6 +21,8 @@ import {
   VaSelect,
   VaTextarea,
   VaTextInput,
+  VaProcessList,
+  VaProcessListItem,
 } from '@department-of-veterans-affairs/web-components/react-bindings';
 
 export default function V3BasePage() {
@@ -466,6 +468,54 @@ export default function V3BasePage() {
                 <li>Item 4</li>
               </ul>
             </VaAdditionalInfo>
+          </div>
+        </div>
+
+        {/* Process List */}
+        <div className="grid-row flex-column border-bottom">
+          <h2 className="grid-col font-ui-md">Process List</h2>
+          <div className="grid-col">
+            <VaProcessList uswds>
+              <VaProcessListItem>
+                <h3>Check to be sure you can request a Board Appeal</h3>
+                <p>
+                  You can request a Board Appeal up to 1 year from the date on
+                  your decision notice. (Exception: if you have a contested
+                  claim, you have only 60 days from the date on your decision
+                  notice to request a Board Appeal.)
+                </p>
+                <p>You can request a Board Appeal for these claim decisions:</p>
+                <ul>
+                  <li>An initial claim</li>
+                  <li>A Supplemental Claim</li>
+                  <li>A Higher-Level Review</li>
+                </ul>
+                <p>
+                  <strong>Note: </strong>
+                  You can’t request a Board Appeal if you’ve already requested
+                  one for this same claim.
+                </p>
+              </VaProcessListItem>
+              <VaProcessListItem>
+                <h3>Gather your information</h3>
+                <p>Here’s what you’ll need to apply:</p>
+                <ul>
+                  <li>Your mailing address</li>
+                  <li>
+                    The VA decision date for each issue you’d like us to review
+                    (this is the date on the decision notice you got in the
+                    mail)
+                  </li>
+                </ul>
+              </VaProcessListItem>
+              <VaProcessListItem>
+                <h3>Start your request</h3>
+                <p>
+                  We’ll take you through each step of the process. It should
+                  take about 30 minutes.
+                </p>
+              </VaProcessListItem>
+            </VaProcessList>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add the V1 `<VaProcessList>` and V3 `<VaProcessList>` and `<VaProcessListItem>` web-components to the DS-playground page
- Add the V3 `<VaProcessList>` and `<VaProcessListItem>` web-components to the DS-V3-playground page

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1966

## Testing done
- Manual testing

## Screenshots
### DS-Playground - Desktop
<img width="1093" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/c753e6ee-6e24-4449-82d1-bb8545f3ca4b"> 

### DS-Playground - Mobile - V1
<img width="386" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/440ecf71-36c3-46a3-b4fb-5b3365784a81"> 

### DS-Playground - Mobile - V3
<img width="389" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/3a7510c9-ebbc-4bab-a446-719118ae89e5"> 

### DS-V3-Playground - Desktop
 <img width="509" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/0d521b11-ac96-4113-a512-0ed403f08a1f">

### DS-V3-Playground - Mobile
<img width="402" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/cbbf813f-bcc0-406e-8766-bbcbdb7ff500">


## What areas of the site does it impact?
- The DS playground pages

## Acceptance criteria
- [ ] The DS playground page has a section for the `<VaProcessList>` web-component
  - [ ] The section has both a V1 and V3 version of the component
  - [ ] The V3 version uses `<VaProcessListItem>` web-components inside of the `<VaProcessList>`
- [ ] The DS-V3-playground page has a section for the `<VaProcessList>` web-component and it uses the `<VaProcessListItem` instead of `<li>` elements
