### PR TITLE
NOD | Retry failed load of contestable issues

### DIFF
--- a/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
@@ -7,10 +7,16 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 import set from 'platform/utilities/data/set';
 import { setData } from 'platform/forms-system/src/js/actions';
 
+import {
+  getContestableIssues as getContestableIssuesAction,
+  FETCH_CONTESTABLE_ISSUES_FAILED,
+} from '../actions';
+
 import { IssueCard } from './IssueCard';
 import { REVIEW_ISSUES, APP_NAME } from '../constants';
 
 import { SELECTED, MAX_LENGTH, LAST_ISSUE } from '../../shared/constants';
+
 import {
   ContestableIssuesLegend,
   NoIssuesLoadedAlert,
@@ -25,6 +31,8 @@ import {
   calculateIndexOffset,
 } from '../../shared/utils/issues';
 import { focusIssue } from '../../shared/utils/focus';
+
+let attempts = 0;
 
 /**
  * ContestableIssuesWidget - Form system parameters passed into this widget
@@ -42,6 +50,8 @@ import { focusIssue } from '../../shared/utils/focus';
  * @param {Boolean} required - Show required flag
  * @param {Object} schema - array schema
  * @param {Object[]} value - array value
+ * @param {Object} contestableIssues - API status & loaded issues
+ * @param {func} getContestableIssues - API action
  * @return {JSX}
  */
 const ContestableIssuesWidget = props => {
@@ -50,6 +60,8 @@ const ContestableIssuesWidget = props => {
     id,
     options,
     formContext = {},
+    contestableIssues, // API loaded issues
+    getContestableIssues,
     additionalIssues,
     setFormData,
     formData,
@@ -59,6 +71,19 @@ const ContestableIssuesWidget = props => {
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [removeIndex, setRemoveIndex] = useState(null);
   const [editState] = useState(window.sessionStorage.getItem(LAST_ISSUE));
+
+  useEffect(
+    () => {
+      if (
+        attempts < 1 &&
+        contestableIssues.status === FETCH_CONTESTABLE_ISSUES_FAILED
+      ) {
+        attempts += 1; // only attempt reload once
+        getContestableIssues();
+      }
+    },
+    [contestableIssues, getContestableIssues],
+  );
 
   useEffect(
     () => {
@@ -246,12 +271,18 @@ const ContestableIssuesWidget = props => {
 
 ContestableIssuesWidget.propTypes = {
   additionalIssues: PropTypes.array,
+  contestableIssues: PropTypes.shape({
+    status: PropTypes.string,
+    issues: PropTypes.array,
+    error: PropTypes.string,
+  }),
   formContext: PropTypes.shape({
     onReviewPage: PropTypes.bool,
     reviewMode: PropTypes.bool,
     submitted: PropTypes.bool,
   }),
   formData: PropTypes.shape({}),
+  getContestableIssues: PropTypes.func,
   id: PropTypes.string,
   options: PropTypes.shape({}),
   setFormData: PropTypes.func,
@@ -261,10 +292,12 @@ ContestableIssuesWidget.propTypes = {
 
 const mapStateToProps = state => ({
   formData: state.form?.data || {},
+  contestableIssues: state.contestableIssues,
   additionalIssues: state.form?.data.additionalIssues || [],
 });
 const mapDispatchToProps = {
   setFormData: setData,
+  getContestableIssues: getContestableIssuesAction,
 };
 
 export { ContestableIssuesWidget };

--- a/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/10182/components/ContestableIssuesWidget.jsx
@@ -76,7 +76,7 @@ const ContestableIssuesWidget = props => {
     () => {
       if (
         attempts < 1 &&
-        contestableIssues.status === FETCH_CONTESTABLE_ISSUES_FAILED
+        contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_FAILED
       ) {
         attempts += 1; // only attempt reload once
         getContestableIssues();

--- a/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -7,6 +7,10 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { ContestableIssuesWidget } from '../../components/ContestableIssuesWidget';
 import { SELECTED } from '../../../shared/constants';
+import {
+  FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+  FETCH_CONTESTABLE_ISSUES_FAILED,
+} from '../../actions';
 
 describe('<ContestableIssuesWidget>', () => {
   const getProps = ({
@@ -14,6 +18,8 @@ describe('<ContestableIssuesWidget>', () => {
     submitted = false,
     onChange = () => {},
     setFormData = () => {},
+    getContestableIssues = () => {},
+    contestableIssues = { status: '' },
   } = {}) => ({
     id: 'id',
     value: [
@@ -28,6 +34,8 @@ describe('<ContestableIssuesWidget>', () => {
       submitted,
     },
     setFormData,
+    getContestableIssues,
+    contestableIssues,
   });
 
   it('should render a list of check boxes (IssueCard component)', () => {
@@ -166,5 +174,32 @@ describe('<ContestableIssuesWidget>', () => {
     await waitFor(() => {
       expect($$('va-alert', container).length).to.equal(0);
     });
+  });
+
+  it('should call getContestableIssues only once, if there was a previous failure', async () => {
+    const getContestableIssuesSpy = sinon.spy();
+    const props = getProps({
+      contestableIssues: { status: FETCH_CONTESTABLE_ISSUES_FAILED },
+      getContestableIssues: getContestableIssuesSpy,
+    });
+    const { rerender } = render(
+      <ContestableIssuesWidget {...props} value={[]} />,
+    );
+
+    rerender(<ContestableIssuesWidget {...props} value={[]} />);
+
+    await waitFor(() => {
+      expect(getContestableIssuesSpy.calledOnce).to.be.true;
+    });
+  });
+  it('should not call getContestableIssues if there was a previous failure', () => {
+    const getContestableIssuesSpy = sinon.spy();
+    const props = getProps({
+      contestableIssues: { status: FETCH_CONTESTABLE_ISSUES_SUCCEEDED },
+      getContestableIssues: getContestableIssuesSpy,
+    });
+    render(<ContestableIssuesWidget {...props} value={[]} />);
+
+    expect(getContestableIssuesSpy.called).to.be.false;
   });
 });

--- a/src/applications/appeals/10182/tests/pages/contestableIssues.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/contestableIssues.unit.spec.jsx
@@ -15,6 +15,9 @@ const mockStore = data => ({
         contestedIssues: [],
       },
     },
+    contestableIssues: {
+      status: '',
+    },
     formContext: {
       onReviewPage: false,
       reviewMode: false,
@@ -25,6 +28,7 @@ const mockStore = data => ({
   subscribe: () => {},
   dispatch: () => ({
     setFormData: () => {},
+    getContestableIssues: () => {},
   }),
 });
 

--- a/src/applications/appeals/shared/content/contestableIssues.jsx
+++ b/src/applications/appeals/shared/content/contestableIssues.jsx
@@ -97,7 +97,7 @@ export const NoIssuesLoadedAlert = () => {
       <va-alert status="error" class="vads-u-margin-bottom--2">
         <h3 slot="headline">We can’t load your issues right now</h3>
         <p>
-          You can try again later, or if you’d like to add your issue manually,
+          You can come back later, or if you’d like to add your issue manually,
           you can select "Add a new issue" to get started.
         </p>
       </va-alert>
@@ -113,7 +113,7 @@ export const noneSelected =
  */
 export const NoneSelectedAlert = ({ count, headerLevel = 3, inReviewMode }) => {
   const wrapAlert = useRef(null);
-  const Header = `H${headerLevel}`;
+  const Header = `h${headerLevel}`;
   const margins = `vads-u-margin-${inReviewMode ? 'y' : 'bottom'}--2`;
 
   useEffect(


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Due to intermittent errors, we wanted to improve Veteran UX experience by attempting to reload contestable issues if the previous API call failed. We only retry one time. We've also updated the alert message to notify the Veteran to return at a later time if the failures persist.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Originally we were going to retry 3x in rapid succession, but that seemed excessive, especially if the service was offline. So now we're retrying one time and updating the alert content to notify the Veteran that returning later may be the only way to get contestable issues from the API endpoint
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#62872](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62872)
- [Design](https://www.sketch.com/s/0424c51d-7818-43ea-8821-6de91eb7ab27/a/qbAvv22)

## Testing done

- _Describe what the old behavior was prior to the change_
 > No retries
- _Describe the steps required to verify your changes are working as expected_
  > - Log into any user in staging
  > - Go to [NOD introduction page](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction)
  > - Open the dev tools panel (F12, or right-click & inspect page)
  > - Go to network ta
  > - Reload NOD page
  > - Right-click on `contestable_issues` in the network "Name" column
  > - Choose "Block request URL" to disable the endpoint
  > - Reload NOD page
  > - Start the form & navigate to contestable issues page
  > - Once on the page, you should see one additional call to the `contestable_issues` endpoint, which will fail because we just blocked the request
  > - Navigate to the previous page
  > - Return to contestable issues page
  > - Note that the `contestable_issues` endpoint was only called once on the contestable issues page
- _Describe the tests completed and the results_
  > Added unit test
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="571" alt="Screenshot 2023-08-22 at 10 25 03 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4e63bb5e-53b8-49ef-b8a9-f739d677c967"> | <img width="571" alt="Screenshot 2023-08-22 at 10 22 57 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b1b6e959-d304-47bd-8586-4c5309f1aab0"> |

## What areas of the site does it impact?

Notice of Disagreement (Board Appeal)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
