### PR TITLE
Remove unused code

### DIFF
--- a/script/install-repos.sh
+++ b/script/install-repos.sh
@@ -16,9 +16,3 @@ if [ ! -d ../vets-api ]; then
 else
   echo "Repo vets-api already cloned."
 fi
-
-# @TODO: if these are not needed anymore, remove.
-# git clone git@github.com:department-of-veterans-affairs/vets-json-schema.git
-# git clone git@github.com:department-of-veterans-affairs/veteran-facing-services-tools.git
-# git clone git@github.com:department-of-veterans-affairs/vets-api.git
-# git clone git@github.com:department-of-veterans-affairs/vets-api-mockdata.git

--- a/script/pre-push.sh
+++ b/script/pre-push.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-# Temporary check due to master -> main branch switch. Remove after 2022
-if [[ `git rev-parse --abbrev-ref origin/HEAD` != 'origin/main' ]]; then
-  echo "ERROR: The vets-website default branch has changed from 'master' to 'main'."
-  echo "Please run the following commands to make the switch locally:"
-  echo "  git branch -m master main"
-  echo "  git fetch origin"
-  echo "  git branch -u origin/main main"
-  echo "  git remote set-head origin -a"
-  exit 1
-fi
-# End temporary check
-
 if [[ ! `git log origin/main.. --no-merges` ]]; then
   echo "No commits to push! Add at least one commit to push this branch to origin."
   exit 1


### PR DESCRIPTION
Removing unused code. The `install-repos.sh` code was added 4 years ago and has been commented out since. `pre-push.sh` states that it should be removed after 2022.