### PR TITLE
Fix broken imports in ERZ app

### DIFF
--- a/src/applications/ezr/tests/e2e/ezr.cypress.spec.js
+++ b/src/applications/ezr/tests/e2e/ezr.cypress.spec.js
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import testForm from '@department-of-veterans-affairs/platform-testing/e2e/cypress/support/form-tester';
-import { createTestConfig } from '@department-of-veterans-affairs/platform-testing/e2e/cypress/support/form-tester/utilities';
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';


### PR DESCRIPTION
## Summary
This PR updates the imports for e2e testing file in the ERZ app folder to fix the failing stress test run in CI. The e2e test is skipped in CI, as the app is new and has yet to be populated with content, but the test itself is running the Stress Tests.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#63039

## Acceptance criteria
- CI Stress Test task successfully completes
