### PR TITLE
fix: remove top border and related styling

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -51,10 +51,6 @@ export function PersonalizationDropdown(props) {
     TOGGLE_NAMES.showAuthenticatedMenuEnhancements,
   );
 
-  const enhancedTopLinkClasses = showAuthenticatedMenuEnhancements
-    ? 'vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-padding-top--1'
-    : '';
-
   const createSignout = useCallback(
     () => (
       <a
@@ -79,7 +75,7 @@ export function PersonalizationDropdown(props) {
         isSSOe={isSSOe}
         showEnhancements={showAuthenticatedMenuEnhancements}
       />
-      <li className={enhancedTopLinkClasses}>
+      <li>
         <a href="/profile" onClick={recordProfileEvent}>
           Profile
         </a>


### PR DESCRIPTION
## Summary

- Minor tweak to styling. It was decided to remove the top border and only keep the bottom border to make the menu links look a little more concise and not split up.
- Only a stylistic change, no behavour changes

 
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/62940

## Testing done

- Tested styling locally. Made sure that it matched up with mockup.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
|   | ![Screenshot 2023-08-29 at 10 46 33 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/b44aab24-dc81-4156-9734-fd997078e319) | ![Screenshot 2023-08-29 at 10 46 16 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/819e1a60-1a88-4f7b-9872-4180a2be8c1f) |

## What areas of the site does it impact?

Header personalized menu

## Acceptance criteria

- [x] padding and border removed for top section of links

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
