### PR TITLE
Add back a <p> in 21P-0847 widget

### DIFF
--- a/src/applications/static-pages/simple-forms/21P-0847/App.js
+++ b/src/applications/static-pages/simple-forms/21P-0847/App.js
@@ -13,6 +13,7 @@ const App = ({ formEnabled }) => {
   if (formEnabled) {
     return (
       <>
+        <p>You can submit this form online or by mail.</p>
         <a
           className="vads-c-action-link--blue"
           href="/supporting-forms-for-claims/substitute-claimant-form-21P-0847"


### PR DESCRIPTION
## Summary

Due to a miscommunication, I erroneously removed the `<p>` tag in a previous commit. This commit restores that `<p>` tag.

## Related issue(s)

https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/508
