### PR TITLE
Check in/62927/next of kin help text

### DIFF
--- a/src/applications/check-in/components/pages/ConfirmablePage/ConfirmablePage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/ConfirmablePage.unit.spec.jsx
@@ -67,6 +67,23 @@ describe('pre-check-in experience', () => {
         expect(getByText('foo-title')).to.exist;
         expect(getByText('Not available')).to.exist;
       });
+      it('renders additional info if provided', () => {
+        const additionalInfo = <div data-testid="additional-info">FOO</div>;
+        const { getByTestId } = render(
+          <CheckInProvider>
+            <ConfirmablePage additionalInfo={additionalInfo} />
+          </CheckInProvider>,
+        );
+        expect(getByTestId('additional-info')).to.exist;
+      });
+      it("doesn't render additional info if not provided", () => {
+        const { queryByTestId } = render(
+          <CheckInProvider>
+            <ConfirmablePage />
+          </CheckInProvider>,
+        );
+        expect(queryByTestId('additional-info')).to.not.exist;
+      });
       it('renders the yes and no buttons with the usa-button-big css class', () => {
         const { getByTestId } = render(
           <CheckInProvider>

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -132,7 +132,7 @@ ConfirmablePage.propTypes = {
   header: PropTypes.string.isRequired,
   noAction: PropTypes.func.isRequired,
   yesAction: PropTypes.func.isRequired,
-  additionalInfo: PropTypes.string,
+  additionalInfo: PropTypes.object,
   eyebrow: PropTypes.string,
   pageType: PropTypes.string,
   router: PropTypes.object,

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -20,6 +20,7 @@ const ConfirmablePage = ({
   header,
   eyebrow = '',
   subtitle,
+  additionalInfo,
   dataFields = [],
   data = {},
   yesAction = () => {},
@@ -98,6 +99,7 @@ const ConfirmablePage = ({
           ))}
         </ul>
       </div>
+      {additionalInfo}
       <>
         <button
           onClick={onYesClick}
@@ -130,6 +132,7 @@ ConfirmablePage.propTypes = {
   header: PropTypes.string.isRequired,
   noAction: PropTypes.func.isRequired,
   yesAction: PropTypes.func.isRequired,
+  additionalInfo: PropTypes.string,
   eyebrow: PropTypes.string,
   pageType: PropTypes.string,
   router: PropTypes.object,

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -1,8 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import PropTypes from 'prop-types';
 import ConfirmablePage from '../ConfirmablePage';
+import { makeSelectApp } from '../../../selectors';
 
 export default function NextOfKinDisplay({
   header = '',
@@ -13,6 +15,9 @@ export default function NextOfKinDisplay({
   noAction = () => {},
   router,
 }) {
+  const selectApp = useMemo(makeSelectApp, []);
+  const { app } = useSelector(selectApp);
+
   const { t } = useTranslation();
   const nextOfKinFields = [
     {
@@ -36,6 +41,21 @@ export default function NextOfKinDisplay({
       key: 'workPhone',
     },
   ];
+  const additionalInfo = (
+    <div
+      data-testid="additional-info"
+      className="vads-u-margin-top--3 vads-u-margin-bottom--3"
+    >
+      <va-additional-info uswds trigger={t('how-to-update-next-of-kin')}>
+        <p>{t('confirm-who-youd-like-to-represent-your-wishes')}</p>
+        <p>
+          {t(
+            `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
+          )}
+        </p>
+      </va-additional-info>
+    </div>
+  );
   const loadingMessage = useCallback(
     () => {
       return (
@@ -55,6 +75,7 @@ export default function NextOfKinDisplay({
         header={header || t('is-this-your-current-next-of-kin-information')}
         eyebrow={eyebrow}
         subtitle={subtitle}
+        additionalInfo={additionalInfo}
         dataFields={nextOfKinFields}
         data={nextOfKin}
         yesAction={yesAction}

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import PropTypes from 'prop-types';
 import ConfirmablePage from '../ConfirmablePage';
@@ -50,9 +50,14 @@ export default function NextOfKinDisplay({
         <div>
           <p>{t('confirm-who-youd-like-to-represent-your-wishes')}</p>
           <p>
-            {t(
-              `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
-            )}
+            <Trans
+              i18nKey={t(
+                `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
+              )}
+              components={[
+                <span key="bold" className="vads-u-font-weight--bold" />,
+              ]}
+            />
           </p>
         </div>
       </va-additional-info>

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -47,12 +47,14 @@ export default function NextOfKinDisplay({
       className="vads-u-margin-top--3 vads-u-margin-bottom--3"
     >
       <va-additional-info uswds trigger={t('how-to-update-next-of-kin')}>
-        {t('confirm-who-youd-like-to-represent-your-wishes')}
-        <br />
-        <br />
-        {t(
-          `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
-        )}
+        <div>
+          <p>{t('confirm-who-youd-like-to-represent-your-wishes')}</p>
+          <p>
+            {t(
+              `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
+            )}
+          </p>
+        </div>
       </va-additional-info>
     </div>
   );

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -48,8 +48,10 @@ export default function NextOfKinDisplay({
     >
       <va-additional-info uswds trigger={t('how-to-update-next-of-kin')}>
         <div>
-          <p>{t('confirm-who-youd-like-to-represent-your-wishes')}</p>
-          <p>
+          <p className="vads-u-margin-top--0">
+            {t('confirm-who-youd-like-to-represent-your-wishes')}
+          </p>
+          <p className="vads-u-margin-bottom--0">
             <Trans
               i18nKey={t(
                 `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.jsx
@@ -47,12 +47,12 @@ export default function NextOfKinDisplay({
       className="vads-u-margin-top--3 vads-u-margin-bottom--3"
     >
       <va-additional-info uswds trigger={t('how-to-update-next-of-kin')}>
-        <p>{t('confirm-who-youd-like-to-represent-your-wishes')}</p>
-        <p>
-          {t(
-            `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
-          )}
-        </p>
+        {t('confirm-who-youd-like-to-represent-your-wishes')}
+        <br />
+        <br />
+        {t(
+          `if-this-isnt-your-correct-information-a-staff-member-can-help--${app}`,
+        )}
       </va-additional-info>
     </div>
   );

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.unit.spec.jsx
@@ -95,6 +95,14 @@ describe('pre-check-in experience', () => {
         expect(getByText(', Ste 234')).to.exist;
         expect(getByText('Los Angeles, CA 90089')).to.exist;
       });
+      it('renders additional info', () => {
+        const { getByTestId } = render(
+          <CheckInProvider>
+            <NextOfKinDisplay />
+          </CheckInProvider>,
+        );
+        expect(getByTestId('additional-info')).to.exist;
+      });
       it('fires the yes function', () => {
         const yesClick = sinon.spy();
         const screen = render(

--- a/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/happy-path/current.happy.path.cypress.spec.js
@@ -60,6 +60,10 @@ describe('Check In Experience', () => {
       );
       cy.injectAxeThenAxeCheck();
       cy.createScreenshots('Day-of-check-in--Next-of-kin');
+      NextOfKin.openAdditionalInfo();
+      cy.createScreenshots(
+        'Day-of-check-in--Next-of-kin--additional-info-open',
+      );
       NextOfKin.attemptToGoToNextPage();
 
       Appointments.validatePageLoaded();

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -229,6 +229,6 @@
   "check-in": "Check-In",
   "how-to-update-next-of-kin": "How to update your next of kin information",
   "confirm-who-youd-like-to-represent-your-wishes": "Confirm who you'd like to represent your wishes for care, medical documentation, and benefits if needed. Your next of kin is often your closest living relative, like your spouse, child, parent, or sibling.",
-  "if-this-isnt-your-correct-information-a-staff-member-can-help--dayOf": "If this isn’t your correct information, select No and a staff member can help you check in and update your information.",
-  "if-this-isnt-your-correct-information-a-staff-member-can-help--preCheckIn": "If this isn’t your correct information, select No and a staff member can help you update your information on the day of your appointment."
+  "if-this-isnt-your-correct-information-a-staff-member-can-help--dayOf": "If this isn’t your correct information, select <0>No</0> and a staff member can help you check in and update your information.",
+  "if-this-isnt-your-correct-information-a-staff-member-can-help--preCheckIn": "If this isn’t your correct information, select <0>No</0> and a staff member can help you update your information on the day of your appointment."
 }

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -226,5 +226,9 @@
   "trying-to-check-in-for-an-appointment--info-message": "Trying to check in for an appointment? Text <0>check in</0> to <1></1>.",
   "were-sorry-cant-file-travel-file-later--info-message": "We’re sorry. We can’t file a travel reimbursement claim for you now. But you can still file within <0>30 days</0> of the appointment.",
   "processing-travel-claim": "<0>We’re processing your travel reimbursement claim.</0> We’ll send you a text to let you know the status of your claim.",
-  "check-in": "Check-In"
+  "check-in": "Check-In",
+  "how-to-update-next-of-kin": "How to update your next of kin information",
+  "confirm-who-youd-like-to-represent-your-wishes": "Confirm who you'd like to represent your wishes for care, medical documentation, and benefits if needed. Your next of kin is often your closest living relative, like your spouse, child, parent, or sibling.",
+  "if-this-isnt-your-correct-information-a-staff-member-can-help--dayOf": "If this isn’t your correct information, select No and a staff member can help you check in and update your information.",
+  "if-this-isnt-your-correct-information-a-staff-member-can-help--preCheckIn": "If this isn’t your correct information, select No and a staff member can help you update your information on the day of your appointment."
 }

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy.path.cypress.spec.js
@@ -67,6 +67,8 @@ describe('Pre-Check In Experience ', () => {
     NextOfKin.validatePageLoaded();
     cy.injectAxeThenAxeCheck();
     cy.createScreenshots('Pre-check-in--Next-of-kin');
+    NextOfKin.openAdditionalInfo();
+    cy.createScreenshots('Pre-check-in--Next-of-kin--additional-info-open');
     NextOfKin.attemptToGoToNextPage();
 
     // page: Confirmation

--- a/src/applications/check-in/pre-check-in/tests/e2e/next-of-kin-display/next.of.kin.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/next-of-kin-display/next.of.kin.display.cypress.spec.js
@@ -47,5 +47,9 @@ describe('Pre-Check In Experience', () => {
       NextOfKin.validateNextOfKinData();
       cy.injectAxeThenAxeCheck();
     });
+    it('Displays additional info', () => {
+      NextOfKin.validateAdditionalInfo.dayOf();
+      cy.injectAxeThenAxeCheck();
+    });
   });
 });

--- a/src/applications/check-in/tests/e2e/pages/NextOfKin.js
+++ b/src/applications/check-in/tests/e2e/pages/NextOfKin.js
@@ -47,6 +47,21 @@ class NextOfKin {
       .should('include.text', '444-555-6666');
   };
 
+  validateAdditionalInfo = {
+    dayOf: () => {
+      cy.get('div[data-testid="additional-info"]').should(
+        'contain.text',
+        'If this isn’t your correct information, select No and a staff member can help you update your information on the day of your appointment.',
+      );
+    },
+    preCheckIn: () => {
+      cy.get('div[data-testid="additional-info"]').should(
+        'contain.text',
+        'If this isn’t your correct information, select No and a staff member can help you update your information on the day of your appointment.',
+      );
+    },
+  };
+
   validateBackButton = () => {
     cy.get('a[data-testid="back-button"]')
       .should('have.text', 'Back to last screen')

--- a/src/applications/check-in/tests/e2e/pages/NextOfKin.js
+++ b/src/applications/check-in/tests/e2e/pages/NextOfKin.js
@@ -69,6 +69,12 @@ class NextOfKin {
       .and('contain', 'emergency-contact');
   };
 
+  openAdditionalInfo = () => {
+    cy.get('.additional-info-title').click({
+      waitForAnimations: true,
+    });
+  };
+
   attemptToGoToNextPage = (button = 'yes') => {
     cy.get(`button[data-testid="${button}-button"]`).click({
       waitForAnimations: true,

--- a/src/applications/check-in/utils/defineWebComponents.js
+++ b/src/applications/check-in/utils/defineWebComponents.js
@@ -8,6 +8,7 @@ import {
   defineCustomElementVaModal, // For global DowntimeApproaching notification
   defineCustomElementVaTelephone,
   defineCustomElementVaTextInput,
+  defineCustomElementVaAdditionalInfo,
 } from '@department-of-veterans-affairs/component-library/dist/components';
 
 defineCustomElementVaAccordion();
@@ -18,3 +19,4 @@ defineCustomElementVaMemorableDate();
 defineCustomElementVaModal();
 defineCustomElementVaTelephone();
 defineCustomElementVaTextInput();
+defineCustomElementVaAdditionalInfo();


### PR DESCRIPTION
## Summary

- Adds the additional info component with content for day of and pre check in to the next of kin view

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#62927](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62927)
 
## Testing done

- cypress
- unit
- visual

## Screenshots

### Day of
![Screen Shot 2023-08-28 at 09 46 26](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/5d4094cd-73ce-42e5-b0e5-33a68e6a7ce2)
### Pre-check In
![Screen Shot 2023-08-28 at 09 48 19](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/a2896605-765e-4774-b23b-450a55e10421)


## What areas of the site does it impact?

Check-in day-of and pre-check-in
