### PR TITLE
Remove green CTAs for 21P-0847 widget

### DIFF
--- a/src/applications/static-pages/simple-forms/21P-0847/App.js
+++ b/src/applications/static-pages/simple-forms/21P-0847/App.js
@@ -13,18 +13,11 @@ const App = ({ formEnabled }) => {
   if (formEnabled) {
     return (
       <>
-        <p>You can submit this form online or by mail.</p>
         <a
           className="vads-c-action-link--blue"
           href="/supporting-forms-for-claims/substitute-claimant-form-21P-0847"
         >
           Submit a request online to be a substitute for a deceased claimant
-        </a>
-        <a
-          className="vads-c-action-link--green"
-          href="/find-forms/about-form-21p-0847/"
-        >
-          Get VA Form 21P-0847 to download
         </a>
       </>
     );
@@ -33,12 +26,6 @@ const App = ({ formEnabled }) => {
   return (
     <>
       <p>You can submit this form by mail.</p>
-      <a
-        className="vads-c-action-link--green"
-        href="/find-forms/about-form-21p-0847/"
-      >
-        Get VA Form 21P-0847 to download
-      </a>
     </>
   );
 };


### PR DESCRIPTION
## Summary

This PR removes some extra HTML content from the widget. I've confirmed that it conforms to other widgets (with the exception of the removal of `You can submit this form online or by mail.`, but that was specifically called out by @tbaker1026 to be removed) so even though I cannot load this locally, I'm confident that it will look correct, per the guidance I've been given.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/473
