### PR TITLE
My VA: hide the benefit application drafts help dropdown

### DIFF
--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { fetchEDUPaymentInformation as fetchEDUPaymentInformationAction } from '@@profile/actions/paymentInformation';
 import { VA_FORM_IDS } from '~/platform/forms/constants';
 import recordEvent from '~/platform/monitoring/record-event';
 import { isVAPatient, isLOA3, selectProfile } from '~/platform/user/selectors';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 
 import { filterOutExpiredForms } from '~/applications/personalization/dashboard/helpers';
 
@@ -14,7 +16,7 @@ import ApplicationsInProgress from './ApplicationsInProgress';
 import BenefitOfInterest from './BenefitOfInterest';
 
 const AllBenefits = () => (
-  <div className="vads-u-margin-top--2">
+  <div className="vads-u-margin-top--2" data-testid="dashboard-all-benefits">
     <va-additional-info trigger="What benefits does VA offer?">
       <p className="vads-u-font-weight--bold">
         Explore VA.gov to learn about the benefits we offer.
@@ -68,6 +70,10 @@ const BenefitsOfInterest = ({ children }) => {
   );
 };
 
+BenefitsOfInterest.propTypes = {
+  children: PropTypes.object,
+};
+
 const ApplyForBenefits = ({ getESREnrollmentStatus, shouldGetESRStatus }) => {
   useEffect(
     () => {
@@ -81,7 +87,11 @@ const ApplyForBenefits = ({ getESREnrollmentStatus, shouldGetESRStatus }) => {
   return (
     <div data-testid="dashboard-section-apply-for-benefits">
       <h2>Apply for VA benefits</h2>
-      <AllBenefits />
+      <Toggler toggleName={Toggler.TOGGLE_NAMES.myVaUseExperimental}>
+        <Toggler.Disabled>
+          <AllBenefits />
+        </Toggler.Disabled>
+      </Toggler>
       <ApplicationsInProgress />
       <BenefitsOfInterest>
         <>
@@ -146,6 +156,11 @@ const ApplyForBenefits = ({ getESREnrollmentStatus, shouldGetESRStatus }) => {
       </BenefitsOfInterest>
     </div>
   );
+};
+
+ApplyForBenefits.propTypes = {
+  getESREnrollmentStatus: PropTypes.func.isRequired,
+  shouldGetESRStatus: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/SavedApplications.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/SavedApplications.jsx
@@ -5,6 +5,7 @@ import { fetchEDUPaymentInformation as fetchEDUPaymentInformationAction } from '
 import PropTypes from 'prop-types';
 import { VA_FORM_IDS } from '~/platform/forms/constants';
 import { isVAPatient, isLOA3, selectProfile } from '~/platform/user/selectors';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 import { filterOutExpiredForms } from '~/applications/personalization/dashboard/helpers';
 
 import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications/hca/utils/actions';
@@ -12,7 +13,7 @@ import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications
 import ApplicationsInProgress from './ApplicationsInProgress';
 
 const AllBenefits = () => (
-  <div className="vads-u-margin-top--2">
+  <div className="vads-u-margin-top--2" data-testid="dashboard-all-benefits">
     <va-additional-info trigger="What benefits does VA offer?">
       <p className="vads-u-font-weight--bold">
         Explore VA.gov to learn about the benefits we offer.
@@ -66,7 +67,11 @@ const SavedApplications = ({ getESREnrollmentStatus, shouldGetESRStatus }) => {
   return (
     <div data-testid="dashboard-section-saved-applications">
       <h2>Benefit application drafts</h2>
-      <AllBenefits />
+      <Toggler toggleName={Toggler.TOGGLE_NAMES.myVaUseExperimental}>
+        <Toggler.Disabled>
+          <AllBenefits />
+        </Toggler.Disabled>
+      </Toggler>
       <ApplicationsInProgress hideH3 />
     </div>
   );

--- a/src/applications/personalization/dashboard/components/notifications/Notifications.jsx
+++ b/src/applications/personalization/dashboard/components/notifications/Notifications.jsx
@@ -2,13 +2,9 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import environment from '~/platform/utilities/environment';
-import {
-  useFeatureToggle,
-  Toggler,
-} from '~/platform/utilities/feature-toggles';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { fetchNotifications } from '../../../common/actions/notifications';
 import DebtNotificationAlert from './DebtNotificationAlert';
-import TestNotification from './TestNotification';
 import DashboardWidgetWrapper from '../DashboardWidgetWrapper';
 
 const debtTemplateId = environment.isProduction()
@@ -68,26 +64,11 @@ export const Notifications = ({
         </DashboardWidgetWrapper>
       )}
       {debtNotifications.map(n => (
-        <Toggler
-          toggleName={Toggler.TOGGLE_NAMES.myVaUseExperimental}
+        <DebtNotificationAlert
           key={n.id}
-        >
-          <Toggler.Enabled>
-            <TestNotification
-              key={n.id}
-              hasError={notificationsError}
-              notification={n}
-            />
-          </Toggler.Enabled>
-
-          <Toggler.Disabled>
-            <DebtNotificationAlert
-              key={n.id}
-              hasError={notificationsError}
-              notification={n}
-            />
-          </Toggler.Disabled>
-        </Toggler>
+          hasError={notificationsError}
+          notification={n}
+        />
       ))}
     </div>
   );

--- a/src/applications/personalization/dashboard/tests/components/notifications/Notifications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/notifications/Notifications.unit.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { expect } from 'chai';
 
 import { renderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-library-helpers';
-import { Toggler } from '~/platform/utilities/feature-toggles/Toggler';
 
 import { Notifications } from '../../../components/notifications/Notifications';
 
@@ -32,11 +31,7 @@ describe('<Notifications />', () => {
         },
       },
     ];
-    const initialState = {
-      featureToggles: {
-        [Toggler.TOGGLE_NAMES.myVaUseExperimental]: false,
-      },
-    };
+    const initialState = {};
     const tree = renderWithStoreAndRouter(
       <Notifications
         getNotifications={() => {}}

--- a/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
@@ -10,6 +10,7 @@ import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enroll
 import notInESR from '@@profile/tests/fixtures/enrollment-system/not-in-esr.json';
 import loa1User from '@@profile/tests/fixtures/users/user-loa1.json';
 import manifest from '~/applications/personalization/dashboard/manifest.json';
+import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 
 import {
   disabilityCompensationExists,
@@ -25,13 +26,17 @@ function sectionHeadingsExist() {
 }
 
 describe('The My VA Dashboard', () => {
+  beforeEach(() => {
+    cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
+    cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
+  });
+
   describe('Should show benefits of interest to Loa1 User', () => {
     beforeEach(() => {
       cy.login(loa1User);
-      cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
-      cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
       cy.visit(manifest.rootUrl);
     });
+
     it('should show info about disability benefits, health care, and education benefits - C15782', () => {
       sectionHeadingsExist();
 
@@ -44,18 +49,45 @@ describe('The My VA Dashboard', () => {
       cy.injectAxeThenAxeCheck();
     });
   });
+
   describe('Should show saved applications to Loa3 User', () => {
     beforeEach(() => {
       const user = makeMockUser();
-      cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
-      cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
       cy.login(user);
       cy.visit(manifest.rootUrl);
     });
+
     it('should show info about saved applications', () => {
       cy.findAllByTestId('dashboard-section-saved-applications').should(
         'exist',
       );
+
+      cy.findAllByTestId('dashboard-all-benefits').should('exist');
+
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+
+  describe('Should not show saved applications to Loa3 User', () => {
+    beforeEach(() => {
+      const user = makeMockUser();
+      cy.intercept('GET', '/v0/feature_toggles*', {
+        data: {
+          type: 'feature_toggles',
+          features: [
+            {
+              name: featureFlagNames.myVaUseExperimental,
+              value: true,
+            },
+          ],
+        },
+      });
+      cy.login(user);
+      cy.visit(manifest.rootUrl);
+    });
+
+    it('should not show the all benefits dropdown', () => {
+      cy.findAllByTestId('dashboard-all-benefits').should('not.exist');
 
       cy.injectAxeThenAxeCheck();
     });

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
@@ -8,7 +8,6 @@
 import { mockUser } from '@@profile/tests/fixtures/users/user';
 import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
-import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 import {
   notificationsError,
   notificationSuccessDismissed,
@@ -112,87 +111,6 @@ describe('The My VA Dashboard - Notifications', () => {
         .click({ waitForAnimations: true });
       cy.wait('@patch');
       cy.findAllByTestId('dashboard-notification-alert').should('not.exist');
-      cy.findByTestId('dashboard-notifications').should('not.exist');
-      // make the a11y check
-      cy.injectAxeThenAxeCheck('#react-root');
-    });
-  });
-
-  context('when new Notification component is showing', () => {
-    beforeEach(() => {
-      cy.intercept('GET', '/v0/feature_toggles*', {
-        data: {
-          type: 'feature_toggles',
-          features: [
-            {
-              name: featureFlagNames.myVaUseExperimental,
-              value: true,
-            },
-          ],
-        },
-      }).as('notificationFeature');
-    });
-    it('and they have a notification - C13025', () => {
-      cy.intercept(
-        '/v0/onsite_notifications',
-        notificationSuccessNotDismissed(Cypress.env('CI')),
-      ).as('notifications2');
-      cy.login(mockUser);
-      cy.visit('my-va/');
-      cy.wait(['@nameB', '@serviceB', '@notifications2']);
-      cy.findByTestId('dashboard-notifications').should('exist');
-      cy.findByTestId('onsite-notification-card').should('exist');
-      // make the a11y check
-      cy.injectAxeThenAxeCheck('#react-root');
-    });
-    it('and they have multiple notifications - C16720', () => {
-      cy.intercept(
-        '/v0/onsite_notifications',
-        multipleNotificationSuccess(Cypress.env('CI')),
-      ).as('notifications3');
-      cy.login(mockUser);
-      cy.visit('my-va/');
-      cy.wait(['@nameB', '@serviceB', '@notifications3']);
-      cy.findByTestId('dashboard-notifications').should('exist');
-      cy.findAllByTestId('onsite-notification-card').should('have.length', 2);
-      // make the a11y check
-      cy.injectAxeThenAxeCheck('#react-root'); // First AXE-check already checked the whole
-    });
-    it('and they have dismissed notifications - C16721', () => {
-      cy.intercept(
-        '/v0/onsite_notifications',
-        notificationSuccessDismissed(Cypress.env('CI')),
-      ).as('notifications4');
-      cy.login(mockUser);
-      cy.visit('my-va/');
-      cy.wait(['@nameB', '@serviceB', '@notifications4']);
-      cy.findByTestId('dashboard-notifications').should('not.exist');
-
-      // make the a11y check
-      cy.injectAxeThenAxeCheck('#react-root');
-    });
-    it('and they dismiss a notification - C16723', () => {
-      cy.intercept(
-        '/v0/onsite_notifications',
-        notificationSuccessNotDismissed(Cypress.env('CI')),
-      ).as('notifications6');
-      cy.intercept(
-        'PATCH',
-        `v0/onsite_notifications/e4213b12-eb44-4b2f-bac5-3384fbde0b7a`,
-        {
-          statusCode: 200,
-          body: notificationSuccessDismissed(),
-          delay: 100,
-        },
-      ).as('patch');
-      cy.login(mockUser);
-      cy.visit('my-va/');
-      cy.wait(['@nameB', '@serviceB', '@notifications6']);
-      cy.findByTestId('dashboard-notifications').should('exist');
-      cy.findAllByTestId('onsite-notification-card').should('have.length', 1);
-      cy.get('button.va-notification-close').click();
-      cy.wait('@patch');
-      cy.findByTestId('onsite-notification-card').should('not.exist');
       cy.findByTestId('dashboard-notifications').should('not.exist');
       // make the a11y check
       cy.injectAxeThenAxeCheck('#react-root');


### PR DESCRIPTION
After reviewing GA data we've decided to remove the submenu "what benefits does VA offer" within the Benefit Application Drafts ("BAD") section on My VA. Before we make this change permanent, we want to temporarily hide this section using a feature flag so we can monitor the impact and then make a more permanent change to remove it all together once we have validation.

## Summary

- Hides the "what benefits does VA offer" dropdown menu from Benefits Applications Drafts
- Place behind the `myVaUseExperimental` feature toggle

## Related issue(s)

- [63379](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63379)

## Testing done

- Local testing using the mock server
- Updated related tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
|  | ![Screenshot 2023-08-23 at 10 24 55 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/534756/b6426080-b09a-43d5-9c2a-abd7d23ebe3b) | ![Screenshot 2023-08-23 at 10 23 50 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/534756/eb5d5c55-6c19-41b6-a96a-64160928cca1)|

## What areas of the site does it impact?
My VA

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
