### PR TITLE
fix: change to checkbox group GA event

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -121,11 +121,10 @@ const NotificationChannel = props => {
               });
 
               const eventPayload = {
-                event: 'int-checkbox-option-click',
-                'checkbox-label': label,
-                'checkbox-description': itemName,
-                'checkbox-required': false,
-                'checkbox-checked': newValue,
+                event: 'int-checkbox-group-option-click',
+                'checkbox-group-optionLabel': `${label} - ${newValue}`,
+                'checkbox-group-label': itemName,
+                'checkbox-group-required': false,
               };
 
               recordEvent(eventPayload);


### PR DESCRIPTION
## Summary

- Change GA event for checkbox interactions to be for the 'checkbox-group' instead of individual checkbox

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/63727

## Testing done

- Checked dataLayer locally

## Screenshots

Here is the event with various properties for the checkbox group option being clicked

![Screenshot 2023-08-29 at 12 14 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/539c0c48-1959-4f1e-a7f5-36c55cd19625)

## What areas of the site does it impact?

Just GA analytics for notification settings checkboxes

## Acceptance criteria

- [x] Event updated

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
