### PR TITLE
Updates vaos-entry to allow for local automated tests

### DIFF
--- a/src/applications/vaos/vaos-entry.jsx
+++ b/src/applications/vaos/vaos-entry.jsx
@@ -8,7 +8,10 @@ import manifest from './manifest.json';
 import reducer from './redux/reducer';
 
 startApp({
-  url: environment.isProduction() ? manifest.rootUrl : manifest.newRootUrl,
+  url:
+    environment.isProduction() || (environment.isLocalhost() && window.Cypress)
+      ? manifest.rootUrl
+      : manifest.newRootUrl,
   createRoutesWithStore,
   reducer,
   entryName: manifest.entryName,


### PR DESCRIPTION
## Summary
Updates URL in `src/applications/vaos/vaos-entry.jsx` to fix local automated tests.

```js
startApp({
  url:
    environment.isProduction() || (environment.isLocalhost() && window.Cypress)
      ? manifest.rootUrl
      : manifest.newRootUrl,
  createRoutesWithStore,
  reducer,
  entryName: manifest.entryName,
});
```
Mentioned by @vbahinwillit in the [DSVA Slack](https://dsva.slack.com/archives/C03LR051S7L/p1692024535001909?thread_ts=1691780404.379019&cid=C03LR051S7L).

The production environment, localhost/cypress uses the older URL (`/health-care/schedule-view-va-appointments/appointments`) and staging uses the new URL (`/my-health/appointments`).

## Testing done

- e2e testing
- unit testing
