### PR TITLE
Update the text for single vs multiple Cerner sites on the Cerner widget

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -207,7 +207,7 @@ export class CernerCallToAction extends Component {
                     cernerFacilities.length === 1
                       ? 'this facility'
                       : 'these facilities'
-                  }, go to My VA Health`}
+                  }, go to My VA Health:`}
                 </p>
                 <div className="vads-u-margin-y--1">
                   <ul className="vads-u-margin-left--1p5 vads-u-margin-bottom--1">

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -203,7 +203,11 @@ export class CernerCallToAction extends Component {
                   Choose the right health portal
                 </h3>
                 <p className="vads-u-font-weight--bold">
-                  {`To ${fillins.cta1} these facilities, go to My VA Health:`}
+                  {`To ${fillins.cta1} ${
+                    cernerFacilities.length === 1
+                      ? 'this facility'
+                      : 'these facilities'
+                  }, go to My VA Health`}
                 </p>
                 <div className="vads-u-margin-y--1">
                   <ul className="vads-u-margin-left--1p5 vads-u-margin-bottom--1">
@@ -246,8 +250,6 @@ export class CernerCallToAction extends Component {
                   className="vads-c-action-link--blue"
                   href={myHealtheVetLink}
                   onClick={onCTALinkClick}
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   {`Go to ${fillins.cta2} on VA.gov`}
                 </a>


### PR DESCRIPTION
## Summary
This PR updates the text in Cerner re-direct widget on the Public Websites page

## Acceptance criteria

- [ ] Given the user is registered at _one_ Cerner site
When the user lands on the Cerner widget in https://www.va.gov/health-care/schedule-view-va-appointments/
Then the message description should display "To manage appointments at this facility, go to My VA Health"
And page design matches the [design spec](https://www.figma.com/file/iqjkZx2EbrZu6leL6YfN45/Cerner-Handoff?type=design&node-id=1851-27388&mode=design&t=pgkIWY55pbPRbPeY-4)

- [ ] Given the user is registered at _multiple_ Cerner sites (two or more)
When the user lands on the Cerner widget in https://www.va.gov/health-care/schedule-view-va-appointments/
Then the message description should display "To manage appointments at these facilities, go to My VA Health"
And page design matches the [design spec](https://www.figma.com/file/iqjkZx2EbrZu6leL6YfN45/Cerner-Handoff?type=design&node-id=1851-27388&mode=design&t=L8VCCynpro2yf5F1-0)

- [ ] Given the user is registered at a Cerner site(s)
When the user lands on the Cerner widget in https://www.va.gov/health-care/schedule-view-va-appointments/ and clicks  on the link `Go to appointments tool on VA.gov`
Then the user will be directed to the Appointments landing page on the same tab.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64048


## Testing done
n/a

## Screenshots
_Single_ Cerner site
![Screenshot 2023-08-28 at 12 05 36 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/0f3bf918-a2ff-4274-bcde-54eb31aeee89)

___
_multiple_ Cerner sites (two or more)
![Screenshot 2023-08-28 at 12 05 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/b73f9e93-8249-44dc-bf4c-1a3955ac96d2)



## What areas of the site does it impact?

Cerner alert widget

