### PR TITLE
VACMS-14861: Update text for yellow ribbon schools text year

### DIFF
--- a/src/applications/yellow-ribbon/constants/index.js
+++ b/src/applications/yellow-ribbon/constants/index.js
@@ -6,4 +6,4 @@ export const TOGGLE_TOOL_TIP = 'yellow-ribbon/TOGGLE_TOOL_TIP';
 export const TOOL_TIP_LABEL = 'Tips to improve search results';
 export const TOOL_TIP_CONTENT =
   "Enter a school's full name. For example, search for New York University not NYU.";
-export const CURRENT_SCHOOL_YEAR = 'August 2022 through July 2023';
+export const CURRENT_SCHOOL_YEAR = 'August 2023 through July 2024';


### PR DESCRIPTION
## Summary
Update to school year text from 2022 to 2023

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14861

## Screenshots
<img width="739" alt="Find_A_Yellow_Ribbon_School___Veterans_Affairs___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/107d4e81-3bfd-46d6-8f29-1d2bc23ec4da">


## What areas of the site does it impact?

Yellow Ribbon School Find a School page

## Acceptance criteria
- [ ] Text is updated to read `You may search for schools participating in the current academic year, August 2023 through July 2024.`
