### PR TITLE
21-10210 - Add page-titles for review-sections edit-button aria-labels

### DIFF
--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -218,7 +218,7 @@ const formConfig = {
       pages: {
         witnessContactInfoPage: {
           path: 'witness-contact-information',
-          title: '',
+          title: 'Your contact information',
           depends: {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
           },
@@ -274,7 +274,7 @@ const formConfig = {
       pages: {
         claimantPersInfoPage: {
           path: 'claimant-personal-information',
-          title: '',
+          title: 'Personal information',
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
@@ -293,7 +293,7 @@ const formConfig = {
       pages: {
         claimantIdInfoPage: {
           path: 'claimant-identification-information',
-          title: '',
+          title: 'Identification information',
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
@@ -312,7 +312,7 @@ const formConfig = {
       pages: {
         claimantAddrInfoPage: {
           path: 'claimant-address-information',
-          title: '',
+          title: 'Mailing address',
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
@@ -331,7 +331,7 @@ const formConfig = {
       pages: {
         claimantContInfoPage: {
           path: 'claimant-contact-information',
-          title: '',
+          title: 'Contact information',
           depends: {
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
           },
@@ -369,7 +369,7 @@ const formConfig = {
       pages: {
         vetPersInfoPage: {
           path: 'veteran-personal-information',
-          title: '',
+          title: 'Personal information',
           scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetPersInfo.uiSchema,
           schema: vetPersInfo.schema,
@@ -386,7 +386,7 @@ const formConfig = {
       pages: {
         veteranIdentificationInfo1: {
           path: 'veteran-identification-information',
-          title: '',
+          title: 'Identification information',
           scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetIdInfo.uiSchema,
           schema: vetIdInfo.schema,
@@ -403,7 +403,7 @@ const formConfig = {
       pages: {
         veteranMailingAddressInfo1: {
           path: 'veteran-mailing-address',
-          title: '',
+          title: 'Mailing address',
           scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetAddrInfo.uiSchema,
           schema: vetAddrInfo.schema,
@@ -420,7 +420,7 @@ const formConfig = {
       pages: {
         veteranContactInfo1: {
           path: 'veteran-contact-information',
-          title: '',
+          title: 'Contact information',
           scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: vetContInfo.uiSchema,
           schema: vetContInfo.schema,

--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -34,9 +34,9 @@ import transformForSubmit from './submit-transformer';
 // import the appropriate file [flow?.json] for the flow you're working on, or
 // noStmtInfo.json for all flows [manually select claimOwnership, claimantType,
 // & witnessRelationshipWithClaimant via UI]
-// import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
+import testData from '../tests/e2e/fixtures/data/noStmtInfo.json';
 
-// const mockData = testData.data;
+const mockData = testData.data;
 
 const pageScrollAndFocus = () => {
   return () => {
@@ -81,7 +81,7 @@ const formConfig = {
   submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
   trackingPrefix: 'lay-witness-10210-',
   dev: {
-    // showNavLinks: true,
+    showNavLinks: true,
   },
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
@@ -149,7 +149,7 @@ const formConfig = {
       pages: {
         claimOwnershipPage: {
           path: 'claim-ownership',
-          title: '',
+          title: 'Original claimant',
           // needs form-level useCustomScrollAndFocus: true to work.
           // chapter's hideFormNavProgress interferes with scrollAndFocusTarget
           // so using a function here to ensure correct focusSelector is used
@@ -157,16 +157,16 @@ const formConfig = {
           scrollAndFocusTarget: pageScrollAndFocus(),
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
-          // initialData:
-          // !!mockData && environment.isLocalhost() && !window.Cypress
-          // ? mockData
-          // : undefined,
+          initialData:
+            !!mockData && environment.isLocalhost() && !window.Cypress
+              ? mockData
+              : undefined,
           uiSchema: claimOwnershipPg.uiSchema,
           schema: claimOwnershipPg.schema,
         },
         claimantTypePage: {
           path: 'claimant-type',
-          title: '',
+          title: 'Veteran status',
           // see comment for scrollAndFocusTarget in claimOwnershipPage above
           scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: claimantType.uiSchema,
@@ -181,7 +181,7 @@ const formConfig = {
         witnessPersInfoPageA: {
           // for Flow 2: 3rd-party claim, vet claimant
           path: 'witness-personal-information-a',
-          title: '',
+          title: 'Name and relationship',
           depends: {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
             claimantType: CLAIMANT_TYPES.VETERAN,
@@ -193,7 +193,7 @@ const formConfig = {
         witnessPersInfoPageB: {
           // for Flow 2: 3rd-party claim, non-vet claimant
           path: 'witness-personal-information-b',
-          title: '',
+          title: 'Name and relationship',
           depends: {
             claimOwnership: CLAIM_OWNERSHIPS.THIRD_PARTY,
             claimantType: CLAIMANT_TYPES.NON_VETERAN,
@@ -204,7 +204,7 @@ const formConfig = {
         },
         witnessOtherRelationshipPage: {
           path: 'witness-other-relationship',
-          title: '',
+          title: 'Relationship description',
           depends: witnessHasOtherRelationship,
           scrollAndFocusTarget: pageScrollAndFocus(),
           uiSchema: witnessOtherRelationship.uiSchema,

--- a/src/applications/simple-forms/21-10210/sass/10210-lay-witness-statement.scss
+++ b/src/applications/simple-forms/21-10210/sass/10210-lay-witness-statement.scss
@@ -83,3 +83,16 @@
   font-size: 1.6rem !important;
   font-weight: 400 !important;
 }
+
+.form-review-panel[data-chapter="claimantPersonalInfoChapter"],
+.form-review-panel[data-chapter="claimantIdInfoChapter"],
+.form-review-panel[data-chapter="claimantAddrInfoChapter"],
+.form-review-panel[data-chapter="claimantContactInfoChapter"],
+.form-review-panel[data-chapter="veteranPersonalInfoChapter"],
+.form-review-panel[data-chapter="veteranIdentificationInfo"],
+.form-review-panel[data-chapter="veteranMailingAddressInfo"],
+.form-review-panel[data-chapter="veteranContactInfo"] {
+  .form-review-panel-page-header {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

- Fix Lay/Witness Statement (21-10210) Review-page multi-page sections' Edit-button aria-labels:
  - For each multi-page chapter in form-config, add back a `title` in each page-block &mdash; they'll get pulled by forms-lib into the Edit-buttons' aria-labels.
  - For each single-page chapter, add a `title` for enable the aria-labels but visually hide the `<h4>`s.
- Team: Platform VA Product Forms

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team#60739 \[see [this comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60739#issuecomment-1692301090)\]

## Testing done

- Local manual-UI, unit-, and E2E-tests were all successful
