### PR TITLE
Remove helper text for Routing Number field

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
@@ -40,8 +40,7 @@ function makeSchemas(prefix) {
 
   const uiSchema = {
     [properties.routingNumber]: {
-      'ui:title':
-        'Routing number (Your bank’s name will appear after you add the 9-digit routing number)',
+      'ui:title': 'Routing number',
       'ui:errorMessages': {
         pattern: 'Please enter your bank’s 9-digit routing number',
         required: 'Please enter your bank’s 9-digit routing number',
@@ -97,6 +96,12 @@ BankInfoForm.propTypes = {
   // Prefix to apply to all the form's schema fields
   formPrefix: PropTypes.string.isRequired,
   formSubmit: PropTypes.func.isRequired,
+  cancelButtonClasses: PropTypes.arrayOf(PropTypes.string),
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
 };
 
 BankInfoForm.defaultProps = {


### PR DESCRIPTION
## Summary

- Removing the helper text for the direct deposit page routing number field. It was deemed confusing and not needed.
- Maintenance: Also updated some prop types

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/62527

## Testing done

- Tested locally, but no logic or testable changes made

## Screenshots


|         | Before | After |
| ------- | ------ | ----- |
|   | ![Screenshot 2023-08-28 at 8 53 03 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/84e4f023-0429-4500-a8f7-2d5a25ce5deb) | ![Screenshot 2023-08-28 at 8 52 28 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/df02c29f-52dd-44d9-8b7e-081afa756844) |

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Routing number helper text removed 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)