### PR TITLE
Add logic to focus first web component in array

### DIFF
--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -287,11 +287,9 @@ export default class ArrayField extends React.Component {
 
       if (wrapper) {
         const focusableElements = getFocusableElements(wrapper);
-        const firstFocusableElement = wrapper.querySelector(
-          focusableElements[0].tagName,
-        );
-
-        firstFocusableElement.focus();
+        if (focusableElements.length) {
+          focusableElements[0].focus();
+        }
       }
     }, 0);
   }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -4,6 +4,7 @@ import {
   focusByOrder,
   getScrollOptions,
 } from 'platform/utilities/ui';
+import { webComponentList } from 'platform/forms-system/src/js/web-component-fields/webComponentList';
 
 export const $ = (selectorOrElement, root) =>
   typeof selectorOrElement === 'string'
@@ -45,14 +46,31 @@ const focusableElements = [
  * @param {HTMLElement|node} block - wrapping element
  * @return {HTMLElement[]}
  */
-export const getFocusableElements = block =>
-  block
-    ? [...block?.querySelectorAll(focusableElements.join(','))].filter(
+export const getFocusableElements = block => {
+  let elements = [];
+
+  if (block) {
+    elements = [
+      ...block.querySelectorAll(
+        [...focusableElements, ...webComponentList].join(','),
+      ),
+    ]
+      .map(el => {
+        if (el.shadowRoot) {
+          return getFocusableElements(el.shadowRoot);
+        }
+        return el;
+      })
+      .flat()
+      .filter(
         // Ignore disabled & hidden elements
         // This does not check the element's visibility or opacity
         el => !el.disabled && el.offsetWidth > 0 && el.offsetHeight > 0,
-      )
-    : [];
+      );
+  }
+
+  return elements;
+};
 
 export const scrollElementName = 'ScrollElement';
 

--- a/src/platform/forms-system/src/js/web-component-fields/webComponentList.js
+++ b/src/platform/forms-system/src/js/web-component-fields/webComponentList.js
@@ -1,0 +1,18 @@
+export const webComponentList = [
+  'va-accordion-item',
+  'va-accordion',
+  'va-alert',
+  'va-breadcrumbs',
+  'va-button-pair',
+  'va-button',
+  'va-checkbox-group',
+  'va-checkbox',
+  'va-memorable-date',
+  'va-number-input',
+  'va-privacy-agreement',
+  'va-radio-option',
+  'va-radio',
+  'va-select',
+  'va-text-input',
+  'va-textarea',
+];


### PR DESCRIPTION
## Summary

- Allow web components to be included when trying to focus the first element of arrays

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#62008

## Testing done

- Browser and unit testing

## What areas of the site does it impact?

All forms that use a arrays with web components

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
