### PR TITLE
Style check status as action link

### DIFF
--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -99,7 +99,7 @@ export class ConfirmationPage extends React.Component {
         <br role="presentation" />
         <a
           href="/claim-or-appeal-status/"
-          className="usa-button usa-button-primary"
+          className="vads-c-action-link--green"
           aria-describedby="delay-note"
         >
           Check the status of your appeal

--- a/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -56,6 +56,7 @@ describe('Confirmation page', () => {
   it('should render the confirmation page', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
     expect(tree).not.to.be.undefined;
+    expect(tree.find('.vads-c-action-link--green').length).to.eq(1);
     tree.unmount();
   });
   it('should render the user name', () => {

--- a/src/applications/appeals/996/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/996/containers/ConfirmationPage.jsx
@@ -109,7 +109,7 @@ export class ConfirmationPage extends React.Component {
         <br role="presentation" />
         <a
           href="/claim-or-appeal-status/"
-          className="usa-button usa-button-primary"
+          className="vads-c-action-link--green"
         >
           Check the status of your decision review
         </a>

--- a/src/applications/appeals/996/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -56,6 +56,7 @@ describe('Confirmation page', () => {
   it('should render the confirmation page', () => {
     const tree = mount(<ConfirmationPage store={fakeStore} />);
     expect(tree).not.to.be.undefined;
+    expect(tree.find('.vads-c-action-link--green').length).to.eq(1);
     tree.unmount();
   });
   it('should render the user name', () => {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In an a11y audit of our NOD form, the "Check the status of your appeal" link on the confirmation page is styled as a primary button, but should be styled as an action link. This styling is also applied to our HLR form. Both need to be updated.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Change style of the link to an action link
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#63230](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63230)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Link to the claim status tool is styled as a button
- _Describe the steps required to verify your changes are working as expected_
  > Fill out an NOD or HLR form in staging, using any mock user, and navigate to the confirmation page. The "Check the status of your appeal" (NOD) and "Check the status of your decision review" (HLR) must be styled as a green action link
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="704" alt="Screenshot 2023-08-24 at 2 24 20 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/fa62f38e-2bef-451f-8e38-f74924e7627a"> | <img width="689" alt="Screenshot 2023-08-24 at 3 04 11 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e15a8537-31ed-46fd-a23c-5315936688a9"> |

## What areas of the site does it impact?

NOD & HLR

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
