### PR TITLE
Adjust rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,6 +113,12 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['*'],
+      rules: {
+        'cypress/unsafe-to-chain-command': 'warn',
+      },
+    },
+    {
       files: [
         '**/*.spec.jsx',
         '**/*.spec.js',
@@ -120,6 +126,7 @@ module.exports = {
         'src/platform/testing/**/*.jsx',
       ],
       rules: {
+        'cypress/unsafe-to-chain-command': 'warn',
         'no-restricted-imports': ['error', 'raven'],
         'no-unused-expressions': 0,
         'react/no-find-dom-node': 0,
@@ -130,9 +137,9 @@ module.exports = {
     {
       files: ['**/*.cypress.spec.js'],
       rules: {
+        'cypress/unsafe-to-chain-command': 'warn',
         '@department-of-veterans-affairs/axe-check-required': 1,
         '@department-of-veterans-affairs/cypress-viewport-deprecated': 1,
-        'cypress/unsafe-to-chain-command': 0,
       },
     },
   ],


### PR DESCRIPTION
## Background

Changes cypress [unsafe-to-chain-command](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/unsafe-to-chain-command.md) from error to warning to allow CI to pass on main.

Slack thread for more info: https://dsva.slack.com/archives/CBU0KDSB1/p1692989518828219