### PR TITLE
21-0845 - Refactor for PDF data-mapping

### DIFF
--- a/src/applications/simple-forms/21-0845/config/form.js
+++ b/src/applications/simple-forms/21-0845/config/form.js
@@ -12,7 +12,7 @@ import transformForSubmit from '../../shared/config/submit-transformer';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import getHelp from '../../shared/components/GetFormHelp';
-import { AUTHORIZER_TYPES } from '../definitions/constants';
+import { AUTHORIZER_TYPES, INFORMATION_SCOPES } from '../definitions/constants';
 // pages
 import authorizerTypePg from '../pages/authorizerType';
 import veteranPersonalInfoPg from '../pages/veteranPersonalInfo';
@@ -302,7 +302,7 @@ const formConfig = {
           path: 'disclosure-information-limited-information',
           title: 'Limited information',
           depends: {
-            informationScope: 'limited',
+            informationScope: INFORMATION_SCOPES.LIMITED,
           },
           uiSchema: limitedInfoPg.uiSchema,
           schema: limitedInfoPg.schema,
@@ -312,6 +312,9 @@ const formConfig = {
         releaseDurationPage: {
           path: 'disclosure-information-release-duration',
           title: 'Release duration',
+          depends: {
+            informationScope: INFORMATION_SCOPES.ANY,
+          },
           uiSchema: releaseDurationPg.uiSchema,
           schema: releaseDurationPg.schema,
           scrollAndFocusTarget: pageFocus(),
@@ -322,6 +325,7 @@ const formConfig = {
           path: 'disclosure-information-release-end-date',
           title: 'Release end date',
           depends: {
+            informationScope: INFORMATION_SCOPES.ANY,
             releaseDuration: 'untilDate',
           },
           uiSchema: releaseEndDatePg.uiSchema,

--- a/src/applications/simple-forms/21-0845/pages/organizationReps.js
+++ b/src/applications/simple-forms/21-0845/pages/organizationReps.js
@@ -42,6 +42,7 @@ export default {
       organizationRepresentatives: {
         type: 'array',
         minItems: 1,
+        maxItems: 2, // PDF only has 2 lines for reps
         items: {
           type: 'object',
           properties: {


### PR DESCRIPTION
## Summary

- Refactor Authorization to Disclose PII (21-0845) to match newly discovered PDF limitations:
  - Make release-duration & release-end-date pages conditional, based on `informationScope` &mdash; hidden if 'limited'; shown if 'any'
  - Limit organization-representatives to 2 max.
- Team: Platform VA Product Forms

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#331

## Testing done

- Local manual-UI and unit-tests were all successful
- NOTE: E2E-spec currently failing locally, but I'm skipping it in CI so it won't block this or any other PR

