### PR TITLE
bugfix - ui validations to prevent error

### DIFF
--- a/src/applications/financial-status-report/pages/income/dependents/index.js
+++ b/src/applications/financial-status-report/pages/income/dependents/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import DependentExplainer from '../../../components/household/DependentExplainer';
+import { validateIsNumber } from '../../../utils/validations';
 
 export const uiSchema = {
   'ui:title': 'Your dependents',
@@ -56,6 +57,7 @@ export const uiSchemaEnhanced = {
       'ui:errorMessages': {
         required: 'Please enter your dependent(s) information.',
       },
+      'ui:validations': [validateIsNumber], // Here's where you're calling the validation function
     },
   },
   'view:components': {

--- a/src/applications/financial-status-report/pages/income/dependents/index.js
+++ b/src/applications/financial-status-report/pages/income/dependents/index.js
@@ -57,7 +57,7 @@ export const uiSchemaEnhanced = {
       'ui:errorMessages': {
         required: 'Please enter your dependent(s) information.',
       },
-      'ui:validations': [validateIsNumber], // Here's where you're calling the validation function
+      'ui:validations': [validateIsNumber],
     },
   },
   'view:components': {

--- a/src/applications/financial-status-report/utils/validations.js
+++ b/src/applications/financial-status-report/utils/validations.js
@@ -154,7 +154,9 @@ export const validateCurrencyArray = (errors, fieldData) => {
   }
 };
 
-export const validateIsNumber = value => {
-  const pattern = /^\d*\.?\d*$/;
-  return pattern.test(value);
+export const validateIsNumber = (errors, value) => {
+  const pattern = /^\d*$/; // This pattern ensures only whole numbers
+  if (!pattern.test(value)) {
+    errors.addError('Please enter a valid number.');
+  }
 };


### PR DESCRIPTION
### Summary
We are required to implement UI validations on the dependent-count text widget within our application. The goal is to ensure that users can only enter numerical values into this field. Any non-numeric input should trigger an error message.

### Acceptance Criteria

- [x]  Numeric Validation: The input field should only accept numerical values (0-9). Any other characters, including special characters or letters, should be considered invalid.

- [x]  Error Message: If the user enters anything other than a number, an error message should be displayed immediately below the input field. The error message could be something like "Please enter a valid number."


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64293


## Testing done

- previously entering a anything other then a number the page would crash
- added error validation to prevent users from continuing with the form until they enter a valid number


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|   Error handling     | 
![Screenshot 2023-08-24 at 3 39 24 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/1f76dab4-7a22-4999-ba9b-e2a172307198)

## What areas of the site does it impact?

FSR dependents form

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed


### Error Handling

- [x] Browser console contains no warnings or errors.

