### PR TITLE
VACMS-14729 PAW: open links in new tab

### DIFF
--- a/src/applications/pact-act/constants/results-set-1-page-2-accordions.jsx
+++ b/src/applications/pact-act/constants/results-set-1-page-2-accordions.jsx
@@ -27,11 +27,15 @@ export const accordions = {
             <li>Reproductive cancer of any type</li>
             <li>Respiratory (breathing-related) cancer of any type</li>
           </ul>
-          <va-link
-            class="vads-u-margin-top--3 vads-u-margin-bottom--3 vads-u-display--block"
+          <a
+            className="vads-u-margin-top--3 vads-u-margin-bottom--3 vads-u-display--block"
             href="/resources/presumptive-cancers-related-to-burn-pit-exposure"
-            text="Learn more about presumptive cancers related to burn pits"
-          />
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more about presumptive cancers related to burn pits (opens in
+            a new tab)
+          </a>
           <p>
             <strong>These illnesses are now presumptive:</strong>
           </p>
@@ -72,10 +76,14 @@ export const accordions = {
               virus)
             </li>
           </ul>
-          <va-link
+          <a
             href="/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-afghanistan/"
-            text="Learn more about Gulf War illnesses and VA disability compensation"
-          />
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more about Gulf War illnesses and VA disability compensation
+            (opens in a new tab)
+          </a>
         </>
       ),
     },

--- a/src/applications/pact-act/containers/results/1/Page2.jsx
+++ b/src/applications/pact-act/containers/results/1/Page2.jsx
@@ -110,11 +110,14 @@ const ResultsSet1Page2 = ({ viewedResultsPage1, router }) => {
           Apply for VA health care
         </a>
         <p>
-          <va-link
-            class="vads-u-margin-top--3 vads-u-display--block"
+          <a
+            className="vads-u-margin-top--3 vads-u-display--block"
             href="/health-care/eligibility/"
-            text="Learn more about health care eligibility"
-          />
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more about health care eligibility (opens in a new tab)
+          </a>
         </p>
       </article>
     </>


### PR DESCRIPTION
## Summary
PACT Act wizard informational links should open in a new tab. This fixes that on the Results page (page 2).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14729

## Testing done
Tested all 3 links to ensure they open in a new tab. Tested 3 action links and they still open in the same tab, as intended.

## Screenshots
Action links (open in same tab)
<img width="700" alt="Screenshot 2023-08-25 at 8 53 49 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/45e15450-4151-42d8-8d6f-0e02aa66049a">
<br/>
<br/>
Informational links (open in new tab)
<img width="700" alt="Screenshot 2023-08-25 at 8 53 10 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/928c9c69-ffff-4629-b5fd-42280c8e7423">
<br/>
<img width="700" alt="Screenshot 2023-08-25 at 8 53 08 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f5620f1a-470b-468f-9c47-793b421f359d">
<br/>
<img width="700" alt="Screenshot 2023-08-25 at 8 53 03 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/7b7c5c6d-7148-41ae-af6f-1d282fc2ab69">

## Acceptance criteria
- [x] Informational links open in new tab and have the message `(opens in a new tab)`

### Quality Assurance & Testing
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added