### PR TITLE
VACMS-14975 IL: Enable Cypress tests and fix dependents input issue

### DIFF
--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -83,7 +83,12 @@ const DependentsPage = ({
 
   const onDependentsInput = event => {
     setError(false);
-    updateDependentsField(parseInt(event.target.value, 10).toString());
+
+    if (event?.target?.value) {
+      updateDependentsField(parseInt(event.target.value, 10)?.toString());
+    } else {
+      updateDependentsField('');
+    }
   };
 
   const onBackClick = () => {

--- a/src/applications/income-limits/tests/income-limits.cypress.spec.js
+++ b/src/applications/income-limits/tests/income-limits.cypress.spec.js
@@ -4,11 +4,7 @@ import nonStandardLimits from './fixtures/non-standard-fixture.json';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-
-// Temporarily disabling these tests because there is a flaky selector that fails 4 out of 20 times
-// An upgrade to the latest Cypress fixes this problem and Platform is actively working on it
-// https://dsva.slack.com/archives/CBU0KDSB1/p1687455543337769
-xdescribe('Income Limits', () => {
+describe('Income Limits', () => {
   describe('current year flow', () => {
     it('navigates through the flow successfully forward and backward', () => {
       cy.visit('/health-care/income-limits');


### PR DESCRIPTION
## Summary
The Platform team upgraded vets-website to Cypress 12 today ([announcement](https://dsva.slack.com/archives/C5HP4GN3F/p1692979858429089)). We were waiting on this to enable the Income Limits Cypress tests because the speed of running tests with Cypress 10 (very, very slow) was creating some flaky selector issues with our tests. I ran the Cypress tests 5 times locally to ensure this problem did not crop up.

We also had a [number input defect](https://dsva.slack.com/archives/C52CL1PKQ/p1692977666471869) reported for the Dependents input. The DS team recently released some changes to the `VaNumberInput` component that make the input more strict about handling numbers. When you erased the number entered in the Dependents input, it was trying to parse an empty string into a number, which gave us `NaN`. 

This issue was not happening on the Zip Code input because Zip Code validation is done by sending the string to the service. Dependents validation must be assessed for a number between 0-100 before allowing the user to move forward, so a number has to be parsed.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14975
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14294 (for Cypress enablement)

## Testing done
Tested Cypress run locally 5 times consecutively. All passed each time.

Tested Dependents input in a few different ways. See video recording below.

## Acceptance criteria
- [x] Dependents field shows blank input instead of `NaN` when the input is erased