### PR TITLE
VA-14277: Preserve wait times panel with Zero wait time

### DIFF
--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -18,7 +18,9 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
           }-patient-wait-time`}
           className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
         >
-          {`${Number(waitTime).toFixed(0)} days`}
+          {Number(waitTime).toFixed(0) === '0'
+            ? 'No Wait'
+            : `${Number(waitTime).toFixed(0)} days`}
         </p>
       </div>
     );
@@ -58,9 +60,9 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
           </p>
           <div className="usa-grid-full">
             <div className="vads-u-display--flex">
-              {serviceExists.new &&
+              {serviceExists.new >= 0 &&
                 this.appointmentWaitTime(serviceExists.new, service)}
-              {serviceExists.established &&
+              {serviceExists.established >= 0 &&
                 this.appointmentWaitTime(
                   serviceExists.established,
                   service,

--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -40,6 +40,9 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
     if (this.props.error) {
       return <FacilityApiAlert />;
     }
+
+    const isWaitTimeValid = waitTime =>
+      typeof waitTime === 'number' && waitTime >= 0;
     const facility = this.props.facility.attributes;
     const service = this.props.service.split('(')[0].toLowerCase();
     const serviceExists = facility?.access?.health.find(
@@ -60,9 +63,9 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
           </p>
           <div className="usa-grid-full">
             <div className="vads-u-display--flex">
-              {serviceExists.new >= 0 &&
+              {isWaitTimeValid(serviceExists.new) &&
                 this.appointmentWaitTime(serviceExists.new, service)}
-              {serviceExists.established >= 0 &&
+              {isWaitTimeValid(serviceExists.established) &&
                 this.appointmentWaitTime(
                   serviceExists.established,
                   service,


### PR DESCRIPTION
The Wait Times panels had a bug in the template where if the number of days to wait was `0`, it only showed that number instead the panel itself. This pull request makes two changes:

1. Adjusts the front-end template so if the number of days are `0`, the panel still renders.
2. A wait times panel with zero will show "no wait" instead of "0 days," as per advice from @mmiddaugh and @swirtSJW looking at the design system.

## Summary

- _(Summarize the changes that have been made to the platform)_ Wait times will properly render an understandable panel when there are zero days of wait time.
- _(If bug, how to reproduce)_ Go to a clinic where the number of days to wait for existing patients is zero.
- _(What is the solution, why is this the solution)_ The solution adjusts the template since the issue lies with how the template handles a data edge case.
- _(Which team do you work for, does your team own the maintenance of this component?)_ Facilities team, and yes.

## Related issue(s)

- [_Link to ticket created in va.gov-cms repo_](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14277)

## Testing done

- _Describe what the old behavior was prior to the change_ The panel did not render, and only showed a `0` character on the page.
- _Describe the steps required to verify your changes are working as expected_ I reproduced the error in my local machine by manually passing in `0` waiting days for existing patients.
- _Describe the tests completed and the results_ Visual, confirmed it was fixed.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |   ![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3564386134373339336163333434303030316431613265642f61386637323132652d666338322d346566352d613137622d386232383134373562343866](https://github.com/department-of-veterans-affairs/vets-website/assets/10790736/f8248c0b-4e8f-4b91-82f7-b58df74007d6)   |  ![Screen Shot 2023-08-22 at 11 14 57 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/10790736/2166239b-736d-4450-8dca-753eb52998c8)

## What areas of the site does it impact?

VAMC Clinic locations

## Acceptance criteria

### Local Testing

1. Run `content-build` with `yarn serve`
2. Run `vets-website` with `yarn watch --env api=https://dev-api.va.gov entry=facilities,static-pages`
3. On `src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx` in `vets-website`, add the following line below line 47:

```jsx
const TESTVAR = 0;
```

4. On the same file for lines 66-71, use the following lines of code:

```jsx
            {TESTVAR >= 0 &&
                this.appointmentWaitTime(
                  TESTVAR,
                  service,
                  true,
                )}
```

5. Visit `http://localhost:3002/butler-health-care/locations/cranberry-township-va-clinic/` and expand the "Primary Care" accordion. The "Existing Patients" panel should now appear as if there are zero wait days.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
