### PR TITLE
bugfix - error handling on dependent ages

### DIFF
--- a/src/applications/financial-status-report/components/household/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/household/DependentAges.jsx
@@ -24,40 +24,46 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
   const [isEditing, setIsEditing] = useState(!isReviewMode);
   const [hasDependentsChanged, setHasDependentsChanged] = useState(false);
 
-  useEffect(() => {
-    const shouldInitializeDependents =
-      !stateDependents.length ||
-      stateDependents.length !== parseInt(hasDependents, 10);
+  useEffect(
+    () => {
+      const shouldInitializeDependents =
+        !stateDependents.length ||
+        stateDependents.length !== parseInt(hasDependents, 10);
 
-    if (shouldInitializeDependents) {
-      const addDependents = Array.from(
-        { length: parseInt(hasDependents, 10) },
-        (_, i) => stateDependents[i] || { dependentAge: '' },
-      );
-      setStateDependents(addDependents);
-      setErrors(Array(addDependents.length).fill(null));
-      dispatch(
-        setData({
-          ...formData,
-          personalData: {
-            ...formData.personalData,
-            dependents: addDependents,
-          },
-        }),
-      );
-      if (isReviewMode) {
-        setHasDependentsChanged(true);
-      } else {
-        setHasDependentsChanged(false); // Reset the hasDependentsChanged state variable
+      if (shouldInitializeDependents) {
+        const addDependents = Array.from(
+          { length: parseInt(hasDependents, 10) },
+          (_, i) => stateDependents[i] || { dependentAge: '' },
+        );
+        setStateDependents(addDependents);
+        setErrors(Array(addDependents.length).fill(null));
+        dispatch(
+          setData({
+            ...formData,
+            personalData: {
+              ...formData.personalData,
+              dependents: addDependents,
+            },
+          }),
+        );
+        if (isReviewMode) {
+          setHasDependentsChanged(true);
+        } else {
+          setHasDependentsChanged(false); // Reset the hasDependentsChanged state variable
+        }
       }
-    }
-  }, [dispatch, hasDependents, isReviewMode, formData, stateDependents]);
+    },
+    [dispatch, hasDependents, isReviewMode, formData, stateDependents],
+  );
 
-  useEffect(() => {
-    if (isReviewMode) {
-      setIsEditing(hasDependentsChanged);
-    }
-  }, [isReviewMode, hasDependentsChanged]);
+  useEffect(
+    () => {
+      if (isReviewMode) {
+        setIsEditing(hasDependentsChanged);
+      }
+    },
+    [isReviewMode, hasDependentsChanged],
+  );
 
   const updateDependents = useCallback(
     (target, i) => {
@@ -86,10 +92,11 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
     if (errors.some(error => error !== null) || hasEmptyInput) {
       event.preventDefault(); // Prevent the form from being submitted when there are errors
       if (hasEmptyInput) {
-        const newErrors = stateDependents.map((dependent, i) =>
-          dependent.dependentAge === ''
-            ? 'Please enter your dependent(s) age.'
-            : errors[i],
+        const newErrors = stateDependents.map(
+          (dependent, i) =>
+            dependent.dependentAge === ''
+              ? 'Please enter your dependent(s) age.'
+              : errors[i],
         );
         setErrors(newErrors);
       }
@@ -173,8 +180,9 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
       ? 'form-review-panel-page-header vads-u-font-size--h5'
       : 'vads-u-margin--0';
 
-  let dependentAgeInputs = stateDependents.map((dependent, i) =>
-    isEditing ? renderAgeInput(dependent, i) : renderAgeText(dependent, i),
+  let dependentAgeInputs = stateDependents.map(
+    (dependent, i) =>
+      isEditing ? renderAgeInput(dependent, i) : renderAgeText(dependent, i),
   );
 
   if (!isEditing) {
@@ -194,16 +202,17 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
           }`}
         >
           <HeaderTag className={className}>Dependents ages</HeaderTag>
-          {isReviewMode && !isEditing && (
-            <ReviewControl
-              // readOnly
-              position="header"
-              isEditing={false}
-              onEditClick={handlers.toggleEditing}
-              ariaLabel={`Edit ${DEPENDENT_AGE_LABELS[1]}`}
-              buttonText="Edit"
-            />
-          )}
+          {isReviewMode &&
+            !isEditing && (
+              <ReviewControl
+                // readOnly
+                position="header"
+                isEditing={false}
+                onEditClick={handlers.toggleEditing}
+                ariaLabel={`Edit ${DEPENDENT_AGE_LABELS[1]}`}
+                buttonText="Edit"
+              />
+            )}
           {!isReviewMode ? (
             <>
               <p className="vads-u-margin-bottom--neg1 vads-u-margin-top--3 vads-u-padding-bottom--0p25 vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base">

--- a/src/applications/financial-status-report/components/household/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/household/DependentAges.jsx
@@ -84,8 +84,7 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
     );
 
     if (errors.some(error => error !== null) || hasEmptyInput) {
-      event.preventDefault(); // Prevent the form from being submitted if there are errors or empty inputs
-
+      event.preventDefault(); // Prevent the form from being submitted if there are errors.
       if (hasEmptyInput) {
         const newErrors = stateDependents.map((dependent, i) =>
           dependent.dependentAge === ''

--- a/src/applications/financial-status-report/components/household/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/household/DependentAges.jsx
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { VaNumberInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { DEPENDENT_AGE_LABELS } from '../../constants/dependentLabels';
-import { validateIsNumber } from '../../utils/validations';
+import { isNumber } from '../../utils/helpers';
 import DependentExplainer from './DependentExplainer';
 import ButtonGroup from '../shared/ButtonGroup';
 import ReviewControl from '../shared/ReviewControl';
@@ -24,46 +24,40 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
   const [isEditing, setIsEditing] = useState(!isReviewMode);
   const [hasDependentsChanged, setHasDependentsChanged] = useState(false);
 
-  useEffect(
-    () => {
-      const shouldInitializeDependents =
-        !stateDependents.length ||
-        stateDependents.length !== parseInt(hasDependents, 10);
+  useEffect(() => {
+    const shouldInitializeDependents =
+      !stateDependents.length ||
+      stateDependents.length !== parseInt(hasDependents, 10);
 
-      if (shouldInitializeDependents) {
-        const addDependents = Array.from(
-          { length: parseInt(hasDependents, 10) },
-          (_, i) => stateDependents[i] || { dependentAge: '' },
-        );
-        setStateDependents(addDependents);
-        setErrors(Array(addDependents.length).fill(null));
-        dispatch(
-          setData({
-            ...formData,
-            personalData: {
-              ...formData.personalData,
-              dependents: addDependents,
-            },
-          }),
-        );
-        if (isReviewMode) {
-          setHasDependentsChanged(true);
-        } else {
-          setHasDependentsChanged(false); // Reset the hasDependentsChanged state variable
-        }
-      }
-    },
-    [dispatch, hasDependents, isReviewMode, formData, stateDependents],
-  );
-
-  useEffect(
-    () => {
+    if (shouldInitializeDependents) {
+      const addDependents = Array.from(
+        { length: parseInt(hasDependents, 10) },
+        (_, i) => stateDependents[i] || { dependentAge: '' },
+      );
+      setStateDependents(addDependents);
+      setErrors(Array(addDependents.length).fill(null));
+      dispatch(
+        setData({
+          ...formData,
+          personalData: {
+            ...formData.personalData,
+            dependents: addDependents,
+          },
+        }),
+      );
       if (isReviewMode) {
-        setIsEditing(hasDependentsChanged);
+        setHasDependentsChanged(true);
+      } else {
+        setHasDependentsChanged(false); // Reset the hasDependentsChanged state variable
       }
-    },
-    [isReviewMode, hasDependentsChanged],
-  );
+    }
+  }, [dispatch, hasDependents, isReviewMode, formData, stateDependents]);
+
+  useEffect(() => {
+    if (isReviewMode) {
+      setIsEditing(hasDependentsChanged);
+    }
+  }, [isReviewMode, hasDependentsChanged]);
 
   const updateDependents = useCallback(
     (target, i) => {
@@ -85,22 +79,29 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
   );
 
   const onSubmit = event => {
-    event.preventDefault();
     const hasEmptyInput = stateDependents.some(
       dependent => dependent.dependentAge === '',
     );
-    if (hasEmptyInput) {
-      const newErrors = stateDependents.map(
-        (dependent, i) =>
+
+    if (errors.some(error => error !== null) || hasEmptyInput) {
+      event.preventDefault(); // Prevent the form from being submitted if there are errors or empty inputs
+
+      if (hasEmptyInput) {
+        const newErrors = stateDependents.map((dependent, i) =>
           dependent.dependentAge === ''
             ? 'Please enter your dependent(s) age.'
             : errors[i],
-      );
-      return setErrors(newErrors);
+        );
+        setErrors(newErrors);
+      }
+
+      return null;
     }
+
     if (isReviewMode) {
       return setIsEditing(false);
     }
+
     return formData['view:streamlinedWaiver']
       ? goForward(formData)
       : goToPath('/monetary-asset-checklist');
@@ -121,7 +122,7 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
       const newErrors = [...errors];
       if (!value) {
         newErrors[i] = 'Please enter your dependent(s) age.';
-      } else if (!validateIsNumber(value)) {
+      } else if (!isNumber(value)) {
         newErrors[i] = 'Please enter only numerical values';
       } else {
         newErrors[i] = null;
@@ -151,6 +152,7 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
         className="input-size-2 no-wrap"
         onBlur={event => handlers.handleBlur(event, i)}
         error={errors[i]}
+        inputMode="numeric"
         required
       />
     </div>
@@ -172,9 +174,8 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
       ? 'form-review-panel-page-header vads-u-font-size--h5'
       : 'vads-u-margin--0';
 
-  let dependentAgeInputs = stateDependents.map(
-    (dependent, i) =>
-      isEditing ? renderAgeInput(dependent, i) : renderAgeText(dependent, i),
+  let dependentAgeInputs = stateDependents.map((dependent, i) =>
+    isEditing ? renderAgeInput(dependent, i) : renderAgeText(dependent, i),
   );
 
   if (!isEditing) {
@@ -194,17 +195,16 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
           }`}
         >
           <HeaderTag className={className}>Dependents ages</HeaderTag>
-          {isReviewMode &&
-            !isEditing && (
-              <ReviewControl
-                // readOnly
-                position="header"
-                isEditing={false}
-                onEditClick={handlers.toggleEditing}
-                ariaLabel={`Edit ${DEPENDENT_AGE_LABELS[1]}`}
-                buttonText="Edit"
-              />
-            )}
+          {isReviewMode && !isEditing && (
+            <ReviewControl
+              // readOnly
+              position="header"
+              isEditing={false}
+              onEditClick={handlers.toggleEditing}
+              ariaLabel={`Edit ${DEPENDENT_AGE_LABELS[1]}`}
+              buttonText="Edit"
+            />
+          )}
           {!isReviewMode ? (
             <>
               <p className="vads-u-margin-bottom--neg1 vads-u-margin-top--3 vads-u-padding-bottom--0p25 vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base">

--- a/src/applications/financial-status-report/components/household/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/household/DependentAges.jsx
@@ -84,7 +84,7 @@ const DependentAges = ({ goForward, goToPath, isReviewMode = false }) => {
     );
 
     if (errors.some(error => error !== null) || hasEmptyInput) {
-      event.preventDefault(); // Prevent the form from being submitted if there are errors.
+      event.preventDefault(); // Prevent the form from being submitted when there are errors
       if (hasEmptyInput) {
         const newErrors = stateDependents.map((dependent, i) =>
           dependent.dependentAge === ''

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -32,6 +32,11 @@ export const fsrConfirmationEmailToggle = state =>
 
 export const allEqual = arr => arr.every(val => val === arr[0]);
 
+export const isNumber = value => {
+  const pattern = /^\d*$/; // This pattern ensures only whole numbers
+  return pattern.test(value);
+};
+
 export const dateFormatter = date => {
   if (!date) return undefined;
   const formatDate = date?.slice(0, -3);


### PR DESCRIPTION
### Summary
We are required to implement UI validations on the dependent-count and dependent-ages text widget within our application. The goal is to ensure that users can only enter numerical values into this field. Any non-numeric input should trigger an error message.

### Acceptance Criteria

- [x]  Numeric Validation: The input field should only accept numerical values (0-9). Any other characters, including special characters or letters, should be considered invalid.

- [x]  Error Message: If the user enters anything other than a number, an error message should be displayed immediately below the input field. The error message could be something like "Please enter a valid number."


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64293


## Testing done

- previously entering a anything other then a number the page would crash
- added error validation to prevent users from continuing with the form until they enter a valid number


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|   Error handling     | 

Dependent Count
![Screenshot 2023-08-24 at 3 39 24 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/1f76dab4-7a22-4999-ba9b-e2a172307198)

Dependent Ages:
![Screenshot 2023-08-25 at 10 13 07 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/77a3d60c-867d-4b7a-a320-98d0a2533e99)

## What areas of the site does it impact?

FSR dependents form

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed


### Error Handling

- [x] Browser console contains no warnings or errors.

