### PR TITLE
Disable Income Limits Cypress tests until Cypress 12 release is stable

### DIFF
--- a/src/applications/income-limits/tests/income-limits.cypress.spec.js
+++ b/src/applications/income-limits/tests/income-limits.cypress.spec.js
@@ -4,7 +4,7 @@ import nonStandardLimits from './fixtures/non-standard-fixture.json';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('Income Limits', () => {
+xdescribe('Income Limits', () => {
   describe('current year flow', () => {
     it('navigates through the flow successfully forward and backward', () => {
       cy.visit('/health-care/income-limits');


### PR DESCRIPTION
Disabling Income Limits Cypress tests for now. The Cypress 12 release introduced linting errors that need to be addressed before we can keep the version upgrade.