### PR TITLE
21-10210 - Change veteran-personal-information page-title span to legend

### DIFF
--- a/src/applications/simple-forms/21-10210/components/VetPersInfoUiTitle.jsx
+++ b/src/applications/simple-forms/21-10210/components/VetPersInfoUiTitle.jsx
@@ -10,9 +10,9 @@ const VetPersInfoUiTitle = props => {
     if (formData.claimOwnership === CLAIM_OWNERSHIPS.SELF) {
       // Flow 3: self-claim
       return (
-        <span className="vads-u-font-family--serif vads-u-font-size--h5 vads-u-font-weight--bold">
+        <legend className="vads-u-font-family--serif vads-u-font-size--h5 vads-u-font-weight--bold">
           Tell us about the Veteran you’re connected to
-        </span>
+        </legend>
       );
     }
     // Flow 4: third-party claim


### PR DESCRIPTION
## Summary

- Change Lay/Witness Statement (21-10210) veteran-personal-information page's title from `<span>` to `<legend>`, so that it's properly announced by screenreaders.
- Team: Platform VA Product Forms

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#60734
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website/pull/25321

## Testing done

- Local manual-UI, unit-, and E2E-testing were all successful
