### PR TITLE
NOD | Fix string replace JS error

### DIFF
--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -97,7 +97,9 @@ export const MAX_LENGTH = {
  */
 export const REGEXP = {
   APOSTROPHE: /\u2019/g,
+  COMMA: /[, ]/g,
   DASH: /-/g,
+  EMPTY_DATE: /(--|-00-00)/,
   PERCENT: /(\s|\b)percent(\s|\b)/gi,
   WHITESPACE: /\s+/g,
 };

--- a/src/applications/appeals/shared/tests/utils/replace.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/replace.unit.spec.js
@@ -12,6 +12,11 @@ describe('replaceDescriptionContent', () => {
     expect(replaceDescriptionContent(null)).to.eq('');
     expect(replaceDescriptionContent('')).to.eq('');
   });
+  it('should return an empty string for non-string types', () => {
+    expect(replaceDescriptionContent({})).to.eq('');
+    expect(replaceDescriptionContent(true)).to.eq('');
+    expect(replaceDescriptionContent(10)).to.eq('');
+  });
   it('should not alter an these strings', () => {
     expect(replaceDescriptionContent('abc 123')).to.eq('abc 123');
     expect(replaceDescriptionContent('a b c 123')).to.eq('a b c 123');
@@ -41,6 +46,11 @@ describe('replaceSubmittedData', () => {
     expect(replaceSubmittedData(null)).to.eq('');
     expect(replaceSubmittedData('')).to.eq('');
   });
+  it('should return an empty string', () => {
+    expect(replaceSubmittedData()).to.eq('');
+    expect(replaceSubmittedData(null)).to.eq('');
+    expect(replaceSubmittedData('')).to.eq('');
+  });
   it('should not alter these strings', () => {
     expect(replaceSubmittedData('abc 123')).to.eq('abc 123');
     expect(replaceSubmittedData('a b c 123')).to.eq('a b c 123');
@@ -58,8 +68,15 @@ describe('replaceSubmittedData', () => {
 });
 
 describe('fixDateFormat', () => {
+  it('should return an empty strings for empty or non-string values', () => {
+    expect(fixDateFormat()).to.eq('');
+    expect(fixDateFormat('')).to.eq('');
+    expect(fixDateFormat({})).to.eq('');
+    expect(fixDateFormat(null)).to.eq('');
+    expect(fixDateFormat(10)).to.eq('');
+  });
   it('should return invalid dates strings', () => {
-    expect(fixDateFormat()).to.eq('-00-00');
+    expect(fixDateFormat('-')).to.eq('-00-00');
     expect(fixDateFormat('200')).to.eq('200-00-00');
   });
   it('should return already properly formatted date string', () => {

--- a/src/applications/appeals/shared/utils/replace.js
+++ b/src/applications/appeals/shared/utils/replace.js
@@ -2,6 +2,18 @@ import { parseISODate } from 'platform/forms-system/src/js/helpers';
 
 import { REGEXP } from '../constants';
 
+/**
+ * Detect non-string & return empty string if it isn't
+ * @param {*} value
+ * @return {string}
+ */
+const coerceStringValue = value => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return '';
+};
+
 /** Replace "percent" with "%" - see va.gov-team/issues/34810
  * Include spacing in regexp so:
  *  "10 percent " => "10% "
@@ -29,16 +41,17 @@ const replaceWhitespace = text => text.replace(REGEXP.WHITESPACE, ' ').trim();
 
 /**
  * Add leading zero to numbers < 10
+ * using slice since we have some Veterans using older Safari versions that
+ * don't support padStart or Intl.NumberFormat
  * @param {String} part - date part (month or day) to add leading zeros to
  * @returns {String}
  */
-// Add leading zero to date month or day; but use slice since we have some
-// Veterans using older Safari versions that don't support padStart
 const addLeadingZero = part => `00${part || ''}`.slice(-2);
 
 /** ***************** */
 
 const descriptionTransformers = [
+  coerceStringValue, // should be first
   // add more here
   replaceWhitespace,
   replacePercent,
@@ -56,6 +69,7 @@ export const replaceDescriptionContent = text =>
   );
 
 const submitTransformers = [
+  coerceStringValue, // should be first
   // add more here
   replaceWhitespace,
   replaceApostrophe,
@@ -79,8 +93,8 @@ export const replaceSubmittedData = text =>
  * @returns {String} YYYY-MM-DD date string
  */
 export const fixDateFormat = date => {
-  const dateString = (date || '').replace(REGEXP.WHITESPACE, '');
-  if (dateString.length === 10) {
+  const dateString = coerceStringValue(date).replace(REGEXP.WHITESPACE, '');
+  if (dateString.length === 10 || dateString === '') {
     return dateString;
   }
   const { day, month, year } = parseISODate(dateString);


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > From a Datadog RUM replay session, we noticed a Veteran unable to submit the NOD form. Datadog reported a generic error, but after examining Sentry, we found a `e.replace is not a function` JS error had occurred.
  > It _seems_ like the save in progress data, or maybe the profile data was replacing a `null` value with an empty object (`{}`) which JS determined to be a truthy value. And because our submit transformation functions check for falsy values and fall back to an empty string, the code was attempting to call `replace` on an object, causing the error
- _(If bug, how to reproduce)_
  > We don't know, but the `e.replace` error started occurring on Aug 20 and continues to this day.
- _(What is the solution, why is this the solution)_
  > We are expecting strings from the values passed into the submit transformer functions, so a string coercion function was written to always return an empty string for non-string values. 
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#64039](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64039)
- [Datadog replay session error](https://vagov.ddog-gov.com/rum/replay/sessions/36985d0c-c498-4074-8381-a6cbd33c0426?event=AgAAAYoZoOLDNu8pFwAAAAAAAAAYAAAAAEFZb1pvT1FPQUFBc1NZcENsbmVLdmdBSAAAACQAAAAAMDE4YTE5YTItM2E4OC00YzZmLTljYzYtMjRjYjNmMzI0NWY0&p_tab=attributes&seed=ce3501ce-75e3-4524-90e4-337a5096a7ec&ts=1692644104596)
- [Sentry error `e.replace is not a function`](http://sentry.vfs.va.gov/organizations/vsp/discover/results/?field=message&name=Notice+of+Disagreement&project=4&query=%28+url%3A%2Adecision-reviews%2Fboard-appeal%2Frequest-board-appeal-form-10182%2F%2A+OR+url%3A%2Anotice_of_disagreement%2A+%29+level%3Aerror+AND+message%3A%22e.replace+is+not+a+function+TypeError+%2Fgenerated%2F10182-board-appeal.entry.js+Vx+Vx%28generated%2F10182-board-appeal.entry%29%22&sort=-message&statsPeriod=7d&widths=-1)
## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Intermittent instance where street address line 2 and 3 are empty objects:

<img width="400" alt="street line 2 and 3 showing square bracket surrounding the words 'object Object', with the second word being capitalized" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/7864a44b-8525-441c-8bf5-b4c8a9cf4686" />

```js
"veteran": {
    "address": {
      "addressLine1": "1252 Main Ave",
      "addressLine2": {},
      "addressLine3": {},
      "addressPou": "CORRESPONDENCE",
      "addressType": "DOMESTIC",
      "city": "Emeryview",
      "countryName": "United States",
      "countryCodeIso2": "US",
      "countryCodeIso3": "USA",
      // ...
    },
},
```

## What areas of the site does it impact?

NOD is the only app encountering this issue, but this fix will apply to NOD, HLR & Supplemental Claims appeals forms

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
