### PR TITLE
NOD | Add Datadog action name to hide PII

### DIFF
--- a/src/applications/appeals/10182/components/IssueCard.jsx
+++ b/src/applications/appeals/10182/components/IssueCard.jsx
@@ -33,20 +33,31 @@ export const IssueCardContent = ({
   return (
     <div id={id} className="widget-content-wrap">
       {description && (
-        <p className="vads-u-margin-bottom--0 dd-privacy-hidden">
+        <p
+          className="vads-u-margin-bottom--0 dd-privacy-hidden"
+          data-dd-action-name="rated issue description"
+        >
           {replaceDescriptionContent(description)}
         </p>
       )}
       {showPercentNumber && (
         <p className="vads-u-margin-bottom--0">
           Current rating:{' '}
-          <strong className="dd-privacy-hidden">{`${ratingIssuePercentNumber}%`}</strong>
+          <strong
+            className="dd-privacy-hidden"
+            data-dd-action-name="rated issue percentage"
+          >
+            {`${ratingIssuePercentNumber}%`}
+          </strong>
         </p>
       )}
       {date && (
         <p>
           Decision date:{' '}
-          <strong className="dd-privacy-hidden">
+          <strong
+            className="dd-privacy-hidden"
+            data-dd-action-name="rated issue decision date"
+          >
             {moment(date, FORMAT_YMD).format(FORMAT_READABLE)}
           </strong>
         </p>
@@ -187,7 +198,11 @@ export const IssueCard = ({
           }`}
           data-index={index}
         >
-          <Header id={`issue-${index}-title`} className={titleClass}>
+          <Header
+            id={`issue-${index}-title`}
+            className={titleClass}
+            data-dd-action-name="issue name"
+          >
             {issueName}
           </Header>
           <IssueCardContent id={`issue-${index}-description`} {...item} />

--- a/src/applications/appeals/10182/components/ShowIssuesList.jsx
+++ b/src/applications/appeals/10182/components/ShowIssuesList.jsx
@@ -8,12 +8,18 @@ const ShowIssuesList = ({ issues }) => (
   <ul>
     {issues.map((issue, index) => (
       <li key={index}>
-        <strong className="capitalize dd-privacy-hidden">
+        <strong
+          className="capitalize dd-privacy-hidden"
+          data-dd-action-name="issue name"
+        >
           {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
         </strong>
         <div>
           Decision date:{' '}
-          <span className="dd-privacy-hidden">
+          <span
+            className="dd-privacy-hidden"
+            data-dd-action-name="issue decision date"
+          >
             {getDate({
               date:
                 issue.attributes?.approxDecisionDate ||

--- a/src/applications/appeals/10182/components/VeteranInformation.jsx
+++ b/src/applications/appeals/10182/components/VeteranInformation.jsx
@@ -34,33 +34,49 @@ const VeteranInformation = ({ profile = {}, veteran = {} }) => {
         Confirm the personal information we have on file for you.
       </h3>
       <div className="blue-bar-block">
-        <strong className="name dd-privacy-hidden">
+        <strong
+          className="name dd-privacy-hidden"
+          data-dd-action-name="full name"
+        >
           {`${first || ''} ${middle || ''} ${last || ''}`}
           {suffix && `, ${suffix}`}
         </strong>
         {ssnLastFour && (
           <p className="ssn">
             Social Security number:{' '}
-            <span className="dd-privacy-mask">{mask(ssnLastFour)}</span>
+            <span className="dd-privacy-mask" data-dd-action-name="SSN">
+              {mask(ssnLastFour)}
+            </span>
           </p>
         )}
         {vaFileLastFour && (
           <p className="vafn">
             VA file number:{' '}
-            <span className="dd-privacy-mask">{mask(vaFileLastFour)}</span>
+            <span
+              className="dd-privacy-mask"
+              data-dd-action-name="VA file number"
+            >
+              {mask(vaFileLastFour)}
+            </span>
           </p>
         )}
         <p>
           Date of birth:{' '}
           {momentDob.isValid() ? (
-            <span className="dob dd-privacy-mask">
+            <span
+              className="dob dd-privacy-mask"
+              data-dd-action-name="Date of birth"
+            >
               {momentDob.format(FORMAT_READABLE)}
             </span>
           ) : null}
         </p>
         <p>
           Gender:{' '}
-          <span className="gender dd-privacy-hidden">
+          <span
+            className="gender dd-privacy-hidden"
+            data-dd-action-name="gender"
+          >
             {(gender && genderLabels[gender]) || ''}
           </span>
         </p>

--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -21,7 +21,9 @@ export class ConfirmationPage extends React.Component {
     const { submission, formId, data } = form;
     const issues = getSelected(data || []).map((issue, index) => (
       <li key={index} className="vads-u-margin-bottom--0">
-        <span className="dd-privacy-hidden">{getIssueName(issue)}</span>
+        <span className="dd-privacy-hidden" data-dd-action-name="issue name">
+          {getIssueName(issue)}
+        </span>
       </li>
     ));
     const fullName = `${name.first} ${name.middle || ''} ${name.last}`;
@@ -50,9 +52,14 @@ export class ConfirmationPage extends React.Component {
             Request a Board Appeal{' '}
             <span className="additional">(Form {formId})</span>
           </h3>
-          for <span className="dd-privacy-hidden">{fullName}</span>
+          for{' '}
+          <span className="dd-privacy-hidden" data-dd-action-name="full name">
+            {fullName}
+          </span>
           {name.suffix && (
-            <span className="dd-privacy-hidden">{`, ${name.suffix}`}</span>
+            <span className="dd-privacy-hidden" data-dd-action-name="suffix">
+              {`, ${name.suffix}`}
+            </span>
           )}
           {submitDate.isValid() && (
             <p>
@@ -119,10 +126,14 @@ ConfirmationPage.propTypes = {
     data: PropTypes.shape({}),
     formId: PropTypes.string,
     submission: PropTypes.shape({
-      timestamp: PropTypes.string,
+      timestamp: PropTypes.instanceOf(Date),
     }),
   }),
-  name: PropTypes.string,
+  name: PropTypes.shape({
+    first: PropTypes.string,
+    middle: PropTypes.string,
+    last: PropTypes.string,
+  }),
 };
 
 function mapStateToProps(state) {

--- a/src/applications/appeals/10182/tests/components/IssueCard.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/IssueCard.unit.spec.jsx
@@ -41,7 +41,8 @@ describe('<IssueCard>', () => {
     const { container } = render(<IssueCard {...props} item={issue} />);
     expect($$('input[type="checkbox"]', container).length).to.equal(1);
     expect($('.widget-title', container).textContent).to.eq('issue-10');
-    expect($('.widget-title.dd-privacy-hidden', container)).to.exist;
+    expect($('.widget-title.dd-privacy-hidden[data-dd-action-name]', container))
+      .to.exist;
     expect($('.widget-content', container).textContent).to.contain('blah');
     expect($('.widget-content', container).textContent).to.contain(
       'Current rating: 10%',
@@ -50,7 +51,7 @@ describe('<IssueCard>', () => {
       'Decision date: January 10, 2021',
     );
     expect($$('a.edit-issue-link').length).to.equal(0);
-    expect($$('.dd-privacy-hidden').length).to.equal(4);
+    expect($$('.dd-privacy-hidden[data-dd-action-name]').length).to.equal(4);
   });
   it('should render an Additional issue', () => {
     const props = getProps({ onEdit: () => {} });
@@ -62,7 +63,7 @@ describe('<IssueCard>', () => {
       'Decision date: February 22, 2021',
     );
     expect($$('a.edit-issue-link').length).to.equal(1);
-    expect($$('.dd-privacy-hidden').length).to.equal(2);
+    expect($$('.dd-privacy-hidden[data-dd-action-name]').length).to.equal(2);
   });
   it('should render a selected issue with appendId included', () => {
     const props = getProps();
@@ -113,7 +114,7 @@ describe('<IssueCardContent>', () => {
       'Decision date: January 20, 2021',
     );
     expect($$('a.edit-issue-link').length).to.equal(0);
-    expect($$('.dd-privacy-hidden').length).to.equal(3);
+    expect($$('.dd-privacy-hidden[data-dd-action-name]').length).to.equal(3);
   });
   it('should render AdditionalIssue content', () => {
     const issue = getAdditionalIssue('21');
@@ -121,6 +122,6 @@ describe('<IssueCardContent>', () => {
     expect($('.widget-content-wrap', container).textContent).to.contain(
       'Decision date: February 21, 2021',
     );
-    expect($$('.dd-privacy-hidden').length).to.equal(1);
+    expect($$('.dd-privacy-hidden[data-dd-action-name]').length).to.equal(1);
   });
 });

--- a/src/applications/appeals/10182/tests/components/ShowIssuesList.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ShowIssuesList.unit.spec.jsx
@@ -43,8 +43,12 @@ describe('ShowIssuesList', () => {
     expect(list.first().text()).to.contain('Decision date: January 1, 2021');
     expect(list.last().text()).to.contain('Issue 4');
     expect(list.last().text()).to.contain('Decision date: February 2, 2021');
-    expect(wrapper.find('strong.dd-privacy-hidden').length).to.eq(4);
-    expect(wrapper.find('span.dd-privacy-hidden').length).to.eq(4);
+    expect(
+      wrapper.find('strong.dd-privacy-hidden[data-dd-action-name]').length,
+    ).to.eq(4);
+    expect(
+      wrapper.find('span.dd-privacy-hidden[data-dd-action-name]').length,
+    ).to.eq(4);
     wrapper.unmount();
   });
 });

--- a/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/VeteranInformation.unit.spec.jsx
@@ -40,8 +40,12 @@ describe('<VeteranInformation>', () => {
 
     expect(text).to.contain('Date of birth: January 5, 2000');
     expect(text).to.contain('Gender: Female');
-    expect(wrapper.find('.dd-privacy-mask').length).to.eq(3);
-    expect(wrapper.find('.dd-privacy-hidden').length).to.eq(2);
+    expect(wrapper.find('.dd-privacy-mask[data-dd-action-name]').length).to.eq(
+      3,
+    );
+    expect(
+      wrapper.find('.dd-privacy-hidden[data-dd-action-name]').length,
+    ).to.eq(2);
 
     wrapper.unmount();
   });

--- a/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -78,8 +78,12 @@ describe('Confirmation page', () => {
   });
   it('should have Datadog class names to hide PII', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
-    expect(tree.find('span.dd-privacy-hidden').length).to.eq(3);
-    expect(tree.find('li .dd-privacy-hidden').length).to.eq(1);
+    expect(
+      tree.find('span.dd-privacy-hidden[data-dd-action-name]').length,
+    ).to.eq(3);
+    expect(
+      tree.find('li .dd-privacy-hidden[data-dd-action-name]').length,
+    ).to.eq(1);
     tree.unmount();
   });
 });

--- a/src/applications/appeals/shared/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/content/areaOfDisagreement.jsx
@@ -36,9 +36,16 @@ export const getIssueTitle = (data = {}, { plainText } = {}) => {
   ) : (
     <>
       {prefix}
-      <span className="dd-privacy-hidden">{name}</span>
+      <span className="dd-privacy-hidden" data-dd-action-name="issue name">
+        {name}
+      </span>
       {joiner}
-      <span className="dd-privacy-hidden">{formattedDate}</span>
+      <span
+        className="dd-privacy-hidden"
+        data-dd-action-name="issue decision date"
+      >
+        {formattedDate}
+      </span>
     </>
   );
 };
@@ -62,10 +69,14 @@ export const issueTitle = (props = {}) => {
 // Only show set values (ignore false & undefined)
 export const AreaOfDisagreementReviewField = ({ children }) => {
   const { formData, name } = children?.props || {};
+  const hidden = name === 'otherEntry';
   return formData ? (
     <div className="review-row">
       <dt>{DISAGREEMENT_TYPES[name]}</dt>
-      <dd className={name === 'otherEntry' ? 'dd-privacy-hidden' : ''}>
+      <dd
+        className={hidden ? 'dd-privacy-hidden' : ''}
+        data-dd-action-name={hidden ? 'something else' : ''}
+      >
         {children}
       </dd>
     </div>

--- a/src/applications/appeals/shared/content/contestableIssues.jsx
+++ b/src/applications/appeals/shared/content/contestableIssues.jsx
@@ -173,8 +173,11 @@ export const removeModalContent = {
   title: 'Are you sure you want to remove this issue?',
   description: issueName => (
     <span>
-      We’ll remove <strong>{issueName}</strong> from the issues you’d like us to
-      review
+      We’ll remove{' '}
+      <strong className="dd-privacy-hidden" data-dd-action-name="issue name">
+        {issueName}
+      </strong>{' '}
+      from the issues you’d like us to review
     </span>
   ),
   yesButton: 'Yes, remove this',

--- a/src/applications/appeals/shared/tests/content/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/content/areaOfDisagreement.unit.spec.jsx
@@ -18,7 +18,9 @@ describe('getIssueTitle', () => {
     expect($('div', container).textContent).to.eq(
       'Disagreement with left arm decision on February 2, 2022',
     );
-    expect($$('.dd-privacy-hidden', container).length).to.eq(2);
+    expect(
+      $$('.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.eq(2);
   });
   it('should return a plain string', () => {
     const result = getIssueTitle(data, { plainText: true });
@@ -97,7 +99,9 @@ describe('AreaOfDisagreementReviewField', () => {
     );
     expect($('dt', container).textContent).to.equal(title);
     expect($('dd', container).textContent).to.equal('Bar');
-    expect($$('dd.dd-privacy-hidden', container).length).to.equal(0);
+    expect(
+      $$('dd.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.equal(0);
   });
 
   it('should render AreaOfDisagreementReviewField with hidden Datadog class', () => {
@@ -116,6 +120,8 @@ describe('AreaOfDisagreementReviewField', () => {
       </AreaOfDisagreementReviewField>,
     );
     expect($('dt', container).textContent).to.equal(title);
-    expect($('dd.dd-privacy-hidden', container).textContent).to.equal('Bar');
+    expect(
+      $('dd.dd-privacy-hidden[data-dd-action-name]', container).textContent,
+    ).to.equal('Bar');
   });
 });

--- a/src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -45,6 +45,6 @@ describe('area of disagreement page', () => {
     // issueTitle isn't called with form data, so we check the static text
     expect(header.textContent).to.contain('Disagreement with');
     expect(header.textContent).to.contain('decision on');
-    expect($('h3 .dd-privacy-hidden', container)).to.exist;
+    expect($('h3 .dd-privacy-hidden[data-dd-action-name]', container)).to.exist;
   });
 });

--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -223,7 +223,7 @@ const ContactInfo = ({
           {content.homePhone}
         </Headers>
         {showSuccessAlert('home-phone', content.homePhone)}
-        <span className="dd-privacy-hidden">
+        <span className="dd-privacy-hidden" data-dd-action-name="home phone">
           <va-telephone contact={homePhoneString} not-clickable />
         </span>
         {loggedIn && (
@@ -244,7 +244,7 @@ const ContactInfo = ({
       <React.Fragment key="mobile">
         <Headers className={headerClassNames}>{content.mobilePhone}</Headers>
         {showSuccessAlert('mobile-phone', content.mobilePhone)}
-        <span className="dd-privacy-hidden">
+        <span className="dd-privacy-hidden" data-dd-action-name="mobile phone">
           <va-telephone contact={mobilePhoneString} not-clickable />
         </span>
         {loggedIn && (
@@ -265,7 +265,9 @@ const ContactInfo = ({
       <React.Fragment key="email">
         <Headers className={headerClassNames}>{content.email}</Headers>
         {showSuccessAlert('email', content.email)}
-        <span className="dd-privacy-hidden">{dataWrap[keys.email] || ''}</span>
+        <span className="dd-privacy-hidden" data-dd-action-name="email">
+          {dataWrap[keys.email] || ''}
+        </span>
         {loggedIn && (
           <p className="vads-u-margin-top--0p5">
             <Link

--- a/src/platform/forms-system/src/js/components/ContactInfoReview.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfoReview.jsx
@@ -87,7 +87,9 @@ const ContactInfoReview = ({ data, editPage, content, keys }) => {
       return value ? (
         <div key={label + index} className="review-row">
           <dt>{label}</dt>
-          <dd className="dd-privacy-hidden">{value}</dd>
+          <dd className="dd-privacy-hidden" data-dd-action-name={label}>
+            {value}
+          </dd>
         </div>
       ) : null;
     })

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -504,7 +504,11 @@ const FileField = props => {
               <li key={index} id={fileListId} className={itemClasses}>
                 {file.uploading && (
                   <div className="schemaform-file-uploading">
-                    <strong id={fileNameId} className="dd-privacy-hidden">
+                    <strong
+                      id={fileNameId}
+                      className="dd-privacy-hidden"
+                      data-dd-action-name="file name"
+                    >
                       {file.name}
                     </strong>
                     <br />
@@ -523,7 +527,11 @@ const FileField = props => {
                 {description && <p>{description}</p>}
                 {!file.uploading && (
                   <>
-                    <strong id={fileNameId} className="dd-privacy-hidden">
+                    <strong
+                      id={fileNameId}
+                      className="dd-privacy-hidden"
+                      data-dd-action-name="file name"
+                    >
                       {file.name}
                     </strong>
                     {file?.size && <div> {displayFileSize(file.size)}</div>}

--- a/src/platform/forms-system/src/js/review/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/review/PhoneNumberWidget.jsx
@@ -9,5 +9,9 @@ export default function PhoneNumberWidget({ value }) {
     )}`;
   }
 
-  return <span className="dd-privacy-hidden">{formatted}</span>;
+  return (
+    <span className="dd-privacy-hidden" data-dd-action-name="phone number">
+      {formatted}
+    </span>
+  );
 }

--- a/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
@@ -91,7 +91,9 @@ describe('<ContactInfo>', () => {
     expect($$('h4', container).length).to.equal(4);
     expect($$('h5', container).length).to.equal(0);
     // mobile phone, home phone, email, mailing address x2
-    expect($$('.dd-privacy-hidden', container).length).to.equal(5);
+    expect(
+      $$('.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.equal(5);
   });
 
   it('should render contact data w/no success messages', () => {

--- a/src/platform/forms-system/test/js/components/ContactInfoReview.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfoReview.unit.spec.jsx
@@ -47,7 +47,9 @@ describe('<ContactInfoReview>', () => {
     expect($('button.edit-page', container)).to.exist;
     expect($('h4', container).textContent).to.eq(content.title);
     expect($$('dt', container).length).to.eq(9);
-    expect($$('dd.dd-privacy-hidden', container).length).to.eq(9);
+    expect(
+      $$('dd.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.eq(9);
     expect(container.innerHTML).to.contain('Home phone');
   });
   it('should render all contact data, except home phone on review page', () => {

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -96,7 +96,8 @@ describe('Schemaform <FileField>', () => {
     );
 
     expect($('li', container).textContent).to.contain('Test file name.pdf');
-    expect($('strong.dd-privacy-hidden', container)).to.exist;
+    expect($('strong.dd-privacy-hidden[data-dd-action-name]', container)).to
+      .exist;
   });
 
   it('should remove files with empty file object when initializing', async () => {

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressView.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressView.jsx
@@ -9,8 +9,15 @@ export default function AddressView({ data: address }) {
   // international address
   return (
     <>
-      <div className="dd-privacy-hidden">{street}</div>
-      <div className="dd-privacy-hidden">{cityStateZip}</div>
+      <div className="dd-privacy-hidden" data-dd-action-name="street">
+        {street}
+      </div>
+      <div
+        className="dd-privacy-hidden"
+        data-dd-action-name="city, state and zip code"
+      >
+        {cityStateZip}
+      </div>
       {country && <div>{country}</div>}
     </>
   );

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneView.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneView.jsx
@@ -12,7 +12,7 @@ export default function PhoneView({ data: phoneData }) {
   );
   const extension = phoneData.extension && <span>x{phoneData.extension}</span>;
   return (
-    <div className="dd-privacy-hidden">
+    <div className="dd-privacy-hidden" data-dd-action-name="phone number">
       {countryCode} {phoneNumber} {extension}
     </div>
   );

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
@@ -192,8 +192,18 @@ class AddressValidationModal extends React.Component {
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
         >
           <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-bottom--0p5">
-            <span className="dd-privacy-hidden">{street}</span>
-            <span className="dd-privacy-hidden">{cityStateZip}</span>
+            <span
+              className="dd-privacy-hidden"
+              data-dd-action-name="street address"
+            >
+              {street}
+            </span>
+            <span
+              className="dd-privacy-hidden"
+              data-dd-action-name="city, state and zip code"
+            >
+              {cityStateZip}
+            </span>
             <span>{country}</span>
 
             {isAddressFromUser &&

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -217,8 +217,18 @@ class AddressValidationView extends React.Component {
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
         >
           <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-bottom--0p5">
-            <span className="dd-privacy-hidden">{street}</span>
-            <span className="dd-privacy-hidden">{cityStateZip}</span>
+            <span
+              className="dd-privacy-hidden"
+              data-dd-action-name="street address"
+            >
+              {street}
+            </span>
+            <span
+              className="dd-privacy-hidden"
+              data-dd-action-name="city, state and zip code"
+            >
+              {cityStateZip}
+            </span>
             <span>{country}</span>
           </div>
         </label>


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > We're setting up Datadog Real User Monitoring (RUM) for our Notice of Disagreement app. While reviewing replay sessions, we noticed that the event side panel would reveal text inside non-interactive elements when clicked. So we're adding a data attribute to change the action name to replace the PII content
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > The action name data attribute is in the Datadog documentation
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#61817](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61817)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Clicking on PII/PHI would include the text of the element in the Datadog event panel
- _Describe the steps required to verify your changes are working as expected_
  > See screenshots
- _Describe the tests completed and the results_
  > Updated unit test to check for both the Datadog class and data-attribute
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|  Datadog RUM |  |
| ------- | ----- |
| Before | <img width="1038" alt="Screenshot 2023-08-16 at 8 24 27 AM (1)" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b618eb61-4769-447d-b0a4-bd1791c77155"> |
| After | <img width="1147" alt="262452749-a951a5a1-f3d5-40e1-b895-e7b629cbb175" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/a90bc538-c4e1-4dea-b626-3add040c5aa0"> |

Screenshots include extra content added based on Datadog class & action name attribute - data seen is from mock user 0

| NOD   |  | 
| ------- | ----- |
| Veteran info | <img width="611" alt="Screenshot 2023-08-23 at 12 17 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/0ed296af-bd5e-4606-8654-5085a4418c16"> |
| Contact info | <img width="585" alt="Screenshot 2023-08-23 at 12 18 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/eb265be8-f240-454e-9532-0d90675cfc40"> |
| Contestable issues | <img width="595" alt="Screenshot 2023-08-23 at 12 18 54 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/ba9aa90a-9e3c-4fb7-9e88-8227634edb05"> |
| Remove modal | <img width="648" alt="Screenshot 2023-08-23 at 12 19 11 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/5815e115-0c47-465f-94c4-6f2a1b5aeaba"> |
| Area of disagreement | <img width="579" alt="Screenshot 2023-08-23 at 12 19 57 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/95a0235e-ad52-46c0-a483-a5ea6fa9bc14"> |
| Issue summary | <img width="584" alt="Screenshot 2023-08-23 at 12 20 24 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/051af3eb-e0f4-4f74-bc88-9ff1f0274910"> |
| Upload file names | <img width="580" alt="Screenshot 2023-08-23 at 12 20 45 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e5d08e89-7586-41f3-a8ac-48db0fcb49c8"> |
| Review & submit Veteran info | <img width="640" alt="Screenshot 2023-08-23 at 12 21 20 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d94f7c4a-be15-4692-92c1-8d766b8f3b18"> |
| Review & submit issues | <img width="625" alt="Screenshot 2023-08-23 at 12 21 55 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/ce091e00-7985-4bee-9614-b357ac98b7ce"> |
| Review & submit Board review options | <img width="627" alt="Screenshot 2023-08-23 at 12 22 09 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e7d9d36f-9d17-4b11-9329-b6a502f6fdc4"> |
| Confirmation page | <img width="669" alt="Screenshot 2023-08-23 at 12 25 06 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/aa5dc124-0fa3-4d4c-b126-f783f706a880"> |

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
