### PR TITLE
[CST] Fixing bug that displays incorrect dates for closed appeals

### DIFF
--- a/src/applications/claims-status/components/ClosedClaimMessage.jsx
+++ b/src/applications/claims-status/components/ClosedClaimMessage.jsx
@@ -10,13 +10,12 @@ import { appealTypes } from '../utils/appeals-v2-helpers';
 import { getClaimType } from '../utils/helpers';
 
 // HELPERS
+const isAppeal = claim => appealTypes.includes(claim.type);
 const isBenefitsClaimOrAppeal = claim =>
   claim.type !== 'education_benefits_claims';
 
 // START lighthouse_migration
 const isEVSSClaim = claim => claim.type === 'evss_claims';
-const isAppeal = claim => appealTypes.includes(claim.type);
-const isEVSSClaimOrAppeal = claim => isEVSSClaim(claim) || isAppeal(claim);
 // END lighthouse_migration
 
 const getRecentlyClosedClaims = claims => {
@@ -75,8 +74,8 @@ const getRecentlyClosedClaims = claims => {
           ...c,
           attributes: {
             ...c.attributes,
-            dateFiled: events[events.length - 1].date,
-            phaseChangeDate: c.attributes.prior_decision_date || events[0].date,
+            claimDate: events[events.length - 1].date,
+            closeDate: c.attributes.prior_decision_date || events[0].date,
           },
         };
       }
@@ -89,13 +88,13 @@ const getRecentlyClosedClaims = claims => {
 const getCloseDate = claim => {
   const { closeDate, phaseChangeDate } = claim.attributes;
 
-  return isEVSSClaimOrAppeal(claim) ? phaseChangeDate : closeDate;
+  return isEVSSClaim(claim) ? phaseChangeDate : closeDate;
 };
 
-const getFileDate = claim => {
+const getClaimDate = claim => {
   const { claimDate, dateFiled } = claim.attributes;
 
-  return isEVSSClaimOrAppeal(claim) ? dateFiled : claimDate;
+  return isEVSSClaim(claim) ? dateFiled : claimDate;
 };
 // END lighthouse_migration
 
@@ -105,7 +104,7 @@ const getLinkText = claim => {
   const claimType = isAppeal(claim)
     ? 'Compensation Appeal'
     : getClaimType(claim);
-  return `Your ${claimType} Received ${formatDate(getFileDate(claim))}`;
+  return `Your ${claimType} Received ${formatDate(getClaimDate(claim))}`;
 };
 
 export default function ClosedClaimMessage({ claims, onClose }) {

--- a/src/applications/claims-status/components/ClosedClaimMessage.jsx
+++ b/src/applications/claims-status/components/ClosedClaimMessage.jsx
@@ -54,7 +54,7 @@ const getRecentlyClosedClaims = claims => {
       // if it was closed more than 30 days ago
       return (
         isClosed &&
-        moment(dateClosed)
+        moment(dateClosed || null)
           .startOf('day')
           .isAfter(
             moment()
@@ -98,7 +98,7 @@ const getClaimDate = claim => {
 };
 // END lighthouse_migration
 
-const formatDate = date => moment(date).format('MMMM D, YYYY');
+const formatDate = date => moment(date || null).format('MMMM D, YYYY');
 
 const getLinkText = claim => {
   const claimType = isAppeal(claim)

--- a/src/applications/claims-status/components/ClosedClaimMessage.jsx
+++ b/src/applications/claims-status/components/ClosedClaimMessage.jsx
@@ -15,6 +15,8 @@ const isBenefitsClaimOrAppeal = claim =>
 
 // START lighthouse_migration
 const isEVSSClaim = claim => claim.type === 'evss_claims';
+const isAppeal = claim => appealTypes.includes(claim.type);
+const isEVSSClaimOrAppeal = claim => isEVSSClaim(claim) || isAppeal(claim);
 // END lighthouse_migration
 
 const getRecentlyClosedClaims = claims => {
@@ -23,7 +25,7 @@ const getRecentlyClosedClaims = claims => {
     .filter(claim => {
       // Check if this is an appeal, if so we want to filter it out
       // if it was closed more than 60 days ago
-      if (appealTypes.includes(claim.type)) {
+      if (isAppeal(claim)) {
         const sixtyDaysAgo = moment()
           .add(-60, 'days')
           .startOf('day');
@@ -46,14 +48,14 @@ const getRecentlyClosedClaims = claims => {
       const { closeDate, open, phaseChangeDate } = claim.attributes;
 
       const isClosed = isEVSSClaim(claim) ? !open : Boolean(closeDate);
-      const closedDate = isEVSSClaim(claim) ? phaseChangeDate : closeDate;
+      const dateClosed = isEVSSClaim(claim) ? phaseChangeDate : closeDate;
       // END lighthouse_migration
 
       // If the claim is not an appeal, we want to filter it out
       // if it was closed more than 30 days ago
       return (
         isClosed &&
-        moment(closedDate)
+        moment(dateClosed)
           .startOf('day')
           .isAfter(
             moment()
@@ -63,7 +65,7 @@ const getRecentlyClosedClaims = claims => {
       );
     })
     .map(c => {
-      if (appealTypes.includes(c.type)) {
+      if (isAppeal(c)) {
         const events = orderBy(
           c.attributes.events,
           [e => moment(e.date).unix()],
@@ -87,17 +89,24 @@ const getRecentlyClosedClaims = claims => {
 const getCloseDate = claim => {
   const { closeDate, phaseChangeDate } = claim.attributes;
 
-  return isEVSSClaim(claim) ? phaseChangeDate : closeDate;
+  return isEVSSClaimOrAppeal(claim) ? phaseChangeDate : closeDate;
 };
 
 const getFileDate = claim => {
   const { claimDate, dateFiled } = claim.attributes;
 
-  return isEVSSClaim(claim) ? dateFiled : claimDate;
+  return isEVSSClaimOrAppeal(claim) ? dateFiled : claimDate;
 };
 // END lighthouse_migration
 
 const formatDate = date => moment(date).format('MMMM D, YYYY');
+
+const getLinkText = claim => {
+  const claimType = isAppeal(claim)
+    ? 'Compensation Appeal'
+    : getClaimType(claim);
+  return `Your ${claimType} Received ${formatDate(getFileDate(claim))}`;
+};
 
 export default function ClosedClaimMessage({ claims, onClose }) {
   const closedClaims = getRecentlyClosedClaims(claims);
@@ -128,7 +137,7 @@ export default function ClosedClaimMessage({ claims, onClose }) {
           <p className="usa-alert-text claims-closed-text" key={claim.id}>
             <Link
               to={
-                appealTypes.includes(claim.type)
+                isAppeal(claim)
                   ? `appeals/${claim.id}/status`
                   : `your-claims/${claim.id}/status`
               }
@@ -136,11 +145,7 @@ export default function ClosedClaimMessage({ claims, onClose }) {
                 recordEvent({ event: 'claims-closed-alert-clicked' });
               }}
             >
-              Your{' '}
-              {appealTypes.includes(claim.type)
-                ? 'Compensation Appeal'
-                : getClaimType(claim)}{' '}
-              – Received {formatDate(getFileDate(claim))}
+              {getLinkText(claim)}
             </Link>{' '}
             has been closed as of {formatDate(getCloseDate(claim))}
           </p>

--- a/src/applications/claims-status/tests/components/ClosedClaimMessage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClosedClaimMessage.unit.spec.jsx
@@ -7,6 +7,83 @@ import moment from 'moment';
 import ClosedClaimMessage from '../../components/ClosedClaimMessage';
 
 describe('<ClosedClaimMessage>', () => {
+  context('Appeals', () => {
+    it('should render closed appeals within 30 days', () => {
+      const closeDate = moment().add(-29, 'days');
+
+      const claims = [
+        {
+          id: 1,
+          type: 'appeal',
+          attributes: {
+            active: false,
+            events: [
+              {
+                type: 'claim_decision',
+                date: '2020-01-01',
+              },
+              {
+                type: 'bva_decision',
+                date: closeDate.format('YYYY-MM-DD'),
+              },
+            ],
+          },
+        },
+      ];
+
+      const screen = render(<ClosedClaimMessage claims={claims} />);
+
+      // Check that the component was rendered
+      expect(screen.getByText('Recently closed:')).to.exist;
+
+      // Check that the dates match up with what we would expect
+      expect(
+        screen.getByText('Your Compensation Appeal Received January 1, 2020'),
+      ).to.exist;
+
+      const closeDateText = closeDate.format('MMMM D, YYYY');
+      expect(screen.getByText(`has been closed as of ${closeDateText}`)).to
+        .exist;
+    });
+
+    it('should not render closed claims at 30 days', () => {
+      const closeDate = moment().add(-30, 'days');
+
+      const claims = [
+        {
+          id: 2,
+          type: 'appeal',
+          attributes: {
+            active: false,
+            events: [
+              {
+                type: 'claim_decision',
+                date: '2021-05-10',
+              },
+              {
+                type: 'bva_decision',
+                date: closeDate.format('YYYY-MM-DD'),
+              },
+            ],
+          },
+        },
+      ];
+
+      const screen = render(<ClosedClaimMessage claims={claims} />);
+
+      // Check that the component was rendered
+      expect(screen.getByText('Recently closed:')).to.exist;
+
+      // Check that the dates match up with what we would expect
+      expect(screen.getByText('Your Compensation Appeal Received May 10, 2021'))
+        .to.exist;
+
+      const closeDateText = closeDate.format('MMMM D, YYYY');
+      expect(screen.getByText(`has been closed as of ${closeDateText}`)).to
+        .exist;
+    });
+  });
+
   context('EVSS claims', () => {
     it('should render closed claims within 30 days', () => {
       const claims = [
@@ -95,7 +172,7 @@ describe('<ClosedClaimMessage>', () => {
       const claims = [
         {
           id: 1,
-          type: 'claims',
+          type: 'claim',
           attributes: {
             claimDate: '2023-01-01',
             closeDate: moment()
@@ -113,7 +190,7 @@ describe('<ClosedClaimMessage>', () => {
       const claims = [
         {
           id: 1,
-          type: 'claims',
+          type: 'claim',
           attributes: {
             claimDate: '2023-01-01',
             closeDate: null,

--- a/src/applications/claims-status/tests/components/ClosedClaimMessage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClosedClaimMessage.unit.spec.jsx
@@ -8,8 +8,8 @@ import ClosedClaimMessage from '../../components/ClosedClaimMessage';
 
 describe('<ClosedClaimMessage>', () => {
   context('Appeals', () => {
-    it('should render closed appeals within 30 days', () => {
-      const closeDate = moment().add(-29, 'days');
+    it('should render closed appeals within 60 days', () => {
+      const closeDate = moment().add(-59, 'days');
 
       const claims = [
         {
@@ -46,8 +46,8 @@ describe('<ClosedClaimMessage>', () => {
         .exist;
     });
 
-    it('should not render closed claims at 30 days', () => {
-      const closeDate = moment().add(-30, 'days');
+    it('should not render closed claims at 60 days', () => {
+      const closeDate = moment().add(-60, 'days');
 
       const claims = [
         {
@@ -72,15 +72,7 @@ describe('<ClosedClaimMessage>', () => {
       const screen = render(<ClosedClaimMessage claims={claims} />);
 
       // Check that the component was rendered
-      expect(screen.getByText('Recently closed:')).to.exist;
-
-      // Check that the dates match up with what we would expect
-      expect(screen.getByText('Your Compensation Appeal Received May 10, 2021'))
-        .to.exist;
-
-      const closeDateText = closeDate.format('MMMM D, YYYY');
-      expect(screen.getByText(`has been closed as of ${closeDateText}`)).to
-        .exist;
+      expect(screen.queryByText('Recently closed:')).to.not.exist;
     });
   });
 


### PR DESCRIPTION
## Summary
The original intent was to update the `ClosedClaimMessage` component to use `date-fns` instead of `moment` but in the process of evaluating the code changes needed, I realized that there was a bug with the way that dates were being selected for appeals objects. The PR that introduced the issue is [here](https://github.com/department-of-veterans-affairs/vets-website/pull/22977/files#diff-56a06db29228b7e7594ef672987f2e94ba992090662387e6bf5b30ebdc197538). Appeals and claims are both supposed to show up in the list of recently closed claims, but the code was only accounting for how to determine which field to use for the file and close dates for claims.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#52942
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
<img width="751" alt="Screenshot 2023-02-01 at 1 33 04 PM" src="https://user-images.githubusercontent.com/13838621/216144811-4991e1d3-a04a-4d25-84aa-27648dee55ec.png">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
