### PR TITLE
[FSR] Bug - Updating transition page URL 

### DIFF
--- a/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
+++ b/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
@@ -49,7 +49,7 @@ export default {
       },
       streamlinedShortTransitionPage: {
         // Transition page - streamlined short form only
-        path: 'transition-page',
+        path: 'skip-questions-explainer',
         title: ' ',
         CustomPage: StreamlinedExplainer,
         CustomPageReview: null,

--- a/src/applications/financial-status-report/config/chapters/householdExpensesChapter.js
+++ b/src/applications/financial-status-report/config/chapters/householdExpensesChapter.js
@@ -301,7 +301,7 @@ export default {
       // End Other Living Expenses
       streamlinedLongTransitionPage: {
         // Transition page - streamlined long form only
-        path: 'transition-page',
+        path: 'skip-questions-explainer',
         title: ' ',
         CustomPage: StreamlinedExplainer,
         CustomPageReview: null,

--- a/src/applications/financial-status-report/tests/e2e/streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/streamlined-waiver-long.cypress.spec.js
@@ -137,7 +137,7 @@ const testConfig = createTestConfig(
           cy.get('.usa-button-primary').click();
         });
       },
-      'transition-page': ({ afterHook }) => {
+      'skip-questions-explainer': ({ afterHook }) => {
         afterHook(() => {
           cy.get('h3').should(
             'have.text',

--- a/src/applications/financial-status-report/tests/e2e/streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/streamlined-waiver-short.cypress.spec.js
@@ -111,7 +111,7 @@ const testConfig = createTestConfig(
           cy.get('.usa-button-primary').click();
         });
       },
-      'transition-page': ({ afterHook }) => {
+      'skip-questions-explainer': ({ afterHook }) => {
         afterHook(() => {
           cy.get('h3').should(
             'have.text',


### PR DESCRIPTION
## Summary
Updated the transition page URL from temporary `/transition-page` to correct `/skip-questions-explainer`. Putting this into affect so we can track it better in GA

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#62443

## Testing done
Local testing completed

## Screenshots
**N/A**

## What areas of the site does it impact?
FSR Streamlined waiver pages

## Acceptance criteria
 - [x] Using correct url for tracking

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
