### PR TITLE
#62996: Event tracker CTA for Cerner Re-direct - Public Website widget

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -11,6 +11,7 @@ import { getButtonType } from 'applications/static-pages/analytics/addButtonLink
 import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { GA_PREFIX } from 'applications/vaos/utils/constants';
 import {
   cernerFacilitiesPropType,
   ehrDataByVhaIdPropType,
@@ -215,7 +216,12 @@ export class CernerCallToAction extends Component {
                   <a
                     className="vads-c-action-link--blue"
                     href={myVAHealthLink}
-                    onClick={onCTALinkClick}
+                    onClick={() => {
+                      recordEvent({
+                        event: `${GA_PREFIX}-vaos-cerner-redirect-static-landing-page`,
+                      });
+                      onCTALinkClick();
+                    }}
                     rel="noreferrer noopener"
                     target="_blank"
                   >

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -218,7 +218,7 @@ export class CernerCallToAction extends Component {
                     href={myVAHealthLink}
                     onClick={() => {
                       recordEvent({
-                        event: `${GA_PREFIX}-vaos-cerner-redirect-static-landing-page`,
+                        event: `${GA_PREFIX}-cerner-redirect-static-landing-page`,
                       });
                       onCTALinkClick();
                     }}

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -11,7 +11,6 @@ import { getButtonType } from 'applications/static-pages/analytics/addButtonLink
 import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { GA_PREFIX } from 'applications/vaos/utils/constants';
 import {
   cernerFacilitiesPropType,
   ehrDataByVhaIdPropType,
@@ -218,7 +217,7 @@ export class CernerCallToAction extends Component {
                     href={myVAHealthLink}
                     onClick={() => {
                       recordEvent({
-                        event: `${GA_PREFIX}-cerner-redirect-static-landing-page`,
+                        event: `vaos-cerner-redirect-static-landing-page`,
                       });
                       onCTALinkClick();
                     }}


### PR DESCRIPTION
## Summary
This PR:
adds Tracking to the `Go to My VA Health` CTA link on the new cerner appointments widget.

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/62996

## Testing done
Tested by clicking the `Go to My VA Health` CTA link in my local instance and confirmed that analytics event was triggered.

## Acceptance criteria
- [x] Given when the user is authenticated and is registered at a Cerner site, when the user is on the Appointments widget on the static landing page and clicks on `Go to My VA Health`, Then it will trigger an event `vaos-cerner-redirect-static-landing-page` in UA4